### PR TITLE
[no ticket][risk=no] Fixing bug with multiple concept sets

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -291,7 +291,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     if (supportsConceptSets(domain)) {
       if (workbenchConfigProvider.get().featureFlags.enableConceptSetSearchV2) {
         final List<DbConceptSetConceptId> dbConceptSetConceptIds =
-            request.getPrePackagedConceptSet().contains(SURVEY)
+            (domain.equals(Domain.SURVEY) && request.getPrePackagedConceptSet().contains(SURVEY))
                 ? conceptBigQueryService.getSurveyQuestionConceptIds().stream()
                     .map(
                         c ->


### PR DESCRIPTION
So the Data Set builder has a bug where the sql generated adds all concepts into each domain query when selecting multiple concept sets.