### PR TITLE
[risk=no] Disable self-copy in Copy to Workspace Modals for Notebooks and Concept Sets

### DIFF
--- a/ui/src/app/components/copy-modal.spec.tsx
+++ b/ui/src/app/components/copy-modal.spec.tsx
@@ -117,7 +117,11 @@ describe('CopyModal', () => {
 
     const options = wrapper.find(Select).find({type: 'option'}).map(e => e.text());
 
-    expect(options).toEqual([workspaces[0].name, workspaces[2].name, workspaces[4].name]);
+    const currentWsOption = workspaces[0].name + ' (current workspace)';
+    const writerWsOption = workspaces[2].name;
+    const writerAltCdrWsOption = workspaces[4].name;
+
+    expect(options).toEqual([currentWsOption, writerWsOption, writerAltCdrWsOption]);
   });
 
   it('should list workspaces with the same CDR version first', async() => {
@@ -135,7 +139,11 @@ describe('CopyModal', () => {
 
     const options = wrapper.find(Select).find({type: 'option'}).map(e => e.text());
 
-    expect(options).toEqual([altCdrWorkspace.name, workspaces[0].name, workspaces[2].name]);
+    const currentWsOption = altCdrWorkspace.name + ' (current workspace)';
+    const otherCdrOwnerWsOption = workspaces[0].name;
+    const otherCdrWriterWsOption = workspaces[2].name;
+
+    expect(options).toEqual([currentWsOption, otherCdrOwnerWsOption, otherCdrWriterWsOption]);
   });
 
   it('should call correct copyNotebook() call after selecting an option and entering a name', async() => {

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -124,6 +124,11 @@ class CopyModalComponent extends React.Component<Props, State> {
     };
   }
 
+  isDestinationSameWorkspace(workspace: Workspace): boolean {
+    const {fromWorkspaceFirecloudName, fromWorkspaceNamespace} = this.props;
+    return workspace.id === fromWorkspaceFirecloudName && workspace.namespace === fromWorkspaceNamespace;
+  }
+
   cdrName(cdrVersionId: string): string {
     const {cdrVersionListResponse} = this.props;
     const version = cdrVersionListResponse.items.find(v => v.cdrVersionId === cdrVersionId);
@@ -151,7 +156,8 @@ class CopyModalComponent extends React.Component<Props, State> {
       label: this.cdrName(versionId),
       options: workspacesByCdr[versionId].map(workspace => ({
         'value': workspace,
-        'label': workspace.name,
+        'label': this.isDestinationSameWorkspace(workspace) ?
+            `${workspace.name} (current workspace)` : workspace.name,
       })),
     }));
   }
@@ -318,6 +324,7 @@ class CopyModalComponent extends React.Component<Props, State> {
           value={destination}
           options={workspaceOptions}
           onChange={(destWorkspace) => this.validateAndSetDestination(destWorkspace)}
+          isOptionDisabled={(option) => this.isDestinationSameWorkspace(option.value)}
         />
         {cdrMismatch && resourceType === ResourceType.CONCEPTSET && <ConceptSetCdrMismatch text={cdrMismatch}/>}
         <div style={headerStyles.formLabel}>Name *</div>

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -355,7 +355,7 @@ const CopyModal = fp.flow(withCdrVersions())(CopyModalComponent);
 
 export {
   CopyModal,
-  CopyModalComponent,
+  CopyModalComponent, // VisibleForTesting
   Props as CopyModalProps,
   State as CopyModalState,
 };


### PR DESCRIPTION
Description:

No ticket.  UX approved by PO + Design.

![no-self-copy](https://user-images.githubusercontent.com/2701406/97192107-f8f3a500-177d-11eb-8e60-562f336e2059.gif)


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
