### PR TITLE
[RW-6035][risk=no] Move Concept Search to separate route

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -20,6 +20,7 @@ import {QueryReportComponent} from './pages/data/cohort-review/query-report.comp
 import {TablePage} from './pages/data/cohort-review/table-page';
 import {CohortActionsComponent} from './pages/data/cohort/cohort-actions';
 import {ConceptHomepageComponent} from './pages/data/concept/concept-homepage';
+import {ConceptSearchComponent} from './pages/data/concept/concept-search';
 import {ConceptSetActionsComponent} from './pages/data/concept/concept-set-actions';
 import {ConceptSetDetailsComponent} from './pages/data/concept/concept-set-details';
 import {ProfilePageComponent} from './pages/profile/profile-page';
@@ -257,13 +258,24 @@ const routes: Routes = [
                       },
                       {
                         path: 'concepts',
-                        component: ConceptHomepageComponent,
-                        canDeactivate: [CanDeactivateGuard],
-                        data: {
-                          title: 'Search Concepts',
-                          breadcrumb: BreadcrumbType.SearchConcepts,
-                          helpContentKey: 'conceptSets'
-                        }
+                        children: [{
+                          path: '',
+                          component: ConceptHomepageComponent,
+                          canDeactivate: [CanDeactivateGuard],
+                          data: {
+                            title: 'Search Concepts',
+                            breadcrumb: BreadcrumbType.SearchConcepts,
+                            helpContentKey: 'conceptSets'
+                          }
+                        }, {
+                          path: ':domain',
+                          component: ConceptSearchComponent,
+                          data: {
+                            title: 'Search Concepts',
+                            breadcrumb: BreadcrumbType.SearchConcepts,
+                            helpContentKey: 'conceptSets'
+                          }
+                        }]
                       },
                       {
                         path: 'concepts/sets',

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -261,7 +261,6 @@ const routes: Routes = [
                         children: [{
                           path: '',
                           component: ConceptHomepageComponent,
-                          canDeactivate: [CanDeactivateGuard],
                           data: {
                             title: 'Search Concepts',
                             breadcrumb: BreadcrumbType.SearchConcepts,
@@ -270,6 +269,7 @@ const routes: Routes = [
                         }, {
                           path: ':domain',
                           component: ConceptSearchComponent,
+                          canDeactivate: [CanDeactivateGuard],
                           data: {
                             title: 'Search Concepts',
                             breadcrumb: BreadcrumbType.SearchConcepts,

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -36,6 +36,7 @@ import {QueryReportComponent} from './pages/data/cohort-review/query-report.comp
 import {TablePage} from './pages/data/cohort-review/table-page';
 import {CohortActionsComponent} from './pages/data/cohort/cohort-actions';
 import {ConceptHomepageComponent} from './pages/data/concept/concept-homepage';
+import {ConceptSearchComponent} from './pages/data/concept/concept-search';
 import {ConceptSetActionsComponent} from './pages/data/concept/concept-set-actions';
 import {ConceptSetDetailsComponent} from './pages/data/concept/concept-set-details';
 import {InitialErrorComponent} from './pages/initial-error/component';
@@ -137,6 +138,7 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     ConceptSetActionsComponent,
     ConceptSetDetailsComponent,
     ConceptHomepageComponent,
+    ConceptSearchComponent,
     ConfirmDeleteModalComponent,
     DataPageComponent,
     DataSetPageComponent,

--- a/ui/src/app/cohort-search/cohort-page/cohort-page.component.tsx
+++ b/ui/src/app/cohort-search/cohort-page/cohort-page.component.tsx
@@ -156,15 +156,19 @@ export const CohortPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSearc
       setTimeout(() => this.setState({updateCount: this.state.updateCount + 1}));
     }
 
-    setSearchContext(context) {
+    setSearchContext(context: any) {
+      context.source = 'cohort';
       currentCohortSearchContextStore.next(context);
       this.setState({searchContext: context});
     }
 
-    render() {
+    get showCohortSearch() {
       const {cohortContext} = this.props;
-      const {cohort, cohortChanged, cohortError, criteria, loading, modalOpen, overview, updateCount, updateGroupListsCount}
-        = this.state;
+      return !!cohortContext && cohortContext.source === 'cohort';
+    }
+
+    render() {
+      const {cohort, cohortChanged, cohortError, criteria, loading, modalOpen, overview, updateCount, updateGroupListsCount} = this.state;
       return <React.Fragment>
         <div style={{minHeight: '28rem', padding: '0.5rem'}}>
           {cohortError
@@ -173,7 +177,7 @@ export const CohortPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSearc
               Sorry, the cohort could not be loaded. Please try again or contact Support in the left hand navigation.
             </div>
             : <React.Fragment>
-              <FlexRowWrap style={{margin: '1rem 0 2rem', ...(!!cohortContext ? {display: 'none'} : {})}}>
+              <FlexRowWrap style={{margin: '1rem 0 2rem', ...(this.showCohortSearch ? {display: 'none'} : {})}}>
                 <div style={colStyle('66.66667')}>
                   <FlexRowWrap style={{margin: '0 -0.5rem'}}>
                     {!!cohort && !!cohort.name && <div style={{height: '1.5rem', padding: '0 0.5rem', width: '100%'}}>
@@ -205,7 +209,7 @@ export const CohortPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSearc
                 </div>
                 {loading && <SpinnerOverlay/>}
               </FlexRowWrap>
-              {!!cohortContext && <CohortSearch/>}
+              {this.showCohortSearch && <CohortSearch/>}
             </React.Fragment>
           }
         </div>

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.tsx
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.tsx
@@ -249,8 +249,7 @@ export const CohortSearch = withCurrentCohortSearchContext()(class extends React
                 selections={selections}/>
             </div>
             : <CriteriaSearch backFn={() => this.closeSearch()}
-                              cohortContext={cohortContext}
-                              source={'criteria'}/>}
+                              cohortContext={cohortContext}/>}
         </div>
       </div>
       <Button type='primary'

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -336,7 +336,7 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
         this.setState({data: null, apiError: false, inputErrors: [], loading: true, searching: true, standardOnly: false});
         const {searchContext: {domain, source, selectedSurvey}, workspace: {cdrVersionId}} = this.props;
         const resp = await cohortBuilderApi().findCriteriaByDomainAndSearchTerm(+cdrVersionId, domain, value.trim(), selectedSurvey);
-        const data = source !== 'criteria' && this.isSurvey
+        const data = source !== 'cohort' && this.isSurvey
           ? resp.items.filter(survey => survey.subtype === CriteriaSubType.QUESTION.toString())
           : resp.items;
         if (data.length && this.checkSource) {
@@ -365,7 +365,7 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
 
     selectIconDisabled() {
       const {searchContext: {source}, selectedIds} = this.props;
-      return source !== 'criteria' && selectedIds && selectedIds.length >= 1000;
+      return source !== 'cohort' && selectedIds && selectedIds.length >= 1000;
     }
 
     selectItem = (row: any) => {

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
@@ -59,7 +59,7 @@ describe('TreeNode', () => {
                                       searchTerms={''}
                                       select={() => {}}
                                       selectedIds={[]}
-                                      source ='criteria'
+                                      source ='cohort'
                                       setAttributes={() => {}}/>);
     expect(wrapper).toBeTruthy();
   });

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -310,7 +310,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
 
   getSelectedValues() {
     const {node: {domainId, path}, source} = this.props;
-    return source === 'criteria'
+    return source === 'cohort'
       ? currentCohortCriteriaStore.getValue().some(crit =>
         crit.parameterId === this.paramId()
           || (![Domain.PHYSICALMEASUREMENT.toString(), Domain.VISIT.toString()].includes(domainId)
@@ -322,7 +322,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
 
   selectIconDisabled() {
     const {selectedIds, source} = this.props;
-    return source !== 'criteria' && selectedIds && selectedIds.length >= 1000;
+    return source !== 'cohort' && selectedIds && selectedIds.length >= 1000;
   }
 
   render() {
@@ -348,8 +348,8 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
         <div style={hover ? {...styles.treeNodeContent, background: colors.light} : styles.treeNodeContent}
           onMouseEnter={() => this.setState({hover: true})}
           onMouseLeave={() => this.setState({hover: false})}>
-          {(selectable && (source === 'criteria' || node.subtype !== 'ANSWER')) && <button style={styles.iconButton}>
-            {hasAttributes && source === 'criteria'
+          {(selectable && (source === 'cohort' || node.subtype !== 'ANSWER')) && <button style={styles.iconButton}>
+            {hasAttributes && source === 'cohort'
               ? <ClrIcon style={{color: colors.accent}}
                   shape='slider' dir='right' size='20'
                   onClick={(e) => this.setAttributes(e, node)}/>

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -199,7 +199,7 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
   }
 
   get criteriaLookupNeeded() {
-    return this.props.source === 'criteria'
+    return this.props.source === 'cohort'
       &&  ![Domain.PHYSICALMEASUREMENT.toString(), Domain.VISIT.toString()].includes(this.props.node.domainId)
       &&  currentCohortCriteriaStore.getValue().some(crit => !crit.id);
   }
@@ -263,7 +263,7 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
 
   get showHeader() {
     const {node: {domainId}, source} = this.props;
-    return !(source === 'criteria' && domainId === Domain.SURVEY.toString())
+    return !(source === 'cohort' && domainId === Domain.SURVEY.toString())
       && domainId !== Domain.PHYSICALMEASUREMENT.toString()
       && domainId !== Domain.VISIT.toString();
   }
@@ -278,7 +278,7 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
 
   selectIconDisabled() {
     const {selectedIds, source} = this.props;
-    return source !== 'criteria' && selectedIds && selectedIds.length >= 1000;
+    return source !== 'cohort' && selectedIds && selectedIds.length >= 1000;
   }
 
   render() {

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -25,6 +25,7 @@ import {
 } from 'app/utils';
 import {
   conceptSetUpdating,
+  currentCohortSearchContextStore,
   currentConceptSetStore,
   currentConceptStore,
   NavStore,
@@ -486,10 +487,9 @@ export const ConceptHomepage = fp.flow(withCurrentWorkspace(), withCurrentConcep
     }
 
     browseDomain(domain: DomainInfo) {
-      const {conceptDomainCounts} = this.state;
-      const activeDomainTab = conceptDomainCounts.find(domainCount => domainCount.domain === domain.domain);
-      currentConceptStore.next([]);
-      this.setState({activeDomainTab: activeDomainTab, searching: true, selectedDomain: domain.domain});
+      const {namespace, id} = this.props.workspace;
+      currentCohortSearchContextStore.next({domain: domain.domain, type: 'PPI', standard: this.state.standardConceptsOnly});
+      NavStore.navigate(['workspaces', namespace, id, 'data', 'concepts', domain.domain]);
     }
 
     browseSurvey(surveyName) {

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -261,7 +261,11 @@ export const ConceptHomepage = fp.flow(withCurrentCohortSearchContext(), withCur
     browseDomain(domain: Domain, surveyName?: string) {
       const {namespace, id} = this.props.workspace;
       currentCohortSearchContextStore.next({domain: domain, searchTerms: this.state.currentSearchString, surveyName});
-      NavStore.navigate(['workspaces', namespace, id, 'data', 'concepts', domain]);
+      let url = `/workspaces/${namespace}/${id}/data/concepts/${domain}`;
+      if (surveyName) {
+        url += `?survey=${encodeURIComponent(surveyName)}`;
+      }
+      NavStore.navigateByUrl(url);
     }
 
     errorMessage() {

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {Button} from 'app/components/buttons';
 import {FadeBox} from 'app/components/containers';
+import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {CriteriaSearch} from 'app/pages/data/criteria-search';
 import {
   ReactWrapperBase,
@@ -12,26 +13,62 @@ import {
   withCurrentWorkspace,
   withUrlParams
 } from 'app/utils';
-import {currentConceptStore, NavStore, setSidebarActiveIconStore} from 'app/utils/navigation';
+import {conceptSetUpdating, currentConceptSetStore, currentConceptStore, NavStore, setSidebarActiveIconStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {Criteria, WorkspaceAccessLevel} from 'generated/fetch';
+import {Subscription} from 'rxjs/Subscription';
 
 interface Props {
   cohortContext: any;
   concept: Array<Criteria>;
+  setConceptSetUpdating: (conceptSetUpdating: boolean) => void;
+  setShowUnsavedModal: (showUnsavedModal: () => Promise<boolean>) => void;
+  setUnsavedConceptChanges: (unsavedConceptChanges: boolean) => void;
   workspace: WorkspaceData;
   urlParams: any;
 }
 
+interface State {
+  // Show if trying to navigate away with unsaved changes
+  showUnsavedModal: boolean;
+}
+
 const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurrentConcept(), withCurrentWorkspace(), withUrlParams())
-  (class extends React.Component<Props> {
+  (class extends React.Component<Props, State> {
+    resolveUnsavedModal: Function;
+    subscription: Subscription;
     constructor(props: any) {
       super(props);
-      this.state = {};
+      this.state = {showUnsavedModal: false};
+      this.showUnsavedModal = this.showUnsavedModal.bind(this);
     }
 
     componentDidMount() {
       currentConceptStore.next([]);
+      this.subscription = currentConceptStore.subscribe(currentConcepts => {
+        if (![null, undefined].includes(currentConcepts)) {
+          const currentConceptSet = currentConceptSetStore.getValue();
+          const unsavedChanges = (!currentConceptSet && currentConcepts.length > 0)
+            || (!!currentConceptSet && JSON.stringify(currentConceptSet.criteriums.sort()) !== JSON.stringify(currentConcepts.sort()));
+          this.props.setUnsavedConceptChanges(unsavedChanges);
+        }
+      });
+      this.subscription.add(conceptSetUpdating.subscribe(updating => this.props.setConceptSetUpdating(updating)));
+      this.props.setShowUnsavedModal(this.showUnsavedModal);
+    }
+
+    componentWillUnmount() {
+      this.subscription.unsubscribe();
+    }
+
+    async showUnsavedModal() {
+      this.setState({showUnsavedModal: true});
+      return await new Promise<boolean>((resolve => this.resolveUnsavedModal = resolve));
+    }
+
+    getModalResponse(res: boolean) {
+      this.setState({showUnsavedModal: false});
+      this.resolveUnsavedModal(res);
     }
 
     get disableFinishButton() {
@@ -41,14 +78,28 @@ const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurrentConce
 
     render() {
       const {cohortContext, urlParams: {domain}, workspace: {id, namespace}} = this.props;
-      return <FadeBox style={{margin: 'auto', paddingTop: '1rem', width: '95.7%'}}>
-        <CriteriaSearch backFn={() => NavStore.navigate(['workspaces', namespace, id, 'data', 'concepts'])}
-                        cohortContext={{domain, source: 'concept'}}
-                        conceptSearchTerms={!!cohortContext ? cohortContext.searchTerms : ''}/>
-        <Button style={{float: 'right', marginBottom: '2rem'}}
-                disabled={this.disableFinishButton}
-                onClick={() => setSidebarActiveIconStore.next('concept')}>Finish & Review</Button>
-      </FadeBox>;
+      const {showUnsavedModal} = this.state;
+      return <React.Fragment>
+        <FadeBox style={{margin: 'auto', paddingTop: '1rem', width: '95.7%'}}>
+          <CriteriaSearch backFn={() => NavStore.navigate(['workspaces', namespace, id, 'data', 'concepts'])}
+                          cohortContext={{domain, source: 'concept'}}
+                          conceptSearchTerms={!!cohortContext ? cohortContext.searchTerms : ''}/>
+          <Button style={{float: 'right', marginBottom: '2rem'}}
+                  disabled={this.disableFinishButton}
+                  onClick={() => setSidebarActiveIconStore.next('concept')}>Finish & Review</Button>
+        </FadeBox>
+        {showUnsavedModal && <Modal>
+          <ModalTitle>Warning! </ModalTitle>
+          <ModalBody>
+            Your concept set has not been saved. If you’d like to save your concepts, please click CANCEL
+            and save your changes in the right sidebar.
+          </ModalBody>
+          <ModalFooter>
+            <Button type='link' onClick={() => this.getModalResponse(false)}>Cancel</Button>
+            <Button type='primary' onClick={() => this.getModalResponse(true)}>Discard Changes</Button>
+          </ModalFooter>
+        </Modal>}
+      </React.Fragment>;
     }
   });
 
@@ -57,7 +108,29 @@ const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurrentConce
 })
 
 export class ConceptSearchComponent extends ReactWrapperBase {
+  conceptSetUpdating: boolean;
+  showUnsavedModal: () => Promise<boolean>;
+  unsavedConceptChanges: boolean;
   constructor() {
-    super(ConceptSearch, []);
+    super(ConceptSearch, ['setConceptSetUpdating', 'setShowUnsavedModal', 'setUnsavedConceptChanges']);
+    this.setConceptSetUpdating = this.setConceptSetUpdating.bind(this);
+    this.setShowUnsavedModal = this.setShowUnsavedModal.bind(this);
+    this.setUnsavedConceptChanges = this.setUnsavedConceptChanges.bind(this);
+  }
+
+  setShowUnsavedModal(showUnsavedModal: () => Promise<boolean>): void {
+    this.showUnsavedModal = showUnsavedModal;
+  }
+
+  setConceptSetUpdating(csUpdating: boolean): void {
+    this.conceptSetUpdating = csUpdating;
+  }
+
+  setUnsavedConceptChanges(unsavedConceptChanges: boolean): void {
+    this.unsavedConceptChanges = unsavedConceptChanges;
+  }
+
+  canDeactivate(): Promise<boolean> | boolean {
+    return !this.unsavedConceptChanges || this.conceptSetUpdating || this.showUnsavedModal();
   }
 }

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -1,0 +1,56 @@
+import {Component} from '@angular/core';
+import * as fp from 'lodash/fp';
+import * as React from 'react';
+
+import {Button} from 'app/components/buttons';
+import {CriteriaSearch} from 'app/pages/data/criteria-search';
+import {
+  ReactWrapperBase,
+  withCurrentConcept,
+  withCurrentWorkspace,
+  withUrlParams
+} from 'app/utils';
+import {NavStore, setSidebarActiveIconStore} from 'app/utils/navigation';
+import {WorkspaceData} from 'app/utils/workspace-data';
+import {Criteria, WorkspaceAccessLevel} from 'generated/fetch';
+
+interface Props {
+  concept: Array<Criteria>;
+  urlParams: any;
+  workspace: WorkspaceData;
+}
+
+const ConceptSearch = fp.flow(withCurrentConcept(), withCurrentWorkspace(), withUrlParams())(class extends React.Component<Props> {
+  constructor(props: any) {
+    super(props);
+    this.state = {};
+  }
+
+  get disableFinishButton() {
+    const {concept, workspace: {accessLevel}} = this.props;
+    return !concept || concept.length === 0 || ![WorkspaceAccessLevel.READER, WorkspaceAccessLevel.WRITER].includes(accessLevel);
+  }
+
+  render() {
+    const {urlParams: {domain}, workspace: {id, namespace}} = this.props;
+    return <React.Fragment>
+      <CriteriaSearch backFn={() => NavStore.navigate(['workspaces', namespace, id, 'data', 'concepts'])}
+                      cohortContext={{domain}}
+                      conceptSearchTerms={''}
+                      source='concept'/>
+      <Button style={{float: 'right', marginBottom: '2rem'}}
+              disabled={this.disableFinishButton}
+              onClick={() => setSidebarActiveIconStore.next('concept')}>Finish & Review</Button>
+    </React.Fragment>;
+  }
+});
+
+@Component({
+  template: '<div #root></div>'
+})
+
+export class ConceptSearchComponent extends ReactWrapperBase {
+  constructor() {
+    super(ConceptSearch, []);
+  }
+}

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -43,9 +43,8 @@ const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurrentConce
       const {cohortContext, urlParams: {domain}, workspace: {id, namespace}} = this.props;
       return <FadeBox style={{margin: 'auto', paddingTop: '1rem', width: '95.7%'}}>
         <CriteriaSearch backFn={() => NavStore.navigate(['workspaces', namespace, id, 'data', 'concepts'])}
-                        cohortContext={{domain}}
-                        conceptSearchTerms={!!cohortContext ? cohortContext.searchTerms : ''}
-                        source='concept'/>
+                        cohortContext={{domain, source: 'concept'}}
+                        conceptSearchTerms={!!cohortContext ? cohortContext.searchTerms : ''}/>
         <Button style={{float: 'right', marginBottom: '2rem'}}
                 disabled={this.disableFinishButton}
                 onClick={() => setSidebarActiveIconStore.next('concept')}>Finish & Review</Button>

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -13,7 +13,14 @@ import {
   withCurrentWorkspace,
   withUrlParams
 } from 'app/utils';
-import {conceptSetUpdating, currentConceptSetStore, currentConceptStore, NavStore, setSidebarActiveIconStore} from 'app/utils/navigation';
+import {
+  conceptSetUpdating,
+  currentConceptSetStore,
+  currentConceptStore,
+  NavStore,
+  queryParamsStore,
+  setSidebarActiveIconStore
+} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {Criteria, WorkspaceAccessLevel} from 'generated/fetch';
 import {Subscription} from 'rxjs/Subscription';
@@ -79,10 +86,11 @@ const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurrentConce
     render() {
       const {cohortContext, urlParams: {domain}, workspace: {id, namespace}} = this.props;
       const {showUnsavedModal} = this.state;
+      const selectedSurvey = queryParamsStore.getValue().survey;
       return <React.Fragment>
         <FadeBox style={{margin: 'auto', paddingTop: '1rem', width: '95.7%'}}>
           <CriteriaSearch backFn={() => NavStore.navigate(['workspaces', namespace, id, 'data', 'concepts'])}
-                          cohortContext={{domain, source: 'concept'}}
+                          cohortContext={{domain, selectedSurvey, source: 'concept'}}
                           conceptSearchTerms={!!cohortContext ? cohortContext.searchTerms : ''}/>
           <Button style={{float: 'right', marginBottom: '2rem'}}
                   disabled={this.disableFinishButton}

--- a/ui/src/app/pages/data/concept/concept-set-details.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-details.tsx
@@ -334,8 +334,7 @@ export const ConceptSetDetails = fp.flow(withUrlParams(), withCurrentWorkspace()
               </FlexRow>
             </div>
             {!!conceptSet.criteriums && <React.Fragment>
-              <CriteriaSearch cohortContext={{domain: conceptSet.domain, type: 'PPI', standard: true}}
-                              source='conceptSetDetails' selectedSurvey={conceptSet.survey}/>
+              <CriteriaSearch cohortContext={{domain: conceptSet.domain, selectedSurvey: conceptSet.survey, source: 'conceptSetDetails'}}/>
               <Button style={{width: '6.5rem', alignSelf: 'flex-end', marginBottom: '2rem'}}
                       onClick={() => setSidebarActiveIconStore.next('concept')}>Finish & Review</Button>
             </React.Fragment>}

--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -136,8 +136,8 @@ interface State {
   selectedIds: Array<string>;
   treeSearchTerms: string;
   loadingSubtree: boolean;
-
 }
+
 export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(class extends React.Component<Props, State>  {
   growl: any;
   growlTimer: NodeJS.Timer;

--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -120,7 +120,6 @@ interface Props {
   cohortContext: any;
   conceptSearchTerms?: string;
   selectedSurvey?: string;
-  source: string;
   urlParams: any;
 }
 
@@ -155,13 +154,13 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
       selectedIds: [],
       selections: [],
       selectedCriteriaList: [],
-      treeSearchTerms: props.source !== 'criteria' ? props.conceptSearchTerms : '',
+      treeSearchTerms: props.cohortContext.source !== 'cohort' ? props.conceptSearchTerms : '',
       loadingSubtree: false
     };
   }
 
   componentDidMount(): void {
-    const {cohortContext: {domain, standard, type}, source} = this.props;
+    const {cohortContext: {domain, standard, source, type}} = this.props;
     let {backMode, mode} = this.state;
     let hierarchyNode;
     if (this.initTree) {
@@ -192,14 +191,15 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
   }
 
   get initTree() {
-    const {cohortContext: {domain}, source} = this.props;
+    const {cohortContext: {domain, source}} = this.props;
     return domain === Domain.VISIT
-      || (source === 'criteria' && domain === Domain.PHYSICALMEASUREMENT)
-      || (source === 'criteria' && domain === Domain.SURVEY);
+      || (source === 'cohort' && domain === Domain.PHYSICALMEASUREMENT)
+      || (source === 'cohort' && domain === Domain.SURVEY);
   }
 
   get isConcept() {
-    return this.props.source === 'concept' || this.props.source === 'conceptSetDetails';
+    const {cohortContext: {source}} = this.props;
+    return source === 'concept' || source === 'conceptSetDetails';
   }
 
   getGrowlStyle() {
@@ -299,20 +299,20 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
   }
 
   render() {
-    const {backFn, cohortContext, conceptSearchTerms, selectedSurvey, source} = this.props;
+    const {backFn, cohortContext, conceptSearchTerms, selectedSurvey} = this.props;
     const {autocompleteSelection, groupSelections, hierarchyNode, loadingSubtree,
       treeSearchTerms, growlVisible} = this.state;
     return <div id='criteria-search-container'>
       {loadingSubtree && <SpinnerOverlay/>}
       <Growl ref={(el) => this.growl = el} style={!growlVisible ? {...styles.growl, display: 'none'} : styles.growl}/>
-      <FlexRowWrap style={{...styles.titleBar, marginTop: source === 'criteria' ? '1rem' : 0}}>
-        {source !== 'conceptSetDetails' && <React.Fragment>
+      <FlexRowWrap style={{...styles.titleBar, marginTop: cohortContext.source === 'cohort' ? '1rem' : 0}}>
+        {cohortContext.source !== 'conceptSetDetails' && <React.Fragment>
           <Clickable style={styles.backArrow} onClick={() => backFn()}>
             <img src={arrowIcon} style={styles.arrowIcon} alt='Go back' />
           </Clickable>
           <h2 style={styles.titleHeader}>{this.domainTitle}</h2>
         </React.Fragment>}
-        <div style={source === 'conceptSetDetails' ? styles.detailExternalLinks : styles.externalLinks}>
+        <div style={cohortContext.source === 'conceptSetDetails' ? styles.detailExternalLinks : styles.externalLinks}>
           {cohortContext.domain === Domain.DRUG && <div>
             <StyledAnchorTag
                 href='https://mor.nlm.nih.gov/RxNav/'
@@ -347,7 +347,7 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
         <Growl ref={(el) => this.growl = el}
                style={!growlVisible ? {...this.getGrowlStyle(), display: 'none'} : this.getGrowlStyle()}/>
         {hierarchyNode && <CriteriaTree
-            source={source}
+            source={cohortContext.source}
             selectedSurvey={selectedSurvey}
             autocompleteSelection={autocompleteSelection}
             back={this.back}
@@ -361,8 +361,7 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
             setSearchTerms={this.setTreeSearchTerms}/>}
          {/*List View (using duplicated version of ListSearch) */}
         {!this.initTree && <div style={this.searchContentStyle('list')}>
-          <ListSearch source={source}
-                      hierarchy={this.showHierarchy}
+          <ListSearch hierarchy={this.showHierarchy}
                       searchContext={cohortContext}
                       searchTerms={conceptSearchTerms}
                       select={this.addSelection}

--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -299,7 +299,7 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
   }
 
   render() {
-    const {backFn, cohortContext, conceptSearchTerms, selectedSurvey} = this.props;
+    const {backFn, cohortContext, conceptSearchTerms} = this.props;
     const {autocompleteSelection, groupSelections, hierarchyNode, loadingSubtree,
       treeSearchTerms, growlVisible} = this.state;
     return <div id='criteria-search-container'>

--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -173,7 +173,7 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
       mode = 'tree';
     }
     this.setState({backMode, hierarchyNode, mode});
-    if (source === 'criteria') {
+    if (source === 'cohort') {
       this.subscription = currentCohortCriteriaStore.subscribe(currentCohortCriteria => {
         this.setState({selectedCriteriaList: currentCohortCriteria});
       });
@@ -298,21 +298,21 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
   }
 
   render() {
-    const {backFn, cohortContext, conceptSearchTerms} = this.props;
+    const {backFn, cohortContext, cohortContext: {domain, selectedSurvey, source}, conceptSearchTerms} = this.props;
     const {autocompleteSelection, groupSelections, hierarchyNode, loadingSubtree,
       treeSearchTerms, growlVisible} = this.state;
     return <div id='criteria-search-container'>
       {loadingSubtree && <SpinnerOverlay/>}
       <Growl ref={(el) => this.growl = el} style={!growlVisible ? {...styles.growl, display: 'none'} : styles.growl}/>
-      <FlexRowWrap style={{...styles.titleBar, marginTop: cohortContext.source === 'cohort' ? '1rem' : 0}}>
-        {cohortContext.source !== 'conceptSetDetails' && <React.Fragment>
+      <FlexRowWrap style={{...styles.titleBar, marginTop: source === 'cohort' ? '1rem' : 0}}>
+        {source !== 'conceptSetDetails' && <React.Fragment>
           <Clickable style={styles.backArrow} onClick={() => backFn()}>
             <img src={arrowIcon} style={styles.arrowIcon} alt='Go back' />
           </Clickable>
           <h2 style={styles.titleHeader}>{this.domainTitle}</h2>
         </React.Fragment>}
-        <div style={cohortContext.source === 'conceptSetDetails' ? styles.detailExternalLinks : styles.externalLinks}>
-          {cohortContext.domain === Domain.DRUG && <div>
+        <div style={source === 'conceptSetDetails' ? styles.detailExternalLinks : styles.externalLinks}>
+          {domain === Domain.DRUG && <div>
             <StyledAnchorTag
                 href='https://mor.nlm.nih.gov/RxNav/'
                 target='_blank'
@@ -321,7 +321,7 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
             </StyledAnchorTag>
             &nbsp;drugs by brand names outside of <AoU/>
           </div>}
-          {cohortContext.domain === Domain.SURVEY && <div>
+          {domain === Domain.SURVEY && <div>
             Find more information about each survey in the&nbsp;
             <StyledAnchorTag
                 href='https://www.researchallofus.org/survey-explorer/'
@@ -346,8 +346,8 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
         <Growl ref={(el) => this.growl = el}
                style={!growlVisible ? {...this.getGrowlStyle(), display: 'none'} : this.getGrowlStyle()}/>
         {hierarchyNode && <CriteriaTree
-            source={cohortContext.source}
-            selectedSurvey={cohortContext.selectedSurvey}
+            source={source}
+            selectedSurvey={selectedSurvey}
             autocompleteSelection={autocompleteSelection}
             back={this.back}
             groupSelections={groupSelections}

--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -290,7 +290,7 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
   }
 
   get domainTitle() {
-    const {cohortContext: {domain, type}, selectedSurvey} = this.props;
+    const {cohortContext: {domain, type, selectedSurvey}} = this.props;
     if (!!selectedSurvey) {
       return selectedSurvey;
     } else {
@@ -348,7 +348,7 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
                style={!growlVisible ? {...this.getGrowlStyle(), display: 'none'} : this.getGrowlStyle()}/>
         {hierarchyNode && <CriteriaTree
             source={cohortContext.source}
-            selectedSurvey={selectedSurvey}
+            selectedSurvey={cohortContext.selectedSurvey}
             autocompleteSelection={autocompleteSelection}
             back={this.back}
             groupSelections={groupSelections}
@@ -365,7 +365,6 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
                       searchContext={cohortContext}
                       searchTerms={conceptSearchTerms}
                       select={this.addSelection}
-                      selectedSurvey={selectedSurvey}
                       selectedIds={this.getListSearchSelectedIds()}/>
         </div>}
       </div>

--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -119,7 +119,6 @@ interface Props {
   backFn?: () => void;
   cohortContext: any;
   conceptSearchTerms?: string;
-  selectedSurvey?: string;
   urlParams: any;
 }
 


### PR DESCRIPTION
- Move concept search page to a separate route from concept homepage
- Cleanup unused code from old concept search ui

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
- [x] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
