### PR TITLE
[risk=no] Update local CDR Versions to match test

### DIFF
--- a/api/config/cdr_versions_local.json
+++ b/api/config/cdr_versions_local.json
@@ -8,8 +8,8 @@
     "creationTime": "2018-06-06 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_3",
-    "elasticIndexBaseName": "synth_r_2020q1_1"
+    "cdrDbName": "cdr",
+    "elasticIndexBaseName": "cdr"
   },
   {
     "cdrVersionId": 2,
@@ -20,8 +20,8 @@
     "creationTime": "2018-06-06 00:00:00Z",
     "releaseNumber": 2,
     "numParticipants": 946237,
-    "cdrDbName": "synth_r_2020q1_3",
-    "elasticIndexBaseName": "synth_r_2019q1_1"
+    "cdrDbName": "cdr",
+    "elasticIndexBaseName": "cdr"
   },
   {
     "cdrVersionId": 3,
@@ -33,7 +33,8 @@
     "creationTime": "2019-09-30 00:00:00Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_8"
+    "cdrDbName": "cdr",
+    "elasticIndexBaseName": "cdr"
   },
   {
     "cdrVersionId": 4,
@@ -46,6 +47,7 @@
     "creationTime": "2020-08-26 00:09:51Z",
     "releaseNumber": 3,
     "numParticipants": 234525,
-    "cdrDbName": "synth_r_2019q4_8"
+    "cdrDbName": "cdr",
+    "elasticIndexBaseName": "cdr"
   }
 ]

--- a/api/config/cdr_versions_local.json
+++ b/api/config/cdr_versions_local.json
@@ -1,42 +1,51 @@
 [
   {
     "cdrVersionId": 1,
-    "name": "Synthetic Dataset v1 (Archived)",
+    "name": "Synthetic Dataset v1",
     "dataAccessLevel": 1,
-    "archivalStatus": 1,
     "bigqueryProject": "fc-aou-cdr-synth-test",
-    "bigqueryDataset": "SR2019q4r3",
+    "bigqueryDataset": "synthetic_cdr20180606",
     "creationTime": "2018-06-06 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,
-    "cdrDbName": "cdr",
-    "elasticIndexBaseName": "cdr"
+    "cdrDbName": "synth_r_2020q1_3",
+    "elasticIndexBaseName": "synth_r_2020q1_1"
   },
   {
     "cdrVersionId": 2,
+    "name": "Synthetic Dataset v2",
+    "dataAccessLevel": 1,
+    "bigqueryProject": "fc-aou-cdr-synth-test",
+    "bigqueryDataset": "synthetic_cdr20180606",
+    "creationTime": "2018-06-06 00:00:00Z",
+    "releaseNumber": 2,
+    "numParticipants": 946237,
+    "cdrDbName": "synth_r_2020q1_3",
+    "elasticIndexBaseName": "synth_r_2019q1_1"
+  },
+  {
+    "cdrVersionId": 3,
     "isDefault": true,
-    "name": "Synthetic Dataset v1",
+    "name": "Synthetic Dataset v3",
     "dataAccessLevel": 1,
     "bigqueryProject": "fc-aou-cdr-synth-test",
     "bigqueryDataset": "SR2019q4r3",
     "creationTime": "2019-09-30 00:00:00Z",
-    "releaseNumber": 1,
-    "numParticipants": 946237,
-    "cdrDbName": "cdr",
-    "elasticIndexBaseName": "cdr"
+    "releaseNumber": 3,
+    "numParticipants": 234525,
+    "cdrDbName": "synth_r_2019q4_8"
   },
   {
-    "cdrVersionId": 3,
+    "cdrVersionId": 4,
     "isDefault": false,
-    "name": "Synthetic Dataset v1 with Microarray",
+    "name": "Synthetic Dataset v3 with Microarray",
     "dataAccessLevel": 1,
     "bigqueryProject": "fc-aou-cdr-synth-test",
     "bigqueryDataset": "SR2019q4r3",
     "microarrayBigqueryDataset": "microarray_data",
     "creationTime": "2020-08-26 00:09:51Z",
-    "releaseNumber": 1,
-    "numParticipants": 946237,
-    "cdrDbName": "cdr",
-    "elasticIndexBaseName": "cdr"
+    "releaseNumber": 3,
+    "numParticipants": 234525,
+    "cdrDbName": "synth_r_2019q4_8"
   }
 ]

--- a/e2e/resources/workbench-config.ts
+++ b/e2e/resources/workbench-config.ts
@@ -22,8 +22,8 @@ const local = {
   apiBaseUrl: process.env.DEV_API_URL || 'http://localhost/v1',
   userEmailDomain: '@fake-research-aou.org',
   collaboratorUsername: 'puppetmaster@fake-research-aou.org',
-  defaultCdrVersionName: 'Synthetic Dataset v1',
-  altCdrVersionName: 'Synthetic Dataset v1 with Microarray',
+  defaultCdrVersionName: 'Synthetic Dataset v3',
+  altCdrVersionName: 'Synthetic Dataset v2',
 };
 
 // workbench test environment


### PR DESCRIPTION
Also resolves the recurring e2e error which looks like:

#### Copy Concept Set to another workspace Workspace OWNER cannot copy Concept Set when CDR Versions mismatch - tests/conceptsets/copy-to-workspace.spec.ts
```
TimeoutError: waiting for XPath "(//label | //*)[text()="Workspace Name" or @aria-label="Workspace Name" or @placeholder="Workspace Name" or @value="Workspace Name"]/ancestor::node()[1]//select/option[text()="Synthetic Dataset v1 with Microarray"]" failed: timeout 10000ms exceeded
```

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
