### PR TITLE
Jaycarlton/access module service

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/AccessConfiguration.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessConfiguration.java
@@ -1,0 +1,17 @@
+package org.pmiops.workbench.access;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.pmiops.workbench.compliance.ComplianceService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AccessConfiguration {
+  @Bean
+  Map<AccessModuleKey, AccessModuleService> getAccessModuleMap(ComplianceService complianceService) {
+    return ImmutableMap.of(
+        AccessModuleKey.DUA_TRAINING, new DuaTrainingAccessModule(complianceService),
+        AccessModuleKey.RESEARCH_ETHICS_TRAINING, new ResearchEthicsTrainingAccessModule(complianceService));
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleKey.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleKey.java
@@ -1,0 +1,10 @@
+package org.pmiops.workbench.access;
+
+/**
+ * Simple key to allow access policies to refer to individual modules.
+ */
+public enum AccessModuleKey {
+  DUA_TRAINING,
+  RESEARCH_ETHICS_TRAINING,
+  TWO_FACTOR_AUTH;
+}

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
@@ -1,0 +1,10 @@
+package org.pmiops.workbench.access;
+
+import org.pmiops.workbench.db.model.DbUser;
+
+/**
+ * Implementations of this service will provide scores for users under various modules.
+ */
+public interface AccessModuleService {
+  AccessScore scoreUser(DbUser user);
+}

--- a/api/src/main/java/org/pmiops/workbench/access/AccessPolicyService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessPolicyService.java
@@ -1,0 +1,10 @@
+package org.pmiops.workbench.access;
+
+import java.util.Map;
+import java.util.Set;
+import org.pmiops.workbench.db.model.DbUser;
+
+public interface AccessPolicyService {
+  Set<AccessModuleKey> getAccessModules();
+  Map<AccessModuleKey, AccessScore> evaluateUser(DbUser dbUser);
+}

--- a/api/src/main/java/org/pmiops/workbench/access/AccessPolicyServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessPolicyServiceImpl.java
@@ -1,0 +1,34 @@
+package org.pmiops.workbench.access;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.pmiops.workbench.db.model.DbUser;
+
+public abstract class AccessPolicyServiceImpl implements AccessPolicyService {
+
+  private Map<AccessModuleKey, AccessModuleService> moduleKeyAccessModuleService;
+  private final InvalidKeyAccessModule invalidKeyAccessModule = new InvalidKeyAccessModule();
+
+  public AccessPolicyServiceImpl(Map<AccessModuleKey, AccessModuleService> moduleKeyAccessModuleService) {
+    this.moduleKeyAccessModuleService = moduleKeyAccessModuleService;
+  }
+
+  /**
+   * Ask each module to rate this user and return a map. TODO(jaycarlton): include human-readable
+   * descriptions for error conditions
+   * @param dbUser user to be evalluated.
+   * @return map from module key to score.
+   */
+  @Override
+  public Map<AccessModuleKey, AccessScore> evaluateUser(DbUser dbUser) {
+    return getAccessModules().stream()
+        .collect(ImmutableMap.toImmutableMap(
+            Function.identity(),
+            accessModuleKey -> scoreUser(accessModuleKey, dbUser)));
+  }
+
+  public AccessScore scoreUser(AccessModuleKey key, DbUser dbUser) {
+    return moduleKeyAccessModuleService.getOrDefault(key, invalidKeyAccessModule).scoreUser(dbUser);
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/access/AccessScore.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessScore.java
@@ -1,8 +1,13 @@
 package org.pmiops.workbench.access;
 
+/**
+ * Possible scores or error conditions for access modules. Do not assume that the ordering is
+ * semantic. New values may be appended later.
+ */
 public enum AccessScore {
   NOT_ATTEMPTED,
   FAILED,
   PENDING,
-  PASSED;
+  PASSED,
+  INVALID_ACCESS_MODULE;
 }

--- a/api/src/main/java/org/pmiops/workbench/access/AccessScore.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessScore.java
@@ -1,0 +1,8 @@
+package org.pmiops.workbench.access;
+
+public enum AccessScore {
+  NOT_ATTEMPTED,
+  FAILED,
+  PENDING,
+  PASSED;
+}

--- a/api/src/main/java/org/pmiops/workbench/access/DuaTrainingAccessModule.java
+++ b/api/src/main/java/org/pmiops/workbench/access/DuaTrainingAccessModule.java
@@ -1,0 +1,20 @@
+package org.pmiops.workbench.access;
+
+import org.pmiops.workbench.compliance.ComplianceService;
+import org.pmiops.workbench.compliance.MoodleBadge;
+import org.pmiops.workbench.db.model.DbUser;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DuaTrainingAccessModule extends MoodleBadgeAccessModule {
+
+  public DuaTrainingAccessModule(
+      ComplianceService complianceService) {
+    super(complianceService);
+  }
+
+  @Override
+  public MoodleBadge getBadge() {
+    return MoodleBadge.DATA_USE_AGREEMENT;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/access/InvalidKeyAccessModule.java
+++ b/api/src/main/java/org/pmiops/workbench/access/InvalidKeyAccessModule.java
@@ -1,0 +1,16 @@
+package org.pmiops.workbench.access;
+
+import org.pmiops.workbench.db.model.DbUser;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InvalidKeyAccessModule implements AccessModuleService {
+
+  public InvalidKeyAccessModule() {
+  }
+
+  @Override
+  public AccessScore scoreUser(DbUser user) {
+    return AccessScore.INVALID_ACCESS_MODULE;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/access/MoodleBadgeAccessModule.java
+++ b/api/src/main/java/org/pmiops/workbench/access/MoodleBadgeAccessModule.java
@@ -1,0 +1,54 @@
+package org.pmiops.workbench.access;
+
+import java.util.Optional;
+import java.util.logging.Logger;
+import org.pmiops.workbench.compliance.ComplianceService;
+import org.pmiops.workbench.compliance.MoodleBadge;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.monitoring.LogsBasedMetricServiceImpl;
+import org.pmiops.workbench.moodle.ApiException;
+import org.pmiops.workbench.moodle.model.BadgeDetailsV2;
+
+/**
+ * Intermediate class for working with with Moodle-backed access module requirements.
+ */
+public abstract class MoodleBadgeAccessModule implements AccessModuleService {
+  private static final Logger log = Logger.getLogger(MoodleBadgeAccessModule.class.getName());
+
+  private ComplianceService complianceService;
+
+  public MoodleBadgeAccessModule(ComplianceService complianceService) {
+    this.complianceService = complianceService;
+  }
+
+  /**
+   * Use the Moodle API to establish whether the user has access to the correct module
+   * @param user
+   * @return
+   */
+  @Override
+  public AccessScore scoreUser(DbUser user) {
+    try {
+      final Optional<BadgeDetailsV2> details = complianceService.getUserBadgeDetails(user.getUsername(), getBadge());
+      return details.map(this::badgeDetailsToAccessScore).orElse(AccessScore.NOT_ATTEMPTED);
+    } catch (ApiException e) {
+      log.warning(e.getMessage());
+      return AccessScore.PENDING;
+    }
+  }
+
+  /**
+   * A Moodle "Badge" corresponds to one trraining course, which maps to an individual
+   * AccessModule in AoU. Implementers need to return the badge name
+   * @return
+   */
+  public abstract MoodleBadge getBadge();
+
+  private AccessScore badgeDetailsToAccessScore(BadgeDetailsV2 details) {
+    if (details.getValid()) {
+      return AccessScore.PASSED;
+    } else {
+      return AccessScore.FAILED;
+    }
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/access/ResearchEthicsTrainingAccessModule.java
+++ b/api/src/main/java/org/pmiops/workbench/access/ResearchEthicsTrainingAccessModule.java
@@ -1,0 +1,19 @@
+package org.pmiops.workbench.access;
+
+import org.pmiops.workbench.compliance.ComplianceService;
+import org.pmiops.workbench.compliance.MoodleBadge;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ResearchEthicsTrainingAccessModule extends MoodleBadgeAccessModule {
+
+  public ResearchEthicsTrainingAccessModule(
+      ComplianceService complianceService) {
+    super(complianceService);
+  }
+
+  @Override
+  public MoodleBadge getBadge() {
+    return MoodleBadge.RESEARCH_ETHICS_TRAINING;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/compliance/ComplianceService.java
+++ b/api/src/main/java/org/pmiops/workbench/compliance/ComplianceService.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.compliance;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.pmiops.workbench.moodle.ApiException;
 import org.pmiops.workbench.moodle.model.BadgeDetailsV1;
 import org.pmiops.workbench.moodle.model.BadgeDetailsV2;
@@ -30,11 +31,11 @@ public interface ComplianceService {
   /**
    * Get details about the Research Ethics Training and the Data Use Agreement badges for a user
    *
-   * @param email
+   * @param username
    * @return map of badge name to badge details
    * @throws ApiException
    */
-  Map<String, BadgeDetailsV2> getUserBadgesByBadgeName(String email) throws ApiException;
+  Map<MoodleBadge, BadgeDetailsV2> getUserBadgesByBadgeName(String username) throws ApiException;
 
-  String getResearchEthicsTrainingField();
+  Optional<BadgeDetailsV2> getUserBadgeDetails(String username, MoodleBadge moodleBadge) throws ApiException;
 }

--- a/api/src/main/java/org/pmiops/workbench/compliance/ComplianceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliance/ComplianceServiceImpl.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.compliance;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Logger;
 import javax.inject.Provider;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -20,21 +21,17 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ComplianceServiceImpl implements ComplianceService {
+  private static final Logger logger = Logger.getLogger(ComplianceServiceImpl.class.getName());
 
-  private MoodleApi api = new MoodleApi();
   private static final String RESPONSE_FORMAT = "json";
   private static final String GET_MOODLE_ID_SEARCH_FIELD = "email";
-  private static final String DUA_BADGE_NAME = "data_use_agreement";
-  private static final String RET_BADGE_NAME =
-      "research_ethics_training"; // 'ret' too much like 'return'
   private static final String MOODLE_EXCEPTION = "moodle_exception";
   private static final String MOODLE_USER_NOT_ALLOWED_ERROR_CODE = "guestsarenotallowed";
-  private CloudStorageService cloudStorageService;
-  private Provider<WorkbenchConfig> configProvider;
 
-  private Provider<MoodleApi> moodleApiProvider;
+  private final CloudStorageService cloudStorageService;
+  private final Provider<WorkbenchConfig> configProvider;
+  private final Provider<MoodleApi> moodleApiProvider;
 
-  private static final Logger logger = Logger.getLogger(ComplianceServiceImpl.class.getName());
 
   @Autowired
   public ComplianceServiceImpl(
@@ -100,19 +97,19 @@ public class ComplianceServiceImpl implements ComplianceService {
   /**
    * Returns a map of Moodle badge names to Moodle badge details for the given Moodle user email.
    *
-   * @param email The research-aou.org email for the user
+   * @param username The research-aou.org email for the user
    * @return A map of badge name to badge details.
    * @throws ApiException if the Moodle API call returns an error because the email is not yet
    *     registered in Moodle.
    */
   @Override
-  public Map<String, BadgeDetailsV2> getUserBadgesByBadgeName(String email) throws ApiException {
+  public Map<MoodleBadge, BadgeDetailsV2> getUserBadgesByBadgeName(String username) throws ApiException {
     if (!enableMoodleCalls()) {
       return new HashMap<>();
     }
 
-    UserBadgeResponseV2 response =
-        moodleApiProvider.get().getMoodleBadgeV2(RESPONSE_FORMAT, getToken(), email);
+    final UserBadgeResponseV2 response =
+        moodleApiProvider.get().getMoodleBadgeV2(RESPONSE_FORMAT, getToken(), username);
     if (response.getException() != null && response.getException().equals(MOODLE_EXCEPTION)) {
       logger.warning(response.getMessage());
       if (response.getErrorcode().equals(MOODLE_USER_NOT_ALLOWED_ERROR_CODE)) {
@@ -121,17 +118,18 @@ public class ComplianceServiceImpl implements ComplianceService {
         throw new ApiException(response.getMessage());
       }
     }
-    Map<String, BadgeDetailsV2> userBadgesByName = new HashMap<>();
+    Map<MoodleBadge, BadgeDetailsV2> userBadgesByName = new HashMap<>();
     if (response.getDua() != null) {
-      userBadgesByName.put(DUA_BADGE_NAME, response.getDua());
+      userBadgesByName.put(MoodleBadge.DATA_USE_AGREEMENT, response.getDua());
     }
     if (response.getRet() != null) {
-      userBadgesByName.put(RET_BADGE_NAME, response.getRet());
+      userBadgesByName.put(MoodleBadge.RESEARCH_ETHICS_TRAINING, response.getRet());
     }
     return userBadgesByName;
   }
 
-  public String getResearchEthicsTrainingField() {
-    return RET_BADGE_NAME;
+  @Override
+  public Optional<BadgeDetailsV2> getUserBadgeDetails(String username, MoodleBadge moodleBadge) throws ApiException {
+    return Optional.ofNullable(getUserBadgesByBadgeName(username).get(moodleBadge));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/compliance/MoodleBadge.java
+++ b/api/src/main/java/org/pmiops/workbench/compliance/MoodleBadge.java
@@ -1,0 +1,16 @@
+package org.pmiops.workbench.compliance;
+
+public enum MoodleBadge {
+  DATA_USE_AGREEMENT("data_use_agreement"),
+  RESEARCH_ETHICS_TRAINING("research_ethics_training");
+
+  private final String badgeName;
+
+  MoodleBadge(String badgeName) {
+    this.badgeName = badgeName;
+  }
+
+  public String getBadgeName() {
+    return badgeName;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -26,6 +26,7 @@ import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.actionaudit.targetproperties.BypassTimeTargetProperty;
 import org.pmiops.workbench.compliance.ComplianceService;
+import org.pmiops.workbench.compliance.MoodleBadge;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao.UserCountGaugeLabelsAndValue;
 import org.pmiops.workbench.db.dao.projection.ProjectedReportingUser;
@@ -756,11 +757,11 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       Timestamp now = new Timestamp(clock.instant().toEpochMilli());
       final Timestamp newComplianceTrainingCompletionTime;
       final Timestamp newComplianceTrainingExpirationTime;
-      Map<String, BadgeDetailsV2> userBadgesByName =
+      final Map<MoodleBadge, BadgeDetailsV2> userBadgesByName =
           complianceService.getUserBadgesByBadgeName(dbUser.getUsername());
-      if (userBadgesByName.containsKey(complianceService.getResearchEthicsTrainingField())) {
+      if (userBadgesByName.containsKey(MoodleBadge.RESEARCH_ETHICS_TRAINING)) {
         BadgeDetailsV2 complianceBadge =
-            userBadgesByName.get(complianceService.getResearchEthicsTrainingField());
+            userBadgesByName.get(MoodleBadge.RESEARCH_ETHICS_TRAINING);
         if (complianceBadge.getValid()) {
           if (dbUser.getComplianceTrainingCompletionTime() == null) {
             // The badge was previously invalid and is now valid.


### PR DESCRIPTION
Sketching out how the access policy and module stuff could go (minus the data model, which isn't really necessary for v1 anyway).

Idea is that each access policy will have a set of keys pointing to individual modules. Each of those has a serviice implementing the logic and managing the dependencies to satisfy the answers we care about. Largely just wrappers for things like the existing compliance logic (one module per Moodle badge, for example), or potentially even more basic things like always passing (HasAPulseModule).

I'm going to see if we can't make the lookup work via dependency injection.


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
