### PR TITLE
[risk=no] Improve user audit page links

### DIFF
--- a/ui/src/app/components/admin/audit-page-component.tsx
+++ b/ui/src/app/components/admin/audit-page-component.tsx
@@ -1,6 +1,6 @@
 import {AuditActionCardListView} from 'app/components/admin/audit-card-list-view';
 import {Navigate} from 'app/components/app-router';
-import {Button} from 'app/components/buttons';
+import {Button, StyledAnchorTag} from 'app/components/buttons';
 import {NumberInput, TextInputWithLabel} from 'app/components/inputs';
 import {TooltipTrigger} from 'app/components/popups';
 import colors from 'app/styles/colors';
@@ -108,6 +108,20 @@ const UserInput = ({initialAuditSubject, auditSubjectType, getNextAuditPath, but
       textAlign: 'center',
       fontWeight: 600
     }}>
+    <TooltipTrigger content={'BigQuery Console page (use pmi-ops.org account)'}>
+      <StyledAnchorTag href={getBigQueryConsoleUrl()}
+                       target='_blank'>
+        BigQuery Console
+      </StyledAnchorTag>
+    </TooltipTrigger>
+    &nbsp;|&nbsp;
+    <TooltipTrigger content={`Admin Page for ${auditSubjectType} ${auditSubject || 'n/a'}`}>
+      <StyledAnchorTag href={auditSubject ? getAdminPageUrl(auditSubject) : undefined}
+                       style={auditSubject ? {} : {cursor: 'not-allowed', color: colors.disabled}}>
+        {auditSubjectType} Admin
+      </StyledAnchorTag>
+    </TooltipTrigger>
+    </div>
     <TooltipTrigger content={'Download actual SQL query for BigQuery Action Audit table. Useful' +
       ' for developers or analysts interested in basing other ad hoc queries off' +
       ' this audit query in the BigQuery console or bq tool.'}>
@@ -117,20 +131,6 @@ const UserInput = ({initialAuditSubject, auditSubjectType, getNextAuditPath, but
         Download SQL
       </Button>
     </TooltipTrigger>
-    <TooltipTrigger content={'BigQuery Console page (use pmi-ops.org account)'}>
-      <Button style={buttonStyle}
-              onClick={() => navigate([getBigQueryConsoleUrl()])}>
-        BigQuery Console
-      </Button>
-    </TooltipTrigger>
-    <TooltipTrigger content={`Admin Page for ${auditSubjectType} ${auditSubject || 'n/a'}`}>
-      <Button style={buttonStyle}
-              disabled={fp.isEmpty(auditSubject)}
-              onClick={() => navigate(getAdminPageUrl(auditSubject))}>
-        {auditSubjectType} Admin
-      </Button>
-    </TooltipTrigger>
-    </div>
   </React.Fragment>;
 };
 

--- a/ui/src/app/components/admin/audit-page-component.tsx
+++ b/ui/src/app/components/admin/audit-page-component.tsx
@@ -6,7 +6,6 @@ import {TooltipTrigger} from 'app/components/popups';
 import colors from 'app/styles/colors';
 import { useDebounce, useToggle } from 'app/utils';
 import {downloadTextFile} from 'app/utils/audit-utils';
-import {navigate} from 'app/utils/navigation';
 import {AuditAction, AuditLogEntry} from 'generated';
 import * as fp from 'lodash/fp';
 import * as moment from 'moment';

--- a/ui/src/app/pages/admin/user-audit.tsx
+++ b/ui/src/app/pages/admin/user-audit.tsx
@@ -23,9 +23,8 @@ const getNextAuditPath = (subject: string) => {
   return `/admin/user-audit/${subject}`;
 };
 
-// Single-user admin page isn't available yet, so go to the main users list page.
 const getAdminPageUrl = (subject: string) => {
-  return ['/admin/user'];
+  return [`/admin/users/${subject}`];
 };
 
 export const UserAudit = () => {


### PR DESCRIPTION
- Switch links to be links instead of buttons
- Update "user admin" link to go to the right page, now that the target page exists.
![image](https://user-images.githubusercontent.com/822298/104081891-9dff1500-51e6-11eb-8fe1-8ebe5680ad04.png)
