### PR TITLE
[no ticket][risk=no] Puppeteer Combining two CDR modal tests

### DIFF
--- a/e2e/tests/workspace/cdr-version-upgrade.spec.ts
+++ b/e2e/tests/workspace/cdr-version-upgrade.spec.ts
@@ -1,69 +1,62 @@
 import WorkspaceCard from 'app/component/workspace-card';
+import {Page} from 'puppeteer';
 import {createWorkspace, signIn} from 'utils/test-utils';
 import {config} from 'resources/workbench-config';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspaceBase from 'app/page/workspace-base';
-import WorkspacesPage from 'app/page/workspaces-page';
 import WorkspaceEditPage from 'app/page/workspace-edit-page';
-import Navigation, {NavLink} from 'app/component/navigation';
 import CdrVersionUpgradeModal from 'app/page/cdr-version-upgrade-modal';
 
-describe('Workspace CDR Version upgrade', () => {
+describe('Workspace CDR Version Upgrade modal', () => {
     beforeEach(async () => {
         await signIn(page);
     });
 
-   test('Clicking the CDR version upgrade flag pops up the upgrade modal', async () => {
-        const workspaceCard: WorkspaceCard = await createWorkspace(page, config.altCdrVersionName);
-        await workspaceCard.clickWorkspaceName();
+   test('Clicking Cancel and Upgrade buttons', async () => {
 
-        const workspacePage: WorkspaceBase = new WorkspaceDataPage(page);
-        expect(await workspacePage.getCdrVersion()).toBe(config.altCdrVersionName);
-        const newVersionFlag = await workspacePage.getNewCdrVersionFlag();
-        await newVersionFlag.click();
+      const workspaceCard: WorkspaceCard = await createWorkspace(page, config.altCdrVersionName);
+      const workspaceName = await workspaceCard.clickWorkspaceName();
 
-        const modal = new CdrVersionUpgradeModal(page);
-        expect(await modal.isLoaded()).toBe(true);
+      const workspacePage: WorkspaceBase = new WorkspaceDataPage(page);
+      const cdrVersion = await workspacePage.getCdrVersion();
+      expect(cdrVersion).toBe(config.altCdrVersionName);
 
-        // hit cancel
-        const cancelButton = await modal.getCancelButton();
-        await cancelButton.click();
+      let modal = await launchCdrUpgradeModal(page);
 
-        // new version flag remains
-        await workspacePage.getNewCdrVersionFlag();
+      // Clicking the Cancel
+      let cancelButton = await modal.getCancelButton();
+      await cancelButton.click();
 
-        // cleanup
-        await workspacePage.deleteWorkspace()
+      // CDR version flag remains
+      await workspacePage.getNewCdrVersionFlag();
+
+      // Clicking the Upgrade button opens the Duplicate Workspace Page
+      modal = await launchCdrUpgradeModal(page);
+      const upgradeButton = await modal.getUpgradeButton();
+      await upgradeButton.click();
+
+      const duplicationPage = new WorkspaceEditPage(page);
+      const upgradeMessage = await duplicationPage.getCdrVersionUpgradeMessage();
+      expect(upgradeMessage).toContain(workspaceName);
+      expect(upgradeMessage).toContain(`${config.altCdrVersionName} to ${config.defaultCdrVersionName}.`);
+
+      cancelButton = await duplicationPage.getCancelButton();
+      await cancelButton.clickAndWait();
+
+      // cleanup
+      await workspacePage.deleteWorkspace()
     });
 
-    test('Clicking the CDR version upgrade button opens the Duplicate Workspace Page', async () => {
-        const workspaceCard: WorkspaceCard = await createWorkspace(page, config.altCdrVersionName);
-        const workspaceName = await workspaceCard.clickWorkspaceName();
-
-        const workspacePage: WorkspaceBase = new WorkspaceDataPage(page);
-
-        const newVersionFlag = await workspacePage.getNewCdrVersionFlag();
-        await newVersionFlag.click();
-
-        const modal = new CdrVersionUpgradeModal(page);
-        expect(await modal.isLoaded()).toBe(true);
-
-        const upgradeButton = await modal.getUpgradeButton();
-        await upgradeButton.click();
-
-        const duplicationPage = new WorkspaceEditPage(page);
-        const upgradeMessage = await duplicationPage.getCdrVersionUpgradeMessage();
-        expect(upgradeMessage).toContain(workspaceName);
-        expect(upgradeMessage).toContain(`${config.altCdrVersionName} to ${config.defaultCdrVersionName}.`);
-
-        // cleanup
-        const cancelButton = await duplicationPage.getCancelButton();
-        await cancelButton.clickAndWait();
-
-        await Navigation.navMenu(page, NavLink.YOUR_WORKSPACES);
-        const workspacesPage = new WorkspacesPage(page);
-        await workspacesPage.waitForLoad();
-
-        await WorkspaceCard.deleteWorkspace(page, workspaceName);
-    });
 });
+
+async function launchCdrUpgradeModal(page: Page): Promise<CdrVersionUpgradeModal> {
+   const workspacePage: WorkspaceBase = new WorkspaceDataPage(page);
+
+   // Clicking the CDR version upgrade flag pops up the upgrade modal
+   const newVersionFlag = await workspacePage.getNewCdrVersionFlag();
+   await newVersionFlag.click();
+
+   const modal = new CdrVersionUpgradeModal(page);
+   expect(await modal.isLoaded()).toBe(true);
+   return modal;
+}

--- a/e2e/tests/workspace/cdr-version-upgrade.spec.ts
+++ b/e2e/tests/workspace/cdr-version-upgrade.spec.ts
@@ -24,8 +24,8 @@ describe('Workspace CDR Version Upgrade modal', () => {
       let modal = await launchCdrUpgradeModal(page);
 
       // Clicking the Cancel
-      let cancelButton = await modal.getCancelButton();
-      await cancelButton.click();
+      const modalCancelButton = await modal.getCancelButton();
+      await modalCancelButton.click();
 
       // CDR version flag remains
       await workspacePage.getNewCdrVersionFlag();
@@ -40,8 +40,8 @@ describe('Workspace CDR Version Upgrade modal', () => {
       expect(upgradeMessage).toContain(workspaceName);
       expect(upgradeMessage).toContain(`${config.altCdrVersionName} to ${config.defaultCdrVersionName}.`);
 
-      cancelButton = await duplicationPage.getCancelButton();
-      await cancelButton.clickAndWait();
+      const editCancelButton = await duplicationPage.getCancelButton();
+      await editCancelButton.clickAndWait();
 
       // cleanup
       await workspacePage.deleteWorkspace()


### PR DESCRIPTION
Combining two small CDR modal tests into one. Faster playback time, one less login and one less new workspace.