### PR TITLE
[noTicket][risk=no] Fix Column Header Alignment issue

### DIFF
--- a/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
+++ b/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
@@ -238,7 +238,7 @@ interface State {
   totalCount: number;
 }
 
-const tableBodyStyle = `
+const tableBodyOverlayStyle = `
   body .tablebody {
     overflow-y: overlay
   }
@@ -506,7 +506,7 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace(), w
               </thead>
             </table>
             <style>
-              {tableBodyStyle}
+              {tableBodyOverlayStyle}
             </style>
             <div style={{height: '15rem'}} className='tablebody'>
               <table className='p-datatable' style={{...styles.table, ...styles.tableBody}}>

--- a/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
+++ b/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
@@ -238,6 +238,12 @@ interface State {
   totalCount: number;
 }
 
+const tableBodyStyle = `
+  body .tablebody {
+    overflow-y: overlay
+  }
+`;
+
 export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace(), withCurrentConcept())(
   class extends React.Component<Props, State> {
     constructor(props: Props) {
@@ -499,7 +505,10 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace(), w
                 </tr>
               </thead>
             </table>
-            <div style={{height: '15rem', overflowY: 'auto'}}>
+            <style>
+              {tableBodyStyle}
+            </style>
+            <div style={{height: '15rem'}} className='tablebody'>
               <table className='p-datatable' style={{...styles.table, ...styles.tableBody}}>
                 <tbody className='p-datatable-tbody'>
                 {displayData.map((row, index) => {


### PR DESCRIPTION
**Issue**:  For Windows, the cohort table column does not align with table body 
![Michael](https://user-images.githubusercontent.com/34481816/97524564-63bdff80-197b-11eb-8d79-d71cdc64b428.png)

**Reason**: The tableBody is enclosed in a div with css property overflow: auto, which includes a scroll bar. In windows the scroll takes up space within the body pushing the column data to the left therefore causing the mis-alignment

**Fix**: Not Ideal: however using overflow: overlay solves the issue as overlay puts the slider over the content rather than alongside. The reason its not ideal is because typescript will throw error if used as style={{overflowY: 'overlay'}} as overlay is not an option as part of the class. Using it via style tag works however as the browser is able to understand it. 

With overflow: overlay - MAC
<img width="1608" alt="Screen Shot 2020-10-29 at 12 20 39 AM" src="https://user-images.githubusercontent.com/34481816/97525154-94eaff80-197c-11eb-9c7b-5dc80d3d8f4d.png">

I can test it on Windows once i push the code to test


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
