### PR TITLE
[RW-5421][risk=no] Implement 'Delete Environment' button in runtime panel

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -534,7 +534,6 @@ export const RuntimePanel = fp.flow(
         onCancel={() => setPanelContent(PanelContent.Customize)}
       />],
       [PanelContent.Customize, () => <Fragment>
-        {/* TODO(RW-5419): Cost estimates go here. */}
         <div style={styles.controlSection}>
           <CostEstimator
               freeCreditsRemaining={creatorFreeCreditsRemaining}

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 
-import {currentWorkspaceStore} from 'app/utils/navigation';
+import {currentWorkspaceStore, serverConfigStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 
 import {profileApi, workspacesApi} from 'app/services/swagger-fetch-clients';
@@ -270,6 +270,7 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCd
                 }</div>
               </div>}
           {!!this.workspaceRuntimeBillingProjectId() &&
+           !serverConfigStore.getValue().enableCustomRuntimes &&
             <ResetRuntimeButton workspaceNamespace={this.workspaceRuntimeBillingProjectId()}/>}
         </div>
       </div>


### PR DESCRIPTION
- Introduced pattern for reuse with create panel and update confirm page: `PanelContent` (open to alternate naming suggestions), which switchCase's the primary content of the panel
- Add the `Delete Environment` link and corresponding confirmation page
- Renamed `runtimeState` to `runtimeStatus`, for consistency
- A bunch of whitespace changes in the main panel - sorry for this: the only actual changes here are:
  - introduction of the switchCase, per above (resulting in indentation changes)
  - some style refactorings for reuse on the delete page
- Hide the old reset button when `enableCustomRuntimes` is on

![delete-runtime](https://user-images.githubusercontent.com/822298/97372224-5b2cd280-1870-11eb-8dc9-5a9c6ba89148.gif)
