### PR TITLE
[RW-5995][risk=no] Show customize during pending runtime operation

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -162,6 +162,18 @@ describe('RuntimePanel', () => {
     expect(runtimeApiStub.runtime.gceConfig.machineType).toEqual('n1-standard-4');
   });
 
+  it('should show customize after create', async() => {
+    runtimeApiStub.runtime = null;
+    runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace});
+
+    const wrapperBefore = await component();
+
+    await mustClickButton(wrapperBefore, 'Create');
+
+    const wrapperAfter = await component();
+    expect(wrapperAfter.find('#runtime-cpu').exists()).toBeTruthy();
+  });
+
   it('should create runtime with preset values instead of getRuntime values if configurationType is GeneralAnalysis', async() => {
     // In the case where the user's latest runtime is a preset (GeneralAnalysis in this case)
     // we should ignore the other runtime config values that were delivered with the getRuntime response

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -795,7 +795,7 @@ export const RuntimePanel = fp.flow(
     // If there's a pendingRuntime, this means there's already a create/update
     // in progress, even if the runtime store doesn't actively reflect this yet.
     // Show the customize panel in this event.
-    [([r, ]) => r === undefined || !pendingRuntime, () => PanelContent.Customize],
+    [([r, ]) => r === undefined || !!pendingRuntime, () => PanelContent.Customize],
     [([r, s]) => r === null || s === RuntimeStatus.Unknown, () => PanelContent.Create],
     [([r, ]) => r.status === RuntimeStatus.Deleted &&
       ([RuntimeConfigurationType.GeneralAnalysis, RuntimeConfigurationType.HailGenomicAnalysis].includes(r.configurationType)),

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -792,7 +792,10 @@ export const RuntimePanel = fp.flow(
   // It's unclear how often that would actually happen.
   const initialPanelContent = fp.cond([
     // currentRuntime being undefined means the first `getRuntime` has still not completed.
-    [([r, ]) => r === undefined, () => PanelContent.Customize],
+
+    // in progress, even if the runtime store doesn't actively reflect this yet.
+    // Show the customize panel in this event.
+    [([r, ]) => r === undefined || !!pendingRuntime, () => PanelContent.Customize],
     [([r, s]) => r === null || s === RuntimeStatus.Unknown, () => PanelContent.Create],
     [([r, ]) => r.status === RuntimeStatus.Deleted &&
       ([RuntimeConfigurationType.GeneralAnalysis, RuntimeConfigurationType.HailGenomicAnalysis].includes(r.configurationType)),

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -792,10 +792,10 @@ export const RuntimePanel = fp.flow(
   // It's unclear how often that would actually happen.
   const initialPanelContent = fp.cond([
     // currentRuntime being undefined means the first `getRuntime` has still not completed.
-
+    // If there's a pendingRuntime, this means there's already a create/update
     // in progress, even if the runtime store doesn't actively reflect this yet.
     // Show the customize panel in this event.
-    [([r, ]) => r === undefined || !!pendingRuntime, () => PanelContent.Customize],
+    [([r, ]) => r === undefined || !pendingRuntime, () => PanelContent.Customize],
     [([r, s]) => r === null || s === RuntimeStatus.Unknown, () => PanelContent.Create],
     [([r, ]) => r.status === RuntimeStatus.Deleted &&
       ([RuntimeConfigurationType.GeneralAnalysis, RuntimeConfigurationType.HailGenomicAnalysis].includes(r.configurationType)),

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -126,7 +126,7 @@ const compareWorkerMemory = (oldRuntime: RuntimeConfig, newRuntime: RuntimeConfi
 };
 
 const compareDataprocWorkerDiskSize = (oldRuntime: RuntimeConfig, newRuntime: RuntimeConfig): RuntimeDiff => {
-  if (oldRuntime.dataprocConfig === null || newRuntime.dataprocConfig === null) {
+  if (!oldRuntime.dataprocConfig || !newRuntime.dataprocConfig) {
     return null;
   }
 
@@ -143,7 +143,7 @@ const compareDataprocWorkerDiskSize = (oldRuntime: RuntimeConfig, newRuntime: Ru
 };
 
 const compareDataprocNumberOfPreemptibleWorkers = (oldRuntime: RuntimeConfig, newRuntime: RuntimeConfig): RuntimeDiff => {
-  if (oldRuntime.dataprocConfig === null || newRuntime.dataprocConfig === null) {
+  if (!oldRuntime.dataprocConfig || !newRuntime.dataprocConfig) {
     return null;
   }
 
@@ -160,7 +160,7 @@ const compareDataprocNumberOfPreemptibleWorkers = (oldRuntime: RuntimeConfig, ne
 };
 
 const compareDataprocNumberOfWorkers = (oldRuntime: RuntimeConfig, newRuntime: RuntimeConfig): RuntimeDiff => {
-  if (oldRuntime.dataprocConfig === null || newRuntime.dataprocConfig === null) {
+  if (!oldRuntime.dataprocConfig || !newRuntime.dataprocConfig) {
     return null;
   }
 


### PR DESCRIPTION
This avoids the awkward gap between pressing "create" and the runtime status not being "Creating" yet. It may be possible to address this in other ways, but the Notebooks API doesn't return the runtime from `CreateRuntime`, and I'm not sure I can count on a strong consistency guarantee of doing create -> Get, and we'd ideally block the panel close on reaching the Creating state.

Also, fix a separate issue I found where `dataprocConfig` was `undefined` and not `null` during runtime comparison (I'm not sure if Leo returned undefined, or that was plumbed through from our preset). I would not make any assumption about what Leo is going to return here, and just handle both cases.