### PR TITLE
[risk=no] Guard against race condition preventing navbar rendering

### DIFF
--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -240,7 +240,7 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCd
           <div style={styles.infoBox} data-test-id='cdrVersion'>
             <div style={styles.infoBoxHeader}>Dataset</div>
             <div style={{fontSize: '0.5rem'}}>
-              {(workspace && cdrVersionListResponse) ? getCdrVersion(workspace, cdrVersionListResponse).name : 'Loading...'}
+              {workspace ? getCdrVersion(workspace, cdrVersionListResponse).name : 'Loading...'}
             </div>
           </div>
           <div style={styles.infoBox} data-test-id='creationDate'>

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -240,7 +240,7 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCd
           <div style={styles.infoBox} data-test-id='cdrVersion'>
             <div style={styles.infoBoxHeader}>Dataset</div>
             <div style={{fontSize: '0.5rem'}}>
-              {workspace ? getCdrVersion(workspace, cdrVersionListResponse).name : 'Loading...'}
+              {(workspace && cdrVersionListResponse) ? getCdrVersion(workspace, cdrVersionListResponse).name : 'Loading...'}
             </div>
           </div>
           <div style={styles.infoBox} data-test-id='creationDate'>

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -104,9 +104,9 @@ export const WorkspaceNavBarReact = fp.flow(
     {activeTabIndex > 0 && navSeparator}
     {fp.map(tab => navTab(tab, restrictTab(props.workspace, tab)), tabs)}
     <div style={{flexGrow: 1}}/>
-    <div data-test-id='cdr-version' style={{textTransform: 'none'}}>
+    {workspace && cdrVersionListResponse && <div data-test-id='cdr-version' style={{textTransform: 'none'}}>
       {getCdrVersion(workspace, cdrVersionListResponse).name}
-    </div>
+    </div>}
   </div>;
 });
 

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -104,7 +104,7 @@ export const WorkspaceNavBarReact = fp.flow(
     {activeTabIndex > 0 && navSeparator}
     {fp.map(tab => navTab(tab, restrictTab(props.workspace, tab)), tabs)}
     <div style={{flexGrow: 1}}/>
-    {workspace && cdrVersionListResponse && <div data-test-id='cdr-version' style={{textTransform: 'none'}}>
+    {workspace && <div data-test-id='cdr-version' style={{textTransform: 'none'}}>
       {getCdrVersion(workspace, cdrVersionListResponse).name}
     </div>}
   </div>;


### PR DESCRIPTION
Fix bug introduced in #4186 - ~if `cdrVersionListResponse` was not yet available, the navbar wouldn't render.
Workspace About may have this same problem, so I also fixed that.~
* if `workspace` was not yet available, the navbar wouldn't render.


Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
