### PR TITLE
[RW-5758][risk=no] Render creation panel when runtime doesn't exist + related cleanup

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -65,15 +65,16 @@ describe('RuntimePanel', () => {
     expect(!wrapper.exists(Spinner));
   });
 
-  it('should render runtime details', async() => {
+  it('should show the create button when no runtime exists', async() => {
+    runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace});
+
     const wrapper = component();
     await handleUseEffect(wrapper);
     await waitOneTickAndUpdate(wrapper);
 
-    const imageDropdown = wrapper.find({'data-test-id': 'runtime-image-dropdown'}).find('label').first();
-    expect(imageDropdown.exists()).toBeTruthy();
-
-    expect(imageDropdown.text()).toContain(runtimeApiStub.runtime.toolDockerImage);
+    const createButton = wrapper.find(Button).find({'aria-label': 'Create'}).first();
+    expect(createButton.exists()).toBeTruthy();
+    expect(createButton.prop('disabled')).toBeFalsy();
   });
 
   it('should restrict memory options by cpu', async() => {

--- a/ui/src/app/utils/runtime-utils.ts
+++ b/ui/src/app/utils/runtime-utils.ts
@@ -74,7 +74,12 @@ export const useCustomRuntime = (currentWorkspaceNamespace): [Runtime, (runtime:
 
   useEffect(() => {
     const runAction = async() => {
-      await runtimeApi().deleteRuntime(currentWorkspaceNamespace);
+      // Only delete if the runtime already exists.
+      // TODO: It is likely more correct here to use the LeoRuntimeInitializer wait for the runtime
+      // to reach a terminal status before attempting deletion.
+      if (runtime && runtime.status !== RuntimeStatus.Deleted) {
+        await runtimeApi().deleteRuntime(currentWorkspaceNamespace);
+      }
       const currentRuntime = await LeoRuntimeInitializer.initialize({
         workspaceNamespace,
         targetRuntime: requestedRuntime


### PR DESCRIPTION
- toolDockerImage will not be controllable for Erwin. Later, we may allow users to change this to an older version of the image.
- remove the "application configuration" header, now that the tool docker image section is gone
- fix a few assumptions to allow the create button to be enabled and functional
- (unrelated opportunistic fix) fix preset menu dropdown being off-center