### PR TITLE
[RW-6053][risk=no] refactoring participant count in concept sets

### DIFF
--- a/api/db/changelog/db.changelog-145-remove-participant-count.xml
+++ b/api/db/changelog/db.changelog-145-remove-participant-count.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="brianfreeman" id="changelog-145-remove-participant-count">
+    <dropColumn columnName="participant_count" tableName="concept_set"/>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -152,7 +152,9 @@
   <include file="changelog/db.changelog-141-populate-prePackagedConcept-table.xml"/>
   <include file="changelog/db.changelog-142-cdr-version-hasCopeSurvey-field.xml"/>
   <include file="changelog/db.changelog-143-alter-concept-set-concept-id.xml"/>
-  <include file="changelog/db.changelog-144-remove-concept-set-concept-id-primarykeyconstraint.xml"/>
+  <include
+    file="changelog/db.changelog-144-remove-concept-set-concept-id-primarykeyconstraint.xml"/>
+  <include file="changelog/db.changelog-145-remove-participant-count.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbConceptSet.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbConceptSet.java
@@ -35,7 +35,6 @@ public class DbConceptSet {
   private DbUser creator;
   private Timestamp creationTime;
   private Timestamp lastModifiedTime;
-  private int participantCount;
   private Set<DbConceptSetConceptId> dbConceptSetConceptIds = new HashSet<>();
 
   public DbConceptSet() {
@@ -51,8 +50,7 @@ public class DbConceptSet {
       long workspaceId,
       DbUser creator,
       Timestamp creationTime,
-      Timestamp lastModifiedTime,
-      int participantCount) {
+      Timestamp lastModifiedTime) {
     setVersion(version);
     setName(name);
     setDomain(domain);
@@ -62,7 +60,6 @@ public class DbConceptSet {
     setCreator(creator);
     setCreationTime(creationTime);
     setLastModifiedTime(lastModifiedTime);
-    setParticipantCount(participantCount);
   }
 
   public DbConceptSet(DbConceptSet cs) {
@@ -75,7 +72,6 @@ public class DbConceptSet {
     setWorkspaceId(cs.getWorkspaceId());
     setCreationTime(cs.getCreationTime());
     setLastModifiedTime(cs.getLastModifiedTime());
-    setParticipantCount(cs.getParticipantCount());
     setConceptSetConceptIds(new HashSet<>(cs.getConceptSetConceptIds()));
   }
 
@@ -191,15 +187,6 @@ public class DbConceptSet {
     this.lastModifiedTime = lastModifiedTime;
   }
 
-  @Column(name = "participant_count")
-  public int getParticipantCount() {
-    return participantCount;
-  }
-
-  public void setParticipantCount(int participantCount) {
-    this.participantCount = participantCount;
-  }
-
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(
       name = "concept_set_concept_id",
@@ -225,7 +212,6 @@ public class DbConceptSet {
     return version == that.version
         && domain == that.domain
         && workspaceId == that.workspaceId
-        && participantCount == that.participantCount
         && Objects.equals(name, that.name)
         && Objects.equals(survey, that.survey)
         && Objects.equals(description, that.description)
@@ -247,7 +233,6 @@ public class DbConceptSet {
         creator,
         creationTime,
         lastModifiedTime,
-        participantCount,
         dbConceptSetConceptIds);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -363,37 +363,22 @@ public class ConceptSetsControllerTest {
     assertThat(conceptSet.getEtag()).isEqualTo(Etags.fromVersion(1));
     assertThat(conceptSet.getLastModifiedTime()).isEqualTo(NOW.toEpochMilli());
     assertThat(conceptSet.getName()).isEqualTo("concept set 1");
-    assertThat(conceptSet.getParticipantCount()).isEqualTo(0);
-
-    assertThat(
-            conceptSetsController
-                .getConceptSet(workspace.getNamespace(), WORKSPACE_NAME, conceptSet.getId())
-                .getBody())
-        .isEqualTo(conceptSet);
-    // Get concept sets will not return the full information, because concepts can have a lot of
-    // information.
-    assertThat(
-            conceptSetsController
-                .getConceptSetsInWorkspace(workspace.getNamespace(), WORKSPACE_NAME)
-                .getBody()
-                .getItems())
-        .contains(conceptSet);
-    assertThat(
-            conceptSetsController
-                .getConceptSetsInWorkspace(workspace2.getNamespace(), WORKSPACE_NAME_2)
-                .getBody()
-                .getItems())
-        .isEmpty();
   }
 
   @Test
-  public void testGetSurveyConceptSet() {
+  public void testGetConceptSet() {
     ConceptSet surveyConceptSet = makeSurveyConceptSet1();
+    surveyConceptSet.setParticipantCount(0);
     assertThat(
             conceptSetsController
                 .getConceptSet(workspace.getNamespace(), WORKSPACE_NAME, surveyConceptSet.getId())
                 .getBody())
         .isEqualTo(surveyConceptSet);
+  }
+
+  @Test
+  public void testGetConceptSetsInWorkspace() {
+    ConceptSet surveyConceptSet = makeSurveyConceptSet1();
     assertThat(
             conceptSetsController
                 .getConceptSetsInWorkspace(workspace.getNamespace(), WORKSPACE_NAME)
@@ -412,30 +397,6 @@ public class ConceptSetsControllerTest {
   public void testGetSurveyConceptSetWrongConceptId() {
     makeSurveyConceptSet1();
     conceptSetsController.getConceptSet(workspace2.getNamespace(), WORKSPACE_NAME_2, 99L);
-  }
-
-  @Test
-  public void testGetConceptSet() {
-    ConceptSet conceptSet = makeConceptSet1();
-    assertThat(
-            conceptSetsController
-                .getConceptSet(workspace.getNamespace(), WORKSPACE_NAME, conceptSet.getId())
-                .getBody())
-        .isEqualTo(conceptSet);
-    // Get concept sets will not return the full information, because concepts can have a lot of
-    // information.
-    assertThat(
-            conceptSetsController
-                .getConceptSetsInWorkspace(workspace.getNamespace(), WORKSPACE_NAME)
-                .getBody()
-                .getItems())
-        .contains(conceptSet);
-    assertThat(
-            conceptSetsController
-                .getConceptSetsInWorkspace(workspace2.getNamespace(), WORKSPACE_NAME_2)
-                .getBody()
-                .getItems())
-        .isEmpty();
   }
 
   @Test(expected = NotFoundException.class)
@@ -464,28 +425,7 @@ public class ConceptSetsControllerTest {
     assertThat(updatedConceptSet.getDomain()).isEqualTo(Domain.CONDITION);
     assertThat(updatedConceptSet.getEtag()).isEqualTo(Etags.fromVersion(2));
     assertThat(updatedConceptSet.getLastModifiedTime()).isEqualTo(newInstant.toEpochMilli());
-    assertThat(updatedConceptSet.getParticipantCount()).isEqualTo(0);
     assertThat(conceptSet.getName()).isEqualTo("new name");
-
-    assertThat(
-            conceptSetsController
-                .getConceptSet(workspace.getNamespace(), WORKSPACE_NAME, conceptSet.getId())
-                .getBody())
-        .isEqualTo(updatedConceptSet);
-    // Get concept sets will not return the full information, because concepts can have a lot of
-    // information.
-    assertThat(
-            conceptSetsController
-                .getConceptSetsInWorkspace(workspace.getNamespace(), WORKSPACE_NAME)
-                .getBody()
-                .getItems())
-        .contains(updatedConceptSet);
-    assertThat(
-            conceptSetsController
-                .getConceptSetsInWorkspace(workspace2.getNamespace(), WORKSPACE_NAME_2)
-                .getBody()
-                .getItems())
-        .isEmpty();
   }
 
   @Test(expected = ConflictException.class)
@@ -542,7 +482,6 @@ public class ConceptSetsControllerTest {
     assertThat(updated.getCriteriums().get(0).getConceptId())
         .isEqualTo(CLIENT_CRITERIA_1.getConceptId());
     assertThat(updated.getEtag()).isNotEqualTo(conceptSet.getEtag());
-    assertThat(updated.getParticipantCount()).isEqualTo(246);
 
     ConceptSet removed =
         conceptSetsController
@@ -555,7 +494,6 @@ public class ConceptSetsControllerTest {
     assertThat(removed.getCriteriums()).hasSize(1);
     assertThat(removed.getEtag()).isNotEqualTo(conceptSet.getEtag());
     assertThat(removed.getEtag()).isNotEqualTo(updated.getEtag());
-    assertThat(removed.getParticipantCount()).isEqualTo(123);
   }
 
   @Test
@@ -604,7 +542,6 @@ public class ConceptSetsControllerTest {
     assertThat(updated.getCriteriums().get(2).getConceptId())
         .isEqualTo(CLIENT_CRITERIA_3.getConceptId());
     assertThat(updated.getEtag()).isNotEqualTo(conceptSet.getEtag());
-    assertThat(updated.getParticipantCount()).isEqualTo(456);
 
     when(conceptBigQueryService.getParticipantCountForConcepts(
             Domain.CONDITION, "condition_occurrence", ImmutableSet.of(dbConceptSetConceptId1)))
@@ -625,7 +562,6 @@ public class ConceptSetsControllerTest {
         .isEqualTo(CLIENT_CRITERIA_1.getConceptId());
     assertThat(removed.getEtag()).isNotEqualTo(conceptSet.getEtag());
     assertThat(removed.getEtag()).isNotEqualTo(updated.getEtag());
-    assertThat(removed.getParticipantCount()).isEqualTo(123);
   }
 
   @Test
@@ -664,7 +600,6 @@ public class ConceptSetsControllerTest {
         .isEqualTo(CLIENT_CRITERIA_4.getConceptId());
     assertThat(conceptSet.getCriteriums().get(2).getConceptId())
         .isEqualTo(CLIENT_CRITERIA_3.getConceptId());
-    assertThat(conceptSet.getParticipantCount()).isEqualTo(456);
   }
 
   @Test(expected = ConflictException.class)

--- a/api/src/test/java/org/pmiops/workbench/conceptset/mapper/ConceptSetMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/conceptset/mapper/ConceptSetMapperTest.java
@@ -53,8 +53,7 @@ public class ConceptSetMapperTest {
             1,
             creator,
             now,
-            now,
-            200);
+            now);
     dbConceptSet.setConceptSetId(1);
   }
 
@@ -66,8 +65,6 @@ public class ConceptSetMapperTest {
     assertThat(clientConceptSet.getDomain()).isEqualTo(dbConceptSet.getDomainEnum());
     assertThat(clientConceptSet.getSurvey()).isEqualTo(dbConceptSet.getSurveysEnum());
     assertThat(clientConceptSet.getName()).isEqualTo(dbConceptSet.getName());
-    assertThat(clientConceptSet.getParticipantCount())
-        .isEqualTo(dbConceptSet.getParticipantCount());
     assertThat(clientConceptSet.getDescription()).isEqualTo(dbConceptSet.getDescription());
     assertThat(clientConceptSet.getCreationTime())
         .isEqualTo(dbConceptSet.getCreationTime().getTime());
@@ -93,15 +90,12 @@ public class ConceptSetMapperTest {
     conceptSetRequest.setConceptSet(clientConceptSet);
     conceptSetRequest.setAddedConceptSetConceptIds(
         Arrays.asList(conceptSetConceptId1, conceptSetConceptId2, conceptSetConceptId3));
-    conceptSetMapper.clientToDbModel(
-        conceptSetRequest, 1l, dbConceptSet.getCreator(), conceptBigQueryService);
+    conceptSetMapper.clientToDbModel(conceptSetRequest, 1l, dbConceptSet.getCreator());
     assertThat(clientConceptSet.getId()).isEqualTo(dbConceptSet.getConceptSetId());
     assertThat(Etags.toVersion(clientConceptSet.getEtag())).isEqualTo(dbConceptSet.getVersion());
     assertThat(clientConceptSet.getDomain()).isEqualTo(dbConceptSet.getDomainEnum());
     assertThat(clientConceptSet.getSurvey()).isEqualTo(dbConceptSet.getSurveysEnum());
     assertThat(clientConceptSet.getName()).isEqualTo(dbConceptSet.getName());
-    assertThat(clientConceptSet.getParticipantCount())
-        .isEqualTo(dbConceptSet.getParticipantCount());
     assertThat(clientConceptSet.getDescription()).isEqualTo(dbConceptSet.getDescription());
     assertThat(clientConceptSet.getCreationTime())
         .isEqualTo(dbConceptSet.getCreationTime().getTime());

--- a/api/src/test/java/org/pmiops/workbench/db/dao/ConceptSetDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/ConceptSetDaoTest.java
@@ -56,8 +56,7 @@ public class ConceptSetDaoTest {
             ws.getWorkspaceId(),
             creator,
             now,
-            now,
-            200);
+            now);
     dbConceptSet.setConceptSetConceptIds(conceptSetConceptIds);
     this.dbConceptSet = conceptSetDao.save(dbConceptSet);
   }


### PR DESCRIPTION
This PR

1. Removes participant_count from the concept_set table in the workbench db
2. Removes call to BQ for the participant count from create/clone of concept sets
3. Adds a call to BQ for the participant count in the fetch of concept sets for edit(this is the only call that needs the count)