### PR TITLE
Chavanr/e2e workspace action share

### DIFF
--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -151,4 +151,15 @@ export default class WorkspaceCard extends CardBase {
     return `//*[@role='button'][./*[${WorkspaceCardSelector.cardNameXpath} and normalize-space(text())="${workspaceName}"]]`
   }
 
+
+  // function to verify if the snowman menu options for WRITER & READER are disabled except duplicate option
+  async workspaceCardMenuOptions(): Promise<void>{
+    const snowmanMenu = await this.getSnowmanMenu();
+    expect(await snowmanMenu.isOptionDisabled(Option.Share)).toBe(true);
+    expect(await snowmanMenu.isOptionDisabled(Option.Edit)).toBe(true);
+    expect(await snowmanMenu.isOptionDisabled(Option.Delete)).toBe(true);
+    expect(await snowmanMenu.isOptionDisabled(Option.Duplicate)).toBe(false);
+  }
+
+
 }

--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -80,7 +80,7 @@ export default class WorkspaceAboutPage extends WorkspaceBase {
   async removeCollab(): Promise<void> {  
     const accessLevel = await this.findUserInCollaboratorList(config.collaboratorUsername);
   if (accessLevel !== null) {
-    await (await (this.shareWorkspace())).removeUser(config.collaboratorUsername);
+    await (await (this.openShareModal())).removeUser(config.collaboratorUsername);
     await waitWhileLoading(page);
     }
   }

--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -5,6 +5,8 @@ import {getPropValue} from 'utils/element-utils';
 import WorkspaceBase from './workspace-base';
 import Button from 'app/element/button';
 import ShareModal from 'app/component/share-modal';
+import {config} from 'resources/workbench-config';
+
 
 export const PageTitle = 'View Workspace Details';
 
@@ -74,4 +76,12 @@ export default class WorkspaceAboutPage extends WorkspaceBase {
     return getPropValue<string>(lastUpdatedDate, 'innerText');
   }
 
+  // if the collaborator is already on this workspace, just remove them before continuing.
+  async removeCollab(): Promise<void> {  
+    const accessLevel = await this.findUserInCollaboratorList(config.collaboratorUsername);
+  if (accessLevel !== null) {
+    await (await (this.shareWorkspace())).removeUser(config.collaboratorUsername);
+    await waitWhileLoading(page);
+    }
+  }
 }

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -11,6 +11,7 @@ import {waitForAttributeEquality, waitWhileLoading} from 'utils/waits-utils';
 import SnowmanMenu from 'app/component/snowman-menu';
 import {getPropValue} from 'utils/element-utils';
 import AuthenticatedPage from './authenticated-page';
+import ShareModal from 'app/component/share-modal';
 
 export const UseFreeCredits = 'Use All of Us free credits';
 
@@ -258,6 +259,16 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
     await modal.clickButton(clickButtonText, {waitForClose: true});
     await waitWhileLoading(this.page);
     return contentText;
+  }
+
+  /**
+   * Share workspace via Workspace Actions snowman menu "Share" option.
+   */
+  async shareWorkspace(): Promise<ShareModal> {
+    await this.selectWorkspaceAction(Option.Share, { waitForNav: false });
+    const modal = new ShareModal(this.page);
+    await modal.waitUntilVisible();
+    return modal;
   }
 
 }

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -1,5 +1,5 @@
 import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
-
+import Link from 'app/element/link';
 import DataResourceCard from 'app/component/data-resource-card';
 import ClrIconLink from 'app/element/clr-icon-link';
 import {Option, Language, ResourceCard} from 'app/text-labels';
@@ -137,6 +137,17 @@ export default class WorkspaceDataPage extends WorkspaceBase {
     const analysisPage = new WorkspaceAnalysisPage(this.page);
     await analysisPage.waitForLoad();
     return analysisPage.createNotebook(notebookName, lang);
+  }
+
+  /**
+   * @param {string} workspaceName
+   */
+  async verifyWorkspaceNameOnDataPage(workspaceName: string): Promise<void> {
+    await this.waitForLoad();
+
+    const workspaceLink = new Link(page, `//a[text()='${workspaceName}']`);
+    await workspaceLink.waitForXPath({visible: true});
+    expect(await workspaceLink.isVisible()).toBe(true);
   }
 
 }

--- a/e2e/tests/workspace/workspace-actions-share.spec.ts
+++ b/e2e/tests/workspace/workspace-actions-share.spec.ts
@@ -1,4 +1,3 @@
-// import ShareModal from 'app/component/share-modal';
 import WorkspaceCard from 'app/component/workspace-card';
 import HomePage from 'app/page/home-page';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
@@ -8,9 +7,8 @@ import {config} from 'resources/workbench-config';
 import {findOrCreateWorkspace, signIn, signInAs, signOut} from 'utils/test-utils';
 import {makeWorkspaceName} from 'utils/str-utils';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-// import WorkspaceBase from 'app/component/workspace-base';
 import {waitWhileLoading} from 'utils/waits-utils';
-// import BasePage from 'app/page/base-page';
+
 
 describe('Share workspace', () => {
 
@@ -73,8 +71,8 @@ describe('Share workspace', () => {
       // create workspace with "No Review Requested" radiobutton selected
        await workspacesPage1.createWorkspace(newWorkspaceName);
   
-     const dataPage = new WorkspaceDataPage(page);
-     await dataPage.verifyWorkspaceNameOnDataPage(newWorkspaceName);
+      const dataPage = new WorkspaceDataPage(page);
+      await dataPage.verifyWorkspaceNameOnDataPage(newWorkspaceName);
      
       const shareWorkspaceModal = await dataPage.shareWorkspace();
       await shareWorkspaceModal.shareWithUser(config.collaboratorUsername, WorkspaceAccessLevel.Writer);

--- a/e2e/tests/workspace/workspace-actions-share.spec.ts
+++ b/e2e/tests/workspace/workspace-actions-share.spec.ts
@@ -1,0 +1,121 @@
+// import ShareModal from 'app/component/share-modal';
+import WorkspaceCard from 'app/component/workspace-card';
+import HomePage from 'app/page/home-page';
+import WorkspaceAboutPage from 'app/page/workspace-about-page';
+import WorkspacesPage from 'app/page/workspaces-page';
+import {LinkText, WorkspaceAccessLevel} from 'app/text-labels';
+import {config} from 'resources/workbench-config';
+import {findOrCreateWorkspace, signIn, signInAs, signOut} from 'utils/test-utils';
+import {makeWorkspaceName} from 'utils/str-utils';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
+// import WorkspaceBase from 'app/component/workspace-base';
+import {waitWhileLoading} from 'utils/waits-utils';
+// import BasePage from 'app/page/base-page';
+
+describe('Share workspace', () => {
+
+  beforeEach(async () => {
+    await signIn(page);
+  });
+
+  // Assume there is at least one workspace preexist
+  describe('From the workspace about or data page via workspace actions menu', () => {
+
+    test('As OWNER, user can share a workspace', async () => {
+      
+      const workspaceCard = await findOrCreateWorkspace(page);
+      await workspaceCard.clickWorkspaceName();
+
+      await (new WorkspaceDataPage(page)).openAboutPage();
+      const aboutPage = new WorkspaceAboutPage(page);
+      await aboutPage.waitForLoad();
+
+      // This test is not hermetic - if the collaborator is already on this
+      // workspace, just remove them before continuing.
+      let accessLevel = await aboutPage.findUserInCollaboratorList(config.collaboratorUsername);
+      if (accessLevel !== null) {
+        await (await aboutPage.shareWorkspace()).removeUser(config.collaboratorUsername);
+        await waitWhileLoading(page);
+      }
+
+      const shareWorkspaceModal = await aboutPage.shareWorkspace();
+      await shareWorkspaceModal.shareWithUser(config.collaboratorUsername, WorkspaceAccessLevel.Owner);
+      // Collab list is refreshed.
+      await page.reload({waitUntil: ['networkidle0', 'domcontentloaded']});
+      await waitWhileLoading(page);
+      
+      accessLevel = await aboutPage.findUserInCollaboratorList(config.collaboratorUsername);
+      expect(accessLevel).toBe(WorkspaceAccessLevel.Owner);
+
+      await aboutPage.shareWorkspace();
+      await shareWorkspaceModal.removeUser(config.collaboratorUsername);
+      await page.reload({waitUntil: ['networkidle0', 'domcontentloaded']});
+      await waitWhileLoading(page);
+
+      accessLevel = await aboutPage.findUserInCollaboratorList(config.collaboratorUsername);
+      expect(accessLevel).toBeNull();
+    });
+
+
+    /**
+     * Test:
+     * - Create a new workspace.
+     * - Share with another user with role Writer.
+     * - Log in as another user.
+     * - Workspace share action should be disabled.
+     */
+    test('Workspace WRITER cannot share edit or delete workspace', async () => {
+
+      const newWorkspaceName = makeWorkspaceName();
+      const workspacesPage1 = new WorkspacesPage(page);
+      await workspacesPage1.load();
+  
+      // create workspace with "No Review Requested" radiobutton selected
+       await workspacesPage1.createWorkspace(newWorkspaceName);
+  
+     const dataPage = new WorkspaceDataPage(page);
+     await dataPage.verifyWorkspaceNameOnDataPage(newWorkspaceName);
+     
+      const shareWorkspaceModal = await dataPage.shareWorkspace();
+      await shareWorkspaceModal.shareWithUser(config.collaboratorUsername, WorkspaceAccessLevel.Writer);
+     
+      await waitWhileLoading(page);
+      await signOut(page);
+
+      // To verify WRITER role is assigned correctly, user with WRITER role will sign in in new Incognito page.
+      const newPage = await signInAs(page, config.collaboratorUsername, config.userPassword);
+
+      const homePage = new HomePage(newPage);
+      await homePage.getSeeAllWorkspacesLink().then((link) => link.click());
+
+      const workspacesPage = new WorkspacesPage(newPage);
+      await workspacesPage.waitForLoad();
+
+      // Verify Workspace Access Level is WRITER.
+      const workspaceCard2 = await WorkspaceCard.findCard(newPage, newWorkspaceName);
+      const accessLevel = await workspaceCard2.getWorkspaceAccessLevel();
+      expect(accessLevel).toBe(WorkspaceAccessLevel.Writer);
+
+      // Share, Edit and Delete actions are disabled.
+      await workspaceCard2.workspaceCardMenuOptions();
+
+      // Make sure the Search input-field in Share modal is disabled.
+      await workspaceCard2.clickWorkspaceName();
+      await (new WorkspaceDataPage(newPage)).openAboutPage();
+      const aboutPage = new WorkspaceAboutPage(newPage);
+      await aboutPage.waitForLoad();
+
+      const accessLevel2 = await aboutPage.findUserInCollaboratorList(config.collaboratorUsername);
+      expect(accessLevel2).toBe(WorkspaceAccessLevel.Writer);
+
+      const modal2 = await aboutPage.openShareModal();
+      const searchInput = await modal2.waitForSearchBox();
+      expect(await searchInput.isDisabled()).toBe(true);
+      await modal2.clickButton(LinkText.Cancel);
+
+      await signOut(newPage);
+    });
+
+  });
+
+});

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -1,4 +1,4 @@
-import Link from 'app/element/link';
+// import Link from 'app/element/link';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspacesPage, {FieldSelector} from 'app/page/workspaces-page';
 import {signIn, performActions} from 'utils/test-utils';
@@ -26,7 +26,8 @@ describe('Creating new workspaces', () => {
     expect(modalTextContent).toContain('Primary purpose of your project (Question 1)Summary of research purpose (Question 2)Population of interest (Question 5)');
     expect(modalTextContent).toContain('You can also make changes to your answers after you create your workspace.');
 
-    await verifyWorkspaceLinkOnDataPage(newWorkspaceName);
+    const dataPage = new WorkspaceDataPage(page);
+    await dataPage.verifyWorkspaceNameOnDataPage(newWorkspaceName);
   });
 
   test('User can create a workspace using all inputs', async () => {
@@ -69,17 +70,8 @@ describe('Creating new workspaces', () => {
     await finishButton.waitUntilEnabled();
     await workspacesPage.clickCreateFinishButton(finishButton);
 
-    await verifyWorkspaceLinkOnDataPage(newWorkspaceName);
+    const dataPage1 = new WorkspaceDataPage(page);
+    await dataPage1.verifyWorkspaceNameOnDataPage(newWorkspaceName);
   });
-
-  // helper function to check visible workspace link on Data page
-  async function verifyWorkspaceLinkOnDataPage(workspaceName: string) {
-    const dataPage = new WorkspaceDataPage(page);
-    await dataPage.waitForLoad();
-
-    const workspaceLink = new Link(page, `//a[text()='${workspaceName}']`);
-    await workspaceLink.waitForXPath({visible: true});
-    expect(await workspaceLink.isVisible()).toBe(true);
-  }
 
 });

--- a/e2e/tests/workspace/workspace-share.spec.ts
+++ b/e2e/tests/workspace/workspace-share.spec.ts
@@ -29,21 +29,16 @@ describe('Share workspace', () => {
 
       const aboutPage = new WorkspaceAboutPage(page);
       await aboutPage.waitForLoad();
-
-      // This test is not hermetic - if the collaborator is already on this
-      // workspace, just remove them before continuing.
-      let accessLevel = await aboutPage.findUserInCollaboratorList(config.collaboratorUsername);
-      if (accessLevel !== null) {
-        await (await aboutPage.openShareModal()).removeUser(config.collaboratorUsername);
-        await waitWhileLoading(page);
-      }
+      
+      // if the collaborator is already on this workspace, just remove them before continuing.
+      await aboutPage.removeCollab();
 
       let shareModal = await aboutPage.openShareModal();
       await shareModal.shareWithUser(config.collaboratorUsername, WorkspaceAccessLevel.Owner);
       // Collab list is refreshed.
       await waitWhileLoading(page);
 
-      accessLevel = await aboutPage.findUserInCollaboratorList(config.collaboratorUsername);
+      let accessLevel = await aboutPage.findUserInCollaboratorList(config.collaboratorUsername);
       expect(accessLevel).toBe(WorkspaceAccessLevel.Owner);
 
       shareModal = await aboutPage.openShareModal();
@@ -92,13 +87,7 @@ describe('Share workspace', () => {
       expect(accessLevel).toBe(WorkspaceAccessLevel.Reader);
 
       // Share, Edit and Delete actions are not available for click.
-      const snowmanMenu = await workspaceCard2.getSnowmanMenu();
-      expect(await snowmanMenu.isOptionDisabled(Option.Share)).toBe(true);
-      expect(await snowmanMenu.isOptionDisabled(Option.Edit)).toBe(true);
-      expect(await snowmanMenu.isOptionDisabled(Option.Delete)).toBe(true);
-
-      // Duplicate action is available for click.
-      expect(await snowmanMenu.isOptionDisabled(Option.Duplicate)).toBe(false);
+      await workspaceCard2.workspaceCardMenuOptions();
 
       // Make sure the Search input-field in Share modal is disabled.
       await workspaceCard2.clickWorkspaceName();


### PR DESCRIPTION
 A new test case file created: to validate if the workspace could be shared via the workspace-action menu. 
1. Share with a collaborator (OWNER level access)
2. Share with a collaborator (WRITER level access) 
3. Share with a collaborator (READER level access) - working on it

**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
