### PR TITLE
[risk=no] e2e: Split WorkspacesPage and WorkspaceEditPage usages

### DIFF
--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -1,10 +1,11 @@
 import {ElementHandle, Page} from 'puppeteer';
-import {Option, WorkspaceAccessLevel} from 'app/text-labels';
 import * as fp from 'lodash/fp';
+
+import {Option, WorkspaceAccessLevel} from 'app/text-labels';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {getPropValue} from 'utils/element-utils';
-import WorkspacesPage from 'app/page/workspaces-page';
 import CardBase from './card-base';
+import WorkspaceEditPage from 'app/page/workspace-edit-page';
 
 const WorkspaceCardSelector = {
   cardRootXpath: '//*[child::*[@data-test-id="workspace-card"]]', // finds 'workspace-card' parent container node
@@ -30,7 +31,7 @@ export default class WorkspaceCard extends CardBase {
     const card = await WorkspaceCard.findCard(page, workspaceName);
     await card.selectSnowmanMenu(Option.Delete, { waitForNav: false });
     // Handle Delete Confirmation modal
-    return new WorkspacesPage(page).dismissDeleteWorkspaceModal();
+    return new WorkspaceEditPage(page).dismissDeleteWorkspaceModal();
   }
 
   /**

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -12,6 +12,7 @@ import {LinkText} from 'app/text-labels';
 import WorkspaceBase, {UseFreeCredits} from './workspace-base';
 import {config} from 'resources/workbench-config';
 import BaseElement from 'app/element/base-element';
+import {makeWorkspaceName} from 'utils/str-utils';
 
 const faker = require('faker/locale/en_US');
 
@@ -355,6 +356,17 @@ export default class WorkspaceEditPage extends WorkspaceBase {
       // click checkbox expands or collapses the section, reveal hidden questions contained inside.
       await researchPurposeCheckbox.check();
     }
+  }
+
+  /**
+   * Type in new workspace name.
+   * @return {string} new workspace name
+   */
+  async fillOutWorkspaceName(): Promise<string> {
+    const newWorkspaceName = makeWorkspaceName();
+    await (await this.getWorkspaceNameTextbox()).type(newWorkspaceName);
+    await (await this.getWorkspaceNameTextbox()).pressTab();
+    return newWorkspaceName;
   }
 
   /**

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -1,8 +1,8 @@
 import {Page} from 'puppeteer';
+
 import Button from 'app/element/button';
 import {Language, LinkText, PageUrl} from 'app/text-labels';
 import WorkspaceEditPage, {FIELD as EDIT_FIELD} from 'app/page/workspace-edit-page';
-import {makeWorkspaceName} from 'utils/str-utils';
 import RadioButton from 'app/element/radiobutton';
 import {findOrCreateWorkspace} from 'utils/test-utils';
 import {waitForDocumentTitle, waitForText, waitWhileLoading} from 'utils/waits-utils';
@@ -12,6 +12,7 @@ import WorkspaceAnalysisPage from './workspace-analysis-page';
 import {config} from 'resources/workbench-config';
 import {UseFreeCredits} from './workspace-base';
 import OldCdrVersionModal from './old-cdr-version-modal';
+import AuthenticatedPage from './authenticated-page';
 
 const faker = require('faker/locale/en_US');
 export const PageTitle = 'View Workspace';
@@ -24,7 +25,7 @@ export const FieldSelector = {
   }
 };
 
-export default class WorkspacesPage extends WorkspaceEditPage {
+export default class WorkspacesPage extends AuthenticatedPage {
 
   constructor(page: Page) {
     super(page);
@@ -91,7 +92,7 @@ export default class WorkspacesPage extends WorkspaceEditPage {
     }
 
     // click CREATE WORKSPACE button
-    const createButton = await this.getCreateWorkspaceButton();
+    const createButton = await editPage.getCreateWorkspaceButton();
     await createButton.waitUntilEnabled();
     return editPage.clickCreateFinishButton(createButton);
   }
@@ -141,17 +142,6 @@ export default class WorkspacesPage extends WorkspaceEditPage {
     await editPage.requestForReviewRadiobutton(reviewRequest);
 
     return editPage;
-  }
-
-  /**
-   * Type in new workspace name.
-   * @return {string} new workspace name
-   */
-  async fillOutWorkspaceName(): Promise<string> {
-    const newWorkspaceName = makeWorkspaceName();
-    await (await this.getWorkspaceNameTextbox()).type(newWorkspaceName);
-    await (await this.getWorkspaceNameTextbox()).pressTab();
-    return newWorkspaceName;
   }
 
   /**

--- a/e2e/tests/workspace/old-cdr-version-modal.spec.ts
+++ b/e2e/tests/workspace/old-cdr-version-modal.spec.ts
@@ -5,6 +5,7 @@ import {Option} from 'app/text-labels';
 import WorkspacesPage from 'app/page/workspaces-page';
 import {makeWorkspaceName} from 'utils/str-utils';
 import OldCdrVersionModal from 'app/page/old-cdr-version-modal';
+import WorkspaceEditPage from 'app/page/workspace-edit-page';
 
 describe('OldCdrVersion Modal restrictions', () => {
     beforeEach(async () => {
@@ -29,7 +30,7 @@ describe('OldCdrVersion Modal restrictions', () => {
 
         // now we can continue
         await createButton.waitUntilEnabled();
-        await workspacesPage.clickCreateFinishButton(createButton);
+        await editPage.clickCreateFinishButton(createButton);
     });
 
     test('OWNER cannot duplicate workspace to an older CDR Version without consenting to restrictions', async () => {
@@ -41,14 +42,14 @@ describe('OldCdrVersion Modal restrictions', () => {
         await workspaceCard.selectSnowmanMenu(Option.Duplicate);
 
         // Fill out Workspace Name should be just enough for successful duplication
-        const workspacesPage = new WorkspacesPage(page);
-        await (await workspacesPage.getWorkspaceNameTextbox()).clear();
-        await workspacesPage.fillOutWorkspaceName();
+        const workspaceEditPage = new WorkspaceEditPage(page);
+        await (await workspaceEditPage.getWorkspaceNameTextbox()).clear();
+        await workspaceEditPage.fillOutWorkspaceName();
 
         // change CDR Version
-        await workspacesPage.selectCdrVersion(config.altCdrVersionName);
+        await workspaceEditPage.selectCdrVersion(config.altCdrVersionName);
 
-        const finishButton = await workspacesPage.getDuplicateWorkspaceButton();
+        const finishButton = await workspaceEditPage.getDuplicateWorkspaceButton();
         expect(await finishButton.isCursorNotAllowed()).toBe(true);
     });
 });

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -6,6 +6,7 @@ import Button from 'app/element/button';
 import * as testData from 'resources/data/workspace-data';
 import {makeWorkspaceName} from 'utils/str-utils';
 import {UseFreeCredits} from 'app/page/workspace-base';
+import WorkspaceEditPage from 'app/page/workspace-edit-page';
 
 describe('Creating new workspaces', () => {
   beforeEach(async () => {
@@ -35,17 +36,19 @@ describe('Creating new workspaces', () => {
     const createNewWorkspaceButton  = await Button.findByName(page, FieldSelector.CreateNewWorkspaceButton.textOption );
     await createNewWorkspaceButton.clickAndWait();
 
+    const workspaceEditPage = new WorkspaceEditPage(page);
+
     // fill out new workspace name
-    const newWorkspaceName = await workspacesPage.fillOutWorkspaceName();
+    const newWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
 
     // select the default CDR Version
-    await workspacesPage.selectCdrVersion();
+    await workspaceEditPage.selectCdrVersion();
 
     // select Billing Account
-    await workspacesPage.selectBillingAccount(UseFreeCredits);
+    await workspaceEditPage.selectBillingAccount(UseFreeCredits);
 
     // fill out question #1 - What is the primary purpose of your project?
-    await workspacesPage.expandResearchPurposeGroup(true); // First, expand accordion: "Research purpose"
+    await workspaceEditPage.expandResearchPurposeGroup(true); // First, expand accordion: "Research purpose"
     await performActions(page, testData.defaultAnswersPrimaryPurpose);
 
     // fill out question #2 - Please provide a summary of your research purpose by responding to the questions.
@@ -64,9 +67,9 @@ describe('Creating new workspaces', () => {
     // -- No Review Required
     await performActions(page, testData.defaultAnswersRequestForReview);
 
-    const finishButton = await workspacesPage.getCreateWorkspaceButton();
+    const finishButton = await workspaceEditPage.getCreateWorkspaceButton();
     await finishButton.waitUntilEnabled();
-    await workspacesPage.clickCreateFinishButton(finishButton);
+    await workspaceEditPage.clickCreateFinishButton(finishButton);
 
     await verifyWorkspaceLinkOnDataPage(newWorkspaceName);
   });

--- a/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
@@ -6,6 +6,7 @@ import OldCdrVersionModal from 'app/page/old-cdr-version-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import Navigation, {NavLink} from 'app/component/navigation';
 import WorkspaceEditPage from 'app/page/workspace-edit-page';
+import WorkspacesPage from '../../app/page/workspaces-page';
 
 describe('Duplicate workspace, changing CDR versions', () => {
     beforeEach(async () => {
@@ -43,7 +44,8 @@ describe('Duplicate workspace, changing CDR versions', () => {
 
         // Delete duplicate workspace via Workspace card in Your Workspaces page.
         await Navigation.navMenu(page, NavLink.YOUR_WORKSPACES);
-        await workspaceEditPage.waitForLoad();
+        const workspacesPage = new WorkspacesPage(page);
+        await workspacesPage.waitForLoad();
 
         await WorkspaceCard.deleteWorkspace(page, duplicateWorkspaceName);
 
@@ -86,7 +88,8 @@ describe('Duplicate workspace, changing CDR versions', () => {
 
         // Delete duplicate workspace via Workspace card in Your Workspaces page.
         await Navigation.navMenu(page, NavLink.YOUR_WORKSPACES);
-        await workspaceEditPage.waitForLoad();
+        const workspacesPage = new WorkspacesPage(page);
+        await workspacesPage.waitForLoad();
 
         await WorkspaceCard.deleteWorkspace(page, duplicateWorkspaceName);
 

--- a/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
@@ -6,7 +6,7 @@ import OldCdrVersionModal from 'app/page/old-cdr-version-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import Navigation, {NavLink} from 'app/component/navigation';
 import WorkspaceEditPage from 'app/page/workspace-edit-page';
-import WorkspacesPage from '../../app/page/workspaces-page';
+import WorkspacesPage from 'app/page/workspaces-page';
 
 describe('Duplicate workspace, changing CDR versions', () => {
     beforeEach(async () => {

--- a/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
@@ -2,10 +2,10 @@ import {createWorkspace, signIn} from 'utils/test-utils';
 import WorkspaceCard from 'app/component/workspace-card';
 import {config} from 'resources/workbench-config';
 import {Option} from 'app/text-labels';
-import WorkspacesPage from 'app/page/workspaces-page';
 import OldCdrVersionModal from 'app/page/old-cdr-version-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import Navigation, {NavLink} from 'app/component/navigation';
+import WorkspaceEditPage from 'app/page/workspace-edit-page';
 
 describe('Duplicate workspace, changing CDR versions', () => {
     beforeEach(async () => {
@@ -21,20 +21,20 @@ describe('Duplicate workspace, changing CDR versions', () => {
         await workspaceCard.selectSnowmanMenu(Option.Duplicate);
 
         // Fill out Workspace Name should be just enough for successful duplication
-        const workspacesPage = new WorkspacesPage(page);
-        await (await workspacesPage.getWorkspaceNameTextbox()).clear();
-        const duplicateWorkspaceName = await workspacesPage.fillOutWorkspaceName();
+        const workspaceEditPage = new WorkspaceEditPage(page);
+        await (await workspaceEditPage.getWorkspaceNameTextbox()).clear();
+        const duplicateWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
 
         // change CDR Version
-        await workspacesPage.selectCdrVersion(config.altCdrVersionName);
+        await workspaceEditPage.selectCdrVersion(config.altCdrVersionName);
 
         // wait for the warning modal and consent to the required restrictions
         const modal = new OldCdrVersionModal(page);
         await modal.consentToOldCdrRestrictions();
 
-        const finishButton = await workspacesPage.getDuplicateWorkspaceButton();
+        const finishButton = await workspaceEditPage.getDuplicateWorkspaceButton();
         await finishButton.waitUntilEnabled();
-        await workspacesPage.clickCreateFinishButton(finishButton);
+        await workspaceEditPage.clickCreateFinishButton(finishButton);
 
         // Duplicate workspace Data page is loaded.
         const dataPage = new WorkspaceDataPage(page);
@@ -43,7 +43,7 @@ describe('Duplicate workspace, changing CDR versions', () => {
 
         // Delete duplicate workspace via Workspace card in Your Workspaces page.
         await Navigation.navMenu(page, NavLink.YOUR_WORKSPACES);
-        await workspacesPage.waitForLoad();
+        await workspaceEditPage.waitForLoad();
 
         await WorkspaceCard.deleteWorkspace(page, duplicateWorkspaceName);
 
@@ -64,20 +64,20 @@ describe('Duplicate workspace, changing CDR versions', () => {
         await workspaceCard.selectSnowmanMenu(Option.Duplicate);
 
         // Fill out Workspace Name should be just enough for successful duplication
-        const workspacesPage = new WorkspacesPage(page);
-        await (await workspacesPage.getWorkspaceNameTextbox()).clear();
-        const duplicateWorkspaceName = await workspacesPage.fillOutWorkspaceName();
+        const workspaceEditPage = new WorkspaceEditPage(page);
+        await (await workspaceEditPage.getWorkspaceNameTextbox()).clear();
+        const duplicateWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
 
         // change CDR Version
-        await workspacesPage.selectCdrVersion(config.defaultCdrVersionName);
+        await workspaceEditPage.selectCdrVersion(config.defaultCdrVersionName);
 
-        const upgradeMessage = await workspacesPage.getCdrVersionUpgradeMessage();
+        const upgradeMessage = await workspaceEditPage.getCdrVersionUpgradeMessage();
         expect(upgradeMessage).toContain(originalWorkspaceName);
         expect(upgradeMessage).toContain(`${config.altCdrVersionName} to ${config.defaultCdrVersionName}.`);
 
-        const finishButton = await workspacesPage.getDuplicateWorkspaceButton();
+        const finishButton = await workspaceEditPage.getDuplicateWorkspaceButton();
         await finishButton.waitUntilEnabled();
-        await workspacesPage.clickCreateFinishButton(finishButton);
+        await workspaceEditPage.clickCreateFinishButton(finishButton);
 
         // Duplicate workspace Data page is loaded.
         const dataPage = new WorkspaceDataPage(page);
@@ -86,7 +86,7 @@ describe('Duplicate workspace, changing CDR versions', () => {
 
         // Delete duplicate workspace via Workspace card in Your Workspaces page.
         await Navigation.navMenu(page, NavLink.YOUR_WORKSPACES);
-        await workspacesPage.waitForLoad();
+        await workspaceEditPage.waitForLoad();
 
         await WorkspaceCard.deleteWorkspace(page, duplicateWorkspaceName);
 

--- a/e2e/tests/workspace/workspace-duplicate.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate.spec.ts
@@ -1,9 +1,9 @@
-import WorkspacesPage from 'app/page/workspaces-page';
 import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 import {Option} from 'app/text-labels';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import Navigation, {NavLink} from 'app/component/navigation';
 import WorkspaceCard from 'app/component/workspace-card';
+import WorkspaceEditPage from 'app/page/workspace-edit-page';
 
 describe('Duplicate workspace', () => {
   beforeEach(async () => {
@@ -25,13 +25,13 @@ describe('Duplicate workspace', () => {
       await workspaceCard.selectSnowmanMenu(Option.Duplicate);
 
       // Fill out Workspace Name should be just enough for successful duplication
-      const workspacesPage = new WorkspacesPage(page);
-      await (await workspacesPage.getWorkspaceNameTextbox()).clear();
-      const duplicateWorkspaceName = await workspacesPage.fillOutWorkspaceName();
+      const workspaceEditPage = new WorkspaceEditPage(page);
+      await (await workspaceEditPage.getWorkspaceNameTextbox()).clear();
+      const duplicateWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
 
-      const finishButton = await workspacesPage.getDuplicateWorkspaceButton();
+      const finishButton = await workspaceEditPage.getDuplicateWorkspaceButton();
       await finishButton.waitUntilEnabled();
-      await workspacesPage.clickCreateFinishButton(finishButton);
+      await workspaceEditPage.clickCreateFinishButton(finishButton);
 
       // Duplicate workspace Data page is loaded.
       const dataPage = new WorkspaceDataPage(page);
@@ -40,7 +40,7 @@ describe('Duplicate workspace', () => {
 
       // Delete duplicate workspace via Workspace card in Your Workspaces page.
       await Navigation.navMenu(page, NavLink.YOUR_WORKSPACES);
-      await workspacesPage.waitForLoad();
+      await workspaceEditPage.waitForLoad();
 
       await WorkspaceCard.deleteWorkspace(page, duplicateWorkspaceName);
 
@@ -55,17 +55,17 @@ describe('Duplicate workspace', () => {
       const dataPage = new WorkspaceDataPage(page);
       await dataPage.selectWorkspaceAction(Option.Duplicate);
 
-      const workspacesPage = new WorkspacesPage(page);
+      const workspaceEditPage = new WorkspaceEditPage(page);
 
       // Fill out Workspace Name
-      await (await workspacesPage.getWorkspaceNameTextbox()).clear();
-      const duplicateWorkspaceName = await workspacesPage.fillOutWorkspaceName();
+      await (await workspaceEditPage.getWorkspaceNameTextbox()).clear();
+      const duplicateWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
       // select "Share workspace with same set of collaborators radiobutton
-      await workspacesPage.clickShareWithCollaboratorsCheckbox();
+      await workspaceEditPage.clickShareWithCollaboratorsCheckbox();
 
-      const finishButton = await workspacesPage.getDuplicateWorkspaceButton();
+      const finishButton = await workspaceEditPage.getDuplicateWorkspaceButton();
       await finishButton.waitUntilEnabled();
-      await workspacesPage.clickCreateFinishButton(finishButton);
+      await workspaceEditPage.clickCreateFinishButton(finishButton);
 
       // Duplicate workspace Data page is loaded.
       await dataPage.waitForLoad();

--- a/e2e/tests/workspace/workspace-duplicate.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate.spec.ts
@@ -4,7 +4,7 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import Navigation, {NavLink} from 'app/component/navigation';
 import WorkspaceCard from 'app/component/workspace-card';
 import WorkspaceEditPage from 'app/page/workspace-edit-page';
-import WorkspacesPage from '../../app/page/workspaces-page';
+import WorkspacesPage from 'app/page/workspaces-page';
 
 describe('Duplicate workspace', () => {
   beforeEach(async () => {

--- a/e2e/tests/workspace/workspace-duplicate.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate.spec.ts
@@ -4,6 +4,7 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import Navigation, {NavLink} from 'app/component/navigation';
 import WorkspaceCard from 'app/component/workspace-card';
 import WorkspaceEditPage from 'app/page/workspace-edit-page';
+import WorkspacesPage from '../../app/page/workspaces-page';
 
 describe('Duplicate workspace', () => {
   beforeEach(async () => {
@@ -40,7 +41,8 @@ describe('Duplicate workspace', () => {
 
       // Delete duplicate workspace via Workspace card in Your Workspaces page.
       await Navigation.navMenu(page, NavLink.YOUR_WORKSPACES);
-      await workspaceEditPage.waitForLoad();
+      const workspacesPage = new WorkspacesPage(page);
+      await workspacesPage.waitForLoad();
 
       await WorkspaceCard.deleteWorkspace(page, duplicateWorkspaceName);
 

--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -1,9 +1,9 @@
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import WorkspacesPage from 'app/page/workspaces-page';
 import {Option, WorkspaceAccessLevel} from 'app/text-labels';
 import * as testData from 'resources/data/workspace-data';
 import {createWorkspace, findOrCreateWorkspace, performActions, signIn} from 'utils/test-utils';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
+import WorkspaceEditPage from 'app/page/workspace-edit-page';
 
 describe('Editing workspace via workspace card snowman menu', () => {
 
@@ -22,19 +22,19 @@ describe('Editing workspace via workspace card snowman menu', () => {
     const workspaceCard = await createWorkspace(page);
     await workspaceCard.selectSnowmanMenu(Option.Edit);
 
-    const workspacesPage = new WorkspacesPage(page);
+    const workspaceEditPage = new WorkspaceEditPage(page);
 
     // CDR Version Select is readonly. Get selected value.
-    const selectedOption = await workspacesPage.selectCdrVersion();
-    const cdrVersionSelect = await workspacesPage.getCdrVersionSelect();
+    const selectedOption = await workspaceEditPage.selectCdrVersion();
+    const cdrVersionSelect = await workspaceEditPage.getCdrVersionSelect();
     const selectedValue = await cdrVersionSelect.getOptionValue(selectedOption);
 
     // Change question #2 answer
     await performActions(page, testData.defaultAnswersResearchPurposeSummary);
 
-    const updateButton = await workspacesPage.getUpdateWorkspaceButton();
+    const updateButton = await workspaceEditPage.getUpdateWorkspaceButton();
     await updateButton.waitUntilEnabled();
-    await workspacesPage.clickCreateFinishButton(updateButton);
+    await workspaceEditPage.clickCreateFinishButton(updateButton);
 
     const dataPage = new WorkspaceDataPage(page);
     await dataPage.waitForLoad();
@@ -97,21 +97,21 @@ describe('Editing workspace via workspace card snowman menu', () => {
     const dataPage = new WorkspaceDataPage(page);
     await dataPage.openAboutPage();
     const aboutPage = new WorkspaceAboutPage(page);
-    await aboutPage.editWorkspace();  
+    await aboutPage.editWorkspace();
 
-    const workspacesPage = new WorkspacesPage(page);
+    const workspaceEditPage = new WorkspaceEditPage(page);
 
      // CDR Version Select is readonly. Get selected value.
-     const selectedOption = await workspacesPage.selectCdrVersion();
-     const cdrVersionSelect = await workspacesPage.getCdrVersionSelect();
+     const selectedOption = await workspaceEditPage.selectCdrVersion();
+     const cdrVersionSelect = await workspaceEditPage.getCdrVersionSelect();
      const selectedValue = await cdrVersionSelect.getOptionValue(selectedOption);
 
      // Change question #2 answer
      await performActions(page, testData.defaultAnswersResearchPurposeSummary);
 
-     const updateButton = await workspacesPage.getUpdateWorkspaceButton();
+     const updateButton = await workspaceEditPage.getUpdateWorkspaceButton();
      await updateButton.waitUntilEnabled();
-     await workspacesPage.clickCreateFinishButton(updateButton);
+     await workspaceEditPage.clickCreateFinishButton(updateButton);
 
      await dataPage.waitForLoad();
 


### PR DESCRIPTION
Description:

Because WorkspacesPage inherited from WorkspaceEditPage, there were some strange semantics going on here.  Split these two completely, to make tests clearer.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
