### PR TITLE
[no ticket][risk=no] adding surveyName as an optional arg for CS search

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -129,7 +129,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   public ResponseEntity<CriteriaListWithCountResponse> findCriteriaByDomainAndSearchTerm(
       Long cdrVersionId, String domain, String term, String surveyName, Integer limit) {
     cdrVersionService.setCdrVersion(cdrVersionId);
-    validateDomain(domain);
+    validateDomain(domain, surveyName);
     validateTerm(term);
     return ResponseEntity.ok(
         cohortBuilderService.findCriteriaByDomainAndSearchTerm(domain, term, surveyName, limit));
@@ -291,6 +291,21 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
         .findFirst()
         .orElseThrow(
             () -> new BadRequestException(String.format(BAD_REQUEST_MESSAGE, "domain", domain)));
+  }
+
+  private void validateDomain(String domain, String surveyName) {
+    Arrays.stream(Domain.values())
+        .filter(domainType -> domainType.toString().equalsIgnoreCase(domain))
+        .findFirst()
+        .orElseThrow(
+            () -> new BadRequestException(String.format(BAD_REQUEST_MESSAGE, "domain", domain)));
+    if (Domain.fromValue(domain).equals(Domain.SURVEY)) {
+      Optional.ofNullable(surveyName)
+          .orElseThrow(
+              () ->
+                  new BadRequestException(
+                      String.format(BAD_REQUEST_MESSAGE, "surveyName", surveyName)));
+    }
   }
 
   private void validateType(String type) {

--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -127,12 +127,12 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
 
   @Override
   public ResponseEntity<CriteriaListWithCountResponse> findCriteriaByDomainAndSearchTerm(
-      Long cdrVersionId, String domain, String term, Integer limit) {
+      Long cdrVersionId, String domain, String term, String surveyName, Integer limit) {
     cdrVersionService.setCdrVersion(cdrVersionId);
     validateDomain(domain);
     validateTerm(term);
     return ResponseEntity.ok(
-        cohortBuilderService.findCriteriaByDomainAndSearchTerm(domain, term, limit));
+        cohortBuilderService.findCriteriaByDomainAndSearchTerm(domain, term, surveyName, limit));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -166,6 +166,24 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
 
   @Query(
       value =
+          "select c1 "
+              + "from DbCriteria c1 "
+              + "where c1.domainId = :domain "
+              + "and c1.subtype = 'QUESTION' "
+              + "and c1.conceptId in ( select c.conceptId "
+              + "                      from DbCriteria c "
+              + "                     where c.domainId = :domain "
+              + "                       and match(c.fullText, concat(:term, '+[', :domain, '_rank1]')) > 0 "
+              + "                       and match(c.path, :id) > 0) "
+              + "order by c1.count desc")
+  Page<DbCriteria> findSurveyQuestionCriteriaByDomainAndIdAndFullText(
+      @Param("domain") String domain,
+      @Param("id") Long id,
+      @Param("term") String term,
+      Pageable page);
+
+  @Query(
+      value =
           "select c from DbCriteria c where domainId=:domain and type=:type and standard=:standard and hierarchy=1 and code like upper(concat(:term,'%')) and match(fullText, concat('+[', :domain, '_rank1]')) > 0 order by c.count desc")
   List<DbCriteria> findCriteriaByDomainAndTypeAndStandardAndCode(
       @Param("domain") String domain,
@@ -219,13 +237,8 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
   List<DbCriteria> findByDomainIdAndType(
       @Param("domainId") String domainId, @Param("type") String type, Sort sort);
 
-  @Query(
-      value =
-          "select c.id from DbCriteria c where domainId = :domainId and conceptId = :conceptId and name = :name")
-  Long findIdByDomainAndConceptIdAndName(
-      @Param("domainId") String domainId,
-      @Param("conceptId") String conceptId,
-      @Param("name") String name);
+  @Query(value = "select c.id from DbCriteria c where domainId = :domainId and name = :name")
+  Long findIdByDomainAndName(@Param("domainId") String domainId, @Param("name") String name);
 
   @Query(
       value =

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -35,7 +35,7 @@ public interface CohortBuilderService {
   List<Criteria> findCriteriaBy(String domain, String type, Boolean standard, Long parentId);
 
   CriteriaListWithCountResponse findCriteriaByDomainAndSearchTerm(
-      String domain, String term, Integer limit);
+      String domain, String term, String surveyName, Integer limit);
 
   List<CriteriaMenuOption> findCriteriaMenuOptions();
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3253,6 +3253,11 @@ paths:
         required: true
         description: the term to search for
       - in: query
+        name: surveyName
+        type: string
+        required: false
+        description: name for the survey to search
+      - in: query
         name: limit
         type: integer
         required: false

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -416,7 +416,7 @@ public class CohortBuilderControllerTest {
         criteria,
         controller
             .findCriteriaByDomainAndSearchTerm(
-                1L, Domain.PHYSICAL_MEASUREMENT.name(), "myTerm", null)
+                1L, Domain.PHYSICAL_MEASUREMENT.name(), "myTerm", null, null)
             .getBody()
             .getItems()
             .get(0));
@@ -444,7 +444,7 @@ public class CohortBuilderControllerTest {
     assertEquals(
         createResponseCriteria(criteria),
         controller
-            .findCriteriaByDomainAndSearchTerm(1L, Domain.CONDITION.name(), "001", null)
+            .findCriteriaByDomainAndSearchTerm(1L, Domain.CONDITION.name(), "001", null, null)
             .getBody()
             .getItems()
             .get(0));
@@ -471,7 +471,7 @@ public class CohortBuilderControllerTest {
 
     List<Criteria> results =
         controller
-            .findCriteriaByDomainAndSearchTerm(1L, Domain.CONDITION.name(), "00", null)
+            .findCriteriaByDomainAndSearchTerm(1L, Domain.CONDITION.name(), "00", null, null)
             .getBody()
             .getItems();
 
@@ -500,7 +500,7 @@ public class CohortBuilderControllerTest {
 
     List<Criteria> results =
         controller
-            .findCriteriaByDomainAndSearchTerm(1L, Domain.DRUG.name(), "672535", null)
+            .findCriteriaByDomainAndSearchTerm(1L, Domain.DRUG.name(), "672535", null, null)
             .getBody()
             .getItems();
     assertEquals(1, results.size());
@@ -529,7 +529,7 @@ public class CohortBuilderControllerTest {
     assertEquals(
         createResponseCriteria(criteria),
         controller
-            .findCriteriaByDomainAndSearchTerm(1L, Domain.CONDITION.name(), "LP12", null)
+            .findCriteriaByDomainAndSearchTerm(1L, Domain.CONDITION.name(), "LP12", null, null)
             .getBody()
             .getItems()
             .get(0));
@@ -557,7 +557,7 @@ public class CohortBuilderControllerTest {
     assertEquals(
         createResponseCriteria(criteria),
         controller
-            .findCriteriaByDomainAndSearchTerm(1L, Domain.CONDITION.name(), "LP12", null)
+            .findCriteriaByDomainAndSearchTerm(1L, Domain.CONDITION.name(), "LP12", null, null)
             .getBody()
             .getItems()
             .get(0));
@@ -587,7 +587,7 @@ public class CohortBuilderControllerTest {
     assertEquals(
         createResponseCriteria(criteria),
         controller
-            .findCriteriaByDomainAndSearchTerm(1L, Domain.DRUG.name(), "LP12", null)
+            .findCriteriaByDomainAndSearchTerm(1L, Domain.DRUG.name(), "LP12", null, null)
             .getBody()
             .getItems()
             .get(0));

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -31,6 +31,7 @@ public class CBCriteriaDaoTest {
 
   @Autowired private CBCriteriaDao cbCriteriaDao;
   @Autowired private JdbcTemplate jdbcTemplate;
+  private DbCriteria surveyCriteria;
   private DbCriteria sourceCriteria;
   private DbCriteria standardCriteria;
   private DbCriteria icd9Criteria;
@@ -44,7 +45,7 @@ public class CBCriteriaDaoTest {
 
   @Before
   public void setUp() {
-    DbCriteria surveyCriteria =
+    surveyCriteria =
         cbCriteriaDao.save(
             DbCriteria.builder()
                 .addDomainId(Domain.SURVEY.toString())
@@ -169,6 +170,24 @@ public class CBCriteriaDaoTest {
                 .addStandard(true)
                 .addParentId(1)
                 .build());
+  }
+
+  @Test
+  public void findIdByDomainAndName() {
+    assertThat(cbCriteriaDao.findIdByDomainAndName(Domain.SURVEY.toString(), "The Basics"))
+        .isEqualTo(surveyCriteria.getId());
+  }
+
+  @Test
+  public void findSurveyQuestionCriteriaByDomainAndIdAndFullText() {
+    PageRequest pageRequest = new PageRequest(0, 100);
+    assertThat(
+            cbCriteriaDao
+                .findSurveyQuestionCriteriaByDomainAndIdAndFullText(
+                    Domain.SURVEY.toString(), surveyCriteria.getId(), "term", pageRequest)
+                .getContent()
+                .get(0))
+        .isEqualTo(surveyCriteria);
   }
 
   @Test


### PR DESCRIPTION
This PR adds surveyName as an optional arg for endpoint `CohortBuilderController#findCriteriaByDomainAndSearchTerm`

- Added 2 new cbCriteriaDao calls
- Added test cases as well
- Added validation for survey domain to throw a BadRequestException if survey name is not provided.