### PR TITLE
[RW-6016][risk=no] Lookup criteria ids when editing a cohort

### DIFF
--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -314,10 +314,12 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
   }
 
   getSelectedValues() {
-    const {node: {path}, source} = this.props;
+    const {node: {domainId, path}, source} = this.props;
     return source === 'criteria'
       ? currentCohortCriteriaStore.getValue().some(crit =>
-        crit.parameterId === this.paramId() || path.split('.').includes(crit.id.toString()))
+        crit.parameterId === this.paramId()
+          || (![Domain.PHYSICALMEASUREMENT.toString(), Domain.VISIT.toString()].includes(domainId)
+          && path.split('.').includes(crit.id.toString())))
       : currentConceptStore.getValue().some(crit =>
         this.paramId(crit) === this.paramId() || path.split('.').includes(crit.id.toString()));
   }

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -319,7 +319,8 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
       ? currentCohortCriteriaStore.getValue().some(crit =>
         crit.parameterId === this.paramId()
           || (![Domain.PHYSICALMEASUREMENT.toString(), Domain.VISIT.toString()].includes(domainId)
-          && path.split('.').includes(crit.id.toString())))
+          && !!crit.id && path.split('.').includes(crit.id.toString()))
+      )
       : currentConceptStore.getValue().some(crit =>
         this.paramId(crit) === this.paramId() || path.split('.').includes(crit.id.toString()));
   }

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -10,7 +10,7 @@ import {cohortBuilderApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, withCdrVersions, withCurrentConcept, withCurrentWorkspace} from 'app/utils';
 import {getCdrVersion} from 'app/utils/cdr-versions';
-import {currentWorkspaceStore, serverConfigStore} from 'app/utils/navigation';
+import {currentCohortCriteriaStore, currentWorkspaceStore, serverConfigStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {
   CdrVersionListResponse,
@@ -144,47 +144,69 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
     }
   }
 
-  loadRootNodes() {
-    const {node: {domainId, id, isStandard, type}, selectedSurvey} = this.props;
-    this.setState({loading: true});
-    const {cdrVersionId} = (currentWorkspaceStore.getValue());
-    const criteriaType = domainId === Domain.DRUG.toString() ? CriteriaType.ATC.toString() : type;
-    const parentId = domainId === Domain.PHYSICALMEASUREMENT.toString() ? null : id;
-    cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard, parentId)
-      .then(resp => {
-        if (domainId === Domain.PHYSICALMEASUREMENT.toString()) {
-          let children = [];
-          resp.items.forEach(child => {
-            child['children'] = [];
-            if (child.parentId === 0) {
-              children.push(child);
-            } else {
-              children = this.addChildToParent(child, children);
-            }
-          });
-          this.setState({children});
-        } else if (domainId === Domain.SURVEY.toString() && selectedSurvey) {
-          // Temp: This should be handle in API
-          this.updatePpiSurveys(resp, resp.items.filter(child => child.name === selectedSurvey));
-        } else if (domainId === Domain.SURVEY.toString() && this.props.source === 'conceptSetDetails') {
-          const selectedSurveyChild = resp.items.filter(child => child.id === this.props.node.parentId);
-          this.updatePpiSurveys(resp, selectedSurveyChild);
-        } else {
-          this.setState({children: resp.items});
-          if (domainId === Domain.SURVEY.toString()) {
-            const rootSurveys = ppiSurveys.getValue();
-            if (!rootSurveys[cdrVersionId]) {
-              rootSurveys[cdrVersionId] = resp.items;
-              ppiSurveys.next(rootSurveys);
-            }
+  async loadRootNodes() {
+    try {
+      const {node: {domainId, id, isStandard, type}, selectedSurvey, source} = this.props;
+      this.setState({loading: true});
+      const {cdrVersionId} = (currentWorkspaceStore.getValue());
+      const criteriaType = domainId === Domain.DRUG.toString() ? CriteriaType.ATC.toString() : type;
+      const parentId = domainId === Domain.PHYSICALMEASUREMENT.toString() ? null : id;
+      const promises = [cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard, parentId)];
+      if (source === 'criteria' && currentCohortCriteriaStore.getValue().some(crit => !crit.id)) {
+        const criteriaRequest = {
+          sourceConceptIds: currentCohortCriteriaStore.getValue().filter(s => !s.isStandard).map(s => s.conceptId),
+          standardConceptIds: currentCohortCriteriaStore.getValue().filter(s => s.isStandard).map(s => s.conceptId),
+        };
+        promises.push(cohortBuilderApi().findCriteriaForCohortEdit(+cdrVersionId, domainId, criteriaRequest));
+      }
+      const [rootNodes, criteriaLookup] = await Promise.all(promises);
+      if (criteriaLookup) {
+        const updatedSelections = currentCohortCriteriaStore.getValue().map(sel => {
+          const criteriaMatch = criteriaLookup.items.find(item => item.conceptId === sel.conceptId
+            && item.isStandard === sel.isStandard
+            && (domainId !== Domain.SURVEY.toString() || item.subtype === sel.subtype)
+            && (sel.subtype !== CriteriaSubType.ANSWER.toString() || (item.value === sel.code))
+          );
+          if (criteriaMatch) {
+            sel.id = criteriaMatch.id;
+          }
+          return sel;
+        });
+        currentCohortCriteriaStore.next(updatedSelections);
+      }
+      if (domainId === Domain.PHYSICALMEASUREMENT.toString()) {
+        let children = [];
+        rootNodes.items.forEach(child => {
+          child['children'] = [];
+          if (child.parentId === 0) {
+            children.push(child);
+          } else {
+            children = this.addChildToParent(child, children);
+          }
+        });
+        this.setState({children});
+      } else if (domainId === Domain.SURVEY.toString() && selectedSurvey) {
+        // Temp: This should be handle in API
+        this.updatePpiSurveys(rootNodes, rootNodes.items.filter(child => child.name === selectedSurvey));
+      } else if (domainId === Domain.SURVEY.toString() && this.props.source === 'conceptSetDetails') {
+        const selectedSurveyChild = rootNodes.items.filter(child => child.id === this.props.node.parentId);
+        this.updatePpiSurveys(rootNodes, selectedSurveyChild);
+      } else {
+        this.setState({children: rootNodes.items});
+        if (domainId === Domain.SURVEY.toString()) {
+          const rootSurveys = ppiSurveys.getValue();
+          if (!rootSurveys[cdrVersionId]) {
+            rootSurveys[cdrVersionId] = rootNodes.items;
+            ppiSurveys.next(rootSurveys);
           }
         }
-      })
-      .catch(error => {
-        console.error(error);
-        this.setState({error: true});
-      })
-      .finally(() => this.setState({loading: false}));
+      }
+    } catch (error) {
+      console.error(error);
+      this.setState({error: true});
+    } finally {
+      this.setState({loading: false});
+    }
   }
 
   updatePpiSurveys(resp, selectedSurveyChild) {

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -152,7 +152,7 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
       const criteriaType = domainId === Domain.DRUG.toString() ? CriteriaType.ATC.toString() : type;
       const parentId = domainId === Domain.PHYSICALMEASUREMENT.toString() ? null : id;
       const promises = [cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard, parentId)];
-      if (source === 'criteria' && currentCohortCriteriaStore.getValue().some(crit => !crit.id)) {
+      if (this.criteriaIdLookupNeeded) {
         const criteriaRequest = {
           sourceConceptIds: currentCohortCriteriaStore.getValue().filter(s => !s.isStandard).map(s => s.conceptId),
           standardConceptIds: currentCohortCriteriaStore.getValue().filter(s => s.isStandard).map(s => s.conceptId),
@@ -207,6 +207,12 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
     } finally {
       this.setState({loading: false});
     }
+  }
+
+  get criteriaIdLookupNeeded() {
+    return this.props.source === 'criteria'
+      &&  ![Domain.PHYSICALMEASUREMENT.toString(), Domain.VISIT.toString()].includes(this.props.node.domainId)
+      &&  currentCohortCriteriaStore.getValue().some(crit => !crit.id);
   }
 
   updatePpiSurveys(resp, selectedSurveyChild) {

--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -360,7 +360,7 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
             selectOption={this.setAutocompleteSelection}
             setSearchTerms={this.setTreeSearchTerms}/>}
          {/*List View (using duplicated version of ListSearch) */}
-        <div style={this.searchContentStyle('list')}>
+        {!this.initTree && <div style={this.searchContentStyle('list')}>
           <ListSearchV2 source={source}
                         hierarchy={this.showHierarchy}
                         searchContext={cohortContext}
@@ -368,7 +368,7 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
                         select={this.addSelection}
                         selectedSurvey={selectedSurvey}
                         selectedIds={this.getListSearchSelectedIds()}/>
-        </div>
+        </div>}
       </div>
      </div>;
   }


### PR DESCRIPTION
- Lookup criteria ids using `findCriteriaForCohortEdit` call when editing a search item from an existing cohort
-- Only called when entering the tree view in Cohort Builder and not needed for Physical Measurement or Visit domains
- Prevent `ListSearch` component from initializing unnecessarily (PM, Survey, and Visit trees in Cohort Builder) 


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally