### PR TITLE
[RW-5779][risk=no] Add fallbacks for Angular route config data

### DIFF
--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -75,7 +75,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
     this.subscriptions.push(routeDataStore.subscribe(
       ({minimizeChrome, helpContentKey, notebookHelpSidebarStyles, contentFullHeightOverride}) => {
         this.helpContentKey = helpContentKey;
-        this.notebookStyles = notebookHelpSidebarStyles;
+        this.notebookStyles = !!notebookHelpSidebarStyles;
         this.contentFullHeightOverride = contentFullHeightOverride;
         this.displayNavBar = !minimizeChrome;
       }
@@ -270,11 +270,15 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
 
       if (child.firstChild) {
         child = child.firstChild;
-      } else if (child.snapshot.data && child.snapshot.data.helpContentKey) {
-        this.helpContentKey = child.snapshot.data.helpContentKey;
-        child = null;
       } else {
-        this.helpContentKey = null;
+        const {
+          helpContentKey = null,
+          notebookHelpSidebarStyles = false,
+          contentFullHeightOverride = false
+        } = child.snapshot.data || {};
+        this.helpContentKey = helpContentKey;
+        this.notebookStyles = notebookHelpSidebarStyles;
+        this.contentFullHeightOverride = contentFullHeightOverride;
         child = null;
       }
     }


### PR DESCRIPTION
This fixes a bug where `this.notebookStyles` was not being properly reset following certain navigations. I'm not sure why it was working in some cases, but there was no logic here to handle `notebookHelpSideBarStyles=true` -> Angular page which doesn't specify `notebookHelpSideBarStyles` (and therefore should be false).