### PR TITLE
[RW-5737][risk=no] Add no results messages on concept homepage

### DIFF
--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -747,21 +747,17 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
               <div style={styles.cardList}>
                 {domainInfoError
                   ? this.errorMessage()
-                  : <React.Fragment>
-                    {conceptDomainCards
-                      .filter(domain => domain.allConceptCount !== 0)
-                      .map((domain, i) => <DomainCard conceptDomainInfo={domain}
-                                                      standardConceptsOnly={standardConceptsOnly}
-                                                      browseInDomain={() => this.browseDomain(domain)}
-                                                      key={i} data-test-id='domain-box'
-                                                      updating={domainsLoading.includes(domain.domain)}/>)}
-                    {conceptDomainCards.every(domain => domain.allConceptCount === 0) && <div>
-                      {conceptDomainCards.some(domain => domainsLoading.includes(domain.domain))
-                        ? <Spinner size={42}/>
-                        : 'No Domain Results. Please type in a new search term.'
-                      }
-                    </div>}
-                  </React.Fragment>
+                  : conceptDomainCards.some(domain => domainsLoading.includes(domain.domain))
+                    ? <Spinner size={42}/>
+                    : conceptDomainCards.every(domain => domain.allConceptCount === 0)
+                      ? 'No Domain Results. Please type in a new search term.'
+                      : conceptDomainCards
+                        .filter(domain => domain.allConceptCount !== 0)
+                        .map((domain, i) => <DomainCard conceptDomainInfo={domain}
+                                                        standardConceptsOnly={standardConceptsOnly}
+                                                        browseInDomain={() => this.browseDomain(domain)}
+                                                        key={i} data-test-id='domain-box'
+                                                        updating={domainsLoading.includes(domain.domain)}/>)
                 }
               </div>
               <div style={styles.sectionHeader}>
@@ -770,39 +766,32 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
               <div style={styles.cardList}>
                 {surveyInfoError
                   ? this.errorMessage()
-                  : <React.Fragment>
-                    {conceptSurveysList
-                      .filter(survey => survey.questionCount > 0)
-                      .map((survey) => <SurveyCard survey={survey}
-                                                   key={survey.orderNumber}
-                                                   browseSurvey={() => this.browseSurvey(survey.name)}
-                                                   updating={surveysLoading.includes(survey.name)}/>)}
-                    {conceptSurveysList.every(survey => survey.questionCount === 0) && <div>
-                      {conceptSurveysList.some(survey => surveysLoading.includes(survey.name))
-                        ? <Spinner size={42}/>
-                        : 'No Survey Question Results. Please type in a new search term.'
-                      }
-                    </div>}
-                  </React.Fragment>
+                  : conceptSurveysList.some(survey => surveysLoading.includes(survey.name))
+                    ? <Spinner size={42}/>
+                    : conceptSurveysList.every(survey => survey.questionCount === 0)
+                      ? 'No Survey Question Results. Please type in a new search term.'
+                      : conceptSurveysList
+                        .filter(survey => survey.questionCount > 0)
+                        .map((survey) => <SurveyCard survey={survey}
+                                                     key={survey.orderNumber}
+                                                     browseSurvey={() => this.browseSurvey(survey.name)}
+                                                     updating={surveysLoading.includes(survey.name)}/>)
                 }
-               </div>
-              {environment.enableNewConceptTabs && <React.Fragment>
+              </div>
+              {environment.enableNewConceptTabs && !!physicalMeasurementsCard && <React.Fragment>
                 <div style={styles.sectionHeader}>
                   Program Physical Measurements
                 </div>
-                <div style={styles.cardList}>
+                <div style={{...styles.cardList, marginBottom: '1rem'}}>
                   {domainInfoError
                     ? this.errorMessage()
-                    : !!physicalMeasurementsCard && (physicalMeasurementsCard.allConceptCount !== 0
-                      ? <PhysicalMeasurementsCard physicalMeasurement={physicalMeasurementsCard}
-                                                browsePhysicalMeasurements={() => this.browseDomain(physicalMeasurementsCard)}
-                                                updating={domainsLoading.includes(Domain.PHYSICALMEASUREMENT)}/>
-                    : <div style={{marginBottom: '1rem'}}>
-                      {domainsLoading.includes(Domain.PHYSICALMEASUREMENT)
-                        ? <Spinner size={42}/>
-                        : 'No Program Physical Measurement Results. Please type in a new search term.'
-                      }
-                    </div>)
+                    : domainsLoading.includes(Domain.PHYSICALMEASUREMENT)
+                      ? <Spinner size={42}/>
+                      : physicalMeasurementsCard.allConceptCount === 0
+                        ? 'No Program Physical Measurement Results. Please type in a new search term.'
+                        : <PhysicalMeasurementsCard physicalMeasurement={physicalMeasurementsCard}
+                                                    browsePhysicalMeasurements={() => this.browseDomain(physicalMeasurementsCard)}
+                                                    updating={domainsLoading.includes(Domain.PHYSICALMEASUREMENT)}/>
                   }
                 </div>
               </React.Fragment>}

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -683,6 +683,8 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
         currentInputString, currentSearchString, domainInfoError, domainsLoading, inputErrors, loadingDomains, surveyInfoError,
         standardConceptsOnly, showSearchError, searching, selectedDomain, selectedSurvey, selectedConceptDomainMap, selectedSurveyQuestions,
         surveyAddModalOpen, surveysLoading} = this.state;
+      const conceptDomainCards = conceptDomainList.filter(domain => domain.domain !== Domain.PHYSICALMEASUREMENT);
+      const physicalMeasurementsCard = conceptDomainList.find(domain => domain.domain === Domain.PHYSICALMEASUREMENT);
       return <React.Fragment>
         <FadeBox style={{margin: 'auto', paddingTop: '1rem', width: '95.7%'}}>
           <FlexRow>
@@ -745,13 +747,21 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
               <div style={styles.cardList}>
                 {domainInfoError
                   ? this.errorMessage()
-                  : conceptDomainList
-                    .filter(item => item.domain !== Domain.PHYSICALMEASUREMENT && item.allConceptCount !== 0)
-                    .map((domain, i) => <DomainCard conceptDomainInfo={domain}
-                                                    standardConceptsOnly={standardConceptsOnly}
-                                                    browseInDomain={() => this.browseDomain(domain)}
-                                                    key={i} data-test-id='domain-box'
-                                                    updating={domainsLoading.includes(domain.domain)}/>)
+                  : <React.Fragment>
+                    {conceptDomainCards
+                      .filter(domain => domain.allConceptCount !== 0)
+                      .map((domain, i) => <DomainCard conceptDomainInfo={domain}
+                                                      standardConceptsOnly={standardConceptsOnly}
+                                                      browseInDomain={() => this.browseDomain(domain)}
+                                                      key={i} data-test-id='domain-box'
+                                                      updating={domainsLoading.includes(domain.domain)}/>)}
+                    {conceptDomainCards.every(domain => domain.allConceptCount === 0) && <div>
+                      {conceptDomainCards.some(domain => domainsLoading.includes(domain.domain))
+                        ? <Spinner size={42}/>
+                        : 'No Domain Results. Please type in a new search term.'
+                      }
+                    </div>}
+                  </React.Fragment>
                 }
               </div>
               <div style={styles.sectionHeader}>
@@ -770,7 +780,7 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
                     {conceptSurveysList.every(survey => survey.questionCount === 0) && <div>
                       {conceptSurveysList.some(survey => surveysLoading.includes(survey.name))
                         ? <Spinner size={42}/>
-                        : 'No Survey Questions found'
+                        : 'No Survey Question Results. Please type in a new search term.'
                       }
                     </div>}
                   </React.Fragment>
@@ -783,13 +793,16 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
                 <div style={styles.cardList}>
                   {domainInfoError
                     ? this.errorMessage()
-                    : conceptDomainList
-                      .filter(item => item.domain === Domain.PHYSICALMEASUREMENT && item.allConceptCount !== 0)
-                      .map((physicalMeasurement, p) =>
-                        <PhysicalMeasurementsCard physicalMeasurement={physicalMeasurement}
-                                                  key={p}
-                                                  browsePhysicalMeasurements={() => this.browseDomain(physicalMeasurement)}
-                                                  updating={domainsLoading.includes(Domain.PHYSICALMEASUREMENT)}/>)
+                    : !!physicalMeasurementsCard && (physicalMeasurementsCard.allConceptCount !== 0
+                      ? <PhysicalMeasurementsCard physicalMeasurement={physicalMeasurementsCard}
+                                                browsePhysicalMeasurements={() => this.browseDomain(physicalMeasurementsCard)}
+                                                updating={domainsLoading.includes(Domain.PHYSICALMEASUREMENT)}/>
+                    : <div style={{marginBottom: '1rem'}}>
+                      {domainsLoading.includes(Domain.PHYSICALMEASUREMENT)
+                        ? <Spinner size={42}/>
+                        : 'No Program Physical Measurement Results. Please type in a new search term.'
+                      }
+                    </div>)
                   }
                 </div>
               </React.Fragment>}

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -760,12 +760,20 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
               <div style={styles.cardList}>
                 {surveyInfoError
                   ? this.errorMessage()
-                  : conceptSurveysList
-                    .filter(survey => survey.questionCount > 0)
-                    .map((survey) => <SurveyCard survey={survey}
-                                                  key={survey.orderNumber}
-                                                  browseSurvey={() => this.browseSurvey(survey.name)}
-                                                  updating={surveysLoading.includes(survey.name)}/>)
+                  : <React.Fragment>
+                    {conceptSurveysList
+                      .filter(survey => survey.questionCount > 0)
+                      .map((survey) => <SurveyCard survey={survey}
+                                                   key={survey.orderNumber}
+                                                   browseSurvey={() => this.browseSurvey(survey.name)}
+                                                   updating={surveysLoading.includes(survey.name)}/>)}
+                    {conceptSurveysList.every(survey => survey.questionCount === 0) && <div>
+                      {conceptSurveysList.some(survey => surveysLoading.includes(survey.name))
+                        ? <Spinner size={42}/>
+                        : 'No Survey Questions found'
+                      }
+                    </div>}
+                  </React.Fragment>
                 }
                </div>
               {environment.enableNewConceptTabs && <React.Fragment>


### PR DESCRIPTION
Show message if there are no cards with counts for any of the three sections. Used same message format as Data Browser.

Example if all sections are empty:
<img width="1306" alt="Screen Shot 2020-10-20 at 9 58 33 AM" src="https://user-images.githubusercontent.com/40036095/96615208-9c4c4200-12c6-11eb-90dd-4f9f6e4e15de.png">

When searching a new term after getting no results, will show a single spinner for each empty section since there are no cards:
<img width="1311" alt="Screen Shot 2020-10-20 at 10 00 05 AM" src="https://user-images.githubusercontent.com/40036095/96615358-c9005980-12c6-11eb-8b96-b8e25940a43d.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
