### PR TITLE
[risk=no] Use creating rather than deleting indicator during compound operation

### DIFF
--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -185,16 +185,16 @@ describe('HelpSidebar', () => {
 
   });
 
-  it('should display "stopping" UX during compound runtime op', async() => {
-    setRuntimeStatus(RuntimeStatus.Running);
+  it('should display "starting" UX during compound runtime op with no runtime', async() => {
+    setRuntimeStatus(RuntimeStatus.Deleting);
     registerCompoundRuntimeOperation(workspaceDataStub.namespace, {aborter: new AbortController()})
     const wrapper = await component();
     await waitForFakeTimersAndUpdate(wrapper);
 
-    expect(statusIcon(wrapper).prop('style').color).toEqual(colors.runtimeStatus.running);
+    expect(statusIcon(wrapper).prop('style').color).toEqual(colors.runtimeStatus.stopping);
 
     act(() => clearRuntime());
     await waitForFakeTimersAndUpdate(wrapper);
-    expect(statusIcon(wrapper).prop('style').color).toEqual(colors.runtimeStatus.stopping);
+    expect(statusIcon(wrapper).prop('style').color).toEqual(colors.runtimeStatus.starting);
   });
 });

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -596,7 +596,10 @@ export const HelpSidebar = fp.flow(
         // If a compound operation is still pending, and we're transitioning
         // through the "Deleted" phase of the runtime, we want to keep showing
         // an activity spinner. Avoids an awkward UX during a delete/create cycle.
-        status = RuntimeStatus.Deleting;
+        // There also be some lag during the runtime creation flow between when
+        // the compound operation starts, and the runtime is set in the store; for
+        // this reason use Creating rather than Deleting here.
+        status = RuntimeStatus.Creating;
       }
 
       // We always want to show the thunderstorm icon.


### PR DESCRIPTION
Currently, there's a flash of a yellow spinner after you do an initial creation, on account of the previous logic. This fixes that, and doesn't make much of a difference for the delete/create cycle.