### PR TITLE
[risk=no] Check against runtime === null, instead of status, for initial content

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -614,7 +614,7 @@ export const RuntimePanel = fp.flow(
   // It's unclear how often that would actually happen.
   const initialPanelContent = fp.cond([
     // currentRuntime being undefined means the first `getRuntime` has still not completed.
-    [([r,]) => r === undefined, () => PanelContent.Customize],
+    [([r, ]) => r === undefined, () => PanelContent.Customize],
     [([r, s]) => r === null || s === RuntimeStatus.Unknown, () => PanelContent.Create],
     [() => true, () => PanelContent.Customize]
   ])([currentRuntime, status]);

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -614,8 +614,8 @@ export const RuntimePanel = fp.flow(
   // It's unclear how often that would actually happen.
   const initialPanelContent = fp.cond([
     // currentRuntime being undefined means the first `getRuntime` has still not completed.
-    [([r, s]) => r === undefined, () => PanelContent.Customize],
-    [([r, s]) => s === null || s === RuntimeStatus.Unknown, () => PanelContent.Create],
+    [([r,]) => r === undefined, () => PanelContent.Customize],
+    [([r, s]) => r === null || s === RuntimeStatus.Unknown, () => PanelContent.Create],
     [() => true, () => PanelContent.Customize]
   ])([currentRuntime, status]);
   const [panelContent, setPanelContent] = useState<PanelContent>(initialPanelContent);


### PR DESCRIPTION
Fix broken UI test.

I'm not sure of which is the defined behavior, but `status` is `undefined` in tests. Either way, this change makes the logic more consistent.

Follow-ups:
- Why did presubmit on the PR not reveal this issue?
- Should status be undefined here? Does it matter?