### PR TITLE
[no ticket][risk=no] BQ Sql tuning

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -1706,7 +1706,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 .operator(Operator.IN)
                 .operands(ImmutableList.of("1"))));
     SearchRequest searchRequest =
-        createSearchRequests(lab.getType(), ImmutableList.of(lab), new ArrayList<>());
+        createSearchRequests(lab.getDomain(), ImmutableList.of(lab), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }
@@ -1726,7 +1726,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             .operands(ImmutableList.of("1", "2"));
     lab.attributes(ImmutableList.of(numerical, categorical));
     SearchRequest searchRequest =
-        createSearchRequests(lab.getType(), ImmutableList.of(lab), new ArrayList<>());
+        createSearchRequests(lab.getDomain(), ImmutableList.of(lab), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }
@@ -1771,7 +1771,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsBloodPressure() {
     SearchParameter pm = bloodPressure().attributes(bpAttributes());
     SearchRequest searchRequest =
-        createSearchRequests(pm.getType(), ImmutableList.of(pm), new ArrayList<>());
+        createSearchRequests(pm.getDomain(), ImmutableList.of(pm), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest), 1);
   }
@@ -2050,7 +2050,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
         survey().subtype(CriteriaSubType.ANSWER.toString()).conceptId(5L).attributes(attributes);
     SearchRequest searchRequest =
         createSearchRequests(
-            ppiValueAsConceptId.getType(),
+            ppiValueAsConceptId.getDomain(),
             ImmutableList.of(ppiValueAsConceptId),
             new ArrayList<>());
     ResponseEntity<Long> response =
@@ -2071,7 +2071,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
         survey().subtype(CriteriaSubType.ANSWER.toString()).conceptId(5L).attributes(attributes);
     SearchRequest searchRequest =
         createSearchRequests(
-            ppiValueAsNumer.getType(), ImmutableList.of(ppiValueAsNumer), new ArrayList<>());
+            ppiValueAsNumer.getDomain(), ImmutableList.of(ppiValueAsNumer), new ArrayList<>());
     ResponseEntity<Long> response =
         controller.countParticipants(cdrVersion.getCdrVersionId(), searchRequest);
     assertParticipants(response, 1);

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -1746,7 +1746,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void countSubjectsLabMoreThanOneSearchParameter() {
     SearchParameter lab1 = measurement();
     SearchParameter lab2 = measurement().conceptId(9L);
-    SearchParameter lab3 = measurement().conceptId(9L);
+    SearchParameter lab3 = measurement().conceptId(11L);
     Attribute labCategorical =
         new Attribute().name(AttrName.CAT).operator(Operator.IN).operands(ImmutableList.of("77"));
     lab3.attributes(ImmutableList.of(labCategorical));


### PR DESCRIPTION
BQ SQL tuning. This PR removes OR between source and standard concepts for Condition and Procedure domains. It is the culprit causing some of our 60s timeouts. 
Example:
```
SELECT * FROM project.dataset.cb_search_all_events
WHERE (is_standard = 1 AND concept_id IN (concept sql)
    OR is_standard = 0 AND concept_id IN (concept sql) )
```

It has been refactored to use UNION ALL
Example:
```
SELECT * FROM project.dataset.cb_search_all_events
WHERE person_id IN (
  SELECT person_id
  FROM project.dataset.SR2019q4r3.cb_search_all_events
  WHERE is_standard = 1
    AND concept_id IN (concept sql)
  UNION ALL
  SELECT person_id
  FROM project.dataset.cb_search_all_events
  WHERE is_standard = 0
    AND concept_id IN (concept sql) )
```
