### PR TITLE
[risk=no] Set maxDelete to 0 when waiting for start/stop/deletion

### DIFF
--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -278,6 +278,7 @@ export const useRuntimeStatus = (currentWorkspaceNamespace): [
           await LeoRuntimeInitializer.initialize({
             workspaceNamespace: currentWorkspaceNamespace,
             maxCreateCount: 0,
+            maxDeleteCount: 0,
             resolutionCondition: (r) => resolutionCondition(r)
           });
         } catch (e) {


### PR DESCRIPTION
With the existing behavior, the runtime initializer will delete if the runtime enters the error state. This would be confusing to the user if it happens.