### PR TITLE
[RW-5977] adding column for standard flag

### DIFF
--- a/api/db/changelog/db.changelog-143-alter-concept-set-concept-id.xml
+++ b/api/db/changelog/db.changelog-143-alter-concept-set-concept-id.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="brianfreeman" id="changelog-143-alter-concept-set-concept-id">
+    <addColumn tableName="concept_set_concept_id">
+      <column name="is_standard" type="boolean" defaultValueBoolean="true"/>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -151,6 +151,7 @@
   <include file="changelog/db.changelog-140-add-prePackagedConcept-table.xml"/>
   <include file="changelog/db.changelog-141-populate-prePackagedConcept-table.xml"/>
   <include file="changelog/db.changelog-142-cdr-version-hasCopeSurvey-field.xml"/>
+  <include file="changelog/db.changelog-143-alter-concept-set-concept-id.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`


### PR DESCRIPTION
Adding column for standard flag to the concept_set_concept_id table. This is needed to complete [RW-5954](https://precisionmedicineinitiative.atlassian.net/browse/RW-5954)(slated for 12-7 release) and [RW-5978](https://precisionmedicineinitiative.atlassian.net/browse/RW-5978)(slated between 11-30 and 12-7 releases). Please deploy locally and confirm that this doesn't break any concept set functionality