### PR TITLE
[RW-6020][risk=no] Puppeteer test users in CircleCI nodes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -575,8 +575,8 @@ jobs:
     steps:
       - checkout-code
       - steps: << parameters.optional_steps >>
-      #- halt-test-check:
-          #dir_names: "api ui e2e"
+      - halt-test-check:
+          dir_names: "api ui e2e"
       - run:
           name: Update test user environment variables
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -575,8 +575,8 @@ jobs:
     steps:
       - checkout-code
       - steps: << parameters.optional_steps >>
-      - halt-test-check:
-          dir_names: "api ui e2e"
+      #- halt-test-check:
+          #dir_names: "api ui e2e"
       - run:
           name: Update test user environment variables
           command: |
@@ -587,11 +587,11 @@ jobs:
                 ;;
               "test")
                 echo 'export TEST_COLLABORATOR=$PUPPETEER_COLLABORATOR_TEST' >> $BASH_ENV
-                echo 'export USER_NAME=$PUPPETEER_USER_TEST' >> $BASH_ENV
+                echo 'export USER_NAME=$(eval echo "\$PUPPETEER_USER_TEST_${CIRCLE_NODE_INDEX}")' >> $BASH_ENV
                 ;;
               "local")
                 echo 'export DEV_COLLABORATOR=$PUPPETEER_COLLABORATOR_LOCAL' >> $BASH_ENV
-                echo 'export USER_NAME=$PUPPETEER_USER_LOCAL' >> $BASH_ENV
+                echo 'export USER_NAME=$(eval echo "\$PUPPETEER_USER_LOCAL_${CIRCLE_NODE_INDEX}")' >> $BASH_ENV
                 ;;
             esac
             echo 'export PASSWORD=$PUPPETEER_USER_PASSWORD' >> $BASH_ENV


### PR DESCRIPTION
Background:
A single Puppeteer test login user is used for all CI jobs triggered by PRs and merge to master branch. 

Issue:
Too many logins by the same user have triggered Google login page captcha which caused tests to fail.

Proposing a solution to reduce chances of getting captcha: Each CircleCI node that tests run in will have a different test user.

CircleCI environment variables
<img width="867" alt="Screen Shot 2020-12-07 at 8 16 04 PM" src="https://user-images.githubusercontent.com/35533885/101425091-6b04f100-38c9-11eb-9897-b2a513712d53.png">
