### PR TITLE
[RW-6004][risk=low] [P4] UI - Cope survey slide out panel still open when selecting nodes from another survey

### DIFF
--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -16,7 +16,8 @@ import {reactStyles, withCurrentWorkspace, withUrlParams} from 'app/utils';
 import {
   attributesSelectionStore,
   currentCohortCriteriaStore,
-  currentConceptStore
+  currentConceptStore,
+  setSidebarActiveIconStore
 } from 'app/utils/navigation';
 import {environment} from 'environments/environment';
 import {Criteria, Domain} from 'generated/fetch';
@@ -232,7 +233,16 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
     });
   }
 
+  closeSidebar() {
+    attributesSelectionStore.next(undefined);
+    setSidebarActiveIconStore.next(undefined);
+  }
+
   addSelection = (selectCriteria)  => {
+    // In case of Criteria/Cohort, close existing attribute sidebar before selecting a new value
+    if (!this.isConcept && !!attributesSelectionStore.getValue()) {
+      this.closeSidebar();
+    }
     let criteriaList = this.state.selectedCriteriaList;
     if (criteriaList && criteriaList.length > 0) {
       criteriaList.push(selectCriteria);


### PR DESCRIPTION
**Issue**: If user selects a criteria of type attribute say COVID and does not take any action (back or add this) the panel remains open even on selecting other criteria.

https://user-images.githubusercontent.com/34481816/103697950-a1886700-4f6e-11eb-91da-b0e25ff0c5ad.mov

**Fix**
If criteria is selected, close attribute panel first before taking any action on selections. 

https://user-images.githubusercontent.com/34481816/103698605-9124bc00-4f6f-11eb-8ec1-591669e7a7d5.mov

 
---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
