### PR TITLE
[RW-5849][risk=moderate] Exclude disabled users from bulk cron

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -264,6 +264,10 @@ public class OfflineUserController implements OfflineUserApiDelegate {
   @Override
   public ResponseEntity<Void> bulkAuditProjectAccess() {
     int errorCount = 0;
+    // For now, continue checking both enabled and disabled users. If needed for performance, this
+    // could be scoped down to just enabled users. However, access to other GCP resources could also
+    // indicate general Google account abuse, which may be a concern regardless of whether or not
+    // the user has been disabled in the Workbench.
     List<DbUser> users = userService.getAllUsers();
     for (DbUser user : users) {
       // TODO(RW-2062): Move to using the gcloud api for list all resources when it is available.

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -73,7 +73,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
     int changeCount = 0;
     int accessLevelChangeCount = 0;
 
-    for (DbUser user : userService.getAllUsers()) {
+    for (DbUser user : userService.getAllUsersExcludingDisabled()) {
       userCount++;
       try {
         Timestamp oldTime = user.getComplianceTrainingCompletionTime();
@@ -138,7 +138,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
     int changeCount = 0;
     int accessLevelChangeCount = 0;
 
-    for (DbUser user : userService.getAllUsers()) {
+    for (DbUser user : userService.getAllUsersExcludingDisabled()) {
       userCount++;
       try {
         // User accounts are registered with Terra on first sign-in. Users who have never signed in
@@ -210,7 +210,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
     int changeCount = 0;
     int accessLevelChangeCount = 0;
 
-    for (DbUser user : userService.getAllUsers()) {
+    for (DbUser user : userService.getAllUsersExcludingDisabled()) {
       userCount++;
       try {
         Timestamp oldTime = user.getTwoFactorAuthCompletionTime();

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -25,6 +25,9 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
   @Query("SELECT user FROM DbUser user")
   List<DbUser> findUsers();
 
+  @Query("SELECT user FROM DbUser user WHERE user.disabled = FALSE")
+  List<DbUser> findUsersExcludingDisabled();
+
   /** Returns the user with their authorities loaded. */
   @Query("SELECT user FROM DbUser user LEFT JOIN FETCH user.authorities WHERE user.userId = :id")
   DbUser findUserWithAuthorities(@Param("id") long id);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -72,6 +72,8 @@ public interface UserService {
 
   List<DbUser> getAllUsers();
 
+  List<DbUser> getAllUsersExcludingDisabled();
+
   @Deprecated // use or create an auditor in org.pmiops.workbench.actionaudit.auditors
   void logAdminUserAction(long targetUserId, String targetAction, Object oldValue, Object newValue);
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -587,6 +587,11 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   @Override
+  public List<DbUser> getAllUsersExcludingDisabled() {
+    return userDao.findUsersExcludingDisabled();
+  }
+
+  @Override
   public void logAdminUserAction(
       long targetUserId, String targetAction, Object oldValue, Object newValue) {
     logAdminAction(targetUserId, null, targetAction, oldValue, newValue);

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
@@ -62,6 +62,7 @@ public class OfflineUserControllerTest {
   @Before
   public void setUp() {
     when(userService.getAllUsersExcludingDisabled()).thenReturn(getUsers());
+    when(userService.getAllUsers()).thenReturn(getUsers());
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
@@ -61,7 +61,7 @@ public class OfflineUserControllerTest {
 
   @Before
   public void setUp() {
-    when(userService.getAllUsers()).thenReturn(getUsers());
+    when(userService.getAllUsersExcludingDisabled()).thenReturn(getUsers());
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
   }
 


### PR DESCRIPTION
This is a temporary band-aid, but it's not strictly necessary to run these crons on users who have been disabled. This should reduce load in production, where a large number of users are disabled.