### PR TITLE
[no ticket][risk=no] Puppeteer e2e test timeout fix

### DIFF
--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -45,7 +45,7 @@ export default class NotebookPage extends AuthenticatedPage {
 
   async isLoaded(): Promise<boolean> {
     await waitForDocumentTitle(this.page, this.documentTitle);
-    await this.waitForKernelIdle();
+    await this.waitForKernelIdle(30000);
     return true;
   }
 

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -14,7 +14,7 @@ beforeEach(async () => {
   await page.setUserAgent(userAgent);
   await page.setViewport({width: 1280, height: 0});
   page.setDefaultNavigationTimeout(60000); // Puppeteer default timeout is 30 seconds.
-  page.setDefaultTimeout(10000);
+  page.setDefaultTimeout(15000);
 });
 
 /**

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,7 +13,7 @@
     "test-local:debug": "cross-env WORKBENCH_ENV=local PUPPETEER_HEADLESS=false DEBUG=true jest --maxWorkers=3",
     "test-staging": "cross-env WORKBENCH_ENV=staging jest --maxWorkers=3",
     "test-staging:debug": "cross-env WORKBENCH_ENV=staging PUPPETEER_HEADLESS=false DEBUG=true jest --maxWorkers=1",
-    "test:ci": "jest --ci --maxWorkers=3",
+    "test:ci": "jest --ci --maxWorkers=2",
     "test:ci:debug": "jest --ci --debug --maxWorkers=1 --bail 1",
     "lint": "tslint --project tsconfig.json",
     "lint:fix": "yarn compile && yarn run lint --fix",

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -263,7 +263,7 @@ export async function waitForText(page: Page,
  */
 export async function waitWhileLoading(page: Page, timeOut: number = 90000): Promise<void> {
   const notBlankPageSelector = '[data-test-id="sign-in-container"], title:not(empty), div.spinner, svg[viewBox]';
-  const spinElementsSelector = '[style*="running spin"], .spinner:empty, [style*="running rotation"]';
+  const spinElementsSelector = '[style*="running spin"], .spinner:empty, svg[style*="running rotation"]:not([aria-hidden="true"])';
 
   await Promise.race([
     // To prevent checking on blank page, wait for elements exist in DOM.


### PR DESCRIPTION
Last three CI jobs have failed with timeout failures. Increasing timeout values in few places to eliminate flaky tests.

```
Failed test:  "Workspace-owner-Jupyter-notebook-action-tests/Copy-notebook-to-another-Workspace-when-CDR-versions-match"
Error: waitForKernelIdle encountered TimeoutError: waiting for selector "#kernel_indicator_icon.kernel_idle_icon" failed: timeout 10000ms exceeded
  console.error
    Notebook kernel is: Kernel Busy

      119 |       ]);
      120 |     } catch (e) {
    > 121 |       console.error(`Notebook kernel is: ${await this.kernelStatus()}`);
          |               ^
      122 |       throw new Error(`waitForKernelIdle encountered ${e}`);
      123 |     }
      124 |   }

      at NotebookPage.waitForKernelIdle (app/page/notebook-page.ts:121:15)
      at NotebookPage.isLoaded (app/page/notebook-page.ts:48:5)
      at NotebookPage.waitForLoad (app/page/authenticated-page.ts:35:5)
      at WorkspaceAnalysisPage.createNotebook (app/page/workspace-analysis-page.ts:77:5)
      at copyNotebookTest (tests/notebook/owner-copy-to-workspace.spec.ts:31:31)
      at Object.<anonymous> (tests/notebook/owner-copy-to-workspace.spec.ts:75:5)
```

