### PR TITLE
[RW-6061][risk=no] Revert "Puppeteer Disable flaky test runtime-status-update.spec"

### DIFF
--- a/e2e/tests/runtime/runtime-status-update.spec.ts
+++ b/e2e/tests/runtime/runtime-status-update.spec.ts
@@ -13,8 +13,7 @@ import NotebookPreviewPage from 'app/page/notebook-preview-page';
 // This one is going to take a long time.
 jest.setTimeout(60 * 30 * 1000);
 
-// Flaky tests. Disable tests now to allow time to address the issue.
-describe.skip('Updating runtime parameters', () => {
+describe('Updating runtime parameters', () => {
   beforeEach(async () => {
     await signIn(page);
     const workspaceCard = await createWorkspace(page, config.altCdrVersionName);


### PR DESCRIPTION
Reverts all-of-us/workbench#4417

Originally flakiness appears to have been caused by issues in the Leo dev environment, which now seem to have subsided. Will continue to monitor.