### PR TITLE
[risk=low][RW-5567] Check CDR Version in notebook query code

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineAuditController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineAuditController.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.model.AuditBigQueryResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -102,7 +103,7 @@ public class OfflineAuditController implements OfflineAuditApiDelegate {
     // purposes within the CDR project itself.
     Set<String> cdrProjects =
         ImmutableList.copyOf(cdrVersionDao.findAll()).stream()
-            .map(v -> v.getBigqueryProject())
+            .map(DbCdrVersion::getBigqueryProject)
             .collect(Collectors.toSet());
     Set<String> whitelist = Sets.union(workspaceDao.findAllWorkspaceNamespaces(), cdrProjects);
 

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -51,6 +51,7 @@ import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.dao.ConceptSetDao;
 import org.pmiops.workbench.db.dao.DataSetDao;
 import org.pmiops.workbench.db.dao.WgsExtractCromwellSubmissionDao;
+import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbConceptSetConceptId;
@@ -829,7 +830,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                                 entry.getValue(),
                                 Domain.fromValue(entry.getKey()),
                                 dataSetExportRequest.getDataSetRequest().getName(),
-                                dbWorkspace.getCdrVersion().getName(),
+                                dbWorkspace.getCdrVersion(),
                                 qualifier,
                                 dataSetExportRequest.getKernelType())),
             generateWgsCode(dataSetExportRequest, dbWorkspace, qualifier).stream())

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -1396,7 +1396,20 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
         displayHeadSection = namespace + "df.head(5)";
         break;
       case R:
-        cdrVersionCheck = "";
+        cdrVersionCheck =
+            String.format(
+                "notebook_cdr <- '%s.%s'\n"
+                    + "runtime_cdr <- Sys.getenv(\"WORKSPACE_CDR\")\n"
+                    + "\n"
+                    + "if(runtime_cdr != notebook_cdr) {\n"
+                    + "    print(paste(\"WARNING: CDR Version mismatch - your query is running in a workspace with a different\",\n"
+                    + "          \"CDR version (\", runtime_cdr,\") from the one where it was first generated. This may\",\n"
+                    + "          \"result in the query becoming invalid or inaccurate if the CDR schema has changed.\",\n"
+                    + "          \"If you've reviewed the query for correct performance, you can remove\",\n"
+                    + "          \"this warning by updating the version number in the notebook_cdr variable above\",\n"
+                    + "          \"to\", runtime_cdr, \".\"))\n"
+                    + "}",
+                cdrVersion.getBigqueryProject(), cdrVersion.getBigqueryDataset());
         sqlSection =
             namespace
                 + "sql <- paste(\""

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -1402,12 +1402,14 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                     + "runtime_cdr <- Sys.getenv(\"WORKSPACE_CDR\")\n"
                     + "\n"
                     + "if(runtime_cdr != notebook_cdr) {\n"
-                    + "    print(paste(\"WARNING: CDR Version mismatch - your query is running in a workspace with a different\",\n"
-                    + "          \"CDR version (\", runtime_cdr,\") from the one where it was first generated. This may\",\n"
-                    + "          \"result in the query becoming invalid or inaccurate if the CDR schema has changed.\",\n"
-                    + "          \"If you've reviewed the query for correct performance, you can remove\",\n"
+                    + "    writeLines(c(\n"
+                    + "        paste(\"WARNING: CDR Version mismatch - your query is running in a workspace with a different\",\n"
+                    + "            \"CDR version (\", runtime_cdr,\") from the one where it was first generated. This may\",\n"
+                    + "            \"result in the query becoming invalid or inaccurate if the CDR schema has changed.\"),\n"
+                    + "        \"\",\n"
+                    + "        paste(\"If you've reviewed the query for correct performance, you can remove\",\n"
                     + "          \"this warning by updating the version number in the notebook_cdr variable above\",\n"
-                    + "          \"to\", runtime_cdr, \".\"))\n"
+                    + "          \"to\", runtime_cdr, \".\")))\n"
                     + "}",
                 cdrVersion.getBigqueryProject(), cdrVersion.getBigqueryDataset());
         sqlSection =

--- a/e2e/resources/r-code/sys-print.R
+++ b/e2e/resources/r-code/sys-print.R
@@ -6,6 +6,7 @@ print_env_var <- function(var) {
 
 vars <- c('OWNER_EMAIL',
           'WORKSPACE_CDR',
+          'WORKSPACE_CDR_VERSION_ID',
           'WORKSPACE_NAMESPACE',
           'GOOGLE_PROJECT', # same as WORKSPACE_NAMESPACE
           'CLUSTER_NAME',

--- a/e2e/resources/r-code/sys-print.R
+++ b/e2e/resources/r-code/sys-print.R
@@ -6,7 +6,6 @@ print_env_var <- function(var) {
 
 vars <- c('OWNER_EMAIL',
           'WORKSPACE_CDR',
-          'WORKSPACE_CDR_VERSION_ID',
           'WORKSPACE_NAMESPACE',
           'GOOGLE_PROJECT', # same as WORKSPACE_NAMESPACE
           'CLUSTER_NAME',


### PR DESCRIPTION
Description:

Add a warning function to the Dataset-generated CDR query code exported to Python and R notebooks which outputs when the runtime CDR differs from the creation time CDR.

Python:
```
if runtime_cdr != notebook_cdr:
    print(("WARNING: CDR Version mismatch - your query is running in a workspace with a different "
          "CDR version ({runtime_cdr}) from the one where it was first generated. This may "
          "result in the query becoming invalid or inaccurate if the CDR schema has changed.\n\n"
          "If you've reviewed the query for correct performance, you can remove "
          "this warning by updating the version number in the notebook_cdr variable above "
          "to {runtime_cdr}.").format(runtime_cdr=runtime_cdr))
```

R:
```
if(runtime_cdr != notebook_cdr) {
    writeLines(c(
        paste("WARNING: CDR Version mismatch - your query is running in a workspace with a different",
          "CDR version (", runtime_cdr,") from the one where it was first generated. This may",
          "result in the query becoming invalid or inaccurate if the CDR schema has changed."),
        '',
        paste("If you've reviewed the query for correct performance, you can remove",
          "this warning by updating the version number in the notebook_cdr variable above",
          "to", runtime_cdr, ".")))
}
```

In action (TODO - error condition only):
![warning_code2](https://user-images.githubusercontent.com/2701406/96293228-6fdbb180-0fb8-11eb-9802-0c22a13f97ab.gif)



 
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
