### PR TITLE
[RW-5938][risk=no] Dueling crons for Reporting

### DIFF
--- a/api/reporting/curl/upload-snapshot-local-query.sh
+++ b/api/reporting/curl/upload-snapshot-local-query.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Start hit the reporting snapshot & upload cron endpoint (insert query mode)
+# locally.
+curl -X GET 'http://localhost:8081/v1/cron/uploadReportingSnapshotQuery' \
+  --header "X-AppEngine-Cron: true"

--- a/api/reporting/curl/upload-snapshot-local-streaming.sh
+++ b/api/reporting/curl/upload-snapshot-local-streaming.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Start hit the reporting snapshot & upload cron endpoint (streaming mode)
+# locally.
+curl -X GET 'http://localhost:8081/v1/cron/uploadReportingSnapshotStreaming' \
+  --header "X-AppEngine-Cron: true"

--- a/api/reporting/curl/upload-snapshot-local.sh
+++ b/api/reporting/curl/upload-snapshot-local.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Start hit the reporting snapshot & upload cron endpoint  locally.
+# Start hit the reporting snapshot & upload cron endpoint (configured implementation)
+# locally.
 curl -X GET 'http://localhost:8081/v1/cron/uploadReportingSnapshot' \
-  --header "X-AppEngine-Cron: true" \
-  --header "Authorization: Bearer `gcloud auth print-access-token`" \
-#   | jq
+  --header "X-AppEngine-Cron: true"

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineReportingController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineReportingController.java
@@ -1,7 +1,7 @@
 package org.pmiops.workbench.api;
 
-import javax.inject.Provider;
-import org.pmiops.workbench.config.WorkbenchConfig;
+import static org.pmiops.workbench.utils.ResponseEntities.noContentRun;
+
 import org.pmiops.workbench.reporting.ReportingService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,20 +9,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class OfflineReportingController implements OfflineReportingApiDelegate {
 
-  private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final ReportingService reportingService;
 
-  public OfflineReportingController(
-      Provider<WorkbenchConfig> workbenchConfigProvider, ReportingService reportingService) {
-    this.workbenchConfigProvider = workbenchConfigProvider;
+  public OfflineReportingController(ReportingService reportingService) {
     this.reportingService = reportingService;
   }
 
   @Override
   public ResponseEntity<Void> uploadReportingSnapshot() {
-    if (workbenchConfigProvider.get().featureFlags.enableReportingUploadCron) {
-      reportingService.takeAndUploadSnapshot();
-    }
-    return ResponseEntity.noContent().build();
+    return noContentRun(reportingService::takeAndUploadSnapshot);
+  }
+
+  @Override
+  public ResponseEntity<Void> uploadReportingSnapshotQuery() {
+    return noContentRun(reportingService::uploadReportingSnapshotDml);
+  }
+
+  @Override
+  public ResponseEntity<Void> uploadReportingSnapshotStreaming() {
+    return noContentRun(reportingService::uploadReportingSnapshotStreaming);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingService.java
@@ -7,4 +7,8 @@ package org.pmiops.workbench.reporting;
  */
 public interface ReportingService {
   void takeAndUploadSnapshot();
+
+  void uploadReportingSnapshotDml();
+
+  void uploadReportingSnapshotStreaming();
 }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
@@ -46,6 +46,18 @@ public class ReportingServiceImpl implements ReportingService {
     getConfiguredUploadService().uploadSnapshot(snapshot);
   }
 
+  @Override
+  public void uploadReportingSnapshotDml() {
+    final ReportingSnapshot snapshot = reportingSnapshotService.takeSnapshot();
+    reportingUploadServiceDmlImpl.uploadSnapshot(snapshot);
+  }
+
+  @Override
+  public void uploadReportingSnapshotStreaming() {
+    final ReportingSnapshot snapshot = reportingSnapshotService.takeSnapshot();
+    reportingUploadServiceStreamingImpl.uploadSnapshot(snapshot);
+  }
+
   /*
    * Currently, we can't access appplication config values at initialization time (since they're
    * all request-scoped). This method is a workaround, and selects the upload service implementation

--- a/api/src/main/java/org/pmiops/workbench/utils/ResponseEntities.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/ResponseEntities.java
@@ -1,0 +1,17 @@
+package org.pmiops.workbench.utils;
+
+import org.springframework.http.ResponseEntity;
+
+public class ResponseEntities {
+
+  /**
+   * Simple wrapper for methods that return 204/No Content.
+   *
+   * @param runnable - action to perform
+   * @return 204 ResponseEntity
+   */
+  public static ResponseEntity<Void> noContentRun(Runnable runnable) {
+    runnable.run();
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1639,7 +1639,8 @@ paths:
         - offlineReporting
         - cron
       description: >
-        Capture a reporting snapshot and beging the upload task to BigQuery reporting dataset.
+        Capture a reporting snapshot and upload to BigQuery reporting dataset using the configured
+        upload method (currently one of DML (insert query) or Streaming).
       operationId: uploadReportingSnapshotQuery
       security: []
       responses:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1606,7 +1606,7 @@ paths:
         - offlineReporting
         - cron
       description: >
-        Capture a reporting snapshot and beging the upload task to BigQuery reporting dataset.
+        Capture a reporting snapshot and begin the upload task to BigQuery reporting dataset.
       operationId: uploadReportingSnapshot
       security: []
       responses:
@@ -1616,7 +1616,39 @@ paths:
           description: Internal Error
           schema:
             "$ref": "#/definitions/ErrorResponse"
-
+  "/v1/cron/uploadReportingSnapshotStreaming":
+    get:
+      tags:
+        - offlineReporting
+        - cron
+      description: >
+        Capture a reporting snapshot and begin the upload task to BigQuery reporting dataset via
+        the streaming implementation.
+      operationId: uploadReportingSnapshotStreaming
+      security: []
+      responses:
+        204:
+          description: No content
+        500:
+          description: Internal Error
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
+  "/v1/cron/uploadReportingSnapshotQuery":
+    get:
+      tags:
+        - offlineReporting
+        - cron
+      description: >
+        Capture a reporting snapshot and beging the upload task to BigQuery reporting dataset.
+      operationId: uploadReportingSnapshotQuery
+      security: []
+      responses:
+        204:
+          description: No content
+        500:
+          description: Internal Error
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
   "/v1/cron/updateResearchPurposeReviewPrompt":
     get:
       tags:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1639,8 +1639,8 @@ paths:
         - offlineReporting
         - cron
       description: >
-        Capture a reporting snapshot and upload to BigQuery reporting dataset using the configured
-        upload method (currently one of DML (insert query) or Streaming).
+        Capture a reporting snapshot and upload to BigQuery reporting dataset using the insert
+        query implementation.
       operationId: uploadReportingSnapshotQuery
       security: []
       responses:

--- a/api/src/main/webapp/WEB-INF/cron_default.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_default.yaml
@@ -86,9 +86,10 @@ cron:
   timezone: America/Chicago
   target: api
 - description: >
-    Compile a snapshot of workbench data for reporting and upload it to  BigQuery.
+    Compile a snapshot of workbench data for reporting and upload it to  BigQuery. Uses reporting.uploadMethod
+    in config to determine upload implementation.
   url: /v1/cron/uploadReportingSnapshot
-  schedule: every day 21:00
+  schedule: every day 19:00
   timezone: America/Chicago
   target: api
 

--- a/api/src/main/webapp/WEB-INF/cron_test.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_test.yaml
@@ -1,0 +1,107 @@
+cron:
+  - description: 'Periodic notebook runtime checks'
+    url: /v1/cron/checkRuntimes
+    schedule: every 3 hours
+    timezone: UTC
+    target: api
+  - description: |
+      Daily sync of compliance training status (via Moodle API). This is just a backup to the primary
+      flow. It should catch expired compliance training, fixup compliance status independent of user
+      navigation, and update on removal of Moodle course completion for some reason.
+    url: /v1/cron/bulkSyncComplianceTrainingStatus
+    schedule: every 24 hours
+    timezone: UTC
+    target: api
+  - description: >
+      Daily sync of eRA Commons linkage status (via FireCloud API). Records changes in the log,
+      but currently does not drive any downstream processes.
+    url: /v1/cron/bulkSyncEraCommonsStatus
+    schedule: every 24 hours
+    timezone: UTC
+    target: api
+  - description: >
+      Update our database cache of users' two-factor authentication settings on their GSuite accounts
+      via Google Directory Service.
+    url: /v1/cron/bulkSyncTwoFactorAuthStatus
+    schedule: every 24 hours
+    timezone: UTC
+    target: api
+  - description: 'Daily audit of gcp resources that users have access to'
+    url: /v1/cron/bulkAuditProjectAccess
+    schedule: every 1 hours
+    timezone: UTC
+    target: api
+  - description: 'If the AoU Billing Project buffer is not full, refill with one or more projects.'
+    url: /v1/cron/bufferBillingProjects
+    schedule: every 1 minutes
+    timezone: UTC
+    target: api
+  - description: 'Fetch a BillingProjectBufferEntry that is in the CREATING state and check its status on Firecloud'
+    url: /v1/cron/syncBillingProjectStatus
+    schedule: every 1 minutes
+    timezone: UTC
+    target: api
+  - description: 'Find BillingProjectBufferEntries that have failed during the creation or assignment step and set their statuses to ERROR'
+    url: /v1/cron/cleanBillingBuffer
+    schedule: every 1 hours
+    timezone: UTC
+    target: api
+  - description: 'Find and alert users that have exceeded their free tier billing usage'
+    url: /v1/cron/checkFreeTierBillingUsage
+    schedule: every 30 minutes
+    timezone: UTC
+    target: api
+  - description: >
+      Find billing projects associated with deleted workspaces and transfer ownership to
+      designated "Garbage Collection" Service Accounts. This legacy process works around the lack of
+      API support for deleting these billing projects directly.
+
+      The Terra delete Account API is now available, and this cron job is deprecated. To be removed
+      as part of RW-3627.
+    url: /v1/cron/billingProjectGarbageCollection
+    schedule: every 1 hours
+    timezone: UTC
+    target: api
+  - description: >
+      Sample all gauge metrics for OpenCensus Monitoring and record them. The one-minute interval is
+      the highest granularity for Stackdriver Monitoring and the lowest interval for an AppEngine
+      cron job.
+    url: /v1/cron/monitoring/updateGaugeMetrics
+    schedule: every 1 minutes
+    timezone: UTC
+    target: api
+  - description: >
+      Export user and workspace data to RDR.
+      RDR export is hard-coded to 9pm CT, to align with VUMC expectations that the daily export is run at a time
+      that is (1) after the close of normal business working hours, and (2) early enough in the evening that the
+      entire export (and downstream data flows) can complete before start of the next business day.
+    url: /v1/cron/exportToRdr
+    schedule: every day 22:00
+    timezone: America/Chicago
+    target: api
+  - description: >
+      For each workspace update the attribute need_rp_prompt if it has been created 15 days/an Year earlier
+    url: /v1/cron/updateResearchPurposeReviewPrompt
+    schedule: every day 21:00
+    timezone: America/Chicago
+    target: api
+  - description: >
+      Compile a snapshot of workbench data for reporting and upload it to  BigQuery. Uses reporting.uploadMethod
+      in config to determine upload implementation.
+    url: /v1/cron/uploadReportingSnapshot
+    schedule: every day 19:00
+    timezone: America/Chicago
+    target: api
+  - description: >
+      Compile a snapshot of workbench data for reporting and upload it to BigQuery. This temporary
+      endppoint uses the streaming upload implementation regardless of the configured reporting.uploadMethod
+      value.
+    url: /v1/cron/uploadReportingSnapshotStreaming
+    schedule: every 6 hours
+    target: api
+  - description: >
+      Compile a snapshot of workbench data for reporting and upload it to BigQuery.
+      Temporary endpoint so we can evaluate the insert query/dml implementation.
+    url: /v1/cron/uploadReportingSnapshotQuery
+    schedule: every 6 hours
+    target: api


### PR DESCRIPTION
We are currently maintaining two different upload to BigQuery implementations.
1. The default, and currently configured in all environments, is the streaming upload method. This method is fast and simple in some ways, but has a potentially deal-breaking flaw because rows can be duplicated. A unique identifier provided for each row enables "best-effort" deduplication.
2. An insert query-based method, using Data Manipulation Language. In this implementation we have to build query strings and interpolate values we care about. The main operational issue with this mode so far is difficulty in making surer all our queries are below the size and complexity limits for queries.  We don't have much data yet for this mode aside from local runs.

The present PR exposes two test probe cron endpoints for the two implementations which should allow us to collect some real data in the logs.


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
