### PR TITLE
[no ticket][risk=no] Puppeteer Update file names pattern for skipping tests in CircleCI

### DIFF
--- a/.circleci/e2e-job-ignore-patterns.txt
+++ b/.circleci/e2e-job-ignore-patterns.txt
@@ -6,5 +6,5 @@
 .log
 .pdf
 .gitignore
-Test.java
-Test.kt
+.java
+.kt


### PR DESCRIPTION
Update ignore file name patterns. It will reduces numbers of test runs in CircleCI.