### PR TITLE
[risk=low][RW-5564] Default to latest CDR on Workspace dupe and show upgrade message

### DIFF
--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -11,6 +11,7 @@ import {buildXPath} from 'app/xpath-builders';
 import {LinkText} from 'app/text-labels';
 import WorkspaceBase, {UseFreeCredits} from './workspace-base';
 import {config} from 'resources/workbench-config';
+import BaseElement from 'app/element/base-element';
 
 const faker = require('faker/locale/en_US');
 
@@ -248,6 +249,18 @@ export default class WorkspaceEditPage extends WorkspaceBase {
    */
   async getCdrVersionSelect(): Promise<Select> {
     return Select.findByName(this.page, FIELD.cdrVersionSelect.textOption);
+  }
+
+  async getCdrVersionUpgradeMessage(): Promise<string> {
+    const xpath = '//*[@data-test-id="cdr-version-upgrade"]';
+    const element = BaseElement.asBaseElement(this.page, await this.page.waitForXPath(xpath));
+    return element.getTextContent();
+  }
+
+  async getCdrVersionWarningMessage(): Promise<string> {
+    const xpath = '//*[@data-test-id="old-cdr-version-warning"]';
+    const element = BaseElement.asBaseElement(this.page, await this.page.waitForXPath(xpath));
+    return element.getTextContent();
   }
 
   async getBillingAccountSelect(): Promise<Select> {

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -257,12 +257,6 @@ export default class WorkspaceEditPage extends WorkspaceBase {
     return element.getTextContent();
   }
 
-  async getCdrVersionWarningMessage(): Promise<string> {
-    const xpath = '//*[@data-test-id="old-cdr-version-warning"]';
-    const element = BaseElement.asBaseElement(this.page, await this.page.waitForXPath(xpath));
-    return element.getTextContent();
-  }
-
   async getBillingAccountSelect(): Promise<Select> {
     return Select.findByName(this.page, FIELD.billingAccountSelect.textOption);
   }

--- a/e2e/tests/workspace/workspace-duplicate.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate.spec.ts
@@ -93,9 +93,6 @@ describe('Duplicate workspace', () => {
     // change CDR Version
     await workspacesPage.selectCdrVersion(config.altCdrVersionName);
 
-    expect(await workspacesPage.getCdrVersionWarningMessage())
-        .toContain('You’ve selected a version that isn’t the most recent.');
-
     const finishButton = await workspacesPage.getDuplicateWorkspaceButton();
     await finishButton.waitUntilEnabled();
     await workspacesPage.clickCreateFinishButton(finishButton);

--- a/e2e/tests/workspace/workspace-duplicate.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate.spec.ts
@@ -133,7 +133,7 @@ describe('Duplicate workspace', () => {
     await workspacesPage.selectCdrVersion(config.defaultCdrVersionName);
 
     const upgradeMessage = await workspacesPage.getCdrVersionUpgradeMessage();
-    expect(upgradeMessage).toContain(`You're duplicating the workspace "${originalWorkspaceName}" to upgrade from`);
+    expect(upgradeMessage).toContain(originalWorkspaceName);
     expect(upgradeMessage).toContain(`${config.altCdrVersionName} to ${config.defaultCdrVersionName}.`);
 
     const finishButton = await workspacesPage.getDuplicateWorkspaceButton();

--- a/e2e/tests/workspace/workspace-duplicate.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate.spec.ts
@@ -1,9 +1,10 @@
 import WorkspacesPage from 'app/page/workspaces-page';
-import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
+import {createWorkspace, findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import {Option} from 'app/text-labels';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import Navigation, {NavLink} from 'app/component/navigation';
 import WorkspaceCard from 'app/component/workspace-card';
+import {config} from 'resources/workbench-config';
 
 describe('Duplicate workspace', () => {
 
@@ -76,4 +77,88 @@ describe('Duplicate workspace', () => {
       await dataPage.deleteWorkspace();
     });
 
+  test('OWNER can duplicate workspace to an older CDR Version via Workspace card', async () => {
+    const workspaceCard: WorkspaceCard = await createWorkspace(page, config.defaultCdrVersionName);
+    const originalWorkspaceName = await workspaceCard.getWorkspaceName();
+
+    await workspaceCard.asElementHandle().hover();
+    // Click on Ellipsis menu "Duplicate" option.
+    await workspaceCard.selectSnowmanMenu(Option.Duplicate);
+
+    // Fill out Workspace Name should be just enough for successful duplication
+    const workspacesPage = new WorkspacesPage(page);
+    await (await workspacesPage.getWorkspaceNameTextbox()).clear();
+    const duplicateWorkspaceName = await workspacesPage.fillOutWorkspaceName();
+
+    // change CDR Version
+    await workspacesPage.selectCdrVersion(config.altCdrVersionName);
+
+    expect(await workspacesPage.getCdrVersionWarningMessage())
+        .toContain('You’ve selected a version that isn’t the most recent.');
+
+    const finishButton = await workspacesPage.getDuplicateWorkspaceButton();
+    await finishButton.waitUntilEnabled();
+    await workspacesPage.clickCreateFinishButton(finishButton);
+
+    // Duplicate workspace Data page is loaded.
+    const dataPage = new WorkspaceDataPage(page);
+    await dataPage.waitForLoad();
+    expect(page.url()).toContain(duplicateWorkspaceName.replace(/-/g, '')); // Remove dash from workspace name
+
+    // Delete duplicate workspace via Workspace card in Your Workspaces page.
+    await Navigation.navMenu(page, NavLink.YOUR_WORKSPACES);
+    await workspacesPage.waitForLoad();
+
+    await WorkspaceCard.deleteWorkspace(page, duplicateWorkspaceName);
+
+    // Verify Delete action was successful.
+    expect(await WorkspaceCard.findCard(page, duplicateWorkspaceName)).toBeFalsy();
+
+    // Delete original workspace via Workspace card
+    await WorkspaceCard.deleteWorkspace(page, originalWorkspaceName);
+    expect(await WorkspaceCard.findCard(page, originalWorkspaceName)).toBeFalsy();
+  });
+
+  test('OWNER can duplicate workspace to a newer CDR Version via Workspace card', async () => {
+    const workspaceCard: WorkspaceCard = await createWorkspace(page, config.altCdrVersionName);
+    const originalWorkspaceName = await workspaceCard.getWorkspaceName();
+
+    await workspaceCard.asElementHandle().hover();
+    // Click on Ellipsis menu "Duplicate" option.
+    await workspaceCard.selectSnowmanMenu(Option.Duplicate);
+
+    // Fill out Workspace Name should be just enough for successful duplication
+    const workspacesPage = new WorkspacesPage(page);
+    await (await workspacesPage.getWorkspaceNameTextbox()).clear();
+    const duplicateWorkspaceName = await workspacesPage.fillOutWorkspaceName();
+
+    // change CDR Version
+    await workspacesPage.selectCdrVersion(config.defaultCdrVersionName);
+
+    const upgradeMessage = await workspacesPage.getCdrVersionUpgradeMessage();
+    expect(upgradeMessage).toContain(`You're duplicating the workspace "${originalWorkspaceName}" to upgrade from`);
+    expect(upgradeMessage).toContain(`${config.altCdrVersionName} to ${config.defaultCdrVersionName}.`);
+
+    const finishButton = await workspacesPage.getDuplicateWorkspaceButton();
+    await finishButton.waitUntilEnabled();
+    await workspacesPage.clickCreateFinishButton(finishButton);
+
+    // Duplicate workspace Data page is loaded.
+    const dataPage = new WorkspaceDataPage(page);
+    await dataPage.waitForLoad();
+    expect(page.url()).toContain(duplicateWorkspaceName.replace(/-/g, '')); // Remove dash from workspace name
+
+    // Delete duplicate workspace via Workspace card in Your Workspaces page.
+    await Navigation.navMenu(page, NavLink.YOUR_WORKSPACES);
+    await workspacesPage.waitForLoad();
+
+    await WorkspaceCard.deleteWorkspace(page, duplicateWorkspaceName);
+
+    // Verify Delete action was successful.
+    expect(await WorkspaceCard.findCard(page, duplicateWorkspaceName)).toBeFalsy();
+
+    // Delete original workspace via Workspace card
+    await WorkspaceCard.deleteWorkspace(page, originalWorkspaceName);
+    expect(await WorkspaceCard.findCard(page, originalWorkspaceName)).toBeFalsy();
+  });
 });

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -1,5 +1,7 @@
 import {Component} from '@angular/core';
 import * as fp from 'lodash/fp';
+import {Column} from 'primereact/column';
+import {DataTable} from 'primereact/datatable';
 import * as React from 'react';
 
 import {Button, Clickable, Link, StyledAnchorTag} from 'app/components/buttons';
@@ -16,7 +18,6 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {
   formatDomain,
   formatDomainString,
-  getCdrVersion,
   reactStyles,
   ReactWrapperBase,
   toggleIncludes,
@@ -26,6 +27,7 @@ import {
   withUserProfile
 } from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
+import {getCdrVersion} from 'app/utils/cdr-versions';
 import {currentWorkspaceStore, navigateAndPreventDefaultIfNoKeysPressed} from 'app/utils/navigation';
 import {apiCallWithGatewayTimeoutRetries} from 'app/utils/retry';
 import {WorkspaceData} from 'app/utils/workspace-data';
@@ -48,8 +50,6 @@ import {
   Profile,
   ValueSet,
 } from 'generated/fetch';
-import {Column} from 'primereact/column';
-import {DataTable} from 'primereact/datatable';
 
 export const styles = reactStyles({
   dataDictionaryHeader: {

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -11,7 +11,8 @@ import {renderResourceCard} from 'app/components/render-resource-card';
 import {ResourceNavigation, StyledResourceType} from 'app/components/resource-card';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {userMetricsApi} from 'app/services/swagger-fetch-clients';
-import {formatWorkspaceResourceDisplayDate, getCdrVersion, reactStyles, withCdrVersions} from 'app/utils';
+import {formatWorkspaceResourceDisplayDate, reactStyles, withCdrVersions} from 'app/utils';
+import {getCdrVersion} from 'app/utils/cdr-versions';
 import {navigateAndPreventDefaultIfNoKeysPressed} from 'app/utils/navigation';
 import {getDisplayName, isNotebook} from 'app/utils/resources';
 import {

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -16,8 +16,9 @@ import {ResetRuntimeButton} from 'app/pages/analysis/reset-runtime-button';
 import {ResearchPurpose} from 'app/pages/workspace/research-purpose';
 import {WorkspaceShare} from 'app/pages/workspace/workspace-share';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
-import {getCdrVersion, reactStyles, ReactWrapperBase, withCdrVersions, withUrlParams, withUserProfile} from 'app/utils';
+import {reactStyles, ReactWrapperBase, withCdrVersions, withUrlParams, withUserProfile} from 'app/utils';
 import {AuthorityGuardedAction, hasAuthorityForAction} from 'app/utils/authorities';
+import {getCdrVersion} from 'app/utils/cdr-versions';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 import {
   BillingAccountType,

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -1,17 +1,18 @@
+import * as fp from 'lodash/fp';
+import * as React from 'react';
+import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
+
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {cdrVersionStore, currentWorkspaceStore, navigate, routeConfigDataStore, serverConfigStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
-import {DisseminateResearchEnum, ResearchOutcomeEnum,
-  SpecificPopulationEnum,UserApi, Workspace, WorkspaceAccessLevel, WorkspacesApi} from 'generated/fetch';
-import * as fp from 'lodash/fp';
-import * as React from 'react';
+import {DisseminateResearchEnum, ResearchOutcomeEnum, SpecificPopulationEnum,UserApi, Workspace, WorkspaceAccessLevel, WorkspacesApi} from 'generated/fetch';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {cdrVersionListResponse} from 'testing/stubs/cdr-versions-api-stub';
 import {UserApiStub} from 'testing/stubs/user-api-stub';
 import {WorkspacesApiStub, workspaceStubs} from 'testing/stubs/workspaces-api-stub';
 import {WorkspaceEdit, WorkspaceEditMode} from 'app/pages/workspace/workspace-edit';
 import {WorkspaceEditSection} from 'app/pages/workspace/workspace-edit-section';
+import {CdrVersionsStubVariables} from 'testing/stubs/cdr-versions-api-stub';
 
 jest.mock('app/utils/navigation', () => ({
   ...(jest.requireActual('app/utils/navigation')),
@@ -184,8 +185,6 @@ describe('WorkspaceEdit', () => {
     // Clicking the icon should collapse all the research purpose sub-categories
     wrapper.find('[data-test-id="research-purpose-button"]').first().simulate('click');
     expect(wrapper.find('[data-test-id="research-purpose-categories"]').length).toBe(0);
-
-
   });
 
   it('supports disable save button if Research Outcome is not answered', async () => {
@@ -214,6 +213,23 @@ describe('WorkspaceEdit', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(workspacesApi.workspaces.length).toEqual(numBefore + 1);
     expect(navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults to upgrading the CDR Version when duplicating a workspace with an older CDR Version', async() => {
+    // init the workspace to a non-default CDR version value
+    const altCdrWorkspace = {...workspace, cdrVersionId: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION_ID}
+    currentWorkspaceStore.next(altCdrWorkspace);
+
+    // duplication will involve a CDR version upgrade by default
+    routeConfigDataStore.next({mode: WorkspaceEditMode.Duplicate});
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    const cdrSelection = wrapper.find('[data-test-id="select-cdr-version"]').find('select').props().value;
+
+    // default CDR version, not the existing workspace's alt CDR version
+    expect(cdrSelection).toBe(CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID);
   });
 
   // regression test for RW-5132

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -231,11 +231,10 @@ describe('WorkspaceEdit', () => {
     // default CDR version, not the existing workspace's alt CDR version
     expect(cdrSelection).toBe(CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID);
 
-    const expectedUpgradeMessage1 = `You're duplicating the workspace "${altCdrWorkspace.name}" to upgrade from`;
-    const expectedUpgradeMessage2 = `${CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION} to ${CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION}.`;
+    const expectedUpgradeMessage = `${CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION} to ${CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION}.`;
     const cdrUpgradeMessage = wrapper.find('[data-test-id="cdr-version-upgrade"]').first().text();
-    expect(cdrUpgradeMessage).toContain(expectedUpgradeMessage1);
-    expect(cdrUpgradeMessage).toContain(expectedUpgradeMessage2);
+    expect(cdrUpgradeMessage).toContain(altCdrWorkspace.name);
+    expect(cdrUpgradeMessage).toContain(expectedUpgradeMessage);
   });
 
   it('does not display the CDR Version upgrade message when duplicating a workspace with the latest CDR Version', async() => {

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -230,6 +230,26 @@ describe('WorkspaceEdit', () => {
 
     // default CDR version, not the existing workspace's alt CDR version
     expect(cdrSelection).toBe(CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID);
+
+    const expectedUpgradeMessage1 = `You're duplicating the workspace "${altCdrWorkspace.name}" to upgrade from`;
+    const expectedUpgradeMessage2 = `${CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION} to ${CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION}.`;
+    const cdrUpgradeMessage = wrapper.find('[data-test-id="cdr-version-upgrade"]').first().text();
+    expect(cdrUpgradeMessage).toContain(expectedUpgradeMessage1);
+    expect(cdrUpgradeMessage).toContain(expectedUpgradeMessage2);
+  });
+
+  it('does not display the CDR Version upgrade message when duplicating a workspace with the latest CDR Version', async() => {
+    // the standard test workspace already has the latest CDR Version but let's make it explicit with a new const
+    const defaultCdrWorkspace = {...workspace, cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID}
+    currentWorkspaceStore.next(defaultCdrWorkspace);
+
+    routeConfigDataStore.next({mode: WorkspaceEditMode.Duplicate});
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    // upgrade message does not appear
+    expect(wrapper.find('[data-test-id="cdr-version-upgrade"]').exists()).toBeFalsy();
   });
 
   // regression test for RW-5132

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -5,7 +5,7 @@ import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {cdrVersionStore, currentWorkspaceStore, navigate, routeConfigDataStore, serverConfigStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {DisseminateResearchEnum, ResearchOutcomeEnum, SpecificPopulationEnum,UserApi, Workspace, WorkspaceAccessLevel, WorkspacesApi} from 'generated/fetch';
+import {DisseminateResearchEnum, ResearchOutcomeEnum, SpecificPopulationEnum,UserApi, WorkspaceAccessLevel, WorkspacesApi} from 'generated/fetch';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {cdrVersionListResponse} from 'testing/stubs/cdr-versions-api-stub';
 import {UserApiStub} from 'testing/stubs/user-api-stub';

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -315,7 +315,8 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
      * "reviewRequested" flag, which depend on the workspace state & edit mode.
      */
     createInitialWorkspaceState(): Workspace {
-      let workspace: Workspace = this.props.workspace;
+      // copy the props into a new object so our modifications here don't affect them
+      let workspace: Workspace = {...this.props.workspace};
       if (this.isMode(WorkspaceEditMode.Create)) {
         workspace = {
           name: '',
@@ -366,13 +367,9 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
         workspace.researchPurpose.reviewRequested = false;
       }
 
-      const selectedCdrIsLive = this.getLiveCdrVersions().some(
-        cdr => cdr.cdrVersionId === workspace.cdrVersionId);
       // We preselect the default CDR version when a new workspace is being
-      // created (via create or duplicate), but leave as-is if the selected CDR
-      // version is live.
-      if (this.isMode(WorkspaceEditMode.Create) ||
-        (this.isMode(WorkspaceEditMode.Duplicate) && !selectedCdrIsLive)) {
+      // created (via create or duplicate)
+      if (this.isMode(WorkspaceEditMode.Create) || (this.isMode(WorkspaceEditMode.Duplicate))) {
         workspace.cdrVersionId = this.props.cdrVersionListResponse.defaultCdrVersionId;
       }
 
@@ -976,7 +973,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             <TooltipTrigger
                 content='To use a different dataset version, duplicate or create a new workspace.'
                 disabled={!(this.isMode(WorkspaceEditMode.Edit))}>
-              <div style={styles.select}>
+              <div data-test-id='select-cdr-version' style={styles.select}>
                 <select style={{borderColor: 'rgb(151, 151, 151)', borderRadius: '6px',
                   height: '1.5rem', width: '12rem'}}
                   value={cdrVersionId}

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -400,7 +400,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
 
       // We preselect the default CDR version when a new workspace is being
       // created (via create or duplicate)
-      if (this.isMode(WorkspaceEditMode.Create) || (this.isMode(WorkspaceEditMode.Duplicate))) {
+      if (this.isMode(WorkspaceEditMode.Create) || this.isMode(WorkspaceEditMode.Duplicate)) {
         workspace.cdrVersionId = this.props.cdrVersionListResponse.defaultCdrVersionId;
       }
 

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -185,12 +185,6 @@ export const styles = reactStyles({
     backgroundColor: colorWithWhiteness(colors.accent, 0.85),
     maxWidth: 'fit-content',
   },
-  warningIcon: {
-    color: colors.warning,
-    height: '20px',
-    width: '20px',
-    align: 'top',
-  },
 });
 
 const CREATE_BILLING_ACCOUNT_OPTION_VALUE = 'CREATE_BILLING_ACCOUNT_OPTION';

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -220,7 +220,7 @@ const CdrVersionUpgrade = (props: UpgradeProps) => {
   const toCdrVersion = <span style={{fontWeight: 'bold'}}>{getCdrVersion(destWorkspace, cdrVersionListResponse).name}</span>;
 
   return <div data-test-id='cdr-version-upgrade' style={styles.cdrVersionUpgrade}>
-    <div>{`You're duplicating the workspace "${srcWorkspace.name}" to upgrade from `} {fromCdrVersion} to {toCdrVersion}.</div>
+    <div>{`You're duplicating the workspace "${srcWorkspace.name}" to upgrade from`} {fromCdrVersion} to {toCdrVersion}.</div>
     <div>Your original workspace will be unaffected. To work with the new data, simply use the new workspace.</div>
   </div>;
 };

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -7,7 +7,7 @@ import {Component} from '@angular/core';
 import {Button, Clickable, Link, StyledAnchorTag} from 'app/components/buttons';
 import {FadeBox} from 'app/components/containers';
 import {FlexColumn, FlexRow} from 'app/components/flex';
-import {ClrIcon, InfoIcon} from 'app/components/icons';
+import {InfoIcon} from 'app/components/icons';
 import {CheckBox, RadioButton, TextArea, TextInput} from 'app/components/inputs';
 import {BulletAlignedUnorderedList} from 'app/components/lists';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -1,20 +1,19 @@
 import {Component, Input} from '@angular/core';
+import * as fp from 'lodash/fp';
+import * as React from 'react';
 
 import {Clickable} from 'app/components/buttons';
 import colors from 'app/styles/colors';
 import {
-  getCdrVersion,
   reactStyles,
   ReactWrapperBase,
   withCdrVersions,
   withCurrentWorkspace,
   withUrlParams
 } from 'app/utils';
+import {getCdrVersion} from 'app/utils/cdr-versions';
 import {NavStore} from 'app/utils/navigation';
-
 import {serverConfigStore} from 'app/utils/navigation';
-import * as fp from 'lodash/fp';
-import * as React from 'react';
 
 const styles = reactStyles({
   container: {

--- a/ui/src/app/utils/authorities.spec.tsx
+++ b/ui/src/app/utils/authorities.spec.tsx
@@ -10,7 +10,7 @@ const accessAuth = {...ProfileStubVariables.PROFILE_STUB, authorities: [Authorit
 const devAuth = {...ProfileStubVariables.PROFILE_STUB, authorities: [Authority.DEVELOPER]}
 const featuredWsAuth = {...ProfileStubVariables.PROFILE_STUB, authorities: [Authority.FEATUREDWORKSPACEADMIN]}
 
-describe('auth', () => {
+describe('authorities', () => {
     it('should correctly authorize INSTITUTION_ADMIN', async () => {
         expect(hasAuthorityForAction(noAuth, AuthorityGuardedAction.INSTITUTION_ADMIN)).toBeFalsy();
         expect(hasAuthorityForAction(accessAuth, AuthorityGuardedAction.INSTITUTION_ADMIN)).toBeFalsy();

--- a/ui/src/app/utils/cdr-versions.spec.tsx
+++ b/ui/src/app/utils/cdr-versions.spec.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+
+import {Workspace, CdrVersion, CdrVersionListResponse} from 'generated/fetch';
+import {WorkspaceStubVariables} from 'testing/stubs/workspace-service-stub';
+import {cdrVersionListResponse} from 'testing/stubs/cdr-versions-api-stub';
+import {getCdrVersion, getDefaultCdrVersion, hasDefaultCdrVersion} from "./cdr-versions";
+
+
+const stubWorkspace: Workspace = {
+    name: WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME,
+    id: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+    namespace: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS
+};
+
+const defaultCdrVersion = cdrVersionListResponse.items[0];
+const altCdrVersion = cdrVersionListResponse.items[1];
+
+const testWorkspace: Workspace = {...stubWorkspace, cdrVersionId: defaultCdrVersion.cdrVersionId};
+const testWorkspaceMissing: Workspace = {...stubWorkspace};
+
+describe('cdr-versions', () => {
+    it('should correctly get the CDR Version structure for a workspace', async () => {
+        expect(getCdrVersion(testWorkspace, cdrVersionListResponse)).toBe(defaultCdrVersion);
+    });
+
+    it('should return undefined for a workspace with an invalid CDR Version ID', async () => {
+        expect(getCdrVersion(testWorkspaceMissing, cdrVersionListResponse)).toBe(undefined);
+    });
+
+    it('should correctly get the default CDR Version structure', async () => {
+        expect(getDefaultCdrVersion(cdrVersionListResponse)).toBe(defaultCdrVersion);
+    });
+
+    it('should correctly get an alternate default CDR Version structure', async () => {
+        const altDefaultResponse = {...cdrVersionListResponse, defaultCdrVersionId: altCdrVersion.cdrVersionId}
+        expect(getDefaultCdrVersion(altDefaultResponse)).toBe(altCdrVersion);
+    });
+
+    it('should detect when a Workspace has the default CDR Version structure', async () => {
+        expect(hasDefaultCdrVersion(testWorkspace, cdrVersionListResponse)).toBeTruthy();
+    });
+
+    it('should detect when a Workspace does not have the default CDR Version structure', async () => {
+        const altWorkspace = {...testWorkspace, cdrVersionId: altCdrVersion.cdrVersionId}
+        expect(hasDefaultCdrVersion(altWorkspace, cdrVersionListResponse)).toBeFalsy();
+    });
+});

--- a/ui/src/app/utils/cdr-versions.tsx
+++ b/ui/src/app/utils/cdr-versions.tsx
@@ -1,0 +1,19 @@
+import {CdrVersion, CdrVersionListResponse, Workspace} from 'generated/fetch';
+
+function getCdrVersion(workspace: Workspace, cdrList: CdrVersionListResponse): CdrVersion {
+  return cdrList.items.find(v => v.cdrVersionId === workspace.cdrVersionId);
+}
+
+function getDefaultCdrVersion(cdrList: CdrVersionListResponse): CdrVersion {
+  return cdrList.items.find(v => v.cdrVersionId === cdrList.defaultCdrVersionId);
+}
+
+function hasDefaultCdrVersion(workspace: Workspace, cdrList: CdrVersionListResponse): boolean {
+  return workspace.cdrVersionId === cdrList.defaultCdrVersionId;
+}
+
+export {
+    getCdrVersion,
+    getDefaultCdrVersion,
+    hasDefaultCdrVersion,
+};

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -1,4 +1,10 @@
 import {ElementRef, OnChanges, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import * as fp from 'lodash/fp';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import {ReplaySubject} from 'rxjs/ReplaySubject';
+const {useEffect, useState} = React;
 
 import {colorWithWhiteness} from 'app/styles/colors';
 import {
@@ -17,20 +23,10 @@ import {
 } from 'app/utils/navigation';
 import {DataAccessLevel, Domain} from 'generated';
 import {
-  CdrVersion,
-  CdrVersionListResponse,
   ConfigResponse,
   DataAccessLevel as FetchDataAccessLevel,
   Domain as FetchDomain,
-  Workspace,
 } from 'generated/fetch';
-import * as fp from 'lodash/fp';
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
-import {ReplaySubject} from 'rxjs/ReplaySubject';
-
-const {useEffect, useState} =  React;
 
 export const WINDOW_REF = 'window-ref';
 
@@ -629,8 +625,4 @@ export function validateInputForMySQL(searchString: string): Array<string> {
     inputErrors.add('There is an unclosed " in the search string');
   }
   return Array.from(inputErrors);
-}
-
-export function getCdrVersion(workspace: Workspace, cdrs: CdrVersionListResponse): CdrVersion {
-  return cdrs.items.find(v => v.cdrVersionId === workspace.cdrVersionId);
 }


### PR DESCRIPTION
Description:

This is only a **partial** completion of RW-5564.  The warning modal for non-latest CDR Version is not implemented here.

This also changes the Workspace Duplication UX to always choose the latest CDR Version for duplication.  It **does not** prevent choosing an older version intentionally.  It also does not warn when doing so - that will be part of the next RW-5564 PR.


<img width="1018" alt="dupe-upgrade" src="https://user-images.githubusercontent.com/2701406/98979844-dbe30400-24e9-11eb-862f-7962fa95b601.png">

Note: "v3 with Microarray" is the older version of the CDR in my local environment.  In production it will likely look more like "you are upgrading from v5 to v8"


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
