### PR TITLE
[risk=low] Update codegen for image changes and quality of life

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -75,6 +76,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
+
   private static final String CDR_STRING = "\\$\\{projectId}.\\$\\{dataSetId}.";
   private static final String PYTHON_CDR_ENV_VARIABLE =
       "\"\"\" + os.environ[\"WORKSPACE_CDR\"] + \"\"\".";
@@ -114,6 +116,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
    */
   @VisibleForTesting
   private static class ValuesLinkingPair {
+
     private List<String> selects;
     private List<String> joins;
 
@@ -145,6 +148,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
    * A subclass used to store a source and a standard concept ID column name.
    */
   private static class DomainConceptIdInfo {
+
     private String sourceConceptIdColumn;
     private String standardConceptIdColumn;
 
@@ -164,6 +168,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
 
   @VisibleForTesting
   public static class QueryAndParameters {
+
     private final String query;
     private final Map<String, QueryParameterValue> namedParameterValues;
 
@@ -721,6 +726,10 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     final String cohortSampleNamesFilename = "cohort_sample_names_" + qualifier + ".txt";
     final String cohortSampleMapFilename = "cohort_sample_map_" + qualifier + ".csv";
     final String cohortVcfFilename = "cohort_" + qualifier + ".vcf";
+    // TODO(RW-5735): Writing to the "tmp" dataset is a temporary workaround.
+    final String cohortExtractTable =
+        "fc-aou-cdr-synth-test.tmp_shared_cohort_extract."
+            + UUID.randomUUID().toString().replace("-", "_");
 
     return ImmutableList.of(
         "person_ids = set()\n"
@@ -740,41 +749,36 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
             + "    for person_id in person_ids:\n"
             + "        cohort_file.write(str(person_id) + '\\n')\n"
             + "    cohort_file.close()\n",
-        "%%bash\n\n"
-            + "uuid=$(cat /proc/sys/kernel/random/uuid | sed s/-/_/g)\n"
-            // TODO: Writing to the "tmp" dataset is a temporary workaround until an alternative,
-            // RW-5735
-            + "EXPORT_TABLE=\"fc-aou-cdr-synth-test.tmp_shared_cohort_extract.${uuid}\"\n"
-            + "\n"
-            + "python3 /genomics/microarray/raw_array_cohort_extract.py \\\n"
+        "!python3 /usr/local/share/raw_array_cohort_extract.py \\\n"
             + "          --dataset fc-aou-cdr-synth-test.microarray_data \\\n"
-            + "          --fq_destination_table ${EXPORT_TABLE} \\\n"
+            + "          --fq_destination_table "
+            + cohortExtractTable
+            + " \\\n"
             + "          --query_project ${GOOGLE_PROJECT} \\\n"
             // TODO: Replace hardcoded dataset reference: RW-5748
-            + "          --sample_mapping_table fc-aou-cdr-synth-test.microarray_data.sample_list \\\n"
+            + "          --fq_sample_mapping_table fc-aou-cdr-synth-test.microarray_data.sample_list \\\n"
             + "          --cohort_sample_names_file "
             + cohortSampleNamesFilename
             + " \\\n"
             + "          --sample_map_outfile "
             + cohortSampleMapFilename
-            + "\n"
-            + "\n"
-            + "gatk ArrayExtractCohort \\\n"
+            + "\n",
+        "!java -jar ${GATK_LOCAL_JAR} ArrayExtractCohort \\\n"
+            // TODO: This value will need to be tuned per environment.
             + "        -R gs://fc-aou-cdr-synth-test-genomics/extract_resources/Homo_sapiens_assembly19.fasta \\\n"
             + "        -O "
             + cohortVcfFilename
             + " \\\n"
-            + "        --probe-info-csv /genomics/microarray/probe_info.csv \\\n"
+            + "        --probe-info-table fc-aou-cdr-synth-test.microarray_data.probe_info \\\n"
             + "        --read-project-id ${GOOGLE_PROJECT} \\\n"
             + "        --cohort-sample-file "
             + cohortSampleMapFilename
             + " \\\n"
             + "        --use-compressed-data \"false\" \\\n"
-            + "        --cohort-extract-table ${EXPORT_TABLE} \\\n"
-            + "\n"
-            + "gsutil cp "
-            + cohortVcfFilename
-            + " ${WORKSPACE_BUCKET}/");
+            + "        --cohort-extract-table "
+            + cohortExtractTable
+            + "\n",
+        "!gsutil cp " + cohortVcfFilename + " ${WORKSPACE_BUCKET}/cohort-extract/");
   }
 
   @Override
@@ -847,7 +851,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
             + "\n"
             + "hl.plot.output_notebook()\n"
             + "bucket = os.environ['WORKSPACE_BUCKET']\n"
-            + "hl.import_vcf(f'{bucket}/"
+            + "hl.import_vcf(f'{bucket}/cohort-extract"
             + cohortVcfFilename
             + "').write(f'{bucket}/"
             + cohortMatrixFilename

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -750,13 +750,13 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
             + "        cohort_file.write(str(person_id) + '\\n')\n"
             + "    cohort_file.close()\n",
         "!python3 /usr/local/share/raw_array_cohort_extract.py \\\n"
-            + "          --dataset fc-aou-cdr-synth-test.microarray_data \\\n"
+            + "          --dataset fc-aou-cdr-synth-test.synthetic_microarray_data \\\n"
             + "          --fq_destination_table "
             + cohortExtractTable
             + " \\\n"
             + "          --query_project ${GOOGLE_PROJECT} \\\n"
             // TODO: Replace hardcoded dataset reference: RW-5748
-            + "          --fq_sample_mapping_table fc-aou-cdr-synth-test.microarray_data.sample_list \\\n"
+            + "          --fq_sample_mapping_table fc-aou-cdr-synth-test.synthetic_microarray_data.sample_list \\\n"
             + "          --cohort_sample_names_file "
             + cohortSampleNamesFilename
             + " \\\n"
@@ -769,7 +769,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
             + "        -O "
             + cohortVcfFilename
             + " \\\n"
-            + "        --probe-info-table fc-aou-cdr-synth-test.microarray_data.probe_info \\\n"
+            + "        --probe-info-table fc-aou-cdr-synth-test.synthetic_microarray_data.probe_info \\\n"
             + "        --read-project-id ${GOOGLE_PROJECT} \\\n"
             + "        --cohort-sample-file "
             + cohortSampleMapFilename
@@ -851,7 +851,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
             + "\n"
             + "hl.plot.output_notebook()\n"
             + "bucket = os.environ['WORKSPACE_BUCKET']\n"
-            + "hl.import_vcf(f'{bucket}/cohort-extract"
+            + "hl.import_vcf(f'{bucket}/cohort-extract/"
             + cohortVcfFilename
             + "').write(f'{bucket}/"
             + cohortMatrixFilename

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -787,10 +787,10 @@ public class DataSetControllerTest {
 
     List<String> codeCells = notebookContentsToStrings(notebookContentsCaptor.getValue());
 
-    assertThat(codeCells.size()).isEqualTo(3);
+    assertThat(codeCells.size()).isEqualTo(5);
     assertThat(codeCells.get(2)).contains("raw_array_cohort_extract.py");
-    assertThat(codeCells.get(2)).contains("gatk ArrayExtractCohort");
-    assertThat(codeCells.get(2)).contains("gsutil cp");
+    assertThat(codeCells.get(3)).contains("ArrayExtractCohort");
+    assertThat(codeCells.get(4)).contains("gsutil cp");
   }
 
   @Test
@@ -810,11 +810,11 @@ public class DataSetControllerTest {
 
     List<String> codeCells = notebookContentsToStrings(notebookContentsCaptor.getValue());
 
-    assertThat(codeCells.size()).isEqualTo(5);
-    assertThat(codeCells.get(2)).contains("gatk ArrayExtractCohort");
-    assertThat(codeCells.get(3)).contains("cohort_phenotypes.to_csv");
-    assertThat(codeCells.get(3)).contains(".phe");
-    assertThat(codeCells.get(4)).contains("plink");
+    assertThat(codeCells.size()).isEqualTo(7);
+    assertThat(codeCells.get(3)).contains("ArrayExtractCohort");
+    assertThat(codeCells.get(5)).contains("cohort_phenotypes.to_csv");
+    assertThat(codeCells.get(5)).contains(".phe");
+    assertThat(codeCells.get(6)).contains("plink");
   }
 
   List<String> notebookContentsToStrings(JSONObject notebookContents) {
@@ -852,11 +852,11 @@ public class DataSetControllerTest {
 
     List<String> codeCells = notebookContentsToStrings(notebookContentsCaptor.getValue());
 
-    assertThat(codeCells.size()).isEqualTo(5);
-    assertThat(codeCells.get(2)).contains("gatk ArrayExtractCohort");
-    assertThat(codeCells.get(3)).contains("cohort_phenotypes.to_csv");
-    assertThat(codeCells.get(3)).contains(".tsv");
-    assertThat(codeCells.get(4)).contains("import hail as hl");
+    assertThat(codeCells.size()).isEqualTo(7);
+    assertThat(codeCells.get(3)).contains("ArrayExtractCohort");
+    assertThat(codeCells.get(5)).contains("cohort_phenotypes.to_csv");
+    assertThat(codeCells.get(5)).contains(".tsv");
+    assertThat(codeCells.get(6)).contains("import hail as hl");
   }
 
   @Test


### PR DESCRIPTION
- Switch to mostly `!` over `%%bash`. I didn't realize this initially, but `!` streams stdout/stderr, while `%%bash` doesn't, which is critical here.
- As a side-effect of that change, make the UUID generation hardcoded across cells
- Update flags per new image locations, flag changes, and other discussion
- Put VCF extracts into a separate folder; may want similar treatment for .mt and .phe files, not sure yet.

Also related find, can add these flags to the GATK extract to subset the data:
```
        --min-probe-id "0" \
        --max-probe-id "20000" \ # up to ~1.9m
```