### PR TITLE
[no ticket][risk=no] Puppeteer refactor findOrCreateWorkspace function

### DIFF
--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -11,7 +11,7 @@ const WorkspaceCardSelector = {
   cardRootXpath: '//*[child::*[@data-test-id="workspace-card"]]', // finds 'workspace-card' parent container node
   cardNameXpath: '@data-test-id="workspace-card-name"',
   accessLevelXpath: './/*[@data-test-id="workspace-access-level"]',
-  dateTimeXpath: '//*[@data-test-id="workspace-card"]/div[3]'
+  dateTimeXpath: './/*[@data-test-id="workspace-card"]/div[3]'
 }
 
 
@@ -36,20 +36,31 @@ export default class WorkspaceCard extends CardBase {
   }
 
   /**
-   * Find all visible Workspace Cards. Assume at least one Card exists.
+   * Find all visible Workspace Cards.
    * @param {Page} page
    * @throws TimeoutError if fails to find Card.
    */
-  static async findAllCards(page: Page): Promise<WorkspaceCard[]> {
+  static async findAllCards(page: Page, accessLevel?: WorkspaceAccessLevel): Promise<WorkspaceCard[]> {
     try {
       await page.waitForXPath(WorkspaceCardSelector.cardRootXpath, {visible: true, timeout: 1000});
     } catch (e) {
       return [];
     }
-    const cards = await page.$x(WorkspaceCardSelector.cardRootXpath);
+    const cardElements = await page.$x(WorkspaceCardSelector.cardRootXpath);
     // transform to WorkspaceCard object
-    const resourceCards = cards.map(card => new WorkspaceCard(page).asCard(card));
-    return resourceCards;
+    const workspaceCards = cardElements.map(card => new WorkspaceCard(page).asCard(card));
+
+    const filtered = [];
+    if (accessLevel !== undefined) {
+      for (const card of workspaceCards) {
+        const cardAccessLevel = await card.getWorkspaceAccessLevel();
+        if (cardAccessLevel === accessLevel) {
+          filtered.push(card);
+        }
+      }
+      return filtered;
+    }
+    return workspaceCards;
   }
 
   static async findAnyCard(page: Page): Promise<WorkspaceCard> {
@@ -77,19 +88,6 @@ export default class WorkspaceCard extends CardBase {
     return null; // not found
   }
 
-  static async getAllCardDetails(page: Page, accessLevel: WorkspaceAccessLevel = WorkspaceAccessLevel.Owner): Promise<any[]> {
-    const cards = await WorkspaceCard.findAllCards(page);
-    const arr = [];
-    for (const card of cards) {
-      const level = await card.getWorkspaceAccessLevel();
-      if (accessLevel === level) {
-        const time = await card.getDateTime();
-        const name = await card.getWorkspaceName();
-        arr.push(card, name, time, accessLevel);
-      }
-    }
-    return arr;
-  }
 
   constructor(page: Page) {
     super(page);
@@ -147,12 +145,11 @@ export default class WorkspaceCard extends CardBase {
     return matchWorkspaceArray;
   }
 
-  async getDateTime(): Promise<string> {
+  async getLastChangedTime(): Promise<string> {
     const [element] = await this.cardElement.$x(WorkspaceCardSelector.dateTimeXpath);
     const wholeText = await getPropValue<string>(element, 'innerText');
     // datetime format is "Last Changed: 01/08/21, 05:22 PM"
-    const timeText = wholeText.replace('Last Changed: ', '').trim();
-    return timeText;
+    return wholeText.replace('Last Changed: ', '').trim();
   }
 
   /**

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -11,6 +11,7 @@ const WorkspaceCardSelector = {
   cardRootXpath: '//*[child::*[@data-test-id="workspace-card"]]', // finds 'workspace-card' parent container node
   cardNameXpath: '@data-test-id="workspace-card-name"',
   accessLevelXpath: './/*[@data-test-id="workspace-access-level"]',
+  dateTimeXpath: '//*[@data-test-id="workspace-card"]/div[3]'
 }
 
 
@@ -131,6 +132,29 @@ export default class WorkspaceCard extends CardBase {
       }
     }
     return matchWorkspaceArray;
+  }
+
+  /**
+   * Finds the oldest Workspace card with OWNER role.
+   * @param level
+   */
+  async getOldestWorkspace(level: WorkspaceAccessLevel = WorkspaceAccessLevel.Owner): Promise<WorkspaceCard> {
+    const workspaceArray = await this.getWorkspaceMatchAccessLevel(WorkspaceAccessLevel.Owner);
+    for (const card of allWorkspaceCards) {
+      const cardDateTime = await this.getDateTime();
+      const oldest = creationDate.reduce((c, n) =>
+         Date.parse(n) < Date.parse(c) ? n : c
+      );
+    }
+  }
+
+  async getDateTime(): Promise<string> {
+    const [element] = await this.cardElement.$x(WorkspaceCardSelector.dateTimeXpath);
+    const wholeText = await getPropValue<string>(element, 'innerText');
+    // datetime format is "Last Changed: 01/08/21, 05:22 PM"
+    const timeText = wholeText.replace('Last Changed: ', '').trim();
+    console.log(timeText);
+    return timeText;
   }
 
   /**

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -46,9 +46,8 @@ export default class WorkspaceCard extends CardBase {
     } catch (e) {
       return [];
     }
-    const cardElements = await page.$x(WorkspaceCardSelector.cardRootXpath);
-    // transform to WorkspaceCard object
-    const workspaceCards = cardElements.map(card => new WorkspaceCard(page).asCard(card));
+    const workspaceCards = (await page.$x(WorkspaceCardSelector.cardRootXpath))
+      .map(card => new WorkspaceCard(page).asCard(card));
 
     const filtered = [];
     if (accessLevel !== undefined) {

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -77,6 +77,19 @@ export default class WorkspaceCard extends CardBase {
     return null; // not found
   }
 
+  static async getAllCardDetails(page: Page, accessLevel: WorkspaceAccessLevel = WorkspaceAccessLevel.Owner): Promise<any[]> {
+    const cards = await WorkspaceCard.findAllCards(page);
+    const arr = [];
+    for (const card of cards) {
+      const level = await card.getWorkspaceAccessLevel();
+      if (accessLevel === level) {
+        const time = await card.getDateTime();
+        const name = await card.getWorkspaceName();
+        arr.push(card, name, time, accessLevel);
+      }
+    }
+    return arr;
+  }
 
   constructor(page: Page) {
     super(page);
@@ -134,26 +147,11 @@ export default class WorkspaceCard extends CardBase {
     return matchWorkspaceArray;
   }
 
-  /**
-   * Finds the oldest Workspace card with OWNER role.
-   * @param level
-   */
-  async getOldestWorkspace(level: WorkspaceAccessLevel = WorkspaceAccessLevel.Owner): Promise<WorkspaceCard> {
-    const workspaceArray = await this.getWorkspaceMatchAccessLevel(WorkspaceAccessLevel.Owner);
-    for (const card of allWorkspaceCards) {
-      const cardDateTime = await this.getDateTime();
-      const oldest = creationDate.reduce((c, n) =>
-         Date.parse(n) < Date.parse(c) ? n : c
-      );
-    }
-  }
-
   async getDateTime(): Promise<string> {
     const [element] = await this.cardElement.$x(WorkspaceCardSelector.dateTimeXpath);
     const wholeText = await getPropValue<string>(element, 'innerText');
     // datetime format is "Last Changed: 01/08/21, 05:22 PM"
     const timeText = wholeText.replace('Last Changed: ', '').trim();
-    console.log(timeText);
     return timeText;
   }
 

--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -79,9 +79,9 @@ export default class WorkspaceAboutPage extends WorkspaceBase {
   // if the collaborator is already on this workspace, just remove them before continuing.
   async removeCollab(): Promise<void> {  
     const accessLevel = await this.findUserInCollaboratorList(config.collaboratorUsername);
-  if (accessLevel !== null) {
-    await (await (this.openShareModal())).removeUser(config.collaboratorUsername);
-    await waitWhileLoading(page);
+    if (accessLevel !== null) {
+      await (await (this.openShareModal())).removeUser(config.collaboratorUsername);
+      await waitWhileLoading(this.page);
     }
   }
 

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -144,7 +144,7 @@ export default class WorkspaceDataPage extends WorkspaceBase {
   async verifyWorkspaceNameOnDataPage(workspaceName: string): Promise<void> {
     await this.waitForLoad();
 
-    const workspaceLink = new Link(page, `//a[text()='${workspaceName}']`);
+    const workspaceLink = new Link(this.page, `//a[text()='${workspaceName}']`);
     await workspaceLink.waitForXPath({visible: true});
     expect(await workspaceLink.isVisible()).toBe(true);
   }

--- a/e2e/tests/home/home-page.spec.ts
+++ b/e2e/tests/home/home-page.spec.ts
@@ -1,5 +1,7 @@
+import BaseElement from 'app/element/base-element';
+import HomePage from 'app/page/home-page';
 import WorkspaceCard from 'app/component/workspace-card';
-import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
+import {signIn} from 'utils/test-utils';
 
 describe('Home page ui tests', () => {
 
@@ -8,9 +10,56 @@ describe('Home page ui tests', () => {
   });
 
   test('Check visibility of Workspace cards', async () => {
-   await WorkspaceCard.getAllCardDetails(page);
-    const workspaceCard = await findOrCreateWorkspace(page);
-    console.log(`oldest workspace card found is: ${await workspaceCard.getWorkspaceName()}`);
+
+    await checkCreateNewWorkspaceLink();
+
+    const allCards = await WorkspaceCard.findAllCards(page);
+    let width;
+    let height;
+    for (const card of allCards) {
+      const cardElem = BaseElement.asBaseElement(page, card.asElementHandle());
+      expect(await cardElem.isVisible()).toBe(true);
+      const size = await cardElem.getSize();
+      expect(size).toBeTruthy();
+      expect(size.height).toBeGreaterThan(1);
+      expect(size.width).toBeGreaterThan(1);
+
+      if (width === undefined || height === undefined) {
+        width = size.width; // Initialize width and height with first card element's size, compare with rest cards
+        height = size.height;
+      } else {
+        expect(size.height).toEqual(height);
+        expect(size.width).toEqual(width);
+      }
+
+      // check workspace name has characters
+      const cardName = await card.getWorkspaceName();
+      await expect(cardName).toMatch(new RegExp(/^[a-zA-Z]+/));
+
+      // check Workspace Action menu for listed actions
+      const snowmanMenu = await card.getSnowmanMenu();
+      // Assumption: test user is workspace Owner.
+      // Check Workspace Actions snowman menu displayes the right set of options.
+      const links = await snowmanMenu.getAllOptionTexts();
+      expect(links).toEqual(expect.arrayContaining(['Share', 'Edit', 'Duplicate', 'Delete']));
+    }
   });
 
 });
+
+async function checkCreateNewWorkspaceLink(): Promise<void> {
+  const homePage = new HomePage(page);
+  const plusIcon = await homePage.getCreateNewWorkspaceLink();
+  expect(plusIcon).toBeTruthy();
+  const classname = await plusIcon.getProperty<string>('className');
+  expect(classname).toBe('is-solid');
+  const shape = await plusIcon.getAttribute('shape');
+  expect(shape).toBe('plus-circle');
+  const hasShape = await plusIcon.hasAttribute('shape');
+  expect(hasShape).toBe(true);
+  const disabled = await plusIcon.isDisabled();
+  expect(disabled).toBe(false);
+  const cursor = await plusIcon.getComputedStyle('cursor');
+  expect(cursor).toBe('pointer');
+  expect(await plusIcon.isVisible()).toBe(true);
+}

--- a/e2e/tests/home/home-page.spec.ts
+++ b/e2e/tests/home/home-page.spec.ts
@@ -1,5 +1,5 @@
 import WorkspaceCard from 'app/component/workspace-card';
-import {signIn} from 'utils/test-utils';
+import {findOrCreateWorkspace, signIn} from 'utils/test-utils';
 
 describe('Home page ui tests', () => {
 
@@ -8,10 +8,9 @@ describe('Home page ui tests', () => {
   });
 
   test('Check visibility of Workspace cards', async () => {
-    const allCards = await WorkspaceCard.findAllCards(page);
-    for (const card of allCards) {
-      await card.getDateTime();
-    }
+   await WorkspaceCard.getAllCardDetails(page);
+    const workspaceCard = await findOrCreateWorkspace(page);
+    console.log(`oldest workspace card found is: ${await workspaceCard.getWorkspaceName()}`);
   });
 
 });

--- a/e2e/tests/home/home-page.spec.ts
+++ b/e2e/tests/home/home-page.spec.ts
@@ -1,5 +1,3 @@
-import BaseElement from 'app/element/base-element';
-import HomePage from 'app/page/home-page';
 import WorkspaceCard from 'app/component/workspace-card';
 import {signIn} from 'utils/test-utils';
 
@@ -10,56 +8,10 @@ describe('Home page ui tests', () => {
   });
 
   test('Check visibility of Workspace cards', async () => {
-
-    await checkCreateNewWorkspaceLink();
-
     const allCards = await WorkspaceCard.findAllCards(page);
-    let width;
-    let height;
     for (const card of allCards) {
-      const cardElem = BaseElement.asBaseElement(page, card.asElementHandle());
-      expect(await cardElem.isVisible()).toBe(true);
-      const size = await cardElem.getSize();
-      expect(size).toBeTruthy();
-      expect(size.height).toBeGreaterThan(1);
-      expect(size.width).toBeGreaterThan(1);
-
-      if (width === undefined || height === undefined) {
-        width = size.width; // Initialize width and height with first card element's size, compare with rest cards
-        height = size.height;
-      } else {
-        expect(size.height).toEqual(height);
-        expect(size.width).toEqual(width);
-      }
-
-      // check workspace name has characters
-      const cardName = await card.getWorkspaceName();
-      await expect(cardName).toMatch(new RegExp(/^[a-zA-Z]+/));
-
-      // check Workspace Action menu for listed actions
-      const snowmanMenu = await card.getSnowmanMenu();
-      // Assumption: test user is workspace Owner.
-      // Check Workspace Actions snowman menu displayes the right set of options.
-      const links = await snowmanMenu.getAllOptionTexts();
-      expect(links).toEqual(expect.arrayContaining(['Share', 'Edit', 'Duplicate', 'Delete']));
+      await card.getDateTime();
     }
   });
 
 });
-
-async function checkCreateNewWorkspaceLink(): Promise<void> {
-  const homePage = new HomePage(page);
-  const plusIcon = await homePage.getCreateNewWorkspaceLink();
-  expect(plusIcon).toBeTruthy();
-  const classname = await plusIcon.getProperty<string>('className');
-  expect(classname).toBe('is-solid');
-  const shape = await plusIcon.getAttribute('shape');
-  expect(shape).toBe('plus-circle');
-  const hasShape = await plusIcon.hasAttribute('shape');
-  expect(hasShape).toBe(true);
-  const disabled = await plusIcon.isDisabled();
-  expect(disabled).toBe(false);
-  const cursor = await plusIcon.getComputedStyle('cursor');
-  expect(cursor).toBe('pointer');
-  expect(await plusIcon.isVisible()).toBe(true);
-}

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -190,7 +190,7 @@ export async function createWorkspace(page: Page, cdrVersionName: string = confi
 }
 
 /**
- * Find a suitable existing workspace which is older than 30 minutes, or create one if workspace does not exist.
+ * Find a suitable existing workspace older than 30 minutes, or create one if workspace does not exist.
  *
  * TODO: this function does a lot of different things.  refactor and split up according to use cases.
  *

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -237,6 +237,9 @@ export async function findOrCreateWorkspace(page: Page, opts: {alwaysCreate?: bo
   }
 
   // Returns one random selected Workspace card.
+
+  const res = existingWorkspaces.filter(workspaceCard => )
+
   const oneWorkspaceCard = fp.shuffle(existingWorkspaces)[0];
   const workspaceCardName = await oneWorkspaceCard.getWorkspaceName();
   console.log(`Found workspace "${workspaceCardName}"`);

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -230,17 +230,17 @@ export async function findOrCreateWorkspace(page: Page, opts: {alwaysCreate?: bo
   // Filter to include Workspaces older than 30 minutes
   const halfHourMillisec = 1000 * 60 * 30;
   const now = Date.now();
-  const filtered = [];
+  const olderWorkspaceCards = [];
   for (const card of existingCards) {
     const workspaceTime = Date.parse(await card.getLastChangedTime());
     const timeDiff = now - workspaceTime;
     if (timeDiff > halfHourMillisec) {
-      filtered.push(card);
+      olderWorkspaceCards.push(card);
     }
   }
 
   // Create new workspace if existing workspace is zero or alwayCreate is true
-  if (alwaysCreate || filtered.length === 0) {
+  if (alwaysCreate || olderWorkspaceCards.length === 0) {
     const name = workspaceName || makeWorkspaceName();
     await workspacesPage.createWorkspace(name);
     console.log(`Created workspace "${name}"`);
@@ -249,7 +249,7 @@ export async function findOrCreateWorkspace(page: Page, opts: {alwaysCreate?: bo
   }
 
   // Return one random Workspace card
-  const randomCard = fp.shuffle(filtered).pop();
+  const randomCard = fp.shuffle(olderWorkspaceCards).pop();
   const cardName = await randomCard.getWorkspaceName();
   const lastChangedTime = await randomCard.getLastChangedTime();
   console.log(`Found workspace "${cardName}". Last changed on ${lastChangedTime}`);

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -227,11 +227,11 @@ export async function findOrCreateWorkspace(page: Page, opts: {alwaysCreate?: bo
   // Find all workspaces with OWNER role
   const existingCards = await WorkspaceCard.findAllCards(page, WorkspaceAccessLevel.Owner);
 
-  // Filter out Workspaces that are younger than 30 minutes
+  // Filter to include Workspaces older than 30 minutes
   const halfHourMillisec = 1000 * 60 * 30;
+  const now = Date.now();
   const filtered = [];
   for (const card of existingCards) {
-    const now = Date.now();
     const workspaceTime = Date.parse(await card.getLastChangedTime());
     const timeDiff = now - workspaceTime;
     if (timeDiff > halfHourMillisec) {

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -237,9 +237,9 @@ export async function findOrCreateWorkspace(page: Page, opts: {alwaysCreate?: bo
 
   // Return one oldest Workspace
   existingWorkspaces.sort((c1, c2) => Date.parse(c1.time) - Date.parse(c2.time));
-  const oldestWorkspace = existingWorkspaces[0]; // oldest workspace
+  const oldestWorkspace: WorkspaceCard = existingWorkspaces[0]; // oldest workspace
   const workspaceCardName = await oldestWorkspace.getWorkspaceName();
-  console.log(`Found workspace "${workspaceCardName}"`);
+  console.log(`Found workspace "${workspaceCardName}". Last changed on ${await oldestWorkspace.getDateTime()}`);
   return oldestWorkspace;
 }
 

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -248,7 +248,7 @@ export async function findOrCreateWorkspace(page: Page, opts: {alwaysCreate?: bo
     return workspaceCard.findCard(name);
   }
 
-  // Return one random selected Workspace card
+  // Return one random Workspace card
   const randomWorkspaceCard = fp.shuffle(filtered).pop();
   const workspaceCardName = await randomWorkspaceCard.getWorkspaceName();
   const lastChangedTime = await randomWorkspaceCard.getLastChangedTime();

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -249,11 +249,11 @@ export async function findOrCreateWorkspace(page: Page, opts: {alwaysCreate?: bo
   }
 
   // Return one random Workspace card
-  const randomWorkspaceCard = fp.shuffle(filtered).pop();
-  const workspaceCardName = await randomWorkspaceCard.getWorkspaceName();
-  const lastChangedTime = await randomWorkspaceCard.getLastChangedTime();
-  console.log(`Found workspace "${workspaceCardName}". Last changed on ${lastChangedTime}`);
-  return randomWorkspaceCard;
+  const randomCard = fp.shuffle(filtered).pop();
+  const cardName = await randomCard.getWorkspaceName();
+  const lastChangedTime = await randomCard.getLastChangedTime();
+  console.log(`Found workspace "${cardName}". Last changed on ${lastChangedTime}`);
+  return randomCard;
 }
 
 export async function centerPoint(element: ElementHandle): Promise<[number, number]> {

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -237,8 +237,6 @@ export async function findOrCreateWorkspace(page: Page, opts: {alwaysCreate?: bo
 
   // Return one oldest Workspace
   existingWorkspaces.sort((c1, c2) => Date.parse(c1.time) - Date.parse(c2.time));
-  console.log(existingWorkspaces);
-
   const oldestWorkspace = existingWorkspaces[0]; // oldest workspace
   const workspaceCardName = await oldestWorkspace.getWorkspaceName();
   console.log(`Found workspace "${workspaceCardName}"`);


### PR DESCRIPTION
Fix test failures caused by data concurrency problem. happens when same workspace is used by more than one tests running concurrently.

`findOrCreateWorkspace` function returns workspaces older than 30 minutes or create new if none found.