### PR TITLE
[RW-5736][risk=no] consolidating DomainType enum into Domain enum

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -53,7 +53,7 @@ import org.pmiops.workbench.model.CriteriaType;
 import org.pmiops.workbench.model.DataFilter;
 import org.pmiops.workbench.model.DemoChartInfo;
 import org.pmiops.workbench.model.DemoChartInfoListResponse;
-import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.GenderOrSexType;
 import org.pmiops.workbench.model.Modifier;
 import org.pmiops.workbench.model.ModifierType;
@@ -200,35 +200,35 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     icd9 =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.CONDITION.toString())
+                .addDomainId(Domain.CONDITION.toString())
                 .addType(CriteriaType.ICD9CM.toString())
                 .addStandard(false)
                 .build());
     icd10 =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.CONDITION.toString())
+                .addDomainId(Domain.CONDITION.toString())
                 .addType(CriteriaType.ICD10CM.toString())
                 .addStandard(false)
                 .build());
     snomedStandard =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.CONDITION.toString())
+                .addDomainId(Domain.CONDITION.toString())
                 .addType(CriteriaType.SNOMED.toString())
                 .addStandard(true)
                 .build());
     snomedSource =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.CONDITION.toString())
+                .addDomainId(Domain.CONDITION.toString())
                 .addType(CriteriaType.SNOMED.toString())
                 .addStandard(false)
                 .build());
     cpt4 =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.PROCEDURE.toString())
+                .addDomainId(Domain.PROCEDURE.toString())
                 .addType(CriteriaType.CPT4.toString())
                 .addStandard(false)
                 .build());
@@ -238,7 +238,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             .addAncestorData(false)
             .addCode("001")
             .addConceptId("0")
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addType(CriteriaType.ICD10CM.toString())
             .addGroup(true)
             .addSelectable(true)
@@ -252,7 +252,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             .addAncestorData(false)
             .addCode("001.1")
             .addConceptId("1")
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addType(CriteriaType.ICD10CM.toString())
             .addGroup(false)
             .addSelectable(true)
@@ -264,7 +264,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     procedureParent1 =
         DbCriteria.builder()
             .addParentId(99999)
-            .addDomainId(DomainType.PROCEDURE.toString())
+            .addDomainId(Domain.PROCEDURE.toString())
             .addType(CriteriaType.SNOMED.toString())
             .addStandard(true)
             .addCode("386637004")
@@ -280,7 +280,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     procedureChild1 =
         DbCriteria.builder()
             .addParentId(procedureParent1.getId())
-            .addDomainId(DomainType.PROCEDURE.toString())
+            .addDomainId(Domain.PROCEDURE.toString())
             .addType(CriteriaType.SNOMED.toString())
             .addStandard(true)
             .addCode("386639001")
@@ -297,7 +297,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     surveyNode =
         DbCriteria.builder()
             .addParentId(0)
-            .addDomainId(DomainType.SURVEY.toString())
+            .addDomainId(Domain.SURVEY.toString())
             .addType(CriteriaType.PPI.toString())
             .addSubtype(CriteriaSubType.SURVEY.toString())
             .addGroup(true)
@@ -309,7 +309,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     questionNode =
         DbCriteria.builder()
             .addParentId(surveyNode.getId())
-            .addDomainId(DomainType.SURVEY.toString())
+            .addDomainId(Domain.SURVEY.toString())
             .addType(CriteriaType.PPI.toString())
             .addSubtype(CriteriaSubType.QUESTION.toString())
             .addGroup(true)
@@ -323,7 +323,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     answerNode =
         DbCriteria.builder()
             .addParentId(questionNode.getId())
-            .addDomainId(DomainType.SURVEY.toString())
+            .addDomainId(Domain.SURVEY.toString())
             .addType(CriteriaType.PPI.toString())
             .addSubtype(CriteriaSubType.ANSWER.toString())
             .addGroup(false)
@@ -378,7 +378,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter icd9() {
     return new SearchParameter()
-        .domain(DomainType.CONDITION.toString())
+        .domain(Domain.CONDITION.toString())
         .type(CriteriaType.ICD9CM.toString())
         .standard(false)
         .ancestorData(false)
@@ -388,7 +388,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter icd10() {
     return new SearchParameter()
-        .domain(DomainType.CONDITION.toString())
+        .domain(Domain.CONDITION.toString())
         .type(CriteriaType.ICD10CM.toString())
         .standard(false)
         .ancestorData(false)
@@ -398,7 +398,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter snomed() {
     return new SearchParameter()
-        .domain(DomainType.CONDITION.toString())
+        .domain(Domain.CONDITION.toString())
         .type(CriteriaType.SNOMED.toString())
         .standard(false)
         .ancestorData(false)
@@ -408,7 +408,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter drug() {
     return new SearchParameter()
-        .domain(DomainType.DRUG.toString())
+        .domain(Domain.DRUG.toString())
         .type(CriteriaType.ATC.toString())
         .group(false)
         .ancestorData(true)
@@ -418,7 +418,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter measurement() {
     return new SearchParameter()
-        .domain(DomainType.MEASUREMENT.toString())
+        .domain(Domain.MEASUREMENT.toString())
         .type(CriteriaType.LOINC.toString())
         .subtype(CriteriaSubType.LAB.toString())
         .group(false)
@@ -429,7 +429,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter visit() {
     return new SearchParameter()
-        .domain(DomainType.VISIT.toString())
+        .domain(Domain.VISIT.toString())
         .type(CriteriaType.VISIT.toString())
         .group(false)
         .ancestorData(false)
@@ -439,7 +439,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter procedure() {
     return new SearchParameter()
-        .domain(DomainType.PROCEDURE.toString())
+        .domain(Domain.PROCEDURE.toString())
         .type(CriteriaType.CPT4.toString())
         .group(false)
         .ancestorData(false)
@@ -449,7 +449,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter bloodPressure() {
     return new SearchParameter()
-        .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+        .domain(Domain.PHYSICAL_MEASUREMENT.toString())
         .type(CriteriaType.PPI.toString())
         .subtype(CriteriaSubType.BP.toString())
         .ancestorData(false)
@@ -459,7 +459,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter hrDetail() {
     return new SearchParameter()
-        .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+        .domain(Domain.PHYSICAL_MEASUREMENT.toString())
         .type(CriteriaType.PPI.toString())
         .subtype(CriteriaSubType.HR_DETAIL.toString())
         .ancestorData(false)
@@ -470,7 +470,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter hr() {
     return new SearchParameter()
-        .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+        .domain(Domain.PHYSICAL_MEASUREMENT.toString())
         .type(CriteriaType.PPI.toString())
         .subtype(CriteriaSubType.HR.toString())
         .ancestorData(false)
@@ -481,7 +481,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter height() {
     return new SearchParameter()
-        .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+        .domain(Domain.PHYSICAL_MEASUREMENT.toString())
         .type(CriteriaType.PPI.toString())
         .subtype(CriteriaSubType.HEIGHT.toString())
         .group(false)
@@ -492,7 +492,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter weight() {
     return new SearchParameter()
-        .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+        .domain(Domain.PHYSICAL_MEASUREMENT.toString())
         .type(CriteriaType.PPI.toString())
         .subtype(CriteriaSubType.WEIGHT.toString())
         .group(false)
@@ -503,7 +503,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter bmi() {
     return new SearchParameter()
-        .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+        .domain(Domain.PHYSICAL_MEASUREMENT.toString())
         .type(CriteriaType.PPI.toString())
         .subtype(CriteriaSubType.BMI.toString())
         .group(false)
@@ -514,7 +514,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter waistCircumference() {
     return new SearchParameter()
-        .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+        .domain(Domain.PHYSICAL_MEASUREMENT.toString())
         .type(CriteriaType.PPI.toString())
         .subtype(CriteriaSubType.WC.toString())
         .group(false)
@@ -525,7 +525,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter hipCircumference() {
     return new SearchParameter()
-        .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+        .domain(Domain.PHYSICAL_MEASUREMENT.toString())
         .type(CriteriaType.PPI.toString())
         .subtype(CriteriaSubType.HC.toString())
         .group(false)
@@ -536,7 +536,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter pregnancy() {
     return new SearchParameter()
-        .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+        .domain(Domain.PHYSICAL_MEASUREMENT.toString())
         .type(CriteriaType.PPI.toString())
         .subtype(CriteriaSubType.PREG.toString())
         .group(false)
@@ -547,7 +547,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter wheelchair() {
     return new SearchParameter()
-        .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+        .domain(Domain.PHYSICAL_MEASUREMENT.toString())
         .type(CriteriaType.PPI.toString())
         .subtype(CriteriaSubType.WHEEL.toString())
         .group(false)
@@ -558,7 +558,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter age() {
     return new SearchParameter()
-        .domain(DomainType.PERSON.toString())
+        .domain(Domain.PERSON.toString())
         .type(CriteriaType.AGE.toString())
         .group(false)
         .ancestorData(false)
@@ -567,7 +567,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter male() {
     return new SearchParameter()
-        .domain(DomainType.PERSON.toString())
+        .domain(Domain.PERSON.toString())
         .type(CriteriaType.GENDER.toString())
         .group(false)
         .standard(true)
@@ -577,7 +577,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter race() {
     return new SearchParameter()
-        .domain(DomainType.PERSON.toString())
+        .domain(Domain.PERSON.toString())
         .type(CriteriaType.RACE.toString())
         .group(false)
         .standard(true)
@@ -587,7 +587,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter ethnicity() {
     return new SearchParameter()
-        .domain(DomainType.PERSON.toString())
+        .domain(Domain.PERSON.toString())
         .type(CriteriaType.ETHNICITY.toString())
         .group(false)
         .standard(true)
@@ -597,7 +597,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter deceased() {
     return new SearchParameter()
-        .domain(DomainType.PERSON.toString())
+        .domain(Domain.PERSON.toString())
         .type(CriteriaType.DECEASED.toString())
         .group(false)
         .standard(true)
@@ -607,7 +607,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter survey() {
     return new SearchParameter()
-        .domain(DomainType.SURVEY.toString())
+        .domain(Domain.SURVEY.toString())
         .type(CriteriaType.PPI.toString())
         .subtype(CriteriaSubType.SURVEY.toString())
         .ancestorData(false)
@@ -618,7 +618,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter copeSurvey() {
     return new SearchParameter()
-        .domain(DomainType.SURVEY.toString())
+        .domain(Domain.SURVEY.toString())
         .type(CriteriaType.PPI.toString())
         .subtype(CriteriaSubType.QUESTION.toString())
         .ancestorData(false)
@@ -686,7 +686,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   private static DbCriteria drugCriteriaParent() {
     return DbCriteria.builder()
         .addParentId(99999)
-        .addDomainId(DomainType.DRUG.toString())
+        .addDomainId(Domain.DRUG.toString())
         .addType(CriteriaType.ATC.toString())
         .addConceptId("21600932")
         .addGroup(true)
@@ -698,7 +698,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   private static DbCriteria drugCriteriaChild(long parentId) {
     return DbCriteria.builder()
         .addParentId(parentId)
-        .addDomainId(DomainType.DRUG.toString())
+        .addDomainId(Domain.DRUG.toString())
         .addType(CriteriaType.RXNORM.toString())
         .addConceptId("1520218")
         .addGroup(false)
@@ -709,7 +709,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   private static DbCriteria icd9CriteriaParent() {
     return DbCriteria.builder()
         .addParentId(99999)
-        .addDomainId(DomainType.CONDITION.toString())
+        .addDomainId(Domain.CONDITION.toString())
         .addType(CriteriaType.ICD9CM.toString())
         .addStandard(false)
         .addCode("001")
@@ -726,7 +726,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   private static DbCriteria icd9CriteriaChild(long parentId) {
     return DbCriteria.builder()
         .addParentId(parentId)
-        .addDomainId(DomainType.CONDITION.toString())
+        .addDomainId(Domain.CONDITION.toString())
         .addType(CriteriaType.ICD9CM.toString())
         .addStandard(false)
         .addCode("001.1")
@@ -750,7 +750,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     assertEquals(4, options.size());
     CriteriaMenuOption option1 =
         new CriteriaMenuOption()
-            .domain(DomainType.CONDITION.toString())
+            .domain(Domain.CONDITION.toString())
             .addTypesItem(
                 new CriteriaMenuSubOption()
                     .type(CriteriaType.ICD10CM.toString())
@@ -765,7 +765,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                     .standardFlags(sourceAndStandardFlags));
     CriteriaMenuOption option2 =
         new CriteriaMenuOption()
-            .domain(DomainType.DRUG.toString())
+            .domain(Domain.DRUG.toString())
             .addTypesItem(
                 new CriteriaMenuSubOption()
                     .type(CriteriaType.ATC.toString())
@@ -776,7 +776,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                     .standardFlags(sourceFlag));
     CriteriaMenuOption option3 =
         new CriteriaMenuOption()
-            .domain(DomainType.PROCEDURE.toString())
+            .domain(Domain.PROCEDURE.toString())
             .addTypesItem(
                 new CriteriaMenuSubOption()
                     .type(CriteriaType.CPT4.toString())
@@ -787,7 +787,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                     .standardFlags(sourceAndStandardFlags));
     CriteriaMenuOption option4 =
         new CriteriaMenuOption()
-            .domain(DomainType.SURVEY.toString())
+            .domain(Domain.SURVEY.toString())
             .addTypesItem(
                 new CriteriaMenuSubOption()
                     .type(CriteriaType.PPI.toString())
@@ -817,7 +817,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     demo.attributes(ImmutableList.of(attribute));
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(), ImmutableList.of(demo), new ArrayList<>());
+            Domain.CONDITION.toString(), ImmutableList.of(demo), new ArrayList<>());
     try {
       controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
       fail("Should have thrown BadRequestException!");
@@ -868,7 +868,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     Modifier modifier = ageModifier().operator(null).operands(new ArrayList<>());
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(), ImmutableList.of(icd9()), ImmutableList.of(modifier));
+            Domain.CONDITION.toString(), ImmutableList.of(icd9()), ImmutableList.of(modifier));
     try {
       controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
       fail("Should have thrown BadRequestException!");
@@ -928,7 +928,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9ConditionOccurrenceChild() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>());
+            Domain.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }
@@ -937,7 +937,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9ConditionOccurrenceChildHasEHRData() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>());
+            Domain.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>());
     searchRequest.addDataFiltersItem("HAS_EHR_DATA");
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
@@ -947,7 +947,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9ConditionOccurrenceChildHasPMData() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>());
+            Domain.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>());
     searchRequest.addDataFiltersItem("HAS_PHYSICAL_MEASUREMENT_DATA");
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
@@ -957,7 +957,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9ConditionOccurrenceChildHasPPISurveyData() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>());
+            Domain.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>());
     searchRequest.addDataFiltersItem("HAS_PPI_SURVEY_DATA");
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
@@ -967,7 +967,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9ConditionOccurrenceChildHasEHRAndPPISurveyData() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>());
+            Domain.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>());
     searchRequest.addDataFiltersItem("HAS_EHR_DATA").addDataFiltersItem("HAS_PPI_SURVEY_DATA");
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
@@ -976,7 +976,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   @Test
   public void temporalGroupExceptions() {
     SearchGroupItem icd9SGI =
-        new SearchGroupItem().type(DomainType.CONDITION.toString()).addSearchParametersItem(icd9());
+        new SearchGroupItem().type(Domain.CONDITION.toString()).addSearchParametersItem(icd9());
 
     SearchGroup temporalGroup = new SearchGroup().items(ImmutableList.of(icd9SGI)).temporal(true);
 
@@ -1004,19 +1004,19 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void firstMentionOfICD9WithModifiersOrSnomed5DaysAfterICD10WithModifiers() {
     SearchGroupItem icd9SGI =
         new SearchGroupItem()
-            .type(DomainType.CONDITION.toString())
+            .type(Domain.CONDITION.toString())
             .addSearchParametersItem(icd9())
             .temporalGroup(0)
             .addModifiersItem(ageModifier());
     SearchGroupItem icd10SGI =
         new SearchGroupItem()
-            .type(DomainType.CONDITION.toString())
+            .type(Domain.CONDITION.toString())
             .addSearchParametersItem(icd10())
             .temporalGroup(1)
             .addModifiersItem(visitModifier());
     SearchGroupItem snomedSGI =
         new SearchGroupItem()
-            .type(DomainType.CONDITION.toString())
+            .type(Domain.CONDITION.toString())
             .addSearchParametersItem(snomed())
             .temporalGroup(0);
 
@@ -1039,9 +1039,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsForSurveyWithAgeModifiers() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.SURVEY.toString(),
-            ImmutableList.of(survey()),
-            ImmutableList.of(ageModifier()));
+            Domain.SURVEY.toString(), ImmutableList.of(survey()), ImmutableList.of(ageModifier()));
 
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
@@ -1051,12 +1049,12 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void firstMentionOfDrug5DaysBeforeICD10WithModifiers() {
     SearchGroupItem drugSGI =
         new SearchGroupItem()
-            .type(DomainType.DRUG.toString())
+            .type(Domain.DRUG.toString())
             .addSearchParametersItem(drug().conceptId(21600932L))
             .temporalGroup(0);
     SearchGroupItem icd10SGI =
         new SearchGroupItem()
-            .type(DomainType.CONDITION.toString())
+            .type(Domain.CONDITION.toString())
             .addSearchParametersItem(icd10())
             .temporalGroup(1)
             .addModifiersItem(visitModifier());
@@ -1080,14 +1078,14 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void anyMentionOfCPT5DaysAfterICD10Child() {
     SearchGroupItem cptSGI =
         new SearchGroupItem()
-            .type(DomainType.CONDITION.toString())
+            .type(Domain.CONDITION.toString())
             .addSearchParametersItem(
                 icd9().type(CriteriaType.CPT4.toString()).group(false).conceptId(1L))
             .temporalGroup(0)
             .addModifiersItem(visitModifier());
     SearchGroupItem icd10SGI =
         new SearchGroupItem()
-            .type(DomainType.CONDITION.toString())
+            .type(Domain.CONDITION.toString())
             .addSearchParametersItem(icd10())
             .temporalGroup(1);
 
@@ -1110,12 +1108,12 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void anyMentionOfCPTWithIn5DaysOfVisit() {
     SearchGroupItem cptSGI =
         new SearchGroupItem()
-            .type(DomainType.PROCEDURE.toString())
+            .type(Domain.PROCEDURE.toString())
             .addSearchParametersItem(procedure())
             .temporalGroup(0);
     SearchGroupItem visitSGI =
         new SearchGroupItem()
-            .type(DomainType.VISIT.toString())
+            .type(Domain.VISIT.toString())
             .addSearchParametersItem(visit())
             .temporalGroup(1);
 
@@ -1137,12 +1135,12 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void firstMentionOfDrugDuringSameEncounterAsMeasurement() {
     SearchGroupItem drugSGI =
         new SearchGroupItem()
-            .type(DomainType.DRUG.toString())
+            .type(Domain.DRUG.toString())
             .addSearchParametersItem(drug())
             .temporalGroup(0);
     SearchGroupItem measurementSGI =
         new SearchGroupItem()
-            .type(DomainType.MEASUREMENT.toString())
+            .type(Domain.MEASUREMENT.toString())
             .addSearchParametersItem(measurement())
             .temporalGroup(1);
 
@@ -1164,12 +1162,12 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void lastMentionOfDrugDuringSameEncounterAsMeasurement() {
     SearchGroupItem drugSGI =
         new SearchGroupItem()
-            .type(DomainType.DRUG.toString())
+            .type(Domain.DRUG.toString())
             .addSearchParametersItem(drug())
             .temporalGroup(0);
     SearchGroupItem measurementSGI =
         new SearchGroupItem()
-            .type(DomainType.MEASUREMENT.toString())
+            .type(Domain.MEASUREMENT.toString())
             .addSearchParametersItem(measurement())
             .temporalGroup(1);
 
@@ -1191,17 +1189,17 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void lastMentionOfDrugDuringSameEncounterAsMeasurementOrVisit() {
     SearchGroupItem drugSGI =
         new SearchGroupItem()
-            .type(DomainType.DRUG.toString())
+            .type(Domain.DRUG.toString())
             .addSearchParametersItem(drug())
             .temporalGroup(0);
     SearchGroupItem measurementSGI =
         new SearchGroupItem()
-            .type(DomainType.MEASUREMENT.toString())
+            .type(Domain.MEASUREMENT.toString())
             .addSearchParametersItem(measurement())
             .temporalGroup(1);
     SearchGroupItem visitSGI =
         new SearchGroupItem()
-            .type(DomainType.VISIT.toString())
+            .type(Domain.VISIT.toString())
             .addSearchParametersItem(visit())
             .temporalGroup(1);
 
@@ -1223,17 +1221,17 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void lastMentionOfMeasurementOrVisit5DaysAfterDrug() {
     SearchGroupItem measurementSGI =
         new SearchGroupItem()
-            .type(DomainType.MEASUREMENT.toString())
+            .type(Domain.MEASUREMENT.toString())
             .addSearchParametersItem(measurement())
             .temporalGroup(0);
     SearchGroupItem visitSGI =
         new SearchGroupItem()
-            .type(DomainType.VISIT.toString())
+            .type(Domain.VISIT.toString())
             .addSearchParametersItem(visit())
             .temporalGroup(0);
     SearchGroupItem drugSGI =
         new SearchGroupItem()
-            .type(DomainType.DRUG.toString())
+            .type(Domain.DRUG.toString())
             .addSearchParametersItem(drug().group(true).conceptId(21600932L))
             .temporalGroup(1);
 
@@ -1256,9 +1254,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9ConditionChildAgeAtEvent() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(),
-            ImmutableList.of(icd9()),
-            ImmutableList.of(ageModifier()));
+            Domain.CONDITION.toString(), ImmutableList.of(icd9()), ImmutableList.of(ageModifier()));
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }
@@ -1267,7 +1263,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9ConditionChildEncounter() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(),
+            Domain.CONDITION.toString(),
             ImmutableList.of(icd9()),
             ImmutableList.of(visitModifier()));
     assertParticipants(
@@ -1281,7 +1277,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(), ImmutableList.of(icd9()), ImmutableList.of(modifier));
+            Domain.CONDITION.toString(), ImmutableList.of(icd9()), ImmutableList.of(modifier));
 
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
@@ -1291,7 +1287,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9ConditionOccurrenceChildAgeAtEventAndOccurrences() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(),
+            Domain.CONDITION.toString(),
             ImmutableList.of(icd9()),
             ImmutableList.of(ageModifier(), occurrencesModifier().operands(ImmutableList.of("2"))));
     assertParticipants(
@@ -1302,7 +1298,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9ConditioChildAgeAtEventAndOccurrencesAndEventDate() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(),
+            Domain.CONDITION.toString(),
             ImmutableList.of(icd9(), icd9().conceptId(2L)),
             ImmutableList.of(ageModifier(), occurrencesModifier(), eventDateModifier()));
     assertParticipants(
@@ -1313,7 +1309,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9ConditionChildEventDate() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(),
+            Domain.CONDITION.toString(),
             ImmutableList.of(icd9()),
             ImmutableList.of(eventDateModifier()));
     assertParticipants(
@@ -1324,7 +1320,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9ConditionNumOfOccurrences() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(),
+            Domain.CONDITION.toString(),
             ImmutableList.of(icd9()),
             ImmutableList.of(occurrencesModifier()));
     assertParticipants(
@@ -1335,7 +1331,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9Child() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>());
+            Domain.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }
@@ -1344,7 +1340,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9ConditionParent() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(),
+            Domain.CONDITION.toString(),
             ImmutableList.of(icd9().group(true).conceptId(44823922L)),
             new ArrayList<>());
     ResponseEntity<Long> response =
@@ -1355,8 +1351,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   @Test
   public void countSubjectsDemoGender() {
     SearchRequest searchRequest =
-        createSearchRequests(
-            DomainType.PERSON.toString(), ImmutableList.of(male()), new ArrayList<>());
+        createSearchRequests(Domain.PERSON.toString(), ImmutableList.of(male()), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }
@@ -1364,8 +1359,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   @Test
   public void countSubjectsDemoRace() {
     SearchRequest searchRequest =
-        createSearchRequests(
-            DomainType.PERSON.toString(), ImmutableList.of(race()), new ArrayList<>());
+        createSearchRequests(Domain.PERSON.toString(), ImmutableList.of(race()), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }
@@ -1374,7 +1368,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsDemoEthnicity() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PERSON.toString(), ImmutableList.of(ethnicity()), new ArrayList<>());
+            Domain.PERSON.toString(), ImmutableList.of(ethnicity()), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }
@@ -1383,7 +1377,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsDemoDec() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PERSON.toString(), ImmutableList.of(deceased()), new ArrayList<>());
+            Domain.PERSON.toString(), ImmutableList.of(deceased()), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }
@@ -1400,8 +1394,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 .operator(Operator.BETWEEN)
                 .operands(ImmutableList.of(String.valueOf(lo), String.valueOf(hi)))));
     SearchRequest searchRequests =
-        createSearchRequests(
-            DomainType.PERSON.toString(), ImmutableList.of(demo), new ArrayList<>());
+        createSearchRequests(Domain.PERSON.toString(), ImmutableList.of(demo), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequests), 2);
   }
@@ -1416,8 +1409,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 .operator(Operator.BETWEEN)
                 .operands(ImmutableList.of("29", "30"))));
     SearchRequest searchRequests =
-        createSearchRequests(
-            DomainType.PERSON.toString(), ImmutableList.of(demo), new ArrayList<>());
+        createSearchRequests(Domain.PERSON.toString(), ImmutableList.of(demo), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequests), 3);
   }
@@ -1432,8 +1424,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 .operator(Operator.BETWEEN)
                 .operands(ImmutableList.of("29", "30"))));
     SearchRequest searchRequests =
-        createSearchRequests(
-            DomainType.PERSON.toString(), ImmutableList.of(demo), new ArrayList<>());
+        createSearchRequests(Domain.PERSON.toString(), ImmutableList.of(demo), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequests), 2);
   }
@@ -1452,18 +1443,17 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 .operands(ImmutableList.of(String.valueOf(lo), String.valueOf(hi)))));
 
     SearchRequest searchRequests =
-        createSearchRequests(
-            DomainType.PERSON.toString(), ImmutableList.of(male()), new ArrayList<>());
+        createSearchRequests(Domain.PERSON.toString(), ImmutableList.of(male()), new ArrayList<>());
 
     SearchGroupItem anotherSearchGroupItem =
         new SearchGroupItem()
-            .type(DomainType.CONDITION.toString())
+            .type(Domain.CONDITION.toString())
             .searchParameters(ImmutableList.of(icd9().conceptId(3L)))
             .modifiers(new ArrayList<>());
 
     SearchGroupItem anotherNewSearchGroupItem =
         new SearchGroupItem()
-            .type(DomainType.PERSON.toString())
+            .type(Domain.PERSON.toString())
             .searchParameters(ImmutableList.of(demoAgeSearchParam))
             .modifiers(new ArrayList<>());
 
@@ -1478,13 +1468,12 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsDemoExcluded() {
     SearchGroupItem excludeSearchGroupItem =
         new SearchGroupItem()
-            .type(DomainType.PERSON.toString())
+            .type(Domain.PERSON.toString())
             .searchParameters(ImmutableList.of(male()));
     SearchGroup excludeSearchGroup = new SearchGroup().addItemsItem(excludeSearchGroupItem);
 
     SearchRequest searchRequests =
-        createSearchRequests(
-            DomainType.PERSON.toString(), ImmutableList.of(male()), new ArrayList<>());
+        createSearchRequests(Domain.PERSON.toString(), ImmutableList.of(male()), new ArrayList<>());
     searchRequests.getExcludes().add(excludeSearchGroup);
 
     assertParticipants(
@@ -1495,7 +1484,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsICD9ParentAndICD10ChildCondition() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(),
+            Domain.CONDITION.toString(),
             ImmutableList.of(icd9().group(true).conceptId(2L), icd10().conceptId(6L)),
             new ArrayList<>());
     ResponseEntity<Long> response =
@@ -1507,7 +1496,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsCPTProcedure() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PROCEDURE.toString(),
+            Domain.PROCEDURE.toString(),
             ImmutableList.of(procedure().conceptId(4L)),
             new ArrayList<>());
     assertParticipants(
@@ -1518,7 +1507,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsSnomedChildCondition() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.CONDITION.toString(),
+            Domain.CONDITION.toString(),
             ImmutableList.of(snomed().standard(true).conceptId(6L)),
             new ArrayList<>());
     assertParticipants(
@@ -1530,7 +1519,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter snomed = snomed().group(true).standard(true).conceptId(4302541L);
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PROCEDURE.toString(), ImmutableList.of(snomed), new ArrayList<>());
+            Domain.PROCEDURE.toString(), ImmutableList.of(snomed), new ArrayList<>());
     ResponseEntity<Long> response =
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
     assertParticipants(response, 1);
@@ -1540,9 +1529,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsVisit() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.VISIT.toString(),
-            ImmutableList.of(visit().conceptId(10L)),
-            new ArrayList<>());
+            Domain.VISIT.toString(), ImmutableList.of(visit().conceptId(10L)), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 2);
   }
@@ -1551,7 +1538,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsVisitModifiers() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.VISIT.toString(),
+            Domain.VISIT.toString(),
             ImmutableList.of(visit().conceptId(10L)),
             ImmutableList.of(occurrencesModifier()));
     assertParticipants(
@@ -1561,8 +1548,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   @Test
   public void countSubjectsDrugChild() {
     SearchRequest searchRequest =
-        createSearchRequests(
-            DomainType.DRUG.toString(), ImmutableList.of(drug()), new ArrayList<>());
+        createSearchRequests(Domain.DRUG.toString(), ImmutableList.of(drug()), new ArrayList<>());
     ResponseEntity<Long> response =
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
     assertParticipants(response, 1);
@@ -1572,7 +1558,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsDrugParent() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.DRUG.toString(),
+            Domain.DRUG.toString(),
             ImmutableList.of(drug().group(true).conceptId(21600932L)),
             new ArrayList<>());
     ResponseEntity<Long> response =
@@ -1584,7 +1570,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsDrugParentAndChild() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.DRUG.toString(),
+            Domain.DRUG.toString(),
             ImmutableList.of(drug().group(true).conceptId(21600932L), drug()),
             new ArrayList<>());
     ResponseEntity<Long> response =
@@ -1596,9 +1582,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsDrugChildEncounter() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.DRUG.toString(),
-            ImmutableList.of(drug()),
-            ImmutableList.of(visitModifier()));
+            Domain.DRUG.toString(), ImmutableList.of(drug()), ImmutableList.of(visitModifier()));
     ResponseEntity<Long> response =
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
     assertParticipants(response, 1);
@@ -1608,7 +1592,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsDrugChildAgeAtEvent() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.DRUG.toString(), ImmutableList.of(drug()), ImmutableList.of(ageModifier()));
+            Domain.DRUG.toString(), ImmutableList.of(drug()), ImmutableList.of(ageModifier()));
     ResponseEntity<Long> response =
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
     assertParticipants(response, 1);
@@ -1618,7 +1602,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsLabEncounter() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.MEASUREMENT.toString(),
+            Domain.MEASUREMENT.toString(),
             ImmutableList.of(measurement()),
             ImmutableList.of(visitModifier()));
     assertParticipants(
@@ -1636,7 +1620,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 .operands(ImmutableList.of("0", "1"))));
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.MEASUREMENT.toString(), ImmutableList.of(lab), new ArrayList<>());
+            Domain.MEASUREMENT.toString(), ImmutableList.of(lab), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }
@@ -1680,7 +1664,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsLabCategoricalAgeAtEvent() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.MEASUREMENT.toString(),
+            Domain.MEASUREMENT.toString(),
             ImmutableList.of(measurement()),
             ImmutableList.of(ageModifier()));
     assertParticipants(
@@ -1730,7 +1714,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter pm = bloodPressure().attributes(attributes);
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
+            Domain.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }
@@ -1749,7 +1733,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(),
+            Domain.PHYSICAL_MEASUREMENT.toString(),
             ImmutableList.of(bpPm, hrPm),
             new ArrayList<>());
 
@@ -1762,7 +1746,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter bpPm = bloodPressure().attributes(bpAttributes());
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(bpPm), new ArrayList<>());
+            Domain.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(bpPm), new ArrayList<>());
 
     List<Attribute> hrAttributes =
         ImmutableList.of(
@@ -1773,7 +1757,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter hrPm = hrDetail().attributes(hrAttributes);
     SearchGroupItem anotherSearchGroupItem =
         new SearchGroupItem()
-            .type(DomainType.PHYSICAL_MEASUREMENT.toString())
+            .type(Domain.PHYSICAL_MEASUREMENT.toString())
             .searchParameters(ImmutableList.of(hrPm))
             .modifiers(new ArrayList<>());
 
@@ -1788,7 +1772,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter hrIrrPm = hr().attributes(irrAttributes);
     SearchGroupItem heartRateIrrSearchGroupItem =
         new SearchGroupItem()
-            .type(DomainType.PHYSICAL_MEASUREMENT.toString())
+            .type(Domain.PHYSICAL_MEASUREMENT.toString())
             .searchParameters(ImmutableList.of(hrIrrPm))
             .modifiers(new ArrayList<>());
 
@@ -1802,7 +1786,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsHeartRateAny() {
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(),
+            Domain.PHYSICAL_MEASUREMENT.toString(),
             ImmutableList.of(hrDetail().conceptId(1586218L)),
             new ArrayList<>());
     assertParticipants(
@@ -1819,7 +1803,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 .operands(ImmutableList.of("45")));
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(),
+            Domain.PHYSICAL_MEASUREMENT.toString(),
             ImmutableList.of(hrDetail().conceptId(1586218L).attributes(attributes)),
             new ArrayList<>());
     assertParticipants(
@@ -1837,7 +1821,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter pm = height().attributes(attributes);
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
+            Domain.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
 
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
@@ -1854,7 +1838,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter pm = weight().attributes(attributes);
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
+            Domain.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
 
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
@@ -1871,7 +1855,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter pm = bmi().attributes(attributes);
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
+            Domain.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
 
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
@@ -1889,9 +1873,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter pm1 = hipCircumference().attributes(attributes);
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(),
-            ImmutableList.of(pm, pm1),
-            new ArrayList<>());
+            Domain.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm, pm1), new ArrayList<>());
 
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
@@ -1908,7 +1890,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter pm = pregnancy().attributes(attributes);
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
+            Domain.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
 
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
@@ -1919,7 +1901,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter pm = wheelchair().attributes(wheelchairAttributes());
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
+            Domain.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
 
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 2);
@@ -1930,7 +1912,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     // Survey
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.SURVEY.toString(), ImmutableList.of(survey()), new ArrayList<>());
+            Domain.SURVEY.toString(), ImmutableList.of(survey()), new ArrayList<>());
     ResponseEntity<Long> response =
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
     assertParticipants(response, 1);
@@ -1941,7 +1923,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     // Cope Survey
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.SURVEY.toString(), ImmutableList.of(copeSurvey()), new ArrayList<>());
+            Domain.SURVEY.toString(), ImmutableList.of(copeSurvey()), new ArrayList<>());
     ResponseEntity<Long> response =
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
     assertParticipants(response, 1);
@@ -2005,7 +1987,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter pm = wheelchair().attributes(wheelchairAttributes());
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
+            Domain.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
 
     DemoChartInfoListResponse response =
         controller
@@ -2029,7 +2011,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter pm = wheelchair().attributes(wheelchairAttributes());
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
+            Domain.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
     searchRequest.addDataFiltersItem("HAS_EHR_DATA");
 
     DemoChartInfoListResponse response =
@@ -2054,7 +2036,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchParameter pm = wheelchair().attributes(wheelchairAttributes());
     SearchRequest searchRequest =
         createSearchRequests(
-            DomainType.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
+            Domain.PHYSICAL_MEASUREMENT.toString(), ImmutableList.of(pm), new ArrayList<>());
 
     DemoChartInfoListResponse response =
         controller

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -61,7 +61,7 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.model.CohortChartData;
 import org.pmiops.workbench.model.CohortChartDataListResponse;
 import org.pmiops.workbench.model.CohortReview;
-import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.EmailVerificationStatus;
 import org.pmiops.workbench.model.Filter;
 import org.pmiops.workbench.model.FilterColumns;
@@ -296,7 +296,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
 
   private static ParticipantData expectedCondition1() {
     return new ParticipantData()
-        .domain(DomainType.CONDITION.toString())
+        .domain(Domain.CONDITION.toString())
         .value("1.0")
         .visitType("visit")
         .standardVocabulary("SNOMED")
@@ -321,7 +321,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
 
   private static ParticipantData expectedCondition2() {
     return new ParticipantData()
-        .domain(DomainType.CONDITION.toString())
+        .domain(Domain.CONDITION.toString())
         .value("1.0")
         .visitType("visit")
         .standardVocabulary("SNOMED")
@@ -367,7 +367,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void getParticipantConditionsSorting() {
-    PageFilterRequest testFilter = new PageFilterRequest().domain(DomainType.CONDITION);
+    PageFilterRequest testFilter = new PageFilterRequest().domain(Domain.CONDITION);
 
     // no sort order or column
     ParticipantDataListResponse response =
@@ -399,7 +399,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void getParticipantConditionsCount() {
-    PageFilterRequest testFilter = new PageFilterRequest().domain(DomainType.CONDITION);
+    PageFilterRequest testFilter = new PageFilterRequest().domain(Domain.CONDITION);
 
     // no sort order or column
     ParticipantDataCountResponse response =
@@ -431,9 +431,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 .property(FilterColumns.STANDARD_VOCABULARY)
                 .values(ImmutableList.of("ICD9CM", "SNOMED")));
     PageFilterRequest testFilter =
-        new PageFilterRequest()
-            .domain(DomainType.CONDITION)
-            .filters(new FilterList().items(filters));
+        new PageFilterRequest().domain(Domain.CONDITION).filters(new FilterList().items(filters));
 
     // no sort order or column
     ParticipantDataListResponse response =
@@ -468,7 +466,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     stubMockFirecloudGetWorkspace();
 
     PageFilterRequest testFilter =
-        new PageFilterRequest().domain(DomainType.CONDITION).page(0).pageSize(1);
+        new PageFilterRequest().domain(Domain.CONDITION).page(0).pageSize(1);
 
     // page 1 should have 1 item
     ParticipantDataListResponse response =
@@ -500,7 +498,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
   @Test
   public void getParticipantAllEventsPagination() {
     PageFilterRequest testFilter =
-        new PageFilterRequest().domain(DomainType.ALL_EVENTS).page(0).pageSize(1);
+        new PageFilterRequest().domain(Domain.ALL_EVENTS).page(0).pageSize(1);
 
     // page 1 should have 1 item
     ParticipantDataListResponse response =
@@ -532,7 +530,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void getParticipantAllEventsSorting() {
-    PageFilterRequest testFilter = new PageFilterRequest().domain(DomainType.ALL_EVENTS);
+    PageFilterRequest testFilter = new PageFilterRequest().domain(Domain.ALL_EVENTS);
 
     // no sort order or column
     ParticipantDataListResponse response =
@@ -571,7 +569,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 NAME,
                 reviewWithoutEHRData.getCohortReviewId(),
                 PARTICIPANT_ID,
-                DomainType.CONDITION.name(),
+                Domain.CONDITION.name(),
                 null)
             .getBody();
 
@@ -602,7 +600,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
           NAME,
           reviewWithoutEHRData.getCohortReviewId(),
           PARTICIPANT_ID,
-          DomainType.CONDITION.name(),
+          Domain.CONDITION.name(),
           -1);
       fail("Should have thrown a BadRequestException!");
     } catch (BadRequestException bre) {
@@ -620,7 +618,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
           NAME,
           reviewWithoutEHRData.getCohortReviewId(),
           PARTICIPANT_ID,
-          DomainType.CONDITION.name(),
+          Domain.CONDITION.name(),
           101);
       fail("Should have thrown a BadRequestException!");
     } catch (BadRequestException bre) {
@@ -634,11 +632,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
   public void getCohortChartDataBadLimit() {
     try {
       controller.getCohortChartData(
-          NAMESPACE,
-          NAME,
-          reviewWithoutEHRData.getCohortReviewId(),
-          DomainType.CONDITION.name(),
-          -1);
+          NAMESPACE, NAME, reviewWithoutEHRData.getCohortReviewId(), Domain.CONDITION.name(), -1);
       fail("Should have thrown a BadRequestException!");
     } catch (BadRequestException bre) {
       // Success
@@ -651,11 +645,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
   public void getCohortChartDataBadLimitOverHundred() {
     try {
       controller.getCohortChartData(
-          NAMESPACE,
-          NAME,
-          reviewWithoutEHRData.getCohortReviewId(),
-          DomainType.CONDITION.name(),
-          101);
+          NAMESPACE, NAME, reviewWithoutEHRData.getCohortReviewId(), Domain.CONDITION.name(), 101);
       fail("Should have thrown a BadRequestException!");
     } catch (BadRequestException bre) {
       // Success
@@ -669,11 +659,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     CohortChartDataListResponse response =
         controller
             .getCohortChartData(
-                NAMESPACE,
-                NAME,
-                reviewWithoutEHRData.getCohortReviewId(),
-                DomainType.LAB.name(),
-                10)
+                NAMESPACE, NAME, reviewWithoutEHRData.getCohortReviewId(), Domain.LAB.name(), 10)
             .getBody();
     assertEquals(3, response.getItems().size());
     assertEquals(
@@ -689,7 +675,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     CohortChartDataListResponse response =
         controller
             .getCohortChartData(
-                NAMESPACE, NAME, reviewWithEHRData.getCohortReviewId(), DomainType.LAB.name(), 10)
+                NAMESPACE, NAME, reviewWithEHRData.getCohortReviewId(), Domain.LAB.name(), 10)
             .getBody();
     assertEquals(3, response.getItems().size());
     assertEquals(
@@ -705,11 +691,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     CohortChartDataListResponse response =
         controller
             .getCohortChartData(
-                NAMESPACE,
-                NAME,
-                reviewWithoutEHRData.getCohortReviewId(),
-                DomainType.DRUG.name(),
-                10)
+                NAMESPACE, NAME, reviewWithoutEHRData.getCohortReviewId(), Domain.DRUG.name(), 10)
             .getBody();
     assertEquals(1, response.getItems().size());
     assertEquals(
@@ -724,7 +706,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 NAMESPACE,
                 NAME,
                 reviewWithoutEHRData.getCohortReviewId(),
-                DomainType.CONDITION.name(),
+                Domain.CONDITION.name(),
                 10)
             .getBody();
     assertEquals(2, response.getItems().size());
@@ -742,7 +724,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 NAMESPACE,
                 NAME,
                 reviewWithoutEHRData.getCohortReviewId(),
-                DomainType.PROCEDURE.name(),
+                Domain.PROCEDURE.name(),
                 10)
             .getBody();
     assertEquals(3, response.getItems().size());

--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -31,7 +31,6 @@ import org.pmiops.workbench.model.DemoChartInfoListResponse;
 import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.DomainCount;
 import org.pmiops.workbench.model.DomainInfoResponse;
-import org.pmiops.workbench.model.DomainType;
 import org.pmiops.workbench.model.GenderOrSexType;
 import org.pmiops.workbench.model.ParticipantDemographics;
 import org.pmiops.workbench.model.SearchGroup;
@@ -72,7 +71,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   public ResponseEntity<CriteriaListResponse> findCriteriaAutoComplete(
       Long cdrVersionId, String domain, String term, String type, Boolean standard, Integer limit) {
     cdrVersionService.setCdrVersion(cdrVersionId);
-    validateDomainType(domain);
+    validateDomain(domain);
     validateType(type);
     validateTerm(term);
     return ResponseEntity.ok(
@@ -130,7 +129,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   public ResponseEntity<CriteriaListWithCountResponse> findCriteriaByDomainAndSearchTerm(
       Long cdrVersionId, String domain, String term, Integer limit) {
     cdrVersionService.setCdrVersion(cdrVersionId);
-    validateDomainType(domain);
+    validateDomain(domain);
     validateTerm(term);
     return ResponseEntity.ok(
         cohortBuilderService.findCriteriaByDomainAndSearchTerm(domain, term, limit));
@@ -156,7 +155,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   public ResponseEntity<CriteriaListResponse> findStandardCriteriaByDomainAndConceptId(
       Long cdrVersionId, String domain, Long conceptId) {
     cdrVersionService.setCdrVersion(cdrVersionId);
-    validateDomainType(domain);
+    validateDomain(domain);
     return ResponseEntity.ok(
         new CriteriaListResponse()
             .items(
@@ -223,7 +222,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   public ResponseEntity<CriteriaListResponse> findCriteriaBy(
       Long cdrVersionId, String domain, String type, Boolean standard, Long parentId) {
     cdrVersionService.setCdrVersion(cdrVersionId);
-    validateDomainType(domain);
+    validateDomain(domain);
     validateType(type);
     return ResponseEntity.ok(
         new CriteriaListResponse()
@@ -287,14 +286,6 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
             .collect(Collectors.toList());
     return allGroups.stream().anyMatch(SearchGroup::getTemporal)
         || allParams.stream().anyMatch(sp -> CriteriaSubType.BP.toString().equals(sp.getSubtype()));
-  }
-
-  private void validateDomainType(String domain) {
-    Arrays.stream(DomainType.values())
-        .filter(domainType -> domainType.toString().equalsIgnoreCase(domain))
-        .findFirst()
-        .orElseThrow(
-            () -> new BadRequestException(String.format(BAD_REQUEST_MESSAGE, "domain", domain)));
   }
 
   private void validateDomain(String domain) {

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -62,7 +62,7 @@ import org.pmiops.workbench.model.CohortReviewListResponse;
 import org.pmiops.workbench.model.CohortStatus;
 import org.pmiops.workbench.model.CreateReviewRequest;
 import org.pmiops.workbench.model.CriteriaType;
-import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.FilterColumns;
 import org.pmiops.workbench.model.ModifyCohortStatusRequest;
@@ -287,7 +287,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
             bigQueryService.filterBigQueryConfig(
                 cohortQueryBuilder.buildDomainChartInfoCounterQuery(
                     new ParticipantCriteria(searchRequest),
-                    Objects.requireNonNull(DomainType.fromValue(domain)),
+                    Objects.requireNonNull(Domain.fromValue(domain)),
                     chartLimit)));
     Map<String, Integer> rm = bigQueryService.getResultMapper(result);
 
@@ -339,9 +339,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
         bigQueryService.executeQuery(
             bigQueryService.filterBigQueryConfig(
                 reviewQueryBuilder.buildChartDataQuery(
-                    participantId,
-                    Objects.requireNonNull(DomainType.fromValue(domain)),
-                    chartLimit)));
+                    participantId, Objects.requireNonNull(Domain.fromValue(domain)), chartLimit)));
     Map<String, Integer> rm = bigQueryService.getResultMapper(result);
 
     ParticipantChartDataListResponse response = new ParticipantChartDataListResponse();
@@ -624,7 +622,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
               : sortColumn;
       List<String> demoList =
           cohortBuilderService.findSortedConceptIdsByDomainIdAndType(
-              DomainType.PERSON.toString(), criteriaSortColumn, sortName);
+              Domain.PERSON.toString(), criteriaSortColumn, sortName);
       if (!demoList.isEmpty()) {
         pageRequest.setSortColumn(
             "FIELD("
@@ -655,8 +653,8 @@ public class CohortReviewController implements CohortReviewApiDelegate {
 
   /** Helper method to convert a collection of {@link FieldValue} to {@link ParticipantData}. */
   private ParticipantData convertRowToParticipantData(
-      Map<String, Integer> rm, List<FieldValue> row, DomainType domain) {
-    if (!domain.equals(DomainType.SURVEY)) {
+      Map<String, Integer> rm, List<FieldValue> row, Domain domain) {
+    if (!domain.equals(Domain.SURVEY)) {
       return new ParticipantData()
           .itemDate(bigQueryService.getDateTime(row, rm.get(START_DATETIME.toString())))
           .domain(bigQueryService.getString(row, rm.get(DOMAIN.toString())))

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
@@ -97,7 +97,7 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
    */
   default Page<DbConcept> findConcepts(
       String keyword, ImmutableList<String> conceptTypes, Domain domainId, Pageable pageable) {
-    if (Domain.PHYSICALMEASUREMENT.equals(domainId)) {
+    if (Domain.PHYSICAL_MEASUREMENT.equals(domainId)) {
       return StringUtils.isBlank(keyword)
           ? findPhysicalMeasurementConcepts(conceptTypes, pageable)
           : findPhysicalMeasurementConcepts(keyword, conceptTypes, pageable);

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -49,7 +49,6 @@ import org.pmiops.workbench.model.DataFilter;
 import org.pmiops.workbench.model.DemoChartInfo;
 import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.DomainInfo;
-import org.pmiops.workbench.model.DomainType;
 import org.pmiops.workbench.model.FilterColumns;
 import org.pmiops.workbench.model.GenderOrSexType;
 import org.pmiops.workbench.model.ParticipantDemographics;
@@ -293,7 +292,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
         (domainToCount.equals(Domain.CONDITION) || domainToCount.equals(Domain.PROCEDURE))
             ? ImmutableList.of(true, false)
             : ImmutableList.of(true);
-    return (domainToCount.equals(Domain.PHYSICALMEASUREMENT))
+    return (domainToCount.equals(Domain.PHYSICAL_MEASUREMENT))
         ? cbCriteriaDao.findPhysicalMeasurementCount(modifyTermMatch(term))
         : cbCriteriaDao.findDomainCount(modifyTermMatch(term), domain, standards);
   }
@@ -371,7 +370,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
             ? new Sort(Sort.Direction.ASC, "name")
             : new Sort(Sort.Direction.DESC, "name");
     List<DbCriteria> criteriaList =
-        cbCriteriaDao.findByDomainIdAndType(DomainType.PERSON.toString(), sortColumn, sort);
+        cbCriteriaDao.findByDomainIdAndType(Domain.PERSON.toString(), sortColumn, sort);
     return criteriaList.stream()
         .map(
             c -> new ConceptIdName().conceptId(new Long(c.getConceptId())).conceptName(c.getName()))

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortQueryBuilder.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
 import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.AgeType;
-import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.SearchGroup;
 import org.pmiops.workbench.model.SearchRequest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -134,7 +134,7 @@ public class CohortQueryBuilder {
    * ParticipantCriteria}.
    */
   public QueryJobConfiguration buildDomainChartInfoCounterQuery(
-      ParticipantCriteria participantCriteria, DomainType domainType, int chartLimit) {
+      ParticipantCriteria participantCriteria, Domain domain, int chartLimit) {
     StringBuilder queryBuilder = new StringBuilder(ID_SQL_TEMPLATE);
     Map<String, QueryParameterValue> params = new HashMap<>();
     addWhereClause(participantCriteria, SEARCH_PERSON_TABLE, queryBuilder, params);
@@ -144,7 +144,7 @@ public class CohortQueryBuilder {
         new StringBuilder(DOMAIN_CHART_INFO_SQL_TEMPLATE.replace("${innerSql}", searchPersonSql));
     String paramName =
         QueryParameterUtil.addQueryParameterValue(
-            params, QueryParameterValue.string(domainType.name()));
+            params, QueryParameterValue.string(domain.name()));
     String endSqlTemplate =
         DOMAIN_CHART_INFO_SQL_GROUP_BY
             .replace("${limit}", Integer.toString(chartLimit))

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
@@ -27,7 +27,7 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.AttrName;
 import org.pmiops.workbench.model.Attribute;
 import org.pmiops.workbench.model.CriteriaType;
-import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.Modifier;
 import org.pmiops.workbench.model.ModifierType;
 import org.pmiops.workbench.model.Operator;
@@ -193,7 +193,7 @@ public final class SearchGroupItemQueryBuilder {
     String domain = searchGroupItem.getType();
 
     // When building sql for demographics - we query against the person table
-    if (DomainType.PERSON.toString().equals(domain)) {
+    if (Domain.PERSON.toString().equals(domain)) {
       return buildDemoSql(queryParams, searchGroupItem);
     }
     // Otherwise build sql against flat denormalized search table
@@ -458,7 +458,7 @@ public final class SearchGroupItemQueryBuilder {
                 Long.class));
     // if the search parameter is ppi/survey then we need to use different column.
     String sqlString =
-        DomainType.SURVEY.toString().equals(parameter.getDomain())
+        Domain.SURVEY.toString().equals(parameter.getDomain())
             ? VALUE_SOURCE_CONCEPT_ID
             : VALUE_AS_CONCEPT_ID;
     if (AttrName.SURVEY_ID.equals(attribute.getName())) {
@@ -616,7 +616,7 @@ public final class SearchGroupItemQueryBuilder {
             .map(SearchParameter::getConceptId)
             .collect(Collectors.toList());
     // Only children exist so no need to do lookups
-    if (!parents.isEmpty() || DomainType.DRUG.toString().equals(domain)) {
+    if (!parents.isEmpty() || Domain.DRUG.toString().equals(domain)) {
       // Parent nodes exist need to do lookups
       if (!parents.isEmpty()) {
         lookupSqlParts.add(
@@ -630,7 +630,7 @@ public final class SearchGroupItemQueryBuilder {
 
       String lookupSql =
           String.format(
-              DomainType.DRUG.toString().equals(domain) ? DRUG_SQL : PARENT_STANDARD_OR_SOURCE_SQL,
+              Domain.DRUG.toString().equals(domain) ? DRUG_SQL : PARENT_STANDARD_OR_SOURCE_SQL,
               standardOrSourceParam,
               domainParam,
               standardOrSourceParam);

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/util/CriteriaLookupUtil.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/util/CriteriaLookupUtil.java
@@ -19,7 +19,7 @@ import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
 import org.pmiops.workbench.cdr.model.DbCriteriaLookup;
 import org.pmiops.workbench.model.CriteriaSubType;
 import org.pmiops.workbench.model.CriteriaType;
-import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.SearchGroup;
 import org.pmiops.workbench.model.SearchGroupItem;
 import org.pmiops.workbench.model.SearchParameter;
@@ -37,13 +37,13 @@ public final class CriteriaLookupUtil {
   private final CBCriteriaDao cbCriteriaDao;
 
   private static class FullTreeType {
-    final DomainType domain;
+    final Domain domain;
     final CriteriaType type;
     final CriteriaSubType subType;
     final Boolean isStandard;
 
     private FullTreeType(
-        DomainType domain, CriteriaType type, CriteriaSubType subType, Boolean isStandard) {
+        Domain domain, CriteriaType type, CriteriaSubType subType, Boolean isStandard) {
       this.domain = domain;
       this.type = type;
       this.subType = subType;
@@ -52,7 +52,7 @@ public final class CriteriaLookupUtil {
 
     static CriteriaLookupUtil.FullTreeType fromParam(SearchParameter param) {
       return new CriteriaLookupUtil.FullTreeType(
-          DomainType.valueOf(param.getDomain()),
+          Domain.valueOf(param.getDomain()),
           CriteriaType.valueOf(param.getType().toUpperCase()),
           param.getSubtype() == null ? null : CriteriaSubType.valueOf(param.getSubtype()),
           param.getStandard());

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/ReviewQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/ReviewQueryBuilder.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
 import org.pmiops.workbench.cohortbuilder.util.QueryParameterValues;
 import org.pmiops.workbench.cohortreview.util.PageRequest;
 import org.pmiops.workbench.exceptions.BadRequestException;
-import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.Filter;
 import org.pmiops.workbench.model.FilterColumns;
 import org.pmiops.workbench.model.Operator;
@@ -179,17 +179,17 @@ public class ReviewQueryBuilder {
   private static final String CLOSE_PAREN = ")";
 
   public QueryJobConfiguration buildQuery(
-      Long participantId, DomainType domain, PageRequest pageRequest) {
+      Long participantId, Domain domain, PageRequest pageRequest) {
     return buildQueryJobConfiguration(participantId, domain, pageRequest, false);
   }
 
   public QueryJobConfiguration buildCountQuery(
-      Long participantId, DomainType domain, PageRequest pageRequest) {
+      Long participantId, Domain domain, PageRequest pageRequest) {
     return buildQueryJobConfiguration(participantId, domain, pageRequest, true);
   }
 
   public QueryJobConfiguration buildChartDataQuery(
-      Long participantId, DomainType domain, Integer limit) {
+      Long participantId, Domain domain, Integer limit) {
     Map<String, QueryParameterValue> params = new HashMap<>();
     params.put(PART_ID, QueryParameterValue.int64(participantId));
     params.put(DOMAIN_PARAM, QueryParameterValue.string(domain.name()));
@@ -207,7 +207,7 @@ public class ReviewQueryBuilder {
   }
 
   private QueryJobConfiguration buildQueryJobConfiguration(
-      Long participantId, DomainType domain, PageRequest pageRequest, boolean isCountQuery) {
+      Long participantId, Domain domain, PageRequest pageRequest, boolean isCountQuery) {
     String finalSql;
     Map<String, QueryParameterValue> params = new HashMap<>();
     List<Filter> filters = pageRequest.getFilters();

--- a/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
+++ b/api/src/main/java/org/pmiops/workbench/concept/ConceptService.java
@@ -177,7 +177,7 @@ public class ConceptService {
     for (DbDomainInfo allDbDomainInfo : allDbDomainInfos) {
       Domain domain = allDbDomainInfo.getDomainEnum();
       DbDomainInfo matchingDbDomainInfo = domainCountMap.get(domain);
-      if (domain.equals(Domain.PHYSICALMEASUREMENT) && pmDomainInfo != null) {
+      if (domain.equals(Domain.PHYSICAL_MEASUREMENT) && pmDomainInfo != null) {
         matchingDbDomainInfo = pmDomainInfo;
       }
       domainCountList.add(

--- a/api/src/main/java/org/pmiops/workbench/dataset/BigQueryTableInfo.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/BigQueryTableInfo.java
@@ -13,7 +13,7 @@ public enum BigQueryTableInfo {
   PERSON(Domain.PERSON, "person"),
   OBSERVATION(Domain.OBSERVATION, "observation"),
   VISIT(Domain.VISIT, "visit_occurrence"),
-  PHYSICALMEASUREMENT(Domain.PHYSICALMEASUREMENT, "measurement");
+  PHYSICALMEASUREMENT(Domain.PHYSICAL_MEASUREMENT, "measurement");
 
   private final Domain domain;
   private final String tableName;

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -268,7 +268,10 @@ public final class DbStorageEnums {
           .put(Domain.VISIT, (short) 7)
           .put(Domain.SURVEY, (short) 8)
           .put(Domain.PERSON, (short) 9)
-          .put(Domain.PHYSICALMEASUREMENT, (short) 10)
+          .put(Domain.PHYSICAL_MEASUREMENT, (short) 10)
+          .put(Domain.ALL_EVENTS, (short) 11)
+          .put(Domain.LAB, (short) 12)
+          .put(Domain.VITAL, (short) 13)
           .build();
 
   // A mapping from our Domain enum to OMOP domain ID values.
@@ -284,7 +287,10 @@ public final class DbStorageEnums {
           .put(Domain.VISIT, "Visit")
           .put(Domain.SURVEY, "Survey")
           .put(Domain.PERSON, "Person")
-          .put(Domain.PHYSICALMEASUREMENT, "Physical Measurement")
+          .put(Domain.PHYSICAL_MEASUREMENT, "Physical Measurement")
+          .put(Domain.ALL_EVENTS, "All Events")
+          .put(Domain.LAB, "Labs")
+          .put(Domain.VITAL, "Vitals")
           .build();
 
   public static Domain domainFromStorage(Short domain) {

--- a/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
+++ b/api/src/main/java/org/pmiops/workbench/elasticsearch/ElasticFilters.java
@@ -22,7 +22,7 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.AttrName;
 import org.pmiops.workbench.model.Attribute;
 import org.pmiops.workbench.model.CriteriaType;
-import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.Modifier;
 import org.pmiops.workbench.model.ModifierType;
 import org.pmiops.workbench.model.SearchGroup;
@@ -135,7 +135,7 @@ public final class ElasticFilters {
           b.filter(QueryBuilders.termQuery("is_deceased", isDeceased));
         }
         for (Attribute attr : param.getAttributes()) {
-          b.filter(attributeToQuery(attr, DomainType.SURVEY.toString().equals(param.getDomain())));
+          b.filter(attributeToQuery(attr, Domain.SURVEY.toString().equals(param.getDomain())));
         }
         for (QueryBuilder f : modFilters) {
           b.filter(f);
@@ -281,8 +281,8 @@ public final class ElasticFilters {
   }
 
   private static boolean isNonNestedSchema(SearchParameter param) {
-    DomainType domainType = DomainType.valueOf(param.getDomain());
-    return DomainType.PERSON.equals(domainType);
+    Domain domain = Domain.valueOf(param.getDomain());
+    return Domain.PERSON.equals(domain);
   }
 
   private Set<String> toleafConceptIds(List<SearchParameter> params) {

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3632,7 +3632,10 @@ definitions:
     - VISIT
     - SURVEY
     - PERSON
-    - PHYSICALMEASUREMENT
+    - PHYSICAL_MEASUREMENT
+    - ALL_EVENTS
+    - LAB
+    - VITAL
   Surveys:
     type: string
     description: a survey for concepts
@@ -6713,7 +6716,7 @@ definitions:
       filters:
         "$ref": "#/definitions/FilterList"
       domain:
-        "$ref": "#/definitions/DomainType"
+        "$ref": "#/definitions/Domain"
         description: Different domain types in omop
   FilterColumns:
     type: string
@@ -6750,22 +6753,6 @@ definitions:
     - SURVEY_NAME
     - QUESTION
     - ANSWER
-  DomainType:
-    type: string
-    enum:
-    - CONDITION
-    - PROCEDURE
-    - OBSERVATION
-    - DRUG
-    - ALL_EVENTS
-    - DEVICE
-    - VISIT
-    - MEASUREMENT
-    - PHYSICAL_MEASUREMENT
-    - LAB
-    - VITAL
-    - SURVEY
-    - PERSON
   SortOrder:
     type: string
     enum:

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -36,8 +36,8 @@ import org.pmiops.workbench.model.Criteria;
 import org.pmiops.workbench.model.CriteriaAttribute;
 import org.pmiops.workbench.model.CriteriaSubType;
 import org.pmiops.workbench.model.CriteriaType;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.DomainInfo;
-import org.pmiops.workbench.model.DomainType;
 import org.pmiops.workbench.model.ParticipantDemographics;
 import org.pmiops.workbench.model.SearchGroup;
 import org.pmiops.workbench.model.SearchGroupItem;
@@ -103,7 +103,7 @@ public class CohortBuilderControllerTest {
   public void findDomainInfos() {
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addType(CriteriaType.ICD9CM.toString())
             .addCount(0L)
             .addHierarchy(true)
@@ -136,7 +136,7 @@ public class CohortBuilderControllerTest {
     DbCriteria surveyCriteria =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.SURVEY.toString())
+                .addDomainId(Domain.SURVEY.toString())
                 .addType(CriteriaType.PPI.toString())
                 .addSubtype(CriteriaSubType.QUESTION.toString())
                 .addCount(0L)
@@ -148,7 +148,7 @@ public class CohortBuilderControllerTest {
                 .build());
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.SURVEY.toString())
+            .addDomainId(Domain.SURVEY.toString())
             .addType(CriteriaType.PPI.toString())
             .addSubtype(CriteriaSubType.ANSWER.toString())
             .addCount(0L)
@@ -180,7 +180,7 @@ public class CohortBuilderControllerTest {
   public void findCriteriaBy() {
     DbCriteria icd9CriteriaParent =
         DbCriteria.builder()
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addType(CriteriaType.ICD9CM.toString())
             .addCount(0L)
             .addHierarchy(true)
@@ -190,7 +190,7 @@ public class CohortBuilderControllerTest {
     cbCriteriaDao.save(icd9CriteriaParent);
     DbCriteria icd9Criteria =
         DbCriteria.builder()
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addType(CriteriaType.ICD9CM.toString())
             .addCount(0L)
             .addHierarchy(true)
@@ -203,7 +203,7 @@ public class CohortBuilderControllerTest {
         createResponseCriteria(icd9CriteriaParent),
         controller
             .findCriteriaBy(
-                1L, DomainType.CONDITION.toString(), CriteriaType.ICD9CM.toString(), false, 0L)
+                1L, Domain.CONDITION.toString(), CriteriaType.ICD9CM.toString(), false, 0L)
             .getBody()
             .getItems()
             .get(0));
@@ -212,7 +212,7 @@ public class CohortBuilderControllerTest {
         controller
             .findCriteriaBy(
                 1L,
-                DomainType.CONDITION.toString(),
+                Domain.CONDITION.toString(),
                 CriteriaType.ICD9CM.toString(),
                 false,
                 icd9CriteriaParent.getId())
@@ -242,7 +242,7 @@ public class CohortBuilderControllerTest {
     }
 
     try {
-      controller.findCriteriaBy(1L, DomainType.CONDITION.toString(), "blah", false, null);
+      controller.findCriteriaBy(1L, Domain.CONDITION.toString(), "blah", false, null);
       fail("Should have thrown a BadRequestException!");
     } catch (BadRequestException bre) {
       // success
@@ -255,7 +255,7 @@ public class CohortBuilderControllerTest {
   public void findCriteriaByDemo() {
     DbCriteria demoCriteria =
         DbCriteria.builder()
-            .addDomainId(DomainType.PERSON.toString())
+            .addDomainId(Domain.PERSON.toString())
             .addType(CriteriaType.AGE.toString())
             .addCount(0L)
             .addParentId(0L)
@@ -265,8 +265,7 @@ public class CohortBuilderControllerTest {
     assertEquals(
         createResponseCriteria(demoCriteria),
         controller
-            .findCriteriaBy(
-                1L, DomainType.PERSON.toString(), CriteriaType.AGE.toString(), false, null)
+            .findCriteriaBy(1L, Domain.PERSON.toString(), CriteriaType.AGE.toString(), false, null)
             .getBody()
             .getItems()
             .get(0));
@@ -276,7 +275,7 @@ public class CohortBuilderControllerTest {
   public void findCriteriaAutoCompleteMatchesSynonyms() {
     DbCriteria criteria =
         DbCriteria.builder()
-            .addDomainId(DomainType.MEASUREMENT.toString())
+            .addDomainId(Domain.MEASUREMENT.toString())
             .addType(CriteriaType.LOINC.toString())
             .addCount(0L)
             .addHierarchy(true)
@@ -290,7 +289,7 @@ public class CohortBuilderControllerTest {
         controller
             .findCriteriaAutoComplete(
                 1L,
-                DomainType.MEASUREMENT.toString(),
+                Domain.MEASUREMENT.toString(),
                 "LP12",
                 CriteriaType.LOINC.toString(),
                 true,
@@ -304,7 +303,7 @@ public class CohortBuilderControllerTest {
   public void findCriteriaAutoCompleteMatchesCode() {
     DbCriteria criteria =
         DbCriteria.builder()
-            .addDomainId(DomainType.MEASUREMENT.toString())
+            .addDomainId(Domain.MEASUREMENT.toString())
             .addType(CriteriaType.LOINC.toString())
             .addCount(0L)
             .addHierarchy(true)
@@ -319,7 +318,7 @@ public class CohortBuilderControllerTest {
         controller
             .findCriteriaAutoComplete(
                 1L,
-                DomainType.MEASUREMENT.toString(),
+                Domain.MEASUREMENT.toString(),
                 "LP12",
                 CriteriaType.LOINC.toString(),
                 true,
@@ -333,7 +332,7 @@ public class CohortBuilderControllerTest {
   public void findCriteriaAutoCompleteSnomed() {
     DbCriteria criteria =
         DbCriteria.builder()
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addType(CriteriaType.SNOMED.toString())
             .addCount(0L)
             .addHierarchy(true)
@@ -346,12 +345,7 @@ public class CohortBuilderControllerTest {
         createResponseCriteria(criteria),
         controller
             .findCriteriaAutoComplete(
-                1L,
-                DomainType.CONDITION.toString(),
-                "LP12",
-                CriteriaType.SNOMED.toString(),
-                true,
-                null)
+                1L, Domain.CONDITION.toString(), "LP12", CriteriaType.SNOMED.toString(), true, null)
             .getBody()
             .getItems()
             .get(0));
@@ -379,7 +373,7 @@ public class CohortBuilderControllerTest {
 
     try {
       controller.findCriteriaAutoComplete(
-          1L, DomainType.CONDITION.toString(), "blah", "blah", null, null);
+          1L, Domain.CONDITION.toString(), "blah", "blah", null, null);
       fail("Should have thrown a BadRequestException!");
     } catch (BadRequestException bre) {
       // success
@@ -395,7 +389,7 @@ public class CohortBuilderControllerTest {
             .addCode("001")
             .addCount(10L)
             .addConceptId("123")
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addGroup(Boolean.TRUE)
             .addSelectable(Boolean.TRUE)
             .addName("chol blah")
@@ -410,7 +404,7 @@ public class CohortBuilderControllerTest {
     assertEquals(
         createResponseCriteria(criteria),
         controller
-            .findCriteriaByDomainAndSearchTerm(1L, DomainType.CONDITION.name(), "001", null)
+            .findCriteriaByDomainAndSearchTerm(1L, Domain.CONDITION.name(), "001", null)
             .getBody()
             .getItems()
             .get(0));
@@ -423,7 +417,7 @@ public class CohortBuilderControllerTest {
             .addCode("00")
             .addCount(10L)
             .addConceptId("123")
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addGroup(Boolean.TRUE)
             .addSelectable(Boolean.TRUE)
             .addName("chol blah")
@@ -437,7 +431,7 @@ public class CohortBuilderControllerTest {
 
     List<Criteria> results =
         controller
-            .findCriteriaByDomainAndSearchTerm(1L, DomainType.CONDITION.name(), "00", null)
+            .findCriteriaByDomainAndSearchTerm(1L, Domain.CONDITION.name(), "00", null)
             .getBody()
             .getItems();
 
@@ -452,7 +446,7 @@ public class CohortBuilderControllerTest {
             .addCode("672535")
             .addCount(-1L)
             .addConceptId("19001487")
-            .addDomainId(DomainType.DRUG.toString())
+            .addDomainId(Domain.DRUG.toString())
             .addGroup(Boolean.FALSE)
             .addSelectable(Boolean.TRUE)
             .addName("4-Way")
@@ -466,7 +460,7 @@ public class CohortBuilderControllerTest {
 
     List<Criteria> results =
         controller
-            .findCriteriaByDomainAndSearchTerm(1L, DomainType.DRUG.name(), "672535", null)
+            .findCriteriaByDomainAndSearchTerm(1L, Domain.DRUG.name(), "672535", null)
             .getBody()
             .getItems();
     assertEquals(1, results.size());
@@ -480,7 +474,7 @@ public class CohortBuilderControllerTest {
             .addCode("LP12")
             .addCount(10L)
             .addConceptId("123")
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addGroup(Boolean.TRUE)
             .addSelectable(Boolean.TRUE)
             .addName("chol blah")
@@ -495,7 +489,7 @@ public class CohortBuilderControllerTest {
     assertEquals(
         createResponseCriteria(criteria),
         controller
-            .findCriteriaByDomainAndSearchTerm(1L, DomainType.CONDITION.name(), "LP12", null)
+            .findCriteriaByDomainAndSearchTerm(1L, Domain.CONDITION.name(), "LP12", null)
             .getBody()
             .getItems()
             .get(0));
@@ -508,7 +502,7 @@ public class CohortBuilderControllerTest {
             .addCode("001")
             .addCount(10L)
             .addConceptId("123")
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addGroup(Boolean.TRUE)
             .addSelectable(Boolean.TRUE)
             .addName("chol blah")
@@ -523,7 +517,7 @@ public class CohortBuilderControllerTest {
     assertEquals(
         createResponseCriteria(criteria),
         controller
-            .findCriteriaByDomainAndSearchTerm(1L, DomainType.CONDITION.name(), "LP12", null)
+            .findCriteriaByDomainAndSearchTerm(1L, Domain.CONDITION.name(), "LP12", null)
             .getBody()
             .getItems()
             .get(0));
@@ -538,7 +532,7 @@ public class CohortBuilderControllerTest {
             .addCode("001")
             .addCount(10L)
             .addConceptId("123")
-            .addDomainId(DomainType.DRUG.toString())
+            .addDomainId(Domain.DRUG.toString())
             .addGroup(Boolean.TRUE)
             .addSelectable(Boolean.TRUE)
             .addName("chol blah")
@@ -553,7 +547,7 @@ public class CohortBuilderControllerTest {
     assertEquals(
         createResponseCriteria(criteria),
         controller
-            .findCriteriaByDomainAndSearchTerm(1L, DomainType.DRUG.name(), "LP12", null)
+            .findCriteriaByDomainAndSearchTerm(1L, Domain.DRUG.name(), "LP12", null)
             .getBody()
             .getItems()
             .get(0));
@@ -568,7 +562,7 @@ public class CohortBuilderControllerTest {
         "insert into cb_criteria_relationship(concept_id_1, concept_id_2) values (12345, 1)");
     DbCriteria criteria =
         DbCriteria.builder()
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addType(CriteriaType.ICD10CM.toString())
             .addStandard(true)
             .addCount(1L)
@@ -579,7 +573,7 @@ public class CohortBuilderControllerTest {
     assertEquals(
         createResponseCriteria(criteria),
         controller
-            .findStandardCriteriaByDomainAndConceptId(1L, DomainType.CONDITION.toString(), 12345L)
+            .findStandardCriteriaByDomainAndConceptId(1L, Domain.CONDITION.toString(), 12345L)
             .getBody()
             .getItems()
             .get(0));
@@ -590,7 +584,7 @@ public class CohortBuilderControllerTest {
   public void findDrugBrandOrIngredientByName() {
     DbCriteria drugATCCriteria =
         DbCriteria.builder()
-            .addDomainId(DomainType.DRUG.toString())
+            .addDomainId(Domain.DRUG.toString())
             .addType(CriteriaType.ATC.toString())
             .addParentId(0L)
             .addCode("LP12345")
@@ -603,7 +597,7 @@ public class CohortBuilderControllerTest {
     cbCriteriaDao.save(drugATCCriteria);
     DbCriteria drugBrandCriteria =
         DbCriteria.builder()
-            .addDomainId(DomainType.DRUG.toString())
+            .addDomainId(Domain.DRUG.toString())
             .addType(CriteriaType.BRAND.toString())
             .addParentId(0L)
             .addCode("LP6789")
@@ -670,7 +664,7 @@ public class CohortBuilderControllerTest {
   public void findParticipantDemographics() {
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.PERSON.toString())
+            .addDomainId(Domain.PERSON.toString())
             .addType(CriteriaType.GENDER.toString())
             .addName("Male")
             .addStandard(true)
@@ -679,7 +673,7 @@ public class CohortBuilderControllerTest {
             .build());
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.PERSON.toString())
+            .addDomainId(Domain.PERSON.toString())
             .addType(CriteriaType.RACE.toString())
             .addName("African American")
             .addStandard(true)
@@ -688,7 +682,7 @@ public class CohortBuilderControllerTest {
             .build());
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.PERSON.toString())
+            .addDomainId(Domain.PERSON.toString())
             .addType(CriteriaType.ETHNICITY.toString())
             .addName("Not Hispanic or Latino")
             .addStandard(true)
@@ -697,7 +691,7 @@ public class CohortBuilderControllerTest {
             .build());
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.PERSON.toString())
+            .addDomainId(Domain.PERSON.toString())
             .addType(CriteriaType.SEX.toString())
             .addName("Male")
             .addStandard(true)

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -70,7 +70,7 @@ import org.pmiops.workbench.model.CohortStatus;
 import org.pmiops.workbench.model.CreateReviewRequest;
 import org.pmiops.workbench.model.CriteriaType;
 import org.pmiops.workbench.model.DataAccessLevel;
-import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.EmailVerificationStatus;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.FilterColumns;
@@ -232,7 +232,7 @@ public class CohortReviewControllerTest {
 
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.PERSON.toString())
+            .addDomainId(Domain.PERSON.toString())
             .addType(CriteriaType.RACE.toString())
             .addParentId(1L)
             .addConceptId(String.valueOf(TestConcepts.ASIAN.conceptId))
@@ -240,7 +240,7 @@ public class CohortReviewControllerTest {
             .build());
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.PERSON.toString())
+            .addDomainId(Domain.PERSON.toString())
             .addType(CriteriaType.GENDER.toString())
             .addParentId(1L)
             .addConceptId(String.valueOf(TestConcepts.FEMALE.conceptId))
@@ -248,7 +248,7 @@ public class CohortReviewControllerTest {
             .build());
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.PERSON.toString())
+            .addDomainId(Domain.PERSON.toString())
             .addType(CriteriaType.GENDER.toString())
             .addParentId(1L)
             .addConceptId(String.valueOf(TestConcepts.MALE.conceptId))
@@ -256,7 +256,7 @@ public class CohortReviewControllerTest {
             .build());
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.PERSON.toString())
+            .addDomainId(Domain.PERSON.toString())
             .addType(CriteriaType.ETHNICITY.toString())
             .addParentId(1L)
             .addConceptId(String.valueOf(TestConcepts.NOT_HISPANIC.conceptId))
@@ -264,7 +264,7 @@ public class CohortReviewControllerTest {
             .build());
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.PERSON.toString())
+            .addDomainId(Domain.PERSON.toString())
             .addType(CriteriaType.RACE.toString())
             .addParentId(1L)
             .addConceptId(String.valueOf(TestConcepts.WHITE.conceptId))
@@ -272,7 +272,7 @@ public class CohortReviewControllerTest {
             .build());
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.PERSON.toString())
+            .addDomainId(Domain.PERSON.toString())
             .addType(CriteriaType.RACE.toString())
             .addParentId(1L)
             .addConceptId(String.valueOf(TestConcepts.PREFER_NOT_TO_ANSWER_RACE.conceptId))
@@ -280,7 +280,7 @@ public class CohortReviewControllerTest {
             .build());
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.PERSON.toString())
+            .addDomainId(Domain.PERSON.toString())
             .addType(CriteriaType.RACE.toString())
             .addParentId(1L)
             .addConceptId(String.valueOf(TestConcepts.PREFER_NOT_TO_ANSWER_ETH.conceptId))
@@ -288,7 +288,7 @@ public class CohortReviewControllerTest {
             .build());
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.PERSON.toString())
+            .addDomainId(Domain.PERSON.toString())
             .addType(CriteriaType.SEX.toString())
             .addParentId(1L)
             .addConceptId(String.valueOf(TestConcepts.SEX_AT_BIRTH.conceptId))

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -14,7 +14,6 @@ import org.pmiops.workbench.cdr.model.DbSurveyVersion;
 import org.pmiops.workbench.model.CriteriaSubType;
 import org.pmiops.workbench.model.CriteriaType;
 import org.pmiops.workbench.model.Domain;
-import org.pmiops.workbench.model.DomainType;
 import org.pmiops.workbench.model.FilterColumns;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -49,7 +48,7 @@ public class CBCriteriaDaoTest {
     surveyCriteria =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.SURVEY.toString())
+                .addDomainId(Domain.SURVEY.toString())
                 .addType(CriteriaType.PPI.toString())
                 .addSubtype(CriteriaSubType.QUESTION.toString())
                 .addGroup(false)
@@ -61,7 +60,7 @@ public class CBCriteriaDaoTest {
     // adding a survey answer
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.SURVEY.toString())
+            .addDomainId(Domain.SURVEY.toString())
             .addType(CriteriaType.PPI.toString())
             .addSubtype(CriteriaSubType.ANSWER.toString())
             .addGroup(false)
@@ -75,7 +74,7 @@ public class CBCriteriaDaoTest {
     sourceCriteria =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.CONDITION.toString())
+                .addDomainId(Domain.CONDITION.toString())
                 .addType(CriteriaType.ICD9CM.toString())
                 .addCount(100L)
                 .addStandard(false)
@@ -86,7 +85,7 @@ public class CBCriteriaDaoTest {
     standardCriteria =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.CONDITION.toString())
+                .addDomainId(Domain.CONDITION.toString())
                 .addType(CriteriaType.SNOMED.toString())
                 .addCount(100L)
                 .addHierarchy(true)
@@ -98,7 +97,7 @@ public class CBCriteriaDaoTest {
     icd9Criteria =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.CONDITION.toString())
+                .addDomainId(Domain.CONDITION.toString())
                 .addType(CriteriaType.ICD9CM.toString())
                 .addCount(100L)
                 .addStandard(false)
@@ -109,7 +108,7 @@ public class CBCriteriaDaoTest {
     icd10Criteria =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.CONDITION.toString())
+                .addDomainId(Domain.CONDITION.toString())
                 .addType(CriteriaType.ICD10CM.toString())
                 .addCount(100L)
                 .addStandard(false)
@@ -120,7 +119,7 @@ public class CBCriteriaDaoTest {
     measurementCriteria =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.MEASUREMENT.toString())
+                .addDomainId(Domain.MEASUREMENT.toString())
                 .addType(CriteriaType.LOINC.toString())
                 .addCount(100L)
                 .addHierarchy(true)
@@ -131,7 +130,7 @@ public class CBCriteriaDaoTest {
     raceAsian =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.PERSON.toString())
+                .addDomainId(Domain.PERSON.toString())
                 .addType(CriteriaType.RACE.toString())
                 .addName("Asian")
                 .addStandard(true)
@@ -139,7 +138,7 @@ public class CBCriteriaDaoTest {
     raceWhite =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.PERSON.toString())
+                .addDomainId(Domain.PERSON.toString())
                 .addType(CriteriaType.RACE.toString())
                 .addName("White")
                 .addStandard(true)
@@ -147,7 +146,7 @@ public class CBCriteriaDaoTest {
     gender =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.PERSON.toString())
+                .addDomainId(Domain.PERSON.toString())
                 .addType(CriteriaType.GENDER.toString())
                 .addName("Male")
                 .addStandard(true)
@@ -156,7 +155,7 @@ public class CBCriteriaDaoTest {
     ethnicity =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.PERSON.toString())
+                .addDomainId(Domain.PERSON.toString())
                 .addType(CriteriaType.ETHNICITY.toString())
                 .addName("Not Hispanic or Latino")
                 .addStandard(true)
@@ -165,7 +164,7 @@ public class CBCriteriaDaoTest {
     sexAtBirth =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.PERSON.toString())
+                .addDomainId(Domain.PERSON.toString())
                 .addType(CriteriaType.SEX.toString())
                 .addName("Male")
                 .addStandard(true)
@@ -206,7 +205,7 @@ public class CBCriteriaDaoTest {
   public void findCriteriaLeavesByDomainAndTypeAndSubtype() {
     List<DbCriteria> criteriaList =
         cbCriteriaDao.findCriteriaLeavesByDomainAndTypeAndSubtype(
-            DomainType.SURVEY.toString(),
+            Domain.SURVEY.toString(),
             CriteriaType.PPI.toString(),
             CriteriaSubType.QUESTION.toString());
     assertThat(criteriaList).containsExactly(surveyCriteria);
@@ -216,7 +215,7 @@ public class CBCriteriaDaoTest {
   public void findExactMatchByCode() {
     // test that we match both source and standard codes
     List<DbCriteria> exactMatchByCode =
-        cbCriteriaDao.findExactMatchByCode(DomainType.CONDITION.toString(), "120");
+        cbCriteriaDao.findExactMatchByCode(Domain.CONDITION.toString(), "120");
     assertThat(exactMatchByCode).containsExactly(standardCriteria, sourceCriteria);
   }
 
@@ -226,7 +225,7 @@ public class CBCriteriaDaoTest {
     List<DbCriteria> criteriaList =
         cbCriteriaDao
             .findCriteriaByDomainAndTypeAndCode(
-                DomainType.CONDITION.toString(),
+                Domain.CONDITION.toString(),
                 CriteriaType.ICD9CM.toString(),
                 Boolean.FALSE,
                 "00",
@@ -240,8 +239,7 @@ public class CBCriteriaDaoTest {
     PageRequest page = new PageRequest(0, 10);
     List<DbCriteria> criteriaList =
         cbCriteriaDao
-            .findCriteriaByDomainAndCode(
-                DomainType.CONDITION.toString(), Boolean.FALSE, "001", page)
+            .findCriteriaByDomainAndCode(Domain.CONDITION.toString(), Boolean.FALSE, "001", page)
             .getContent();
     assertThat(criteriaList).containsExactly(icd9Criteria);
   }
@@ -252,7 +250,7 @@ public class CBCriteriaDaoTest {
     List<DbCriteria> measurements =
         cbCriteriaDao
             .findCriteriaByDomainAndFullText(
-                DomainType.MEASUREMENT.toString(), Boolean.TRUE, "001", page)
+                Domain.MEASUREMENT.toString(), Boolean.TRUE, "001", page)
             .getContent();
     assertThat(measurements).containsExactly(measurementCriteria);
   }
@@ -261,11 +259,11 @@ public class CBCriteriaDaoTest {
   public void findCriteriaByDomainIdAndTypeAndParentIdOrderByIdAsc() {
     List<DbCriteria> actualIcd9s =
         cbCriteriaDao.findCriteriaByDomainIdAndTypeAndParentIdOrderByIdAsc(
-            DomainType.CONDITION.toString(), CriteriaType.ICD9CM.toString(), false, 0L);
+            Domain.CONDITION.toString(), CriteriaType.ICD9CM.toString(), false, 0L);
     assertThat(actualIcd9s).containsExactly(sourceCriteria, icd9Criteria);
     List<DbCriteria> actualIcd10s =
         cbCriteriaDao.findCriteriaByDomainIdAndTypeAndParentIdOrderByIdAsc(
-            DomainType.CONDITION.toString(), CriteriaType.ICD10CM.toString(), false, 0L);
+            Domain.CONDITION.toString(), CriteriaType.ICD10CM.toString(), false, 0L);
     assertThat(actualIcd10s).containsExactly(icd10Criteria);
   }
 
@@ -273,7 +271,7 @@ public class CBCriteriaDaoTest {
   public void findCriteriaByDomainAndTypeOrderByIdAsc() {
     final List<DbCriteria> demoList =
         cbCriteriaDao.findCriteriaByDomainAndTypeOrderByIdAsc(
-            DomainType.PERSON.toString(), CriteriaType.RACE.toString());
+            Domain.PERSON.toString(), CriteriaType.RACE.toString());
     assertThat(demoList).containsExactly(raceAsian, raceWhite);
   }
 
@@ -282,7 +280,7 @@ public class CBCriteriaDaoTest {
     PageRequest page = new PageRequest(0, 10);
     List<DbCriteria> labs =
         cbCriteriaDao.findCriteriaByDomainAndTypeAndStandardAndCode(
-            DomainType.MEASUREMENT.toString(), CriteriaType.LOINC.toString(), true, "LP123", page);
+            Domain.MEASUREMENT.toString(), CriteriaType.LOINC.toString(), true, "LP123", page);
     assertThat(labs).containsExactly(measurementCriteria);
   }
 
@@ -291,7 +289,7 @@ public class CBCriteriaDaoTest {
     PageRequest page = new PageRequest(0, 10);
     List<DbCriteria> conditions =
         cbCriteriaDao.findCriteriaByDomainAndTypeAndStandardAndFullText(
-            DomainType.CONDITION.toString(), CriteriaType.SNOMED.toString(), true, "myMatch", page);
+            Domain.CONDITION.toString(), CriteriaType.SNOMED.toString(), true, "myMatch", page);
     assertThat(conditions).containsExactly(standardCriteria);
   }
 
@@ -309,7 +307,7 @@ public class CBCriteriaDaoTest {
   public void findStandardCriteriaByDomainAndConceptId() {
     assertThat(
             cbCriteriaDao.findStandardCriteriaByDomainAndConceptId(
-                DomainType.CONDITION.toString(), false, ImmutableList.of("1")))
+                Domain.CONDITION.toString(), false, ImmutableList.of("1")))
         .containsExactly(icd10Criteria);
   }
 
@@ -319,10 +317,7 @@ public class CBCriteriaDaoTest {
     parentConceptIds.add("1");
     List<DbCriteria> results =
         cbCriteriaDao.findCriteriaParentsByDomainAndTypeAndParentConceptIds(
-            DomainType.CONDITION.toString(),
-            CriteriaType.SNOMED.toString(),
-            true,
-            parentConceptIds);
+            Domain.CONDITION.toString(), CriteriaType.SNOMED.toString(), true, parentConceptIds);
     assertThat(results).containsExactly(standardCriteria);
   }
 
@@ -342,14 +337,14 @@ public class CBCriteriaDaoTest {
     Sort sort = new Sort(Direction.ASC, "name");
     List<DbCriteria> criteriaList =
         cbCriteriaDao.findByDomainIdAndType(
-            DomainType.PERSON.toString(), FilterColumns.RACE.toString(), sort);
+            Domain.PERSON.toString(), FilterColumns.RACE.toString(), sort);
     assertThat(criteriaList).containsExactly(raceAsian, raceWhite).inOrder();
 
     // reverse
     sort = new Sort(Direction.DESC, "name");
     criteriaList =
         cbCriteriaDao.findByDomainIdAndType(
-            DomainType.PERSON.toString(), FilterColumns.RACE.toString(), sort);
+            Domain.PERSON.toString(), FilterColumns.RACE.toString(), sort);
     assertThat(criteriaList).containsExactly(raceWhite, raceAsian).inOrder();
   }
 
@@ -357,47 +352,47 @@ public class CBCriteriaDaoTest {
   public void findMenuOptions() {
     List<DbMenuOption> options = cbCriteriaDao.findMenuOptions();
     DbMenuOption option1 = options.get(0);
-    assertThat(option1.getDomain()).isEqualTo(DomainType.CONDITION.toString());
+    assertThat(option1.getDomain()).isEqualTo(Domain.CONDITION.toString());
     assertThat(option1.getType()).isEqualTo("ICD10CM");
     assertThat(option1.getStandard()).isFalse();
 
     DbMenuOption option2 = options.get(1);
-    assertThat(option2.getDomain()).isEqualTo(DomainType.CONDITION.toString());
+    assertThat(option2.getDomain()).isEqualTo(Domain.CONDITION.toString());
     assertThat(option2.getType()).isEqualTo("ICD9CM");
     assertThat(option2.getStandard()).isFalse();
 
     DbMenuOption option3 = options.get(2);
-    assertThat(option3.getDomain()).isEqualTo(DomainType.CONDITION.toString());
+    assertThat(option3.getDomain()).isEqualTo(Domain.CONDITION.toString());
     assertThat(option3.getType()).isEqualTo("SNOMED");
     assertThat(option3.getStandard()).isTrue();
 
     DbMenuOption option4 = options.get(3);
-    assertThat(option4.getDomain()).isEqualTo(DomainType.MEASUREMENT.toString());
+    assertThat(option4.getDomain()).isEqualTo(Domain.MEASUREMENT.toString());
     assertThat(option4.getType()).isEqualTo("LOINC");
     assertThat(option4.getStandard()).isTrue();
 
     DbMenuOption option5 = options.get(4);
-    assertThat(option5.getDomain()).isEqualTo(DomainType.PERSON.toString());
+    assertThat(option5.getDomain()).isEqualTo(Domain.PERSON.toString());
     assertThat(option5.getType()).isEqualTo("ETHNICITY");
     assertThat(option5.getStandard()).isTrue();
 
     DbMenuOption option6 = options.get(5);
-    assertThat(option6.getDomain()).isEqualTo(DomainType.PERSON.toString());
+    assertThat(option6.getDomain()).isEqualTo(Domain.PERSON.toString());
     assertThat(option6.getType()).isEqualTo("GENDER");
     assertThat(option6.getStandard()).isTrue();
 
     DbMenuOption option7 = options.get(6);
-    assertThat(option7.getDomain()).isEqualTo(DomainType.PERSON.toString());
+    assertThat(option7.getDomain()).isEqualTo(Domain.PERSON.toString());
     assertThat(option7.getType()).isEqualTo("RACE");
     assertThat(option7.getStandard()).isTrue();
 
     DbMenuOption option8 = options.get(7);
-    assertThat(option8.getDomain()).isEqualTo(DomainType.PERSON.toString());
+    assertThat(option8.getDomain()).isEqualTo(Domain.PERSON.toString());
     assertThat(option8.getType()).isEqualTo("SEX");
     assertThat(option8.getStandard()).isTrue();
 
     DbMenuOption option9 = options.get(8);
-    assertThat(option9.getDomain()).isEqualTo(DomainType.SURVEY.toString());
+    assertThat(option9.getDomain()).isEqualTo(Domain.SURVEY.toString());
     assertThat(option9.getType()).isEqualTo("PPI");
     assertThat(option9.getStandard()).isFalse();
   }

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/ConceptDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/ConceptDaoTest.java
@@ -12,7 +12,6 @@ import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.model.CriteriaSubType;
 import org.pmiops.workbench.model.CriteriaType;
 import org.pmiops.workbench.model.Domain;
-import org.pmiops.workbench.model.DomainType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
@@ -105,7 +104,7 @@ public class ConceptDaoTest {
     DbCriteria surveyCriteria =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.SURVEY.toString())
+                .addDomainId(Domain.SURVEY.toString())
                 .addType(CriteriaType.PPI.toString())
                 .addSubtype(CriteriaSubType.SURVEY.toString())
                 .addGroup(true)
@@ -117,7 +116,7 @@ public class ConceptDaoTest {
     DbCriteria questionCriteria =
         cbCriteriaDao.save(
             DbCriteria.builder()
-                .addDomainId(DomainType.SURVEY.toString())
+                .addDomainId(Domain.SURVEY.toString())
                 .addType(CriteriaType.PPI.toString())
                 .addSubtype(CriteriaSubType.QUESTION.toString())
                 .addGroup(true)
@@ -131,7 +130,7 @@ public class ConceptDaoTest {
 
     cbCriteriaDao.save(
         DbCriteria.builder()
-            .addDomainId(DomainType.SURVEY.toString())
+            .addDomainId(Domain.SURVEY.toString())
             .addType(CriteriaType.PPI.toString())
             .addSubtype(CriteriaSubType.ANSWER.toString())
             .addGroup(false)
@@ -193,7 +192,7 @@ public class ConceptDaoTest {
     Pageable page = new PageRequest(0, 100, new Sort(Direction.DESC, "countValue"));
     Slice<DbConcept> concepts =
         conceptDao.findConcepts(
-            "height", ImmutableList.of("S", "C"), Domain.PHYSICALMEASUREMENT, page);
+            "height", ImmutableList.of("S", "C"), Domain.PHYSICAL_MEASUREMENT, page);
     assertThat(concepts).hasSize(0);
   }
 
@@ -201,7 +200,8 @@ public class ConceptDaoTest {
   public void findStandardConceptsPhysicalMeasurementsWithoutKeyword() {
     Pageable page = new PageRequest(0, 100, new Sort(Direction.DESC, "countValue"));
     Slice<DbConcept> concepts =
-        conceptDao.findConcepts(null, ImmutableList.of("S", "C"), Domain.PHYSICALMEASUREMENT, page);
+        conceptDao.findConcepts(
+            null, ImmutableList.of("S", "C"), Domain.PHYSICAL_MEASUREMENT, page);
     assertThat(concepts).hasSize(0);
   }
 
@@ -210,11 +210,11 @@ public class ConceptDaoTest {
     Pageable page = new PageRequest(0, 100, new Sort(Direction.DESC, "countValue"));
     Slice<DbConcept> concepts =
         conceptDao.findConcepts(
-            "Height", ImmutableList.of("S", "C", ""), Domain.PHYSICALMEASUREMENT, page);
+            "Height", ImmutableList.of("S", "C", ""), Domain.PHYSICAL_MEASUREMENT, page);
     assertThat(concepts)
         .containsExactly(
             physicalMeasurement.domainId(
-                DbStorageEnums.domainToDomainId(Domain.PHYSICALMEASUREMENT)));
+                DbStorageEnums.domainToDomainId(Domain.PHYSICAL_MEASUREMENT)));
   }
 
   @Test
@@ -222,11 +222,11 @@ public class ConceptDaoTest {
     Pageable page = new PageRequest(0, 100, new Sort(Direction.DESC, "countValue"));
     Slice<DbConcept> concepts =
         conceptDao.findConcepts(
-            null, ImmutableList.of("S", "C", ""), Domain.PHYSICALMEASUREMENT, page);
+            null, ImmutableList.of("S", "C", ""), Domain.PHYSICAL_MEASUREMENT, page);
     assertThat(concepts)
         .containsExactly(
             physicalMeasurement.domainId(
-                DbStorageEnums.domainToDomainId(Domain.PHYSICALMEASUREMENT)));
+                DbStorageEnums.domainToDomainId(Domain.PHYSICAL_MEASUREMENT)));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapperTest.java
@@ -15,7 +15,7 @@ import org.pmiops.workbench.model.CriteriaAttribute;
 import org.pmiops.workbench.model.CriteriaSubType;
 import org.pmiops.workbench.model.CriteriaType;
 import org.pmiops.workbench.model.DataFilter;
-import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.SurveyVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -47,7 +47,7 @@ public class CohortBuilderMapperTest {
             .parentCount(100L)
             .childCount(0L)
             .conceptId(12345L)
-            .domainId(DomainType.CONDITION.toString())
+            .domainId(Domain.CONDITION.toString())
             .hasAttributes(true)
             .path("path")
             .value("value")
@@ -70,7 +70,7 @@ public class CohortBuilderMapperTest {
                     .addParentCount(100L)
                     .addChildCount(null)
                     .addConceptId("12345")
-                    .addDomainId(DomainType.CONDITION.toString())
+                    .addDomainId(Domain.CONDITION.toString())
                     .addAttribute(true)
                     .addPath("path")
                     .addSynonyms("syn")

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/util/CriteriaLookupUtilTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/util/CriteriaLookupUtilTest.java
@@ -14,7 +14,7 @@ import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.CriteriaType;
-import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.SearchGroup;
 import org.pmiops.workbench.model.SearchGroupItem;
 import org.pmiops.workbench.model.SearchParameter;
@@ -66,7 +66,7 @@ public class CriteriaLookupUtilTest {
     DbCriteria drugNode1 =
         DbCriteria.builder()
             .addParentId(99999)
-            .addDomainId(DomainType.DRUG.toString())
+            .addDomainId(Domain.DRUG.toString())
             .addType(CriteriaType.ATC.toString())
             .addConceptId("21600002")
             .addGroup(true)
@@ -76,7 +76,7 @@ public class CriteriaLookupUtilTest {
     DbCriteria drugNode2 =
         DbCriteria.builder()
             .addParentId(drugNode1.getId())
-            .addDomainId(DomainType.DRUG.toString())
+            .addDomainId(Domain.DRUG.toString())
             .addType(CriteriaType.RXNORM.toString())
             .addConceptId("19069022")
             .addGroup(false)
@@ -86,7 +86,7 @@ public class CriteriaLookupUtilTest {
     DbCriteria drugNode3 =
         DbCriteria.builder()
             .addParentId(drugNode1.getId())
-            .addDomainId(DomainType.DRUG.toString())
+            .addDomainId(Domain.DRUG.toString())
             .addType(CriteriaType.RXNORM.toString())
             .addConceptId("1036094")
             .addGroup(false)
@@ -106,7 +106,7 @@ public class CriteriaLookupUtilTest {
     List<Long> childConceptIds = ImmutableList.of(19069022L, 1036094L);
     SearchParameter searchParameter =
         new SearchParameter()
-            .domain(DomainType.DRUG.toString())
+            .domain(Domain.DRUG.toString())
             .type(CriteriaType.ATC.toString())
             .group(true)
             .ancestorData(true)
@@ -127,7 +127,7 @@ public class CriteriaLookupUtilTest {
     DbCriteria drugNode1 =
         DbCriteria.builder()
             .addParentId(99999)
-            .addDomainId(DomainType.DRUG.toString())
+            .addDomainId(Domain.DRUG.toString())
             .addType(CriteriaType.ATC.toString())
             .addConceptId("21600002")
             .addGroup(true)
@@ -137,7 +137,7 @@ public class CriteriaLookupUtilTest {
     DbCriteria drugNode2 =
         DbCriteria.builder()
             .addParentId(drugNode1.getId())
-            .addDomainId(DomainType.DRUG.toString())
+            .addDomainId(Domain.DRUG.toString())
             .addType(CriteriaType.RXNORM.toString())
             .addConceptId("19069022")
             .addGroup(false)
@@ -157,7 +157,7 @@ public class CriteriaLookupUtilTest {
     List<Long> childConceptIds = ImmutableList.of(1666666L);
     SearchParameter searchParameter =
         new SearchParameter()
-            .domain(DomainType.DRUG.toString())
+            .domain(Domain.DRUG.toString())
             .type(CriteriaType.RXNORM.toString())
             .group(true)
             .ancestorData(true)
@@ -178,7 +178,7 @@ public class CriteriaLookupUtilTest {
     DbCriteria icd9Parent =
         DbCriteria.builder()
             .addParentId(0)
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addType(CriteriaType.ICD9CM.toString())
             .addGroup(true)
             .addSelectable(true)
@@ -190,7 +190,7 @@ public class CriteriaLookupUtilTest {
     DbCriteria icd9Child1 =
         DbCriteria.builder()
             .addParentId(icd9Parent.getId())
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addType(CriteriaType.ICD9CM.toString())
             .addGroup(false)
             .addSelectable(true)
@@ -202,7 +202,7 @@ public class CriteriaLookupUtilTest {
     DbCriteria icd9Child2 =
         DbCriteria.builder()
             .addParentId(icd9Parent.getId())
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addType(CriteriaType.ICD9CM.toString())
             .addGroup(false)
             .addSelectable(true)
@@ -215,7 +215,7 @@ public class CriteriaLookupUtilTest {
     List<Long> childConceptIds = ImmutableList.of(44829697L, 44835564L);
     SearchParameter searchParameter =
         new SearchParameter()
-            .domain(DomainType.CONDITION.toString())
+            .domain(Domain.CONDITION.toString())
             .type(CriteriaType.ICD9CM.toString())
             .group(true)
             .standard(false)

--- a/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
+++ b/api/src/test/java/org/pmiops/workbench/elasticsearch/ElasticFiltersTest.java
@@ -20,7 +20,7 @@ import org.pmiops.workbench.model.AttrName;
 import org.pmiops.workbench.model.Attribute;
 import org.pmiops.workbench.model.CriteriaSubType;
 import org.pmiops.workbench.model.CriteriaType;
-import org.pmiops.workbench.model.DomainType;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.Modifier;
 import org.pmiops.workbench.model.ModifierType;
 import org.pmiops.workbench.model.Operator;
@@ -49,7 +49,7 @@ public class ElasticFiltersTest {
 
   private static DbCriteria icd9Criteria() {
     return DbCriteria.builder()
-        .addDomainId(DomainType.CONDITION.toString())
+        .addDomainId(Domain.CONDITION.toString())
         .addType(CriteriaType.ICD9CM.toString())
         .addAttribute(Boolean.FALSE)
         .addStandard(false)
@@ -59,7 +59,7 @@ public class ElasticFiltersTest {
 
   private static DbCriteria drugCriteria() {
     return DbCriteria.builder()
-        .addDomainId(DomainType.DRUG.toString())
+        .addDomainId(Domain.DRUG.toString())
         .addType(CriteriaType.ATC.toString())
         .addAttribute(Boolean.FALSE)
         .addStandard(true)
@@ -68,7 +68,7 @@ public class ElasticFiltersTest {
 
   private static DbCriteria basicsCriteria() {
     return DbCriteria.builder()
-        .addDomainId(DomainType.SURVEY.toString())
+        .addDomainId(Domain.SURVEY.toString())
         .addType(CriteriaType.PPI.toString())
         .addSubtype(CriteriaSubType.SURVEY.toString())
         .addAttribute(Boolean.FALSE)
@@ -114,7 +114,7 @@ public class ElasticFiltersTest {
         DbCriteria.builder()
             .addCode("005")
             .addConceptId("775")
-            .addDomainId(DomainType.CONDITION.toString())
+            .addDomainId(Domain.CONDITION.toString())
             .addType(CriteriaType.SNOMED.toString())
             .addAttribute(Boolean.FALSE)
             .addGroup(false)
@@ -200,7 +200,7 @@ public class ElasticFiltersTest {
     leafParam2 =
         new SearchParameter()
             .conceptId(772L)
-            .domain(DomainType.CONDITION.toString())
+            .domain(Domain.CONDITION.toString())
             .type(CriteriaType.ICD9CM.toString())
             .ancestorData(false)
             .standard(false)
@@ -303,7 +303,7 @@ public class ElasticFiltersTest {
                                 .addSearchParametersItem(
                                     new SearchParameter()
                                         .conceptId(21600002L)
-                                        .domain(DomainType.DRUG.toString())
+                                        .domain(Domain.DRUG.toString())
                                         .type(CriteriaType.ATC.toString())
                                         .ancestorData(true)
                                         .standard(true)
@@ -330,7 +330,7 @@ public class ElasticFiltersTest {
                                     new SearchParameter()
                                         .value("001")
                                         .conceptId(771L)
-                                        .domain(DomainType.CONDITION.toString())
+                                        .domain(Domain.CONDITION.toString())
                                         .type(CriteriaType.ICD9CM.toString())
                                         .group(true)
                                         .ancestorData(false)
@@ -357,7 +357,7 @@ public class ElasticFiltersTest {
                                     new SearchParameter()
                                         .value("001")
                                         .conceptId(771L)
-                                        .domain(DomainType.CONDITION.toString())
+                                        .domain(Domain.CONDITION.toString())
                                         .type(CriteriaType.ICD9CM.toString())
                                         .group(false)
                                         .ancestorData(false)
@@ -365,7 +365,7 @@ public class ElasticFiltersTest {
                                 .addSearchParametersItem(
                                     new SearchParameter()
                                         .conceptId(477L)
-                                        .domain(DomainType.CONDITION.toString())
+                                        .domain(Domain.CONDITION.toString())
                                         .type(CriteriaType.SNOMED.toString())
                                         .group(false)
                                         .ancestorData(false)
@@ -410,7 +410,7 @@ public class ElasticFiltersTest {
                             new SearchGroupItem()
                                 .addSearchParametersItem(
                                     new SearchParameter()
-                                        .domain(DomainType.SURVEY.toString())
+                                        .domain(Domain.SURVEY.toString())
                                         .type(CriteriaType.PPI.toString())
                                         .subtype(CriteriaSubType.ANSWER.toString())
                                         .conceptId(7771L)
@@ -439,7 +439,7 @@ public class ElasticFiltersTest {
                             new SearchGroupItem()
                                 .addSearchParametersItem(
                                     new SearchParameter()
-                                        .domain(DomainType.SURVEY.toString())
+                                        .domain(Domain.SURVEY.toString())
                                         .type(CriteriaType.PPI.toString())
                                         .subtype(CriteriaSubType.ANSWER.toString())
                                         .conceptId(777L)
@@ -559,7 +559,7 @@ public class ElasticFiltersTest {
     SearchParameter heightAnyParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+            .domain(Domain.PHYSICAL_MEASUREMENT.toString())
             .type(CriteriaType.PPI.toString())
             .standard(false)
             .ancestorData(false)
@@ -589,7 +589,7 @@ public class ElasticFiltersTest {
     SearchParameter heightParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+            .domain(Domain.PHYSICAL_MEASUREMENT.toString())
             .type(CriteriaType.PPI.toString())
             .group(false)
             .ancestorData(false)
@@ -623,7 +623,7 @@ public class ElasticFiltersTest {
     SearchParameter weightParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+            .domain(Domain.PHYSICAL_MEASUREMENT.toString())
             .type(CriteriaType.PPI.toString())
             .standard(false)
             .ancestorData(false)
@@ -650,7 +650,7 @@ public class ElasticFiltersTest {
     SearchParameter genderParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .domain(DomainType.PERSON.toString())
+            .domain(Domain.PERSON.toString())
             .type(CriteriaType.GENDER.toString())
             .standard(true)
             .ancestorData(false)
@@ -674,7 +674,7 @@ public class ElasticFiltersTest {
     SearchParameter genderParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .domain(DomainType.PERSON.toString())
+            .domain(Domain.PERSON.toString())
             .type(CriteriaType.GENDER.toString())
             .group(false)
             .ancestorData(false)
@@ -698,7 +698,7 @@ public class ElasticFiltersTest {
     SearchParameter genderParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .domain(DomainType.PERSON.toString())
+            .domain(Domain.PERSON.toString())
             .type(CriteriaType.GENDER.toString())
             .group(false)
             .ancestorData(false)
@@ -725,7 +725,7 @@ public class ElasticFiltersTest {
     SearchParameter raceParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .domain(DomainType.PERSON.toString())
+            .domain(Domain.PERSON.toString())
             .type(CriteriaType.RACE.toString())
             .group(false)
             .ancestorData(false)
@@ -749,7 +749,7 @@ public class ElasticFiltersTest {
     SearchParameter ethParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .domain(DomainType.PERSON.toString())
+            .domain(Domain.PERSON.toString())
             .type(CriteriaType.ETHNICITY.toString())
             .group(false)
             .ancestorData(false)
@@ -771,7 +771,7 @@ public class ElasticFiltersTest {
   public void testDeceasedQuery() {
     SearchParameter deceasedParam =
         new SearchParameter()
-            .domain(DomainType.PERSON.toString())
+            .domain(Domain.PERSON.toString())
             .type(CriteriaType.DECEASED.toString())
             .standard(true)
             .ancestorData(false)
@@ -799,7 +799,7 @@ public class ElasticFiltersTest {
     SearchParameter pregParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .domain(DomainType.PHYSICAL_MEASUREMENT.toString())
+            .domain(Domain.PHYSICAL_MEASUREMENT.toString())
             .type(CriteriaType.PPI.toString())
             .group(false)
             .ancestorData(false)
@@ -833,7 +833,7 @@ public class ElasticFiltersTest {
     SearchParameter measParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .domain(DomainType.MEASUREMENT.toString())
+            .domain(Domain.MEASUREMENT.toString())
             .type(CriteriaType.LOINC.toString())
             .group(false)
             .ancestorData(false)
@@ -861,7 +861,7 @@ public class ElasticFiltersTest {
     SearchParameter visitParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .domain(DomainType.VISIT.toString())
+            .domain(Domain.VISIT.toString())
             .type(CriteriaType.VISIT.toString())
             .ancestorData(false)
             .standard(true)
@@ -887,7 +887,7 @@ public class ElasticFiltersTest {
     Object right = now.minusYears(20).toLocalDate();
     SearchParameter ageParam =
         new SearchParameter()
-            .domain(DomainType.PERSON.toString())
+            .domain(Domain.PERSON.toString())
             .type(CriteriaType.AGE.toString())
             .group(false)
             .ancestorData(false)
@@ -922,7 +922,7 @@ public class ElasticFiltersTest {
     Object right = 34;
     SearchParameter ageAtConsentParam =
         new SearchParameter()
-            .domain(DomainType.PERSON.toString())
+            .domain(Domain.PERSON.toString())
             .type(CriteriaType.AGE.toString())
             .group(false)
             .ancestorData(false)
@@ -954,7 +954,7 @@ public class ElasticFiltersTest {
     Object right = now.minusYears(20).toLocalDate();
     SearchParameter ageParam =
         new SearchParameter()
-            .domain(DomainType.PERSON.toString())
+            .domain(Domain.PERSON.toString())
             .type(CriteriaType.AGE.toString())
             .group(false)
             .ancestorData(false)
@@ -968,7 +968,7 @@ public class ElasticFiltersTest {
     SearchParameter ethParam =
         new SearchParameter()
             .conceptId(Long.parseLong(conceptId))
-            .domain(DomainType.PERSON.toString())
+            .domain(Domain.PERSON.toString())
             .type(CriteriaType.ETHNICITY.toString())
             .group(false)
             .ancestorData(false)

--- a/api/src/test/java/org/pmiops/workbench/test/SearchRequests.java
+++ b/api/src/test/java/org/pmiops/workbench/test/SearchRequests.java
@@ -3,7 +3,6 @@ package org.pmiops.workbench.test;
 import java.util.Arrays;
 import org.pmiops.workbench.model.CriteriaType;
 import org.pmiops.workbench.model.Domain;
-import org.pmiops.workbench.model.DomainType;
 import org.pmiops.workbench.model.Modifier;
 import org.pmiops.workbench.model.ModifierType;
 import org.pmiops.workbench.model.Operator;
@@ -25,11 +24,11 @@ public class SearchRequests {
 
   public static SearchRequest genderRequest(long... conceptIds) {
     SearchGroupItem searchGroupItem =
-        new SearchGroupItem().id("id1").type(DomainType.PERSON.toString());
+        new SearchGroupItem().id("id1").type(Domain.PERSON.toString());
     for (long conceptId : conceptIds) {
       SearchParameter parameter =
           new SearchParameter()
-              .domain(DomainType.PERSON.toString())
+              .domain(Domain.PERSON.toString())
               .type(CriteriaType.GENDER.toString())
               .conceptId(conceptId)
               .group(false)
@@ -78,7 +77,7 @@ public class SearchRequests {
   public static SearchRequest temporalRequest() {
     SearchParameter icd9 =
         new SearchParameter()
-            .domain(DomainType.CONDITION.toString())
+            .domain(Domain.CONDITION.toString())
             .type(CriteriaType.ICD9CM.toString())
             .group(false)
             .conceptId(1L)
@@ -94,7 +93,7 @@ public class SearchRequests {
             .ancestorData(false);
     SearchParameter snomed =
         new SearchParameter()
-            .domain(DomainType.CONDITION.toString())
+            .domain(Domain.CONDITION.toString())
             .type(CriteriaType.SNOMED.name())
             .group(false)
             .conceptId(4L)
@@ -103,17 +102,17 @@ public class SearchRequests {
 
     SearchGroupItem icd9SGI =
         new SearchGroupItem()
-            .type(DomainType.CONDITION.toString())
+            .type(Domain.CONDITION.toString())
             .addSearchParametersItem(icd9)
             .temporalGroup(0);
     SearchGroupItem icd10SGI =
         new SearchGroupItem()
-            .type(DomainType.CONDITION.toString())
+            .type(Domain.CONDITION.toString())
             .addSearchParametersItem(icd10)
             .temporalGroup(1);
     SearchGroupItem snomedSGI =
         new SearchGroupItem()
-            .type(DomainType.CONDITION.toString())
+            .type(Domain.CONDITION.toString())
             .addSearchParametersItem(snomed)
             .temporalGroup(0);
 
@@ -142,17 +141,17 @@ public class SearchRequests {
 
   public static SearchRequest icd9Codes() {
     return codesRequest(
-        DomainType.CONDITION.toString(), CriteriaType.ICD9CM.toString(), true, ICD9_GROUP_CODE);
+        Domain.CONDITION.toString(), CriteriaType.ICD9CM.toString(), true, ICD9_GROUP_CODE);
   }
 
   public static SearchRequest icd9CodesChildren() {
     return codesRequest(
-        DomainType.CONDITION.toString(), CriteriaType.ICD9CM.toString(), false, ICD9_GROUP_CODE);
+        Domain.CONDITION.toString(), CriteriaType.ICD9CM.toString(), false, ICD9_GROUP_CODE);
   }
 
   public static SearchRequest icd9CodeWithModifiers() {
     return modifierRequest(
-        DomainType.CONDITION.toString(),
+        Domain.CONDITION.toString(),
         CriteriaType.ICD9CM.toString(),
         ICD9_GROUP_CODE,
         new Modifier()

--- a/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
@@ -23,7 +23,7 @@ import {reactStyles, withCurrentCohortCriteria, withCurrentWorkspace} from 'app/
 import {triggerEvent} from 'app/utils/analytics';
 import {currentCohortCriteriaStore, currentWorkspaceStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {AttrName, CriteriaSubType, DomainType, Operator} from 'generated/fetch';
+import {AttrName, CriteriaSubType, Domain, Operator} from 'generated/fetch';
 
 const styles = reactStyles({
   countPreview: {
@@ -624,17 +624,17 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
 
     get isMeasurement() {
       const {node: {domainId}} = this.props;
-      return domainId === DomainType.MEASUREMENT;
+      return domainId === Domain.MEASUREMENT;
     }
 
     get isPhysicalMeasurement() {
       const {node: {domainId}} = this.props;
-      return domainId === DomainType.PHYSICALMEASUREMENT;
+      return domainId === Domain.PHYSICALMEASUREMENT;
     }
 
     get isSurvey() {
       const {node: {domainId}} = this.props;
-      return domainId === DomainType.SURVEY;
+      return domainId === Domain.SURVEY;
     }
 
     get isBloodPressure() {

--- a/ui/src/app/cohort-search/attributes-page/attributes-page.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page/attributes-page.component.tsx
@@ -19,7 +19,7 @@ import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {currentWorkspaceStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {AttrName, CriteriaSubType, DomainType, Operator} from 'generated/fetch';
+import {AttrName, CriteriaSubType, Domain, Operator} from 'generated/fetch';
 
 const styles = reactStyles({
   countPreview: {
@@ -459,17 +459,17 @@ export const AttributesPage = withCurrentWorkspace() (
 
     get isMeasurement() {
       const {node: {domainId}} = this.props;
-      return domainId === DomainType.MEASUREMENT;
+      return domainId === Domain.MEASUREMENT;
     }
 
     get isPhysicalMeasurement() {
       const {node: {domainId}} = this.props;
-      return domainId === DomainType.PHYSICALMEASUREMENT;
+      return domainId === Domain.PHYSICALMEASUREMENT;
     }
 
     get isSurvey() {
       const {node: {domainId}} = this.props;
-      return domainId === DomainType.SURVEY;
+      return domainId === Domain.SURVEY;
     }
 
     get isBloodPressure() {

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.tsx
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.tsx
@@ -1,11 +1,11 @@
 import {shallow} from 'enzyme';
 import * as React from 'react';
 
-import {DomainType} from 'generated/fetch';
+import {Domain} from 'generated/fetch';
 import {CohortSearch} from './cohort-search.component';
 
 const searchContextStub = {
-  domain: DomainType.CONDITION,
+  domain: Domain.CONDITION,
   item: {
     searchParameters: []
   }

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.tsx
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.tsx
@@ -21,7 +21,7 @@ import {
   setSidebarActiveIconStore,
 } from 'app/utils/navigation';
 import {environment} from 'environments/environment';
-import {Criteria, CriteriaType, DomainType, TemporalMention, TemporalTime} from 'generated/fetch';
+import {Criteria, CriteriaType, Domain, TemporalMention, TemporalTime} from 'generated/fetch';
 
 const styles = reactStyles({
   arrowIcon: {
@@ -120,7 +120,7 @@ function initGroup(role: string, item: any) {
 
 export function saveCriteria(selections?: Array<Selection>) {
   const {domain, groupId, item, role, type} = currentCohortSearchContextStore.getValue();
-  if (domain === DomainType.PERSON) {
+  if (domain === Domain.PERSON) {
     triggerEvent('Cohort Builder Search', 'Click', `Demo - ${typeToTitle(type)} - Finish`);
   }
   const searchRequest = searchRequestStore.getValue();
@@ -241,7 +241,7 @@ export const CohortSearch = withCurrentCohortSearchContext()(class extends React
     if (type === CriteriaType.DECEASED) {
       this.selectDeceased();
     } else {
-      const title = domain === DomainType.PERSON ? typeToTitle(type) : domainToTitle(domain);
+      const title = domain === Domain.PERSON ? typeToTitle(type) : domainToTitle(domain);
       let {backMode, mode} = this.state;
       let hierarchyNode;
       if (this.initTree) {
@@ -297,9 +297,9 @@ export const CohortSearch = withCurrentCohortSearchContext()(class extends React
 
   get initTree() {
     const {cohortContext: {domain}} = this.props;
-    return domain === DomainType.PHYSICALMEASUREMENT
-      || domain === DomainType.SURVEY
-      || domain === DomainType.VISIT;
+    return domain === Domain.PHYSICALMEASUREMENT
+      || domain === Domain.SURVEY
+      || domain === Domain.VISIT;
   }
 
   searchContentStyle(mode: string) {
@@ -359,7 +359,7 @@ export const CohortSearch = withCurrentCohortSearchContext()(class extends React
       type: CriteriaType.DECEASED.toString(),
       name: 'Deceased',
       group: false,
-      domainId: DomainType.PERSON.toString(),
+      domainId: Domain.PERSON.toString(),
       hasAttributes: false,
       selectable: true,
       attributes: []
@@ -368,7 +368,7 @@ export const CohortSearch = withCurrentCohortSearchContext()(class extends React
   }
 
   get showDataBrowserLink() {
-    return [DomainType.CONDITION, DomainType.PROCEDURE, DomainType.MEASUREMENT, DomainType.DRUG]
+    return [Domain.CONDITION, Domain.PROCEDURE, Domain.MEASUREMENT, Domain.DRUG]
     .includes(this.props.cohortContext.domain);
   }
 
@@ -387,7 +387,7 @@ export const CohortSearch = withCurrentCohortSearchContext()(class extends React
           </Clickable>
           <h2 style={styles.titleHeader}>{title}</h2>
           <div style={styles.externalLinks}>
-            {cohortContext.domain === DomainType.DRUG && <div>
+            {cohortContext.domain === Domain.DRUG && <div>
               <StyledAnchorTag
                   href='https://mor.nlm.nih.gov/RxNav/'
                   target='_blank'
@@ -408,11 +408,11 @@ export const CohortSearch = withCurrentCohortSearchContext()(class extends React
           </div>
         </div>
         <div style={
-          (cohortContext.domain === DomainType.PERSON && cohortContext.type !== CriteriaType.AGE)
+          (cohortContext.domain === Domain.PERSON && cohortContext.type !== CriteriaType.AGE)
             ? {marginBottom: '3.5rem'}
             : {height: 'calc(100% - 3.5rem)'}
         }>
-          {cohortContext.domain === DomainType.PERSON ? <div style={{flex: 1, overflow: 'auto'}}>
+          {cohortContext.domain === Domain.PERSON ? <div style={{flex: 1, overflow: 'auto'}}>
               <DemographicsV2
                 count={count}
                 criteriaType={cohortContext.type}

--- a/ui/src/app/cohort-search/constant.ts
+++ b/ui/src/app/cohort-search/constant.ts
@@ -1,17 +1,17 @@
-import {AttrName, DomainType, ModifierType, Operator} from 'generated/fetch';
+import {AttrName, Domain, ModifierType, Operator} from 'generated/fetch';
 
 export const PROGRAM_TYPES = [
-  DomainType[DomainType.PERSON],
-  DomainType[DomainType.SURVEY],
-  DomainType[DomainType.PHYSICALMEASUREMENT]
+  Domain[Domain.PERSON],
+  Domain[Domain.SURVEY],
+  Domain[Domain.PHYSICALMEASUREMENT]
 ];
 
 export const DOMAIN_TYPES = [
-  DomainType[DomainType.CONDITION],
-  DomainType[DomainType.PROCEDURE],
-  DomainType[DomainType.DRUG],
-  DomainType[DomainType.MEASUREMENT],
-  DomainType[DomainType.VISIT]
+  Domain[Domain.CONDITION],
+  Domain[Domain.PROCEDURE],
+  Domain[Domain.DRUG],
+  Domain[Domain.MEASUREMENT],
+  Domain[Domain.VISIT]
 ];
 
 export const PM_UNITS = {

--- a/ui/src/app/cohort-search/demographics/demographics-v2.component.tsx
+++ b/ui/src/app/cohort-search/demographics/demographics-v2.component.tsx
@@ -11,7 +11,7 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {currentWorkspaceStore} from 'app/utils/navigation';
-import {AttrName, CriteriaType, DomainType, Operator} from 'generated/fetch';
+import {AttrName, CriteriaType, Domain, Operator} from 'generated/fetch';
 
 const styles = reactStyles({
   ageContainer: {
@@ -92,7 +92,7 @@ const styles = reactStyles({
 const ageNode = {
   hasAncestorData: false,
   code: '',
-  domainId: DomainType.PERSON,
+  domainId: Domain.PERSON,
   group: false,
   isStandard: true,
   type: CriteriaType.AGE,
@@ -176,7 +176,7 @@ export class DemographicsV2 extends React.Component<Props, State> {
     const {criteriaType, selections} = this.props;
     const {cdrVersionId} = currentWorkspaceStore.getValue();
     this.setState({loading: true});
-    const response = await cohortBuilderApi().findCriteriaBy(+cdrVersionId, DomainType.PERSON.toString(), criteriaType.toString());
+    const response = await cohortBuilderApi().findCriteriaBy(+cdrVersionId, Domain.PERSON.toString(), criteriaType.toString());
     const nodes = response.items.filter(item => item.count !== -1)
       .sort(sortByCountThenName)
       .map(node => ({...node, parameterId: `param${node.conceptId || node.code}`}));

--- a/ui/src/app/cohort-search/demographics/demographics.component.tsx
+++ b/ui/src/app/cohort-search/demographics/demographics.component.tsx
@@ -12,7 +12,7 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {currentWorkspaceStore, serverConfigStore, setSidebarActiveIconStore} from 'app/utils/navigation';
-import {AttrName, CriteriaType, DomainType, Operator} from 'generated/fetch';
+import {AttrName, CriteriaType, Domain, Operator} from 'generated/fetch';
 
 const styles = reactStyles({
   ageContainer: {
@@ -114,7 +114,7 @@ const ageNode = {
   hasAncestorData: false,
   attributes: [],
   code: '',
-  domainId: DomainType.PERSON,
+  domainId: Domain.PERSON,
   group: false,
   name: 'Age',
   parameterId: 'age-param',
@@ -200,7 +200,7 @@ export class Demographics extends React.Component<Props, State> {
     const {criteriaType, selections} = this.props;
     const {cdrVersionId} = currentWorkspaceStore.getValue();
     this.setState({loading: true});
-    const response = await cohortBuilderApi().findCriteriaBy(+cdrVersionId, DomainType.PERSON.toString(), criteriaType.toString());
+    const response = await cohortBuilderApi().findCriteriaBy(+cdrVersionId, Domain.PERSON.toString(), criteriaType.toString());
     const nodes = response.items.filter(item => item.count !== -1)
       .sort(sortByCountThenName)
       .map(node => ({...node, parameterId: `param${node.conceptId || node.code}`}));
@@ -379,7 +379,7 @@ export class Demographics extends React.Component<Props, State> {
       excludes: [],
       includes: [{
         items: [{
-          type: DomainType.PERSON.toString(),
+          type: Domain.PERSON.toString(),
           searchParameters: [mapParameter(parameter)],
           modifiers: []
         }],

--- a/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
+++ b/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
@@ -15,7 +15,7 @@ import {reactStyles, withCdrVersions, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {attributesSelectionStore, setSidebarActiveIconStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {CdrVersion, CdrVersionListResponse, CriteriaType, DomainType} from 'generated/fetch';
+import {CdrVersion, CdrVersionListResponse, CriteriaType, Domain} from 'generated/fetch';
 
 const borderStyle = `1px solid ${colorWithWhiteness(colors.dark, 0.7)}`;
 const styles = reactStyles({
@@ -246,7 +246,7 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace())(
     }
 
     get checkSource() {
-      return [DomainType.CONDITION, DomainType.PROCEDURE].includes(this.props.searchContext.domain);
+      return [Domain.CONDITION, Domain.PROCEDURE].includes(this.props.searchContext.domain);
     }
 
     selectItem = (row: any) => {
@@ -413,7 +413,7 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace())(
                 Return to source code
               </Clickable>.
             </div>}
-            {domain === DomainType.DRUG && <div>
+            {domain === Domain.DRUG && <div>
               Your search may bring back brand names, generics and ingredients. Only ingredients may be added to your search criteria.
             </div>}
             {!!totalCount && <div>
@@ -475,7 +475,7 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace())(
           {!standardOnly && !displayData.length && <div>No results found</div>}
         </div>}
         {loading && <SpinnerOverlay/>}
-        {error && <div style={{...styles.error, ...(domain === DomainType.DRUG ? {marginTop: '3.75rem'} : {})}}>
+        {error && <div style={{...styles.error, ...(domain === Domain.DRUG ? {marginTop: '3.75rem'} : {})}}>
           <ClrIcon style={{margin: '0 0.5rem 0 0.25rem'}} className='is-solid' shape='exclamation-triangle' size='22'/>
           Sorry, the request cannot be completed. Please try again or contact Support in the left hand navigation.
           {standardOnly && <Clickable style={styles.vocabLink} onClick={() => this.getResults(sourceMatch.code)}>

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -12,7 +12,7 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {CriteriaType, DomainType} from 'generated/fetch';
+import {CriteriaType, Domain} from 'generated/fetch';
 
 const borderStyle = `1px solid ${colorWithWhiteness(colors.dark, 0.7)}`;
 const styles = reactStyles({
@@ -212,7 +212,7 @@ export const ListSearch = withCurrentWorkspace()(
     }
 
     get checkSource() {
-      return [DomainType.CONDITION, DomainType.PROCEDURE].includes(this.props.searchContext.domain);
+      return [Domain.CONDITION, Domain.PROCEDURE].includes(this.props.searchContext.domain);
     }
 
     selectItem = (row: any) => {
@@ -320,7 +320,7 @@ export const ListSearch = withCurrentWorkspace()(
     render() {
       const {searchContext: {domain}} = this.props;
       const {data, error, ingredients, loading, standardOnly, sourceMatch, standardData} = this.state;
-      const listStyle = domain === DomainType.DRUG ? {...styles.listContainer, marginTop: '4.25rem'} : styles.listContainer;
+      const listStyle = domain === Domain.DRUG ? {...styles.listContainer, marginTop: '4.25rem'} : styles.listContainer;
       const showStandardOption = !standardOnly && !!standardData && standardData.length > 0;
       const displayData = standardOnly ? standardData : data;
       return <div style={{overflow: 'auto'}}>
@@ -331,7 +331,7 @@ export const ListSearch = withCurrentWorkspace()(
               placeholder={`Search ${domainToTitle(domain)} by code or description`}
               onKeyPress={this.handleInput} />
           </div>
-          {domain === DomainType.DRUG && <div style={styles.drugsText}>
+          {domain === Domain.DRUG && <div style={styles.drugsText}>
             Your search may bring back brand names, generics and ingredients. Only ingredients may be added to your search criteria.
           </div>}
         </div>
@@ -389,7 +389,7 @@ export const ListSearch = withCurrentWorkspace()(
           {!standardOnly && !displayData.length && <div>No results found</div>}
         </div>}
         {loading && <SpinnerOverlay/>}
-        {error && <div style={{...styles.error, ...(domain === DomainType.DRUG ? {marginTop: '3.75rem'} : {})}}>
+        {error && <div style={{...styles.error, ...(domain === Domain.DRUG ? {marginTop: '3.75rem'} : {})}}>
           <ClrIcon style={{margin: '0 0.5rem 0 0.25rem'}} className='is-solid' shape='exclamation-triangle' size='22'/>
           Sorry, the request cannot be completed. Please try again or contact Support in the left hand navigation.
           {standardOnly && <Clickable style={styles.vocabLink} onClick={() => this.getResults(sourceMatch.code)}>

--- a/ui/src/app/cohort-search/modal/modal.component.spec.tsx
+++ b/ui/src/app/cohort-search/modal/modal.component.spec.tsx
@@ -1,11 +1,11 @@
 import {shallow} from 'enzyme';
 import * as React from 'react';
 
-import {DomainType} from 'generated/fetch';
+import {Domain} from 'generated/fetch';
 import {CBModal} from './modal.component';
 
 const searchContextStub = {
-  domain: DomainType.CONDITION,
+  domain: Domain.CONDITION,
   item: {
     searchParameters: []
   }

--- a/ui/src/app/cohort-search/modal/modal.component.tsx
+++ b/ui/src/app/cohort-search/modal/modal.component.tsx
@@ -16,7 +16,7 @@ import colors, {addOpacity, colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {environment} from 'environments/environment';
-import {Criteria, CriteriaType, DomainType, TemporalMention, TemporalTime} from 'generated/fetch';
+import {Criteria, CriteriaType, Domain, TemporalMention, TemporalTime} from 'generated/fetch';
 
 const styles = reactStyles({
   footer: {
@@ -218,7 +218,7 @@ export class CBModal extends React.Component<Props, State> {
       if (type === CriteriaType.DECEASED) {
         this.selectDeceased();
       } else {
-        const title = domain === DomainType.PERSON ? typeToTitle(type) : domainToTitle(domain);
+        const title = domain === Domain.PERSON ? typeToTitle(type) : domainToTitle(domain);
         let {backMode, mode} = this.state;
         let hierarchyNode;
         if (this.initTree) {
@@ -256,7 +256,7 @@ export class CBModal extends React.Component<Props, State> {
   finish = () => {
     const {searchContext: {domain, groupId, item, role, type}} = this.props;
     const {selections} = this.state;
-    if (domain === DomainType.PERSON) {
+    if (domain === Domain.PERSON) {
       triggerEvent('Cohort Builder Search', 'Click', `Demo - ${typeToTitle(type)} - Finish`);
     }
     const searchRequest = searchRequestStore.getValue();
@@ -280,36 +280,36 @@ export class CBModal extends React.Component<Props, State> {
 
   get attributeTitle() {
     const {attributesNode: {domainId, name}} = this.state;
-    return domainId === DomainType.PHYSICALMEASUREMENT.toString() ? stripHtml(name) : domainId + ' Detail';
+    return domainId === Domain.PHYSICALMEASUREMENT.toString() ? stripHtml(name) : domainId + ' Detail';
   }
 
   get showModifiers() {
     const {searchContext: {domain}} = this.props;
-    return domain !== DomainType.PHYSICALMEASUREMENT &&
-      domain !== DomainType.PERSON;
+    return domain !== Domain.PHYSICALMEASUREMENT &&
+      domain !== Domain.PERSON;
   }
 
   get initTree() {
     const {searchContext: {domain}} = this.props;
-    return domain === DomainType.PHYSICALMEASUREMENT
-      || domain === DomainType.SURVEY
-      || domain === DomainType.VISIT;
+    return domain === Domain.PHYSICALMEASUREMENT
+      || domain === Domain.SURVEY
+      || domain === Domain.VISIT;
   }
 
   get showDataBrowserLink() {
     const {searchContext: {domain}} = this.props;
     const {mode} = this.state;
-    return (domain === DomainType.CONDITION
-      || domain === DomainType.PROCEDURE
-      || domain === DomainType.MEASUREMENT
-      || domain === DomainType.DRUG)
+    return (domain === Domain.CONDITION
+      || domain === Domain.PROCEDURE
+      || domain === Domain.MEASUREMENT
+      || domain === Domain.DRUG)
       && (mode === 'list' || mode === 'tree');
   }
 
   get leftColumnStyle() {
     const {searchContext: {domain, type}} = this.props;
     let width = '66.66667%';
-    if (domain === DomainType.PERSON) {
+    if (domain === Domain.PERSON) {
       width = type === CriteriaType.AGE ? '100%' : '50%';
     }
     return {
@@ -321,7 +321,7 @@ export class CBModal extends React.Component<Props, State> {
   }
 
   get rightColumnStyle() {
-    const width = this.props.searchContext.domain === DomainType.PERSON ? '50%' : '33.33333%';
+    const width = this.props.searchContext.domain === Domain.PERSON ? '50%' : '33.33333%';
     return {
       flex: `0 0 ${width}`,
       maxWidth: width,
@@ -422,7 +422,7 @@ export class CBModal extends React.Component<Props, State> {
       type: CriteriaType.DECEASED.toString(),
       name: 'Deceased',
       group: false,
-      domainId: DomainType.PERSON.toString(),
+      domainId: Domain.PERSON.toString(),
       hasAttributes: false,
       selectable: true,
       attributes: []
@@ -443,7 +443,7 @@ export class CBModal extends React.Component<Props, State> {
         ...(open ? {opacity: 1, visibility: 'visible', transform: 'scale(1.0'} : {})
       }}>
         <div style={styles.modalContainer}
-          className={`modal-container${domain === DomainType.PERSON ? ' demographics' : ''}${type === CriteriaType.AGE ? ' age' : ''}`}>
+          className={`modal-container${domain === Domain.PERSON ? ' demographics' : ''}${type === CriteriaType.AGE ? ' age' : ''}`}>
           <div style={styles.modalContent}>
             <div style={this.leftColumnStyle}>
               <div style={styles.titleBar}>
@@ -474,7 +474,7 @@ export class CBModal extends React.Component<Props, State> {
                 </div>
                 <div style={{display: 'table', height: '100%'}}>
                   <div style={{display: 'table-cell', height: '100%', verticalAlign: 'middle'}}>
-                    {domain === DomainType.DRUG && <div>
+                    {domain === Domain.DRUG && <div>
                       <a href='https://mor.nlm.nih.gov/RxNav/' target='_blank' rel='noopener noreferrer'>
                         Explore
                       </a>
@@ -490,8 +490,8 @@ export class CBModal extends React.Component<Props, State> {
                   <ClrIcon size='24' shape='close'/>
                 </Button>}
               </div>
-              <div style={(domain === DomainType.PERSON && type !== CriteriaType.AGE) ? {marginBottom: '3.5rem'} : {height: 'calc(100% - 3.5rem)'}}>
-                {domain === DomainType.PERSON ? <div style={{flex: 1, overflow: 'auto'}}>
+              <div style={(domain === Domain.PERSON && type !== CriteriaType.AGE) ? {marginBottom: '3.5rem'} : {height: 'calc(100% - 3.5rem)'}}>
+                {domain === Domain.PERSON ? <div style={{flex: 1, overflow: 'auto'}}>
                   <Demographics
                     count={count}
                     criteriaType={type}

--- a/ui/src/app/cohort-search/modifier-page/modifier-page-modal.component.spec.tsx
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page-modal.component.spec.tsx
@@ -3,7 +3,7 @@ import {mount, shallow} from 'enzyme';
 import {cohortBuilderApi, registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore, serverConfigStore, urlParamsStore} from 'app/utils/navigation';
 import {
-  CohortBuilderApi, CohortsApi, DomainType, ModifierType,
+  CohortBuilderApi, CohortsApi, Domain, ModifierType,
   WorkspacesApi
 } from 'generated/fetch';
 import * as React from 'react';
@@ -40,7 +40,7 @@ describe('ListModifierPage', () => {
   });
 
   it('should display Only Age Event modifier for SURVEY', async() => {
-    const survey = DomainType.SURVEY;
+    const survey = Domain.SURVEY;
     const wrapper = mount(<ModifierPageModal disabled={() => {
     }} wizard={{}}
                                         searchContext={{domain: survey, item: {modifiers: []}}}/>);

--- a/ui/src/app/cohort-search/modifier-page/modifier-page-modal.component.tsx
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page-modal.component.tsx
@@ -15,7 +15,7 @@ import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {serverConfigStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {Criteria, CriteriaType, DomainType, ModifierType, Operator} from 'generated/fetch';
+import {Criteria, CriteriaType, Domain, ModifierType, Operator} from 'generated/fetch';
 
 const styles = reactStyles({
   header: {
@@ -279,7 +279,7 @@ export const ModifierPageModal = withCurrentWorkspace()(
         if (!encountersOptions) {
           // get options for visit modifier from api
           const res = await cohortBuilderApi().findCriteriaBy(
-            +cdrVersionId, DomainType[DomainType.VISIT], CriteriaType[CriteriaType.VISIT]);
+            +cdrVersionId, Domain[Domain.VISIT], CriteriaType[CriteriaType.VISIT]);
           encountersOptions = res.items;
           encountersStore.next(encountersOptions);
         }
@@ -314,7 +314,7 @@ export const ModifierPageModal = withCurrentWorkspace()(
     get formState() {
       const {searchContext: {domain}} = this.props;
       const {formState} = this.state;
-      return domain === DomainType.SURVEY ?
+      return domain === Domain.SURVEY ?
         formState.filter(form => SURVEY_MODIFIERS.indexOf(form.name) > -1) : formState;
     }
 
@@ -397,7 +397,7 @@ export const ModifierPageModal = withCurrentWorkspace()(
 
     get addEncounters() {
       const {searchContext: {domain}} = this.props;
-      return ![DomainType.PHYSICALMEASUREMENT, DomainType.VISIT].includes(domain);
+      return ![Domain.PHYSICALMEASUREMENT, Domain.VISIT].includes(domain);
     }
 
     calculate = async() => {

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
@@ -15,7 +15,7 @@ import {reactStyles, withCurrentCohortSearchContext, withCurrentWorkspace} from 
 import {triggerEvent} from 'app/utils/analytics';
 import {currentCohortSearchContextStore, serverConfigStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {Criteria, CriteriaType, DomainType, ModifierType, Operator} from 'generated/fetch';
+import {Criteria, CriteriaType, Domain, ModifierType, Operator} from 'generated/fetch';
 
 
 const styles = reactStyles({
@@ -215,7 +215,7 @@ export const ModifierPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSea
     async componentDidMount() {
       const {cohortContext: {domain}, workspace: {cdrVersionId}} = this.props;
       const {formState} = this.state;
-      if (domain !== DomainType.SURVEY) {
+      if (domain !== Domain.SURVEY) {
         formState.push({
           name: ModifierType.NUMOFOCCURRENCES,
           label: 'Has Occurrences',
@@ -258,7 +258,7 @@ export const ModifierPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSea
         if (!encountersOptions) {
           // get options for visit modifier from api
           const res = await cohortBuilderApi().findCriteriaBy(
-            +cdrVersionId, DomainType[DomainType.VISIT], CriteriaType[CriteriaType.VISIT]);
+            +cdrVersionId, Domain[Domain.VISIT], CriteriaType[CriteriaType.VISIT]);
           encountersOptions = res.items;
           encountersStore.next(encountersOptions);
         }
@@ -293,7 +293,7 @@ export const ModifierPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSea
     get formState() {
       const {cohortContext: {domain}} = this.props;
       const {formState} = this.state;
-      return domain === DomainType.SURVEY ?
+      return domain === Domain.SURVEY ?
         formState.filter(form => SURVEY_MODIFIERS.indexOf(form.name) > -1) : formState;
     }
 
@@ -376,7 +376,7 @@ export const ModifierPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSea
 
     get addEncounters() {
       const {cohortContext: {domain}} = this.props;
-      return ![DomainType.PHYSICALMEASUREMENT, DomainType.SURVEY, DomainType.VISIT].includes(domain);
+      return ![Domain.PHYSICALMEASUREMENT, Domain.SURVEY, Domain.VISIT].includes(domain);
     }
 
     calculate = async() => {

--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -11,7 +11,7 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {highlightSearchTerm, reactStyles} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {currentWorkspaceStore} from 'app/utils/navigation';
-import {Criteria, CriteriaType, DomainType} from 'generated/fetch';
+import {Criteria, CriteriaType, Domain} from 'generated/fetch';
 import {Key} from 'ts-key-enum';
 
 const styles = reactStyles({
@@ -178,7 +178,7 @@ export class SearchBar extends React.Component<Props, State> {
   componentDidUpdate(prevProps: Readonly<Props>): void {
     const {node: {domainId}, searchTerms} = this.props;
     if (searchTerms !== prevProps.searchTerms) {
-      if (domainId === DomainType.PHYSICALMEASUREMENT.toString()) {
+      if (domainId === Domain.PHYSICALMEASUREMENT.toString()) {
         triggerEvent(`Cohort Builder Search - Physical Measurements`, 'Search', searchTerms);
       } else if (this.state.optionSelected) {
         this.setState({optionSelected: false});
@@ -193,7 +193,7 @@ export class SearchBar extends React.Component<Props, State> {
     triggerEvent(`Cohort Builder Search - ${domainToTitle(domainId)}`, 'Search', searchTerms);
     this.setState({loading: true});
     const {cdrVersionId} = currentWorkspaceStore.getValue();
-    const apiCall = domainId === DomainType.DRUG.toString()
+    const apiCall = domainId === Domain.DRUG.toString()
       ? cohortBuilderApi().findDrugBrandOrIngredientByValue(+cdrVersionId, searchTerms)
       : cohortBuilderApi().findCriteriaAutoComplete(+cdrVersionId, domainId, searchTerms, type, isStandard);
     apiCall.then(resp => {

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.spec.tsx
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.spec.tsx
@@ -1,10 +1,10 @@
 import {shallow} from 'enzyme';
 import * as React from 'react';
 
-import {DomainType} from 'generated/fetch';
+import {Domain} from 'generated/fetch';
 import {SearchGroupItem} from './search-group-item.component';
 
-const itemStub = {id: 'item_id', searchParameters: [], status: 'active', type: DomainType.CONDITION}
+const itemStub = {id: 'item_id', searchParameters: [], status: 'active', type: Domain.CONDITION}
 describe('SearchGroupItem', () => {
   it('should render', () => {
     const wrapper = shallow(<SearchGroupItem role='includes' groupId='group_id' item={itemStub} index={0} updateGroup={() => {}}/>);

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
@@ -12,7 +12,7 @@ import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {currentWorkspaceStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {CriteriaType, DomainType, Modifier, ModifierType, ResourceType, SearchGroupItem as Item, SearchRequest} from 'generated/fetch';
+import {CriteriaType, Domain, Modifier, ModifierType, ResourceType, SearchGroupItem as Item, SearchRequest} from 'generated/fetch';
 import {Menu} from 'primereact/menu';
 import {OverlayPanel} from 'primereact/overlaypanel';
 import Timeout = NodeJS.Timeout;
@@ -107,9 +107,9 @@ class SearchGroupItemParameter extends React.Component<{parameter: any}, {toolti
   render() {
     const {parameter, parameter: {domainId}} = this.props;
     const {tooltip} = this.state;
-    const showCode = [DomainType.CONDITION, DomainType.DRUG, DomainType.MEASUREMENT, DomainType.PROCEDURE].includes(domainId);
+    const showCode = [Domain.CONDITION, Domain.DRUG, Domain.MEASUREMENT, Domain.PROCEDURE].includes(domainId);
     return <div ref={el => this.element = el} style={styles.parameter}>
-      <span style={domainId === DomainType.PERSON ? {textTransform: 'capitalize'} : {}}
+      <span style={domainId === Domain.PERSON ? {textTransform: 'capitalize'} : {}}
             onMouseEnter={(e) => tooltip && this.overlay.show(e)} onMouseLeave={() => tooltip && this.overlay.hide()}>
         {showCode && <b>{parameter.code}</b>} {parameter.name}
       </span>
@@ -168,7 +168,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
         this.getItemCount();
       }
       if (!!modifiers && modifiers.some(mod => mod.name === ModifierType.ENCOUNTERS) && !encounters) {
-        cohortBuilderApi().findCriteriaBy(+cdrVersionId, DomainType[DomainType.VISIT], CriteriaType[CriteriaType.VISIT]).then(res => {
+        cohortBuilderApi().findCriteriaBy(+cdrVersionId, Domain[Domain.VISIT], CriteriaType[CriteriaType.VISIT]).then(res => {
           encountersStore.next(res.items);
           this.setState({encounters: res.items});
         });
@@ -297,7 +297,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
       const {item: {count, modifiers, name, searchParameters, status, type}} = this.props;
       const {error, loading, paramListOpen, renaming} = this.state;
       const codeDisplay = searchParameters.length > 1 ? 'Codes' : 'Code';
-      const titleDisplay = type === DomainType.PERSON.toString() ? typeToTitle(searchParameters[0].type) : domainToTitle(type);
+      const titleDisplay = type === Domain.PERSON.toString() ? typeToTitle(searchParameters[0].type) : domainToTitle(type);
       const itemName = !!name ? name : `Contains ${titleDisplay} ${codeDisplay}`;
       const showCount = !loading && status !== 'hidden' && count !== undefined;
       const actionItems = [

--- a/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
+++ b/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
@@ -12,7 +12,7 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {currentWorkspaceStore} from 'app/utils/navigation';
-import {DomainType, SearchRequest} from 'generated/fetch';
+import {Domain, SearchRequest} from 'generated/fetch';
 
 function initItem(id: string, type: string) {
   return {
@@ -166,26 +166,26 @@ export class SearchGroupList extends React.Component<Props, State> {
     cohortBuilderApi().findCriteriaMenuOptions(+cdrVersionId).then(res => {
       criteriaMenuOptions[cdrVersionId] = res.items.reduce((acc, opt) => {
         const {domain, types} = opt;
-        if (PROGRAM_TYPES.includes(DomainType[domain])) {
+        if (PROGRAM_TYPES.includes(Domain[domain])) {
           const option = {
             name: domainToTitle(domain),
             domain,
             type: types[0].type,
             standard: types[0].standardFlags[0].standard,
-            order: PROGRAM_TYPES.indexOf(DomainType[domain])
+            order: PROGRAM_TYPES.indexOf(Domain[domain])
           };
-          if (domain === DomainType[DomainType.PERSON]) {
+          if (domain === Domain[Domain.PERSON]) {
             option['children'] = types.map(subopt => ({name: typeToTitle(subopt.type), domain, type: subopt.type}));
           }
           acc.programTypes.push(option);
         }
-        if (DOMAIN_TYPES.includes(DomainType[domain])) {
+        if (DOMAIN_TYPES.includes(Domain[domain])) {
           acc.domainTypes.push({
             name: domainToTitle(domain),
             domain,
             type: types[0].type,
             standard: types[0].standardFlags[0].standard,
-            order: DOMAIN_TYPES.indexOf(DomainType[domain])});
+            order: DOMAIN_TYPES.indexOf(Domain[domain])});
         }
         return acc;
       }, {programTypes: [], domainTypes: []});
@@ -223,7 +223,7 @@ export class SearchGroupList extends React.Component<Props, State> {
     const category = `${role === 'includes' ? 'Add' : 'Excludes'} Criteria`;
     // If domain is PERSON, list the type as well as the domain in the label
     const label = domainToTitle(domain) +
-      (domain === DomainType.PERSON ? ' - ' + typeToTitle(type) : '') +
+      (domain === Domain.PERSON ? ' - ' + typeToTitle(type) : '') +
       ' - Cohort Builder';
     triggerEvent(category, 'Click', `${category} - ${label}`);
     let context: any;

--- a/ui/src/app/cohort-search/search-group/search-group.component.spec.tsx
+++ b/ui/src/app/cohort-search/search-group/search-group.component.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore} from 'app/utils/navigation';
-import {CohortBuilderApi, DomainType} from 'generated/fetch';
+import {CohortBuilderApi, Domain} from 'generated/fetch';
 import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
 import {SearchGroup} from './search-group.component';
@@ -11,7 +11,7 @@ import {SearchGroup} from './search-group.component';
 const itemsStub = [
   {
     id: 'itemA',
-    type: DomainType.MEASUREMENT,
+    type: Domain.MEASUREMENT,
     searchParameters: [],
     modifiers: [],
     count: 1,
@@ -21,7 +21,7 @@ const itemsStub = [
   },
   {
     id: 'itemB',
-    type: DomainType.MEASUREMENT,
+    type: Domain.MEASUREMENT,
     searchParameters: [],
     modifiers: [],
     count: 2,
@@ -31,7 +31,7 @@ const itemsStub = [
   },
   {
     id: 'itemC',
-    type: DomainType.MEASUREMENT,
+    type: Domain.MEASUREMENT,
     searchParameters: [],
     modifiers: [],
     count: 3,
@@ -40,7 +40,7 @@ const itemsStub = [
     status: 'active'
   }
 ];
-const groupStub = {id: 'group_id', items: itemsStub, status: 'active', type: DomainType.CONDITION};
+const groupStub = {id: 'group_id', items: itemsStub, status: 'active', type: Domain.CONDITION};
 describe('SearchGroup', () => {
   beforeEach(() => {
     registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());

--- a/ui/src/app/cohort-search/search-group/search-group.component.tsx
+++ b/ui/src/app/cohort-search/search-group/search-group.component.tsx
@@ -18,7 +18,7 @@ import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {isAbortError} from 'app/utils/errors';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {DomainType, ResourceType, SearchRequest, TemporalMention, TemporalTime} from 'generated/fetch';
+import {Domain, ResourceType, SearchRequest, TemporalMention, TemporalTime} from 'generated/fetch';
 
 const styles = reactStyles({
   card: {
@@ -325,7 +325,7 @@ export const SearchGroup = withCurrentWorkspace()(
     }
 
     get disableTemporal() {
-      return this.items.some(it => [DomainType.PHYSICALMEASUREMENT, DomainType.PERSON, DomainType.SURVEY].includes(it.type));
+      return this.items.some(it => [Domain.PHYSICALMEASUREMENT, Domain.PERSON, Domain.SURVEY].includes(it.type));
     }
 
     remove() {
@@ -388,7 +388,7 @@ export const SearchGroup = withCurrentWorkspace()(
       } else {
         const category = `${role === 'includes' ? 'Add' : 'Excludes'} Criteria`;
         // If domain is PERSON, list the type as well as the domain in the label
-        const label = `${domainToTitle(domain)} ${(domain === DomainType.PERSON ? `- ${typeToTitle(type)}` : '')} - Cohort Builder`;
+        const label = `${domainToTitle(domain)} ${(domain === Domain.PERSON ? `- ${typeToTitle(type)}` : '')} - Cohort Builder`;
         triggerEvent(category, 'Click', `${category} - ${label}`);
       }
       const itemId = generateId('items');

--- a/ui/src/app/cohort-search/selection-list/selection-list.component.spec.tsx
+++ b/ui/src/app/cohort-search/selection-list/selection-list.component.spec.tsx
@@ -1,7 +1,7 @@
 import {shallow} from 'enzyme';
 import * as React from 'react';
 
-import {DomainType} from 'generated/fetch';
+import {Domain} from 'generated/fetch';
 import {SelectionList} from './selection-list.component';
 
 describe('SelectionList', () => {
@@ -9,7 +9,7 @@ describe('SelectionList', () => {
     const wrapper = shallow(<SelectionList back={() => {}}
                                            close={() => {}}
                                            disableFinish={false}
-                                           domain={DomainType.CONDITION}
+                                           domain={Domain.CONDITION}
                                            finish={() => {}}
                                            removeSelection={() => {}}
                                            selections={[]}

--- a/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
+++ b/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
@@ -17,7 +17,7 @@ import {
   serverConfigStore,
   setSidebarActiveIconStore
 } from 'app/utils/navigation';
-import {Attribute, Criteria, DomainType, Modifier} from 'generated/fetch';
+import {Attribute, Criteria, Domain, Modifier} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 
 const proIcons = {
@@ -201,15 +201,15 @@ export class SelectionInfoModal extends React.Component<SelectionInfoProps, Sele
 
   get showType() {
     return ![
-      DomainType.PHYSICALMEASUREMENT.toString(),
-      DomainType.DRUG.toString(),
-      DomainType.SURVEY.toString()
+      Domain.PHYSICALMEASUREMENT.toString(),
+      Domain.DRUG.toString(),
+      Domain.SURVEY.toString()
     ].includes(this.props.selection.domainId);
   }
 
   get showOr() {
     const {index, selection} = this.props;
-    return index > 0 && selection.domainId !== DomainType.PERSON.toString();
+    return index > 0 && selection.domainId !== Domain.PERSON.toString();
   }
 
   render() {
@@ -249,9 +249,9 @@ export class SelectionInfo extends React.Component<SelectionInfoProps, Selection
 
   get showType() {
     return ![
-      DomainType.PHYSICALMEASUREMENT.toString(),
-      DomainType.DRUG.toString(),
-      DomainType.SURVEY.toString()
+      Domain.PHYSICALMEASUREMENT.toString(),
+      Domain.DRUG.toString(),
+      Domain.SURVEY.toString()
     ].includes(this.props.selection.domainId);
   }
 
@@ -283,7 +283,7 @@ interface Props {
   back: Function;
   close: Function;
   disableFinish: boolean;
-  domain: DomainType;
+  domain: Domain;
   finish: Function;
   removeSelection: Function;
   selections: Array<Selection>;
@@ -307,7 +307,7 @@ export class SelectionListModalVersion extends React.Component<Props> {
   }
 
   get showModifiers() {
-    return ![DomainType.PHYSICALMEASUREMENT, DomainType.PERSON, DomainType.SURVEY].includes(this.props.domain);
+    return ![Domain.PHYSICALMEASUREMENT, Domain.PERSON, Domain.SURVEY].includes(this.props.domain);
   }
 
   get showNext() {
@@ -429,8 +429,8 @@ export const SelectionList = fp.flow(withCurrentCohortCriteria(), withCurrentCoh
     get showModifierButton() {
       const {criteria} = this.props;
       return criteria && criteria.length > 0 &&
-        criteria[0].domainId !== DomainType.PHYSICALMEASUREMENT.toString()
-        && criteria[0].domainId !== DomainType.PERSON.toString();
+        criteria[0].domainId !== Domain.PHYSICALMEASUREMENT.toString()
+        && criteria[0].domainId !== Domain.PERSON.toString();
     }
 
     get showAttributesOrModifiers() {

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore, serverConfigStore} from 'app/utils/navigation';
-import {CohortBuilderApi, DomainType} from 'generated/fetch';
+import {CohortBuilderApi, Domain} from 'generated/fetch';
 import defaultServerConfig from 'testing/default-server-config';
 import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
@@ -31,7 +31,7 @@ const surveyCOPETreeNodeStub = {
   code: '',
   conceptId: 1333342,
   count: 0,
-  domainId: DomainType.SURVEY.toString(),
+  domainId: Domain.SURVEY.toString(),
   group: true,
   hasAttributes: false,
   id: 328232,

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -18,7 +18,7 @@ import {
   serverConfigStore,
   setSidebarActiveIconStore
 } from 'app/utils/navigation';
-import {AttrName, Criteria, CriteriaSubType, CriteriaType, DomainType, Operator} from 'generated/fetch';
+import {AttrName, Criteria, CriteriaSubType, CriteriaType, Domain, Operator} from 'generated/fetch';
 
 const COPE_SURVEY_ID = 1333342;
 export const COPE_SURVEY_GROUP_NAME = 'COVID-19 Participant Experience (COPE) Survey';
@@ -152,7 +152,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
 
   componentDidUpdate(prevProps: Readonly<TreeNodeProps>): void {
     const {autocompleteSelection, node: {domainId, group}, searchTerms} = this.props;
-    if (domainId === DomainType.PHYSICALMEASUREMENT.toString() && group && searchTerms !== prevProps.searchTerms) {
+    if (domainId === Domain.PHYSICALMEASUREMENT.toString() && group && searchTerms !== prevProps.searchTerms) {
       this.searchChildren();
     }
     if (!!autocompleteSelection && autocompleteSelection !== prevProps.autocompleteSelection) {
@@ -164,10 +164,10 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
     const {node: {conceptId, count, domainId, id, isStandard, name, type}} = this.props;
     this.setState({loading: true});
     const {cdrVersionId} = (currentWorkspaceStore.getValue());
-    const criteriaType = domainId === DomainType.DRUG.toString() ? CriteriaType.ATC.toString() : type;
+    const criteriaType = domainId === Domain.DRUG.toString() ? CriteriaType.ATC.toString() : type;
     cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard, id)
       .then(resp => {
-        if (resp.items.length === 0 && domainId === DomainType.DRUG.toString()) {
+        if (resp.items.length === 0 && domainId === Domain.DRUG.toString()) {
           cohortBuilderApi()
             .findCriteriaBy(+cdrVersionId, domainId, CriteriaType[CriteriaType.RXNORM], isStandard, id)
             .then(rxResp => {
@@ -175,7 +175,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
             }, () => this.setState({error: true}));
         } else {
           this.setState({children: resp.items, loading: false});
-          if (resp.items.length > 0 && domainId === DomainType.SURVEY.toString() && !resp.items[0].group) {
+          if (resp.items.length > 0 && domainId === Domain.SURVEY.toString() && !resp.items[0].group) {
             // save questions in the store so we can display them along with answers if selected
             const questions = ppiQuestions.getValue();
             questions[id] = {conceptId, count, name};
@@ -221,11 +221,11 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
       const {children, expanded} = this.state;
       if (!expanded) {
         if (parentId === 0) {
-          const labelName = domainId === DomainType.SURVEY.toString() ? name : subTypeToTitle(subtype);
+          const labelName = domainId === Domain.SURVEY.toString() ? name : subTypeToTitle(subtype);
           const message = source === 'concept' ? 'Concept Search' : 'Cohort Builder Search';
           triggerEvent(message, 'Click', `${domainToTitle(domainId)} - ${labelName} - Expand`);
         }
-        if (domainId !== DomainType.PHYSICALMEASUREMENT.toString() && !children) {
+        if (domainId !== Domain.PHYSICALMEASUREMENT.toString() && !children) {
           this.loadChildren();
         }
       }
@@ -235,7 +235,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
 
   get paramId() {
     const {node: {code, conceptId, domainId, id}} = this.props;
-    return `param${!!conceptId && domainId !== DomainType.SURVEY.toString() ? (conceptId + code) : id}`;
+    return `param${!!conceptId && domainId !== Domain.SURVEY.toString() ? (conceptId + code) : id}`;
   }
 
   get isPMCat() {
@@ -268,7 +268,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
           operator: Operator.IN,
           operands: [value]
         });
-      } else if (domainId === DomainType.SURVEY.toString() && !group) {
+      } else if (domainId === Domain.SURVEY.toString() && !group) {
         const question = ppiQuestions.getValue()[parentId];
         if (question) {
           name = `${question.name} - ${name}`;
@@ -330,12 +330,12 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
       source, scrollToMatch, searchTerms, select, selectedIds,
       setAttributes} = this.props;
     const {children, error, expanded, hover, loading, searchMatch} = this.state;
-    const nodeChildren = domainId === DomainType.PHYSICALMEASUREMENT.toString() ? node.children : children;
+    const nodeChildren = domainId === Domain.PHYSICALMEASUREMENT.toString() ? node.children : children;
     const selected = serverConfigStore.getValue().enableCohortBuilderV2
       ? this.getSelectedValues()
       : selectedIds.includes(this.paramId) ||
         groupSelections.includes(parentId);
-    const displayName = domainId === DomainType.PHYSICALMEASUREMENT.toString() && !!searchTerms
+    const displayName = domainId === Domain.PHYSICALMEASUREMENT.toString() && !!searchTerms
       ? highlightSearchTerm(searchTerms, name, colors.success)
       : name;
     return <React.Fragment>

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -9,7 +9,7 @@ import {cohortBuilderApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {currentWorkspaceStore, serverConfigStore} from 'app/utils/navigation';
-import {Criteria, CriteriaSubType, CriteriaType, DomainType} from 'generated/fetch';
+import {Criteria, CriteriaSubType, CriteriaType, Domain} from 'generated/fetch';
 
 const styles = reactStyles({
   error: {
@@ -111,11 +111,11 @@ export const CriteriaTree = withCurrentWorkspace()(class extends React.Component
     const {node: {domainId, id, isStandard, type}, selectedSurvey} = this.props;
     this.setState({loading: true});
     const {cdrVersionId} = (currentWorkspaceStore.getValue());
-    const criteriaType = domainId === DomainType.DRUG.toString() ? CriteriaType.ATC.toString() : type;
-    const parentId = domainId === DomainType.PHYSICALMEASUREMENT.toString() ? null : id;
+    const criteriaType = domainId === Domain.DRUG.toString() ? CriteriaType.ATC.toString() : type;
+    const parentId = domainId === Domain.PHYSICALMEASUREMENT.toString() ? null : id;
     cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard, parentId)
     .then(resp => {
-      if (domainId === DomainType.PHYSICALMEASUREMENT.toString()) {
+      if (domainId === Domain.PHYSICALMEASUREMENT.toString()) {
         let children = [];
         resp.items.forEach(child => {
           child['children'] = [];
@@ -126,7 +126,7 @@ export const CriteriaTree = withCurrentWorkspace()(class extends React.Component
           }
         });
         this.setState({children});
-      } else if (domainId === DomainType.SURVEY.toString() &&  selectedSurvey) {
+      } else if (domainId === Domain.SURVEY.toString() &&  selectedSurvey) {
         // Temp: This should be handle in API
         const selectedSurveyChild = resp.items.filter(child => child.name === selectedSurvey);
         if (selectedSurveyChild && selectedSurveyChild.length > 0) {
@@ -136,7 +136,7 @@ export const CriteriaTree = withCurrentWorkspace()(class extends React.Component
               });
         } else {
           this.setState({children: resp.items});
-          if (domainId === DomainType.SURVEY.toString()) {
+          if (domainId === Domain.SURVEY.toString()) {
             const rootSurveys = ppiSurveys.getValue();
             if (!rootSurveys[cdrVersionId]) {
               rootSurveys[cdrVersionId] = resp.items;
@@ -146,7 +146,7 @@ export const CriteriaTree = withCurrentWorkspace()(class extends React.Component
         }
       } else {
         this.setState({children: resp.items});
-        if (domainId === DomainType.SURVEY.toString()) {
+        if (domainId === Domain.SURVEY.toString()) {
           const rootSurveys = ppiSurveys.getValue();
           if (!rootSurveys[cdrVersionId]) {
             rootSurveys[cdrVersionId] = resp.items;
@@ -183,9 +183,9 @@ export const CriteriaTree = withCurrentWorkspace()(class extends React.Component
 
   get showHeader() {
     const {node: {domainId}} = this.props;
-    return domainId !== DomainType.PHYSICALMEASUREMENT.toString()
-      && domainId !== DomainType.SURVEY.toString()
-      && domainId !== DomainType.VISIT.toString();
+    return domainId !== Domain.PHYSICALMEASUREMENT.toString()
+      && domainId !== Domain.SURVEY.toString()
+      && domainId !== Domain.VISIT.toString();
   }
 
   // Hides the tree node for COPE survey if enableCOPESurvey config flag is set to false
@@ -200,7 +200,7 @@ export const CriteriaTree = withCurrentWorkspace()(class extends React.Component
       setSearchTerms} = this.props;
     const {children, error, ingredients, loading} = this.state;
     return <React.Fragment>
-      {node.domainId !== DomainType.VISIT.toString() &&
+      {node.domainId !== Domain.VISIT.toString() &&
         <div style={serverConfigStore.getValue().enableCohortBuilderV2
           ? {...styles.searchBarContainer, backgroundColor: 'transparent', width: '65%'}
           : styles.searchBarContainer}>

--- a/ui/src/app/cohort-search/utils.ts
+++ b/ui/src/app/cohort-search/utils.ts
@@ -3,7 +3,7 @@ import {
   AgeType,
   CriteriaSubType,
   CriteriaType,
-  DomainType, GenderOrSexType,
+  Domain, GenderOrSexType,
   SearchGroup,
   SearchGroupItem,
   SearchParameter,
@@ -14,7 +14,7 @@ import {
 import {idsInUse} from './search-state.service';
 
 export function typeDisplay(parameter): string {
-  if ([DomainType.CONDITION, DomainType.PROCEDURE, DomainType.MEASUREMENT].includes(parameter.domainId)) {
+  if ([Domain.CONDITION, Domain.PROCEDURE, Domain.MEASUREMENT].includes(parameter.domainId)) {
     return parameter.code;
   }
 }
@@ -55,40 +55,40 @@ export function attributeDisplay(parameter): string {
 
 export function domainToTitle(domain: any): string {
   switch (domain) {
-    case DomainType.PERSON:
+    case Domain.PERSON:
       domain = 'Demographics';
       break;
-    case DomainType.MEASUREMENT:
+    case Domain.MEASUREMENT:
       domain = 'Labs and Measurements';
       break;
-    case DomainType.PHYSICALMEASUREMENT:
+    case Domain.PHYSICALMEASUREMENT:
       domain = 'Physical Measurements';
       break;
-    case DomainType.VISIT:
+    case Domain.VISIT:
       domain = 'Visits';
       break;
-    case DomainType.DRUG:
+    case Domain.DRUG:
       domain = 'Drugs';
       break;
-    case DomainType.CONDITION:
+    case Domain.CONDITION:
       domain = 'Conditions';
       break;
-    case DomainType.PROCEDURE:
+    case Domain.PROCEDURE:
       domain = 'Procedures';
       break;
-    case DomainType.OBSERVATION:
+    case Domain.OBSERVATION:
       domain = 'Observations';
       break;
-    case DomainType.LAB:
+    case Domain.LAB:
       domain = 'Labs';
       break;
-    case DomainType.VITAL:
+    case Domain.VITAL:
       domain = 'Vitals';
       break;
-    case DomainType.SURVEY:
+    case Domain.SURVEY:
       domain = 'Surveys';
       break;
-    case DomainType.ALLEVENTS:
+    case Domain.ALLEVENTS:
       domain = 'All Events';
       break;
   }
@@ -339,7 +339,7 @@ export function mapParameter(sp: any) {
   if (conceptId !== null && conceptId !== undefined) {
     param.conceptId = conceptId;
   }
-  if (domainId === DomainType.SURVEY) {
+  if (domainId === Domain.SURVEY) {
     param.subtype = subtype;
   }
   if (value) {
@@ -354,17 +354,17 @@ export function hasActiveItems(group: any) {
   return group.items.some(it => it.status === 'active');
 }
 
-export function getTypeAndStandard(searchParameters: Array<any>, type: DomainType) {
+export function getTypeAndStandard(searchParameters: Array<any>, type: Domain) {
   switch (type) {
-    case DomainType.PERSON:
+    case Domain.PERSON:
       const _type = searchParameters[0].type === CriteriaType.DECEASED
         ? CriteriaType.AGE : searchParameters[0].type;
       return {type: _type, standard: false};
-    case DomainType.PHYSICALMEASUREMENT:
+    case Domain.PHYSICALMEASUREMENT:
       return {type: searchParameters[0].type, standard: false};
-    case DomainType.SURVEY:
+    case Domain.SURVEY:
       return {type: searchParameters[0].type, standard: false};
-    case DomainType.VISIT:
+    case Domain.VISIT:
       return {type: searchParameters[0].type, standard: true};
     default:
       return {type: null, standard: null};

--- a/ui/src/app/pages/data/cohort-review/cohort-definition.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-definition.component.tsx
@@ -2,7 +2,7 @@ import {domainToTitle} from 'app/cohort-search/utils';
 import {cohortReviewStore} from 'app/services/review-state.service';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
-import {CriteriaType, DomainType} from 'generated/fetch';
+import {CriteriaType, Domain} from 'generated/fetch';
 import * as React from 'react';
 
 const css = `
@@ -82,7 +82,7 @@ export class CohortDefinition extends React.Component<{}, {definition: any}> {
   }
 
   mapParams(domain: string, params: Array<any>, mod) {
-    const groupedData = domain === DomainType[DomainType.DRUG]
+    const groupedData = domain === Domain[Domain.DRUG]
       ? this.getGroupedData(params, 'group')
       : this.getGroupedData(params, 'domain');
     if (mod.length) {
@@ -95,7 +95,7 @@ export class CohortDefinition extends React.Component<{}, {definition: any}> {
   getModifierFormattedData(groupedData, params, mod, domain) {
     let typeMatched;
     const modArray =  params.map(eachParam => {
-      if (eachParam.domain === DomainType.DRUG) {
+      if (eachParam.domain === Domain.DRUG) {
         typeMatched = groupedData.find( matched => matched.group === eachParam.group.toString());
       } else {
         typeMatched = groupedData.find( matched => matched.group === eachParam.domain);
@@ -125,22 +125,22 @@ export class CohortDefinition extends React.Component<{}, {definition: any}> {
   getOtherTreeFormattedData(groupedData, params, domain) {
     let typeMatched;
     const noModArray = params.map(param => {
-      if (param.domain === DomainType.DRUG) {
+      if (param.domain === Domain.DRUG) {
         typeMatched = groupedData.find( matched => matched.group === param.group.toString());
       } else {
         typeMatched = groupedData.find( matched => matched.group === param.domain);
       }
-      if (param.domain === DomainType.PERSON) {
+      if (param.domain === Domain.PERSON) {
         return {items: param.type === CriteriaType.DECEASED ? `${domainToTitle(domain)}
                       | ${param.name}` :
             `${domainToTitle(domain)}
                       | ${this.operatorConversion(param.type)} | ${param.name}`,
           domain: param.domain};
-      } else if (param.domain === DomainType.VISIT) {
+      } else if (param.domain === Domain.VISIT) {
         return {items: `${domainToTitle(domain)} | ${typeMatched.customString}`,
           domain: param.domain};
       } else {
-        return domain === DomainType.CONDITION || domain === DomainType.PROCEDURE ?
+        return domain === Domain.CONDITION || domain === Domain.PROCEDURE ?
         {items: `${domainToTitle(domain)} | ${param.type} | ${typeMatched.customString}`,
           domain: param.domain} :
         {items: `${domainToTitle(domain)} | ${typeMatched.customString}`,
@@ -171,15 +171,15 @@ export class CohortDefinition extends React.Component<{}, {definition: any}> {
   }
 
   getFormattedString(acc, d) {
-    if (d.domain === DomainType.DRUG) {
+    if (d.domain === Domain.DRUG) {
       if (d.group === false) {
         return acc === '' ? `RXNORM | ${d.value}` : `${acc}, ${d.value}`;
       } else {
         return acc === '' ? `ATC | ${d.value}` : `${acc}, ${d.value}`;
       }
-    } else if (d.domain === DomainType.PHYSICALMEASUREMENT || d.domain === DomainType.VISIT) {
+    } else if (d.domain === Domain.PHYSICALMEASUREMENT || d.domain === Domain.VISIT) {
       return acc === '' ? `${d.name}` : `${acc}, ${d.name}`;
-    } else if (d.domain === DomainType.SURVEY) {
+    } else if (d.domain === Domain.SURVEY) {
       if (!d.group) {
         return  acc === '' ? `${d.name}` :
           `${acc}, ${d.name}`;
@@ -257,8 +257,8 @@ export class CohortDefinition extends React.Component<{}, {definition: any}> {
                       {param.map((crit, c) => (
                         <React.Fragment key={c}>
                           {c > 0 && <React.Fragment>
-                            {crit.domain === DomainType.PERSON && <div>AND</div>}
-                            {crit.domain !== DomainType.PERSON && <div>OR</div>}
+                            {crit.domain === Domain.PERSON && <div>AND</div>}
+                            {crit.domain !== Domain.PERSON && <div>OR</div>}
                           </React.Fragment>}
                           <div>{crit.items}</div>
                         </React.Fragment>

--- a/ui/src/app/pages/data/cohort-review/cohort-review.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review.tsx
@@ -10,7 +10,7 @@ import {cohortBuilderApi, cohortReviewApi, cohortsApi} from 'app/services/swagge
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase} from 'app/utils';
 import {currentWorkspaceStore, navigate, urlParamsStore} from 'app/utils/navigation';
-import {Cohort, CriteriaType, DomainType, ReviewStatus, SortOrder, WorkspaceAccessLevel} from 'generated/fetch';
+import {Cohort, CriteriaType, Domain, ReviewStatus, SortOrder, WorkspaceAccessLevel} from 'generated/fetch';
 
 const styles = reactStyles({
   title: {
@@ -56,7 +56,7 @@ export class CohortReview extends React.Component<{}, State> {
     cohortsApi().getCohort(ns, wsid, cid).then(cohort => this.setState({cohort}));
     if (!visitsFilterOptions.getValue()) {
       cohortBuilderApi().findCriteriaBy(
-        +cdrVersionId, DomainType[DomainType.VISIT], CriteriaType[CriteriaType.VISIT]
+        +cdrVersionId, Domain[Domain.VISIT], CriteriaType[CriteriaType.VISIT]
       ).then(response => {
         visitsFilterOptions.next([
           {value: null, label: 'Any'},

--- a/ui/src/app/pages/data/cohort-review/detail-tab-table.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-tab-table.component.tsx
@@ -10,7 +10,7 @@ import {datatableStyles} from 'app/styles/datatable';
 import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {DomainType, Operator, PageFilterRequest, SortOrder} from 'generated/fetch';
+import {Domain, Operator, PageFilterRequest, SortOrder} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import * as moment from 'moment';
 import {Column} from 'primereact/column';
@@ -173,13 +173,13 @@ const filterIcons = {
 const rowsPerPage = 25;
 const lazyLoadSize = 125;
 const domains = [
-  DomainType.CONDITION,
-  DomainType.PROCEDURE,
-  DomainType.DRUG,
-  DomainType.OBSERVATION,
-  DomainType.PHYSICALMEASUREMENT,
-  DomainType.LAB,
-  DomainType.VITAL,
+  Domain.CONDITION,
+  Domain.PROCEDURE,
+  Domain.DRUG,
+  Domain.OBSERVATION,
+  Domain.PHYSICALMEASUREMENT,
+  Domain.LAB,
+  Domain.VITAL,
 ];
 
 class NameContainer extends React.Component<{data: any, vocab: string}, {showMore: boolean}> {
@@ -228,7 +228,7 @@ class NameContainer extends React.Component<{data: any, vocab: string}, {showMor
 interface Props {
   tabName: string;
   columns: Array<any>;
-  domain: DomainType;
+  domain: Domain;
   participantId: number;
   workspace: WorkspaceData;
   filterState: any;
@@ -445,7 +445,7 @@ export const DetailTabTable = withCurrentWorkspace()(
         .getParticipantData(namespace, id, cohortReviewId, participantId, request, {signal: this.dataAborter.signal})
         .then(response => {
           data = response.items.map(item => {
-            if (domain === DomainType.VITAL || domain === DomainType.LAB) {
+            if (domain === Domain.VITAL || domain === Domain.LAB) {
               item['itemTime'] = moment(item.itemDate, 'YYYY-MM-DD HH:mm Z').format('hh:mm a z');
             }
             item.itemDate = moment(item.itemDate).format('YYYY-MM-DD');
@@ -621,13 +621,13 @@ export const DetailTabTable = withCurrentWorkspace()(
           return itemDate >= min && itemDate <= max;
         });
       }
-      if (domain !== DomainType.SURVEY && (ageMin || ageMax)) {
+      if (domain !== Domain.SURVEY && (ageMin || ageMax)) {
         const min = ageMin || 0;
         const max = ageMax || 120;
         data = data.filter(item => item.ageAtEvent >= min && item.ageAtEvent <= max);
       }
-      if (domain !== DomainType.SURVEY
-        && domain !== DomainType.PHYSICALMEASUREMENT
+      if (domain !== Domain.SURVEY
+        && domain !== Domain.PHYSICALMEASUREMENT
         && visits) {
         data = data.filter(item => visits === item.visitType);
       }
@@ -661,7 +661,7 @@ export const DetailTabTable = withCurrentWorkspace()(
                   data = [];
                   break;
                 } else if (!columnFilters[col].includes('Select All')
-                  && !(vocab === 'source' && domain === DomainType.OBSERVATION)) {
+                  && !(vocab === 'source' && domain === Domain.OBSERVATION)) {
                   data = data.filter(row => columnFilters[col].includes(row[col]));
                 }
               } else {

--- a/ui/src/app/pages/data/cohort-review/detail-tabs.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-tabs.component.tsx
@@ -11,7 +11,7 @@ import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {DomainType, FilterColumns} from 'generated/fetch';
+import {Domain, FilterColumns} from 'generated/fetch';
 import {TabPanel, TabView} from 'primereact/tabview';
 import {Observable} from 'rxjs/Observable';
 import {from} from 'rxjs/observable/from';
@@ -184,7 +184,7 @@ const graph = {
 const tabs = [
   {
     name: 'All Events',
-    domain: DomainType.ALLEVENTS,
+    domain: Domain.ALLEVENTS,
     columns: {
       standard: [
         itemDate, visitType, standardCode, standardVocabulary, standardName, value,
@@ -196,7 +196,7 @@ const tabs = [
     }
   }, {
     name: 'Conditions',
-    domain: DomainType.CONDITION,
+    domain: Domain.CONDITION,
     columns: {
       standard: [
         itemDate, standardCode, standardVocabulary, standardName, ageAtEvent, visitType
@@ -207,7 +207,7 @@ const tabs = [
     }
   }, {
     name: 'Procedures',
-    domain: DomainType.PROCEDURE,
+    domain: Domain.PROCEDURE,
     columns: {
       standard: [
         itemDate, standardCode, standardVocabulary, standardName, ageAtEvent, visitType
@@ -218,7 +218,7 @@ const tabs = [
     }
   }, {
     name: 'Drugs',
-    domain: DomainType.DRUG,
+    domain: Domain.DRUG,
     columns: {
       standard: [
         itemDate, standardName, ageAtEvent, numMentions, firstMention, lastMention, visitType
@@ -229,7 +229,7 @@ const tabs = [
     }
   }, {
     name: 'Observations',
-    domain: DomainType.OBSERVATION,
+    domain: Domain.OBSERVATION,
     columns: {
       standard: [
         itemDate, standardName, standardCode, standardVocabulary, ageAtEvent, visitType
@@ -240,7 +240,7 @@ const tabs = [
     }
   }, {
     name: 'Physical Measurements',
-    domain: DomainType.PHYSICALMEASUREMENT,
+    domain: Domain.PHYSICALMEASUREMENT,
     columns: {
       standard: [
         itemDate, standardCode, standardVocabulary, standardName, value, ageAtEvent
@@ -251,7 +251,7 @@ const tabs = [
     }
   }, {
     name: 'Labs',
-    domain: DomainType.LAB,
+    domain: Domain.LAB,
     columns: {
       standard: [
         itemDate, itemTime, standardName, graph, value, ageAtEvent, visitType
@@ -262,7 +262,7 @@ const tabs = [
     }
   }, {
     name: 'Vitals',
-    domain: DomainType.VITAL,
+    domain: Domain.VITAL,
     columns: {
       standard: [
         itemDate, itemTime, standardName, graph, value, ageAtEvent, visitType
@@ -273,7 +273,7 @@ const tabs = [
     }
   }, {
     name: 'Surveys',
-    domain: DomainType.SURVEY,
+    domain: Domain.SURVEY,
     columns: {
       standard: [
         itemDate, survey, question, answer
@@ -286,9 +286,9 @@ const tabs = [
 ];
 
 const domainList = [
-  DomainType[DomainType.CONDITION],
-  DomainType[DomainType.PROCEDURE],
-  DomainType[DomainType.DRUG]
+  Domain[Domain.CONDITION],
+  Domain[Domain.PROCEDURE],
+  Domain[Domain.DRUG]
 ];
 const EVENT_CATEGORY = 'Review Individual';
 

--- a/ui/src/app/pages/data/cohort-review/query-report.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/query-report.component.tsx
@@ -13,7 +13,7 @@ import {
   AgeType,
   Cohort,
   CohortReview,
-  DomainType,
+  Domain,
   GenderOrSexType,
   SearchRequest
 } from 'generated/fetch';
@@ -176,10 +176,10 @@ const demoTitle = {
   paddingBottom: '0.5rem'
 };
 
-const domains = [DomainType[DomainType.CONDITION],
-  DomainType[DomainType.PROCEDURE],
-  DomainType[DomainType.DRUG],
-  DomainType[DomainType.LAB]];
+const domains = [Domain[Domain.CONDITION],
+  Domain[Domain.PROCEDURE],
+  Domain[Domain.DRUG],
+  Domain[Domain.LAB]];
 
 export interface QueryReportProps {
   workspace: WorkspaceData;

--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -9,7 +9,7 @@ import {
   currentCohortCriteriaStore,
   currentConceptStore
 } from 'app/utils/navigation';
-import {Criteria, DomainType} from 'generated/fetch';
+import {Criteria, Domain} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import {Growl} from 'primereact/growl';
 import * as React from 'react';
@@ -130,9 +130,9 @@ export class CriteriaSearch extends React.Component<Props, State>  {
 
   get initTree() {
     const {cohortContext: {domain}} = this.props;
-    return domain === DomainType.PHYSICALMEASUREMENT
-        || domain === DomainType.SURVEY
-        || domain === DomainType.VISIT;
+    return domain === Domain.PHYSICALMEASUREMENT
+        || domain === Domain.SURVEY
+        || domain === Domain.VISIT;
   }
 
   get isConcept() {

--- a/ui/src/testing/stubs/cohort-builder-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-builder-service-stub.ts
@@ -8,7 +8,6 @@ import {
   Domain,
   DomainCount,
   DomainInfoResponse,
-  DomainType,
   ParticipantDemographics, SurveyCount, SurveysResponse
 } from 'generated/fetch';
 import {DomainStubVariables, SurveyStubVariables} from 'testing/stubs/concepts-api-stub';
@@ -30,7 +29,7 @@ const criteriaStub = {
   group: false,
   selectable: true,
   conceptId: 123,
-  domainId: DomainType[DomainType.CONDITION],
+  domainId: Domain[Domain.CONDITION],
   hasAttributes: false,
   path: '0',
 };

--- a/ui/src/testing/stubs/cohort-review-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-review-service-stub.ts
@@ -3,7 +3,7 @@ import {
   CohortReview,
   CohortReviewApi, CohortReviewListResponse,
   CohortStatus,
-  DomainType,
+  Domain,
   EmptyResponse,
   ParticipantChartDataListResponse,
   ParticipantCohortAnnotation,
@@ -62,7 +62,7 @@ const participantDataStub = {
   itemDate: '',
   standardName: '',
   ageAtEvent: 22,
-  domainType: DomainType.CONDITION
+  domainType: Domain.CONDITION
 };
 
 const participantDataListResponseStub = {


### PR DESCRIPTION
Cohort Builder uses DomainType enum and Concept Sets uses Domain enum. This is causing issues with the unification of the two tools. I've opted for sticking with the Domain enum since it is persisted in the db. 