### PR TITLE
[RW-6044][risk=no] Correctly encode preview page parameter

### DIFF
--- a/ui/src/app/pages/analysis/notebook-redirect.tsx
+++ b/ui/src/app/pages/analysis/notebook-redirect.tsx
@@ -314,7 +314,8 @@ export const NotebookRedirect = fp.flow(
           runtime !== undefined && (runtime === null || runtime.status !== RuntimeStatus.Running)) {
         navigate([
           'workspaces', workspace.namespace, workspace.id,
-          'notebooks', 'preview', encodeURIComponent(this.getFullNotebookName())
+          // navigate will encode the notebook name automatically
+          'notebooks', 'preview', this.getFullNotebookName()
         ]);
       }
     }


### PR DESCRIPTION
Unfortunately the mock matchers are overly specific in Jest, I didn't see a way to cover this case without making it into a change-detector test.