### PR TITLE
[RW-5920][risk=no] Fix lingering sidebar on notebooks pages

### DIFF
--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -9,6 +9,7 @@ import {
   navigate,
   nextWorkspaceWarmupStore,
   routeConfigDataStore,
+  setSidebarActiveIconStore,
   urlParamsStore,
   userProfileStore
 } from 'app/utils/navigation';
@@ -97,6 +98,8 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
           this.setHelpContentKeyAndMaybeSetNotebookStyles();
           // Close sidebar on route change unless navigating between participants in cohort review
           if (this.helpContentKey !== 'reviewParticipantDetail') {
+            // Reset store to prevent blank sidebar on notebook pages
+            setSidebarActiveIconStore.next(null);
             this.setSidebarState(false);
           }
         }));


### PR DESCRIPTION
Blank sidebar in notebooks was caused by init of `HelpSidebar` with a value still set in `setSidebarActiveIconStore` from a previous page, so the sidebar would open with no content to display. Fixed by resetting `setSidebarActiveIconStore` when we close the sidebar for a route change.