### PR TITLE
[risk=low][RW-5561] Fix for Copy Notebook from Analysis page

### DIFF
--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5785,6 +5785,13 @@ definitions:
       "$ref": "#/definitions/WorkspaceResource"
   WorkspaceResource:
     type: object
+    required:
+      - workspaceNamespace
+      - workspaceFirecloudName
+      - workspaceBillingStatus
+      - cdrVersionId
+      - permission
+      - modifiedTime
     properties:
       workspaceId:
         type: integer

--- a/ui/src/app/components/resource-card.spec.tsx
+++ b/ui/src/app/components/resource-card.spec.tsx
@@ -5,6 +5,7 @@ import {cohortReviewStubs} from 'testing/stubs/cohort-review-service-stub';
 import {CohortsApiStub} from 'testing/stubs/cohorts-api-stub';
 import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
 import {ResourceCard} from './resource-card';
+import {BillingStatus,WorkspaceResource} from 'generated/fetch';
 
 const ResourceCardWrapper = {
   cohortCard: {
@@ -12,77 +13,85 @@ const ResourceCardWrapper = {
     workspaceNamespace: 'defaultNamespace',
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'OWNER',
+    workspaceBillingStatus: BillingStatus.ACTIVE,
     cohort: new CohortsApiStub().cohorts[0],
     modifiedTime: new Date().toISOString()
-  },
+  } as WorkspaceResource,
   readonlyCohortCard: {
     workspaceId: 1,
     workspaceNamespace: 'defaultNamespace',
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'READER',
+    workspaceBillingStatus: BillingStatus.ACTIVE,
     cohort: new CohortsApiStub().cohorts[0],
     modifiedTime: new Date().toISOString()
-  },
+  } as WorkspaceResource,
   cohortReviewCard: {
     workspaceId: 1,
     workspaceNamespace: 'defaultNamespace',
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'OWNER',
+    workspaceBillingStatus: BillingStatus.ACTIVE,
     cohortReview: cohortReviewStubs[0],
     modifiedTime: new Date().toISOString()
-  },
+  } as WorkspaceResource,
   readonlyCohortReviewCard: {
     workspaceId: 1,
     workspaceNamespace: 'defaultNamespace',
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'READER',
+    workspaceBillingStatus: BillingStatus.ACTIVE,
     cohortReview: cohortReviewStubs[0],
     modifiedTime: new Date().toISOString()
-  },
+  } as WorkspaceResource,
   conceptSetCard: {
     workspaceId: 1,
     workspaceNamespace: 'defaultNamespace',
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'OWNER',
+    workspaceBillingStatus: BillingStatus.ACTIVE,
     conceptSet: new ConceptSetsApiStub().conceptSets[0],
     modifiedTime: new Date().toISOString()
-  },
+  } as WorkspaceResource,
   readonlyConceptSetCard: {
     workspaceId: 1,
     workspaceNamespace: 'defaultNamespace',
     workspaceFirecloudName: 'defaultFire cloudName',
     permission: 'READER',
+    workspaceBillingStatus: BillingStatus.ACTIVE,
     conceptSet: new ConceptSetsApiStub().conceptSets[0],
     modifiedTime: new Date().toISOString()
-  },
+  } as WorkspaceResource,
   notebookCard: {
     workspaceId: 1,
     workspaceNamespace: 'defaultNamespace',
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'OWNER',
+    workspaceBillingStatus: BillingStatus.ACTIVE,
     notebook: {
       'name': 'mockFile.ipynb',
       'path': 'gs://bucket/notebooks/mockFile.ipynb',
       'lastModifiedTime': 100
     },
     modifiedTime: new Date().toISOString()
-  },
+  } as WorkspaceResource,
   readonlyNotebookCard: {
     workspaceId: 1,
     workspaceNamespace: 'defaultNamespace',
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'READER',
+    workspaceBillingStatus: BillingStatus.ACTIVE,
     notebook: {
       'name': 'mockFile.ipynb',
       'path': 'gs://bucket/notebooks/mockFile.ipynb',
       'lastModifiedTime': 100
     },
     modifiedTime: new Date().toISOString()
-  }
+  } as WorkspaceResource,
 };
 
 describe('ResourceCardComponent', () => {
-  const component = (resourceCard: Object) => {
+  const component = (resourceCard: WorkspaceResource) => {
     return mount(<ResourceCard
         onDuplicateResource={() => {}}
         resourceCard={resourceCard}

--- a/ui/src/app/components/resource-card.spec.tsx
+++ b/ui/src/app/components/resource-card.spec.tsx
@@ -6,6 +6,7 @@ import {CohortsApiStub} from 'testing/stubs/cohorts-api-stub';
 import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
 import {ResourceCard} from './resource-card';
 import {BillingStatus,WorkspaceResource} from 'generated/fetch';
+import {CdrVersionsStubVariables} from "../../testing/stubs/cdr-versions-api-stub";
 
 const ResourceCardWrapper = {
   cohortCard: {
@@ -14,6 +15,7 @@ const ResourceCardWrapper = {
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'OWNER',
     workspaceBillingStatus: BillingStatus.ACTIVE,
+    cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     cohort: new CohortsApiStub().cohorts[0],
     modifiedTime: new Date().toISOString()
   } as WorkspaceResource,
@@ -23,6 +25,7 @@ const ResourceCardWrapper = {
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'READER',
     workspaceBillingStatus: BillingStatus.ACTIVE,
+    cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     cohort: new CohortsApiStub().cohorts[0],
     modifiedTime: new Date().toISOString()
   } as WorkspaceResource,
@@ -32,6 +35,7 @@ const ResourceCardWrapper = {
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'OWNER',
     workspaceBillingStatus: BillingStatus.ACTIVE,
+    cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     cohortReview: cohortReviewStubs[0],
     modifiedTime: new Date().toISOString()
   } as WorkspaceResource,
@@ -41,6 +45,7 @@ const ResourceCardWrapper = {
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'READER',
     workspaceBillingStatus: BillingStatus.ACTIVE,
+    cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     cohortReview: cohortReviewStubs[0],
     modifiedTime: new Date().toISOString()
   } as WorkspaceResource,
@@ -50,6 +55,7 @@ const ResourceCardWrapper = {
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'OWNER',
     workspaceBillingStatus: BillingStatus.ACTIVE,
+    cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     conceptSet: new ConceptSetsApiStub().conceptSets[0],
     modifiedTime: new Date().toISOString()
   } as WorkspaceResource,
@@ -59,6 +65,7 @@ const ResourceCardWrapper = {
     workspaceFirecloudName: 'defaultFire cloudName',
     permission: 'READER',
     workspaceBillingStatus: BillingStatus.ACTIVE,
+    cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     conceptSet: new ConceptSetsApiStub().conceptSets[0],
     modifiedTime: new Date().toISOString()
   } as WorkspaceResource,
@@ -68,6 +75,7 @@ const ResourceCardWrapper = {
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'OWNER',
     workspaceBillingStatus: BillingStatus.ACTIVE,
+    cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     notebook: {
       'name': 'mockFile.ipynb',
       'path': 'gs://bucket/notebooks/mockFile.ipynb',
@@ -81,6 +89,7 @@ const ResourceCardWrapper = {
     workspaceFirecloudName: 'defaultFirecloudName',
     permission: 'READER',
     workspaceBillingStatus: BillingStatus.ACTIVE,
+    cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     notebook: {
       'name': 'mockFile.ipynb',
       'path': 'gs://bucket/notebooks/mockFile.ipynb',

--- a/ui/src/app/pages/analysis/notebook-list.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.tsx
@@ -13,12 +13,11 @@ import {withCurrentWorkspace} from 'app/utils';
 import {convertToResource} from 'app/utils/resourceActions';
 import {WorkspaceData} from 'app/utils/workspace-data';
 
-
 import {NotebookResourceCard} from 'app/pages/analysis/notebook-resource-card';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {ACTION_DISABLED_INVALID_BILLING} from 'app/utils/strings';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
-import {BillingStatus, FileDetail, ResourceType, WorkspaceAccessLevel} from 'generated/fetch';
+import {BillingStatus, FileDetail, ResourceType} from 'generated/fetch';
 
 const styles = {
   heading: {
@@ -84,10 +83,8 @@ export const NotebookList = withCurrentWorkspace()(class extends React.Component
   }
 
   render() {
-    const {workspace, workspace: {namespace, id, accessLevel, cdrVersionId}} = this.props;
+    const {workspace} = this.props;
     const {notebookList, notebookNameList, creating, loading} = this.state;
-    // TODO Remove this cast when we switch to fetch types
-    const al = accessLevel as unknown as WorkspaceAccessLevel;
     return <FadeBox style={{margin: 'auto', marginTop: '1rem', width: '95.7%'}}>
       <div style={styles.heading}>
         Notebooks&nbsp;
@@ -114,7 +111,7 @@ export const NotebookList = withCurrentWorkspace()(class extends React.Component
           {notebookList.map((notebook, index) => {
             return <NotebookResourceCard
               key={index}
-              resource={convertToResource(notebook, namespace, id, cdrVersionId, al, ResourceType.NOTEBOOK)}
+              resource={convertToResource(notebook, ResourceType.NOTEBOOK, workspace)}
               existingNameList={notebookNameList}
               onUpdate={() => this.loadNotebooks()}
               disableDuplicate={workspace.billingStatus === BillingStatus.INACTIVE}

--- a/ui/src/app/pages/analysis/notebook-list.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.tsx
@@ -84,7 +84,7 @@ export const NotebookList = withCurrentWorkspace()(class extends React.Component
   }
 
   render() {
-    const {workspace, workspace: {namespace, id, accessLevel}} = this.props;
+    const {workspace, workspace: {namespace, id, accessLevel, cdrVersionId}} = this.props;
     const {notebookList, notebookNameList, creating, loading} = this.state;
     // TODO Remove this cast when we switch to fetch types
     const al = accessLevel as unknown as WorkspaceAccessLevel;
@@ -114,7 +114,7 @@ export const NotebookList = withCurrentWorkspace()(class extends React.Component
           {notebookList.map((notebook, index) => {
             return <NotebookResourceCard
               key={index}
-              resource={convertToResource(notebook, namespace, id, al, ResourceType.NOTEBOOK)}
+              resource={convertToResource(notebook, namespace, id, cdrVersionId, al, ResourceType.NOTEBOOK)}
               existingNameList={notebookNameList}
               onUpdate={() => this.loadNotebooks()}
               disableDuplicate={workspace.billingStatus === BillingStatus.INACTIVE}

--- a/ui/src/app/utils/resourceActions.ts
+++ b/ui/src/app/utils/resourceActions.ts
@@ -8,6 +8,7 @@ import {
   WorkspaceAccessLevel,
   WorkspaceResource
 } from 'generated/fetch';
+import {WorkspaceData} from './workspace-data';
 
 export function toDisplay(resourceType: ResourceType): string {
   switch (resourceType) {
@@ -32,30 +33,23 @@ export function toDisplay(resourceType: ResourceType): string {
 
 export interface ConvertToResourcesArgs {
   list:  FileDetail[] | Cohort[] | CohortReview[] | ConceptSet[] | DataSet[];
-  workspaceNamespace: string;
-  workspaceId: string;
-  cdrVersionId: string;
-  accessLevel: WorkspaceAccessLevel;
   resourceType: ResourceType;
+  workspace: WorkspaceData;
 }
 
 export function convertToResources(args: ConvertToResourcesArgs): WorkspaceResource[] {
   const resourceList = [];
   for (const resource of args.list) {
-    resourceList.push(convertToResource(
-      resource, args.workspaceNamespace, args.workspaceId, args.cdrVersionId, args.accessLevel, args.resourceType));
+    resourceList.push(convertToResource(resource, args.resourceType, args.workspace));
   }
   return resourceList;
 }
 
 export function convertToResource(
   resource: FileDetail | Cohort | CohortReview | ConceptSet | DataSet,
-  workspaceNamespace: string,
-  workspaceId: string,
-  cdrVersionId: string,
-  accessLevel: WorkspaceAccessLevel,
-  resourceType: ResourceType): WorkspaceResource {
-
+  resourceType: ResourceType,
+  workspace: WorkspaceData): WorkspaceResource {
+  const {namespace, id, accessLevel, cdrVersionId, billingStatus} = workspace;
   let modifiedTime: string;
   if (!resource.lastModifiedTime) {
     modifiedTime = new Date().toDateString();
@@ -63,11 +57,12 @@ export function convertToResource(
     modifiedTime = new Date(resource.lastModifiedTime).toString();
   }
   const newResource: WorkspaceResource = {
-    workspaceNamespace: workspaceNamespace,
-    workspaceFirecloudName: workspaceId,
+    workspaceNamespace: namespace,
+    workspaceFirecloudName: id,
     permission: WorkspaceAccessLevel[accessLevel],
-    modifiedTime: modifiedTime,
-    cdrVersionId
+    modifiedTime,
+    cdrVersionId,
+    workspaceBillingStatus: billingStatus,
   };
   if (resourceType === ResourceType.NOTEBOOK) {
     newResource.notebook = <FileDetail>resource;

--- a/ui/src/app/utils/resourceActions.ts
+++ b/ui/src/app/utils/resourceActions.ts
@@ -34,6 +34,7 @@ export interface ConvertToResourcesArgs {
   list:  FileDetail[] | Cohort[] | CohortReview[] | ConceptSet[] | DataSet[];
   workspaceNamespace: string;
   workspaceId: string;
+  cdrVersionId: string;
   accessLevel: WorkspaceAccessLevel;
   resourceType: ResourceType;
 }
@@ -41,16 +42,20 @@ export interface ConvertToResourcesArgs {
 export function convertToResources(args: ConvertToResourcesArgs): WorkspaceResource[] {
   const resourceList = [];
   for (const resource of args.list) {
-    resourceList.push(convertToResource(resource, args.workspaceNamespace, args.workspaceId,
-      args.accessLevel, args.resourceType));
+    resourceList.push(convertToResource(
+      resource, args.workspaceNamespace, args.workspaceId, args.cdrVersionId, args.accessLevel, args.resourceType));
   }
   return resourceList;
 }
 
-export function convertToResource(resource: FileDetail | Cohort | CohortReview | ConceptSet
-  | DataSet, workspaceNamespace: string, workspaceId: string,
+export function convertToResource(
+  resource: FileDetail | Cohort | CohortReview | ConceptSet | DataSet,
+  workspaceNamespace: string,
+  workspaceId: string,
+  cdrVersionId: string,
   accessLevel: WorkspaceAccessLevel,
   resourceType: ResourceType): WorkspaceResource {
+
   let modifiedTime: string;
   if (!resource.lastModifiedTime) {
     modifiedTime = new Date().toDateString();
@@ -61,7 +66,8 @@ export function convertToResource(resource: FileDetail | Cohort | CohortReview |
     workspaceNamespace: workspaceNamespace,
     workspaceFirecloudName: workspaceId,
     permission: WorkspaceAccessLevel[accessLevel],
-    modifiedTime: modifiedTime
+    modifiedTime: modifiedTime,
+    cdrVersionId
   };
   if (resourceType === ResourceType.NOTEBOOK) {
     newResource.notebook = <FileDetail>resource;

--- a/ui/src/testing/stubs/cohorts-api-stub.ts
+++ b/ui/src/testing/stubs/cohorts-api-stub.ts
@@ -11,6 +11,7 @@ import {
   WorkspaceResource
 } from 'generated/fetch';
 import {CohortListResponse} from 'generated/fetch/api';
+import {CdrVersionsStubVariables} from './cdr-versions-api-stub';
 import {WorkspaceStubVariables} from './workspace-service-stub';
 
 export let DEFAULT_COHORT_ID = 1;
@@ -92,6 +93,7 @@ export class CohortsApiStub extends CohortsApi {
       workspaceNamespace: stubWorkspace.namespace,
       workspaceId: stubWorkspace.id,
       accessLevel: WorkspaceAccessLevel.OWNER,
+      cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
       resourceType: ResourceType.COHORT
     };
     this.resourceList = convertToResources(convertToResourceArgs);

--- a/ui/src/testing/stubs/cohorts-api-stub.ts
+++ b/ui/src/testing/stubs/cohorts-api-stub.ts
@@ -11,7 +11,6 @@ import {
   WorkspaceResource
 } from 'generated/fetch';
 import {CohortListResponse} from 'generated/fetch/api';
-import {CdrVersionsStubVariables} from './cdr-versions-api-stub';
 import {WorkspaceStubVariables} from './workspace-service-stub';
 
 export let DEFAULT_COHORT_ID = 1;
@@ -90,11 +89,8 @@ export class CohortsApiStub extends CohortsApi {
     this.workspaces = [stubWorkspace];
     const convertToResourceArgs: ConvertToResourcesArgs = {
       list: this.cohorts,
-      workspaceNamespace: stubWorkspace.namespace,
-      workspaceId: stubWorkspace.id,
-      accessLevel: WorkspaceAccessLevel.OWNER,
-      cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
-      resourceType: ResourceType.COHORT
+      resourceType: ResourceType.COHORT,
+      workspace: {...stubWorkspace, accessLevel: WorkspaceAccessLevel.OWNER},
     };
     this.resourceList = convertToResources(convertToResourceArgs);
   }

--- a/ui/src/testing/stubs/user-metrics-api-stub.ts
+++ b/ui/src/testing/stubs/user-metrics-api-stub.ts
@@ -1,4 +1,5 @@
-import {UserMetricsApi} from 'generated/fetch';
+import {BillingStatus, UserMetricsApi, WorkspaceResource} from 'generated/fetch';
+import {CdrVersionsStubVariables} from './cdr-versions-api-stub';
 
 export class UserMetricsApiStub extends UserMetricsApi {
   constructor() {
@@ -6,15 +7,16 @@ export class UserMetricsApiStub extends UserMetricsApi {
   }
 
   getUserRecentResources() {
-    return Promise.resolve([
-      {
-        modifiedTime: '2019-01-28 20:13:58.0',
-        notebook: {lastModifiedTime: null, name: 'a.ipynb', path: 'gs://q/notebooks/'},
-        permission: 'OWNER',
-        workspaceFirecloudName: 'q',
-        workspaceId: 1,
-        workspaceNamespace: 'z'
-      }
-    ]);
+    const resource: WorkspaceResource = {
+      modifiedTime: '2019-01-28 20:13:58.0',
+      notebook: {lastModifiedTime: null, name: 'a.ipynb', path: 'gs://q/notebooks/'},
+      permission: 'OWNER',
+      workspaceFirecloudName: 'q',
+      workspaceId: 1,
+      workspaceNamespace: 'z',
+      cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
+      workspaceBillingStatus: BillingStatus.ACTIVE,
+    };
+    return Promise.resolve([resource]);
   }
 }

--- a/ui/src/testing/stubs/workspaces-api-stub.ts
+++ b/ui/src/testing/stubs/workspaces-api-stub.ts
@@ -350,6 +350,7 @@ export class WorkspacesApiStub extends WorkspacesApi {
         workspaceNamespace: workspaceNamespace,
         workspaceId: workspaceId,
         accessLevel: WorkspaceAccessLevel.OWNER,
+        cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
       };
       const workspaceResources = convertToResources(
         {...convertToResourcesBaseArgs, list: cohortReviewStubs, resourceType: ResourceType.COHORTREVIEW})

--- a/ui/src/testing/stubs/workspaces-api-stub.ts
+++ b/ui/src/testing/stubs/workspaces-api-stub.ts
@@ -27,6 +27,7 @@ import * as fp from 'lodash/fp';
 
 import {appendNotebookFileSuffix, dropNotebookFileSuffix} from 'app/pages/analysis/util';
 import {convertToResources} from 'app/utils/resourceActions';
+import {WorkspaceData} from 'app/utils/workspace-data';
 import {CopyRequest, EmptyResponse} from 'generated';
 import {CdrVersionsStubVariables} from './cdr-versions-api-stub';
 import {cohortReviewStubs} from './cohort-review-service-stub';
@@ -346,20 +347,21 @@ export class WorkspacesApiStub extends WorkspacesApi {
     workspaceId: string,
     resourceTypes: WorkspaceResourcesRequest): Promise<WorkspaceResourceResponse> {
     return new Promise<WorkspaceResourceResponse>(resolve => {
-      const convertToResourcesBaseArgs = {
-        workspaceNamespace: workspaceNamespace,
-        workspaceId: workspaceId,
+      const workspace: WorkspaceData = {
+        namespace: workspaceNamespace,
+        id: workspaceId,
+        name: WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME,
         accessLevel: WorkspaceAccessLevel.OWNER,
         cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
       };
       const workspaceResources = convertToResources(
-        {...convertToResourcesBaseArgs, list: cohortReviewStubs, resourceType: ResourceType.COHORTREVIEW})
+        {workspace, list: cohortReviewStubs, resourceType: ResourceType.COHORTREVIEW})
         .concat(convertToResources(
-          {...convertToResourcesBaseArgs, list: exampleCohortStubs, resourceType: ResourceType.COHORT}))
+          {workspace, list: exampleCohortStubs, resourceType: ResourceType.COHORT}))
         .concat(convertToResources(
-          {...convertToResourcesBaseArgs, list: DataSetApiStub.stubDataSets(), resourceType: ResourceType.DATASET}))
+          {workspace, list: DataSetApiStub.stubDataSets(), resourceType: ResourceType.DATASET}))
         .concat(convertToResources(
-          {...convertToResourcesBaseArgs, list: ConceptSetsApiStub.stubConceptSets(), resourceType: ResourceType.CONCEPTSET}));
+          {workspace, list: ConceptSetsApiStub.stubConceptSets(), resourceType: ResourceType.CONCEPTSET}));
       resolve(workspaceResources);
     });
   }


### PR DESCRIPTION
Description:

Fix an oversight from #4064 : I didn't test copying notebooks with CDR differences from the Analysis page.  Copying from Analysis takes a different path from Recent Resources copies, and this didn't include the new `cdrVersionId` field, so the source CDR was unknown when creating the Copy Modal.

Fixing this was a one-line change: setting `cdrVersionId` from the associated workspace.  The rest is tightening the type checking around WorkspaceResource and test updates to deal with these changes.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
