### PR TITLE
[RW-6001][risk=no] Fix disable conditions for COPE attribute buttons

### DIFF
--- a/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
@@ -247,7 +247,7 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
         countError: false,
         form: {anyValue: false, anyVersion: false, num: [], cat: []},
         formErrors: [],
-        formValid: true,
+        formValid: false,
         isCOPESurvey: false,
         loading: true,
         options: [
@@ -288,7 +288,7 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
         form.num = subtype === CriteriaSubType[CriteriaSubType.BP]
           ? JSON.parse(JSON.stringify(PREDEFINED_ATTRIBUTES.BP_DETAIL))
           : [{name: subtype, operator: 'ANY', operands: []}];
-        this.setState({form, count: this.nodeCount, loading: false, options});
+        this.setState({count: this.nodeCount, form, formValid: true, loading: false, options});
       }
     }
 
@@ -436,7 +436,7 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
 
     validateForm() {
       const {form, isCOPESurvey} = this.state;
-      if ((form.anyValue || form.num.length === 0) && (!isCOPESurvey || form.anyVersion)) {
+      if ((form.anyValue || (isCOPESurvey && form.num.length === 0)) && (!isCOPESurvey || form.anyVersion)) {
         this.setState({formValid: true, formErrors: []});
       } else {
         let formValid = true, operatorSelected = form.num.length !== 0;

--- a/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
@@ -508,12 +508,7 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
       }, '');
       const paramConceptId = isCOPESurvey && !!value ? value : conceptId;
       // make sure param ID is unique for different checkbox combinations
-      const catValues = form.cat.reduce((cat, acc) => {
-        if (cat.checked) {
-          acc += cat.valueAsConceptId;
-        }
-        return acc;
-      }, '');
+      const catValues = form.cat.filter(c => c.checked).map(c => c.valueAsConceptId).join('');
       return `param${(paramConceptId || id) + code + catValues}`;
     }
 

--- a/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page-v2/attributes-page-v2.component.tsx
@@ -268,6 +268,7 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
         // A different node has been selected, so we reset the form and load the new attributes
         this.setState({
           form: {anyValue: false, anyVersion: false, num: [], cat: []},
+          formErrors: [],
           loading: true
         }, () => this.initAttributeForm());
       }
@@ -380,9 +381,10 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
       let {node: {count}} = this.props;
       form.anyValue = checked;
       if (checked) {
-        form.num = form.num.map(attr =>
-          ({...attr, operator: this.isPhysicalMeasurement ? 'ANY' : null, operands: []}));
-        form.cat = form.cat.map(attr => ({...attr, checked: false}));
+        form.num = form.num.map(attr => ({...attr, operator: this.isPhysicalMeasurement ? 'ANY' : null, operands: []}));
+        if (this.isMeasurement) {
+          form.cat = form.cat.map(attr => ({...attr, checked: false}));
+        }
       }
       if (!checked || count === -1) {
         count = null;
@@ -473,7 +475,12 @@ export const AttributesPageV2 = fp.flow(withCurrentWorkspace(), withCurrentCohor
         }, new Set());
         // The second condition sets formValid to false if this is a Measurements or COPE attribute with no operator selected from the
         // dropdown and no categorical checkboxes checked
-        formValid = formValid && !((this.isMeasurement || isCOPESurvey) && !operatorSelected && !form.cat.some(attr => attr.checked));
+        if (this.isMeasurement && formValid) {
+          formValid = operatorSelected || form.cat.some(attr => attr.checked);
+        }
+        if (isCOPESurvey && formValid) {
+          formValid = (form.anyValue || operatorSelected) && (form.anyVersion || form.cat.some(attr => attr.checked));
+        }
         this.setState({formErrors: Array.from(formErrors), formValid});
       }
     }


### PR DESCRIPTION
- Fix issue where Add and Calculate buttons were disabled when they should have been enabled
- Clear form error messages when switching attribute nodes
- Fix issue that prevents multiple answers being selected from the same COPE question
- Display question and answer for COPE answer selections
<img width="570" alt="Screen Shot 2020-12-03 at 2 16 17 PM" src="https://user-images.githubusercontent.com/40036095/101083635-6f9c7300-3572-11eb-80d4-5d1b1e88385e.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
