### PR TITLE
[RW-5801][risk=no] Standardize runtimeStore.set callers

### DIFF
--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -151,14 +151,12 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
         this.workspace = workspace;
         this.accessLevel = workspace.accessLevel;
         currentWorkspaceStore.next(workspace);
+        runtimeStore.set({workspaceNamespace: workspace.namespace, runtime: undefined});
         this.pollAborter.abort();
         this.pollAborter = new AbortController();
         try {
           await LeoRuntimeInitializer.initialize({
             workspaceNamespace: workspace.namespace,
-            onPoll: (runtime) => {
-              runtimeStore.set({runtime: runtime, workspaceNamespace: workspace.namespace});
-            },
             pollAbortSignal: this.pollAborter.signal,
             maxCreateCount: 0,
             maxDeleteCount: 0,

--- a/ui/src/app/utils/runtime-utils.ts
+++ b/ui/src/app/utils/runtime-utils.ts
@@ -29,10 +29,12 @@ const useRuntime = (currentWorkspaceNamespace) => {
       () => runtimeStore.set({workspaceNamespace: null, runtime: null}),
       async() => {
         const leoRuntime = await runtimeApi().getRuntime(currentWorkspaceNamespace);
-        runtimeStore.set({
-          workspaceNamespace: currentWorkspaceNamespace,
-          runtime: leoRuntime
-        });
+        if (currentWorkspaceNamespace === runtimeStore.get().workspaceNamespace) {
+          runtimeStore.set({
+            workspaceNamespace: currentWorkspaceNamespace,
+            runtime: leoRuntime
+          });
+        }
       });
 
     if (currentWorkspaceNamespace !== runtimeStore.get().workspaceNamespace) {
@@ -80,17 +82,10 @@ export const useCustomRuntime = (currentWorkspaceNamespace): [Runtime, (runtime:
       if (runtime && runtime.status !== RuntimeStatus.Deleted) {
         await runtimeApi().deleteRuntime(currentWorkspaceNamespace);
       }
-      const currentRuntime = await LeoRuntimeInitializer.initialize({
+      await LeoRuntimeInitializer.initialize({
         workspaceNamespace,
         targetRuntime: requestedRuntime
       });
-
-      if (currentWorkspaceNamespace === workspaceNamespace) {
-        runtimeStore.set({
-          workspaceNamespace: currentWorkspaceNamespace,
-          runtime: currentRuntime
-        });
-      }
     };
 
     if (requestedRuntime !== undefined && !fp.equals(requestedRuntime, runtime)) {


### PR DESCRIPTION
1. Always check for namespace consistency when setting the runtime store, to ensure the async payload is still relevant.
2. Don't call set if you're already calling `LeoRuntimeInitializer`, this already sets (e.g. onPoll setter).
3. Explicitly clear the runtime store when workspace context changes.