### PR TITLE
[risk=no][RW-3768] Dumb hack to allow non-interactive runs of bq instead of crashing in a new Local env

### DIFF
--- a/api/src/dev/server/Dockerfile
+++ b/api/src/dev/server/Dockerfile
@@ -75,6 +75,9 @@ RUN curl -O https://bin.equinox.io/c/htRtQZagtfg/rainforest-cli-stable-linux-amd
   tar -xvf rainforest-cli-stable-linux-amd64.tgz && rm rainforest-cli-stable-linux-amd64.tgz && \
   mv rainforest /usr/local/bin
 
+# Prevent bq interactively asking us to choose a default project
+RUN touch .bigqueryrc
+
 COPY with-mysql-login.sh /usr/local/bin
 COPY with-uid.sh /usr/local/bin
 


### PR DESCRIPTION
Description:

The first time (a certain version of?) `bq` is run in a new environment, it outputs an interactive prompt to choose a default project and populate `.bigqueryrc`.  If that happens to be a script, the command fails because the script is not interactive. 
 I was unable to find a way to tell `bq` "stop that, I'm a script!" but it doesn't do this if a `.bigqueryrc` is present.  So let's set one.

Aside: an initial warmup run in our docker env is not sufficient because we don't have write access to `.bigqueryrc` at docker run time.  Every run will prompt and fail in this way.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
