### PR TITLE
[risk=no] e2e: rename findWorkspace() and use createWorkspace() to be more explicit

### DIFF
--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -4,7 +4,7 @@ import {Language, LinkText, PageUrl} from 'app/text-labels';
 import WorkspaceEditPage, {FIELD as EDIT_FIELD} from 'app/page/workspace-edit-page';
 import {makeWorkspaceName} from 'utils/str-utils';
 import RadioButton from 'app/element/radiobutton';
-import {findWorkspace} from 'utils/test-utils';
+import {findOrCreateWorkspace} from 'utils/test-utils';
 import {waitForDocumentTitle, waitForText, waitWhileLoading} from 'utils/waits-utils';
 import ReactSelect from 'app/element/react-select';
 import WorkspaceDataPage from './workspace-data-page';
@@ -146,7 +146,7 @@ export default class WorkspacesPage extends WorkspaceEditPage {
    */
   async createNotebook(opts: {workspaceName: string, notebookName: string, lang?: Language}): Promise<WorkspaceAnalysisPage> {
     const {workspaceName, notebookName, lang} = opts;
-    const workspaceCard = await findWorkspace(this.page, {workspaceName, create: true});
+    const workspaceCard = await findOrCreateWorkspace(this.page, {workspaceName, alwaysCreate: true});
     await workspaceCard.clickWorkspaceName();
 
     const dataPage = new WorkspaceDataPage(this.page);

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -7,7 +7,7 @@ import Link from 'app/element/link';
 import {Option, LinkText, ResourceCard} from 'app/text-labels';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import {waitForText, waitWhileLoading} from 'utils/waits-utils';
 
 
@@ -27,7 +27,7 @@ describe('User can create new Cohorts', () => {
    */
   test('Add Cohort of Physical Measurements BMI', async () => {
 
-    const workspaceCard = await findWorkspace(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
     // Wait for the Data page.
@@ -115,7 +115,7 @@ describe('User can create new Cohorts', () => {
    */
   test('Add Cohort of EKG condition with modifiers', async () => {
 
-    const workspaceCard = await findWorkspace(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
     // Wait for the Data page.

--- a/e2e/tests/cohorts/cohorts-rename.spec.ts
+++ b/e2e/tests/cohorts/cohorts-rename.spec.ts
@@ -5,7 +5,7 @@ import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import {waitForNumericalString, waitForText} from 'utils/waits-utils';
 
 
@@ -29,7 +29,7 @@ describe('User can create, modify, rename and delete Cohort', () => {
    */
   test('Add cohort including Demographics Age', async () => {
 
-    const workspaceCard = await findWorkspace(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
     const dataPage = new WorkspaceDataPage(page);

--- a/e2e/tests/cohorts/cohorts-review.spec.ts
+++ b/e2e/tests/cohorts/cohorts-review.spec.ts
@@ -1,4 +1,4 @@
-import {findWorkspace, isValidDate, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, isValidDate, signIn, waitWhileLoading} from 'utils/test-utils';
 import {Option, LinkText, ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import CohortBuildPage from 'app/page/cohort-build-page';
@@ -27,7 +27,7 @@ describe('Cohort review tests', () => {
   test('Create Cohort and a Review Set for 100 participants', async () => {
     const reviewSetNumberOfParticipants = 100;
 
-    await findWorkspace(page).then(card => card.clickWorkspaceName());
+    await findOrCreateWorkspace(page).then(card => card.clickWorkspaceName());
 
     const dataPage = new WorkspaceDataPage(page);
     const cohortCard = await dataPage.createCohort();

--- a/e2e/tests/cohorts/cohorts-review.spec.ts
+++ b/e2e/tests/cohorts/cohorts-review.spec.ts
@@ -1,4 +1,4 @@
-import {findOrCreateWorkspace, isValidDate, signIn, waitWhileLoading} from 'utils/test-utils';
+import {findOrCreateWorkspace, isValidDate, signIn} from 'utils/test-utils';
 import {Option, LinkText, ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import CohortBuildPage from 'app/page/cohort-build-page';

--- a/e2e/tests/cohorts/cohorts-ui.spec.ts
+++ b/e2e/tests/cohorts/cohorts-ui.spec.ts
@@ -2,7 +2,7 @@ import CohortBuildPage from 'app/page/cohort-build-page';
 import {PhysicalMeasurementsCriteria} from 'app/page/cohort-search-page';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import {TabLabels} from 'app/page/workspace-base';
 
@@ -19,7 +19,7 @@ describe('Cohorts UI tests', () => {
    * Confirm Discard Changes.
    */
   test('Discard Changes', async () => {
-    const workspaceCard = await findWorkspace(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
     // Wait for the Data page.

--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -2,7 +2,7 @@ import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
 import DataResourceCard from 'app/component/data-resource-card';
 import ConceptSetActionsPage from 'app/page/conceptset-actions-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import {waitForText} from 'utils/waits-utils';
 import {ResourceCard} from 'app/text-labels';
 
@@ -18,7 +18,7 @@ describe('Create Concept Sets from Domains', () => {
    * - Delete Concept Set.
    */
   test('Create Concept Set from Conditions domain', async () => {
-    const workspaceCard = await findWorkspace(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button.
@@ -81,7 +81,7 @@ describe('Create Concept Sets from Domains', () => {
    * - Delete Dataset, Concept Set.
    */
   test('Create Concept Sets from Drug Exposures and Measurements domains', async () => {
-    const workspaceCard = await findWorkspace(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button.

--- a/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
@@ -5,8 +5,7 @@ import {SaveOption} from 'app/page/conceptset-save-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {ResourceCard} from 'app/text-labels';
 import {makeRandomName, makeString} from 'utils/str-utils';
-import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
-
+import {createWorkspace, signIn} from 'utils/test-utils';
 
 describe('Editing and rename Concept Set', () => {
 
@@ -24,7 +23,7 @@ describe('Editing and rename Concept Set', () => {
    */
   test('Workspace OWNER can edit Concept Set', async () => {
 
-    const workspaceName = await findOrCreateWorkspace(page, {alwaysCreate: true}).then(card => card.clickWorkspaceName());
+    const workspaceName = await createWorkspace(page).then(card => card.clickWorkspaceName());
 
     const dataPage = new WorkspaceDataPage(page);
     let conceptSearchPage = await dataPage.openConceptSetSearch(Domain.Procedures);

--- a/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
@@ -5,7 +5,7 @@ import {SaveOption} from 'app/page/conceptset-save-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {ResourceCard} from 'app/text-labels';
 import {makeRandomName, makeString} from 'utils/str-utils';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 
 
 describe('Editing and rename Concept Set', () => {
@@ -24,7 +24,7 @@ describe('Editing and rename Concept Set', () => {
    */
   test('Workspace OWNER can edit Concept Set', async () => {
 
-    const workspaceName = await findWorkspace(page, {create: true}).then(card => card.clickWorkspaceName());
+    const workspaceName = await findOrCreateWorkspace(page, {alwaysCreate: true}).then(card => card.clickWorkspaceName());
 
     const dataPage = new WorkspaceDataPage(page);
     let conceptSearchPage = await dataPage.openConceptSetSearch(Domain.Procedures);

--- a/e2e/tests/conceptsets/copy-to-workspace.spec.ts
+++ b/e2e/tests/conceptsets/copy-to-workspace.spec.ts
@@ -7,7 +7,7 @@ import {SaveOption} from 'app/page/conceptset-save-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {LinkText, ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
-import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
+import {createWorkspace, signIn} from 'utils/test-utils';
 import {config} from 'resources/workbench-config';
 
 async function createConceptSet(srcWorkspaceCard: WorkspaceCard) {

--- a/e2e/tests/conceptsets/copy-to-workspace.spec.ts
+++ b/e2e/tests/conceptsets/copy-to-workspace.spec.ts
@@ -7,7 +7,7 @@ import {SaveOption} from 'app/page/conceptset-save-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {LinkText, ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
-import {createWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import {config} from 'resources/workbench-config';
 
 async function createConceptSet(srcWorkspaceCard: WorkspaceCard) {

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -3,7 +3,7 @@ import ClrIconLink from 'app/element/clr-icon-link';
 import CohortBuildPage from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {Option, ResourceCard} from 'app/text-labels';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import {waitForText, waitWhileLoading} from 'utils/waits-utils';
 
 describe('Dataset test', () => {
@@ -22,7 +22,7 @@ describe('Dataset test', () => {
    * - Delete Dataset.
    */
   test('Can create Dataset with user-defined Cohorts', async () => {
-    const workspaceCard = await findWorkspace(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Cohorts button

--- a/e2e/tests/datasets/dataset-rename.spec.ts
+++ b/e2e/tests/datasets/dataset-rename.spec.ts
@@ -2,7 +2,7 @@ import DataResourceCard from 'app/component/data-resource-card';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 
 describe('Dataset test', () => {
 
@@ -19,7 +19,7 @@ describe('Dataset test', () => {
    * - Delete dataset.
    */
   test('Can create and rename Dataset', async () => {
-    const workspaceCard = await findWorkspace(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button

--- a/e2e/tests/datasets/export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/export-py-notebook.spec.ts
@@ -4,7 +4,7 @@ import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {Option, ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import {waitForText, waitWhileLoading} from 'utils/waits-utils';
 
 describe('Create Dataset', () => {
@@ -18,7 +18,7 @@ describe('Create Dataset', () => {
     * Finally delete Dataset.
     */
   test('Export dataset to notebook in Python language', async () => {
-    const workspaceCard = await findWorkspace(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button.
@@ -80,7 +80,7 @@ describe('Create Dataset', () => {
    * - Export dataset to notebook thru snowman menu.
    */
   test('Export dataset to notebook thru snowman menu', async () => {
-    await findWorkspace(page).then(card => card.clickWorkspaceName());
+    await findOrCreateWorkspace(page).then(card => card.clickWorkspaceName());
 
     // Click Add Datasets button.
     const dataPage = new WorkspaceDataPage(page);

--- a/e2e/tests/datasets/export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/export-r-notebook.spec.ts
@@ -3,7 +3,7 @@ import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import {makeRandomName} from 'utils/str-utils';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import {waitForText, waitWhileLoading} from 'utils/waits-utils';
 import CohortActionsPage from 'app/page/cohort-actions-page';
 import {Ethnicity} from 'app/page/cohort-search-page';
@@ -21,7 +21,7 @@ describe('Create Dataset', () => {
    * Delete Cohort, Dataset, and Notebook.
    */
   test('Export dataset to notebook in R language', async () => {
-    const workspaceCard = await findWorkspace(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
     const workspaceName = await workspaceCard.clickWorkspaceName();
 
     // Click Add Datasets button

--- a/e2e/tests/notebook/notebook-download.spec.ts
+++ b/e2e/tests/notebook/notebook-download.spec.ts
@@ -1,7 +1,7 @@
 import NotebookDownloadModal from 'app/page/notebook-download-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {makeRandomName} from 'utils/str-utils';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import {getPropValue} from 'utils/element-utils';
 import {waitForFn} from 'utils/waits-utils';
 
@@ -45,7 +45,7 @@ describe('Jupyter notebook download test', () => {
    */
   test('download notebook with policy warnings', async () => {
 
-    const workspaceCard = await findWorkspace(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
     const dataPage = new WorkspaceDataPage(page);

--- a/e2e/tests/notebook/notebook-python3.spec.ts
+++ b/e2e/tests/notebook/notebook-python3.spec.ts
@@ -1,6 +1,6 @@
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {makeRandomName} from 'utils/str-utils';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import DataResourceCard from 'app/component/data-resource-card';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import {ResourceCard} from 'app/text-labels';
@@ -21,7 +21,7 @@ describe('Jupyter notebook tests in Python language', () => {
    * - Verify contents are unchanged.
    */
   test('Run code from file', async () => {
-    const workspaceCard = await findWorkspace(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
     const dataPage = new WorkspaceDataPage(page);

--- a/e2e/tests/notebook/notebook-r.spec.ts
+++ b/e2e/tests/notebook/notebook-r.spec.ts
@@ -2,7 +2,6 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {Language} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
-import {CellType} from 'app/page/notebook-cell';
 
 // Notebook server start may take a long time. Set maximum test running time to 20 minutes.
 jest.setTimeout(20 * 60 * 1000);

--- a/e2e/tests/notebook/notebook-r.spec.ts
+++ b/e2e/tests/notebook/notebook-r.spec.ts
@@ -1,7 +1,8 @@
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {Language} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
+import {CellType} from 'app/page/notebook-cell';
 
 // Notebook server start may take a long time. Set maximum test running time to 20 minutes.
 jest.setTimeout(20 * 60 * 1000);
@@ -13,7 +14,7 @@ describe('Jupyter notebook tests in R language', () => {
   });
 
   test('Run code from file', async () => {
-    const workspaceCard = await findWorkspace(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
     const notebookName = makeRandomName('r-notebook');

--- a/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
@@ -50,9 +50,9 @@ async function copyNotebookTest(srcCdrVersionName: string, destCdrVersionName: s
   const deleteModalTextContent = await analysisPage.deleteResource(sourceNotebookName, ResourceCard.Notebook);
   expect(deleteModalTextContent).toContain(`Are you sure you want to delete Notebook: ${sourceNotebookName}?`);
 
-    // Perform actions in copied notebook.
-    // Open destination Workspace
-    await findOrCreateWorkspace(page, {workspaceName: destWorkspace}).then(card => card.clickWorkspaceName());
+  // Perform actions in copied notebook.
+  // Open destination Workspace
+  await findOrCreateWorkspace(page, {workspaceName: destWorkspace}).then(card => card.clickWorkspaceName());
 
   // Verify copy-to notebook exists in destination Workspace
   await dataPage.openAnalysisPage();

--- a/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/owner-copy-to-workspace.spec.ts
@@ -3,7 +3,7 @@ import Modal from 'app/component/modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {LinkText, ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
-import {createWorkspace, findWorkspace, signIn} from 'utils/test-utils';
+import {createWorkspace, findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import {config} from 'resources/workbench-config';
 
 // Notebook server start may take a long time. Set maximum test running time to 20 minutes.
@@ -50,9 +50,9 @@ async function copyNotebookTest(srcCdrVersionName: string, destCdrVersionName: s
   const deleteModalTextContent = await analysisPage.deleteResource(sourceNotebookName, ResourceCard.Notebook);
   expect(deleteModalTextContent).toContain(`Are you sure you want to delete Notebook: ${sourceNotebookName}?`);
 
-  // Perform actions in copied notebook.
-  // Open destination Workspace
-  await findWorkspace(page, {workspaceName: destWorkspace}).then(card => card.clickWorkspaceName());
+    // Perform actions in copied notebook.
+    // Open destination Workspace
+    await findOrCreateWorkspace(page, {workspaceName: destWorkspace}).then(card => card.clickWorkspaceName());
 
   // Verify copy-to notebook exists in destination Workspace
   await dataPage.openAnalysisPage();

--- a/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
@@ -8,7 +8,7 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {Option, Language, LinkText, ResourceCard, WorkspaceAccessLevel} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
 import {makeRandomName} from 'utils/str-utils';
-import {findOrCreateWorkspace, signIn, signInAs, signOut} from 'utils/test-utils';
+import {createWorkspace, signIn, signInAs, signOut} from 'utils/test-utils';
 import {waitWhileLoading} from 'utils/waits-utils';
 
 jest.setTimeout(20 * 60 * 1000);
@@ -31,7 +31,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
    * - Delete clone notebook.
    */
   test('Workspace reader copy notebook to another workspace', async () => {
-    const workspaceName = await findOrCreateWorkspace(page, {alwaysCreate: true}).then(card => card.clickWorkspaceName());
+    const workspaceName = await createWorkspace(page).then(card => card.clickWorkspaceName());
 
     const dataPage = new WorkspaceDataPage(page);
     const notebookName = makeRandomName('py');
@@ -59,7 +59,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
     const newPage = await signInAs(page, config.collaboratorUsername, config.userPassword);
 
     // Create a new Workspace. This is the copy to workspace.
-    const collaboratorWorkspaceName = await findOrCreateWorkspace(newPage, {alwaysCreate: true}).then(card => card.getWorkspaceName());
+    const collaboratorWorkspaceName = await createWorkspace(newPage).then(card => card.getWorkspaceName());
 
     // Verify shared Workspace Access Level is READER.
     const workspaceCard = await WorkspaceCard.findCard(newPage, workspaceName);

--- a/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
@@ -8,7 +8,7 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {Option, Language, LinkText, ResourceCard, WorkspaceAccessLevel} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
 import {makeRandomName} from 'utils/str-utils';
-import {findWorkspace, signIn, signInAs, signOut} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn, signInAs, signOut} from 'utils/test-utils';
 import {waitWhileLoading} from 'utils/waits-utils';
 
 jest.setTimeout(20 * 60 * 1000);
@@ -31,7 +31,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
    * - Delete clone notebook.
    */
   test('Workspace reader copy notebook to another workspace', async () => {
-    const workspaceName = await findWorkspace(page, {create: true}).then(card => card.clickWorkspaceName());
+    const workspaceName = await findOrCreateWorkspace(page, {alwaysCreate: true}).then(card => card.clickWorkspaceName());
 
     const dataPage = new WorkspaceDataPage(page);
     const notebookName = makeRandomName('py');
@@ -59,7 +59,7 @@ describe('Workspace reader Jupyter notebook action tests', () => {
     const newPage = await signInAs(page, config.collaboratorUsername, config.userPassword);
 
     // Create a new Workspace. This is the copy to workspace.
-    const collaboratorWorkspaceName = await findWorkspace(newPage, {create: true}).then(card => card.getWorkspaceName());
+    const collaboratorWorkspaceName = await findOrCreateWorkspace(newPage, {alwaysCreate: true}).then(card => card.getWorkspaceName());
 
     // Verify shared Workspace Access Level is READER.
     const workspaceCard = await WorkspaceCard.findCard(newPage, workspaceName);

--- a/e2e/tests/workspace/workspace-clone.spec.ts
+++ b/e2e/tests/workspace/workspace-clone.spec.ts
@@ -1,5 +1,5 @@
 import WorkspacesPage from 'app/page/workspaces-page';
-import {findWorkspace, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import {Option} from 'app/text-labels';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import Navigation, {NavLink} from 'app/component/navigation';
@@ -19,7 +19,7 @@ describe('Clone workspace', () => {
    * - Delete clone workspace.
    */
     test('OWNER can clone workspace via Workspace card', async () => {
-      const workspaceCard = await findWorkspace(page);
+      const workspaceCard = await findOrCreateWorkspace(page);
 
       await workspaceCard.asElementHandle().hover();
       // Click on Ellipsis menu "Duplicate" option.
@@ -50,7 +50,7 @@ describe('Clone workspace', () => {
     });
 
     test('OWNER can clone workspace via Workspace action menu', async () => {
-      const workspaceCard = await findWorkspace(page);
+      const workspaceCard = await findOrCreateWorkspace(page);
       await workspaceCard.clickWorkspaceName();
 
       const dataPage = new WorkspaceDataPage(page);

--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -2,9 +2,8 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspacesPage from 'app/page/workspaces-page';
 import {Option} from 'app/text-labels';
 import * as testData from 'resources/data/workspace-data';
-import {findOrCreateWorkspace, performActions, signIn} from 'utils/test-utils';
+import {createWorkspace, performActions, signIn} from 'utils/test-utils';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
-
 
 describe('Editing workspace via workspace card snowman menu', () => {
 
@@ -20,7 +19,7 @@ describe('Editing workspace via workspace card snowman menu', () => {
    * - Verify Workspace Information in ABOUT tab.
    */
   test('User as OWNER can edit workspace', async () => {
-    const workspaceCard = await findOrCreateWorkspace(page, {alwaysCreate: true});
+    const workspaceCard = await createWorkspace(page);
     await workspaceCard.selectSnowmanMenu(Option.Edit);
 
     const workspacesPage = new WorkspacesPage(page);

--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -2,7 +2,7 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspacesPage from 'app/page/workspaces-page';
 import {Option} from 'app/text-labels';
 import * as testData from 'resources/data/workspace-data';
-import {findWorkspace, performActions, signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, performActions, signIn} from 'utils/test-utils';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
 
 
@@ -20,7 +20,7 @@ describe('Editing workspace via workspace card snowman menu', () => {
    * - Verify Workspace Information in ABOUT tab.
    */
   test('User as OWNER can edit workspace', async () => {
-    const workspaceCard = await findWorkspace(page, {create: true});
+    const workspaceCard = await findOrCreateWorkspace(page, {alwaysCreate: true});
     await workspaceCard.selectSnowmanMenu(Option.Edit);
 
     const workspacesPage = new WorkspacesPage(page);

--- a/e2e/tests/workspace/workspace-share.spec.ts
+++ b/e2e/tests/workspace/workspace-share.spec.ts
@@ -6,7 +6,7 @@ import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspacesPage from 'app/page/workspaces-page';
 import {Option, LinkText, WorkspaceAccessLevel} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
-import {findOrCreateWorkspace, signIn, signInAs, signOut} from 'utils/test-utils';
+import {createWorkspace, findOrCreateWorkspace, signIn, signInAs, signOut} from 'utils/test-utils';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {waitWhileLoading} from 'utils/waits-utils';
 
@@ -64,7 +64,7 @@ describe('Share workspace', () => {
      */
     test('Workspace READER cannot share edit or delete workspace', async () => {
 
-      const workspaceCard = await findOrCreateWorkspace(page, {alwaysCreate: true});
+      const workspaceCard = await createWorkspace(page);
       const workspaceName = await workspaceCard.getWorkspaceName();
 
       // Open the Share modal

--- a/e2e/tests/workspace/workspace-share.spec.ts
+++ b/e2e/tests/workspace/workspace-share.spec.ts
@@ -6,7 +6,7 @@ import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspacesPage from 'app/page/workspaces-page';
 import {Option, LinkText, WorkspaceAccessLevel} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
-import {findWorkspace, signIn, signInAs, signOut} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn, signInAs, signOut} from 'utils/test-utils';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {waitWhileLoading} from 'utils/waits-utils';
 
@@ -21,7 +21,7 @@ describe('Share workspace', () => {
 
     test('As OWNER, user can share a workspace', async () => {
       
-      const workspaceCard = await findWorkspace(page);
+      const workspaceCard = await findOrCreateWorkspace(page);
       await workspaceCard.clickWorkspaceName();
 
       const notebooksLink = await Link.findByName(page, {name: 'About'});
@@ -64,7 +64,7 @@ describe('Share workspace', () => {
      */
     test('Workspace READER cannot share edit or delete workspace', async () => {
 
-      const workspaceCard = await findWorkspace(page, {create: true});
+      const workspaceCard = await findOrCreateWorkspace(page, {alwaysCreate: true});
       const workspaceName = await workspaceCard.getWorkspaceName();
 
       // Open the Share modal


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
