### PR TITLE
Redirect on runtime state change

### DIFF
--- a/ui/src/app/pages/analysis/notebook-redirect.tsx
+++ b/ui/src/app/pages/analysis/notebook-redirect.tsx
@@ -23,11 +23,12 @@ import {
 } from 'app/utils';
 import {LeoRuntimeInitializer} from 'app/utils/leo-runtime-initializer';
 import {Kernels} from 'app/utils/notebook-kernels';
-import {runtimeStore, RuntimeStore, withStore} from 'app/utils/stores';
+import {RuntimeStore} from 'app/utils/stores';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {environment} from 'environments/environment';
 import {Profile, Runtime, RuntimeStatus} from 'generated/fetch';
 import {appendNotebookFileSuffix, dropNotebookFileSuffix} from './util';
+import {withRuntimeState} from 'app/utils/runtime-utils';
 
 export enum Progress {
   Unknown,
@@ -222,7 +223,7 @@ const runtimeApiRetryTimeoutMillis = 10000;
 const runtimeApiRetryAttempts = 5;
 const redirectMillis = 1000;
 
-export const NotebookRedirect = fp.flow(withStore(runtimeStore, 'runtimeState'), withUserProfile(), withCurrentWorkspace(),
+export const NotebookRedirect = fp.flow(withUserProfile(), withRuntimeState(), withCurrentWorkspace(),
   withQueryParams())(class extends React.Component<Props, State> {
 
     private pollTimer: NodeJS.Timer;
@@ -390,9 +391,9 @@ export const NotebookRedirect = fp.flow(withStore(runtimeStore, 'runtimeState'),
 
     render() {
       const {showErrorModal, progress, progressComplete, leoUrl} = this.state;
-      const {runtimeState: {runtime = {}}} = this.props;
+      const {runtimeState} = this.props;
 
-      if (runtime && runtime.status !== RuntimeStatus.Running && progress === Progress.Loaded) {
+      if (runtimeState !== RuntimeStatus.Running && progress === Progress.Loaded) {
         this.initializeRuntimeStatusChecking(this.props.workspace.namespace);
       }
 

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -156,9 +156,9 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
         try {
           await LeoRuntimeInitializer.initialize({
             workspaceNamespace: workspace.namespace,
-            onPoll: (runtime) => {
-              runtimeStore.set({runtime: runtime, workspaceNamespace: workspace.namespace});
-            },
+            // onPoll: (runtime) => {
+            //   runtimeStore.set({runtime: runtime, workspaceNamespace: workspace.namespace});
+            // },
             pollAbortSignal: this.pollAborter.signal,
             maxCreateCount: 0,
             maxDeleteCount: 0,

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -1,0 +1,114 @@
+import {runtimeApi} from 'app/services/swagger-fetch-clients';
+import {switchCase} from 'app/utils';
+import { withAsyncErrorHandling } from 'app/utils';
+import {
+  LeoRuntimeInitializer,
+} from 'app/utils/leo-runtime-initializer';
+import {
+  runtimeStore,
+  useStore
+} from 'app/utils/stores';
+import {Runtime, RuntimeStatus} from 'generated/fetch';
+import * as fp from 'lodash/fp';
+
+import * as React from 'react';
+
+const {useState, useEffect} = React;
+
+export enum RuntimeStatusRequest {
+  Delete = 'Delete'
+}
+
+// useRuntime hook is a simple hook to populate the runtime store.
+// This is only used by other runtime hooks
+const useRuntime = (currentWorkspaceNamespace) => {
+  // No cleanup is being handled at the moment.
+  // When the user initiates a runtime change we want that change to take place even if they navigate away
+  useEffect(() => {
+    const getRuntime = withAsyncErrorHandling(
+      () => runtimeStore.set({workspaceNamespace: null, runtime: null}),
+      async() => {
+        const leoRuntime = await runtimeApi().getRuntime(currentWorkspaceNamespace);
+        runtimeStore.set({
+          workspaceNamespace: currentWorkspaceNamespace,
+          runtime: leoRuntime
+        });
+      });
+
+    if (currentWorkspaceNamespace !== runtimeStore.get().workspaceNamespace) {
+      runtimeStore.set({workspaceNamespace: currentWorkspaceNamespace, runtime: undefined});
+      getRuntime();
+    }
+  }, []);
+};
+
+// useRuntimeState hook can be used to change the state of the runtime
+// Only 'Delete' is supported at the moment
+export const useRuntimeState = (currentWorkspaceNamespace): [RuntimeStatus | undefined, (statusRequest: RuntimeStatusRequest) => void]  => {
+  const [runtimeStatus, setRuntimeState] = useState<RuntimeStatusRequest>();
+  const {runtime} = useStore(runtimeStore);
+  useRuntime(currentWorkspaceNamespace);
+
+  useEffect(() => {
+    // Additional state changes can be put here
+    if (!!runtimeStatus) {
+      switchCase(runtimeStatus,
+        [RuntimeStatusRequest.Delete, async() => {
+          await runtimeApi().deleteRuntime(currentWorkspaceNamespace);
+          await LeoRuntimeInitializer.initialize({workspaceNamespace: currentWorkspaceNamespace, maxCreateCount: 0});
+        }]);
+    }
+
+  }, [runtimeStatus]);
+
+  return [runtime ? runtime.status : undefined, setRuntimeState];
+};
+
+// useCustomRuntime Hook can request a new runtime config
+// The LeoRuntimeInitializer could potentially be rolled into this code to completely manage
+// all runtime state.
+export const useCustomRuntime = (currentWorkspaceNamespace): [Runtime, (runtime: Runtime) => void] => {
+  const {runtime, workspaceNamespace} = useStore(runtimeStore);
+  const [requestedRuntime, setRequestedRuntime] = useState<Runtime>();
+  useRuntime(currentWorkspaceNamespace);
+
+  useEffect(() => {
+    const runAction = async() => {
+      // Only delete if the runtime already exists.
+      // TODO: It is likely more correct here to use the LeoRuntimeInitializer wait for the runtime
+      // to reach a terminal status before attempting deletion.
+      if (runtime && runtime.status !== RuntimeStatus.Deleted) {
+        await runtimeApi().deleteRuntime(currentWorkspaceNamespace);
+      }
+      const currentRuntime = await LeoRuntimeInitializer.initialize({
+        workspaceNamespace,
+        targetRuntime: requestedRuntime
+      });
+
+      if (currentWorkspaceNamespace === workspaceNamespace) {
+        runtimeStore.set({
+          workspaceNamespace: currentWorkspaceNamespace,
+          runtime: currentRuntime
+        });
+      }
+    };
+
+    if (requestedRuntime !== undefined && !fp.equals(requestedRuntime, runtime)) {
+      runAction();
+    }
+  }, [requestedRuntime]);
+
+  return [runtime, setRequestedRuntime];
+};
+
+/**
+ * HOC that injects the value of the given store as a prop. When the store changes, the wrapped
+ * component will re-render
+ */
+export const withRuntimeState = () => WrappedComponent => {
+  return props => {
+    console.log('P:',props, props.workspace.namespace);
+    const [value] = useRuntimeState(props.workspace.namespace);
+    return <WrappedComponent {...props} runtimeState={value}/> ;
+  };
+}; 


### PR DESCRIPTION
This is a draft/concept PR for handling state changes/redirects of the runtime.

The concept is to use the `useRuntimeStatus` hook.
Some issues I ran into:
1. `component.ts` directly updates the runtime store - this may need to remain, but I disabled it for now
2. The `progress` state needs to be reset when the runtime status changes

Please take a look - if this looks reasonable, it may make sense to have a separate pre-req PR, essentially changing the `runtimeStore` to something of a private store (I have not coded this up). This would mean moving all of the `runtimeStore` and `runtime-utils` code to the `leo-runtime-initializer` and updating the `help-sidebar` to use the `withRuntimeState` wrapper.

From there, handling the redirect should be simple and reliable.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
