### PR TITLE
[risk=no] Fix clear input function on concept search homepage

### DIFF
--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -248,14 +248,15 @@ export const ConceptHomepage = fp.flow(withCurrentCohortSearchContext(), withCur
     }
 
     clearSearch() {
+      currentConceptStore.next(null);
+      currentCohortSearchContextStore.next(undefined);
       this.setState({
         currentInputString: '',
         currentSearchString: '',
+        loadingDomains: true,
         inputErrors: [],
         showSearchError: false,
-      });
-      currentConceptStore.next(null);
-      this.setState({loadingDomains: true}, () => this.loadDomainsAndSurveys());
+      }, () => this.loadDomainsAndSurveys());
     }
 
     browseDomain(domain: Domain, surveyName?: string) {


### PR DESCRIPTION
Fix issue in Concept Search where searching within a domain, then going back to the homepage and clicking the clear search icon in the search input causes unneeded api calls that fail.

https://user-images.githubusercontent.com/40036095/103854003-13e36f00-5075-11eb-86ec-9b4c2788eae9.mov

After fix:

https://user-images.githubusercontent.com/40036095/103854516-3cb83400-5076-11eb-9a33-ac6cdb1739db.mov





