### PR TITLE
[RW-5852][risk=no] Add preset/UserOverride labels to Leonardo updateRuntime endpoint

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -27,6 +27,7 @@ import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoUpdateRuntimeRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoUserJupyterExtensionConfig;
 import org.pmiops.workbench.model.Runtime;
+import org.pmiops.workbench.model.RuntimeConfigurationType;
 import org.pmiops.workbench.notebooks.api.ProxyApi;
 import org.pmiops.workbench.notebooks.model.LocalizationEntry;
 import org.pmiops.workbench.notebooks.model.Localize;
@@ -106,12 +107,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     runtimeLabels.put(LeonardoMapper.RUNTIME_LABEL_AOU, "true");
     runtimeLabels.put(LeonardoMapper.RUNTIME_LABEL_CREATED_BY, userEmail);
 
-    if (runtime.getConfigurationType() != null) {
-      runtimeLabels.put(
-          LeonardoMapper.RUNTIME_LABEL_AOU_CONFIG,
-          LeonardoMapper.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(
-              runtime.getConfigurationType()));
-    }
+    runtimeLabels.putAll(buildRuntimeConfigurationLabels(runtime.getConfigurationType()));
 
     LeonardoCreateRuntimeRequest request =
         new LeonardoCreateRuntimeRequest()
@@ -195,13 +191,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
   @Override
   public void updateRuntime(Runtime runtime) {
-    Map<String, String> runtimeLabels = new HashMap<>();
-    if (runtime.getConfigurationType() != null) {
-      runtimeLabels.put(
-          LeonardoMapper.RUNTIME_LABEL_AOU_CONFIG,
-          LeonardoMapper.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(
-              runtime.getConfigurationType()));
-    }
+    Map<String, String> runtimeLabels = buildRuntimeConfigurationLabels(runtime.getConfigurationType());
 
     leonardoRetryHandler.run(
         (context) -> {
@@ -217,6 +207,17 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
                       .labelsToUpsert(runtimeLabels));
           return null;
         });
+  }
+
+  private Map<String, String> buildRuntimeConfigurationLabels(RuntimeConfigurationType runtimeConfigurationType) {
+    Map<String, String> runtimeLabels = new HashMap<>();
+    if (runtimeConfigurationType != null) {
+      runtimeLabels.put(
+          LeonardoMapper.RUNTIME_LABEL_AOU_CONFIG,
+          LeonardoMapper.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(
+              runtimeConfigurationType));
+    }
+    return runtimeLabels;
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -195,8 +195,13 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
   @Override
   public void updateRuntime(Runtime runtime) {
-    // TODO: Apply labels on updateRuntime,
-    // https://precisionmedicineinitiative.atlassian.net/browse/RW-5852
+    Map<String, String> runtimeLabels = new HashMap<>();
+    if (runtime.getConfigurationType() != null) {
+      runtimeLabels.put(
+          LeonardoMapper.RUNTIME_LABEL_AOU_CONFIG,
+          LeonardoMapper.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(
+              runtime.getConfigurationType()));
+    }
 
     leonardoRetryHandler.run(
         (context) -> {
@@ -207,9 +212,9 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
                   runtime.getRuntimeName(),
                   new LeonardoUpdateRuntimeRequest()
                       .allowStop(true)
-                      .runtimeConfig(
-                          buildRuntimeConfig(
-                              runtime, userProvider.get().getClusterConfigDefault())));
+                      .runtimeConfig(buildRuntimeConfig(runtime, userProvider.get().getClusterConfigDefault()))
+                      .labelsToUpsert(runtimeLabels)
+              );
           return null;
         });
   }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -191,7 +191,8 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
   @Override
   public void updateRuntime(Runtime runtime) {
-    Map<String, String> runtimeLabels = buildRuntimeConfigurationLabels(runtime.getConfigurationType());
+    Map<String, String> runtimeLabels =
+        buildRuntimeConfigurationLabels(runtime.getConfigurationType());
 
     leonardoRetryHandler.run(
         (context) -> {
@@ -209,7 +210,8 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
         });
   }
 
-  private Map<String, String> buildRuntimeConfigurationLabels(RuntimeConfigurationType runtimeConfigurationType) {
+  private Map<String, String> buildRuntimeConfigurationLabels(
+      RuntimeConfigurationType runtimeConfigurationType) {
     Map<String, String> runtimeLabels = new HashMap<>();
     if (runtimeConfigurationType != null) {
       runtimeLabels.put(

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.notebooks;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -212,14 +213,14 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
   private Map<String, String> buildRuntimeConfigurationLabels(
       RuntimeConfigurationType runtimeConfigurationType) {
-    Map<String, String> runtimeLabels = new HashMap<>();
     if (runtimeConfigurationType != null) {
-      runtimeLabels.put(
+      return Collections.singletonMap(
           LeonardoMapper.RUNTIME_LABEL_AOU_CONFIG,
           LeonardoMapper.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(
               runtimeConfigurationType));
+    } else {
+      return new HashMap<>();
     }
-    return runtimeLabels;
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -212,9 +212,9 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
                   runtime.getRuntimeName(),
                   new LeonardoUpdateRuntimeRequest()
                       .allowStop(true)
-                      .runtimeConfig(buildRuntimeConfig(runtime, userProvider.get().getClusterConfigDefault()))
-                      .labelsToUpsert(runtimeLabels)
-              );
+                      .runtimeConfig(
+                          buildRuntimeConfig(runtime, userProvider.get().getClusterConfigDefault()))
+                      .labelsToUpsert(runtimeLabels));
           return null;
         });
   }

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -2783,6 +2783,14 @@ components:
           description: The number of minutes of idle time to elapse before the cluster is
             autopaused. If autopause is set to false, this value is disregarded.
             A value of 0 is equivalent to autopause being turned off.
+        labelsToUpsert:
+          type: object
+          description: Labels to update or add on the runtime. Of type Map[String, String]. You cannot alter default labels or add a label with a null value.
+        labelsToDelete:
+          type: array
+          description: A set of label keys to remove from the runtime labels. Of type Set[String]. You cannot delete a default label.
+          items:
+            type: string
     CreateDiskRequest:
       description: "Creates a new persistent disk"
       type: object

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -1023,6 +1023,13 @@ public class RuntimeControllerTest {
         .isEqualTo(dataprocConfig.getMasterMachineType());
     assertThat(actualRuntimeConfig.getMasterDiskSize())
         .isEqualTo(dataprocConfig.getMasterDiskSize());
+
+    assertThat(updateRuntimeRequestCaptor.getValue().getLabelsToUpsert())
+        .isEqualTo(
+            Collections.singletonMap(
+                LeonardoMapper.RUNTIME_LABEL_AOU_CONFIG,
+                LeonardoMapper.RUNTIME_CONFIGURATION_TYPE_ENUM_TO_STORAGE_MAP.get(
+                    RuntimeConfigurationType.USEROVERRIDE)));
   }
 
   @Test


### PR DESCRIPTION
Verified manually that the `configurationType` updates when changing from UserOverride to preset and preset to UserOverride on update.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
