### PR TITLE
[RW-6090] [risk=no] Add workspace_namespace column to schema definition generation scripts

### DIFF
--- a/api/reporting/schemas/generate_all_tables.rb
+++ b/api/reporting/schemas/generate_all_tables.rb
@@ -13,7 +13,6 @@
 #
 require 'open3'
 
-# Ugly wrapper script for reporting-wizard.rb. Just use all the files in the csv directory
 input_dir = File.expand_path(ARGV[0])
 describe_csv_dir = File.join(input_dir, 'mysql_describe_csv')
 output_dir = File.expand_path(ARGV[1])

--- a/api/reporting/schemas/generate_all_tables.rb
+++ b/api/reporting/schemas/generate_all_tables.rb
@@ -1,4 +1,16 @@
 #!/usr/bin/ruby
+#
+# A wrapper script to call reporting-wizard repeatedly on all Workbench MySQL tables. This will send
+# generated files to a specified output directory. Typically, output is sent to a scratch space
+# and then files / snippets are manually copied to the right target location (e.g. Swagger schema
+# files, Java code, or JSON schema files in workbench-terraform-modules).
+#
+# Example invocation:
+#
+# > cd workbench/api/reporting/schemas
+# > ruby generate_all_tables.rb ./input /tmp/reporting-output
+# > cat /tmp/reporting-output/big_query_json/workspace.json
+#
 require 'open3'
 
 # Ugly wrapper script for reporting-wizard.rb. Just use all the files in the csv directory

--- a/api/reporting/schemas/input/descriptions/workspace.yaml
+++ b/api/reporting/schemas/input/descriptions/workspace.yaml
@@ -97,3 +97,6 @@ workspace:
   workspace_id: |
       Primary key of the workspace table in Workrbench application database. Along with
       snapshot_timestamp, serves as a pseudo-primary key for this table.
+  workspace_namespace: |
+      The workspace "namespace", which corresponds to the Google Cloud Project ID associated with
+      the workspace.

--- a/api/reporting/schemas/input/excluded_columns/workspace.txt
+++ b/api/reporting/schemas/input/excluded_columns/workspace.txt
@@ -7,4 +7,3 @@ firecloud_name
 firecloud_uuid
 rp_population
 version
-workspace_namespace

--- a/api/reporting/schemas/latest/workspace.json
+++ b/api/reporting/schemas/latest/workspace.json
@@ -173,5 +173,10 @@
     "name": "workspace_id",
     "type": "INT64",
     "description": "Primary key of the workspace table in Workrbench application database. Along with\nsnapshot_timestamp, serves as a pseudo-primary key for this table."
+  },
+  {
+    "name": "workspace_namespace",
+    "type": "STRING",
+    "description": "The workspace \"namespace\", which corresponds to the Google Cloud Project ID associated with the workspace."
   }
 ]


### PR DESCRIPTION
Three things going on in this PR:

1. Small change to the reporting auto-gen script, to remove `workspace_namespace` as an excluded field.
2. Add some docs and a concrete invocation example to the reporting auto-gen script, after some trial and error.
3. Paste the generated schema JSON into the `latest/workspace.json` file. I'm pretty sure this file will be deprecated in favor of Terraform, but I wanted to keep it in sync for now.

For context: nothing in this PR will affect the operation of the Workbench. This code is simply used to guide the copy-pasting of config & code into other parts of the Workbench system, which will result in distinct PRs.