### PR TITLE
[RW-5384][risk=no] Check for duplicate rows after streaming upload

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/actionaudit/ActionAuditQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/ActionAuditQueryServiceImpl.java
@@ -75,7 +75,6 @@ public class ActionAuditQueryServiceImpl implements ActionAuditQueryService {
             .build();
 
     final TableResult tableResult = bigQueryService.executeQuery(queryJobConfiguration);
-
     final List<AuditLogEntry> logEntries = auditLogEntryMapper.tableResultToLogEntries(tableResult);
     final String queryHeader =
         String.format(

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceDmlImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceDmlImpl.java
@@ -60,6 +60,7 @@ public class ReportingUploadServiceDmlImpl implements ReportingUploadService {
   private static final long MAX_WAIT_TIME = Duration.ofSeconds(60).toMillis();
 
   private final BigQueryService bigQueryService;
+  private ReportingVerificationService reportingVerificationService;
   private final Provider<Stopwatch> stopwatchProvider;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
 
@@ -76,9 +77,11 @@ public class ReportingUploadServiceDmlImpl implements ReportingUploadService {
 
   public ReportingUploadServiceDmlImpl(
       BigQueryService bigQueryService,
+      ReportingVerificationService reportingVerificationService,
       Provider<Stopwatch> stopwatchProvider,
       Provider<WorkbenchConfig> workbenchConfigProvider) {
     this.bigQueryService = bigQueryService;
+    this.reportingVerificationService = reportingVerificationService;
     this.stopwatchProvider = stopwatchProvider;
     this.workbenchConfigProvider = workbenchConfigProvider;
   }
@@ -106,6 +109,11 @@ public class ReportingUploadServiceDmlImpl implements ReportingUploadService {
     logger.info(
         LogFormatters.rate(
             "DML Insert", uploadStopwatch.elapsed(), insertJobs.size(), "Insert Queries"));
+
+    // verify correct number of rows. I don't believe this should ever be off for this
+    // implementation,
+    // outside of an error condition that would have already thrown.
+    reportingVerificationService.verifyAndLog(reportingSnapshot);
   }
 
   private TableResult executeWithTimeout(QueryJobConfiguration job) {

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationService.java
@@ -1,0 +1,11 @@
+package org.pmiops.workbench.reporting;
+
+import org.pmiops.workbench.model.ReportingSnapshot;
+import org.pmiops.workbench.model.ReportingUploadDetails;
+
+public interface ReportingVerificationService {
+
+  ReportingUploadDetails getUploadDetails(ReportingSnapshot reportingSnapshot);
+
+  ReportingUploadDetails verifyAndLog(ReportingSnapshot reportingSnapshot);
+}

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
@@ -1,0 +1,154 @@
+package org.pmiops.workbench.reporting;
+
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.QueryParameterValue;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.StreamSupport;
+import javax.inject.Provider;
+import org.pmiops.workbench.api.BigQueryService;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.model.ReportingSnapshot;
+import org.pmiops.workbench.model.ReportingUploadDetails;
+import org.pmiops.workbench.model.ReportingUploadResult;
+import org.pmiops.workbench.reporting.insertion.CohortColumnValueExtractor;
+import org.pmiops.workbench.reporting.insertion.InstitutionColumnValueExtractor;
+import org.pmiops.workbench.reporting.insertion.UserColumnValueExtractor;
+import org.pmiops.workbench.reporting.insertion.WorkspaceColumnValueExtractor;
+import org.pmiops.workbench.utils.FieldValues;
+import org.pmiops.workbench.utils.LogFormatters;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReportingVerificationServiceImpl implements ReportingVerificationService {
+  private static final Logger logger =
+      Logger.getLogger(ReportingVerificationServiceImpl.class.getName());
+
+  private final BigQueryService bigQueryService;
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
+  private Provider<Stopwatch> stopwatchProvider;
+
+  public ReportingVerificationServiceImpl(
+      BigQueryService bigQueryService,
+      Provider<WorkbenchConfig> workbenchConfigProvider,
+      Provider<Stopwatch> stopwatchProvider) {
+    this.bigQueryService = bigQueryService;
+    this.workbenchConfigProvider = workbenchConfigProvider;
+    this.stopwatchProvider = stopwatchProvider;
+  }
+
+  @Override
+  public ReportingUploadDetails getUploadDetails(ReportingSnapshot snapshot) {
+    final Stopwatch verifyStopwatch = stopwatchProvider.get();
+    verifyStopwatch.start();
+
+    final ReportingUploadDetails result =
+        new ReportingUploadDetails()
+            .snapshotTimestamp(snapshot.getCaptureTimestamp())
+            .projectId(getProjectId())
+            .dataset(getDataset())
+            .uploads(
+                ImmutableList.of(
+                    getUploadResult(
+                        UserColumnValueExtractor.TABLE_NAME,
+                        snapshot.getCaptureTimestamp(),
+                        snapshot.getUsers().size()),
+                    getUploadResult(
+                        WorkspaceColumnValueExtractor.TABLE_NAME,
+                        snapshot.getCaptureTimestamp(),
+                        snapshot.getWorkspaces().size()),
+                    getUploadResult(
+                        CohortColumnValueExtractor.TABLE_NAME,
+                        snapshot.getCaptureTimestamp(),
+                        snapshot.getCohorts().size()),
+                    getUploadResult(
+                        InstitutionColumnValueExtractor.TABLE_NAME,
+                        snapshot.getCaptureTimestamp(),
+                        snapshot.getInstitutions().size())));
+    verifyStopwatch.stop();
+    logger.info(LogFormatters.duration("Verification queries", verifyStopwatch.elapsed()));
+    return result;
+  }
+
+  @Override
+  public ReportingUploadDetails verifyAndLog(ReportingSnapshot reportingSnapshot) {
+    // check each table. Note that for streaming inputs, not all rows may be immediately available.
+    final ReportingUploadDetails uploadDetails = getUploadDetails(reportingSnapshot);
+    final StringBuilder sb =
+        new StringBuilder(
+            String.format("Verifying Snapshot %d:\n", reportingSnapshot.getCaptureTimestamp()));
+    sb.append("Table\tUploaded\tExpected\tDifference(%)\n");
+    Level detailsLogLevel = Level.INFO;
+    for (final ReportingUploadResult result : uploadDetails.getUploads()) {
+      final long delta = result.getDestinationRowCount() - result.getSourceRowCount();
+      final String relativeDelta;
+      if (result.getSourceRowCount() == 0) {
+        relativeDelta = "";
+      } else {
+        relativeDelta = String.format(" (%.3f%%)", 100.0 * delta / result.getSourceRowCount());
+      }
+      sb.append(
+          String.format(
+              "%s\t%d\t%d\t%d%s\n",
+              result.getTableName(),
+              result.getSourceRowCount(),
+              result.getDestinationRowCount(),
+              delta,
+              relativeDelta));
+      if (!result.getDestinationRowCount().equals(result.getSourceRowCount())) {
+        detailsLogLevel = Level.WARNING;
+      }
+    }
+    logger.log(detailsLogLevel, sb.toString());
+    return uploadDetails;
+  }
+
+  public String getDataset() {
+    return workbenchConfigProvider.get().reporting.dataset;
+  }
+
+  public String getProjectId() {
+    return workbenchConfigProvider.get().server.projectId;
+  }
+
+  private ReportingUploadResult getUploadResult(
+      String tableName, long snapshotTimestamp, long sourceRowCount) {
+    return new ReportingUploadResult()
+        .tableName(tableName)
+        .sourceRowCount(sourceRowCount)
+        .destinationRowCount(getActualRowCount(tableName, snapshotTimestamp));
+  }
+
+  private Long getActualRowCount(String tableName, long snapshotTimestamp) {
+    final QueryJobConfiguration queryJobConfiguration = buildJob(tableName, snapshotTimestamp);
+    return StreamSupport.stream(
+            bigQueryService.executeQuery(queryJobConfiguration).getValues().spliterator(), false)
+        .findFirst()
+        .flatMap(fv -> FieldValues.getLong(fv, "actual_count"))
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    String.format(
+                        "Failed to obtain verification count for table %s at snapshot %d",
+                        tableName, snapshotTimestamp)));
+  }
+
+  private QueryJobConfiguration buildJob(String tableName, long snapshotTimestamp) {
+    return QueryJobConfiguration.newBuilder(buildQuery(tableName))
+        .addNamedParameter("snapshot_timestamp", QueryParameterValue.int64(snapshotTimestamp))
+        .build();
+  }
+
+  private String buildQuery(String tableName) {
+    final String queryTemplate =
+        "SELECT\n"
+            + "  COUNT(*) AS actual_count\n"
+            + "FROM\n"
+            + "  `%s.%s.%s` \n"
+            + "WHERE\n"
+            + "  snapshot_timestamp =  @snapshot_timestamp;";
+    return String.format(queryTemplate, getProjectId(), getDataset(), tableName);
+  }
+}

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8240,6 +8240,37 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/ReportingWorkspace"
+  ReportingUploadDetails:
+    type: object
+    properties:
+      snapshotTimestamp:
+        description: Snapshot timestamp for this upload, in Epoch millis
+        type: integer
+        format: int64
+      projectId:
+        description: Project containing the BigQuery dataset
+        type: string
+      dataset:
+        description: Reporting Dataset
+        type: string
+      uploads:
+        type: array
+        items:
+          "$ref": "#/definitions/ReportingUploadResult"
+  ReportingUploadResult:
+    type: object
+    properties:
+      tableName:
+        description: BigQuery table name
+        type: string
+      sourceRowCount:
+        description: Number of rows in source to be insertted
+        type: integer
+        format: int64
+      destinationRowCount:
+        description: Number of rows present in query
+        type: integer
+        format: int64
   ReportingUser:
     x-aou-note: |-
       This code was generated using reporting-wizard.rb at 2020-09-30T16:18:29-04:00.

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingUploadServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingUploadServiceTest.java
@@ -97,6 +97,7 @@ public class ReportingUploadServiceTest {
     ReportingUploadServiceStreamingImpl.class,
     ReportingTestConfig.class
   })
+  @MockBean({ReportingVerificationService.class})
   public static class config {
     @Bean
     public Clock getClock() {


### PR DESCRIPTION
Little service to count rows in all the reporting tables with a given timestamp, to help catch duplicate rows. Logs to warning or info level accordingly.

This check shouldn't be necessary for the batch insert query implementation, but it's easy enough to add it there.

Output looks something like this (will add new tables as they come online):
```
api_1                    | Nov 30, 2020 7:44:18 PM org.pmiops.workbench.reporting.ReportingSnapshotServiceImpl getApplicationDbData
api_1                    | INFO: Application DB Queries: 68ms
api_1                    | Nov 30, 2020 7:44:19 PM org.pmiops.workbench.reporting.ReportingSnapshotServiceImpl convertToReportingSnapshot
api_1                    | INFO: Conversion to ReportingSnapshot: 309ms
api_1                    | Nov 30, 2020 7:44:19 PM org.pmiops.workbench.reporting.ReportingUploadServiceStreamingImpl uploadSnapshot
api_1                    | INFO: Streaming upload into cohort table: 2 in 155ms (12.903226 rows/sec)
api_1                    | Streaming upload into institution table: 20 in 159ms (125.786164 rows/sec)
api_1                    | Streaming upload into user table: 1 in 160ms (6.250000 rows/sec)
api_1                    | Streaming upload into workspace table: 15 in 145ms (103.448276 rows/sec)
api_1                    | 
api_1                    | Nov 30, 2020 7:44:24 PM org.pmiops.workbench.reporting.ReportingVerificationServiceImpl checkUploads
api_1                    | INFO: Verification queries: 5s 37ms
api_1                    | Nov 30, 2020 7:44:24 PM org.pmiops.workbench.reporting.ReportingVerificationServiceImpl verifyAndLog
api_1                    | INFO: Verifying Snapshot 1606765458906:
api_1                    | Table	Uploaded	Expected	Difference(%)
api_1                    | user	1	1	0 (0.000%)
api_1                    | workspace	15	15	0 (0.000%)
api_1                    | cohort	2	2	0 (0.000%)
api_1                    | institution	20	20	0 (0.000%)
```


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
