### PR TITLE
[RW-5797][RW-5798][RW-5800][risk=no] Bug fixes for presets and dataproc

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -50,6 +50,7 @@ public interface LeonardoMapper {
   GceConfig toGceConfig(LeonardoGceConfig leonardoGceConfig);
 
   @Mapping(target = "cloudService", ignore = true)
+  @Mapping(target = "bootDiskSize", ignore = true)
   LeonardoGceConfig toLeonardoGceConfig(GceConfig gceConfig);
 
   @AfterMapping

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5537,9 +5537,6 @@ definitions:
         description: >
           Optional, the size in gigabytes of the disk on the GCE VM.
           Minimum size is 50GB. If unspecified, default size is 100GB.
-      bootDiskSize:
-        type: integer
-        description: size for boot disk. For old runtimes (prior 6/22/2020, gce runtimes don't have a separate boot disk)
       machineType:
         type: string
         description: >

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -859,8 +859,7 @@ public class RuntimeControllerTest {
 
     runtimeController.createRuntime(
         BILLING_PROJECT_ID,
-        new Runtime()
-            .gceConfig(new GceConfig().bootDiskSize(10).diskSize(50).machineType("standard")));
+        new Runtime().gceConfig(new GceConfig().diskSize(50).machineType("standard")));
 
     verify(userRuntimesApi)
         .createRuntime(
@@ -879,7 +878,6 @@ public class RuntimeControllerTest {
                     LeonardoRuntimeConfig.class)
                 .getCloudService())
         .isEqualTo(LeonardoRuntimeConfig.CloudServiceEnum.GCE);
-    assertThat(createLeonardoGceConfig.getBootDiskSize()).isEqualTo(10);
     assertThat(createLeonardoGceConfig.getDiskSize()).isEqualTo(50);
 
     assertThat(createLeonardoGceConfig.getMachineType()).isEqualTo("standard");

--- a/ui/src/app/components/popups.tsx
+++ b/ui/src/app/components/popups.tsx
@@ -29,6 +29,22 @@ const styles = {
   }
 };
 
+// Enable stubbing out dimensions for testing purposes. Enzyme does not have
+// associated DOM, and therefore cannot do bounding box computations.
+let popupDimensionsOverride = null;
+export const stubPopupDimensions = (stub = {
+  element: {width: 0, height: 0},
+  target: {top: 0, bottom: 0, left: 0, right: 0},
+  viewport: {width: 0, height: 0}
+}) => popupDimensionsOverride = stub;
+
+const computeNewDimensions = (el, target) => (popupDimensionsOverride || {
+  element: fp.pick(['width', 'height'], el.current.getBoundingClientRect()),
+  target: fp.pick(['top', 'bottom', 'left', 'right'],
+    document.getElementById(target).getBoundingClientRect()),
+  viewport: {width: window.innerWidth, height: window.innerHeight}
+});
+
 interface WithDynamicPositionProps {
   target: string;
 }
@@ -66,12 +82,7 @@ export const withDynamicPosition = () => WrappedComponent => {
       const {target} = this.props;
       const {dimensions} = this.state;
       this.animation = requestAnimationFrame(() => this.reposition());
-      const newDimensions = {
-        element: fp.pick(['width', 'height'], this.element.current.getBoundingClientRect()),
-        target: fp.pick(['top', 'bottom', 'left', 'right'],
-          document.getElementById(target).getBoundingClientRect()),
-        viewport: {width: window.innerWidth, height: window.innerHeight}
-      };
+      const newDimensions = computeNewDimensions(this.element, target);
       if (!fp.isEqual(newDimensions, dimensions)) {
         this.setState({dimensions: newDimensions});
       }

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -4,10 +4,11 @@ import * as React from 'react';
 
 import {Button} from 'app/components/buttons';
 import {Spinner} from 'app/components/spinners';
-import {RuntimePanel, Props} from 'app/pages/analysis/runtime-panel';
+import {ComputeType, RuntimePanel, Props} from 'app/pages/analysis/runtime-panel';
 import {workspaceStubs} from 'testing/stubs/workspaces-api-stub';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import defaultServerConfig from 'testing/default-server-config';
+import {runtimePresets} from 'app/utils/runtime-presets';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
 import {RuntimeApi} from 'generated/fetch/api';
@@ -15,6 +16,7 @@ import {WorkspaceAccessLevel} from 'generated/fetch';
 import {runtimeStore} from 'app/utils/stores';
 import {cdrVersionListResponse, CdrVersionsStubVariables} from 'testing/stubs/cdr-versions-api-stub';
 import {cdrVersionStore, serverConfigStore} from 'app/utils/navigation';
+import { RuntimeConfigurationType } from 'generated/fetch';
 
 
 
@@ -53,6 +55,48 @@ describe('RuntimePanel', () => {
     };
   });
 
+  const pickDropdownOption = async(wrapper, id, label) => {
+    act(() => { wrapper.find(id).first().simulate('click') });
+    const item = wrapper.find(`${id} .p-dropdown-item`).find({'aria-label': label}).first()
+    expect(item.exists()).toBeTruthy();
+
+    act(() => { item.simulate('click') });
+
+    // In some cases, picking an option may require some waiting, e.g. for
+    // rerendering of RAM options based on CPU selection.
+    await waitOneTickAndUpdate(wrapper);
+  };
+
+  const enterNumberInput = (wrapper, id, value) => {
+    // TODO: Find a way to invoke this without props.
+    act(() => { wrapper.find(id).first().prop('onChange')({value} as any)});
+  };
+
+  const pickMainCpu = (wrapper, cpu) => pickDropdownOption(wrapper, '#runtime-cpu', cpu);
+  const pickMainRam = (wrapper, ram) => pickDropdownOption(wrapper, '#runtime-ram', ram);
+  const pickMainDiskSize = (wrapper, diskSize) => enterNumberInput(wrapper, '#runtime-disk', diskSize);
+  const pickComputeType = (wrapper, computeType) => pickDropdownOption(wrapper, '#runtime-compute', computeType);
+  const pickWorkerCpu = (wrapper, cpu) => pickDropdownOption(wrapper, '#worker-cpu', cpu);
+  const pickWorkerRam = (wrapper, cpu) => pickDropdownOption(wrapper, '#worker-ram', cpu);
+  const pickWorkerDiskSize = (wrapper, diskSize) => enterNumberInput(wrapper, '#worker-disk', diskSize);
+  const pickNumWorkers = (wrapper, n) => enterNumberInput(wrapper, '#num-workers', n);
+  const pickNumPreemptibleWorkers = (wrapper, n) => enterNumberInput(wrapper, '#num-preemptible', n);
+
+  const pickPreset = async(wrapper, {displayName}) => {
+    act(() => { wrapper.find({'data-test-id': 'runtime-presets-menu'}).first().simulate('click') });
+    act(() => { (document.querySelector(`#popup-root [aria-label="${displayName}"]`) as HTMLElement).click() });
+    await waitOneTickAndUpdate(wrapper);
+  }
+
+  const mustClickCreateButton = async(wrapper) => {
+    const createButton = wrapper.find(Button).find({'aria-label': 'Create'}).first();
+    expect(createButton.exists()).toBeTruthy();
+    expect(createButton.prop('disabled')).toBeFalsy();
+
+    act(() => { createButton.simulate('click') });
+    await waitOneTickAndUpdate(wrapper);
+  };
+
   it('should show loading spinner while loading', async() => {
     const wrapper = component();
     await handleUseEffect(wrapper);
@@ -69,18 +113,13 @@ describe('RuntimePanel', () => {
 
   it('should allow creation when no runtime exists with defaults', async() => {
     runtimeApiStub.runtime = null;
-    runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace});
+    act(() => { runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace}) });
 
     const wrapper = component();
     await handleUseEffect(wrapper);
     await waitOneTickAndUpdate(wrapper);
 
-    const createButton = wrapper.find(Button).find({'aria-label': 'Create'}).first();
-    expect(createButton.exists()).toBeTruthy();
-    expect(createButton.prop('disabled')).toBeFalsy();
-
-    act(() => { createButton.simulate('click') });
-    await waitOneTickAndUpdate(wrapper);
+    await mustClickCreateButton(wrapper);
 
     expect(runtimeApiStub.runtime.status).toEqual('Creating');
     expect(runtimeApiStub.runtime.gceConfig.machineType).toEqual('n1-standard-4');
@@ -88,74 +127,55 @@ describe('RuntimePanel', () => {
 
   it('should allow creation with GCE config', async() => {
     runtimeApiStub.runtime = null;
-    runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace});
+    act(() => { runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace}) });
 
     const wrapper = component();
     await handleUseEffect(wrapper);
     await waitOneTickAndUpdate(wrapper);
 
-    act(() => { wrapper.find('#runtime-cpu').first().simulate('click') });
-    act(() => { wrapper.find('#runtime-cpu .p-dropdown-item').find({'aria-label': 8}).first().simulate('click') });
-    await waitOneTickAndUpdate(wrapper);
+    await pickMainCpu(wrapper, 8);
+    await pickMainRam(wrapper, 52);
+    pickMainDiskSize(wrapper, 75);
 
-    act(() => { wrapper.find('#runtime-ram').first().find('.p-dropdown-item').first().simulate('click') });
-    act(() => { wrapper.find('#runtime-ram .p-dropdown-item').find({'aria-label': 52}).first().simulate('click') });
-
-    // TODO: Find a way to invoke this without props.
-    act(() => { wrapper.find('*[id="runtime-disk"]').first().prop('onChange')({value: 75} as any)});
-
-    const createButton = wrapper.find(Button).find({'aria-label': 'Create'}).first();
-    expect(createButton.exists()).toBeTruthy();
-    expect(createButton.prop('disabled')).toBeFalsy();
-
-    act(() => { createButton.simulate('click') });
-    await waitOneTickAndUpdate(wrapper);
+    await mustClickCreateButton(wrapper);
 
     expect(runtimeApiStub.runtime.status).toEqual('Creating');
-    expect(runtimeApiStub.runtime.gceConfig.machineType).toEqual('n1-highmem-8');
-    expect(runtimeApiStub.runtime.gceConfig.diskSize).toEqual(75);
+    expect(runtimeApiStub.runtime.configurationType)
+      .toEqual(RuntimeConfigurationType.UserOverride);
+    expect(runtimeApiStub.runtime.gceConfig).toEqual({
+      machineType: 'n1-highmem-8',
+      diskSize: 75
+    });
     expect(runtimeApiStub.runtime.dataprocConfig).toBeFalsy();
   });
 
   it('should allow creation with Dataproc config', async() => {
     runtimeApiStub.runtime = null;
-    runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace});
+    act(() => { runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace}) });
 
     const wrapper = component();
     await handleUseEffect(wrapper);
     await waitOneTickAndUpdate(wrapper);
 
     // master settings
-    act(() => { wrapper.find('#runtime-cpu').first().simulate('click') });
-    act(() => { wrapper.find('#runtime-cpu .p-dropdown-item').find({'aria-label': 2}).first().simulate('click') });
-    await waitOneTickAndUpdate(wrapper);
-    act(() => { wrapper.find('#runtime-ram').first().find('.p-dropdown-item').first().simulate('click') });
-    act(() => { wrapper.find('#runtime-ram .p-dropdown-item').find({'aria-label': 7.5}).first().simulate('click') });
-    act(() => { wrapper.find('#runtime-disk').first().prop('onChange')({value: 100} as any)});
+    await pickMainCpu(wrapper, 2);
+    await pickMainRam(wrapper, 7.5);
+    pickMainDiskSize(wrapper, 100);
 
-    // pick Dataproc
-    act(() => { wrapper.find('#runtime-compute').first().simulate('click') });
-    act(() => { wrapper.find('#runtime-compute .p-dropdown-item').find({'aria-label': 'Dataproc Cluster'}).first().simulate('click') });
-    await waitOneTickAndUpdate(wrapper);
+    await pickComputeType(wrapper, ComputeType.Dataproc);
 
     // worker settings
-    act(() => { wrapper.find('#worker-cpu').first().simulate('click') });
-    act(() => { wrapper.find('#worker-cpu .p-dropdown-item').find({'aria-label': 8}).first().simulate('click') });
-    await waitOneTickAndUpdate(wrapper);
-    wrapper.find('#worker-ram').first().find('.p-dropdown-item').first().simulate('click');
-    wrapper.find('#worker-ram .p-dropdown-item').find({'aria-label': 30}).first().simulate('click');
-    act(() => { wrapper.find('#worker-disk').first().prop('onChange')({value: 300} as any)});
-    act(() => { wrapper.find('#num-workers').first().prop('onChange')({value: 10} as any)});
-    act(() => { wrapper.find('#num-preemptible').first().prop('onChange')({value: 20} as any)});
+    await pickWorkerCpu(wrapper, 8);
+    await pickWorkerRam(wrapper, 30);
+    pickWorkerDiskSize(wrapper, 300);
+    pickNumWorkers(wrapper, 10);
+    pickNumPreemptibleWorkers(wrapper, 20);
 
-    const createButton = wrapper.find(Button).find({'aria-label': 'Create'}).first();
-    expect(createButton.exists()).toBeTruthy();
-    expect(createButton.prop('disabled')).toBeFalsy();
-
-    act(() => { createButton.simulate('click') });
-    await waitOneTickAndUpdate(wrapper);
+    await mustClickCreateButton(wrapper);
 
     expect(runtimeApiStub.runtime.status).toEqual('Creating');
+    expect(runtimeApiStub.runtime.configurationType)
+      .toEqual(RuntimeConfigurationType.UserOverride);
     expect(runtimeApiStub.runtime.dataprocConfig).toEqual({
       masterMachineType: 'n1-standard-2',
       masterDiskSize: 100,
@@ -165,6 +185,123 @@ describe('RuntimePanel', () => {
       numberOfPreemptibleWorkers: 20
     });
     expect(runtimeApiStub.runtime.gceConfig).toBeFalsy();
+  });
+
+  it('should allow configuration via GCE preset', async() => {
+    runtimeApiStub.runtime = null;
+    act(() => { runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace}) });
+
+    const wrapper = component();
+    await handleUseEffect(wrapper);
+    await waitOneTickAndUpdate(wrapper);
+
+    // Ensure set the form to something non-standard to start
+    await pickMainCpu(wrapper, 8);
+    pickMainDiskSize(wrapper, 75);
+    await pickComputeType(wrapper, ComputeType.Dataproc);
+
+    await pickPreset(wrapper, runtimePresets.generalAnalysis);
+
+    await mustClickCreateButton(wrapper);
+
+    expect(runtimeApiStub.runtime.status).toEqual('Creating');
+    expect(runtimeApiStub.runtime.configurationType)
+      .toEqual(RuntimeConfigurationType.GeneralAnalysis);
+    expect(runtimeApiStub.runtime.gceConfig)
+      .toEqual(runtimePresets.generalAnalysis.runtimeTemplate.gceConfig);
+    expect(runtimeApiStub.runtime.dataprocConfig).toBeFalsy();
+  });
+
+  it('should allow configuration via dataproc preset', async() => {
+    runtimeApiStub.runtime = null;
+    act(() => { runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace}) });
+
+    const wrapper = component();
+    await handleUseEffect(wrapper);
+    await waitOneTickAndUpdate(wrapper);
+
+    await pickPreset(wrapper, runtimePresets.hailAnalysis);
+
+    await mustClickCreateButton(wrapper);
+
+    expect(runtimeApiStub.runtime.status).toEqual('Creating');
+    expect(runtimeApiStub.runtime.configurationType)
+      .toEqual(RuntimeConfigurationType.HailGenomicAnalysis);
+    expect(runtimeApiStub.runtime.dataprocConfig)
+      .toEqual(runtimePresets.hailAnalysis.runtimeTemplate.dataprocConfig);
+    expect(runtimeApiStub.runtime.gceConfig).toBeFalsy();
+  });
+
+  it('should allow configuration via dataproc preset from modified form', async() => {
+    runtimeApiStub.runtime = null;
+    act(() => { runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace}) });
+
+    const wrapper = component();
+    await handleUseEffect(wrapper);
+    await waitOneTickAndUpdate(wrapper);
+
+    // Configure the form - we expect all of the changes to be overwritten by
+    // the Hail preset selection.
+    await pickMainCpu(wrapper, 2);
+    await pickMainRam(wrapper, 7.5);
+    pickMainDiskSize(wrapper, 100);
+    await pickComputeType(wrapper, ComputeType.Dataproc);
+    await pickWorkerCpu(wrapper, 8);
+    await pickWorkerRam(wrapper, 30);
+    pickWorkerDiskSize(wrapper, 300);
+    pickNumWorkers(wrapper, 10);
+    pickNumPreemptibleWorkers(wrapper, 20);
+
+    await pickPreset(wrapper, runtimePresets.hailAnalysis);
+
+    await mustClickCreateButton(wrapper);
+
+    expect(runtimeApiStub.runtime.status).toEqual('Creating');
+    expect(runtimeApiStub.runtime.configurationType)
+      .toEqual(RuntimeConfigurationType.HailGenomicAnalysis);
+    expect(runtimeApiStub.runtime.dataprocConfig)
+      .toEqual(runtimePresets.hailAnalysis.runtimeTemplate.dataprocConfig);
+    expect(runtimeApiStub.runtime.gceConfig).toBeFalsy();
+  });
+
+  it('should tag as user override after preset modification', async() => {
+    runtimeApiStub.runtime = null;
+    act(() => { runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace}) });
+
+    const wrapper = component();
+    await handleUseEffect(wrapper);
+    await waitOneTickAndUpdate(wrapper);
+
+    // Take the preset but make a solitary modification.
+    await pickPreset(wrapper, runtimePresets.hailAnalysis);
+    pickNumPreemptibleWorkers(wrapper, 20);
+
+    await mustClickCreateButton(wrapper);
+
+    expect(runtimeApiStub.runtime.status).toEqual('Creating');
+    expect(runtimeApiStub.runtime.configurationType)
+      .toEqual(RuntimeConfigurationType.UserOverride);
+  });
+
+  it('should tag as preset if configuration matches', async() => {
+    runtimeApiStub.runtime = null;
+    act(() => { runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace}) });
+
+    const wrapper = component();
+    await handleUseEffect(wrapper);
+    await waitOneTickAndUpdate(wrapper);
+
+    // Take the preset, make a change, then revert.
+    await pickPreset(wrapper, runtimePresets.generalAnalysis);
+    await pickComputeType(wrapper, ComputeType.Dataproc);
+    await pickWorkerCpu(wrapper, 2);
+    await pickComputeType(wrapper, ComputeType.Standard);
+
+    await mustClickCreateButton(wrapper);
+
+    expect(runtimeApiStub.runtime.status).toEqual('Creating');
+    expect(runtimeApiStub.runtime.configurationType)
+      .toEqual(RuntimeConfigurationType.GeneralAnalysis);
   });
 
   it('should restrict memory options by cpu', async() => {

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -7,13 +7,14 @@ import {Spinner} from 'app/components/spinners';
 import {RuntimePanel, Props} from 'app/pages/analysis/runtime-panel';
 import {workspaceStubs} from 'testing/stubs/workspaces-api-stub';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
+import defaultServerConfig from 'testing/default-server-config';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
 import {RuntimeApi} from 'generated/fetch/api';
 import {WorkspaceAccessLevel} from 'generated/fetch';
 import {runtimeStore} from 'app/utils/stores';
 import {cdrVersionListResponse, CdrVersionsStubVariables} from 'testing/stubs/cdr-versions-api-stub';
-import {cdrVersionStore} from 'app/utils/navigation';
+import {cdrVersionStore, serverConfigStore} from 'app/utils/navigation';
 
 
 
@@ -37,6 +38,7 @@ describe('RuntimePanel', () => {
 
   beforeEach(() => {
     cdrVersionStore.next(cdrVersionListResponse);
+    serverConfigStore.next({...defaultServerConfig, enableCustomRuntimes: true});
     runtimeApiStub = new RuntimeApiStub();
     runtimeApiStub.runtime.dataprocConfig = null;
     registerApiClient(RuntimeApi, runtimeApiStub);
@@ -65,7 +67,8 @@ describe('RuntimePanel', () => {
     expect(!wrapper.exists(Spinner));
   });
 
-  it('should show the create button when no runtime exists', async() => {
+  it('should allow creation when no runtime exists with defaults', async() => {
+    runtimeApiStub.runtime = null;
     runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace});
 
     const wrapper = component();
@@ -75,6 +78,93 @@ describe('RuntimePanel', () => {
     const createButton = wrapper.find(Button).find({'aria-label': 'Create'}).first();
     expect(createButton.exists()).toBeTruthy();
     expect(createButton.prop('disabled')).toBeFalsy();
+
+    act(() => { createButton.simulate('click') });
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(runtimeApiStub.runtime.status).toEqual('Creating');
+    expect(runtimeApiStub.runtime.gceConfig.machineType).toEqual('n1-standard-4');
+  });
+
+  it('should allow creation with GCE config', async() => {
+    runtimeApiStub.runtime = null;
+    runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace});
+
+    const wrapper = component();
+    await handleUseEffect(wrapper);
+    await waitOneTickAndUpdate(wrapper);
+
+    act(() => { wrapper.find('#runtime-cpu').first().simulate('click') });
+    act(() => { wrapper.find('#runtime-cpu .p-dropdown-item').find({'aria-label': 8}).first().simulate('click') });
+    await waitOneTickAndUpdate(wrapper);
+
+    act(() => { wrapper.find('#runtime-ram').first().find('.p-dropdown-item').first().simulate('click') });
+    act(() => { wrapper.find('#runtime-ram .p-dropdown-item').find({'aria-label': 52}).first().simulate('click') });
+
+    // TODO: Find a way to invoke this without props.
+    act(() => { wrapper.find('*[id="runtime-disk"]').first().prop('onChange')({value: 75} as any)});
+
+    const createButton = wrapper.find(Button).find({'aria-label': 'Create'}).first();
+    expect(createButton.exists()).toBeTruthy();
+    expect(createButton.prop('disabled')).toBeFalsy();
+
+    act(() => { createButton.simulate('click') });
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(runtimeApiStub.runtime.status).toEqual('Creating');
+    expect(runtimeApiStub.runtime.gceConfig.machineType).toEqual('n1-highmem-8');
+    expect(runtimeApiStub.runtime.gceConfig.diskSize).toEqual(75);
+    expect(runtimeApiStub.runtime.dataprocConfig).toBeFalsy();
+  });
+
+  it('should allow creation with Dataproc config', async() => {
+    runtimeApiStub.runtime = null;
+    runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace});
+
+    const wrapper = component();
+    await handleUseEffect(wrapper);
+    await waitOneTickAndUpdate(wrapper);
+
+    // master settings
+    act(() => { wrapper.find('#runtime-cpu').first().simulate('click') });
+    act(() => { wrapper.find('#runtime-cpu .p-dropdown-item').find({'aria-label': 2}).first().simulate('click') });
+    await waitOneTickAndUpdate(wrapper);
+    act(() => { wrapper.find('#runtime-ram').first().find('.p-dropdown-item').first().simulate('click') });
+    act(() => { wrapper.find('#runtime-ram .p-dropdown-item').find({'aria-label': 7.5}).first().simulate('click') });
+    act(() => { wrapper.find('#runtime-disk').first().prop('onChange')({value: 100} as any)});
+
+    // pick Dataproc
+    act(() => { wrapper.find('#runtime-compute').first().simulate('click') });
+    act(() => { wrapper.find('#runtime-compute .p-dropdown-item').find({'aria-label': 'Dataproc Cluster'}).first().simulate('click') });
+    await waitOneTickAndUpdate(wrapper);
+
+    // worker settings
+    act(() => { wrapper.find('#worker-cpu').first().simulate('click') });
+    act(() => { wrapper.find('#worker-cpu .p-dropdown-item').find({'aria-label': 8}).first().simulate('click') });
+    await waitOneTickAndUpdate(wrapper);
+    wrapper.find('#worker-ram').first().find('.p-dropdown-item').first().simulate('click');
+    wrapper.find('#worker-ram .p-dropdown-item').find({'aria-label': 30}).first().simulate('click');
+    act(() => { wrapper.find('#worker-disk').first().prop('onChange')({value: 300} as any)});
+    act(() => { wrapper.find('#num-workers').first().prop('onChange')({value: 10} as any)});
+    act(() => { wrapper.find('#num-preemptible').first().prop('onChange')({value: 20} as any)});
+
+    const createButton = wrapper.find(Button).find({'aria-label': 'Create'}).first();
+    expect(createButton.exists()).toBeTruthy();
+    expect(createButton.prop('disabled')).toBeFalsy();
+
+    act(() => { createButton.simulate('click') });
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(runtimeApiStub.runtime.status).toEqual('Creating');
+    expect(runtimeApiStub.runtime.dataprocConfig).toEqual({
+      masterMachineType: 'n1-standard-2',
+      masterDiskSize: 100,
+      workerMachineType: 'n1-standard-8',
+      workerDiskSize: 300,
+      numberOfWorkers: 10,
+      numberOfPreemptibleWorkers: 20
+    });
+    expect(runtimeApiStub.runtime.gceConfig).toBeFalsy();
   });
 
   it('should restrict memory options by cpu', async() => {

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -74,7 +74,7 @@ const presetEquals = (a: Runtime, b: Runtime): boolean => {
   return fp.isEqual(strip(a), strip(b));
 };
 
-enum ComputeType {
+export enum ComputeType {
   Standard = 'Standard VM',
   Dataproc = 'Dataproc Cluster'
 }
@@ -158,7 +158,7 @@ const DataProcConfigSelector = ({onChange, dataprocConfig})  => {
 
   // If the dataprocConfig prop changes from externally, reset the selectors accordingly.
   useEffect(() => {
-    setSelectedDiskSize(numberOfWorkers);
+    setSelectedNumWorkers(numberOfWorkers);
     setSelectedPreemptible(numberOfPreemptibleWorkers);
     setSelectedWorkerMachine(initialMachine);
     setSelectedDiskSize(workerDiskSize);
@@ -256,13 +256,15 @@ export const RuntimePanel = fp.flow(withCurrentWorkspace(), withCdrVersions())((
                               return <MenuItem
                               style={styles.presetMenuItem}
                               key={i}
+                              aria-label={preset.displayName}
                               onClick={() => {
                                 // renaming to avoid shadowing
                                 const {runtimeTemplate} = preset;
                                 const {presetDiskSize, presetMachineName, presetCompute} = fp.cond([
-                                  [() => !!runtimeTemplate.gceConfig, ({gceConfig}) => ({
-                                    presetDiskSize: gceConfig.diskSize,
-                                    presetMachineName: gceConfig.machineType,
+                                  // Can't destructure due to shadowing.
+                                  [() => !!runtimeTemplate.gceConfig, (tmpl: Runtime) => ({
+                                    presetDiskSize: tmpl.gceConfig.diskSize,
+                                    presetMachineName: tmpl.gceConfig.machineType,
                                     presetCompute: ComputeType.Standard
                                   })],
                                   [() => !!runtimeTemplate.dataprocConfig, ({dataprocConfig: {masterDiskSize, masterMachineType}}) => ({

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -66,10 +66,11 @@ const defaultDiskSize = 50;
 // Returns true if two runtimes are equivalent in terms of the fields which are
 // affected by runtime presets.
 const presetEquals = (a: Runtime, b: Runtime): boolean => {
-  const pick = ['gceConfig', 'dataprocConfig'];
-  // numberOfWorkerLocalSSDs is currently part of the API spec, but is not used by the panel.
-  const ignore = ['dataprocConfig.numberOfWorkerLocalSSDs'];
-  const strip = fp.flow(fp.pick(pick), fp.omit(ignore));
+  const strip = fp.flow(
+    // In the future, things like toolDockerImage and autopause may be considerations.
+    fp.pick(['gceConfig', 'dataprocConfig']),
+    // numberOfWorkerLocalSSDs is currently part of the API spec, but is not used by the panel.
+    fp.omit(['dataprocConfig.numberOfWorkerLocalSSDs']));
   return fp.isEqual(strip(a), strip(b));
 };
 

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -71,7 +71,7 @@ const presetEquals = (a: Runtime, b: Runtime): boolean => {
   const ignore = ['dataprocConfig.numberOfWorkerLocalSSDs'];
   const strip = fp.flow(fp.pick(pick), fp.omit(ignore));
   return fp.isEqual(strip(a), strip(b));
-}
+};
 
 enum ComputeType {
   Standard = 'Standard VM',
@@ -259,9 +259,9 @@ export const RuntimePanel = fp.flow(withCurrentWorkspace(), withCdrVersions())((
                                 // renaming to avoid shadowing
                                 const {runtimeTemplate} = preset;
                                 const {presetDiskSize, presetMachineName, presetCompute} = fp.cond([
-                                  [() => !!runtimeTemplate.gceConfig, ({gceConfig: {diskSize, machineType}}) => ({
-                                    presetDiskSize: diskSize,
-                                    presetMachineName: machineType,
+                                  [() => !!runtimeTemplate.gceConfig, ({gceConfig}) => ({
+                                    presetDiskSize: gceConfig.diskSize,
+                                    presetMachineName: gceConfig.machineType,
                                     presetCompute: ComputeType.Standard
                                   })],
                                   [() => !!runtimeTemplate.dataprocConfig, ({dataprocConfig: {masterDiskSize, masterMachineType}}) => ({

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -156,7 +156,7 @@ const DataProcConfigSelector = ({onChange, dataprocConfig})  => {
   const [selectedWorkerMachine, setSelectedWorkerMachine] = useState<Machine>(initialMachine);
   const [selectedDiskSize, setSelectedDiskSize] = useState<number>(workerDiskSize);
 
-  // If the dataprocConfig prop changes from externally, reset the selectors accordingly.
+  // If the dataprocConfig prop changes externally, reset the selectors accordingly.
   useEffect(() => {
     setSelectedNumWorkers(numberOfWorkers);
     setSelectedPreemptible(numberOfPreemptibleWorkers);

--- a/ui/src/app/utils/runtime-presets.ts
+++ b/ui/src/app/utils/runtime-presets.ts
@@ -11,7 +11,7 @@ export const runtimePresets: {
       // TODO: Support specifying toolDockerImage here.
       gceConfig: {
         machineType: 'n1-standard-4',
-        bootDiskSize: 50
+        diskSize: 50
       }
     }
   },
@@ -22,8 +22,10 @@ export const runtimePresets: {
       dataprocConfig: {
         masterMachineType: 'n1-standard-4',
         masterDiskSize: 50,
-        numberOfWorkers: 3
-        // Take the Leo defaults for workers, currently 100GB disk and n1-standard-4
+        workerMachineType: 'n1-standard-4',
+        workerDiskSize: 50,
+        numberOfWorkers: 2,
+        numberOfPreemptibleWorkers: 0
       }
     }
   }

--- a/ui/src/testing/stubs/runtime-api-stub.ts
+++ b/ui/src/testing/stubs/runtime-api-stub.ts
@@ -33,8 +33,9 @@ export class RuntimeApiStub extends RuntimeApi {
     });
   }
 
-  createRuntime(workspaceNamespace: string, options?: any): Promise<{}> {
+  createRuntime(workspaceNamespace: string, runtime: Runtime): Promise<{}> {
     return new Promise<{}>(resolve => {
+      this.runtime = {...runtime, status: RuntimeStatus.Creating};
       resolve({});
     });
   }

--- a/ui/test-setup.js
+++ b/ui/test-setup.js
@@ -8,6 +8,8 @@ const enzyme = require("enzyme");
 const Adapter = require("enzyme-adapter-react-16");
 
 const {setupCustomValidators} = require('./src/app/services/setup');
+const {stubPopupDimensions} = require('./src/app/components/popups');
 
 setupCustomValidators();
+stubPopupDimensions();
 enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
Changes:
- Bug: `bootDiskSize` is an outdated property, just remove it - this caused a few bugs
- Bug: dataproc master settings were ignored
- Bug: preset now affects compute type
- Feature: Show genomics analysis preset IFF hasMicroarrayData
- Preset calculation performed at the end instead, this is less error prone and more future-proof
- Test coverage of form configuration through to the `createRuntime` call
- Test coverage of both presets