### PR TITLE
[RW-5955][risk=no] Problem with dataset survey preview rendering

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -297,7 +297,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                 .replace("${tableName}", BigQueryDataSetTableInfo.getTableName(domain)));
 
     final List<Long> conceptIds =
-        SURVEY.equals(request.getPrePackagedConceptSet())
+        Domain.SURVEY.equals(request.getDomain())
             ? conceptBigQueryService.getSurveyQuestionConceptIds()
             : conceptSetDao.findAllByConceptSetIdIn(request.getConceptSetIds()).stream()
                 .flatMap(cs -> cs.getConceptIds().stream())


### PR DESCRIPTION
Problem with dataset survey preview rendering. 
The equals below now returns false
`SURVEY.equals(request.getPrePackagedConceptSet())`
because `getPrePackagedConceptSet()` used to return an enum but now returns a list of enums.
Solved by changing equals to use the Domain enum instead.