### PR TITLE
[risk=low] Double test env billing buffer size

### DIFF
--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -26,7 +26,7 @@
     "projectNamePrefix": "aou-rw-test-",
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 2,
-    "bufferCapacity": 100,
+    "bufferCapacity": 200,
     "bufferRefillProjectsPerTask": 1,
     "defaultFreeCreditsDollarLimit": 300.0,
     "freeTierCostAlertThresholds": [


### PR DESCRIPTION
We should also look at the number of projects that a single puppeteer test run is consuming. I think it is probably way too high currently.