### PR TITLE
[RW-5840][risk=no] Show warning for unsaved changes in Concept search

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -2,6 +2,7 @@ import {NgModule} from '@angular/core';
 import {NavigationEnd, Router, RouterModule, Routes} from '@angular/router';
 
 import {AppRouting} from './app-routing';
+import {CanDeactivateGuard} from './guards/can-deactivate-guard.service';
 import {RegistrationGuard} from './guards/registration-guard.service';
 import {SignInGuard} from './guards/sign-in-guard.service';
 
@@ -257,6 +258,7 @@ const routes: Routes = [
                       {
                         path: 'concepts',
                         component: ConceptHomepageComponent,
+                        canDeactivate: [CanDeactivateGuard],
                         data: {
                           title: 'Search Concepts',
                           breadcrumb: BreadcrumbType.SearchConcepts,

--- a/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
+++ b/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
@@ -412,6 +412,22 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace(), w
       }
     }
 
+    get textInputPlaceholder() {
+      const {searchContext: {domain}, selectedSurvey, source} = this.props;
+      switch (source) {
+        case 'concept':
+          return `Search ${!!selectedSurvey ? selectedSurvey : domainToTitle(domain)} by code or description`;
+        case 'conceptSetDetails':
+          return `Search ${this.isSurvey ? 'across all ' : ''}${domainToTitle(domain)} by code or description`;
+        case 'criteria':
+          return `Search ${domainToTitle(domain)} by code or description`;
+      }
+    }
+
+    get isSurvey() {
+      return this.props.searchContext.domain === Domain.SURVEY;
+    }
+
     renderRow(row: any, child: boolean, elementId: string) {
       const {hoverId, ingredients} = this.state;
       const attributes = this.props.source === 'criteria' && row.hasAttributes;
@@ -484,7 +500,7 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace(), w
             <ClrIcon shape='search' size='18'/>
             <TextInput style={styles.searchInput}
                        value={searchTerms}
-                       placeholder={`Search ${domainToTitle(domain)} by code or description`}
+                       placeholder={this.textInputPlaceholder}
                        onChange={(e) => this.setState({searchTerms: e})}
                        onKeyPress={this.handleInput} />
             {source === 'conceptSetDetails' && searching && <Clickable style={styles.clearSearchIcon}

--- a/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
+++ b/ui/src/app/cohort-search/list-search-v2/list-search-v2.component.tsx
@@ -313,7 +313,7 @@ export const ListSearchV2 = fp.flow(withCdrVersions(), withCurrentWorkspace(), w
         this.setState({data: null, error: false, loading: true, searching: true, standardOnly: false});
         const {searchContext: {domain}, source, selectedSurvey, workspace: {cdrVersionId}} = this.props;
         const resp = await cohortBuilderApi().findCriteriaByDomainAndSearchTerm(+cdrVersionId, domain, value.trim(), selectedSurvey);
-        const data = source !== 'criteria' && domain === Domain.SURVEY
+        const data = source !== 'criteria' && this.isSurvey
           ? resp.items.filter(survey => survey.subtype === CriteriaSubType.QUESTION.toString())
           : resp.items;
         if (data.length && this.checkSource) {

--- a/ui/src/app/pages/data/concept/concept-add-modal.tsx
+++ b/ui/src/app/pages/data/concept/concept-add-modal.tsx
@@ -11,7 +11,7 @@ import {Spinner, SpinnerOverlay} from 'app/components/spinners';
 import {conceptSetsApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, summarizeErrors, withCurrentWorkspace} from 'app/utils';
-import {serverConfigStore} from 'app/utils/navigation';
+import {conceptSetUpdating, serverConfigStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {
   ConceptSet,
@@ -111,8 +111,8 @@ export const ConceptAddModal = withCurrentWorkspace()
   async saveConcepts() {
     const {workspace: {namespace, id}} = this.props;
     const {onSave, activeDomainTab} = this.props;
-    const {selectedSet, addingToExistingSet, newSetDescription,
-      name, selectedConceptsInDomain} = this.state;
+    const {selectedSet, addingToExistingSet, newSetDescription, name, selectedConceptsInDomain} = this.state;
+    conceptSetUpdating.next(true);
     this.setState({saving: true});
     const conceptIds = fp.map(selected => selected.conceptId, selectedConceptsInDomain);
 

--- a/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
@@ -30,6 +30,7 @@ import {
   WorkspaceStubVariables
 } from 'testing/stubs/workspaces-api-stub';
 import {Key} from 'ts-key-enum';
+import {CohortPage} from '../../../cohort-search/cohort-page/cohort-page.component';
 
 
 function isSelectedDomain(
@@ -68,19 +69,25 @@ describe('ConceptHomepage', () => {
   });
 
   it('should render', () => {
-    const wrapper = mount(<ConceptHomepage />);
+    const wrapper = mount(<ConceptHomepage setConceptSetUpdating={() => {}}
+                                           setShowUnsavedModal={() => {}}
+                                           setUnsavedConceptChanges={() => {}}/>);
     expect(wrapper).toBeTruthy();
   });
 
   it('should have one card per domain.', async() => {
-    const wrapper = mount(<ConceptHomepage />);
+    const wrapper = mount(<ConceptHomepage setConceptSetUpdating={() => {}}
+                                           setShowUnsavedModal={() => {}}
+                                           setUnsavedConceptChanges={() => {}}/>);
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find('[data-test-id="domain-box-name"]').length)
       .toBe(DomainStubVariables.STUB_DOMAINS.length);
   });
 
   it('should have one card per survey.', async() => {
-    const wrapper = mount(<ConceptHomepage />);
+    const wrapper = mount(<ConceptHomepage setConceptSetUpdating={() => {}}
+                                           setShowUnsavedModal={() => {}}
+                                           setUnsavedConceptChanges={() => {}}/>);
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find('[data-test-id="survey-box-name"]').length)
       .toBe(SurveyStubVariables.STUB_SURVEYS.length);
@@ -90,7 +97,9 @@ describe('ConceptHomepage', () => {
     const conceptSpy = jest.spyOn(conceptsApi(), 'searchConcepts');
     const countSpy = jest.spyOn(conceptsApi(), 'domainCounts');
     const surveySpy = jest.spyOn(conceptsApi(), 'searchSurveys');
-    const wrapper = mount(<ConceptHomepage />);
+    const wrapper = mount(<ConceptHomepage setConceptSetUpdating={() => {}}
+                                           setShowUnsavedModal={() => {}}
+                                           setUnsavedConceptChanges={() => {}}/>);
     await waitOneTickAndUpdate(wrapper);
     searchTable(defaultSearchTerm, wrapper);
     await waitOneTickAndUpdate(wrapper);
@@ -147,7 +156,9 @@ describe('ConceptHomepage', () => {
     const conceptSpy = jest.spyOn(conceptsApi(), 'searchConcepts');
     const countSpy = jest.spyOn(conceptsApi(), 'domainCounts');
     const surveySpy = jest.spyOn(conceptsApi(), 'searchSurveys');
-    const wrapper = mount(<ConceptHomepage />);
+    const wrapper = mount(<ConceptHomepage setConceptSetUpdating={() => {}}
+                                           setShowUnsavedModal={() => {}}
+                                           setUnsavedConceptChanges={() => {}}/>);
     await waitOneTickAndUpdate(wrapper);
     const termWithInvalidChars = defaultSearchTerm + '(';
     searchTable(termWithInvalidChars, wrapper);
@@ -165,7 +176,9 @@ describe('ConceptHomepage', () => {
   it('should change search criteria when standard only not checked', async() => {
     const spy = jest.spyOn(conceptsApi(), 'searchConcepts');
     const selectedDomain = DomainStubVariables.STUB_DOMAINS[1];
-    const wrapper = mount(<ConceptHomepage />);
+    const wrapper = mount(<ConceptHomepage setConceptSetUpdating={() => {}}
+                                           setShowUnsavedModal={() => {}}
+                                           setUnsavedConceptChanges={() => {}}/>);
     await waitOneTickAndUpdate(wrapper);
 
     wrapper.find('[data-test-id="standardConceptsCheckBox"] input').first()
@@ -194,7 +207,9 @@ describe('ConceptHomepage', () => {
   });
 
   it('should display the selected concepts on header', async() => {
-    const wrapper = mount(<ConceptHomepage />);
+    const wrapper = mount(<ConceptHomepage setConceptSetUpdating={() => {}}
+                                           setShowUnsavedModal={() => {}}
+                                           setUnsavedConceptChanges={() => {}}/>);
     await waitOneTickAndUpdate(wrapper);
     searchTable(defaultSearchTerm, wrapper);
     await waitOneTickAndUpdate(wrapper);
@@ -205,7 +220,9 @@ describe('ConceptHomepage', () => {
   });
 
   it('should display the selected concepts on sliding button', async() => {
-    const wrapper = mount(<ConceptHomepage />);
+    const wrapper = mount(<ConceptHomepage setConceptSetUpdating={() => {}}
+                                           setShowUnsavedModal={() => {}}
+                                           setUnsavedConceptChanges={() => {}}/>);
     await waitOneTickAndUpdate(wrapper);
     searchTable(defaultSearchTerm, wrapper);
     await waitOneTickAndUpdate(wrapper);
@@ -221,7 +238,9 @@ describe('ConceptHomepage', () => {
   });
 
   it('should clear search and selected concepts', async() => {
-    const wrapper = mount(<ConceptHomepage />);
+    const wrapper = mount(<ConceptHomepage setConceptSetUpdating={() => {}}
+                                           setShowUnsavedModal={() => {}}
+                                           setUnsavedConceptChanges={() => {}}/>);
     await waitOneTickAndUpdate(wrapper);
     searchTable(defaultSearchTerm, wrapper);
     await waitOneTickAndUpdate(wrapper);
@@ -235,7 +254,9 @@ describe('ConceptHomepage', () => {
   });
 
   it('should clear search box and reset page to default view', async() => {
-    const wrapper = mount(<ConceptHomepage />);
+    const wrapper = mount(<ConceptHomepage setConceptSetUpdating={() => {}}
+                                           setShowUnsavedModal={() => {}}
+                                           setUnsavedConceptChanges={() => {}}/>);
     await waitOneTickAndUpdate(wrapper);
     searchTable(defaultSearchTerm, wrapper);
     await waitOneTickAndUpdate(wrapper);
@@ -256,7 +277,9 @@ describe('ConceptHomepage', () => {
   });
 
   it('should display all Concept selected message when header checkbox is selected', async() => {
-    const wrapper = mount(<ConceptHomepage />);
+    const wrapper = mount(<ConceptHomepage setConceptSetUpdating={() => {}}
+                                           setShowUnsavedModal={() => {}}
+                                           setUnsavedConceptChanges={() => {}}/>);
     await waitOneTickAndUpdate(wrapper);
     searchTable('headerText', wrapper);
     await waitOneTickAndUpdate(wrapper);

--- a/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
@@ -30,7 +30,6 @@ import {
   WorkspaceStubVariables
 } from 'testing/stubs/workspaces-api-stub';
 import {Key} from 'ts-key-enum';
-import {CohortPage} from '../../../cohort-search/cohort-page/cohort-page.component';
 
 
 function isSelectedDomain(

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -27,6 +27,7 @@ import {
   withCurrentWorkspace
 } from 'app/utils';
 import {
+  conceptSetUpdating,
   currentConceptSetStore,
   currentConceptStore,
   NavStore,
@@ -196,6 +197,7 @@ const PhysicalMeasurementsCard: React.FunctionComponent<{physicalMeasurement: Do
     };
 
 interface Props {
+  setConceptSetUpdating: (conceptSetUpdating: boolean) => void;
   setShowUnsavedModal: (showUnsavedModal: () => Promise<boolean>) => void;
   setUnsavedConceptChanges: (unsavedConceptChanges: boolean) => void;
   workspace: WorkspaceData;
@@ -328,6 +330,7 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
           this.props.setUnsavedConceptChanges(unsavedChanges);
           this.setState({unsavedChanges});
         });
+      this.subscription.add(conceptSetUpdating.subscribe(updating => this.props.setConceptSetUpdating(updating)));
       this.props.setShowUnsavedModal(this.showUnsavedModal);
     }
 
@@ -896,10 +899,12 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
   template: '<div #root></div>'
 })
 export class ConceptHomepageComponent extends ReactWrapperBase {
+  conceptSetUpdating: boolean;
   showUnsavedModal: () => Promise<boolean>;
   unsavedConceptChanges: boolean;
   constructor() {
-    super(ConceptHomepage, ['setShowUnsavedModal', 'setUnsavedConceptChanges']);
+    super(ConceptHomepage, ['setConceptSetUpdating', 'setShowUnsavedModal', 'setUnsavedConceptChanges']);
+    this.setConceptSetUpdating = this.setConceptSetUpdating.bind(this);
     this.setShowUnsavedModal = this.setShowUnsavedModal.bind(this);
     this.setUnsavedConceptChanges = this.setUnsavedConceptChanges.bind(this);
   }
@@ -908,12 +913,16 @@ export class ConceptHomepageComponent extends ReactWrapperBase {
     this.showUnsavedModal = showUnsavedModal;
   }
 
+  setConceptSetUpdating(csUpdating: boolean): void {
+    this.conceptSetUpdating = csUpdating;
+  }
+
   setUnsavedConceptChanges(unsavedConceptChanges: boolean): void {
     this.unsavedConceptChanges = unsavedConceptChanges;
   }
 
   canDeactivate(): Promise<boolean> | boolean {
-    return !this.unsavedConceptChanges || this.showUnsavedModal();
+    return !this.unsavedConceptChanges || this.conceptSetUpdating || this.showUnsavedModal();
   }
 }
 

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -321,15 +321,15 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
 
     componentDidMount() {
       this.loadDomainsAndSurveys();
-      this.subscription = currentConceptStore
-        .filter(currentConcepts => ![null, undefined].includes(currentConcepts))
-        .subscribe(currentConcepts => {
+      this.subscription = currentConceptStore.subscribe(currentConcepts => {
+        if (![null, undefined].includes(currentConcepts)) {
           const currentConceptSet = currentConceptSetStore.getValue();
           const unsavedChanges = (!currentConceptSet && currentConcepts.length > 0)
             || (!!currentConceptSet && JSON.stringify(currentConceptSet.criteriums.sort()) !== JSON.stringify(currentConcepts.sort()));
           this.props.setUnsavedConceptChanges(unsavedChanges);
           this.setState({unsavedChanges});
-        });
+        }
+      });
       this.subscription.add(conceptSetUpdating.subscribe(updating => this.props.setConceptSetUpdating(updating)));
       this.props.setShowUnsavedModal(this.showUnsavedModal);
     }

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -880,7 +880,7 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
           <ModalTitle>Warning! </ModalTitle>
           <ModalBody>
             Your concept set has not been saved. If you’d like to save your concepts, please click CANCEL
-            and click FINISH AND REVIEW to save your criteria.
+            and save your changes in the right sidebar.
           </ModalBody>
           <ModalFooter>
             <Button type='link' onClick={onModalCancel}>Cancel</Button>

--- a/ui/src/app/pages/data/concept/concept-list.tsx
+++ b/ui/src/app/pages/data/concept/concept-list.tsx
@@ -14,7 +14,13 @@ import {
   withCurrentConceptSet,
   withCurrentWorkspace
 } from 'app/utils';
-import {currentConceptSetStore, currentConceptStore, NavStore, setSidebarActiveIconStore} from 'app/utils/navigation';
+import {
+  conceptSetUpdating,
+  currentConceptSetStore,
+  currentConceptStore,
+  NavStore,
+  setSidebarActiveIconStore
+} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {ConceptSet, Criteria, Domain, DomainCount, UpdateConceptSetRequest} from 'generated/fetch';
 
@@ -84,6 +90,7 @@ export const  ConceptListPage = fp.flow(withCurrentWorkspace(), withCurrentConce
 
     async updateConceptSet() {
       const {concept, conceptSet, workspace: {namespace, id}} = this.props;
+      conceptSetUpdating.next(true);
       this.setState({updating: true});
       // Selections that don't exist on the existing concept set are added
       const addedIds = getConceptIdsToAddOrRemove(concept, conceptSet.criteriums);
@@ -177,8 +184,7 @@ export const  ConceptListPage = fp.flow(withCurrentWorkspace(), withCurrentConce
             Close
           </Button>
         </FlexRowWrap>
-        {conceptAddModalOpen &&
-        <ConceptAddModal activeDomainTab={this.getDomainCount()}
+        {conceptAddModalOpen && <ConceptAddModal activeDomainTab={this.getDomainCount()}
                          selectedConcepts={this.props.concept}
                          onSave={(conceptSet) => this.afterConceptsSaved(conceptSet)}
                          onClose={() => this.closeConceptAddModal()}/>}

--- a/ui/src/app/pages/data/concept/concept-set-actions.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-actions.tsx
@@ -7,7 +7,7 @@ import {SpinnerOverlay} from 'app/components/spinners';
 import {conceptSetsApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
-import {navigate, navigateByUrl, urlParamsStore} from 'app/utils/navigation';
+import {conceptSetUpdating, navigate, navigateByUrl, urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {ConceptSet} from 'generated/fetch';
 import * as React from 'react';
@@ -79,6 +79,7 @@ export const ConceptSetActions = withCurrentWorkspace()(
     }
 
     componentDidMount(): void {
+      conceptSetUpdating.next(false);
       const csid = urlParamsStore.getValue().csid;
       this.setState({conceptSetLoading: true});
       if (csid) {

--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -34,6 +34,7 @@ export const currentConceptStore = new BehaviorSubject<Array<Criteria>>(undefine
 export const attributesSelectionStore = new BehaviorSubject<Criteria>(undefined);
 export const currentCohortSearchContextStore = new BehaviorSubject<any>(undefined);
 export const setSidebarActiveIconStore = new BehaviorSubject<string>(null);
+export const conceptSetUpdating = new BehaviorSubject<boolean>(false);
 
 export const userProfileStore =
   new BehaviorSubject<{ profile: Profile, reload: Function, updateCache: Function }>({


### PR DESCRIPTION
- Add warning modal for unsaved changes when leaving concept search
- Update placeholder text in text input for surveys
<img width="629" alt="Screen Shot 2020-11-04 at 2 02 17 PM" src="https://user-images.githubusercontent.com/40036095/98165599-cd726800-1eab-11eb-87bb-46ac329a7fd3.png">
<img width="1038" alt="Screen Shot 2020-11-04 at 2 01 50 PM" src="https://user-images.githubusercontent.com/40036095/98165621-d4997600-1eab-11eb-8e48-6764d284a99e.png">
<img width="1011" alt="Screen Shot 2020-11-04 at 2 01 27 PM" src="https://user-images.githubusercontent.com/40036095/98165635-db27ed80-1eab-11eb-912e-86a76693aa04.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
