### PR TITLE
[RW-5704][risk=no] Enable CS search to query Physical Measurements from the concept table

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
@@ -38,7 +38,8 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
           "select distinct c from DbConcept c "
               + "where (c.countValue > 0 or c.sourceCountValue > 0) "
               + "and matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0 "
-              + "and c.domainId = ?2")
+              + "and c.domainId = ?2 "
+              + "and c.standardConcept IN ('')")
   Page<DbConcept> findConcepts(String keyword, String domainId, Pageable page);
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
@@ -33,6 +33,14 @@ public interface ConceptDao extends CrudRepository<DbConcept, Long> {
   Page<DbConcept> findConcepts(
       String keyword, ImmutableList<String> conceptTypes, String domainId, Pageable page);
 
+  @Query(
+      value =
+          "select distinct c from DbConcept c "
+              + "where (c.countValue > 0 or c.sourceCountValue > 0) "
+              + "and matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0 "
+              + "and c.domainId = ?2")
+  Page<DbConcept> findConcepts(String keyword, String domainId, Pageable page);
+
   /**
    * Return standard or all concepts in each vocabulary for the specified domain matching the
    * specified expression, matching concept name, synonym, ID, or code.

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -23,20 +23,20 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.cdr.dao.CBCriteriaAttributeDao;
 import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
 import org.pmiops.workbench.cdr.dao.CBDataFilterDao;
+import org.pmiops.workbench.cdr.dao.ConceptDao;
 import org.pmiops.workbench.cdr.dao.DomainInfoDao;
 import org.pmiops.workbench.cdr.dao.PersonDao;
 import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
+import org.pmiops.workbench.cdr.model.DbConcept;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbCriteriaAttribute;
 import org.pmiops.workbench.cdr.model.DbMenuOption;
 import org.pmiops.workbench.cohortbuilder.mapper.CohortBuilderMapper;
-import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.AgeType;
 import org.pmiops.workbench.model.AgeTypeCount;
 import org.pmiops.workbench.model.ConceptIdName;
@@ -60,6 +60,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -69,11 +70,13 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   private static final Integer DEFAULT_CRITERIA_SEARCH_LIMIT = 250;
   private static final ImmutableList<String> MYSQL_FULL_TEXT_CHARS =
       ImmutableList.of("\"", "+", "-", "*", "(", ")");
+  private static final ImmutableList<String> STANDARD_CONCEPTS = ImmutableList.of("S", "C");
 
   private BigQueryService bigQueryService;
   private CohortQueryBuilder cohortQueryBuilder;
   private CBCriteriaAttributeDao cbCriteriaAttributeDao;
   private CBCriteriaDao cbCriteriaDao;
+  private ConceptDao conceptDao;
   private CBDataFilterDao cbDataFilterDao;
   private DomainInfoDao domainInfoDao;
   private PersonDao personDao;
@@ -86,6 +89,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
       CohortQueryBuilder cohortQueryBuilder,
       CBCriteriaAttributeDao cbCriteriaAttributeDao,
       CBCriteriaDao cbCriteriaDao,
+      ConceptDao conceptDao,
       CBDataFilterDao cbDataFilterDao,
       DomainInfoDao domainInfoDao,
       PersonDao personDao,
@@ -95,6 +99,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
     this.cohortQueryBuilder = cohortQueryBuilder;
     this.cbCriteriaAttributeDao = cbCriteriaAttributeDao;
     this.cbCriteriaDao = cbCriteriaDao;
+    this.conceptDao = conceptDao;
     this.cbDataFilterDao = cbDataFilterDao;
     this.domainInfoDao = domainInfoDao;
     this.personDao = personDao;
@@ -141,7 +146,6 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   @Override
   public List<Criteria> findCriteriaAutoComplete(
       String domain, String term, String type, Boolean standard, Integer limit) {
-    validateSearchTerm(term);
     PageRequest pageRequest =
         new PageRequest(0, Optional.ofNullable(limit).orElse(DEFAULT_TREE_SEARCH_LIMIT));
     List<DbCriteria> criteriaList =
@@ -176,10 +180,32 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   @Override
   public CriteriaListWithCountResponse findCriteriaByDomainAndSearchTerm(
       String domain, String term, Integer limit) {
-    validateSearchTerm(term);
-    Page<DbCriteria> dbCriteriaPage;
+    if (DomainType.fromValue(domain).equals(DomainType.PHYSICAL_MEASUREMENT)) {
+      final String keyword = modifyTermMatch(term);
+      PageRequest pageRequest =
+          new PageRequest(
+              0,
+              Optional.ofNullable(limit).orElse(DEFAULT_CRITERIA_SEARCH_LIMIT),
+              new Sort(Direction.DESC, "countValue"));
+      Page<DbConcept> dbConcepts = conceptDao.findConcepts(keyword, domain, pageRequest);
+      return new CriteriaListWithCountResponse()
+          .items(
+              dbConcepts.getContent().stream()
+                  .map(
+                      c -> {
+                        boolean isStandard = STANDARD_CONCEPTS.contains(c.getStandardConcept());
+                        return cohortBuilderMapper.dbModelToClient(
+                            c,
+                            isStandard,
+                            isStandard ? c.getCountValue() : c.getSourceCountValue());
+                      })
+                  .collect(Collectors.toList()))
+          .totalCount(dbConcepts.getTotalElements());
+    }
+
     PageRequest pageRequest =
         new PageRequest(0, Optional.ofNullable(limit).orElse(DEFAULT_CRITERIA_SEARCH_LIMIT));
+    Page<DbCriteria> dbCriteriaPage;
     List<DbCriteria> exactMatchByCode = cbCriteriaDao.findExactMatchByCode(domain, term);
     boolean isStandard = exactMatchByCode.isEmpty() || exactMatchByCode.get(0).getStandard();
 
@@ -409,14 +435,6 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
         .collect(Collectors.toList());
   }
 
-  private void validateSearchTerm(String term) {
-    if (StringUtils.isEmpty(term)) {
-      throw new BadRequestException(
-          String.format(
-              "Bad Request: Please provide a valid search term: \"%s\" is not valid.", term));
-    }
-  }
-
   private String modifyTermMatch(String term) {
     if (!MYSQL_FULL_TEXT_CHARS.stream()
         .filter(term::contains)
@@ -427,7 +445,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
 
     String[] keywords = term.split("\\W+");
     if (keywords.length == 1 && keywords[0].length() <= 3) {
-      return "+\"" + keywords[0];
+      return "+\"" + keywords[0] + "+\"";
     }
 
     return IntStream.range(0, keywords.length)

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -68,6 +68,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
 
   private static final Integer DEFAULT_TREE_SEARCH_LIMIT = 100;
   private static final Integer DEFAULT_CRITERIA_SEARCH_LIMIT = 250;
+  private static final String MEASUREMENT = "Measurement";
   private static final ImmutableList<String> MYSQL_FULL_TEXT_CHARS =
       ImmutableList.of("\"", "+", "-", "*", "(", ")");
   private static final ImmutableList<String> STANDARD_CONCEPTS = ImmutableList.of("S", "C");
@@ -180,14 +181,14 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   @Override
   public CriteriaListWithCountResponse findCriteriaByDomainAndSearchTerm(
       String domain, String term, Integer limit) {
-    if (DomainType.fromValue(domain).equals(DomainType.PHYSICAL_MEASUREMENT)) {
+    if (Domain.fromValue(domain).equals(Domain.PHYSICAL_MEASUREMENT)) {
       final String keyword = modifyTermMatch(term);
       PageRequest pageRequest =
           new PageRequest(
               0,
               Optional.ofNullable(limit).orElse(DEFAULT_CRITERIA_SEARCH_LIMIT),
               new Sort(Direction.DESC, "countValue"));
-      Page<DbConcept> dbConcepts = conceptDao.findConcepts(keyword, domain, pageRequest);
+      Page<DbConcept> dbConcepts = conceptDao.findConcepts(keyword, MEASUREMENT, pageRequest);
       return new CriteriaListWithCountResponse()
           .items(
               dbConcepts.getContent().stream()

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapper.java
@@ -62,6 +62,7 @@ public interface CohortBuilderMapper {
     criteria.setIsStandard(isStandard);
     criteria.setChildCount(childCount);
     criteria.setParentCount(0L);
+    criteria.setSelectable(true);
   }
 
   CriteriaAttribute dbModelToClient(DbCriteriaAttribute source);

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapper.java
@@ -61,6 +61,7 @@ public interface CohortBuilderMapper {
       @MappingTarget Criteria criteria, @Context Boolean isStandard, @Context Long childCount) {
     criteria.setIsStandard(isStandard);
     criteria.setChildCount(childCount);
+    criteria.setParentCount(0L);
   }
 
   CriteriaAttribute dbModelToClient(DbCriteriaAttribute source);

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapper.java
@@ -1,8 +1,12 @@
 package org.pmiops.workbench.cohortbuilder.mapper;
 
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.pmiops.workbench.cdr.model.DbAgeTypeCount;
+import org.pmiops.workbench.cdr.model.DbConcept;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbCriteriaAttribute;
 import org.pmiops.workbench.cdr.model.DbDataFilter;
@@ -32,6 +36,32 @@ public interface CohortBuilderMapper {
   @Mapping(target = "hasHierarchy", source = "hierarchy")
   @Mapping(target = "isStandard", source = "standard")
   Criteria dbModelToClient(DbCriteria source);
+
+  @Mapping(target = "code", source = "conceptCode")
+  @Mapping(target = "name", source = "conceptName")
+  @Mapping(target = "type", source = "vocabularyId")
+  @Mapping(target = "isStandard", source = "standardConcept", qualifiedByName = "toIsStandard")
+  @Mapping(target = "childCount", ignore = true)
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "parentId", ignore = true)
+  @Mapping(target = "subtype", ignore = true)
+  @Mapping(target = "count", ignore = true)
+  @Mapping(target = "parentCount", ignore = true)
+  @Mapping(target = "group", ignore = true)
+  @Mapping(target = "selectable", ignore = true)
+  @Mapping(target = "hasAttributes", ignore = true)
+  @Mapping(target = "path", ignore = true)
+  @Mapping(target = "value", ignore = true)
+  @Mapping(target = "hasHierarchy", ignore = true)
+  @Mapping(target = "hasAncestorData", ignore = true)
+  Criteria dbModelToClient(DbConcept source, @Context Boolean isStandard, @Context Long childCount);
+
+  @AfterMapping
+  default void afterMappingDbModelToClient(
+      @MappingTarget Criteria criteria, @Context Boolean isStandard, @Context Long childCount) {
+    criteria.setIsStandard(isStandard);
+    criteria.setChildCount(childCount);
+  }
 
   CriteriaAttribute dbModelToClient(DbCriteriaAttribute source);
 

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import javax.inject.Provider;
 import org.junit.Before;
@@ -15,9 +16,11 @@ import org.pmiops.workbench.cdr.CdrVersionService;
 import org.pmiops.workbench.cdr.dao.CBCriteriaAttributeDao;
 import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
 import org.pmiops.workbench.cdr.dao.CBDataFilterDao;
+import org.pmiops.workbench.cdr.dao.ConceptDao;
 import org.pmiops.workbench.cdr.dao.DomainInfoDao;
 import org.pmiops.workbench.cdr.dao.PersonDao;
 import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
+import org.pmiops.workbench.cdr.model.DbConcept;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbCriteriaAttribute;
 import org.pmiops.workbench.cdr.model.DbDomainInfo;
@@ -66,6 +69,7 @@ public class CohortBuilderControllerTest {
   @Mock private CdrVersionService cdrVersionService;
   @Autowired private CBCriteriaDao cbCriteriaDao;
   @Autowired private CBCriteriaAttributeDao cbCriteriaAttributeDao;
+  @Autowired private ConceptDao conceptDao;
   @Autowired private CBDataFilterDao cbDataFilterDao;
   @Autowired private DomainInfoDao domainInfoDao;
   @Autowired private PersonDao personDao;
@@ -89,6 +93,7 @@ public class CohortBuilderControllerTest {
             cohortQueryBuilder,
             cbCriteriaAttributeDao,
             cbCriteriaDao,
+            conceptDao,
             cbDataFilterDao,
             domainInfoDao,
             personDao,
@@ -380,6 +385,39 @@ public class CohortBuilderControllerTest {
       assertEquals(
           "Bad Request: Please provide a valid type. blah is not valid.", bre.getMessage());
     }
+  }
+
+  @Test
+  public void findCriteriaByDomainAndSearchTermPhysicalMeasurement() {
+    DbConcept dbConcept =
+        conceptDao.save(
+            new DbConcept()
+                .conceptId(123L)
+                .conceptName("chol blah")
+                .conceptCode("myTerm")
+                .standardConcept("")
+                .sourceCountValue(10L)
+                .domainId(DomainType.PHYSICAL_MEASUREMENT.toString())
+                .vocabularyId(CriteriaType.ICD9CM.toString()));
+
+    Criteria criteria =
+        new Criteria()
+            .code(dbConcept.getConceptCode())
+            .conceptId(dbConcept.getConceptId())
+            .childCount(dbConcept.getSourceCountValue())
+            .domainId(dbConcept.getDomainId())
+            .name(dbConcept.getConceptName())
+            .type(dbConcept.getVocabularyId())
+            .isStandard(ImmutableList.of("S", "C").contains(dbConcept.getStandardConcept()));
+
+    assertEquals(
+        criteria,
+        controller
+            .findCriteriaByDomainAndSearchTerm(
+                1L, DomainType.PHYSICAL_MEASUREMENT.name(), "myTerm", null)
+            .getBody()
+            .getItems()
+            .get(0));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -397,7 +397,7 @@ public class CohortBuilderControllerTest {
                 .conceptCode("myTerm")
                 .standardConcept("")
                 .sourceCountValue(10L)
-                .domainId(DomainType.PHYSICAL_MEASUREMENT.toString())
+                .domainId(Domain.MEASUREMENT.toString())
                 .vocabularyId(CriteriaType.ICD9CM.toString()));
 
     Criteria criteria =
@@ -414,7 +414,7 @@ public class CohortBuilderControllerTest {
         criteria,
         controller
             .findCriteriaByDomainAndSearchTerm(
-                1L, DomainType.PHYSICAL_MEASUREMENT.name(), "myTerm", null)
+                1L, Domain.PHYSICAL_MEASUREMENT.name(), "myTerm", null)
             .getBody()
             .getItems()
             .get(0));

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -397,7 +397,7 @@ public class CohortBuilderControllerTest {
                 .conceptCode("myTerm")
                 .standardConcept("")
                 .sourceCountValue(10L)
-                .domainId(Domain.MEASUREMENT.toString())
+                .domainId("Measurement")
                 .vocabularyId(CriteriaType.ICD9CM.toString()));
 
     Criteria criteria =
@@ -405,9 +405,11 @@ public class CohortBuilderControllerTest {
             .code(dbConcept.getConceptCode())
             .conceptId(dbConcept.getConceptId())
             .childCount(dbConcept.getSourceCountValue())
+            .parentCount(0L)
             .domainId(dbConcept.getDomainId())
             .name(dbConcept.getConceptName())
             .type(dbConcept.getVocabularyId())
+            .selectable(true)
             .isStandard(ImmutableList.of("S", "C").contains(dbConcept.getStandardConcept()));
 
     assertEquals(

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapperTest.java
@@ -5,6 +5,7 @@ import static com.google.common.truth.Truth.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pmiops.workbench.cdr.model.DbAgeTypeCount;
+import org.pmiops.workbench.cdr.model.DbConcept;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbCriteriaAttribute;
 import org.pmiops.workbench.cdr.model.DbDataFilter;
@@ -117,6 +118,27 @@ public class CohortBuilderMapperTest {
                     .addEstCount("2")
                     .build()))
         .isEqualTo(expectedCriteriaAttribute);
+  }
+
+  @Test
+  public void dbModelToClientDbConcept() {
+    DbConcept dbConcept =
+        new DbConcept()
+            .conceptName("name")
+            .conceptCode("code")
+            .vocabularyId("vocab")
+            .standardConcept("")
+            .sourceCountValue(100L)
+            .conceptId(12345L);
+    assertThat(cohortBuilderMapper.dbModelToClient(dbConcept, false, 100L))
+        .isEqualTo(
+            new Criteria()
+                .name("name")
+                .code("code")
+                .type("vocab")
+                .conceptId(12345L)
+                .isStandard(false)
+                .childCount(100L));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/mapper/CohortBuilderMapperTest.java
@@ -138,6 +138,8 @@ public class CohortBuilderMapperTest {
                 .type("vocab")
                 .conceptId(12345L)
                 .isStandard(false)
+                .selectable(true)
+                .parentCount(0L)
                 .childCount(100L));
   }
 

--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -143,9 +143,9 @@ export class CriteriaSearch extends React.Component<Props, State>  {
   }
 
   get initTree() {
-    const {cohortContext: {domain}} = this.props;
-    return domain === Domain.PHYSICALMEASUREMENT
-        || domain === Domain.SURVEY
+    const {cohortContext: {domain}, source} = this.props;
+    return (domain === Domain.PHYSICALMEASUREMENT && source === 'criteria')
+      || domain === Domain.SURVEY
         || domain === Domain.VISIT;
   }
 


### PR DESCRIPTION
Enable CS search to query Physical Measurements from the concept table

- Modified `CohortBuilderController#findCriteriaByDomainAndSearchTerm` to query concept table for the Physical Measurements domain
- Modified CohortBuilderMapper to map a DbConcept to a Criteria model object
- Updated test cases