### PR TITLE
[risk=no] Use WorkbenchConfig.createEmptyConfig() in tests wherever possible

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -165,9 +165,9 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Before
   public void setUp() {
-    WorkbenchConfig testConfig = new WorkbenchConfig();
-    testConfig.elasticsearch = new WorkbenchConfig.ElasticsearchConfig();
+    WorkbenchConfig testConfig = WorkbenchConfig.createEmptyConfig();
     testConfig.elasticsearch.enableElasticsearchBackend = false;
+
     when(configProvider.get()).thenReturn(testConfig);
 
     when(firecloudService.isUserMemberOfGroup(anyString(), anyString())).thenReturn(true);

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -203,7 +203,6 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
 
   @Before
   public void setUp() {
-    workbenchConfigProvider.get().featureFlags = new WorkbenchConfig.FeatureFlagsConfig();
     dataSetServiceImpl =
         new DataSetServiceImpl(
             bigQueryService,

--- a/api/src/bigquerytest/java/org/pmiops/workbench/testconfig/WorkbenchConfigConfig.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/testconfig/WorkbenchConfigConfig.java
@@ -1,8 +1,6 @@
 package org.pmiops.workbench.testconfig;
 
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.config.WorkbenchConfig.CdrConfig;
-import org.pmiops.workbench.config.WorkbenchConfig.FireCloudConfig;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
@@ -11,10 +9,8 @@ public class WorkbenchConfigConfig {
 
   @Bean
   public WorkbenchConfig workbenchConfig() {
-    WorkbenchConfig workbenchConfig = new WorkbenchConfig();
-    workbenchConfig.cdr = new CdrConfig();
+    WorkbenchConfig workbenchConfig = WorkbenchConfig.createEmptyConfig();
     workbenchConfig.cdr.debugQueries = true;
-    workbenchConfig.firecloud = new FireCloudConfig();
     workbenchConfig.firecloud.registeredDomainName = "all-of-us-registered-test";
     return workbenchConfig;
   }

--- a/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
@@ -71,10 +71,8 @@ public class AuthDomainControllerTest {
     adminUser.setUserId(0L);
     when(fireCloudService.createGroup(any())).thenReturn(new FirecloudManagedGroupWithMembers());
     when(userProvider.get()).thenReturn(adminUser);
-    WorkbenchConfig config = new WorkbenchConfig();
-    config.firecloud = new WorkbenchConfig.FireCloudConfig();
+    WorkbenchConfig config = WorkbenchConfig.createEmptyConfig();
     config.firecloud.registeredDomainName = "";
-    config.access = new WorkbenchConfig.AccessConfig();
     config.access.enableDataUseAgreement = true;
     FakeClock clock = new FakeClock(Instant.now());
     UserService userService =

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -48,7 +48,6 @@ import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.conceptset.mapper.ConceptSetMapperImpl;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.config.WorkbenchConfig.BillingConfig;
 import org.pmiops.workbench.dataset.DataSetService;
 import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
@@ -264,9 +263,7 @@ public class CohortsControllerTest {
 
     @Bean
     WorkbenchConfig workbenchConfig() {
-      WorkbenchConfig workbenchConfig = new WorkbenchConfig();
-      workbenchConfig.featureFlags = new WorkbenchConfig.FeatureFlagsConfig();
-      workbenchConfig.billing = new BillingConfig();
+      WorkbenchConfig workbenchConfig = WorkbenchConfig.createEmptyConfig();
       workbenchConfig.billing.accountId = "free-tier";
       return workbenchConfig;
     }

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -42,7 +42,6 @@ import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.conceptset.mapper.ConceptSetMapperImpl;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.config.WorkbenchConfig.BillingConfig;
 import org.pmiops.workbench.dataset.DataSetService;
 import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
@@ -263,9 +262,7 @@ public class ConceptSetsControllerTest {
 
     @Bean
     WorkbenchConfig workbenchConfig() {
-      WorkbenchConfig workbenchConfig = new WorkbenchConfig();
-      workbenchConfig.featureFlags = new WorkbenchConfig.FeatureFlagsConfig();
-      workbenchConfig.billing = new BillingConfig();
+      WorkbenchConfig workbenchConfig = WorkbenchConfig.createEmptyConfig();
       workbenchConfig.billing.accountId = "free-tier";
       return workbenchConfig;
     }

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -277,7 +277,6 @@ public class DataSetControllerTest {
     @Bean
     WorkbenchConfig workbenchConfig() {
       WorkbenchConfig workbenchConfig = WorkbenchConfig.createEmptyConfig();
-      workbenchConfig.billing = new WorkbenchConfig.BillingConfig();
       workbenchConfig.billing.accountId = "free-tier";
       return workbenchConfig;
     }

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
@@ -17,7 +17,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.config.WorkbenchConfig.FireCloudConfig;
 import org.pmiops.workbench.leonardo.api.RuntimesApi;
 import org.pmiops.workbench.leonardo.model.LeonardoAuditInfo;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
@@ -55,7 +54,6 @@ public class OfflineRuntimeControllerTest {
     @Bean
     public WorkbenchConfig workbenchConfig() {
       WorkbenchConfig config = WorkbenchConfig.createEmptyConfig();
-      config.firecloud = new FireCloudConfig();
       config.firecloud.notebookRuntimeMaxAgeDays = (int) MAX_AGE.toDays();
       config.firecloud.notebookRuntimeIdleMaxAgeDays = (int) IDLE_MAX_AGE.toDays();
       return config;

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -24,8 +24,6 @@ import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.compliance.ComplianceService;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.config.WorkbenchConfig.BillingConfig;
-import org.pmiops.workbench.config.WorkbenchConfig.FeatureFlagsConfig;
 import org.pmiops.workbench.db.dao.AdminActionHistoryDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.DbStorageEnums;
@@ -61,7 +59,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class UserControllerTest {
 
   private static final FakeClock CLOCK = new FakeClock(Instant.now(), ZoneId.systemDefault());
-  private static WorkbenchConfig config = new WorkbenchConfig();
+  private static final WorkbenchConfig config = WorkbenchConfig.createEmptyConfig();
   private static DbUser user = new DbUser();
   private static long incrementedUserId = 1;
   private static final Cloudbilling testCloudbilling = TestMockFactory.createMockedCloudbilling();
@@ -117,9 +115,6 @@ public class UserControllerTest {
 
   @Before
   public void setUp() {
-    config.firecloud = new WorkbenchConfig.FireCloudConfig();
-    config.featureFlags = new FeatureFlagsConfig();
-
     saveFamily();
   }
 
@@ -297,7 +292,6 @@ public class UserControllerTest {
 
   @Test
   public void listBillingAccounts_upgradeYES_freeYES_cloudYES() throws IOException {
-    config.billing = new BillingConfig();
     config.billing.accountId = "free-tier";
     config.featureFlags.enableBillingUpgrade = true;
 
@@ -319,7 +313,6 @@ public class UserControllerTest {
 
   @Test
   public void listBillingAccounts_upgradeYES_freeYES_cloudNO() throws IOException {
-    config.billing = new BillingConfig();
     config.billing.accountId = "free-tier";
     config.featureFlags.enableBillingUpgrade = true;
 
@@ -340,7 +333,6 @@ public class UserControllerTest {
 
   @Test
   public void listBillingAccounts_upgradeYES_freeNO_cloudYES() throws IOException {
-    config.billing = new BillingConfig();
     config.billing.accountId = "free-tier";
     config.featureFlags.enableBillingUpgrade = true;
 
@@ -360,7 +352,6 @@ public class UserControllerTest {
 
   @Test
   public void listBillingAccounts_upgradeYES_freeNO_cloudNO() throws IOException {
-    config.billing = new BillingConfig();
     config.billing.accountId = "free-tier";
     config.featureFlags.enableBillingUpgrade = true;
 
@@ -378,7 +369,6 @@ public class UserControllerTest {
 
   @Test
   public void listBillingAccounts_upgradeNO_freeYES_cloudYES() throws IOException {
-    config.billing = new BillingConfig();
     config.billing.accountId = "free-tier";
     config.featureFlags.enableBillingUpgrade = false;
 
@@ -399,7 +389,6 @@ public class UserControllerTest {
 
   @Test
   public void listBillingAccounts_upgradeNO_freeYES_cloudNO() throws IOException {
-    config.billing = new BillingConfig();
     config.billing.accountId = "free-tier";
     config.featureFlags.enableBillingUpgrade = false;
 
@@ -420,7 +409,6 @@ public class UserControllerTest {
 
   @Test
   public void listBillingAccounts_upgradeNO_freeNO_cloudYES() throws IOException {
-    config.billing = new BillingConfig();
     config.billing.accountId = "free-tier";
     config.featureFlags.enableBillingUpgrade = false;
 
@@ -445,7 +433,6 @@ public class UserControllerTest {
 
   @Test
   public void listBillingAccounts_upgradeNO_freeNO_cloudNO() throws IOException {
-    config.billing = new BillingConfig();
     config.billing.accountId = "free-tier";
     config.featureFlags.enableBillingUpgrade = false;
 

--- a/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -24,7 +24,6 @@ import org.pmiops.workbench.cohortreview.AnnotationQueryBuilder;
 import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.config.WorkbenchConfig.CdrConfig;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.dao.CohortReviewDao;
@@ -108,8 +107,7 @@ public class CohortMaterializationServiceTest {
 
     @Bean
     public WorkbenchConfig workbenchConfig() {
-      WorkbenchConfig workbenchConfig = new WorkbenchConfig();
-      workbenchConfig.cdr = new CdrConfig();
+      WorkbenchConfig workbenchConfig = WorkbenchConfig.createEmptyConfig();
       workbenchConfig.cdr.debugQueries = false;
       return workbenchConfig;
     }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
@@ -130,9 +130,7 @@ public class DataSetServiceTest {
 
     @Bean
     WorkbenchConfig workbenchConfig() {
-      WorkbenchConfig workbenchConfig = new WorkbenchConfig();
-      workbenchConfig.featureFlags = new WorkbenchConfig.FeatureFlagsConfig();
-      return workbenchConfig;
+      return WorkbenchConfig.createEmptyConfig();
     }
   }
 

--- a/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/AuthInterceptorTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.services.oauth2.model.Userinfoplus;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
@@ -27,8 +26,6 @@ import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.api.ProfileApi;
 import org.pmiops.workbench.auth.UserInfoService;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.config.WorkbenchConfig.AuthConfig;
-import org.pmiops.workbench.config.WorkbenchConfig.GoogleDirectoryServiceConfig;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbUser;
@@ -94,10 +91,7 @@ public class AuthInterceptorTest {
   @Before
   public void setUp() {
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
-    workbenchConfig.googleDirectoryService = new GoogleDirectoryServiceConfig();
     workbenchConfig.googleDirectoryService.gSuiteDomain = "fake-domain.org";
-    workbenchConfig.auth = new AuthConfig();
-    workbenchConfig.auth.serviceAccountApiUsers = new ArrayList<>();
     workbenchConfig.auth.serviceAccountApiUsers.add("service-account@appspot.gserviceaccount.com");
     user = new DbUser();
     user.setUserId(USER_ID);

--- a/api/src/test/java/org/pmiops/workbench/mail/MailServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/mail/MailServiceImplTest.java
@@ -93,14 +93,10 @@ public class MailServiceImplTest {
   }
 
   private WorkbenchConfig createWorkbenchConfig() {
-    WorkbenchConfig workbenchConfig = new WorkbenchConfig();
-    workbenchConfig.mandrill = new WorkbenchConfig.MandrillConfig();
+    WorkbenchConfig workbenchConfig = WorkbenchConfig.createEmptyConfig();
     workbenchConfig.mandrill.fromEmail = "test-donotreply@fake-research-aou.org";
     workbenchConfig.mandrill.sendRetries = 3;
-    workbenchConfig.googleCloudStorageService =
-        new WorkbenchConfig.GoogleCloudStorageServiceConfig();
     workbenchConfig.googleCloudStorageService.credentialsBucketName = "test-bucket";
-    workbenchConfig.admin = new WorkbenchConfig.AdminConfig();
     workbenchConfig.admin.loginUrl = "http://localhost:4200/";
     return workbenchConfig;
   }

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -89,8 +89,7 @@ public class WorkspaceServiceTest {
   static class Configuration {
     @Bean
     WorkbenchConfig workbenchConfig() {
-      WorkbenchConfig workbenchConfig = new WorkbenchConfig();
-      workbenchConfig.billing = new WorkbenchConfig.BillingConfig();
+      WorkbenchConfig workbenchConfig = WorkbenchConfig.createEmptyConfig();
       workbenchConfig.billing.accountId = "free-tier-account";
       return workbenchConfig;
     }


### PR DESCRIPTION
Description:

Minor unit test cleanup.  Does not touch application code so we should ignore puppeteer in this case.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
