### PR TITLE
[RW-5734] Show concept results with attributes

### DIFF
--- a/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
+++ b/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
@@ -359,7 +359,7 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace())(
 
     renderRow(row: any, child: boolean, elementId: string) {
       const {hoverId, ingredients} = this.state;
-      const attributes = row.hasAttributes;
+      const attributes = this.props.source === 'criteria' && row.hasAttributes;
       const brand = row.type === CriteriaType.BRAND;
       const displayName = row.name + (brand ? ' (BRAND NAME)' : '');
       const selected = !attributes && !brand && this.props.selectedIds.includes(this.getParamId(row));
@@ -410,14 +410,6 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace())(
           <ClrIcon style={styles.infoIcon} className='is-solid' shape='info-standard'/>
         </TooltipTrigger>
       </FlexRow>;
-    }
-
-    get isConcept() {
-      return this.props.source && this.props.source === 'concept';
-    }
-
-    hideAttributesRow(row) {
-      return !row.hasAttributes || !this.isConcept;
     }
 
     render() {
@@ -483,10 +475,10 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace())(
                   const open = ingredients[row.id] && ingredients[row.id].open;
                   const err = ingredients[row.id] && ingredients[row.id].error;
                   return <React.Fragment key={index}>
-                    {this.hideAttributesRow(row)  && this.renderRow(row, false, index)}
+                    {this.renderRow(row, false, index)}
                     {open && !err && ingredients[row.id].items.map((item, i) => {
                       return <React.Fragment key={i}>
-                        {this.hideAttributesRow(row) && this.renderRow(item, true, `${index}.${i}`)}
+                        {this.renderRow(item, true, `${index}.${i}`)}
                       </React.Fragment>;
                     })}
                     {open && err && <tr>

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -347,7 +347,6 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
               shape={'angle ' + (expanded ? 'down' : 'right')}
               size='16'/>}
         </button>}
-        {(!hasAttributes || source !== 'concept') &&
         <div style={hover ? {...styles.treeNodeContent, background: colors.light} : styles.treeNodeContent}
           onMouseEnter={() => this.setState({hover: true})}
           onMouseLeave={() => this.setState({hover: false})}>
@@ -375,7 +374,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
           {this.showCount && <div style={{whiteSpace: 'nowrap'}}>
             <span style={styles.count}>{count.toLocaleString()}</span>
           </div>}
-        </div>}
+        </div>
       </div>
       {!!nodeChildren && nodeChildren.length > 0 &&
         <div style={{display: expanded ? 'block' : 'none', marginLeft: nodeChildren[0].group ? '0.875rem' : '2rem'}}>


### PR DESCRIPTION
Remove filter for criteria with attributes in concept search and make selectable with regular select icon instead of attributes slider icon.

Concept Search:
<img width="1165" alt="Screen Shot 2020-10-16 at 12 44 40 AM" src="https://user-images.githubusercontent.com/40036095/96217804-fce72200-0f48-11eb-81f5-e230a77ddb2e.png">

Cohort Builder:
<img width="1184" alt="Screen Shot 2020-10-16 at 12 45 02 AM" src="https://user-images.githubusercontent.com/40036095/96217828-14260f80-0f49-11eb-8e7b-0a355e9e8fe0.png">


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] I have run and tested this change locally
