### PR TITLE
[RW-5831][risk=medium] Show warning message when 1000 concepts are added

### DIFF
--- a/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
+++ b/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
@@ -342,7 +342,7 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace(), w
 
     selectIconDisabled() {
       const {selectedIds, source} = this.props;
-      return source !== 'criteria' && selectedIds && selectedIds.length === 1000;
+      return source !== 'criteria' && selectedIds && selectedIds.length >= 1000;
     }
 
     selectItem = (row: any) => {
@@ -423,7 +423,7 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace(), w
       const loadingIngredients = ingredients[row.id] && ingredients[row.id].loading;
       const columnStyle = child ?
         {...styles.columnBodyName, paddingLeft: '1.25rem'} : styles.columnBodyName;
-      const selectIconStyle = this.selectIconDisabled() ? {...styles.selectIcon, ...styles.disabledIcon} : styles.selectIcon;
+      const selectIconStyle = this.selectIconDisabled() ? {...styles.selectIcon, ...styles.disableSelectIcon} : styles.selectIcon;
       return <tr style={{height: '1.75rem'}}>
         <td style={{...columnStyle, width: '31%', textAlign: 'left', borderLeft: 0, padding: '0 0.25rem'}}>
           {row.selectable && <div style={styles.selectDiv}>

--- a/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
+++ b/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
@@ -62,6 +62,10 @@ const styles = reactStyles({
     color: colorWithWhiteness(colors.success, -0.5),
     cursor: 'pointer'
   },
+  disableSelectIcon: {
+    opacity: 0.4,
+    cursor: 'not-allowed'
+  },
   selectedIcon: {
     marginRight: '0.4rem',
     color: colorWithWhiteness(colors.success, -0.5),
@@ -336,6 +340,11 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace(), w
       return [Domain.CONDITION, Domain.PROCEDURE].includes(this.props.searchContext.domain);
     }
 
+    selectIconDisabled() {
+      const {selectedIds, source} = this.props;
+      return source !== 'criteria' && selectedIds && selectedIds.length === 1000;
+    }
+
     selectItem = (row: any) => {
       let param = {parameterId: this.getParamId(row), ...row, attributes: []};
       if (row.domainId === Domain.SURVEY) {
@@ -414,14 +423,16 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace(), w
       const loadingIngredients = ingredients[row.id] && ingredients[row.id].loading;
       const columnStyle = child ?
         {...styles.columnBodyName, paddingLeft: '1.25rem'} : styles.columnBodyName;
+      const selectIconStyle = this.selectIconDisabled() ? {...styles.selectIcon, ...styles.disabledIcon} : styles.selectIcon;
       return <tr style={{height: '1.75rem'}}>
         <td style={{...columnStyle, width: '31%', textAlign: 'left', borderLeft: 0, padding: '0 0.25rem'}}>
-          {row.selectable && <div style={{...styles.selectDiv}}>
+          {row.selectable && <div style={styles.selectDiv}>
             {attributes &&
               <ClrIcon style={styles.attrIcon} shape='slider' dir='right' size='20' onClick={() => this.setAttributes(row)}/>
             }
             {selected && <ClrIcon style={styles.selectedIcon} shape='check-circle' size='20'/>}
-            {unselected && <ClrIcon style={styles.selectIcon} shape='plus-circle' size='16' onClick={() => this.selectItem(row)}/>}
+            {unselected && <ClrIcon style={selectIconStyle} shape='plus-circle' size='16'
+                                    onClick={() => this.selectItem(row)}/>}
             {brand && !loadingIngredients &&
               <ClrIcon style={styles.brandIcon}
                 shape={'angle ' + (open ? 'down' : 'right')} size='20'
@@ -465,6 +476,9 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace(), w
       const showStandardOption = !standardOnly && !!standardData && standardData.length > 0;
       const displayData = standardOnly ? standardData : data;
       return <div style={{overflow: 'auto'}}>
+        {this.selectIconDisabled() && <div style={{color: colors.warning, fontWeight: 'bold', maxWidth: '1000px'}}>
+          NOTE: Concept Set can have only 1000 concepts. Please delete some concepts before adding more.
+        </div>}
         <div style={styles.searchContainer}>
           <div style={styles.searchBar}>
             <ClrIcon shape='search' size='18'/>

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -81,13 +81,9 @@ const styles = reactStyles({
     color: colors.select,
     margin: '5px'
   },
-  disableSelectIcon: {
+  disableIcon: {
     opacity: 0.4,
     cursor: 'not-allowed'
-  },
-  selected: {
-    cursor: 'not-allowed',
-    opacity: 0.4
   },
   treeNode: {
     alignItems: 'center',
@@ -344,10 +340,10 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
     const displayName = domainId === Domain.PHYSICALMEASUREMENT.toString() && !!searchTerms
       ? highlightSearchTerm(searchTerms, name, colors.success)
       : name;
-    const selectIconStyle = this.selectIconDisabled() ? {...styles.selectIcon, ...styles.disableSelectIcon} : styles.selectIcon;
+    const selectIconStyle = this.selectIconDisabled() ? {...styles.selectIcon, ...styles.disableIcon} : styles.selectIcon;
 
     return <React.Fragment>
-        <div style={{...styles.treeNode}} id={`node${id}`} onClick={() => this.toggleExpanded()}>
+      <div style={{...styles.treeNode}} id={`node${id}`} onClick={() => this.toggleExpanded()}>
         {group && <button style={styles.iconButton}>
           {loading
             ? <Spinner size={16}/>
@@ -365,7 +361,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
                   shape='slider' dir='right' size='20'
                   onClick={(e) => this.setAttributes(e, node)}/>
               : selected
-                ? <ClrIcon style={styles.selected}
+                ? <ClrIcon style={{...styles.selectIcon, ...styles.disableIcon}}
                     shape='check-circle' size='20'/>
                 : <ClrIcon style={selectIconStyle}
                     shape='plus-circle' size='20'

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -81,6 +81,10 @@ const styles = reactStyles({
     color: colors.select,
     margin: '5px'
   },
+  disableSelectIcon: {
+    opacity: 0.4,
+    cursor: 'not-allowed'
+  },
   selected: {
     cursor: 'not-allowed',
     opacity: 0.4
@@ -321,6 +325,11 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
 
   }
 
+  selectIconDisabled() {
+    const {selectedIds, source} = this.props;
+    return source !== 'criteria' && selectedIds && selectedIds.length >= 1000;
+  }
+
   render() {
     const {autocompleteSelection, groupSelections, node,
       node: {code, count, domainId, id, group, hasAttributes, name, parentId, selectable},
@@ -335,8 +344,13 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
     const displayName = domainId === Domain.PHYSICALMEASUREMENT.toString() && !!searchTerms
       ? highlightSearchTerm(searchTerms, name, colors.success)
       : name;
+    const selectIconStyle = this.selectIconDisabled() ? {...styles.selectIcon, ...styles.disableSelectIcon} : styles.selectIcon;
+
     return <React.Fragment>
-      <div style={{...styles.treeNode}} id={`node${id}`} onClick={() => this.toggleExpanded()}>
+      {this.selectIconDisabled() && <div style={{color: colors.warning, fontWeight: 'bold', maxWidth: '1000px'}}>
+        NOTE: Concept Set can have only 1000 concepts. Please delete some concepts before adding more.
+      </div>}1
+        <div style={{...styles.treeNode}} id={`node${id}`} onClick={() => this.toggleExpanded()}>
         {group && <button style={styles.iconButton}>
           {loading
             ? <Spinner size={16}/>
@@ -354,7 +368,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
                   shape='slider' dir='right' size='20'
                   onClick={(e) => this.setAttributes(e, node)}/>
               : selected
-                ? <ClrIcon style={{...styles.selectIcon, ...styles.selected}}
+                ? <ClrIcon style={selectIconStyle}
                     shape='check-circle' size='20'/>
                 : <ClrIcon style={styles.selectIcon}
                     shape='plus-circle' size='20'

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -347,9 +347,6 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
     const selectIconStyle = this.selectIconDisabled() ? {...styles.selectIcon, ...styles.disableSelectIcon} : styles.selectIcon;
 
     return <React.Fragment>
-      {this.selectIconDisabled() && <div style={{color: colors.warning, fontWeight: 'bold', maxWidth: '1000px'}}>
-        NOTE: Concept Set can have only 1000 concepts. Please delete some concepts before adding more.
-      </div>}1
         <div style={{...styles.treeNode}} id={`node${id}`} onClick={() => this.toggleExpanded()}>
         {group && <button style={styles.iconButton}>
           {loading
@@ -368,9 +365,9 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
                   shape='slider' dir='right' size='20'
                   onClick={(e) => this.setAttributes(e, node)}/>
               : selected
-                ? <ClrIcon style={selectIconStyle}
+                ? <ClrIcon style={styles.selected}
                     shape='check-circle' size='20'/>
-                : <ClrIcon style={styles.selectIcon}
+                : <ClrIcon style={selectIconStyle}
                     shape='plus-circle' size='20'
                     onClick={(e) => this.select(e)}/>
             }

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -219,6 +219,11 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
       : true;
   }
 
+  selectIconDisabled() {
+    const {selectedIds, source} = this.props;
+    return source !== 'criteria' && selectedIds && selectedIds.length >= 1000;
+  }
+
   render() {
     const {autocompleteSelection, back, groupSelections, node, scrollToMatch, searchTerms, select, selectedIds, selectOption, setAttributes,
       setSearchTerms} = this.props;

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -229,6 +229,9 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
       setSearchTerms} = this.props;
     const {children, error, ingredients, loading} = this.state;
     return <React.Fragment>
+      {this.selectIconDisabled() && <div style={{color: colors.warning, fontWeight: 'bold', maxWidth: '1000px'}}>
+        NOTE: Concept Set can have only 1000 concepts. Please delete some concepts before adding more.
+      </div>}
       {node.domainId !== Domain.VISIT.toString() &&
         <div style={serverConfigStore.getValue().enableCohortBuilderV2
           ? {...styles.searchBarContainer, backgroundColor: 'transparent', width: '65%'}


### PR DESCRIPTION
When there are 1000 concepts in concept set:

- Show warning message

- Disable + icons

<img width="1587" alt="Screen Shot 2020-11-02 at 10 18 54 AM" src="https://user-images.githubusercontent.com/34481816/97885177-074d3e00-1cf5-11eb-8194-e8ba58b0ee4f.png">


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
