### PR TITLE
[RW-5763][risk=no] Allow cheaper GCE and Dataproc worker machine types

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -380,6 +380,32 @@ describe('RuntimePanel', () => {
     expect(wrapper.find(Button).find({'aria-label': 'Next'}).first().prop('disabled')).toBeTruthy();
   });
 
+  it('should respect divergent sets of valid machine types across compute types', async() => {
+    const wrapper = await component();
+
+    await pickMainCpu(wrapper, 1);
+    await pickMainRam(wrapper, 3.75);
+
+    await pickComputeType(wrapper, ComputeType.Dataproc);
+
+    // n1-standard-1 is illegal for Dataproc, so it should restore the default.
+    expect(getMainCpu(wrapper)).toBe(4);
+    expect(getMainRam(wrapper)).toBe(15);
+  });
+
+  it('should carry over valid main machine type across compute types', async() => {
+    const wrapper = await component();
+
+    await pickMainCpu(wrapper, 2);
+    await pickMainRam(wrapper, 7.5);
+
+    await pickComputeType(wrapper, ComputeType.Dataproc);
+
+    // n1-standard-2 is legal for Dataproc, so it should remain.
+    expect(getMainCpu(wrapper)).toBe(2);
+    expect(getMainRam(wrapper)).toBe(7.5);
+  });
+
   it('should warn user about reboot if there are updates that require one - increase disk size', async() => {
     const wrapper = await component();
 

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -16,7 +16,6 @@ import {
   withUserProfile
 } from 'app/utils';
 import {
-  allMachineTypes,
   ComputeType,
   findMachineByName,
   Machine,
@@ -24,9 +23,9 @@ import {
   machineRunningCostBreakdown,
   machineStorageCost,
   machineStorageCostBreakdown,
-  validLeoGceMachineTypes,
   validLeoDataprocMasterMachineTypes,
-  validLeoDataprocWorkerMachineTypes
+  validLeoDataprocWorkerMachineTypes,
+  validLeoGceMachineTypes
 } from 'app/utils/machines';
 import {formatUsd} from 'app/utils/numbers';
 import {runtimePresets} from 'app/utils/runtime-presets';

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -257,7 +257,7 @@ const MachineSelector = ({onChange, selectedMachine, machineType, disabled, idPr
             // maybeGetMachine,
             onChange
             )(validMachineTypes) }
-        disabled={disabled}        
+        disabled={disabled}
         value={memory}
         />
   </Fragment>;
@@ -384,7 +384,7 @@ const PresetSelector = ({
                                       presetCompute: ComputeType.Dataproc
                                     })]
                                   ])(runtimeTemplate);
-                                  const presetMachineType = fp.find(({name}) => name === presetMachineName, validLeonardoMachineTypes);
+                                  const presetMachineType = findMachineByName(presetMachineName);
 
                                   setSelectedDiskSize(presetDiskSize);
                                   setSelectedMachine(presetMachineType);
@@ -678,7 +678,7 @@ export const RuntimePanel = fp.flow(
   // default machine type if switching compute types would invalidate the main
   // machine type choice.
   useEffect(() => {
-    if (!validMainMachineTypes.find(({name}) => name === selectedMachine)) {
+    if (!validMainMachineTypes.find(({name}) => name === selectedMachine.name)) {
       setSelectedMachine(initialMasterMachine);
     }
   }, [selectedCompute]);

--- a/ui/src/app/utils/machines.ts
+++ b/ui/src/app/utils/machines.ts
@@ -47,9 +47,14 @@ export const allMachineTypes: Machine[] = fp.map(({ price, preemptiblePrice, ...
   ...details
 }), machineBases); // adding prices for ephemeral IP's, per https://cloud.google.com/compute/network-pricing#ipaddress
 
-// There are issues launching Leo runtimes with <4GB ram.
-// See https://broadworkbench.atlassian.net/browse/SATURN-1337
-export const validLeonardoMachineTypes = allMachineTypes.filter(({memory}) => memory >= 4);
+// Following constraints follow findings on RW-5763, last tested 11/19/20. Using
+// machine types below this limit results in either an immediate ERROR status,
+// or a delayed ERROR status after the runtime times out in the CREATING state.
+// See also https://broadworkbench.atlassian.net/browse/SATURN-1337, where the
+// determination was made for Dataproc master machines only.
+export const validLeoGceMachineTypes = allMachineTypes.filter(({memory}) => memory >= 2);
+export const validLeoDataprocMasterMachineTypes = allMachineTypes.filter(({memory}) => memory > 4);
+export const validLeoDataprocWorkerMachineTypes = allMachineTypes.filter(({memory}) => memory >= 3);
 
 export const findMachineByName = (machineToFind: string) => fp.find(({name}) => name === machineToFind, allMachineTypes);
 


### PR DESCRIPTION
Will add a test to cover the `useEffect` - going to wait on https://github.com/all-of-us/workbench/pull/4281 before I include this.