### PR TITLE
[risk=no] Fix a UI bug: could not edit WS name in the middle of the field

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1027,7 +1027,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                                 required={!this.isMode(WorkspaceEditMode.Duplicate)}>
           <FlexRow style={{alignItems: 'baseline'}}>
             <TextInput type='text' style={styles.textInput} autoFocus placeholder='Workspace Name'
-              defaultValue = {name}
+              value = {name}
               onChange={v => this.setState(fp.set(['workspace', 'name'], v))}/>
             <TooltipTrigger
                 content='To use a different dataset version, duplicate or create a new workspace.'

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -614,15 +614,16 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
     }
 
     renderHeader() {
-      switch (this.props.routeConfigData.mode) {
+      // use workspace name from props instead of state here
+      // because it's a record of the initial value
+      const {routeConfigData: {mode}, workspace: {name}} = this.props;
+      switch (mode) {
         case WorkspaceEditMode.Create:
           return 'Create a new workspace';
         case WorkspaceEditMode.Edit:
-          return 'Edit workspace \"' + this.state.workspace.name + '\"';
+          return 'Edit workspace \"' + name + '\"';
         case WorkspaceEditMode.Duplicate:
-          // use workspace name from props instead of state here
-          // because it's a record of the initial value
-          return 'Duplicate workspace \"' + this.props.workspace.name + '\"';
+          return 'Duplicate workspace \"' + name + '\"';
       }
     }
 
@@ -1026,7 +1027,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
                                 required={!this.isMode(WorkspaceEditMode.Duplicate)}>
           <FlexRow style={{alignItems: 'baseline'}}>
             <TextInput type='text' style={styles.textInput} autoFocus placeholder='Workspace Name'
-              value = {name}
+              defaultValue = {name}
               onChange={v => this.setState(fp.set(['workspace', 'name'], v))}/>
             <TooltipTrigger
                 content='To use a different dataset version, duplicate or create a new workspace.'

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -616,14 +616,14 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
     renderHeader() {
       // use workspace name from props instead of state here
       // because it's a record of the initial value
-      const {routeConfigData: {mode}, workspace: {name}} = this.props;
+      const {routeConfigData: {mode}, workspace} = this.props;
       switch (mode) {
         case WorkspaceEditMode.Create:
           return 'Create a new workspace';
         case WorkspaceEditMode.Edit:
-          return 'Edit workspace \"' + name + '\"';
+          return 'Edit workspace \"' + workspace.name + '\"';
         case WorkspaceEditMode.Duplicate:
-          return 'Duplicate workspace \"' + name + '\"';
+          return 'Duplicate workspace \"' + workspace.name + '\"';
       }
     }
 


### PR DESCRIPTION
Description:

Attempting to edit a workspace name does not work correctly.  Here I'm succeeding at adding "end is fine" but failing at updating in the middle with "middle is not"

![middle edit bad](https://user-images.githubusercontent.com/2701406/103552791-70c70580-4e7a-11eb-8fb0-dfc2da68509d.gif)

This is similar behavior to something we've seen before with Duplicate Workspace, and the fix is the same.  Not sure why we didn't fix both then.

Editing in the middle now works:

![middle_now_ok](https://user-images.githubusercontent.com/2701406/103553477-7ec95600-4e7b-11eb-9c30-c87f9668e181.gif)

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
