### PR TITLE
[risk=no] Add a spinner to the Workspace create/duplicate confirmation modal

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1428,6 +1428,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
               {this.renderButtonText()}
             </ModalTitle>
             <ModalBody style={{color: colors.primary, lineHeight: '1rem', marginTop: '0.25rem'}}>
+              {loading && <SpinnerOverlay overrideStylesOverlay={styles.spinner}/>}
               <div>Your responses to these questions:</div>
               <div style={{margin: '0.25rem 0 0.25rem 1rem'}}>
                 <span style={{fontWeight: 600}}>Primary purpose of your project</span> (Question 1)<br/>


### PR DESCRIPTION
I got annoyed enough to add this.

![Modal_Spinner](https://user-images.githubusercontent.com/2701406/102541552-89fc4380-407e-11eb-8566-e01ea2177689.gif)


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
