### PR TITLE
[no ticket][risk=no] Make notebook queries more efficient

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -736,5 +736,14 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
     fitbitHeartRateLinking_personId.setDenormalizedName("PERSON_ID");
 
     dsLinkingDao.save(fitbitHeartRateLinking_personId);
+
+    DbDSLinking fitbitHeartRateLinking_coreTable = new DbDSLinking();
+    fitbitHeartRateLinking_coreTable.setOmopSql("CORE_TABLE_FOR_DOMAIN");
+    fitbitHeartRateLinking_coreTable.setJoinValue(
+        "from `${projectId}.${dataSetId}.heart_rate_minute_level` heart_rate_minute_level");
+    fitbitHeartRateLinking_coreTable.setDomain("Fitbit_heart_rate_level");
+    fitbitHeartRateLinking_coreTable.setDenormalizedName("CORE_TABLE_FOR_DOMAIN");
+
+    dsLinkingDao.save(fitbitHeartRateLinking_coreTable);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -566,10 +566,17 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     final ValuesLinkingPair valuesLinkingPair =
         getValueSelectsAndJoins(domainValuePairsForCurrentDomain);
 
-    queryBuilder
-        .append(String.join(", ", valuesLinkingPair.getSelects()))
-        .append(" from ( SELECT * ")
-        .append(valuesLinkingPair.getDomainTable());
+    if (domain.equals(Domain.SURVEY)) {
+      queryBuilder
+          .append(String.join(", ", valuesLinkingPair.getSelects()))
+          .append(" ")
+          .append(valuesLinkingPair.getDomainTable());
+    } else {
+      queryBuilder
+          .append(String.join(", ", valuesLinkingPair.getSelects()))
+          .append(" from ( SELECT * ")
+          .append(valuesLinkingPair.getDomainTable());
+    }
 
     final Optional<String> conceptSetSqlInClauseMaybe =
         buildConceptIdListClause(domain, conceptSetsSelected);
@@ -639,9 +646,13 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
         queryBuilder.append(", DATE");
       }
     }
-    queryBuilder
-        .append(") " + valuesLinkingPair.getTableAlias() + " ")
-        .append(valuesLinkingPair.formatJoins());
+
+    if (!domain.equals(Domain.SURVEY)) {
+      queryBuilder.append(") " + valuesLinkingPair.getTableAlias());
+      if (!valuesLinkingPair.formatJoins().equals("")) {
+        queryBuilder.append(" " + valuesLinkingPair.formatJoins());
+      }
+    }
     return buildQueryJobConfiguration(cohortParameters, queryBuilder.toString());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -1100,12 +1100,12 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
             .map(DbDSLinking::getOmopSql)
             .collect(ImmutableList.toImmutableList());
 
-    final String domainTable =
+    final ImmutableList<String> coreTable =
         valuesLinkingTableResult.stream()
             .filter(fieldValue -> fieldValue.getOmopSql().equals("CORE_TABLE_FOR_DOMAIN"))
             .map(DbDSLinking::getJoinValue)
-            .findFirst()
-            .get();
+            .collect(ImmutableList.toImmutableList());
+    String domainTable = coreTable.isEmpty() ? "" : coreTable.get(0);
 
     final ImmutableList<String> valueJoins =
         valuesLinkingTableResult.stream()

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -89,6 +89,9 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
       "SELECT ${columns} \nFROM `${projectId}.${dataSetId}.${tableName}`";
   private static final String LIMIT_20 = " LIMIT 20";
   private static final String PERSON_ID_COLUMN_NAME = "PERSON_ID";
+  private static final ImmutableList<Domain> OUTER_QUERY_DOMAIN =
+      ImmutableList.of(
+          Domain.CONDITION, Domain.DRUG, Domain.MEASUREMENT, Domain.OBSERVATION, Domain.PROCEDURE);
 
   @Override
   public Collection<MeasurementBundle> getGaugeData() {
@@ -566,15 +569,15 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     final ValuesLinkingPair valuesLinkingPair =
         getValueSelectsAndJoins(domainValuePairsForCurrentDomain);
 
-    if (domain.equals(Domain.SURVEY)) {
+    if (OUTER_QUERY_DOMAIN.contains(domain)) {
       queryBuilder
           .append(String.join(", ", valuesLinkingPair.getSelects()))
-          .append(" ")
+          .append(" from ( SELECT * ")
           .append(valuesLinkingPair.getDomainTable());
     } else {
       queryBuilder
           .append(String.join(", ", valuesLinkingPair.getSelects()))
-          .append(" from ( SELECT * ")
+          .append(" ")
           .append(valuesLinkingPair.getDomainTable());
     }
 
@@ -647,7 +650,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
       }
     }
 
-    if (!domain.equals(Domain.SURVEY)) {
+    if (OUTER_QUERY_DOMAIN.contains(domain)) {
       queryBuilder.append(") " + valuesLinkingPair.getTableAlias());
       if (!valuesLinkingPair.formatJoins().equals("")) {
         queryBuilder.append(" " + valuesLinkingPair.formatJoins());


### PR DESCRIPTION
Make notebook queries more efficient. So BQ sql runs more efficiently when conditions are applied to base table before joining to other tables. In some cases this reduces the runtime from about 30mins to 30secs. For example:
![Screen Shot 2020-12-02 at 10 22 52 AM](https://user-images.githubusercontent.com/3904919/100900355-63d48200-3488-11eb-9496-0e44b82d2313.png)

The existing codebase executed joins before conditions are added to the base table.
![Screen Shot 2020-12-02 at 10 19 54 AM](https://user-images.githubusercontent.com/3904919/100899939-f6c0ec80-3487-11eb-87ca-43b7edcf4090.png)