### PR TITLE
[risk=low] Recent Resources Table improvements

### DIFF
--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -1,3 +1,6 @@
+import * as fp from 'lodash/fp';
+import * as React from 'react';
+
 import {navigate, queryParamsStore, serverConfigStore} from 'app/utils/navigation';
 
 import {
@@ -22,11 +25,7 @@ import {hasRegisteredAccessFetch, reactStyles, withUserProfile} from 'app/utils'
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {fetchWithGlobalErrorHandler} from 'app/utils/retry';
 import {supportUrls} from 'app/utils/zendesk';
-import {
-  Profile,
-} from 'generated/fetch';
-import * as fp from 'lodash/fp';
-import * as React from 'react';
+import {Profile, WorkspaceResponseListResponse} from 'generated/fetch';
 
 export const styles = reactStyles({
   bottomBanner: {
@@ -89,9 +88,9 @@ interface State {
   quickTourResourceOffset: number;
   trainingCompleted: boolean;
   twoFactorAuthCompleted: boolean;
+  userWorkspacesResponse: WorkspaceResponseListResponse;
   videoOpen: boolean;
   videoId: string;
-  userHasWorkspaces: boolean | null;
 }
 
 export const Homepage = withUserProfile()(class extends React.Component<Props, State> {
@@ -115,9 +114,9 @@ export const Homepage = withUserProfile()(class extends React.Component<Props, S
       quickTourResourceOffset: 0,
       trainingCompleted: undefined,
       twoFactorAuthCompleted: undefined,
+      userWorkspacesResponse: undefined,
       videoOpen: false,
       videoId: '',
-      userHasWorkspaces: null,
     };
   }
 
@@ -234,10 +233,13 @@ export const Homepage = withUserProfile()(class extends React.Component<Props, S
   }
 
   async checkWorkspaces() {
-    const userWorkspacesResponse = (await fetchWithGlobalErrorHandler(() => workspacesApi().getWorkspaces()));
-    this.setState({
-      userHasWorkspaces: userWorkspacesResponse && userWorkspacesResponse.items.length > 0
-    });
+    return fetchWithGlobalErrorHandler(() => workspacesApi().getWorkspaces())
+        .then(response => this.setState({ userWorkspacesResponse: response}));
+  }
+
+  userHasWorkspaces(): boolean {
+    const {userWorkspacesResponse} = this.state;
+    return userWorkspacesResponse && userWorkspacesResponse.items.length > 0;
   }
 
   openVideo(videoId: string): void {
@@ -343,11 +345,11 @@ export const Homepage = withUserProfile()(class extends React.Component<Props, S
                             <RecentWorkspaces />
                           </FlexColumn>
                           <FlexColumn>
-                            {this.state.userHasWorkspaces !== null &&
+                            {this.state.userWorkspacesResponse &&
 
                               <React.Fragment>
-                                {this.state.userHasWorkspaces ?
-                                <RecentResources/> :
+                                {this.userHasWorkspaces() ?
+                                <RecentResources workspaces={this.state.userWorkspacesResponse.items}/> :
 
                                 <div data-test-id='getting-started'
                                      style={{

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -252,7 +252,7 @@ export const Homepage = withUserProfile()(class extends React.Component<Props, S
     const {betaAccessGranted, videoOpen, accessTasksLoaded, accessTasksRemaining,
       eraCommonsError, eraCommonsLinked, eraCommonsLoading, firstVisitTraining,
       trainingCompleted, quickTour, videoId, twoFactorAuthCompleted,
-      dataUserCodeOfConductCompleted, quickTourResourceOffset
+      dataUserCodeOfConductCompleted, quickTourResourceOffset, userWorkspacesResponse
     } = this.state;
     // This calculates the limit for quickTourResources items that can be seen without scrolling. Takes the width of the parent element
     // and divides by the width of an individual resource item (276px). The default limit is 4 since the min width of the parent element
@@ -345,11 +345,11 @@ export const Homepage = withUserProfile()(class extends React.Component<Props, S
                             <RecentWorkspaces />
                           </FlexColumn>
                           <FlexColumn>
-                            {this.state.userWorkspacesResponse &&
+                            {userWorkspacesResponse &&
 
                               <React.Fragment>
                                 {this.userHasWorkspaces() ?
-                                <RecentResources workspaces={this.state.userWorkspacesResponse.items}/> :
+                                <RecentResources workspaces={userWorkspacesResponse.items}/> :
 
                                 <div data-test-id='getting-started'
                                      style={{

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -13,7 +13,7 @@ import {SpinnerOverlay} from 'app/components/spinners';
 import {userMetricsApi} from 'app/services/swagger-fetch-clients';
 import {formatWorkspaceResourceDisplayDate, getCdrVersion, reactStyles, withCdrVersions} from 'app/utils';
 import {navigateAndPreventDefaultIfNoKeysPressed} from 'app/utils/navigation';
-import {getDisplayName} from 'app/utils/resources';
+import {getDisplayName, isNotebook} from 'app/utils/resources';
 import {
   CdrVersionListResponse,
   Workspace,
@@ -41,9 +41,16 @@ const styles = reactStyles({
   }
 });
 
-const WorkspaceNavigation = (props: {workspace: Workspace, style?: CSSProperties}) => {
-  const {workspace: {name, namespace, id}, style} = props;
-  const url = `/workspaces/${namespace}/${id}/data`;
+interface NavProps {
+  workspace: Workspace;
+  resource: WorkspaceResource;
+  style?: CSSProperties;
+}
+
+const WorkspaceNavigation = (props: NavProps) => {
+  const {workspace: {name, namespace, id}, resource, style} = props;
+  const tab = isNotebook(resource) ? 'notebooks' : 'data';
+  const url = `/workspaces/${namespace}/${id}/${tab}`;
 
   return <Clickable>
     <a data-test-id='workspace-navigation'
@@ -115,7 +122,7 @@ const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
           menu: renderResourceMenu(r),
           resourceType: <ResourceNavigation resource={r}><StyledResourceType resource={r}/></ResourceNavigation>,
           resourceName: <ResourceNavigation resource={r} style={styles.navigation}>{getDisplayName(r)}</ResourceNavigation>,
-          workspaceName: <WorkspaceNavigation workspace={getWorkspace(r)} style={styles.navigation}/>,
+          workspaceName: <WorkspaceNavigation workspace={getWorkspace(r)} resource={r} style={styles.navigation}/>,
           formattedLastModified: formatWorkspaceResourceDisplayDate(r.modifiedTime),
           cdrVersionName: getCdrVersionName(r),
         };


### PR DESCRIPTION
Description:

Follow up to #4242 after Sprint review:
* home page calls getWorkspaces() once instead of twice
* workspace navigation links from notebooks go to the notebooks page

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
