### PR TITLE
[RW-2674][risk=low] Code duplication between New Data Set and Export Data Set modals.

### DIFF
--- a/ui/src/app/pages/data/data-set/export-data-set.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-data-set.spec.tsx
@@ -1,0 +1,64 @@
+import {mount} from 'enzyme';
+import * as React from 'react';
+
+import {dataSetApi, registerApiClient} from 'app/services/swagger-fetch-clients';
+import {
+  DataSetApi,
+  DataSetRequest,
+  KernelTypeEnum,
+  PrePackagedConceptSetEnum,
+  WorkspacesApi} from 'generated/fetch';
+import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
+import {DataSetApiStub} from 'testing/stubs/data-set-api-stub';
+import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
+import {DataSetExportRequest} from 'generated/fetch';
+import {NewDataSetModal} from './new-dataset-modal';
+import GenomicsAnalysisToolEnum = DataSetExportRequest.GenomicsAnalysisToolEnum;
+import GenomicsDataTypeEnum = DataSetExportRequest.GenomicsDataTypeEnum;
+import {ExportDataSet} from "./export-data-set";
+
+const prePackagedConceptSet = Array.of(PrePackagedConceptSetEnum.NONE);
+const workspaceNamespace = 'workspaceNamespace';
+const workspaceId = 'workspaceId';
+
+let dataSet;
+
+const createExportDataSetModal = () => {
+  return <ExportDataSet newNotebook={()=>{}}
+                        updateNotebookName={()=>{}}
+                        workspaceNamespace={workspaceNamespace}
+                        workspaceFirecloudName={workspaceId}
+                        dataSetRequest={dataSet}
+  />;
+};
+
+describe('ExportDataSet', () => {
+  beforeEach(() => {
+    window.open = jest.fn();
+    dataSet = undefined;
+    registerApiClient(WorkspacesApi, new WorkspacesApiStub());
+    registerApiClient(DataSetApi, new DataSetApiStub());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render', () => {
+    const wrapper = mount(createExportDataSetModal());
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('should only display code when button pressed', async() => {
+    const wrapper = mount(createExportDataSetModal());
+    expect(wrapper.find('[data-test-id="code-text-box"]').exists()).toBeFalsy();
+    await waitOneTickAndUpdate(wrapper);
+    expect(wrapper.find('[data-test-id="code-preview-button"]')
+        .first().text()).toEqual('See Code Preview');
+    wrapper.find('[data-test-id="code-preview-button"]').first().simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+    expect(wrapper.find('[data-test-id="code-preview-button"]')
+        .first().text()).toEqual('Hide Preview');
+  });
+
+});

--- a/ui/src/app/pages/data/data-set/export-data-set.tsx
+++ b/ui/src/app/pages/data/data-set/export-data-set.tsx
@@ -1,0 +1,178 @@
+import {Button, TabButton} from 'app/components/buttons';
+import {SmallHeader, styles as headerStyles} from 'app/components/headers';
+import {RadioButton, Select, TextArea, TextInput} from 'app/components/inputs';
+import {SpinnerOverlay} from 'app/components/spinners';
+import {dataSetApi, workspacesApi} from 'app/services/swagger-fetch-clients';
+import {AnalyticsTracker} from 'app/utils/analytics';
+import {
+  DataSetRequest,
+  FileDetail,
+  KernelTypeEnum
+} from 'generated/fetch';
+import * as React from 'react';
+
+interface Props {
+  dataSetRequest: DataSetRequest;
+  newNotebook: Function;
+  updateNotebookName: Function;
+  workspaceNamespace: string;
+  workspaceFirecloudName: string;
+}
+
+interface State {
+  existingNotebooks: FileDetail[];
+  kernelType: KernelTypeEnum;
+  loading: boolean;
+  newNotebook: boolean;
+  notebookName: string;
+  notebooksLoading: boolean;
+  previewedKernelType: KernelTypeEnum;
+  queries: Map<KernelTypeEnum, String>;
+  seePreview: boolean;
+}
+const styles = {
+  codePreviewSelector: {
+    display: 'flex',
+    marginTop: '1rem'
+  },
+  codePreviewSelectorTab: {
+    width: '2.6rem'
+  }
+};
+
+export class ExportDataSet extends React.Component<Props, State> {
+
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      existingNotebooks: [],
+      kernelType: KernelTypeEnum.Python,
+      loading: false,
+      newNotebook: true,
+      notebookName: '',
+      notebooksLoading: true,
+      previewedKernelType: KernelTypeEnum.Python,
+      queries: new Map([[KernelTypeEnum.Python, undefined], [KernelTypeEnum.R, undefined]]),
+      seePreview: false,
+    };
+  }
+
+  componentDidMount() {
+    this.loadNotebooks();
+    this.generateQuery();
+  }
+
+  private async loadNotebooks() {
+    try {
+      const {workspaceNamespace, workspaceFirecloudName} = this.props;
+      this.setState({notebooksLoading: true});
+      const existingNotebooks =
+          await workspacesApi().getNoteBookList(workspaceNamespace, workspaceFirecloudName);
+      this.setState({existingNotebooks});
+    } catch (error) {
+      console.error(error);
+    } finally {
+      this.setState({notebooksLoading: false});
+    }
+  }
+
+  async generateQuery() {
+    const {dataSetRequest, workspaceNamespace, workspaceFirecloudName} = this.props;
+    dataSetApi().generateCode(
+      workspaceNamespace,
+      workspaceFirecloudName,
+      KernelTypeEnum.Python.toString(),
+      dataSetRequest).then(pythonCode => {
+        this.setState(({queries}) => ({
+          queries: queries.set(KernelTypeEnum.Python, pythonCode.code)}));
+      });
+    dataSetApi().generateCode(
+      workspaceNamespace,
+      workspaceFirecloudName,
+      KernelTypeEnum.R.toString(),
+      dataSetRequest).then(rCode => {
+        this.setState(({queries}) => ({queries: queries.set(KernelTypeEnum.R, rCode.code)}));
+      });
+  }
+
+  setNotebookName(notebook) {
+    this.setState({notebookName: notebook});
+    this.props.newNotebook(true);
+    this.props.updateNotebookName(notebook);
+  }
+
+  setExistingNotebook(notebook) {
+    this.setState({newNotebook: notebook === ''});
+    this.setState({notebookName: notebook});
+    this.props.newNotebook(false);
+    this.props.updateNotebookName(notebook);
+  }
+
+  render() {
+    const {
+      existingNotebooks,
+      newNotebook,
+      notebookName,
+      notebooksLoading,
+      previewedKernelType,
+      queries,
+      seePreview
+    } = this.state;
+    const selectOptions = [{label: '(Create a new notebook)', value: ''}]
+        .concat(existingNotebooks.map(notebook => ({
+          value: notebook.name.slice(0, -6),
+          label: notebook.name.slice(0, -6)
+        })));
+    return <React.Fragment>{notebooksLoading && <SpinnerOverlay />}<Button style={{marginTop: '1rem'}} data-test-id='code-preview-button'
+            onClick={() => {
+              if (!seePreview) {
+                AnalyticsTracker.DatasetBuilder.SeeCodePreview();
+              }
+              this.setState({seePreview: !seePreview});
+            }}>
+      {seePreview ? 'Hide Preview' : 'See Code Preview'}
+    </Button>
+    {seePreview && <React.Fragment>
+      {Array.from(queries.values())
+        .filter(query => query !== undefined).length === 0 && <SpinnerOverlay />}
+      <div style={styles.codePreviewSelector}>
+        {Object.keys(KernelTypeEnum).map(kernelTypeEnumKey => KernelTypeEnum[kernelTypeEnumKey])
+          .map((kernelTypeEnum, i) =>
+                <TabButton onClick={() => this.setState({previewedKernelType: kernelTypeEnum})}
+                           key={i}
+                           active={previewedKernelType === kernelTypeEnum}
+                           style={styles.codePreviewSelectorTab}
+                           disabled={queries.get(kernelTypeEnum) === undefined}>
+                  {kernelTypeEnum}
+                </TabButton>)}
+      </div>
+      <TextArea disabled={true} onChange={() => {}}
+                data-test-id='code-text-box'
+                value={queries.get(previewedKernelType)} />
+    </React.Fragment>}
+    <div style={{marginTop: '1rem'}}>
+      <Select value={this.state.notebookName}
+              options={selectOptions}
+              onChange={v => this.setExistingNotebook(v)}/>
+    </div>
+    {newNotebook && <React.Fragment>
+      <SmallHeader style={{fontSize: 14, marginTop: '1rem'}}>Notebook Name</SmallHeader>
+      <TextInput onChange={(v) => this.setNotebookName(v)}
+                 value={notebookName} data-test-id='notebook-name-input'/>
+      <div style={headerStyles.formLabel}>
+        Programming Language:
+      </div>
+      {Object.keys(KernelTypeEnum).map(kernelTypeEnumKey => KernelTypeEnum[kernelTypeEnumKey])
+        .map((kernelTypeEnum, i) =>
+              <label key={i} style={{display: 'block'}}>
+                <RadioButton
+                    checked={this.state.kernelType === kernelTypeEnum}
+                    onChange={() => this.setState({kernelType: kernelTypeEnum})}
+                />
+                &nbsp;{kernelTypeEnum}
+              </label>
+          )}
+    </React.Fragment>}
+      </React.Fragment>;
+  }
+}

--- a/ui/src/app/pages/data/data-set/export-data-set.tsx
+++ b/ui/src/app/pages/data/data-set/export-data-set.tsx
@@ -105,7 +105,7 @@ export class ExportDataSet extends React.Component<Props, State> {
   setExistingNotebook(notebook) {
     this.setState({newNotebook: notebook === ''});
     this.setState({notebookName: notebook});
-    this.props.newNotebook(false);
+    this.props.newNotebook(notebook === '');
     this.props.updateNotebookName(notebook);
   }
 

--- a/ui/src/app/pages/data/data-set/export-data-set.tsx
+++ b/ui/src/app/pages/data/data-set/export-data-set.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 interface Props {
   dataSetRequest: DataSetRequest;
   newNotebook: Function;
+  notebookType?: Function;
   updateNotebookName: Function;
   workspaceNamespace: string;
   workspaceFirecloudName: string;
@@ -108,6 +109,11 @@ export class ExportDataSet extends React.Component<Props, State> {
     this.props.updateNotebookName(notebook);
   }
 
+  onKernelTypeChange(kernelType) {
+    this.setState({kernelType: kernelType});
+    this.props.notebookType(kernelType);
+  }
+
   render() {
     const {
       existingNotebooks,
@@ -166,8 +172,9 @@ export class ExportDataSet extends React.Component<Props, State> {
         .map((kernelTypeEnum, i) =>
               <label key={i} style={{display: 'block'}}>
                 <RadioButton
+                    data-test-id={'kernel-type-' + kernelTypeEnum.toLowerCase()}
                     checked={this.state.kernelType === kernelTypeEnum}
-                    onChange={() => this.setState({kernelType: kernelTypeEnum})}
+                    onChange={() => this.onKernelTypeChange(kernelTypeEnum)}
                 />
                 &nbsp;{kernelTypeEnum}
               </label>

--- a/ui/src/app/pages/data/data-set/new-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/new-dataset-modal.tsx
@@ -84,6 +84,12 @@ class NewDataSetModal extends React.Component<Props, State> {
     };
   }
 
+  componentDidMount() {
+    if (this.props.dataSet) {
+      this.setState({name: this.props.dataSet.name});
+    }
+  }
+
   async updateDataSet() {
     const {dataSet, workspaceNamespace, workspaceId} = this.props;
     const {name} = this.state;
@@ -240,6 +246,10 @@ class NewDataSetModal extends React.Component<Props, State> {
         </TooltipTrigger>
         <React.Fragment>  {exportToNotebook && <ExportDataSet
             dataSetRequest={this.getDataSetRequest()}
+            notebookType={(kernelTypeEnum) => this.setState({
+              kernelType: kernelTypeEnum,
+              includeRawMicroarrayData: kernelTypeEnum === KernelTypeEnum.R ? false : this.state.includeRawMicroarrayData
+            })}
             newNotebook={(v) => this.setState({newNotebook: v})}
             updateNotebookName={(v) => this.setState({notebookName: v})}
             workspaceNamespace={this.props.workspaceNamespace} workspaceFirecloudName={this.props.workspaceId}/>}

--- a/ui/src/app/pages/data/data-set/new-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/new-dataset-modal.tsx
@@ -1,14 +1,13 @@
 import {AlertDanger} from 'app/components/alert';
-import {Button, TabButton} from 'app/components/buttons';
-import {SmallHeader, styles as headerStyles} from 'app/components/headers';
-import {CheckBox, RadioButton, Select, TextArea, TextInput} from 'app/components/inputs';
+import {Button} from 'app/components/buttons';
+import {styles as headerStyles} from 'app/components/headers';
+import {CheckBox, RadioButton, TextInput} from 'app/components/inputs';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {TooltipTrigger} from 'app/components/popups';
-import {SpinnerOverlay} from 'app/components/spinners';
 import {TextColumn} from 'app/components/text-column';
 import {appendNotebookFileSuffix} from 'app/pages/analysis/util';
 
-import {dataSetApi, workspacesApi} from 'app/services/swagger-fetch-clients';
+import {dataSetApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {summarizeErrors} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
@@ -29,6 +28,7 @@ import * as React from 'react';
 import {validate} from 'validate.js';
 import GenomicsAnalysisToolEnum = DataSetExportRequest.GenomicsAnalysisToolEnum;
 import GenomicsDataTypeEnum = DataSetExportRequest.GenomicsDataTypeEnum;
+import {ExportDataSet} from './export-data-set';
 
 interface Props {
   closeFunction: Function;
@@ -62,16 +62,6 @@ interface State {
   genomicsAnalysisTool: GenomicsAnalysisToolEnum;
 }
 
-const styles = {
-  codePreviewSelector: {
-    display: 'flex',
-    marginTop: '1rem'
-  },
-  codePreviewSelectorTab: {
-    width: '2.6rem'
-  }
-};
-
 class NewDataSetModal extends React.Component<Props, State> {
   constructor(props) {
     super(props);
@@ -92,28 +82,6 @@ class NewDataSetModal extends React.Component<Props, State> {
       includeRawMicroarrayData: false,
       genomicsAnalysisTool: GenomicsAnalysisToolEnum.NONE
     };
-  }
-
-  componentDidMount() {
-    this.generateQuery();
-    this.loadNotebooks();
-  }
-
-  private async loadNotebooks() {
-    try {
-      const {workspaceNamespace, workspaceId} = this.props;
-      if (this.props.dataSet) {
-        this.setState({name: this.props.dataSet.name});
-      }
-      this.setState({notebooksLoading: true});
-      const existingNotebooks =
-        await workspacesApi().getNoteBookList(workspaceNamespace, workspaceId);
-      this.setState({existingNotebooks});
-    } catch (error) {
-      console.error(error);
-    } finally {
-      this.setState({notebooksLoading: false});
-    }
   }
 
   async updateDataSet() {
@@ -208,8 +176,7 @@ class NewDataSetModal extends React.Component<Props, State> {
     this.saveDataSet();
   }
 
-  async generateQuery() {
-    const {workspaceNamespace, workspaceId} = this.props;
+  getDataSetRequest() {
     const dataSetRequest: DataSetRequest = {
       name: 'dataSet',
       conceptSetIds: this.props.selectedConceptSetIds,
@@ -218,23 +185,8 @@ class NewDataSetModal extends React.Component<Props, State> {
       includesAllParticipants: this.props.includesAllParticipants,
       prePackagedConceptSet: this.props.prePackagedConceptSet
     };
-    dataSetApi().generateCode(
-      workspaceNamespace,
-      workspaceId,
-      KernelTypeEnum.Python.toString(),
-      dataSetRequest).then(pythonCode => {
-        this.setState(({queries}) => ({
-          queries: queries.set(KernelTypeEnum.Python, pythonCode.code)}));
-      });
-    dataSetApi().generateCode(
-      workspaceNamespace,
-      workspaceId,
-      KernelTypeEnum.R.toString(),
-      dataSetRequest).then(rCode => {
-        this.setState(({queries}) => ({queries: queries.set(KernelTypeEnum.R, rCode.code)}));
-      });
+    return dataSetRequest;
   }
-
   render() {
     const {
       conflictDataSetName,
@@ -244,18 +196,8 @@ class NewDataSetModal extends React.Component<Props, State> {
       name,
       newNotebook,
       notebookName,
-      notebooksLoading,
       existingNotebooks,
-      previewedKernelType,
-      queries,
-      seePreview
     } = this.state;
-
-    const selectOptions = [{label: '(Create a new notebook)', value: ''}]
-      .concat(existingNotebooks.map(notebook => ({
-        value: notebook.name.slice(0, -6),
-        label: notebook.name.slice(0, -6)
-      })));
 
     const errors = validate({name, notebookName}, {
       name: {
@@ -296,65 +238,11 @@ class NewDataSetModal extends React.Component<Props, State> {
               color: colors.primary}}>Export to notebook</div>
           </div>
         </TooltipTrigger>
-        {exportToNotebook && <React.Fragment>
-          {notebooksLoading && <SpinnerOverlay />}
-          <Button style={{marginTop: '1rem'}} data-test-id='code-preview-button'
-                  onClick={() => {
-                    if (!seePreview) {
-                      AnalyticsTracker.DatasetBuilder.SeeCodePreview();
-                    }
-                    this.setState({seePreview: !seePreview});
-                  }}>
-            {seePreview ? 'Hide Preview' : 'See Code Preview'}
-          </Button>
-          {seePreview && <React.Fragment>
-            {Array.from(queries.values())
-              .filter(query => query !== undefined).length === 0 && <SpinnerOverlay />}
-            <div style={styles.codePreviewSelector}>
-              {Object.keys(KernelTypeEnum)
-                .map(kernelTypeEnumKey => KernelTypeEnum[kernelTypeEnumKey])
-                .map((kernelTypeEnum, i) =>
-                  <TabButton onClick={() => this.setState({previewedKernelType: kernelTypeEnum})}
-                             key={i}
-                             active={previewedKernelType === kernelTypeEnum}
-                             style={styles.codePreviewSelectorTab}
-                             disabled={queries.get(kernelTypeEnum) === undefined}>
-                    {kernelTypeEnum}
-                  </TabButton>)}
-            </div>
-            <TextArea disabled={true} onChange={() => {}}
-                      data-test-id='code-text-box'
-                      value={queries.get(previewedKernelType)} />
-          </React.Fragment>}
-          <div style={{marginTop: '1rem'}}>
-            <Select value={this.state.notebookName}
-                    options={selectOptions}
-                    onChange={v => this.setState({notebookName: v, newNotebook: v === ''})}/>
-          </div>
-          {newNotebook && <React.Fragment>
-            <SmallHeader style={{fontSize: 14, marginTop: '1rem'}}>Notebook Name</SmallHeader>
-            <TextInput onChange={(v) => this.setState({notebookName: v})}
-                       value={notebookName} data-test-id='notebook-name-input'/>
-            <div style={headerStyles.formLabel}>
-              Programming Language:
-            </div>
-            {Object.keys(KernelTypeEnum).map(kernelTypeEnumKey => KernelTypeEnum[kernelTypeEnumKey])
-              .map((kernelTypeEnum, i) =>
-                <label key={i} style={{display: 'block'}}>
-                  <RadioButton
-                    data-test-id={'kernel-type-' + kernelTypeEnum.toLowerCase()}
-                    checked={this.state.kernelType === kernelTypeEnum}
-                    onChange={() => {
-                      this.setState({
-                        kernelType: kernelTypeEnum,
-                        includeRawMicroarrayData: kernelTypeEnum === KernelTypeEnum.R ? false : this.state.includeRawMicroarrayData
-                      });
-                    }}
-                  />
-                  &nbsp;{kernelTypeEnum}
-                </label>
-              )}
-          </React.Fragment>}
+        <React.Fragment>  {exportToNotebook && <ExportDataSet
+            dataSetRequest={this.getDataSetRequest()}
+            newNotebook={(v) => this.setState({newNotebook: v})}
+            updateNotebookName={(v) => this.setState({notebookName: v})}
+            workspaceNamespace={this.props.workspaceNamespace} workspaceFirecloudName={this.props.workspaceId}/>}
           {this.props.displayMicroarrayOptions && this.state.kernelType === KernelTypeEnum.Python &&
           <div style={{border: '1px solid grey', padding: '.5rem', paddingTop: 0, marginTop: '.5rem'}}>
             <TextColumn>
@@ -391,7 +279,7 @@ class NewDataSetModal extends React.Component<Props, State> {
               })}
             </div>}
           </div> }
-        </React.Fragment>}
+        </React.Fragment>
       </ModalBody>
       <ModalFooter>
         <Button type='secondary'


### PR DESCRIPTION
Extract the common (generate query and notebook selection) code from New Data set modal and export data set modal
---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
