### PR TITLE
[risk=no] Fix code and selected icon display for tree nodes

### DIFF
--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -311,7 +311,8 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
     return source === 'criteria'
       ? currentCohortCriteriaStore.getValue().some(crit =>
         crit.parameterId === this.paramId() || path.split('.').includes(crit.id.toString()))
-      : currentConceptStore.getValue().some(crit => this.paramId(crit) === this.paramId());
+      : currentConceptStore.getValue().some(crit =>
+        this.paramId(crit) === this.paramId() || path.split('.').includes(crit.id.toString()));
   }
 
   selectIconDisabled() {

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -306,6 +306,11 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
        name === COPE_SURVEY_GROUP_NAME;
   }
 
+  get showCode() {
+    const {node: {code, domainId, name}} = this.props;
+    return domainId !== Domain.SURVEY.toString() && !!code && code !== name;
+  }
+
   getSelectedValues() {
     const {node: {path}, source} = this.props;
     return source === 'criteria'
@@ -362,7 +367,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
                     onClick={(e) => this.select(e)}/>
             }
           </button>}
-          {(!!code && code !== name) && <div style={styles.code}>{code}</div>}
+          {this.showCode && <div style={styles.code}>{code}</div>}
           <TooltipTrigger content={<div>{displayName}</div>} disabled={!this.state.truncated}>
             <div style={styles.name} ref={(e) => this.name = e}>
               <span data-test-id='displayName' style={searchMatch ? styles.searchMatch : {}}>{displayName}

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -307,18 +307,11 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
   }
 
   getSelectedValues() {
-    const {node: {parentId}} = this.props;
-    if (this.props.source === 'criteria') {
-      return currentCohortCriteriaStore.getValue()
-        .some(crit =>
-              crit.parameterId === this.paramId() ||
-              parentId.toString() === this.paramId()
-          );
-    } else {
-      return currentConceptStore.getValue()
-        .some(crit => this.paramId(crit) === this.paramId());
-    }
-
+    const {node: {path}, source} = this.props;
+    return source === 'criteria'
+      ? currentCohortCriteriaStore.getValue().some(crit =>
+        crit.parameterId === this.paramId() || path.split('.').includes(crit.id.toString()))
+      : currentConceptStore.getValue().some(crit => this.paramId(crit) === this.paramId());
   }
 
   selectIconDisabled() {


### PR DESCRIPTION
- Hide codes for surveys
- Disable all children when parent node selected
<img width="923" alt="Screen Shot 2020-11-16 at 2 31 59 PM" src="https://user-images.githubusercontent.com/40036095/99305057-e0c0f400-2818-11eb-960b-c66521d0ee6d.png">
<img width="1290" alt="Screen Shot 2020-11-16 at 2 32 43 PM" src="https://user-images.githubusercontent.com/40036095/99305061-e1f22100-2818-11eb-843c-ce7625ac07ea.png">
