### PR TITLE
[no ticket][risk=no] Puppeteer Default timeout to 30 seconds

### DIFF
--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -14,7 +14,7 @@ beforeEach(async () => {
   await page.setUserAgent(userAgent);
   await page.setViewport({width: 1280, height: 0});
   page.setDefaultNavigationTimeout(60000); // Puppeteer default timeout is 30 seconds.
-  page.setDefaultTimeout(15000);
+  page.setDefaultTimeout(30000);
 });
 
 /**


### PR DESCRIPTION
I made a merge mistake. Restoring timeout back to 30 seconds.