### PR TITLE
[RW-5658][risk=no] Fully remove deprecated enableGceAsNotebookRuntimeDefault (pt 2/2)

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -112,7 +112,6 @@
     "enableReportingUploadCron": true,
     "enableCOPESurvey": true,
     "enableCustomRuntimes": true,
-    "enableGceAsNotebookRuntimeDefault": true,
     "enableFitbit": true
   },
   "actionAudit": {

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -115,7 +115,6 @@
     "enableReportingUploadCron": false,
     "enableCOPESurvey": false,
     "enableCustomRuntimes": false,
-    "enableGceAsNotebookRuntimeDefault": true,
     "enableFitbit": false
   },
   "actionAudit": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -112,7 +112,6 @@
     "enableReportingUploadCron": true,
     "enableCOPESurvey": true,
     "enableCustomRuntimes": false,
-    "enableGceAsNotebookRuntimeDefault": true,
     "enableFitbit": false
   },
   "actionAudit": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -112,7 +112,6 @@
     "enableReportingUploadCron": true,
     "enableCOPESurvey": false,
     "enableCustomRuntimes": false,
-    "enableGceAsNotebookRuntimeDefault": true,
     "enableFitbit": false
   },
   "actionAudit": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -112,7 +112,6 @@
     "enableReportingUploadCron": true,
     "enableCOPESurvey": false,
     "enableCustomRuntimes": false,
-    "enableGceAsNotebookRuntimeDefault": true,
     "enableFitbit": false
   },
   "actionAudit": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -112,7 +112,6 @@
     "enableReportingUploadCron": true,
     "enableCOPESurvey": false,
     "enableCustomRuntimes": false,
-    "enableGceAsNotebookRuntimeDefault": true,
     "enableFitbit": false
   },
   "actionAudit": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -112,7 +112,6 @@
     "enableReportingUploadCron": true,
     "enableCOPESurvey": true,
     "enableCustomRuntimes": true,
-    "enableGceAsNotebookRuntimeDefault": true,
     "enableFitbit": false
   },
   "actionAudit": {

--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -48,8 +48,6 @@ public class ConfigController implements ConfigApiDelegate {
             .enableResearchReviewPrompt(config.featureFlags.enableResearchPurposePrompt)
             .enableCOPESurvey(config.featureFlags.enableCOPESurvey)
             .enableCustomRuntimes(config.featureFlags.enableCustomRuntimes)
-            .enableGceAsNotebookRuntimeDefault(
-                config.featureFlags.enableGceAsNotebookRuntimeDefault)
             .enableFitbit(config.featureFlags.enableFitbit)
             .runtimeImages(
                 Stream.concat(

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -269,9 +269,6 @@ public class WorkbenchConfig {
     public boolean enableCOPESurvey;
     // Whether users should be able to customize notebook runtime settings.
     public boolean enableCustomRuntimes;
-    // Whether Leonardo notebooks runtimes should default to GCE (instead of Dataproc).
-    // TODO(RW-5658): Deprecated.
-    public boolean enableGceAsNotebookRuntimeDefault;
     // Flag to indicate if whether to display FitBit data
     public boolean enableFitbit;
   }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3986,10 +3986,6 @@ definitions:
         type: boolean
         default: false
         description: Whether user should be able to customize notebook runtime settings.
-      enableGceAsNotebookRuntimeDefault:
-        type: boolean
-        default: false
-        description: Whether the notebook runtime should default to GCE (vs Dataproc).
       enableFitbit:
         type: boolean
         default: false


### PR DESCRIPTION
**Do not merge:** until after the next release (containing https://github.com/all-of-us/workbench/pull/4213)