### PR TITLE
[RW-6042][risk=no] Allow typing in runtime disk size inputs

### DIFF
--- a/ui/src/app/components/warning-message.tsx
+++ b/ui/src/app/components/warning-message.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 export const WarningMessage = ({children}) => {
   return <FlexRow
     style={{
+      alignItems: 'center',
       backgroundColor: colorWithWhiteness(colors.warning, .9),
       border: `1px solid ${colors.warning}`,
       borderRadius: '5px',

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -859,6 +859,10 @@ describe('RuntimePanel', () => {
 
     await pickWorkerDiskSize(wrapper, 4900);
     expect(getCreateButton().prop('disabled')).toBeTruthy();
+
+    await pickMainDiskSize(wrapper, 50);
+    await pickWorkerDiskSize(wrapper, 50);
+    expect(getCreateButton().prop('disabled')).toBeFalsy();
   });
 
   it('should prevent runtime update when disk size is invalid', async() => {
@@ -878,5 +882,9 @@ describe('RuntimePanel', () => {
 
     await pickWorkerDiskSize(wrapper, 4900);
     expect(getNextButton().prop('disabled')).toBeTruthy();
+
+    await pickMainDiskSize(wrapper, 50);
+    await pickWorkerDiskSize(wrapper, 50);
+    expect(getNextButton().prop('disabled')).toBeFalsy();
   });
 });

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -838,4 +838,46 @@ describe('RuntimePanel', () => {
     const wrapper = await component();
     expect(wrapper.find('[data-test-id="runtime-status-icon"]').first().prop('src')).toBe(`${iconsDir}/compute-none.svg`);
   });
+
+  it('should prevent runtime creation when disk size is invalid', async() => {
+    runtimeApiStub.runtime = null;
+    act(() => { runtimeStore.set({runtime: null, workspaceNamespace: workspaceStubs[0].namespace}) });
+    const wrapper = await component();
+    await mustClickButton(wrapper, 'Customize');
+    const getCreateButton = () => wrapper.find({'aria-label': 'Create'}).first();
+
+    console.log("pick main disk size");
+    await pickMainDiskSize(wrapper, 49);
+    expect(getCreateButton().prop('disabled')).toBeTruthy();
+
+    await pickMainDiskSize(wrapper, 4900);
+    expect(getCreateButton().prop('disabled')).toBeTruthy();
+
+    await pickMainDiskSize(wrapper, 50);
+    await pickComputeType(wrapper, ComputeType.Dataproc);
+    await pickWorkerDiskSize(wrapper, 49);
+    expect(getCreateButton().prop('disabled')).toBeTruthy();
+
+    await pickWorkerDiskSize(wrapper, 4900);
+    expect(getCreateButton().prop('disabled')).toBeTruthy();
+  });
+
+  it('should prevent runtime update when disk size is invalid', async() => {
+    const wrapper = await component();
+    const getNextButton = () => wrapper.find({'aria-label': 'Next'}).first();
+
+    await pickMainDiskSize(wrapper, 49);
+    expect(getNextButton().prop('disabled')).toBeTruthy();
+
+    await pickMainDiskSize(wrapper, 4900);
+    expect(getNextButton().prop('disabled')).toBeTruthy();
+
+    await pickMainDiskSize(wrapper, 50);
+    await pickComputeType(wrapper, ComputeType.Dataproc);
+    await pickWorkerDiskSize(wrapper, 49);
+    expect(getNextButton().prop('disabled')).toBeTruthy();
+
+    await pickWorkerDiskSize(wrapper, 4900);
+    expect(getNextButton().prop('disabled')).toBeTruthy();
+  });
 });

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -846,7 +846,6 @@ describe('RuntimePanel', () => {
     await mustClickButton(wrapper, 'Customize');
     const getCreateButton = () => wrapper.find({'aria-label': 'Create'}).first();
 
-    console.log("pick main disk size");
     await pickMainDiskSize(wrapper, 49);
     expect(getCreateButton().prop('disabled')).toBeTruthy();
 

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -875,8 +875,8 @@ export const RuntimePanel = fp.flow(
         lessThanOrEqualTo: 4000,
         message: message
       }
-    }
-  }
+    };
+  };
 
   // 50 GB is the minimum GCP limit for disk size, 4000 GB is our arbitrary limit for not making a
   // disk that is way too big and expensive ($.22 an hour)

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -1041,6 +1041,11 @@ export const RuntimePanel = fp.flow(
             <div>You've made changes that require recreating your environment to take effect.</div>
          </WarningMessage>
        }
+       {(errors || dataprocErrors) &&
+         <WarningMessage>
+           {getErrorsTooltipContent()}
+         </WarningMessage>
+       }
        <FlexRow style={{justifyContent: 'space-between', marginTop: '.75rem'}}>
          <Link
            style={{...styles.deleteLink, ...(
@@ -1050,12 +1055,7 @@ export const RuntimePanel = fp.flow(
            aria-label='Delete Environment'
            disabled={disableControls || !runtimeExists}
            onClick={() => setPanelContent(PanelContent.Delete)}>Delete Environment</Link>
-         <TooltipTrigger
-             content={(errors || dataprocErrors) && getErrorsTooltipContent()}
-             side='left'
-         >
            {!runtimeExists ? renderCreateButton() : renderNextButton()}
-         </TooltipTrigger>
        </FlexRow>
      </Fragment>],
       [PanelContent.Confirm, () => <ConfirmUpdatePanel initialRuntimeConfig={initialRuntimeConfig}

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -874,10 +874,10 @@ export const RuntimePanel = fp.flow(
       numericality: {
         greaterThanOrEqualTo: 50,
         lessThanOrEqualTo: 4000,
-        message: "^Disk size must be between 50 and 4000 GB"
+        message: '^Disk size must be between 50 and 4000 GB'
       }
     }
-  }
+  };
   // We don't clear dataproc config when we change compute type so we can't combine this with the
   // above or else we can end up with phantom validation fails
   const dataprocValidators = {
@@ -885,31 +885,36 @@ export const RuntimePanel = fp.flow(
       numericality: {
         greaterThanOrEqualTo: 50,
         lessThanOrEqualTo: 4000,
-        message: "must be between 50 and 4000 GB"
+        message: 'must be between 50 and 4000 GB'
       }
     },
     workerDiskSize: {
       numericality: {
         greaterThanOrEqualTo: 50,
         lessThanOrEqualTo: 4000,
-        message: "must be between 50 and 4000 GB"
+        message: 'must be between 50 and 4000 GB'
       }
     }
-  }
+  };
   const errors = validate({selectedDiskSize}, validators);
   const {masterDiskSize = null, workerDiskSize = null} = selectedDataprocConfig || {};
-  const dataprocErrors = selectedCompute === ComputeType.Dataproc ? validate({masterDiskSize, workerDiskSize}, dataprocValidators) : undefined;
+  const dataprocErrors = selectedCompute === ComputeType.Dataproc
+      ? validate({masterDiskSize, workerDiskSize}, dataprocValidators)
+      : undefined;
   const runtimeCanBeCreated = !errors && !dataprocErrors;
   // Casting to RuntimeStatus here because it can't easily be done at the destructuring level
   // where we get 'status' from
-  const runtimeCanBeUpdated = runtimeChanged && [RuntimeStatus.Running, RuntimeStatus.Stopped].includes(status as RuntimeStatus) && !errors && !dataprocErrors;
+  const runtimeCanBeUpdated = runtimeChanged
+      && [RuntimeStatus.Running, RuntimeStatus.Stopped].includes(status as RuntimeStatus)
+      && !errors
+      && !dataprocErrors;
 
   const getErrorsTooltipContent = () => {
-    let errorDivs = [];
-    errors && errorDivs.push(summarizeErrors(errors));
-    dataprocErrors && errorDivs.push(summarizeErrors(dataprocErrors));
+    const errorDivs = [];
+    errorDivs.push(summarizeErrors(errors));
+    errorDivs.push(summarizeErrors(dataprocErrors));
     return errorDivs;
-  }
+  };
 
   const renderUpdateButton = () => {
     return <Button

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -10,7 +10,8 @@ import {workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors, {addOpacity, colorWithWhiteness} from 'app/styles/colors';
 import {
   DEFAULT,
-  reactStyles, summarizeErrors,
+  reactStyles,
+  summarizeErrors,
   switchCase,
   withCdrVersions,
   withCurrentWorkspace,
@@ -867,34 +868,26 @@ export const RuntimePanel = fp.flow(
     return runtimeRequest;
   };
 
-  // 50 GB is the minimum GCP limit for disk size, 4000 GB is our arbitrary limit for not making a
-  // disk that is way too big and expensive ($.22 an hour)
-  const validators = {
-    selectedDiskSize: {
+  const diskSizeValidatorWithMessage = (message) => {
+    return {
       numericality: {
         greaterThanOrEqualTo: 50,
         lessThanOrEqualTo: 4000,
-        message: '^Disk size must be between 50 and 4000 GB'
+        message: message
       }
     }
+  }
+
+  // 50 GB is the minimum GCP limit for disk size, 4000 GB is our arbitrary limit for not making a
+  // disk that is way too big and expensive ($.22 an hour)
+  const validators = {
+    selectedDiskSize: diskSizeValidatorWithMessage('^Disk size must be between 50 and 4000 GB')
   };
   // We don't clear dataproc config when we change compute type so we can't combine this with the
   // above or else we can end up with phantom validation fails
   const dataprocValidators = {
-    masterDiskSize: {
-      numericality: {
-        greaterThanOrEqualTo: 50,
-        lessThanOrEqualTo: 4000,
-        message: 'must be between 50 and 4000 GB'
-      }
-    },
-    workerDiskSize: {
-      numericality: {
-        greaterThanOrEqualTo: 50,
-        lessThanOrEqualTo: 4000,
-        message: 'must be between 50 and 4000 GB'
-      }
-    }
+    masterDiskSize: diskSizeValidatorWithMessage('^Master disk size must be between 50 and 4000 GB'),
+    workerDiskSize: diskSizeValidatorWithMessage('^Worker disk size must be between 50 and 4000 GB')
   };
   const errors = validate({selectedDiskSize}, validators);
   const {masterDiskSize = null, workerDiskSize = null} = selectedDataprocConfig || {};

--- a/ui/src/testing/stubs/runtime-api-stub.ts
+++ b/ui/src/testing/stubs/runtime-api-stub.ts
@@ -17,7 +17,7 @@ export const defaultGceConfig = (): GceConfig => ({
 export const defaultDataprocConfig = (): DataprocConfig => ({
   masterMachineType: 'n1-standard-4',
   masterDiskSize: 80,
-  workerDiskSize: 40,
+  workerDiskSize: 50,
   workerMachineType: 'n1-standard-4',
   numberOfWorkers: 1,
   numberOfPreemptibleWorkers: 2,


### PR DESCRIPTION
<img width="708" alt="Screen Shot 2021-01-05 at 3 12 41 PM" src="https://user-images.githubusercontent.com/1847690/103694184-83b80380-4f68-11eb-91a2-af9a53902101.png">


You can type directly into the input, and proceeding (create/update/next) is disabled until the number in the input is between 50 (GCP minimum disk GB) and 4000 (AoU maximum disk GB).

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
