### PR TITLE
[RW-6119][risk=no] Remove duplicate BQ sql from CS and DS

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
@@ -82,7 +82,7 @@ public class ConceptBigQueryServiceTest extends BigQueryBaseTest {
                     dbConceptSetConceptId2,
                     dbConceptSetConceptId3,
                     dbConceptSetConceptId4)))
-        .isEqualTo(0);
+        .isEqualTo(1);
   }
 
   @Test
@@ -118,11 +118,11 @@ public class ConceptBigQueryServiceTest extends BigQueryBaseTest {
 
   @Override
   public List<String> getTableNames() {
-    return ImmutableList.of("condition_occurrence", "cb_criteria");
+    return ImmutableList.of("condition_occurrence", "cb_criteria", "cb_search_all_events");
   }
 
   @Override
   public String getTestDataDirectory() {
-    return MATERIALIZED_DATA;
+    return CB_DATA;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
@@ -54,29 +54,28 @@ public class ConceptBigQueryService {
         partitionSourceAndStandard.get(false).stream()
             .map(DbConceptSetConceptId::getConceptId)
             .collect(Collectors.toList());
-    StringBuilder innerSql = new StringBuilder("select count(distinct person_id) person_count\n");
-    innerSql.append("from ");
-    innerSql.append(String.format("`${projectId}.${dataSetId}.%s`", omopTable));
-    innerSql.append(" where ");
+    StringBuilder innerSql = new StringBuilder();
     ImmutableMap.Builder<String, QueryParameterValue> paramMap = ImmutableMap.builder();
     if (!standardList.isEmpty()) {
-      innerSql.append(conceptColumns.getStandardConceptColumn().name);
+      innerSql.append("select person_id\n");
+      innerSql.append("from `${projectId}.${dataSetId}.cb_search_all_events`\n");
+      innerSql.append("where is_standard = 1 and concept_id in ");
       generateParentChildLookupSql(
           innerSql, domain, "standardConceptIds", 1, standardList, paramMap);
+      innerSql.append("\n");
       if (!sourceList.isEmpty()) {
-        innerSql.append(" or ");
+        innerSql.append(" union all\n");
       }
     }
     if (!sourceList.isEmpty()) {
-      if (Domain.SURVEY.equals(domain)) {
-        innerSql.append("observation_source_concept_id");
-      } else {
-        innerSql.append(conceptColumns.getSourceConceptColumn().name);
-      }
+      innerSql.append("select person_id\n");
+      innerSql.append("from `${projectId}.${dataSetId}.cb_search_all_events`\n");
+      innerSql.append("where is_standard = 0 and concept_id in ");
       generateParentChildLookupSql(innerSql, domain, "sourceConceptIds", 0, sourceList, paramMap);
     }
+    String finalSql = "select count(distinct person_id) person_count from (\n" + innerSql + ")";
     QueryJobConfiguration jobConfiguration =
-        QueryJobConfiguration.newBuilder(innerSql.toString())
+        QueryJobConfiguration.newBuilder(finalSql.toString())
             .setNamedParameters(paramMap.build())
             .setUseLegacySql(false)
             .build();
@@ -96,14 +95,13 @@ public class ConceptBigQueryService {
       String domainParam = (standardOrSource == 1 ? "standardDomain" : "sourceDomain");
       String standardParam = (standardOrSource == 1 ? "standard" : "source");
       sqlBuilder.append(
-          " in "
-              + String.format(
-                  Domain.DRUG.equals(domain) ? DRUG_CHILD_LOOKUP_SQL : CHILD_LOOKUP_SQL,
-                  "@" + domainParam,
-                  "@" + standardParam,
-                  "@" + conceptIdsParam,
-                  "@" + domainParam,
-                  "@" + standardParam));
+          String.format(
+              Domain.DRUG.equals(domain) ? DRUG_CHILD_LOOKUP_SQL : CHILD_LOOKUP_SQL,
+              "@" + domainParam,
+              "@" + standardParam,
+              "@" + conceptIdsParam,
+              "@" + domainParam,
+              "@" + standardParam));
       paramMap.put(
           conceptIdsParam, QueryParameterValue.array(conceptIds.toArray(new Long[0]), Long.class));
       paramMap.put(domainParam, QueryParameterValue.string(domain.toString()));

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
@@ -44,8 +44,6 @@ public final class SearchGroupItemQueryBuilder {
 
   private static final int STANDARD = 1;
   private static final int SOURCE = 0;
-  private static final int GROUP = 1;
-  private static final int NOT_GROUP = 0;
 
   private static final ImmutableMap<AttrName, String> AGE_COLUMN_SQL_MAP =
       ImmutableMap.of(

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
@@ -72,41 +72,49 @@ public final class SearchGroupItemQueryBuilder {
       "select distinct person_id, entry_date, concept_id\n"
           + "from `${projectId}.${dataSetId}.cb_search_all_events`\n"
           + "where ";
+  private static final String STANDARD_SQL = "is_standard = %s";
+  private static final String CONCEPT_ID_UNNEST_SQL = "concept_id in unnest(%s)";
+  private static final String CONCEPT_ID_IN_SQL = "concept_id in";
   private static final String STANDARD_OR_SOURCE_SQL =
-      "is_standard = %s and concept_id in unnest(%s)\n";
-  private static final String PARENT_STANDARD_OR_SOURCE_SQL =
-      "is_standard = %s and concept_id in (select distinct c.concept_id\n"
+      STANDARD_SQL + AND + CONCEPT_ID_UNNEST_SQL + "\n";
+  public static final String CHILD_LOOKUP_SQL =
+      " (select distinct c.concept_id\n"
           + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
-          + "join (${childLookup}) a\n"
-          + "on (c.path like concat('%%.', a.id, '.%%') or c.path like concat('%%.', a.id) or c.path like concat(a.id, '.%%'))\n"
-          + "where domain_id = %s\n"
-          + "and is_standard = %s\n"
-          + "and is_selectable = 1)\n";
-  private static final String DRUG_SQL =
-      "is_standard = %s and concept_id in (select distinct ca.descendant_id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria_ancestor` ca\n"
-          + "join (select distinct c.concept_id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
-          + "join (${childLookup}) a\n"
-          + "on (c.path like concat('%%.', a.id, '.%%') or c.path like concat('%%.', a.id))\n"
-          + "where domain_id = %s\n"
-          + "and is_standard = %s\n"
-          + "and is_selectable = 1) b on (ca.ancestor_id = b.concept_id))";
-  private static final String CHILD_LOOKUP =
-      "select cast(cr.id as string) as id\n"
+          + "join (select cast(cr.id as string) as id\n"
           + "from `${projectId}.${dataSetId}.cb_criteria` cr\n"
           + "where domain_id = %s\n"
           + "and is_standard = %s\n"
           + "and concept_id in unnest(%s)\n"
-          + "and is_selectable = 1\n";
+          + "and is_selectable = 1) a\n"
+          + "on (c.path like concat('%%.', a.id, '.%%') or c.path like concat('%%.', a.id) or c.path like concat(a.id, '.%%'))\n"
+          + "where domain_id = %s\n"
+          + "and is_standard = %s\n"
+          + "and is_selectable = 1)";
+  public static final String DRUG_CHILD_LOOKUP_SQL =
+      " (select distinct ca.descendant_id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria_ancestor` ca\n"
+          + "join (select distinct c.concept_id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
+          + "join (select cast(cr.id as string) as id\n"
+          + "from `${projectId}.${dataSetId}.cb_criteria` cr\n"
+          + "where domain_id = %s\n"
+          + "and is_standard = %s\n"
+          + "and concept_id in unnest(%s)\n"
+          + "and is_selectable = 1) a\n"
+          + "on (c.path like concat('%%.', a.id, '.%%') or c.path like concat('%%.', a.id))\n"
+          + "where domain_id = %s\n"
+          + "and is_standard = %s\n"
+          + "and is_selectable = 1) b on (ca.ancestor_id = b.concept_id))";
+  private static final String PARENT_STANDARD_OR_SOURCE_SQL =
+      STANDARD_SQL + AND + CONCEPT_ID_IN_SQL + CHILD_LOOKUP_SQL;
+  private static final String DRUG_SQL =
+      STANDARD_SQL + AND + CONCEPT_ID_IN_SQL + DRUG_CHILD_LOOKUP_SQL;
   private static final String VALUE_AS_NUMBER = " value_as_number %s %s";
   private static final String VALUE_AS_NUMBER_IS_NOT_NULL = " and value_as_number is not null";
   private static final String VALUE_AS_CONCEPT_ID = " value_as_concept_id %s unnest(%s)";
   private static final String VALUE_SOURCE_CONCEPT_ID = " value_source_concept_id %s unnest(%s)";
   private static final String SOURCE_CONCEPT_SURVEY_ID =
       " and survey_version_concept_id %s unnest(%s)";
-  private static final String STANDARD_CONCEPT_SQL =
-      "is_standard = %s and concept_id in unnest(%s)";
   private static final String SYSTOLIC_SQL = " and systolic %s %s";
   private static final String DIASTOLIC_SQL = " and diastolic %s %s";
 
@@ -460,7 +468,7 @@ public final class SearchGroupItemQueryBuilder {
                     : conceptIds.toArray(new Long[0]),
                 Long.class));
     StringBuilder sqlBuilder =
-        new StringBuilder(String.format(STANDARD_CONCEPT_SQL, standardParam, conceptIdParam));
+        new StringBuilder(String.format(STANDARD_OR_SOURCE_SQL, standardParam, conceptIdParam));
     if (!nums.isEmpty()) {
       if (!conceptIds.isEmpty()) {
         // attribute.conceptId is unique to blood pressure attributes
@@ -658,17 +666,20 @@ public final class SearchGroupItemQueryBuilder {
         String domainParam =
             QueryParameterUtil.addQueryParameterValue(
                 queryParams, QueryParameterValue.string(domain));
+        String conceptIdsParam =
+            QueryParameterUtil.addQueryParameterValue(
+                queryParams,
+                QueryParameterValue.array(conceptIds.toArray(new Long[0]), Long.class));
         // Lookup child nodes
-        String lookupSql =
+        queryParts.add(
             String.format(
                 Domain.DRUG.toString().equals(domain) ? DRUG_SQL : PARENT_STANDARD_OR_SOURCE_SQL,
                 standardOrSourceParam,
                 domainParam,
-                standardOrSourceParam);
-        queryParts.add(
-            lookupSql.replace(
-                "${childLookup}",
-                generateLookupSql(queryParams, conceptIds, domainParam, standardOrSourceParam)));
+                standardOrSourceParam,
+                conceptIdsParam,
+                domainParam,
+                standardOrSourceParam));
       } else {
         // Children only
         String conceptIdsParam =
@@ -679,17 +690,6 @@ public final class SearchGroupItemQueryBuilder {
             String.format(STANDARD_OR_SOURCE_SQL, standardOrSourceParam, conceptIdsParam));
       }
     }
-  }
-
-  private static String generateLookupSql(
-      Map<String, QueryParameterValue> queryParams,
-      List<Long> conceptIds,
-      String domainParam,
-      String standardOrSourceParam) {
-    String conceptIdsParam =
-        QueryParameterUtil.addQueryParameterValue(
-            queryParams, QueryParameterValue.array(conceptIds.toArray(new Long[0]), Long.class));
-    return String.format(CHILD_LOOKUP, domainParam, standardOrSourceParam, conceptIdsParam);
   }
 
   /** Helper method to return a modifier. */

--- a/api/src/main/java/org/pmiops/workbench/dataset/BigQueryDataSetTableInfo.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/BigQueryDataSetTableInfo.java
@@ -1,145 +1,68 @@
 package org.pmiops.workbench.dataset;
 
+import static org.pmiops.workbench.cohortbuilder.SearchGroupItemQueryBuilder.CHILD_LOOKUP_SQL;
+import static org.pmiops.workbench.cohortbuilder.SearchGroupItemQueryBuilder.DRUG_CHILD_LOOKUP_SQL;
+
 import org.pmiops.workbench.model.Domain;
 
 public enum BigQueryDataSetTableInfo {
   CONDITION(
       Domain.CONDITION,
       "ds_condition_occurrence",
-      " condition_concept_id in (select concept_id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
-          + "join (select cast(id as string)  as id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria`\n"
-          + "where concept_id in unnest(@standardConceptIds)\n"
-          + "and domain_id = 'CONDITION'\n"
-          + "and is_standard = 1) a\n"
-          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id))\n"
-          + "and domain_id = 'CONDITION'\n"
-          + "and is_standard = 1)\n ",
-      " condition_source_concept_id in (select concept_id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
-          + "join (select cast(id as string)  as id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria`\n"
-          + "where concept_id in unnest(@sourceConceptIds)\n"
-          + "and domain_id = 'CONDITION'\n"
-          + "and is_standard = 0) a\n"
-          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id))"
-          + "and domain_id = 'CONDITION'\n"
-          + "and is_standard = 0)",
-      " (condition_concept_id in unnest(@conceptIds) or condition_source_concept_id in unnest(@conceptIds))"),
+      " condition_concept_id in "
+          + String.format(
+              CHILD_LOOKUP_SQL, "'CONDITION'", 1, "@standardConceptIds", "'CONDITION'", 1),
+      " condition_source_concept_id in "
+          + String.format(
+              CHILD_LOOKUP_SQL, "'CONDITION'", 0, "@sourceConceptIds", "'CONDITION'", 0)),
   PROCEDURE(
       Domain.PROCEDURE,
       "ds_procedure_occurrence",
-      " procedure_concept_id in (select concept_id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
-          + "join (select cast(id as string)  as id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria`\n"
-          + "where concept_id in unnest(@standardConceptIds)\n"
-          + "and domain_id = 'PROCEDURE'\n"
-          + "and is_standard = 1) a\n"
-          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id))\n"
-          + "and domain_id = 'PROCEDURE'\n"
-          + "and is_standard = 1)\n ",
-      " procedure_source_concept_id in (select concept_id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
-          + "join (select cast(id as string)  as id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria`\n"
-          + "where concept_id in unnest(@sourceConceptIds)\n"
-          + "and domain_id = 'PROCEDURE'\n"
-          + "and is_standard = 0) a\n"
-          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id))\n"
-          + "and domain_id = 'PROCEDURE'\n"
-          + "and is_standard = 0)",
-      " (procedure_concept_id in unnest(@conceptIds) or procedure_source_concept_id in unnest(@conceptIds))"),
+      " procedure_concept_id in "
+          + String.format(
+              CHILD_LOOKUP_SQL, "'PROCEDURE'", 1, "@standardConceptIds", "'PROCEDURE'", 1),
+      " procedure_source_concept_id in "
+          + String.format(
+              CHILD_LOOKUP_SQL, "'PROCEDURE'", 0, "@sourceConceptIds", "'PROCEDURE'", 0)),
   DRUG(
       Domain.DRUG,
       "ds_drug_exposure",
-      " drug_concept_id in (select distinct ca.descendant_id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria_ancestor` ca\n"
-          + "join (select distinct c.concept_id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
-          + "join (select cast(cr.id as string) as id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria` cr\n"
-          + "where domain_id = 'DRUG'\n"
-          + "and concept_id in unnest(@standardConceptIds)\n"
-          + ") a\n"
-          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id))\n"
-          + "and domain_id = 'DRUG'\n"
-          + ") b on (ca.ancestor_id = b.concept_id))",
-      " drug_source_concept_id in (select distinct ca.descendant_id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria_ancestor` ca\n"
-          + "join (select distinct c.concept_id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
-          + "join (select cast(cr.id as string) as id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria` cr\n"
-          + "where domain_id = 'DRUG'\n"
-          + "and concept_id in unnest(@sourceConceptIds)\n"
-          + ") a\n"
-          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id))\n"
-          + "and domain_id = 'DRUG'\n"
-          + ") b on (ca.ancestor_id = b.concept_id))",
-      " (drug_concept_id in unnest(@conceptIds) or drug_source_concept_id in unnest(@conceptIds))"),
+      " drug_concept_id in "
+          + String.format(DRUG_CHILD_LOOKUP_SQL, "'DRUG'", 1, "@standardConceptIds", "'DRUG'", 1),
+      " drug_source_concept_id in "
+          + String.format(DRUG_CHILD_LOOKUP_SQL, "'DRUG'", 0, "@sourceConceptIds", "'DRUG'", 0)),
   MEASUREMENT(
       Domain.MEASUREMENT,
       "ds_measurement",
-      " measurement_concept_id in (select concept_id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
-          + "join (select cast(id as string)  as id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria`\n"
-          + "where concept_id in unnest(@standardConceptIds)\n"
-          + "and domain_id = 'MEASUREMENT'\n"
-          + "and is_standard = 1) a\n"
-          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id))\n"
-          + "and domain_id = 'MEASUREMENT'\n"
-          + "and is_standard = 1)",
-      " measurement_source_concept_id in (select concept_id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
-          + "join (select cast(id as string)  as id\n"
-          + "from `${projectId}.${dataSetId}.cb_criteria`\n"
-          + "where concept_id in unnest(@sourceConceptIds)\n"
-          + "and domain_id = 'MEASUREMENT'\n"
-          + "and is_standard = 0) a\n"
-          + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id))\n"
-          + "and domain_id = 'MEASUREMENT'\n"
-          + "and is_standard = 0)",
-      " (measurement_concept_id in unnest(@conceptIds) or measurement_source_concept_id in unnest(@conceptIds))"),
-  SURVEY(
-      Domain.SURVEY,
-      "ds_survey",
-      null,
-      " question_concept_id in unnest(@sourceConceptIds)",
-      " question_concept_id in unnest(@conceptIds)"),
-  PERSON(Domain.PERSON, "ds_person", null, null, null),
+      " measurement_concept_id in "
+          + String.format(
+              CHILD_LOOKUP_SQL, "'MEASUREMENT'", 1, "@standardConceptIds", "'MEASUREMENT'", 1),
+      " measurement_source_concept_id in "
+          + String.format(
+              CHILD_LOOKUP_SQL, "'MEASUREMENT'", 0, "@sourceConceptIds", "'MEASUREMENT'", 0)),
+  SURVEY(Domain.SURVEY, "ds_survey", null, " question_concept_id in unnest(@sourceConceptIds)"),
+  PERSON(Domain.PERSON, "ds_person", null, null),
   OBSERVATION(
       Domain.OBSERVATION,
       "ds_observation",
       " observation_concept_id in unnest(@standardConceptIds)",
-      " observation_source_concept_id in unnest(@sourceConceptIds)",
-      " (observation_concept_id in unnest(@conceptIds) or observation_source_concept_id in unnest(@conceptIds))"),
-  FITBIT_HEART_RATE_SUMMARY(
-      Domain.FITBIT_HEART_RATE_SUMMARY, "ds_heart_rate_summary", null, null, null),
-  FITBIT_HEART_RATE_LEVEL(
-      Domain.FITBIT_HEART_RATE_LEVEL, "ds_heart_rate_minute_level", null, null, null),
-  FITBIT_ACTIVITY(Domain.FITBIT_ACTIVITY, "ds_activity_summary", null, null, null),
-  FITBIT_INTRADAY_STEPS(Domain.FITBIT_INTRADAY_STEPS, "ds_steps_intraday", null, null, null);
+      " observation_source_concept_id in unnest(@sourceConceptIds)"),
+  FITBIT_HEART_RATE_SUMMARY(Domain.FITBIT_HEART_RATE_SUMMARY, "ds_heart_rate_summary", null, null),
+  FITBIT_HEART_RATE_LEVEL(Domain.FITBIT_HEART_RATE_LEVEL, "ds_heart_rate_minute_level", null, null),
+  FITBIT_ACTIVITY(Domain.FITBIT_ACTIVITY, "ds_activity_summary", null, null),
+  FITBIT_INTRADAY_STEPS(Domain.FITBIT_INTRADAY_STEPS, "ds_steps_intraday", null, null);
 
   private final Domain domain;
   private final String tableName;
   private final String standardConceptIdIn;
   private final String sourceConceptIdIn;
-  private final String conceptIdInOld;
 
   BigQueryDataSetTableInfo(
-      Domain domain,
-      String tableName,
-      String standardConceptIdIn,
-      String sourceConceptIdIn,
-      String conceptIdInOld) {
+      Domain domain, String tableName, String standardConceptIdIn, String sourceConceptIdIn) {
     this.domain = domain;
     this.tableName = tableName;
     this.standardConceptIdIn = standardConceptIdIn;
     this.sourceConceptIdIn = sourceConceptIdIn;
-    this.conceptIdInOld = conceptIdInOld;
   }
 
   public static String getTableName(Domain domain) {
@@ -155,15 +78,6 @@ public enum BigQueryDataSetTableInfo {
     for (BigQueryDataSetTableInfo info : values()) {
       if (info.domain.equals(domain)) {
         return standard ? info.standardConceptIdIn : info.sourceConceptIdIn;
-      }
-    }
-    return null;
-  }
-
-  public static String getConceptIdInOld(Domain domain) {
-    for (BigQueryDataSetTableInfo info : values()) {
-      if (info.domain.equals(domain)) {
-        return info.conceptIdInOld;
       }
     }
     return null;

--- a/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
@@ -328,17 +328,18 @@ public class DataSetServiceTest {
             domain1, ImmutableList.of(conceptSet1, conceptSet2));
     assertThat(listClauseMaybe.map(String::trim).orElse(""))
         .isEqualTo(
-            "( condition_concept_id in (select concept_id\n"
+            "( condition_concept_id in  (select distinct c.concept_id\n"
                 + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
-                + "join (select cast(id as string)  as id\n"
-                + "from `${projectId}.${dataSetId}.cb_criteria`\n"
-                + "where concept_id in (3, 2, 1, 6, 5, 4)\n"
-                + "and domain_id = 'CONDITION'\n"
-                + "and is_standard = 1) a\n"
-                + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id))\n"
-                + "and domain_id = 'CONDITION'\n"
-                + "and is_standard = 1)\n"
-                + " )");
+                + "join (select cast(cr.id as string) as id\n"
+                + "from `${projectId}.${dataSetId}.cb_criteria` cr\n"
+                + "where domain_id = 'CONDITION'\n"
+                + "and is_standard = 1\n"
+                + "and concept_id in (3, 2, 1, 6, 5, 4)\n"
+                + "and is_selectable = 1) a\n"
+                + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%'))\n"
+                + "where domain_id = 'CONDITION'\n"
+                + "and is_standard = 1\n"
+                + "and is_selectable = 1))");
   }
 
   @Test
@@ -351,17 +352,18 @@ public class DataSetServiceTest {
             Domain.CONDITION, ImmutableList.of(conceptSet1, conceptSet2));
     assertThat(listClauseMaybe.map(String::trim).orElse(""))
         .isEqualTo(
-            "( condition_concept_id in (select concept_id\n"
+            "( condition_concept_id in  (select distinct c.concept_id\n"
                 + "from `${projectId}.${dataSetId}.cb_criteria` c\n"
-                + "join (select cast(id as string)  as id\n"
-                + "from `${projectId}.${dataSetId}.cb_criteria`\n"
-                + "where concept_id in (3, 2, 1)\n"
-                + "and domain_id = 'CONDITION'\n"
-                + "and is_standard = 1) a\n"
-                + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id))\n"
-                + "and domain_id = 'CONDITION'\n"
-                + "and is_standard = 1)\n"
-                + " )");
+                + "join (select cast(cr.id as string) as id\n"
+                + "from `${projectId}.${dataSetId}.cb_criteria` cr\n"
+                + "where domain_id = 'CONDITION'\n"
+                + "and is_standard = 1\n"
+                + "and concept_id in (3, 2, 1)\n"
+                + "and is_selectable = 1) a\n"
+                + "on (c.path like concat('%.', a.id, '.%') or c.path like concat('%.', a.id) or c.path like concat(a.id, '.%'))\n"
+                + "where domain_id = 'CONDITION'\n"
+                + "and is_standard = 1\n"
+                + "and is_selectable = 1))");
   }
 
   @Test


### PR DESCRIPTION
This PR removes duplicate BQ sql from

1. SearchGroupItemQueryBuilder
2. ConceptBigQueryService
3. BigQueryDataSetTableInfo

and fixes test cases.