### PR TITLE
[RW-5921][risk=no] Lazy runtime initialization should pick accurate configuration

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -768,7 +768,10 @@ export const RuntimePanel = fp.flow(
   const {hasMicroarrayData} = fp.find({cdrVersionId}, cdrVersionListResponse.items) || {hasMicroarrayData: false};
   let [{currentRuntime, pendingRuntime}, setRequestedRuntime] = useCustomRuntime(namespace);
 
-  currentRuntime = applyPresetOverride(currentRuntime);
+  // If the runtime has been deleted, it's possible that the default preset values have changed since its creation
+  if (currentRuntime.status === RuntimeStatus.Deleted) {
+    currentRuntime = applyPresetOverride(currentRuntime);
+  }
 
   // Prioritize the "pendingRuntime", if any. When an update is pending, we want
   // to render the target runtime details, which  may not match the current runtime.
@@ -790,8 +793,6 @@ export const RuntimePanel = fp.flow(
       () => PanelContent.Create],
     [() => true, () => PanelContent.Customize]
   ])([currentRuntime, status]);
-  console.log(currentRuntime);
-  console.log(initialPanelContent);
   const [panelContent, setPanelContent] = useState<PanelContent>(initialPanelContent);
 
   const [selectedDiskSize, setSelectedDiskSize] = useState(diskSize);

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -769,7 +769,7 @@ export const RuntimePanel = fp.flow(
   let [{currentRuntime, pendingRuntime}, setRequestedRuntime] = useCustomRuntime(namespace);
 
   // If the runtime has been deleted, it's possible that the default preset values have changed since its creation
-  if (currentRuntime.status === RuntimeStatus.Deleted) {
+  if (currentRuntime && currentRuntime.status === RuntimeStatus.Deleted) {
     currentRuntime = applyPresetOverride(currentRuntime);
   }
 

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -29,9 +29,8 @@ import {
   validLeoGceMachineTypes
 } from 'app/utils/machines';
 import {formatUsd} from 'app/utils/numbers';
-import {runtimePresets} from 'app/utils/runtime-presets';
+import {applyPresetOverride, runtimePresets} from 'app/utils/runtime-presets';
 import {
-  applyPresetOverride,
   getRuntimeConfigDiffs,
   RuntimeConfig,
   RuntimeDiffState,
@@ -791,6 +790,8 @@ export const RuntimePanel = fp.flow(
       () => PanelContent.Create],
     [() => true, () => PanelContent.Customize]
   ])([currentRuntime, status]);
+  console.log(currentRuntime);
+  console.log(initialPanelContent);
   const [panelContent, setPanelContent] = useState<PanelContent>(initialPanelContent);
 
   const [selectedDiskSize, setSelectedDiskSize] = useState(diskSize);

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -31,6 +31,7 @@ import {
 import {formatUsd} from 'app/utils/numbers';
 import {runtimePresets} from 'app/utils/runtime-presets';
 import {
+  applyPresetOverride,
   getRuntimeConfigDiffs,
   RuntimeConfig,
   RuntimeDiffState,
@@ -766,18 +767,9 @@ export const RuntimePanel = fp.flow(
   const {profile} = profileState;
 
   const {hasMicroarrayData} = fp.find({cdrVersionId}, cdrVersionListResponse.items) || {hasMicroarrayData: false};
-  const [{currentRuntime, pendingRuntime}, setRequestedRuntime] = useCustomRuntime(namespace);
+  let [{currentRuntime, pendingRuntime}, setRequestedRuntime] = useCustomRuntime(namespace);
 
-  // if runtime configuration type is a default, override its config with preset values
-  if (currentRuntime && currentRuntime.status === RuntimeStatus.Deleted) {
-    const runtimePresetKey = fp.keys(runtimePresets)
-      .find(key => runtimePresets[key].runtimeTemplate.configurationType === currentRuntime.configurationType);
-
-    if (runtimePresetKey) {
-      currentRuntime.gceConfig = runtimePresets[runtimePresetKey].runtimeTemplate.gceConfig;
-      currentRuntime.dataprocConfig = runtimePresets[runtimePresetKey].runtimeTemplate.dataprocConfig;
-    }
-  }
+  currentRuntime = applyPresetOverride(currentRuntime);
 
   // Prioritize the "pendingRuntime", if any. When an update is pending, we want
   // to render the target runtime details, which  may not match the current runtime.

--- a/ui/src/app/utils/leo-runtime-initializer.spec.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.spec.tsx
@@ -9,12 +9,10 @@ import {RuntimeApi} from 'generated/fetch/api';
 import SpyInstance = jest.SpyInstance;
 import expect = jest.Expect;
 import {RuntimesApi as LeoRuntimesApi} from 'notebooks-generated/fetch';
-import {RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
+import {defaultRuntime, RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
 import {LeoRuntimesApiStub} from 'testing/stubs/leo-runtimes-api-stub';
 import {RuntimeConfigurationType} from 'generated/fetch';
-import {defaultGceConfig, defaultRuntime} from '../../testing/stubs/runtime-api-stub';
 import {serverConfigStore} from "./navigation";
-import any = jasmine.any;
 
 let mockGetRuntime: SpyInstance;
 let mockCreateRuntime: SpyInstance;

--- a/ui/src/app/utils/leo-runtime-initializer.spec.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.spec.tsx
@@ -190,7 +190,7 @@ describe('RuntimeInitializer', () => {
     }), jasmine.any(Object));
   });
 
-  it('should use preset values during lazy runtime instantiation if a preset was selected', async() => {
+  it('should use preset values during lazy runtime creation if a preset was selected', async() => {
     serverConfigStore.next({gsuiteDomain: 'researchallofus.org', enableCustomRuntimes: true});
     mockGetRuntime.mockImplementation(namespace => {
       return {

--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -195,6 +195,7 @@ export class LeoRuntimeInitializer {
       throw new ExceededActionCountError(
         `Reached max runtime create count (${this.maxCreateCount})`, this.currentRuntime);
     }
+
     let runtime: Runtime;
     if (serverConfigStore.getValue().enableCustomRuntimes && this.targetRuntime) {
       runtime = this.targetRuntime;

--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -293,6 +293,7 @@ export class LeoRuntimeInitializer {
   }
 
   private async poll() {
+
     // Overall strategy: continue polling the get-runtime endpoint, with capped exponential backoff,
     // until we either reach our goal state (a RUNNING runtime) or run up against the overall
     // timeout threshold.

--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -198,7 +198,8 @@ export class LeoRuntimeInitializer {
     let runtime: Runtime;
     if (serverConfigStore.getValue().enableCustomRuntimes && this.targetRuntime) {
       runtime = this.targetRuntime;
-    } else if (this.currentRuntime) {
+    } else if (this.currentRuntime && this.currentRuntime.status === RuntimeStatus.Deleted) {
+      // If the runtime has been deleted, it's possible that the default preset values have changed since its creation
       runtime = applyPresetOverride(this.currentRuntime);
     } else {
       runtime = {...runtimePresets.generalAnalysis.runtimeTemplate};

--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -1,11 +1,10 @@
 import {leoRuntimesApi} from 'app/services/notebooks-swagger-fetch-clients';
 import {runtimeApi} from 'app/services/swagger-fetch-clients';
 import {isAbortError, reportError} from 'app/utils/errors';
-import {runtimePresets} from 'app/utils/runtime-presets';
+import {applyPresetOverride, runtimePresets} from 'app/utils/runtime-presets';
 import {runtimeStore} from 'app/utils/stores';
 import {Runtime, RuntimeStatus} from 'generated/fetch';
 import {serverConfigStore} from './navigation';
-import {applyPresetOverride} from './runtime-utils';
 
 // We're only willing to wait 20 minutes total for a runtime to initialize. After that we return
 // a rejected promise no matter what.

--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -198,8 +198,7 @@ export class LeoRuntimeInitializer {
     let runtime: Runtime;
     if (serverConfigStore.getValue().enableCustomRuntimes && this.targetRuntime) {
       runtime = this.targetRuntime;
-    } else if (this.currentRuntime && this.currentRuntime.status === RuntimeStatus.Deleted) {
-      // If the runtime has been deleted, it's possible that the default preset values have changed since its creation
+    } else if (this.currentRuntime) {
       runtime = applyPresetOverride(this.currentRuntime);
     } else {
       runtime = {...runtimePresets.generalAnalysis.runtimeTemplate};

--- a/ui/src/app/utils/runtime-presets.ts
+++ b/ui/src/app/utils/runtime-presets.ts
@@ -1,4 +1,5 @@
-import {Runtime, RuntimeConfigurationType} from 'generated/fetch';
+import {Runtime, RuntimeConfigurationType, RuntimeStatus} from 'generated/fetch';
+import * as fp from 'lodash/fp';
 
 export const runtimePresets: {
   [runtimePresetName: string]: {displayName: string, runtimeTemplate: Runtime}
@@ -28,4 +29,27 @@ export const runtimePresets: {
       }
     }
   }
+};
+
+export const applyPresetOverride = (runtime) => {
+  if (!runtime) {
+    return runtime;
+  }
+
+  const newRuntime = {...runtime};
+
+  // if runtime configuration type is a default, override its config with preset values
+  // The Deleted check is so that we only update the user's runtime to the latest preset values
+  // after they delete their runtime (ex. not while its actively in use).
+  if (newRuntime && newRuntime.status === RuntimeStatus.Deleted) {
+    const runtimePresetKey = fp.keys(runtimePresets)
+    .find(key => runtimePresets[key].runtimeTemplate.configurationType === newRuntime.configurationType);
+
+    if (runtimePresetKey) {
+      newRuntime.gceConfig = runtimePresets[runtimePresetKey].runtimeTemplate.gceConfig;
+      newRuntime.dataprocConfig = runtimePresets[runtimePresetKey].runtimeTemplate.dataprocConfig;
+    }
+  }
+
+  return newRuntime;
 };

--- a/ui/src/app/utils/runtime-presets.ts
+++ b/ui/src/app/utils/runtime-presets.ts
@@ -1,4 +1,4 @@
-import {Runtime, RuntimeConfigurationType, RuntimeStatus} from 'generated/fetch';
+import {Runtime, RuntimeConfigurationType} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 
 export const runtimePresets: {

--- a/ui/src/app/utils/runtime-presets.ts
+++ b/ui/src/app/utils/runtime-presets.ts
@@ -38,17 +38,12 @@ export const applyPresetOverride = (runtime) => {
 
   const newRuntime = {...runtime};
 
-  // if runtime configuration type is a default, override its config with preset values
-  // The Deleted check is so that we only update the user's runtime to the latest preset values
-  // after they delete their runtime (ex. not while its actively in use).
-  if (newRuntime && newRuntime.status === RuntimeStatus.Deleted) {
-    const runtimePresetKey = fp.keys(runtimePresets)
+  const runtimePresetKey = fp.keys(runtimePresets)
     .find(key => runtimePresets[key].runtimeTemplate.configurationType === newRuntime.configurationType);
 
-    if (runtimePresetKey) {
-      newRuntime.gceConfig = runtimePresets[runtimePresetKey].runtimeTemplate.gceConfig;
-      newRuntime.dataprocConfig = runtimePresets[runtimePresetKey].runtimeTemplate.dataprocConfig;
-    }
+  if (runtimePresetKey) {
+    newRuntime.gceConfig = runtimePresets[runtimePresetKey].runtimeTemplate.gceConfig;
+    newRuntime.dataprocConfig = runtimePresets[runtimePresetKey].runtimeTemplate.dataprocConfig;
   }
 
   return newRuntime;

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -281,7 +281,7 @@ export const useRuntimeStatus = (currentWorkspaceNamespace): [
             resolutionCondition: (r) => resolutionCondition(r)
           });
         } catch (e) {
-          // gxceededActionCountError is expected, as we exceed our create limit of 0.
+          // ExceededActionCountError is expected, as we exceed our create limit of 0.
           if (!(e instanceof ExceededActionCountError ||
               e instanceof LeoRuntimeInitializationAbortedError)) {
             throw e;

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -8,7 +8,6 @@ import {compoundRuntimeOpStore, markCompoundRuntimeOperationCompleted, registerC
 import {DataprocConfig, Runtime, RuntimeStatus} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-import {runtimePresets} from './runtime-presets';
 
 const {useState, useEffect} = React;
 
@@ -282,7 +281,7 @@ export const useRuntimeStatus = (currentWorkspaceNamespace): [
             resolutionCondition: (r) => resolutionCondition(r)
           });
         } catch (e) {
-          // ExceededActionCountError is expected, as we exceed our create limit of 0.
+          // gxceededActionCountError is expected, as we exceed our create limit of 0.
           if (!(e instanceof ExceededActionCountError ||
               e instanceof LeoRuntimeInitializationAbortedError)) {
             throw e;
@@ -308,25 +307,6 @@ export const useRuntimeStatus = (currentWorkspaceNamespace): [
     setRuntimeStatus(req);
   };
   return [runtime ? runtime.status : undefined, setStatusRequest];
-};
-
-export const applyPresetOverride = (runtime) => {
-  const newRuntime = {...runtime};
-
-  // if runtime configuration type is a default, override its config with preset values
-  // The Deleted check is so that we only update the user's runtime to the latest preset values
-  // after they delete their runtime (ex. not while its actively in use).
-  if (newRuntime && newRuntime.status === RuntimeStatus.Deleted) {
-    const runtimePresetKey = fp.keys(runtimePresets)
-    .find(key => runtimePresets[key].runtimeTemplate.configurationType === newRuntime.configurationType);
-
-    if (runtimePresetKey) {
-      newRuntime.gceConfig = runtimePresets[runtimePresetKey].runtimeTemplate.gceConfig;
-      newRuntime.dataprocConfig = runtimePresets[runtimePresetKey].runtimeTemplate.dataprocConfig;
-    }
-  }
-
-  return newRuntime;
 };
 
 // useCustomRuntime Hook can request a new runtime config


### PR DESCRIPTION
Description:
- Lazily create the user's latest runtime is a valid one has been saved. No video since the status updates take too long.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
