### PR TITLE
[no ticket][risk=no] fixing cdr version issue which is breaking e2e tests

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -25,6 +25,7 @@ import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.billing.BillingProjectBufferService;
 import org.pmiops.workbench.billing.EmptyBufferException;
 import org.pmiops.workbench.billing.FreeTierBillingService;
+import org.pmiops.workbench.cdr.CdrVersionContext;
 import org.pmiops.workbench.cdrselector.WorkspaceResourcesService;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
@@ -942,6 +943,8 @@ public class WorkspacesController implements WorkspacesApiDelegate {
 
     final DbWorkspace dbWorkspace =
         workspaceService.getRequiredWithCohorts(workspaceNamespace, workspaceId);
+    // When loading resources we are not accessing CDR tables for concept sets
+    CdrVersionContext.setCdrVersionNoCheckAuthDomain(dbWorkspace.getCdrVersion());
     WorkspaceResourceResponse workspaceResourceResponse = new WorkspaceResourceResponse();
     workspaceResourceResponse.addAll(
         workspaceResourcesService.getWorkspaceResources(


### PR DESCRIPTION
@NehaBroad made a change 
https://github.com/all-of-us/workbench/blob/aaeeefea96401fbd00bc8d727b2536ed0fc8c42f/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java#L198-L198
that now accesses the cloud CDR tables, so we needed to set the CDR version before running this query.