### PR TITLE
[no ticket][risk=no] Puppeteer Disable flaky test runtime-status-update.spec

### DIFF
--- a/e2e/tests/runtime/runtime-status-update.spec.ts
+++ b/e2e/tests/runtime/runtime-status-update.spec.ts
@@ -13,7 +13,8 @@ import NotebookPreviewPage from 'app/page/notebook-preview-page';
 // This one is going to take a long time.
 jest.setTimeout(60 * 30 * 1000);
 
-describe('Updating runtime parameters', () => {
+// Flaky tests. Disable tests now to allow time to address the issue.
+xdescribe('Updating runtime parameters', () => {
   beforeEach(async () => {
     await signIn(page);
     const workspaceCard = await createWorkspace(page, config.altCdrVersionName);

--- a/e2e/tests/runtime/runtime-status-update.spec.ts
+++ b/e2e/tests/runtime/runtime-status-update.spec.ts
@@ -14,7 +14,7 @@ import NotebookPreviewPage from 'app/page/notebook-preview-page';
 jest.setTimeout(60 * 30 * 1000);
 
 // Flaky tests. Disable tests now to allow time to address the issue.
-xdescribe('Updating runtime parameters', () => {
+describe.skip('Updating runtime parameters', () => {
   beforeEach(async () => {
     await signIn(page);
     const workspaceCard = await createWorkspace(page, config.altCdrVersionName);


### PR DESCRIPTION
Disable now to allow time to fix flaky functions used by tests.