### PR TITLE
[risk=low][RW-5720] Display CDR Version name string in Workspace navbar

### DIFF
--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -16,7 +16,7 @@ import {ResetRuntimeButton} from 'app/pages/analysis/reset-runtime-button';
 import {ResearchPurpose} from 'app/pages/workspace/research-purpose';
 import {WorkspaceShare} from 'app/pages/workspace/workspace-share';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
-import {cdrVersion, reactStyles, ReactWrapperBase, withCdrVersions, withUrlParams, withUserProfile} from 'app/utils';
+import {getCdrVersion, reactStyles, ReactWrapperBase, withCdrVersions, withUrlParams, withUserProfile} from 'app/utils';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 import {
   Authority,
@@ -239,7 +239,9 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCd
           </h3>
           <div style={styles.infoBox} data-test-id='cdrVersion'>
             <div style={styles.infoBoxHeader}>Dataset</div>
-            <div style={{fontSize: '0.5rem'}}>{workspace ? cdrVersion(workspace, cdrVersionListResponse).name : 'Loading...'}</div>
+            <div style={{fontSize: '0.5rem'}}>
+              {workspace ? getCdrVersion(workspace, cdrVersionListResponse).name : 'Loading...'}
+            </div>
           </div>
           <div style={styles.infoBox} data-test-id='creationDate'>
             <div style={styles.infoBoxHeader}>Creation Date</div>

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -16,12 +16,11 @@ import {ResetRuntimeButton} from 'app/pages/analysis/reset-runtime-button';
 import {ResearchPurpose} from 'app/pages/workspace/research-purpose';
 import {WorkspaceShare} from 'app/pages/workspace/workspace-share';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
-import {reactStyles, ReactWrapperBase, withCdrVersions, withUrlParams, withUserProfile} from 'app/utils';
+import {cdrVersion, reactStyles, ReactWrapperBase, withCdrVersions, withUrlParams, withUserProfile} from 'app/utils';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 import {
   Authority,
   BillingAccountType,
-  CdrVersion,
   CdrVersionListResponse,
   Profile,
   UserRole,
@@ -36,7 +35,6 @@ interface WorkspaceProps {
 
 interface WorkspaceState {
   sharing: boolean;
-  cdrVersion: CdrVersion;
   workspace: WorkspaceData;
   workspaceFreeTierUsage: number;
   workspaceUserRoles: UserRole[];
@@ -104,7 +102,6 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCd
     super(props);
     this.state = {
       sharing: false,
-      cdrVersion: undefined,
       workspace: undefined,
       workspaceFreeTierUsage: undefined,
       workspaceUserRoles: [],
@@ -117,8 +114,6 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCd
     await this.reloadWorkspace(currentWorkspaceStore.getValue());
     this.loadFreeTierUsage();
     this.loadUserRoles();
-    const cdrs = this.props.cdrVersionListResponse.items;
-    this.setState({cdrVersion: cdrs.find(v => v.cdrVersionId === this.state.workspace.cdrVersionId)});
   }
 
   async loadFreeTierUsage() {
@@ -204,8 +199,8 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCd
   }
 
   render() {
-    const {profileState: {profile}} = this.props;
-    const {cdrVersion, workspace, workspaceUserRoles, sharing, publishing} = this.state;
+    const {profileState: {profile}, cdrVersionListResponse} = this.props;
+    const {workspace, workspaceUserRoles, sharing, publishing} = this.state;
     return <div style={styles.mainPage}>
       <FlexColumn style={{margin: '1rem', width: '98%'}}>
         <ResearchPurpose data-test-id='researchPurpose'/>
@@ -244,7 +239,7 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCd
           </h3>
           <div style={styles.infoBox} data-test-id='cdrVersion'>
             <div style={styles.infoBoxHeader}>Dataset</div>
-            <div style={{fontSize: '0.5rem'}}>{cdrVersion ? cdrVersion.name : 'Loading...'}</div>
+            <div style={{fontSize: '0.5rem'}}>{workspace ? cdrVersion(workspace, cdrVersionListResponse).name : 'Loading...'}</div>
           </div>
           <div style={styles.infoBox} data-test-id='creationDate'>
             <div style={styles.infoBoxHeader}>Creation Date</div>

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -4,6 +4,9 @@ import {mount} from 'enzyme';
 import * as React from 'react';
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
 import {cdrVersionListResponse} from 'testing/stubs/cdr-versions-api-stub';
+import {CdrVersionsStubVariables} from "../../../testing/stubs/cdr-versions-api-stub";
+import {WorkspaceAccessLevel} from "../../../generated/fetch";
+import {workspaceStubs} from "../../../testing/stubs/workspaces-api-stub";
 
 describe('WorkspaceNavBarComponent', () => {
 
@@ -56,5 +59,21 @@ describe('WorkspaceNavBarComponent', () => {
     expect(wrapper.find({'data-test-id': 'About'}).first().props().disabled).toBeFalsy();
 
   });
+
+  it('should display the default CDR Version', () => {
+    const wrapper = component();
+    expect(wrapper.find({'data-test-id': 'cdr-version'}).first().text())
+        .toEqual(CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION);
+  })
+
+  it('should display an alternative CDR Version', () => {
+    const altWorkspace = workspaceDataStub;
+    altWorkspace.cdrVersionId = CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION_ID;
+    currentWorkspaceStore.next(altWorkspace);
+
+    const wrapper = component();
+    expect(wrapper.find({'data-test-id': 'cdr-version'}).first().text())
+        .toEqual(CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION);
+  })
 
 });

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -1,8 +1,9 @@
 import {WorkspaceNavBarReact} from 'app/pages/workspace/workspace-nav-bar';
-import {currentWorkspaceStore, NavStore, serverConfigStore, urlParamsStore} from 'app/utils/navigation';
+import {cdrVersionStore, currentWorkspaceStore, NavStore, serverConfigStore, urlParamsStore} from 'app/utils/navigation';
 import {mount} from 'enzyme';
 import * as React from 'react';
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
+import {cdrVersionListResponse} from 'testing/stubs/cdr-versions-api-stub';
 
 describe('WorkspaceNavBarComponent', () => {
 
@@ -19,6 +20,7 @@ describe('WorkspaceNavBarComponent', () => {
     urlParamsStore.next({ns: workspaceDataStub.namespace, wsid: workspaceDataStub.id});
     serverConfigStore.next({
       gsuiteDomain: 'fake-research-aou.org', enableResearchReviewPrompt: true});
+    cdrVersionStore.next(cdrVersionListResponse);
   });
 
   it('should render', () => {

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -4,9 +4,7 @@ import {mount} from 'enzyme';
 import * as React from 'react';
 import {workspaceDataStub} from 'testing/stubs/workspaces-api-stub';
 import {cdrVersionListResponse} from 'testing/stubs/cdr-versions-api-stub';
-import {CdrVersionsStubVariables} from "../../../testing/stubs/cdr-versions-api-stub";
-import {WorkspaceAccessLevel} from "../../../generated/fetch";
-import {workspaceStubs} from "../../../testing/stubs/workspaces-api-stub";
+import {CdrVersionsStubVariables} from 'testing/stubs/cdr-versions-api-stub';
 
 describe('WorkspaceNavBarComponent', () => {
 

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -104,7 +104,9 @@ export const WorkspaceNavBarReact = fp.flow(
     {activeTabIndex > 0 && navSeparator}
     {fp.map(tab => navTab(tab, restrictTab(props.workspace, tab)), tabs)}
     <div style={{flexGrow: 1}}/>
-    {workspace && <div style={{textTransform: 'none'}}>{cdrVersion(workspace, cdrVersionListResponse).name}</div>}
+    {workspace && <div data-test-id='cdr-version' style={{textTransform: 'none'}}>
+      {cdrVersion(workspace, cdrVersionListResponse).name}
+    </div>}
   </div>;
 });
 

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -18,25 +18,42 @@ import * as React from 'react';
 
 const styles = reactStyles({
   container: {
-    display: 'flex', alignItems: 'center', backgroundColor: colors.secondary,
-    fontWeight: 500, color: 'white', textTransform: 'uppercase',
-    height: 60, paddingRight: 16,
+    display: 'flex',
+    alignItems: 'center',
+    backgroundColor: colors.secondary,
+    fontWeight: 500,
+    color: 'white',
+    textTransform: 'uppercase',
+    height: 60,
+    paddingRight: 16,
     boxShadow: 'inset rgba(0, 0, 0, 0.12) 0px 3px 2px 0px',
     width: 'calc(100% + 1.2rem)',
     marginLeft: '-0.6rem',
-    paddingLeft: 80, borderBottom: `5px solid ${colors.accent}`, flex: 'none'
+    paddingLeft: 80,
+    borderBottom: `5px solid ${colors.accent}`,
+    flex: 'none'
   },
   tab: {
-    minWidth: 140, flexGrow: 0, padding: '0 20px',
+    minWidth: 140,
+    flexGrow: 0,
+    padding: '0 20px',
     color: colors.white,
-    alignSelf: 'stretch', display: 'flex', justifyContent: 'center', alignItems: 'center'
+    alignSelf: 'stretch',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center'
   },
   active: {
-    backgroundColor: 'rgba(255,255,255,0.15)', color: 'unset',
-    borderBottom: `4px solid ${colors.accent}`, fontWeight: 'bold'
+    backgroundColor: 'rgba(255,255,255,0.15)',
+    color: 'unset',
+    borderBottom: `4px solid ${colors.accent}`,
+    fontWeight: 'bold'
   },
   separator: {
-    background: 'rgba(255,255,255,0.15)', width: 1, height: 48, flexShrink: 0
+    background: 'rgba(255,255,255,0.15)',
+    width: 1,
+    height: 48,
+    flexShrink: 0
   },
   disabled: {
     color: colors.disabled
@@ -87,7 +104,7 @@ export const WorkspaceNavBarReact = fp.flow(
     {activeTabIndex > 0 && navSeparator}
     {fp.map(tab => navTab(tab, restrictTab(props.workspace, tab)), tabs)}
     <div style={{flexGrow: 1}}/>
-    {workspace && <div>{cdrVersion(workspace, cdrVersionListResponse).name}</div>}
+    {workspace && <div style={{textTransform: 'none'}}>{cdrVersion(workspace, cdrVersionListResponse).name}</div>}
   </div>;
 });
 

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -3,7 +3,7 @@ import {Component, Input} from '@angular/core';
 import {Clickable} from 'app/components/buttons';
 import colors from 'app/styles/colors';
 import {
-  cdrVersion,
+  getCdrVersion,
   reactStyles,
   ReactWrapperBase,
   withCdrVersions,
@@ -104,9 +104,9 @@ export const WorkspaceNavBarReact = fp.flow(
     {activeTabIndex > 0 && navSeparator}
     {fp.map(tab => navTab(tab, restrictTab(props.workspace, tab)), tabs)}
     <div style={{flexGrow: 1}}/>
-    {workspace && <div data-test-id='cdr-version' style={{textTransform: 'none'}}>
-      {cdrVersion(workspace, cdrVersionListResponse).name}
-    </div>}
+    <div data-test-id='cdr-version' style={{textTransform: 'none'}}>
+      {getCdrVersion(workspace, cdrVersionListResponse).name}
+    </div>
   </div>;
 });
 

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -2,13 +2,19 @@ import {Component, Input} from '@angular/core';
 
 import {Clickable} from 'app/components/buttons';
 import colors from 'app/styles/colors';
-import {reactStyles, ReactWrapperBase, withCurrentWorkspace, withUrlParams} from 'app/utils';
+import {
+  cdrVersion,
+  reactStyles,
+  ReactWrapperBase,
+  withCdrVersions,
+  withCurrentWorkspace,
+  withUrlParams
+} from 'app/utils';
 import {NavStore} from 'app/utils/navigation';
 
 import {serverConfigStore} from 'app/utils/navigation';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-
 
 const styles = reactStyles({
   container: {
@@ -53,10 +59,10 @@ function restrictTab(workspace, tab) {
 export const WorkspaceNavBarReact = fp.flow(
   withCurrentWorkspace(),
   withUrlParams(),
+  withCdrVersions(),
 )(props => {
-  const {tabPath, urlParams: {ns: namespace, wsid: id}} = props;
+  const {tabPath, workspace, urlParams: {ns: namespace, wsid: id}, cdrVersionListResponse} = props;
   const activeTabIndex = fp.findIndex(['link', tabPath], tabs);
-
 
   const navTab = (currentTab, disabled) => {
     const {name, link} = currentTab;
@@ -81,6 +87,7 @@ export const WorkspaceNavBarReact = fp.flow(
     {activeTabIndex > 0 && navSeparator}
     {fp.map(tab => navTab(tab, restrictTab(props.workspace, tab)), tabs)}
     <div style={{flexGrow: 1}}/>
+    {workspace && <div>{cdrVersion(workspace, cdrVersionListResponse).name}</div>}
   </div>;
 });
 

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -631,6 +631,6 @@ export function validateInputForMySQL(searchString: string): Array<string> {
   return Array.from(inputErrors);
 }
 
-export function cdrVersion(workspace: Workspace, cdrs: CdrVersionListResponse): CdrVersion {
+export function getCdrVersion(workspace: Workspace, cdrs: CdrVersionListResponse): CdrVersion {
   return cdrs.items.find(v => v.cdrVersionId === workspace.cdrVersionId);
 }

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -17,9 +17,12 @@ import {
 } from 'app/utils/navigation';
 import {DataAccessLevel, Domain} from 'generated';
 import {
+  CdrVersion,
+  CdrVersionListResponse,
   ConfigResponse,
   DataAccessLevel as FetchDataAccessLevel,
   Domain as FetchDomain,
+  Workspace,
 } from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
@@ -626,4 +629,8 @@ export function validateInputForMySQL(searchString: string): Array<string> {
     inputErrors.add('There is an unclosed " in the search string');
   }
   return Array.from(inputErrors);
+}
+
+export function cdrVersion(workspace: Workspace, cdrs: CdrVersionListResponse): CdrVersion {
+  return cdrs.items.find(v => v.cdrVersionId === workspace.cdrVersionId);
 }


### PR DESCRIPTION
Description:

Also added a cdrVersion() function to utils and updated Workspace About to remove a state variable

<img width="1271" alt="cdr version in navbar" src="https://user-images.githubusercontent.com/2701406/96490037-46b45e80-120e-11eb-8cb3-bced87fd5d90.png">


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
