### PR TITLE
[risk=no] Add an EnvironmentBase interface for typesafety

### DIFF
--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -5,7 +5,7 @@ export enum ZendeskEnv {
   Sandbox = 'sandbox'
 }
 
-export interface Environment {
+export interface EnvironmentBase {
   // Permanent environment variables.
   //
   // The URL to use when making API requests against the AoU API. This is used
@@ -15,13 +15,6 @@ export interface Environment {
   // The OAuth2 client ID. Used by the sign-in module to authenticate the user.
   // Example value: '56507752110-ovdus1lkreopsfhlovejvfgmsosveda6.apps.googleusercontent.com'
   clientId: string;
-  // Indicates that the current server is a local server where client-side
-  // debugging should be enabled (e.g. console.log, or devtools APIs).
-  debug: boolean;
-  // A prefix to add to the site title (shown in the tab title).
-  // Example value: 'Test' would cause the following full title:
-  // "Homepage | [Test] All of Us Researcher Workbench"
-  displayTag: string;
   // Indicates if the displayTag should be shown in the web app. If it is true,
   // a small label will be added under the "All of Us" logo in the header.
   shouldShowDisplayTag: boolean;
@@ -68,4 +61,14 @@ export interface Environment {
   //
   // The UI environment config should be restricted to truly UI-specific environment variables, such
   // as server API endpoints and client IDs.
+}
+
+export interface Environment extends EnvironmentBase {
+  // Indicates that the current server is a local server where client-side
+  // debugging should be enabled (e.g. console.log, or devtools APIs).
+  debug: boolean;
+  // A prefix to add to the site title (shown in the tab title).
+  // Example value: 'Test' would cause the following full title:
+  // "Homepage | [Test] All of Us Researcher Workbench"
+  displayTag: string;
 }

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -1,8 +1,8 @@
-import {ZendeskEnv} from 'environments/environment-type';
+import {EnvironmentBase, ZendeskEnv} from 'environments/environment-type';
 
 // The values are shared across the deployed test env as well as the local dev
 // environments.
-export const testEnvironmentBase = {
+export const testEnvironmentBase: EnvironmentBase = {
   allOfUsApiUrl: 'https://api-dot-all-of-us-workbench-test.appspot.com',
   clientId: '602460048110-5uk3vds3igc9qo0luevroc2uc3okgbkt.apps.googleusercontent.com',
   // Captcha Site key for test is same as that of local since both point to the same server keys


### PR DESCRIPTION
Description:

`testEnvironmentBase` was untyped, which tripped me up a bit when working with environment flags.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
