### PR TITLE
[risk=no] Handle runtime error statuses

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -143,6 +143,18 @@ describe('RuntimePanel', () => {
     expect(runtimeApiStub.runtime.gceConfig.machineType).toEqual('n1-standard-4');
   });
 
+  it('should allow creation when runtime has error status', async() => {
+    runtimeApiStub.runtime.status = RuntimeStatus.Error;
+    act(() => { runtimeStore.set({runtime: runtimeApiStub.runtime, workspaceNamespace: workspaceStubs[0].namespace}) });
+
+    const wrapper = await component();
+
+    await mustClickCreateButton(wrapper);
+
+    // Kicks off a deletion to first clear the error status runtime.
+    expect(runtimeApiStub.runtime.status).toEqual('Deleting');
+  });
+
   it('should allow creation with GCE config', async() => {
     runtimeApiStub.runtime = null;
     act(() => { runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace}) });

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -628,7 +628,7 @@ export const RuntimePanel = fp.flow(
   const [selectedDataprocConfig, setSelectedDataprocConfig] = useState<DataprocConfig | null>(dataprocConfig);
 
   const selectedMachineType = selectedMachine && selectedMachine.name;
-  const runtimeExists = (status && status !== RuntimeStatus.Deleted) || !!pendingRuntime;
+  const runtimeExists = (status && ![RuntimeStatus.Deleted, RuntimeStatus.Error].includes(status)) || !!pendingRuntime;
   const runtimeChanged = !fp.equals(selectedMachine, initialMasterMachine) ||
     selectedDiskSize !== diskSize ||
     !fp.equals(selectedDataprocConfig, dataprocConfig) ||


### PR DESCRIPTION
Currently, you're stuck if you have a runtime in the error status - you can't delete or update the runtime. With this change, the UX is similar to not having a runtime at all.