### PR TITLE
[RW-6090] [risk=low] API changes to add workspace_namespace to reporting output.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -66,7 +66,8 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
             + "  rp_scientific_approach,\n"
             + "  rp_social_behavioral,\n"
             + "  rp_time_requested,\n"
-            + "  workspace_id\n"
+            + "  workspace_id, \n"
+            + "  workspace_namespace \n"
             + "FROM workspace",
         (rs, unused) ->
             new ReportingWorkspace()
@@ -104,7 +105,8 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 .rpScientificApproach(rs.getString("rp_scientific_approach"))
                 .rpSocialBehavioral(rs.getBoolean("rp_social_behavioral"))
                 .rpTimeRequested(offsetDateTimeUtc(rs.getTimestamp("rp_time_requested")))
-                .workspaceId(rs.getLong("workspace_id")));
+                .workspaceId(rs.getLong("workspace_id"))
+                .workspaceNamespace(rs.getString("workspace_namespace")));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceColumnValueExtractor.java
@@ -47,7 +47,8 @@ public enum WorkspaceColumnValueExtractor implements ColumnValueExtractor<Report
   RP_SCIENTIFIC_APPROACH("rp_scientific_approach", ReportingWorkspace::getRpScientificApproach),
   RP_SOCIAL_BEHAVIORAL("rp_social_behavioral", ReportingWorkspace::getRpSocialBehavioral),
   RP_TIME_REQUESTED("rp_time_requested", w -> toInsertRowString(w.getRpTimeRequested())),
-  WORKSPACE_ID("workspace_id", ReportingWorkspace::getWorkspaceId);
+  WORKSPACE_ID("workspace_id", ReportingWorkspace::getWorkspaceId),
+  WORKSPACE_NAMESPACE("workspace_namespace", ReportingWorkspace::getWorkspaceNamespace);
 
   private static final String TABLE_NAME = "workspace";
   private final String parameterName;

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8447,6 +8447,11 @@ definitions:
         description: |-
           Prirmary key of the workspace table in Workrbench application database. Along with
           snapshot_timestamp, serves as a pseudo-primary key for this table.
+      workspaceNamespace:
+        type: string
+        description: |-
+          The workspace "namespace", which corresponds to the Google Cloud Project ID associated with
+          the workspace.
   ReportingWorkspaceFreeTierUsage:
     x-aou-note: |-
       This code was generated using reporting-wizard.rb at 2021-01-05T17:36:27-08:00.

--- a/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
@@ -67,6 +67,7 @@ public class ReportingTestUtils {
   public static final Timestamp WORKSPACE__RP_TIME_REQUESTED =
       Timestamp.from(Instant.parse("2015-06-07T00:00:00.00Z"));
   public static final Long WORKSPACE__WORKSPACE_ID = 34L;
+  public static final String WORKSPACE__WORKSPACE_NAMESPACE = "aou-rw-12345";
 
   // This code was generated using reporting-wizard.rb at 2021-01-05T17:36:27-08:00.
   // Manual modification should be avoided if possible as this is a one-time generation
@@ -181,6 +182,7 @@ public class ReportingTestUtils {
     assertThat(workspace.getRpSocialBehavioral()).isEqualTo(WORKSPACE__RP_SOCIAL_BEHAVIORAL);
     assertTimeApprox(workspace.getRpTimeRequested(), WORKSPACE__RP_TIME_REQUESTED);
     assertThat(workspace.getWorkspaceId()).isEqualTo(expectedWorkspaceId);
+    assertThat(workspace.getWorkspaceNamespace()).isEqualTo(WORKSPACE__WORKSPACE_NAMESPACE);
   }
 
   public static void assertDtoWorkspaceFields(ReportingWorkspace workspace) {
@@ -223,7 +225,8 @@ public class ReportingTestUtils {
         .rpScientificApproach(WORKSPACE__RP_SCIENTIFIC_APPROACH)
         .rpSocialBehavioral(WORKSPACE__RP_SOCIAL_BEHAVIORAL)
         .rpTimeRequested(offsetDateTimeUtc(WORKSPACE__RP_TIME_REQUESTED))
-        .workspaceId(WORKSPACE__WORKSPACE_ID);
+        .workspaceId(WORKSPACE__WORKSPACE_ID)
+        .workspaceNamespace(WORKSPACE__WORKSPACE_NAMESPACE);
   }
 
   public static DbWorkspace createDbWorkspace(DbUser creator, DbCdrVersion cdrVersion) {
@@ -261,6 +264,7 @@ public class ReportingTestUtils {
     workspace.setSocialBehavioral(WORKSPACE__RP_SOCIAL_BEHAVIORAL);
     workspace.setTimeRequested(WORKSPACE__RP_TIME_REQUESTED);
     workspace.setWorkspaceId(WORKSPACE__WORKSPACE_ID);
+    workspace.setWorkspaceNamespace(WORKSPACE__WORKSPACE_NAMESPACE);
     return workspace;
   }
 


### PR DESCRIPTION
This PR should cause the reporting cronjob to begin including `workspace_namespace` in the reporting output. See https://github.com/all-of-us/workbench/pull/4439 for the related PR that updates the auto-gen scripts to include the new column.

My process for making these changes was more or less:

1. Copy the new snippet of YAML from the auto-generated workbench output:
`cat /tmp/reporting-output/swagger_yaml/workspace.yaml`
2. Look for places where ReportingWorkspace seems to be referenced, and add an equivalent entry for `workspace_namespace`.
3. Update tests. 

I verified this end-to-end by running a local server, hitting the CRON endpoint, and checking the contenxt of the `all-of-us-workbench-test:reporting_local` dataset (whose schema has already been updated to include the new column). All worked as expected.

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [X] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests