### PR TITLE
[risk=low] Ensures the inclusion of sa-key.json in the docker-sync container

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -198,7 +198,13 @@ def dev_up()
   at_exit do
     common.run_inline %W{docker-compose down}
   end
-  ensure_docker_sync()
+
+  # ensures that sa-key.json is included in the docker-sync image
+  # This is necessary because docker-compose exposes it as GOOGLE_APPLICATION_CREDENTIALS
+  # which is needed to construct the IamCredentialsClient Bean
+  ServiceAccountContext.new(TEST_PROJECT).run do
+    ensure_docker_sync()
+  end
 
   overall_bm = Benchmark.measure {
     common.status "Database startup..."


### PR DESCRIPTION
Description:

I suspect that I am more prone to this issue because I aggressively delete my local sa-key.json out of paranoia.

It's possible to get into a state where dev-up will start without sa-key.json and only recreate it after performing a docker-sync.  This causes the app to fail with the following message:
```
java.io.IOException: Error reading credential file from environment variable GOOGLE_APPLICATION_CREDENTIALS, value '/w/api/sa-key.json': File does not exist.
```

This PR adds a step to ensure the keyfile exists before docker-sync.
 
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
