### PR TITLE
[no ticket][risk=no] Puppeteer menu base abstract class

### DIFF
--- a/e2e/app/component/annotation-field-modal.ts
+++ b/e2e/app/component/annotation-field-modal.ts
@@ -65,7 +65,7 @@ export default class AnnotationFieldModal extends Modal {
   // create a Review-Wide Annotation Field name
   async createNewAnnotationName(newName?: string): Promise<void> {
     await this.beginCreateNewAnnotationName(newName);
-    await this.clickButton(LinkText.Create);
+    await this.clickButton(LinkText.Create, {waitForClose: true});
     await waitWhileLoading(this.page);
     console.log(`created annotation field: "${newName}"`);
   }

--- a/e2e/app/component/base-menu.ts
+++ b/e2e/app/component/base-menu.ts
@@ -35,7 +35,6 @@ export default abstract class BaseMenu extends Container {
       let rootXpath = this.getXpath();
       const len = selections.length;
       for (let i=0; i<len; i++) {
-         console.log(`rootXpath: ${rootXpath}`);
          const menuItemLink = await this.findMenuItemLink(selections[i], rootXpath);
          if (i === (len - 1)) {
             // If it is the last menu item, click on it.
@@ -80,7 +79,6 @@ export default abstract class BaseMenu extends Container {
    // Find and hover over menu item
    protected async findMenuItemLink(menuItemText: string, menuParentXpath: string): Promise<ElementHandle> {
       const menuItemSelector = `${menuParentXpath}${this.getMenuItemXpath(menuItemText)}`;
-      console.log(`menuitem selector: ${menuItemSelector}`);
       const link = await this.page.waitForXPath(menuItemSelector, {visible: true});
       await link.hover();
       await link.focus();

--- a/e2e/app/component/base-menu.ts
+++ b/e2e/app/component/base-menu.ts
@@ -1,6 +1,6 @@
 import {Page} from 'puppeteer';
 import Container from 'app/container';
-import {Option} from 'app/text-labels';
+import {MenuOption} from 'app/text-labels';
 import {waitWhileLoading} from 'utils/waits-utils';
 import {getPropValue} from 'utils/element-utils';
 import Link from 'app/element/link';
@@ -18,7 +18,7 @@ export default abstract class BaseMenu extends Container {
     * @param menuSelections
     * @param opt
     */
-   async select(menuSelections: Option | Option[], opt: { waitForNav?: boolean } = {}): Promise<void> {
+   async select(menuSelections: MenuOption | MenuOption[], opt: { waitForNav?: boolean } = {}): Promise<void> {
       const { waitForNav = false } = opt;
 
       let selections = [];

--- a/e2e/app/component/base-menu.ts
+++ b/e2e/app/component/base-menu.ts
@@ -1,0 +1,91 @@
+import Container from 'app/container';
+import {Option} from 'app/text-labels';
+import {ElementHandle, Page} from 'puppeteer';
+import {waitWhileLoading} from 'utils/waits-utils';
+import {getPropValue} from 'utils/element-utils';
+
+export default abstract class BaseMenu extends Container {
+
+   protected abstract getMenuItemXpath(menuItemText: string): string;
+
+   protected constructor(page: Page, xpath: string) {
+      super(page, xpath);
+   }
+
+   /**
+    * Select menuitems.
+    * @param menuSelections
+    * @param opt
+    */
+   async select(menuSelections: Option | Option[], opt: { waitForNavi?: boolean } = {}): Promise<void> {
+      const { waitForNavi = false } = opt;
+
+      let selections = [];
+      // Handle case when menuSelections is not array.
+      if (typeof menuSelections === 'string') {
+         selections.push(menuSelections);
+      } else {
+         selections = [...menuSelections];
+      }
+
+      // Wait for top-level menu dropdown open and has visible menu items.
+      await this.waitUntilVisible();
+
+      // Iterate orderly.
+      let rootXpath = this.getXpath();
+      const len = selections.length;
+      for (let i=0; i<len; i++) {
+         console.log(`rootXpath: ${rootXpath}`);
+         const menuItemLink = await this.findMenuItemLink(selections[i], rootXpath);
+         if (i === (len - 1)) {
+            // If it is the last menu item, click on it.
+            if (waitForNavi) {
+               await Promise.all([
+                  this.page.waitForNavigation({waitUntil: ['load', 'networkidle0']}),
+                  menuItemLink.click()
+               ]);
+            } else {
+               await menuItemLink.click();
+            }
+         }
+         rootXpath = `${rootXpath}/ul`; // submenu xpath
+      }
+
+      // Wait for menu close and disappear.
+      await waitWhileLoading(this.page);
+   }
+
+   /**
+    *  Get all menu items texts.
+    */
+   protected async getMenuItemTexts(selector: string): Promise<string[]> {
+      await this.page.waitForXPath(selector, {visible: true});
+      const menuItemLinks = await this.page.$x(selector);
+      const actionTextsArray = [];
+      for (const element of menuItemLinks) {
+         actionTextsArray.push(await getPropValue<string>(element, 'textContent'));
+      }
+      return actionTextsArray;
+   }
+
+   protected async isOpen(): Promise<boolean> {
+      try {
+         await this.page.waitForXPath(this.getXpath(), {visible: true, timeout: 2000});
+         return true;
+      } catch (err) {
+         return false;
+      }
+   }
+
+   // Find and hover over menu item
+   protected async findMenuItemLink(menuItemText: string, menuParentXpath: string): Promise<ElementHandle> {
+      const menuItemSelector = `${menuParentXpath}${this.getMenuItemXpath(menuItemText)}`;
+      console.log(`menuitem selector: ${menuItemSelector}`);
+      const link = await this.page.waitForXPath(menuItemSelector, {visible: true});
+      await link.hover();
+      await link.focus();
+      await this.page.waitForTimeout(500);
+      return link;
+   }
+
+}

--- a/e2e/app/component/base-menu.ts
+++ b/e2e/app/component/base-menu.ts
@@ -1,8 +1,9 @@
+import {Page} from 'puppeteer';
 import Container from 'app/container';
 import {Option} from 'app/text-labels';
-import {ElementHandle, Page} from 'puppeteer';
 import {waitWhileLoading} from 'utils/waits-utils';
 import {getPropValue} from 'utils/element-utils';
+import Link from 'app/element/link';
 
 export default abstract class BaseMenu extends Container {
 
@@ -77,13 +78,9 @@ export default abstract class BaseMenu extends Container {
    }
 
    // Find and hover over menu item
-   protected async findMenuItemLink(menuItemText: string, menuParentXpath: string): Promise<ElementHandle> {
+   protected async findMenuItemLink(menuItemText: string, menuParentXpath: string): Promise<Link> {
       const menuItemSelector = `${menuParentXpath}${this.getMenuItemXpath(menuItemText)}`;
-      const link = await this.page.waitForXPath(menuItemSelector, {visible: true});
-      await link.hover();
-      await link.focus();
-      await this.page.waitForTimeout(500);
-      return link;
+      return new Link(this.page, menuItemSelector);
    }
 
 }

--- a/e2e/app/component/base-menu.ts
+++ b/e2e/app/component/base-menu.ts
@@ -18,7 +18,7 @@ export default abstract class BaseMenu extends Container {
     * @param menuSelections
     * @param opt
     */
-   async select(menuSelections: MenuOption | MenuOption[], opt: { waitForNav?: boolean } = {}): Promise<void> {
+   async select(menuSelections: string | MenuOption | MenuOption[], opt: { waitForNav?: boolean } = {}): Promise<void> {
       const { waitForNav = false } = opt;
 
       let selections = [];

--- a/e2e/app/component/base-menu.ts
+++ b/e2e/app/component/base-menu.ts
@@ -80,7 +80,9 @@ export default abstract class BaseMenu extends Container {
    // Find and hover over menu item
    protected async findMenuItemLink(menuItemText: string, menuParentXpath: string): Promise<Link> {
       const menuItemSelector = `${menuParentXpath}${this.getMenuItemXpath(menuItemText)}`;
-      return new Link(this.page, menuItemSelector);
+      const link = new Link(this.page, menuItemSelector);
+      await link.focus();
+      return link;
    }
 
 }

--- a/e2e/app/component/base-menu.ts
+++ b/e2e/app/component/base-menu.ts
@@ -17,8 +17,8 @@ export default abstract class BaseMenu extends Container {
     * @param menuSelections
     * @param opt
     */
-   async select(menuSelections: Option | Option[], opt: { waitForNavi?: boolean } = {}): Promise<void> {
-      const { waitForNavi = false } = opt;
+   async select(menuSelections: Option | Option[], opt: { waitForNav?: boolean } = {}): Promise<void> {
+      const { waitForNav = false } = opt;
 
       let selections = [];
       // Handle case when menuSelections is not array.
@@ -38,7 +38,7 @@ export default abstract class BaseMenu extends Container {
          const menuItemLink = await this.findMenuItemLink(selections[i], rootXpath);
          if (i === (len - 1)) {
             // If it is the last menu item, click on it.
-            if (waitForNavi) {
+            if (waitForNav) {
                await Promise.all([
                   this.page.waitForNavigation({waitUntil: ['load', 'networkidle0']}),
                   menuItemLink.click()

--- a/e2e/app/component/base-menu.ts
+++ b/e2e/app/component/base-menu.ts
@@ -29,7 +29,7 @@ export default abstract class BaseMenu extends Container {
          selections = [...menuSelections];
       }
 
-      // Wait for top-level menu dropdown open and has visible menu items.
+      // Wait for top-level menu dropdown open.
       await this.waitUntilVisible();
 
       // Iterate orderly.
@@ -82,6 +82,7 @@ export default abstract class BaseMenu extends Container {
       const menuItemSelector = `${menuParentXpath}${this.getMenuItemXpath(menuItemText)}`;
       const link = new Link(this.page, menuItemSelector);
       await link.focus();
+      await this.page.waitForTimeout(200);
       return link;
    }
 

--- a/e2e/app/component/card-base.ts
+++ b/e2e/app/component/card-base.ts
@@ -28,7 +28,7 @@ export default abstract class CardBase extends Container {
     return new SnowmanMenu(this.page);
   }
 
-  async selectSnowmanMenu(options: MenuOption | MenuOption[], opt: { waitForNav?: boolean } = {}): Promise<void> {
+  async selectSnowmanMenu(options: MenuOption, opt: { waitForNav?: boolean } = {}): Promise<void> {
     return this.getSnowmanMenu().then(menu => menu.select(options, opt));
   }
 

--- a/e2e/app/component/card-base.ts
+++ b/e2e/app/component/card-base.ts
@@ -28,8 +28,8 @@ export default abstract class CardBase extends Container {
     return new SnowmanMenu(this.page);
   }
 
-  async selectSnowmanMenu(option: Option, opt: { waitForNav?: boolean } = {}): Promise<void> {
-    return this.getSnowmanMenu().then(menu => menu.select(option, opt));
+  async selectSnowmanMenu(options: Option | Option[], opt: { waitForNavi?: boolean } = {}): Promise<void> {
+    return this.getSnowmanMenu().then(menu => menu.select(options, opt));
   }
 
 

--- a/e2e/app/component/card-base.ts
+++ b/e2e/app/component/card-base.ts
@@ -28,7 +28,7 @@ export default abstract class CardBase extends Container {
     return new SnowmanMenu(this.page);
   }
 
-  async selectSnowmanMenu(options: Option | Option[], opt: { waitForNavi?: boolean } = {}): Promise<void> {
+  async selectSnowmanMenu(options: Option | Option[], opt: { waitForNav?: boolean } = {}): Promise<void> {
     return this.getSnowmanMenu().then(menu => menu.select(options, opt));
   }
 

--- a/e2e/app/component/card-base.ts
+++ b/e2e/app/component/card-base.ts
@@ -1,5 +1,5 @@
 import {ElementHandle, Page} from 'puppeteer';
-import {Option} from 'app/text-labels';
+import {MenuOption} from 'app/text-labels';
 import Container from 'app/container';
 import SnowmanMenu, {snowmanIconXpath} from './snowman-menu';
 
@@ -28,7 +28,7 @@ export default abstract class CardBase extends Container {
     return new SnowmanMenu(this.page);
   }
 
-  async selectSnowmanMenu(options: Option | Option[], opt: { waitForNav?: boolean } = {}): Promise<void> {
+  async selectSnowmanMenu(options: MenuOption | MenuOption[], opt: { waitForNav?: boolean } = {}): Promise<void> {
     return this.getSnowmanMenu().then(menu => menu.select(options, opt));
   }
 

--- a/e2e/app/component/help-sidebar.ts
+++ b/e2e/app/component/help-sidebar.ts
@@ -29,7 +29,7 @@ export default class HelpSidebar extends Container {
     await this.waitUntilSectionVisible(SectionSelectors.AttributesForm);
 
     const selectMenu = await SelectMenu.findByName(this.page, {ancestorLevel: 0}, this);
-    await selectMenu.clickMenuItem(filterSign);
+    await selectMenu.selectOption(filterSign);
 
     const numberField = await this.page.waitForXPath(`${this.xpath}//input[@type="number"]`, {visible: true});
     await numberField.type(String(filterValue));
@@ -59,7 +59,7 @@ export default class HelpSidebar extends Container {
     await this.waitUntilSectionVisible(SectionSelectors.ModifiersForm);
 
     const selectMenu = await SelectMenu.findByName(this.page, {name: 'Age At Event', ancestorLevel: 1}, this);
-    await selectMenu.clickMenuItem(filterSign);
+    await selectMenu.selectOption(filterSign);
     const numberField = await this.page.waitForXPath(`${this.xpath}//input[@type="number"]`, {visible: true});
     // Issue with Puppeteer type() function: typing value in this textbox doesn't always trigger change event. workaround is needed.
     // Error: "Sorry, the request cannot be completed. Please try again or contact Support in the left hand navigation."

--- a/e2e/app/component/help-sidebar.ts
+++ b/e2e/app/component/help-sidebar.ts
@@ -29,7 +29,7 @@ export default class HelpSidebar extends Container {
     await this.waitUntilSectionVisible(SectionSelectors.AttributesForm);
 
     const selectMenu = await SelectMenu.findByName(this.page, {ancestorLevel: 0}, this);
-    await selectMenu.selectOption(filterSign);
+    await selectMenu.select(filterSign);
 
     const numberField = await this.page.waitForXPath(`${this.xpath}//input[@type="number"]`, {visible: true});
     await numberField.type(String(filterValue));
@@ -59,7 +59,7 @@ export default class HelpSidebar extends Container {
     await this.waitUntilSectionVisible(SectionSelectors.ModifiersForm);
 
     const selectMenu = await SelectMenu.findByName(this.page, {name: 'Age At Event', ancestorLevel: 1}, this);
-    await selectMenu.selectOption(filterSign);
+    await selectMenu.select(filterSign);
     const numberField = await this.page.waitForXPath(`${this.xpath}//input[@type="number"]`, {visible: true});
     // Issue with Puppeteer type() function: typing value in this textbox doesn't always trigger change event. workaround is needed.
     // Error: "Sorry, the request cannot be completed. Please try again or contact Support in the left hand navigation."

--- a/e2e/app/component/modal.ts
+++ b/e2e/app/component/modal.ts
@@ -58,7 +58,7 @@ export default class Modal extends Container {
        fp.map(item => item.waitFn()),
        fp.concat([button.click()])
     )([
-      {shouldWait: waitForNav, waitFn: () => this.page.waitForNavigation({waitUntil: ['domcontentloaded', 'networkidle0']})},
+      {shouldWait: waitForNav, waitFn: () => this.page.waitForNavigation({waitUntil: ['load', 'networkidle0']})},
       {shouldWait: waitForClose, waitFn: () => this.waitUntilClose()}
     ]));
   }

--- a/e2e/app/component/modal.ts
+++ b/e2e/app/component/modal.ts
@@ -11,7 +11,7 @@ import * as fp from 'lodash/fp';
 import {waitWhileLoading} from 'utils/waits-utils';
 
 const Selector = {
-  defaultDialog: '//*[@role="dialog"]',
+  defaultDialog: '//*[@id="popup-root"]//*[@role="dialog" and contains(@class, "after-open")]',
 }
 
 export default class Modal extends Container {
@@ -49,8 +49,9 @@ export default class Modal extends Container {
    * @param {string} buttonLabel The button text label.
    * @param waitOptions Wait for navigation or/and modal close after click button.
    */
-  async clickButton(buttonLabel: LinkText, waitOptions: {waitForNav?: boolean, waitForClose?: boolean} = {}): Promise<void> {
-    const { waitForNav = false, waitForClose = false } = waitOptions;
+  async clickButton(buttonLabel: LinkText,
+                    waitOptions: {waitForNav?: boolean, waitForClose?: boolean, timeout?: number} = {}): Promise<void> {
+    const { waitForNav = false, waitForClose = false, timeout } = waitOptions;
     const button = await this.waitForButton(buttonLabel);
     await button.waitUntilEnabled();
     await Promise.all( fp.flow(
@@ -59,7 +60,7 @@ export default class Modal extends Container {
        fp.concat([button.click()])
     )([
       {shouldWait: waitForNav, waitFn: () => this.page.waitForNavigation({waitUntil: ['load', 'networkidle0']})},
-      {shouldWait: waitForClose, waitFn: () => this.waitUntilClose()}
+      {shouldWait: waitForClose, waitFn: () => this.waitUntilClose(timeout)}
     ]));
   }
 
@@ -79,8 +80,8 @@ export default class Modal extends Container {
     return Checkbox.findByName(this.page, {name: checkboxName}, this);
   }
 
-  async waitUntilClose(): Promise<void> {
-    await this.page.waitForXPath(this.xpath, {hidden: true, timeout: 60000});
+  async waitUntilClose(timeout: number = 60000): Promise<void> {
+    await this.page.waitForXPath(this.xpath, {hidden: true, timeout});
   }
 
   /**

--- a/e2e/app/component/runtime-panel.ts
+++ b/e2e/app/component/runtime-panel.ts
@@ -66,7 +66,7 @@ export default class RuntimePanel extends Container {
 
   async pickCpus(cpus: number): Promise<void> {
     const cpusDropdown = await SelectMenu.findByName(this.page, {id: 'runtime-cpu'});
-    return await cpusDropdown.selectOption(cpus.toString());
+    return await cpusDropdown.select(cpus.toString());
   }
 
   async getCpus(): Promise<string> {
@@ -76,7 +76,7 @@ export default class RuntimePanel extends Container {
 
   async pickRamGbs(ramGbs: number): Promise<void> {
     const ramDropdown = await SelectMenu.findByName(this.page, {id: 'runtime-ram'});
-    return await ramDropdown.selectOption(ramGbs.toString());
+    return await ramDropdown.select(ramGbs.toString());
   }
 
   async getRamGbs(): Promise<string> {
@@ -96,7 +96,7 @@ export default class RuntimePanel extends Container {
 
   async pickComputeType(computeType: ComputeType): Promise<void> {
     const computeTypeDropdown = await SelectMenu.findByName(this.page, {id: 'runtime-compute'});
-    return await computeTypeDropdown.selectOption(computeType);
+    return await computeTypeDropdown.select(computeType);
   }
 
   async pickDataprocNumWorkers(numWorkers: number): Promise<void> {
@@ -121,7 +121,7 @@ export default class RuntimePanel extends Container {
 
   async pickWorkerCpus(workerCpus: number): Promise<void> {
     const workerCpusDropdown = await SelectMenu.findByName(this.page, {id: 'worker-cpu'});
-    return await workerCpusDropdown.selectOption(workerCpus.toString());
+    return await workerCpusDropdown.select(workerCpus.toString());
   }
 
   async getWorkerCpus(): Promise<string> {
@@ -131,7 +131,7 @@ export default class RuntimePanel extends Container {
 
   async pickWorkerRamGbs(workerRamGbs: number): Promise<void> {
     const workerRamDropdown = await SelectMenu.findByName(this.page, {id: 'worker-ram'});
-    return await workerRamDropdown.selectOption(workerRamGbs.toString());
+    return await workerRamDropdown.select(workerRamGbs.toString());
   }
 
   async getWorkerRamGbs(): Promise<string> {
@@ -151,7 +151,7 @@ export default class RuntimePanel extends Container {
 
   async pickRuntimePreset(runtimePreset: RuntimePreset): Promise<void> {
     const runtimePresetMenu = await SelectMenu.findByName(this.page, {id: 'runtime-presets-menu'});
-    return await runtimePresetMenu.selectOption(runtimePreset);
+    return await runtimePresetMenu.select(runtimePreset);
   }
 
   buildStatusIconSrc = (startStopIconState: StartStopIconState) => {

--- a/e2e/app/component/runtime-panel.ts
+++ b/e2e/app/component/runtime-panel.ts
@@ -66,7 +66,7 @@ export default class RuntimePanel extends Container {
 
   async pickCpus(cpus: number): Promise<void> {
     const cpusDropdown = await SelectMenu.findByName(this.page, {id: 'runtime-cpu'});
-    return await cpusDropdown.clickMenuItem(cpus.toString());
+    return await cpusDropdown.selectOption(cpus.toString());
   }
 
   async getCpus(): Promise<string> {
@@ -76,7 +76,7 @@ export default class RuntimePanel extends Container {
 
   async pickRamGbs(ramGbs: number): Promise<void> {
     const ramDropdown = await SelectMenu.findByName(this.page, {id: 'runtime-ram'});
-    return await ramDropdown.clickMenuItem(ramGbs.toString());
+    return await ramDropdown.selectOption(ramGbs.toString());
   }
 
   async getRamGbs(): Promise<string> {
@@ -96,7 +96,7 @@ export default class RuntimePanel extends Container {
 
   async pickComputeType(computeType: ComputeType): Promise<void> {
     const computeTypeDropdown = await SelectMenu.findByName(this.page, {id: 'runtime-compute'});
-    return await computeTypeDropdown.clickMenuItem(computeType);
+    return await computeTypeDropdown.selectOption(computeType);
   }
 
   async pickDataprocNumWorkers(numWorkers: number): Promise<void> {
@@ -121,7 +121,7 @@ export default class RuntimePanel extends Container {
 
   async pickWorkerCpus(workerCpus: number): Promise<void> {
     const workerCpusDropdown = await SelectMenu.findByName(this.page, {id: 'worker-cpu'});
-    return await workerCpusDropdown.clickMenuItem(workerCpus.toString());
+    return await workerCpusDropdown.selectOption(workerCpus.toString());
   }
 
   async getWorkerCpus(): Promise<string> {
@@ -131,7 +131,7 @@ export default class RuntimePanel extends Container {
 
   async pickWorkerRamGbs(workerRamGbs: number): Promise<void> {
     const workerRamDropdown = await SelectMenu.findByName(this.page, {id: 'worker-ram'});
-    return await workerRamDropdown.clickMenuItem(workerRamGbs.toString());
+    return await workerRamDropdown.selectOption(workerRamGbs.toString());
   }
 
   async getWorkerRamGbs(): Promise<string> {
@@ -151,7 +151,7 @@ export default class RuntimePanel extends Container {
 
   async pickRuntimePreset(runtimePreset: RuntimePreset): Promise<void> {
     const runtimePresetMenu = await SelectMenu.findByName(this.page, {id: 'runtime-presets-menu'});
-    return await runtimePresetMenu.clickMenuItem(runtimePreset);
+    return await runtimePresetMenu.selectOption(runtimePreset);
   }
 
   buildStatusIconSrc = (startStopIconState: StartStopIconState) => {

--- a/e2e/app/component/select-menu.ts
+++ b/e2e/app/component/select-menu.ts
@@ -1,7 +1,7 @@
+import {Page} from 'puppeteer';
 import Container from 'app/container';
 import {buildXPath} from 'app/xpath-builders';
 import {ElementType, XPathOptions} from 'app/xpath-options';
-import {Page} from 'puppeteer';
 import {getPropValue} from 'utils/element-utils';
 import BaseMenu from './base-menu';
 
@@ -20,37 +20,15 @@ export default class SelectMenu extends BaseMenu {
   constructor(page: Page, xpath: string  = defaultMenuXpath) {
     super(page, xpath);
   }
-
+// select(menuSelections: MenuOption | MenuOption[], opt: { waitForNav?: boolean } = {}): Promise<void>
   /**
    * Select an option in a Select element.
    * @param {string} textValue Partial or full string to click in Select.
    * @param {number} maxAttempts Default try count is 2.
    */
-  async selectOption(textValue: string, maxAttempts: number = 2): Promise<void> {
-
-    const clickText = async () => {
-      await this.open(2);
-      const link = await this.findMenuItemLink(textValue, this.getXpath());
-      const textContent = await getPropValue<string>(await link.asElementHandle(), 'textContent');
-      await link.click();
-      return textContent;
-    };
-
-    const clickAndCheck = async () => {
-      maxAttempts--;
-      const shouldSelectedValue = await clickText();
-      // compare to displayed text in Select textbox
-      const displayedValue = await this.getSelectedValue();
-      if (shouldSelectedValue === displayedValue) {
-        return shouldSelectedValue; // success
-      }
-      if (maxAttempts <= 0) {
-        return null;
-      }
-      return await this.page.waitForTimeout(2000).then(clickAndCheck); // two seconds pause and retry
-    };
-
-    await clickAndCheck();
+  async select(option: string, opt: { waitForNav?: boolean } = {}): Promise<void> {
+    await this.open();
+    await super.select(option, opt);
   }
 
   /**

--- a/e2e/app/component/select-menu.ts
+++ b/e2e/app/component/select-menu.ts
@@ -31,7 +31,7 @@ export default class SelectMenu extends BaseMenu {
     const clickText = async () => {
       await this.open(2);
       const link = await this.findMenuItemLink(textValue, this.getXpath());
-      const textContent = await getPropValue<string>(link, 'textContent');
+      const textContent = await getPropValue<string>(await link.asElementHandle(), 'textContent');
       await link.click();
       return textContent;
     };

--- a/e2e/app/component/select-menu.ts
+++ b/e2e/app/component/select-menu.ts
@@ -1,21 +1,23 @@
 import Container from 'app/container';
-import BaseElement from 'app/element/base-element';
 import {buildXPath} from 'app/xpath-builders';
 import {ElementType, XPathOptions} from 'app/xpath-options';
 import {Page} from 'puppeteer';
 import {getPropValue} from 'utils/element-utils';
+import BaseMenu from './base-menu';
 
-export default class SelectMenu extends Container {
+const defaultMenuXpath = '//*[contains(concat(" ", normalize-space(@class), " "), " p-dropdown ")]' +
+   '[.//*[contains(concat(" ", normalize-space(@class), " "), " p-input-overlay-visible ")]]';
+
+export default class SelectMenu extends BaseMenu {
 
   static async findByName(page: Page, xOpt: XPathOptions = {}, container?: Container): Promise<SelectMenu> {
     xOpt.type = ElementType.Dropdown;
     const menuXpath = buildXPath(xOpt, container);
     const selectMenu = new SelectMenu(page, menuXpath);
-    await page.waitForXPath(menuXpath, {visible: true});
     return selectMenu;
   }
 
-  constructor(page: Page, xpath: string) {
+  constructor(page: Page, xpath: string  = defaultMenuXpath) {
     super(page, xpath);
   }
 
@@ -24,17 +26,13 @@ export default class SelectMenu extends Container {
    * @param {string} textValue Partial or full string to click in Select.
    * @param {number} maxAttempts Default try count is 2.
    */
-  async clickMenuItem(textValue: string, maxAttempts: number = 2): Promise<void> {
+  async selectOption(textValue: string, maxAttempts: number = 2): Promise<void> {
 
     const clickText = async () => {
       await this.open(2);
-      const selector = this.xpath + `//li[contains(normalize-space(text()), "${textValue}")]`;
-      const selectValue = await this.page.waitForXPath(selector, {visible: true});
-      const baseElement = BaseElement.asBaseElement(this.page, selectValue);
-      const textContent = await baseElement.getTextContent(); // get full text
-      await selectValue.click();
-      // need to make sure dropdown is disappeared, so it cannot interfere with clicking on elements below.
-      await this.waitUntilDropdownClosed();
+      const link = await this.findMenuItemLink(textValue, this.getXpath());
+      const textContent = await getPropValue<string>(link, 'textContent');
+      await link.click();
       return textContent;
     };
 
@@ -59,16 +57,24 @@ export default class SelectMenu extends Container {
    * Returns selected value in Select.
    */
   async getSelectedValue(): Promise<string> {
-    const selector = this.xpath + '/label';
+    const selector = this.xpath + '//*[contains(normalize-space(@class), "p-inputtext")]';
     const displayedValue = await this.page.waitForXPath(selector, { visible: true });
     return getPropValue<string>(displayedValue, 'innerText');
   }
 
   /**
-   * Open Select dropdown.
-   * @param {number} maxAttempts Default is 1.
+   *  Get texts of all visible options.
    */
-  private async open(maxAttempts: number = 1): Promise<void> {
+  async getAllOptionTexts(): Promise<string[]> {
+    const selector = `${this.getXpath()}//*[@role="option"]/text()`;
+    return this.getMenuItemTexts(selector);
+  }
+
+  /**
+   * Open Select dropdown.
+   * @param {number} maxAttempts Default is 2.
+   */
+  private async open(maxAttempts: number = 2): Promise<void> {
     const click = async () => {
       await this.toggle();
       const opened = await this.isOpen();
@@ -92,25 +98,8 @@ export default class SelectMenu extends Container {
     await dropdownTrigger.dispose();
   }
 
-  private async isOpen(): Promise<boolean> {
-    const selector = this.xpath + '/*[contains(concat(" ", normalize-space(@class), " "), " p-dropdown-panel ")]';
-    try {
-      const panel = await this.page.waitForXPath(selector, {visible: true});
-      const classNameString = await getPropValue<string>(panel, 'className');
-      const splits = classNameString.toString().split(' ');
-      await panel.dispose();
-      return splits.includes('p-input-overlay-visible');
-    } catch (err) {
-      return false;
-    }
-  }
-
-  private async waitUntilDropdownClosed() {
-    const xpath = this.xpath + '/*[contains(concat(" ", normalize-space(@class), " "), " p-input-overlay-visible ")]';
-    await this.page.waitForXPath(xpath, {hidden: true}).catch((err) => {
-      console.error('Select dropdown is not closed.');
-      throw err;
-    })
+  getMenuItemXpath(menuItemText: string): string {
+    return `//*[@role="option" and normalize-space()="${menuItemText}"]`;
   }
 
 }

--- a/e2e/app/component/select-menu.ts
+++ b/e2e/app/component/select-menu.ts
@@ -20,7 +20,7 @@ export default class SelectMenu extends BaseMenu {
   constructor(page: Page, xpath: string  = defaultMenuXpath) {
     super(page, xpath);
   }
-// select(menuSelections: MenuOption | MenuOption[], opt: { waitForNav?: boolean } = {}): Promise<void>
+
   /**
    * Select an option in a Select element.
    * @param {string} textValue Partial or full string to click in Select.

--- a/e2e/app/component/snowman-menu.ts
+++ b/e2e/app/component/snowman-menu.ts
@@ -1,5 +1,5 @@
 import {Page} from 'puppeteer';
-import {Option} from 'app/text-labels';
+import {MenuOption} from 'app/text-labels';
 import Link from 'app/element/link';
 import BaseMenu from './base-menu';
 
@@ -22,9 +22,9 @@ export default class SnowmanMenu extends BaseMenu {
 
   /**
    * Determine if an option in snowman menu is disabled.
-   * @param {Option} option Snowman menuitem.
+   * @param {MenuOption} option Snowman menuitem.
    */
-  async isOptionDisabled(option: Option): Promise<boolean> {
+  async isOptionDisabled(option: MenuOption): Promise<boolean> {
     const link = this.findOptionLink(option);
     return link.isCursorNotAllowed();
   }
@@ -33,7 +33,7 @@ export default class SnowmanMenu extends BaseMenu {
     return `//*[@role="button" and normalize-space()="${menuItemText}"]`;
   }
 
-  private findOptionLink(option: Option): Link {
+  private findOptionLink(option: MenuOption): Link {
     const selector = `${this.getXpath()}${this.getMenuItemXpath(option)}`;
     return new Link(this.page, selector);
   }

--- a/e2e/app/component/snowman-menu.ts
+++ b/e2e/app/component/snowman-menu.ts
@@ -34,7 +34,7 @@ export default class SnowmanMenu extends BaseMenu {
   }
 
   private findOptionLink(option: Option): Link {
-    const selector = `${this.getXpath()}//*[@role='button' and text()='${option}']`;
+    const selector = `${this.getXpath()}${this.getMenuItemXpath(option)}`;
     return new Link(this.page, selector);
   }
 

--- a/e2e/app/component/tiered-menu.ts
+++ b/e2e/app/component/tiered-menu.ts
@@ -1,47 +1,19 @@
-import Container from 'app/container';
-import {ElementHandle, Page} from 'puppeteer';
-import {waitWhileLoading} from 'utils/waits-utils';
+import {Page} from 'puppeteer';
+import BaseMenu from './base-menu';
 
-const defaultXpath = '//*[contains(concat(" ", normalize-space(@class), " "), " p-menu-overlay-visible ")]';
+const menuXpath = '//*[contains(concat(" ", normalize-space(@class), " "), " p-tieredmenu ")' +
+        'or contains(concat(" ", normalize-space(@class), " "), " p-menu ")]' +
+        '[contains(concat(" ", normalize-space(@class), " "), " p-menu-overlay-visible ")]';
 
-// Cascading menus
-export default class TieredMenu extends Container {
+export default class TieredMenu extends BaseMenu {
 
-  constructor(page: Page, xpath: string = defaultXpath) {
+  constructor(page: Page, xpath: string = menuXpath) {
     super(page, xpath);
   }
 
-  /**
-   * Select options in menu.
-   * @param {string[]} options
-   */
-  async select(options: string[]): Promise<void> {
-    const menuXpath = `${this.xpath}//ul`;
-
-    // Make sure menu dropdown is open and visible.
-    await this.page.waitForXPath(menuXpath, {visible: true});
-
-    const findLink = async (menuItemText): Promise<ElementHandle> => {
-      const selector = `${menuXpath}/li[contains(concat(" ", normalize-space()), " ${menuItemText}")]`;
-      const elem = await this.page.waitForXPath(selector, {visible: true});
-      await elem.hover();
-      await elem.focus();
-      return elem;
-    };
-
-    // Iterate thru array in an orderly fashion. Hover over menu option. Click on last menu option.
-    const num = options.length;
-    for (let i=0; i<num; i++) {
-      const link = await findLink(options[i]);
-      if (i >= (num - 1)) {
-        await link.click();
-        await waitWhileLoading(this.page);
-      }
-      await link.dispose();
-    }
-
-    await this.page.waitForXPath(menuXpath, {hidden: true});
+  getMenuItemXpath(menuItemText: string): string {
+    return '//*[not(contains(concat(" ", normalize-space(@class), " "), " menuitem-header "))]' +
+       `[./*[@role="menuitem" and normalize-space()="${menuItemText}"]]`;
   }
-
 
 }

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -29,7 +29,7 @@ export default class WorkspaceCard extends CardBase {
    */
   static async deleteWorkspace(page: Page, workspaceName: string): Promise<string[]> {
     const card = await WorkspaceCard.findCard(page, workspaceName);
-    await card.selectSnowmanMenu(Option.Delete, { waitForNavi: false });
+    await card.selectSnowmanMenu(Option.Delete, { waitForNav: false });
     // Handle Delete Confirmation modal
     return new WorkspaceEditPage(page).dismissDeleteWorkspaceModal();
   }

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -29,7 +29,7 @@ export default class WorkspaceCard extends CardBase {
    */
   static async deleteWorkspace(page: Page, workspaceName: string): Promise<string[]> {
     const card = await WorkspaceCard.findCard(page, workspaceName);
-    await card.selectSnowmanMenu(Option.Delete, { waitForNav: false });
+    await card.selectSnowmanMenu(Option.Delete, { waitForNavi: false });
     // Handle Delete Confirmation modal
     return new WorkspaceEditPage(page).dismissDeleteWorkspaceModal();
   }

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -1,6 +1,6 @@
 import {ElementHandle, Page} from 'puppeteer';
 import * as fp from 'lodash/fp';
-import {Option, WorkspaceAccessLevel} from 'app/text-labels';
+import {MenuOption, WorkspaceAccessLevel} from 'app/text-labels';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {getPropValue} from 'utils/element-utils';
 import CardBase from './card-base';
@@ -29,7 +29,7 @@ export default class WorkspaceCard extends CardBase {
    */
   static async deleteWorkspace(page: Page, workspaceName: string): Promise<string[]> {
     const card = await WorkspaceCard.findCard(page, workspaceName);
-    await card.selectSnowmanMenu(Option.Delete, { waitForNav: false });
+    await card.selectSnowmanMenu(MenuOption.Delete, { waitForNav: false });
     // Handle Delete Confirmation modal
     return new WorkspaceEditPage(page).dismissDeleteWorkspaceModal();
   }
@@ -182,15 +182,15 @@ export default class WorkspaceCard extends CardBase {
     const snowmanMenu = await this.getSnowmanMenu();
     const accessLevel = await this.getWorkspaceAccessLevel();
     if (accessLevel !== WorkspaceAccessLevel.Owner) {
-      expect(await snowmanMenu.isOptionDisabled(Option.Share)).toBe(true);
-      expect(await snowmanMenu.isOptionDisabled(Option.Edit)).toBe(true);
-      expect(await snowmanMenu.isOptionDisabled(Option.Delete)).toBe(true);
-      expect(await snowmanMenu.isOptionDisabled(Option.Duplicate)).toBe(false);
+      expect(await snowmanMenu.isOptionDisabled(MenuOption.Share)).toBe(true);
+      expect(await snowmanMenu.isOptionDisabled(MenuOption.Edit)).toBe(true);
+      expect(await snowmanMenu.isOptionDisabled(MenuOption.Delete)).toBe(true);
+      expect(await snowmanMenu.isOptionDisabled(MenuOption.Duplicate)).toBe(false);
       } else if (accessLevel === WorkspaceAccessLevel.Owner) { 
-      expect(await snowmanMenu.isOptionDisabled(Option.Share)).toBe(false);
-      expect(await snowmanMenu.isOptionDisabled(Option.Edit)).toBe(false);
-      expect(await snowmanMenu.isOptionDisabled(Option.Delete)).toBe(false);
-      expect(await snowmanMenu.isOptionDisabled(Option.Duplicate)).toBe(false);
+      expect(await snowmanMenu.isOptionDisabled(MenuOption.Share)).toBe(false);
+      expect(await snowmanMenu.isOptionDisabled(MenuOption.Edit)).toBe(false);
+      expect(await snowmanMenu.isOptionDisabled(MenuOption.Delete)).toBe(false);
+      expect(await snowmanMenu.isOptionDisabled(MenuOption.Duplicate)).toBe(false);
   }
   }
 }

--- a/e2e/app/container.ts
+++ b/e2e/app/container.ts
@@ -9,7 +9,7 @@ export default class Container {
   constructor(protected readonly page: Page, protected xpath?: string) { }
 
   getXpath(): string {
-    return this.xpath;
+    return (this.xpath === undefined) ? '' : this.xpath;
   }
 
   async waitUntilVisible(): Promise<ElementHandle> {

--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -31,7 +31,7 @@ export default class BaseElement extends Container {
    * @param {WaitForSelectorOptions} waitOptions
    */
   async waitForXPath(waitOptions: WaitForSelectorOptions = {visible: true}): Promise<ElementHandle> {
-    if (this.element !== undefined) return this.element.asElement();
+    if (this.xpath === undefined && this.element !== undefined) return this.element.asElement();
     try {
       return this.page.waitForXPath(this.xpath, waitOptions).then(elemt => this.element = elemt.asElement());
     } catch (err) {

--- a/e2e/app/page/cohort-build-page.ts
+++ b/e2e/app/page/cohort-build-page.ts
@@ -64,7 +64,7 @@ export default class CohortBuildPage extends AuthenticatedPage {
     const descriptionTextarea = await modal.waitForTextarea('DESCRIPTION');
     await descriptionTextarea.type(description);
 
-    await modal.clickButton(LinkText.Save, {waitForClose: true});
+    await modal.clickButton(LinkText.Save, {waitForClose: true, timeout: 120000});
     await waitWhileLoading(this.page);
 
     return cohortName;

--- a/e2e/app/page/cohort-build-page.ts
+++ b/e2e/app/page/cohort-build-page.ts
@@ -64,7 +64,7 @@ export default class CohortBuildPage extends AuthenticatedPage {
     const descriptionTextarea = await modal.waitForTextarea('DESCRIPTION');
     await descriptionTextarea.type(description);
 
-    await modal.clickButton(LinkText.Save, {waitForClose: true, timeout: 120000});
+    await modal.clickButton(LinkText.Save, {waitForClose: true, timeout: 2  * 60 * 1000});
     await waitWhileLoading(this.page);
 
     return cohortName;

--- a/e2e/app/page/cohort-build-page.ts
+++ b/e2e/app/page/cohort-build-page.ts
@@ -7,7 +7,7 @@ import {ElementType} from 'app/xpath-options';
 import {makeRandomName} from 'utils/str-utils';
 import {waitForDocumentTitle, waitForNumericalString, waitWhileLoading} from 'utils/waits-utils';
 import {buildXPath} from 'app/xpath-builders';
-import {LinkText} from 'app/text-labels';
+import {LinkText, Option} from 'app/text-labels';
 import AuthenticatedPage from './authenticated-page';
 import CohortParticipantsGroup from './cohort-participants-group';
 
@@ -42,7 +42,7 @@ export default class CohortBuildPage extends AuthenticatedPage {
     await createCohortButton.waitUntilEnabled();
     await createCohortButton.click(); // Click dropdown trigger to open menu
     const menu =  new TieredMenu(this.page);
-    await menu.select(['Save']);
+    await menu.select(Option.Save);
   }
 
   async saveCohortAs(cohortName?: string, description?: string): Promise<string> {

--- a/e2e/app/page/cohort-build-page.ts
+++ b/e2e/app/page/cohort-build-page.ts
@@ -7,7 +7,7 @@ import {ElementType} from 'app/xpath-options';
 import {makeRandomName} from 'utils/str-utils';
 import {waitForDocumentTitle, waitForNumericalString, waitWhileLoading} from 'utils/waits-utils';
 import {buildXPath} from 'app/xpath-builders';
-import {LinkText, Option} from 'app/text-labels';
+import {LinkText, MenuOption} from 'app/text-labels';
 import AuthenticatedPage from './authenticated-page';
 import CohortParticipantsGroup from './cohort-participants-group';
 
@@ -42,7 +42,7 @@ export default class CohortBuildPage extends AuthenticatedPage {
     await createCohortButton.waitUntilEnabled();
     await createCohortButton.click(); // Click dropdown trigger to open menu
     const menu =  new TieredMenu(this.page);
-    await menu.select(Option.Save);
+    await menu.select(MenuOption.Save);
   }
 
   async saveCohortAs(cohortName?: string, description?: string): Promise<string> {

--- a/e2e/app/page/cohort-participants-group.ts
+++ b/e2e/app/page/cohort-participants-group.ts
@@ -5,16 +5,10 @@ import {waitForNumericalString, waitForText, waitWhileLoading} from 'utils/waits
 import CohortSearchPage from 'app/page/cohort-search-page';
 import CriteriaSearchPage, {FilterSign, PhysicalMeasurementsCriteria} from 'app/page/criteria-search-page';
 import TieredMenu from 'app/component/tiered-menu';
-import {LinkText} from 'app/text-labels';
+import {LinkText, Option} from 'app/text-labels';
 import {snowmanIconXpath} from 'app/component/snowman-menu';
 import Button from 'app/element/button';
 import HelpSidebar from 'app/component/help-sidebar';
-
-enum GroupMenuOption {
-   EditGroupName  = 'Edit group name',
-   SuppressGroupFromTotalCount = 'Suppress group from total count',
-   DeleteGroup = 'Delete group',
-}
 
 export default class CohortParticipantsGroup {
 
@@ -50,9 +44,9 @@ export default class CohortParticipantsGroup {
    * Build Cohort Criteria page: Group snowman menu
    * @param {GroupMenuOption} option
    */
-  async selectGroupSnowmanMenu(option: GroupMenuOption): Promise<void> {
+  async selectGroupSnowmanMenu(option: Option): Promise<void> {
     const menu = new TieredMenu(this.page);
-    return menu.select([option.toString()]);
+    return menu.select(option);
   }
 
   /**
@@ -62,7 +56,7 @@ export default class CohortParticipantsGroup {
    */
   async editGroupName(newGroupName: string): Promise<void> {
     await this.clickSnowmanIcon();
-    await this.selectGroupSnowmanMenu(GroupMenuOption.EditGroupName);
+    await this.selectGroupSnowmanMenu(Option.EditGroupName);
     const modal = new Modal(this.page);
     const textbox = await modal.waitForTextbox('New Name:');
     await textbox.type(newGroupName);
@@ -75,7 +69,7 @@ export default class CohortParticipantsGroup {
    */
   async deleteGroup(): Promise<ElementHandle[]> {
     await this.clickSnowmanIcon();
-    await this.selectGroupSnowmanMenu(GroupMenuOption.DeleteGroup);
+    await this.selectGroupSnowmanMenu(Option.DeleteGroup);
     try {
       await waitForText(this.page, 'This group has been deleted');
     } catch (err) {
@@ -86,33 +80,33 @@ export default class CohortParticipantsGroup {
   }
 
   async includePhysicalMeasurement(criteriaName: PhysicalMeasurementsCriteria, value: number): Promise<string> {
-    await this.clickCriteriaMenuItems(['Physical Measurements']);
+    await this.clickCriteriaMenuItems([Option.PhysicalMeasurements]);
     const searchPage = new CriteriaSearchPage(this.page);
     await searchPage.waitForLoad();
     return searchPage.filterPhysicalMeasurementValue(criteriaName, FilterSign.GreaterThanOrEqualTo, value);
   }
 
   async includeDemographicsDeceased(): Promise<string> {
-    await this.clickCriteriaMenuItems(['Demographics', 'Deceased']);
+    await this.clickCriteriaMenuItems([Option.Demographics, Option.Deceased]);
     return this.getGroupCount();
   }
 
   async includeConditions(): Promise<CriteriaSearchPage> {
-    await this.clickCriteriaMenuItems(['Conditions']);
+    await this.clickCriteriaMenuItems([Option.Conditions]);
     const searchPage = new CriteriaSearchPage(this.page);
     await searchPage.waitForLoad();
     return searchPage;
   }
 
   async includeDrugs(): Promise<CriteriaSearchPage> {
-    await this.clickCriteriaMenuItems(['Drugs']);
+    await this.clickCriteriaMenuItems([Option.Drugs]);
     const searchPage = new CriteriaSearchPage(this.page);
     await searchPage.waitForLoad();
     return searchPage;
   }
 
   async includeEthnicity(): Promise<CohortSearchPage> {
-    await this.clickCriteriaMenuItems(['Demographics', 'Ethnicity']);
+    await this.clickCriteriaMenuItems([Option.Demographics, Option.Ethnicity]);
     const searchPage = new CohortSearchPage(this.page);
     await searchPage.waitForLoad();
     return searchPage;
@@ -123,7 +117,7 @@ export default class CohortParticipantsGroup {
   }
 
   async includeAge(minAge: number, maxAge: number): Promise<string> {
-    await this.clickCriteriaMenuItems(['Demographics', 'Age']);
+    await this.clickCriteriaMenuItems([Option.Demographics, Option.Age]);
     const searchPage = new CohortSearchPage(this.page);
     await searchPage.waitForLoad();
     const results = await searchPage.addAge(minAge, maxAge);
@@ -132,13 +126,13 @@ export default class CohortParticipantsGroup {
   }
 
   async includeVisits(): Promise<CriteriaSearchPage> {
-    await this.clickCriteriaMenuItems(['Visits']);
+    await this.clickCriteriaMenuItems([Option.Visits]);
     const searchPage = new CriteriaSearchPage(this.page);
     await searchPage.waitForLoad();
     return searchPage;
   }
 
-  private async clickCriteriaMenuItems(menuItemLinks: string[]): Promise<void> {
+  private async clickCriteriaMenuItems(menuItemLinks: Option[]): Promise<void> {
     const menu = await this.openTieredMenu();
     await menu.select(menuItemLinks);
   }

--- a/e2e/app/page/cohort-participants-group.ts
+++ b/e2e/app/page/cohort-participants-group.ts
@@ -5,7 +5,7 @@ import {waitForNumericalString, waitForText, waitWhileLoading} from 'utils/waits
 import CohortSearchPage from 'app/page/cohort-search-page';
 import CriteriaSearchPage, {FilterSign, PhysicalMeasurementsCriteria} from 'app/page/criteria-search-page';
 import TieredMenu from 'app/component/tiered-menu';
-import {LinkText, Option} from 'app/text-labels';
+import {LinkText, MenuOption} from 'app/text-labels';
 import {snowmanIconXpath} from 'app/component/snowman-menu';
 import Button from 'app/element/button';
 import HelpSidebar from 'app/component/help-sidebar';
@@ -44,7 +44,7 @@ export default class CohortParticipantsGroup {
    * Build Cohort Criteria page: Group snowman menu
    * @param {GroupMenuOption} option
    */
-  async selectGroupSnowmanMenu(option: Option): Promise<void> {
+  async selectGroupSnowmanMenu(option: MenuOption): Promise<void> {
     const menu = new TieredMenu(this.page);
     return menu.select(option);
   }
@@ -56,7 +56,7 @@ export default class CohortParticipantsGroup {
    */
   async editGroupName(newGroupName: string): Promise<void> {
     await this.clickSnowmanIcon();
-    await this.selectGroupSnowmanMenu(Option.EditGroupName);
+    await this.selectGroupSnowmanMenu(MenuOption.EditGroupName);
     const modal = new Modal(this.page);
     const textbox = await modal.waitForTextbox('New Name:');
     await textbox.type(newGroupName);
@@ -69,7 +69,7 @@ export default class CohortParticipantsGroup {
    */
   async deleteGroup(): Promise<ElementHandle[]> {
     await this.clickSnowmanIcon();
-    await this.selectGroupSnowmanMenu(Option.DeleteGroup);
+    await this.selectGroupSnowmanMenu(MenuOption.DeleteGroup);
     try {
       await waitForText(this.page, 'This group has been deleted');
     } catch (err) {
@@ -80,33 +80,33 @@ export default class CohortParticipantsGroup {
   }
 
   async includePhysicalMeasurement(criteriaName: PhysicalMeasurementsCriteria, value: number): Promise<string> {
-    await this.clickCriteriaMenuItems([Option.PhysicalMeasurements]);
+    await this.clickCriteriaMenuItems([MenuOption.PhysicalMeasurements]);
     const searchPage = new CriteriaSearchPage(this.page);
     await searchPage.waitForLoad();
     return searchPage.filterPhysicalMeasurementValue(criteriaName, FilterSign.GreaterThanOrEqualTo, value);
   }
 
   async includeDemographicsDeceased(): Promise<string> {
-    await this.clickCriteriaMenuItems([Option.Demographics, Option.Deceased]);
+    await this.clickCriteriaMenuItems([MenuOption.Demographics, MenuOption.Deceased]);
     return this.getGroupCount();
   }
 
   async includeConditions(): Promise<CriteriaSearchPage> {
-    await this.clickCriteriaMenuItems([Option.Conditions]);
+    await this.clickCriteriaMenuItems([MenuOption.Conditions]);
     const searchPage = new CriteriaSearchPage(this.page);
     await searchPage.waitForLoad();
     return searchPage;
   }
 
   async includeDrugs(): Promise<CriteriaSearchPage> {
-    await this.clickCriteriaMenuItems([Option.Drugs]);
+    await this.clickCriteriaMenuItems([MenuOption.Drugs]);
     const searchPage = new CriteriaSearchPage(this.page);
     await searchPage.waitForLoad();
     return searchPage;
   }
 
   async includeEthnicity(): Promise<CohortSearchPage> {
-    await this.clickCriteriaMenuItems([Option.Demographics, Option.Ethnicity]);
+    await this.clickCriteriaMenuItems([MenuOption.Demographics, MenuOption.Ethnicity]);
     const searchPage = new CohortSearchPage(this.page);
     await searchPage.waitForLoad();
     return searchPage;
@@ -117,7 +117,7 @@ export default class CohortParticipantsGroup {
   }
 
   async includeAge(minAge: number, maxAge: number): Promise<string> {
-    await this.clickCriteriaMenuItems([Option.Demographics, Option.Age]);
+    await this.clickCriteriaMenuItems([MenuOption.Demographics, MenuOption.Age]);
     const searchPage = new CohortSearchPage(this.page);
     await searchPage.waitForLoad();
     const results = await searchPage.addAge(minAge, maxAge);
@@ -126,13 +126,13 @@ export default class CohortParticipantsGroup {
   }
 
   async includeVisits(): Promise<CriteriaSearchPage> {
-    await this.clickCriteriaMenuItems([Option.Visits]);
+    await this.clickCriteriaMenuItems([MenuOption.Visits]);
     const searchPage = new CriteriaSearchPage(this.page);
     await searchPage.waitForLoad();
     return searchPage;
   }
 
-  private async clickCriteriaMenuItems(menuItemLinks: Option[]): Promise<void> {
+  private async clickCriteriaMenuItems(menuItemLinks: MenuOption[]): Promise<void> {
     const menu = await this.openTieredMenu();
     await menu.select(menuItemLinks);
   }

--- a/e2e/app/page/conceptset-page.ts
+++ b/e2e/app/page/conceptset-page.ts
@@ -3,7 +3,7 @@ import {waitForDocumentTitle, waitWhileLoading} from 'utils/waits-utils';
 import SnowmanMenu from 'app/component/snowman-menu';
 import {buildXPath} from 'app/xpath-builders';
 import {ElementType} from 'app/xpath-options';
-import {Option} from 'app/text-labels';
+import {MenuOption} from 'app/text-labels';
 import Button from 'app/element/button';
 import Textbox from 'app/element/textbox';
 import {getPropValue} from 'utils/element-utils';
@@ -28,7 +28,7 @@ export default class ConceptSetPage extends AuthenticatedPage {
   }
 
   async openCopyToWorkspaceModal(conceptSetName: string): Promise<CopyModal> {
-    await this.getSnowmanMenu(conceptSetName).then(menu => menu.select(Option.CopyToAnotherWorkspace, {waitForNav: false}));
+    await this.getSnowmanMenu(conceptSetName).then(menu => menu.select(MenuOption.CopyToAnotherWorkspace, {waitForNav: false}));
     const modal = new CopyModal(this.page);
     await modal.waitForLoad();
     return modal;

--- a/e2e/app/page/conceptset-page.ts
+++ b/e2e/app/page/conceptset-page.ts
@@ -28,7 +28,7 @@ export default class ConceptSetPage extends AuthenticatedPage {
   }
 
   async openCopyToWorkspaceModal(conceptSetName: string): Promise<CopyModal> {
-    await this.getSnowmanMenu(conceptSetName).then(menu => menu.select(Option.CopyToAnotherWorkspace, {waitForNavi: false}));
+    await this.getSnowmanMenu(conceptSetName).then(menu => menu.select(Option.CopyToAnotherWorkspace, {waitForNav: false}));
     const modal = new CopyModal(this.page);
     await modal.waitForLoad();
     return modal;

--- a/e2e/app/page/conceptset-page.ts
+++ b/e2e/app/page/conceptset-page.ts
@@ -28,7 +28,7 @@ export default class ConceptSetPage extends AuthenticatedPage {
   }
 
   async openCopyToWorkspaceModal(conceptSetName: string): Promise<CopyModal> {
-    await this.getSnowmanMenu(conceptSetName).then(menu => menu.select(Option.CopyToAnotherWorkspace, {waitForNav: false}));
+    await this.getSnowmanMenu(conceptSetName).then(menu => menu.select(Option.CopyToAnotherWorkspace, {waitForNavi: false}));
     const modal = new CopyModal(this.page);
     await modal.waitForLoad();
     return modal;

--- a/e2e/app/page/create-account-page.ts
+++ b/e2e/app/page/create-account-page.ts
@@ -65,12 +65,12 @@ export const FieldSelector = {
   },
   InstitutionSelect: {
     textOption: {
-      type:ElementType.Dropdown, name:'Select your institution', ancestorLevel:1
+      type:ElementType.Dropdown, name:'Select your institution', ancestorLevel: 2
     }
   },
   DescribeRole: {
     textOption: {
-      type: ElementType.Dropdown, containsText: 'describes your role', ancestorLevel: 1
+      type: ElementType.Dropdown, containsText: 'describes your role', ancestorLevel: 2
     }
   }
 };
@@ -152,7 +152,7 @@ export default class CreateAccountPage extends BasePage {
   // select Institution Affiliation from a dropdown
   async selectInstitution(selectTextValue: string): Promise<void> {
     const dropdown = await SelectMenu.findByName(this.page, FieldSelector.InstitutionSelect.textOption);
-    return dropdown.clickMenuItem(selectTextValue);
+    return dropdown.selectOption(selectTextValue);
   }
 
   async getInstitutionValue(): Promise<string> {
@@ -163,13 +163,13 @@ export default class CreateAccountPage extends BasePage {
   // select Education Level from a dropdown
   async selectEducationLevel(selectTextValue: string): Promise<void> {
     const dropdown = await SelectMenu.findByName(this.page, FieldSelector.EducationLevelSelect.textOption);
-    return dropdown.clickMenuItem(selectTextValue);
+    return dropdown.selectOption(selectTextValue);
   }
 
   // select Year of Birth from a dropdown
   async selectYearOfBirth(year: string): Promise<void> {
     const dropdown = await SelectMenu.findByName(this.page, FieldSelector.BirthYearSelect.textOption);
-    return dropdown.clickMenuItem(year);
+    return dropdown.selectOption(year);
   }
 
   // Combined steps to make test code cleaner and shorter
@@ -189,7 +189,7 @@ export default class CreateAccountPage extends BasePage {
     await ClrIconLink.findByName(this.page, {containsText: LabelAlias.InstitutionEmail, ancestorLevel: 2, iconShape: 'success-standard'});
 
     const roleSelect = await SelectMenu.findByName(this.page, FieldSelector.DescribeRole.textOption);
-    await roleSelect.clickMenuItem(InstitutionRoleSelectValue.UndergraduteStudent);
+    await roleSelect.selectOption(InstitutionRoleSelectValue.UndergraduteStudent);
   }
 
   // Step 1: Accepting Terms of Use and Privacy statement.

--- a/e2e/app/page/create-account-page.ts
+++ b/e2e/app/page/create-account-page.ts
@@ -152,7 +152,7 @@ export default class CreateAccountPage extends BasePage {
   // select Institution Affiliation from a dropdown
   async selectInstitution(selectTextValue: string): Promise<void> {
     const dropdown = await SelectMenu.findByName(this.page, FieldSelector.InstitutionSelect.textOption);
-    return dropdown.selectOption(selectTextValue);
+    return dropdown.select(selectTextValue);
   }
 
   async getInstitutionValue(): Promise<string> {
@@ -163,13 +163,13 @@ export default class CreateAccountPage extends BasePage {
   // select Education Level from a dropdown
   async selectEducationLevel(selectTextValue: string): Promise<void> {
     const dropdown = await SelectMenu.findByName(this.page, FieldSelector.EducationLevelSelect.textOption);
-    return dropdown.selectOption(selectTextValue);
+    return dropdown.select(selectTextValue);
   }
 
   // select Year of Birth from a dropdown
   async selectYearOfBirth(year: string): Promise<void> {
     const dropdown = await SelectMenu.findByName(this.page, FieldSelector.BirthYearSelect.textOption);
-    return dropdown.selectOption(year);
+    return dropdown.select(year);
   }
 
   // Combined steps to make test code cleaner and shorter
@@ -189,7 +189,7 @@ export default class CreateAccountPage extends BasePage {
     await ClrIconLink.findByName(this.page, {containsText: LabelAlias.InstitutionEmail, ancestorLevel: 2, iconShape: 'success-standard'});
 
     const roleSelect = await SelectMenu.findByName(this.page, FieldSelector.DescribeRole.textOption);
-    await roleSelect.selectOption(InstitutionRoleSelectValue.UndergraduteStudent);
+    await roleSelect.select(InstitutionRoleSelectValue.UndergraduteStudent);
   }
 
   // Step 1: Accepting Terms of Use and Privacy statement.

--- a/e2e/app/page/criteria-search-page.ts
+++ b/e2e/app/page/criteria-search-page.ts
@@ -129,7 +129,7 @@ export default class CriteriaSearchPage extends AuthenticatedPage {
 
   async addAgeModifier(filterSign: FilterSign, filterValue: number): Promise<string> {
     const selectMenu = await SelectMenu.findByName(this.page, {name: 'Age At Event', ancestorLevel: 2});
-    await selectMenu.selectOption(filterSign);
+    await selectMenu.select(filterSign);
     const numberField = await this.page.waitForXPath(`${this.containerXpath}//input[@type="number"]`, {visible: true});
     // Issue with Puppeteer type() function: typing value in this textbox doesn't always trigger change event. workaround is needed.
     // Error: "Sorry, the request cannot be completed. Please try again or contact Support in the left hand navigation."

--- a/e2e/app/page/criteria-search-page.ts
+++ b/e2e/app/page/criteria-search-page.ts
@@ -129,7 +129,7 @@ export default class CriteriaSearchPage extends AuthenticatedPage {
 
   async addAgeModifier(filterSign: FilterSign, filterValue: number): Promise<string> {
     const selectMenu = await SelectMenu.findByName(this.page, {name: 'Age At Event', ancestorLevel: 2});
-    await selectMenu.clickMenuItem(filterSign);
+    await selectMenu.selectOption(filterSign);
     const numberField = await this.page.waitForXPath(`${this.containerXpath}//input[@type="number"]`, {visible: true});
     // Issue with Puppeteer type() function: typing value in this textbox doesn't always trigger change event. workaround is needed.
     // Error: "Sorry, the request cannot be completed. Please try again or contact Support in the left hand navigation."

--- a/e2e/app/page/google-login.ts
+++ b/e2e/app/page/google-login.ts
@@ -109,7 +109,7 @@ export default class GoogleLoginPage {
       submitButton.click(),
     ]);
     await submitButton.dispose();
-    await this.page.waitForSelector('app-signed-in', {timeout: (60 * 1000)})
+    await this.page.waitForSelector('app-signed-in', {timeout: (1 * 60 * 1000)})
       .catch(async (err) => {
         // Two main reasons why error is throw are caused by "Enter Recovery Email" page or login captcha.
         // At this time, we can only handle "Enter Recover Email" page if it exists.

--- a/e2e/app/page/home-page.ts
+++ b/e2e/app/page/home-page.ts
@@ -21,9 +21,9 @@ export default class HomePage extends AuthenticatedPage {
 
   async isLoaded(): Promise<boolean> {
     await waitForDocumentTitle(this.page, PageTitle);
+    await waitWhileLoading(this.page);
     // Look for "See All Workspaces" link.
     await this.getSeeAllWorkspacesLink().then( (element) => element.asElementHandle());
-    await waitWhileLoading(this.page);
     // Look for either a workspace card or the "Create your first workspace" msg.
     await Promise.race([
       this.page.waitForXPath('//*[@data-test-id="workspace-card"]', {visible: true}),

--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -51,7 +51,7 @@ export default class NotebookPage extends AuthenticatedPage {
       console.warn(`Reloading "${this.documentTitle}" because cannot find the Run button`);
       await this.page.reload({waitUntil: ['networkidle0', 'load']});
     }
-    await this.waitForKernelIdle(600000); // 10 minutes
+    await this.waitForKernelIdle(10 * 60 * 1000); // 10 minutes
     return true;
   }
 
@@ -183,7 +183,7 @@ export default class NotebookPage extends AuthenticatedPage {
     const cell = cellIndex === -1 ? await this.findLastCell() : await this.findCell(cellIndex);
     const inputCell = await cell.focus();
 
-    const {code, codeFile, timeOut = 120000, markdownWorkaround = false} = opts;
+    const {code, codeFile, timeOut = 2 * 60 * 1000, markdownWorkaround = false} = opts;
 
     let codeToRun;
     if (code !== undefined) {

--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -51,7 +51,7 @@ export default class NotebookPage extends AuthenticatedPage {
       console.warn(`Reloading "${this.documentTitle}" because cannot find the Run button`);
       await this.page.reload({waitUntil: ['networkidle0', 'load']});
     }
-    await this.waitForKernelIdle(300000); // 5 minutes
+    await this.waitForKernelIdle(600000); // 10 minutes
     return true;
   }
 

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -91,7 +91,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
   async duplicateNotebook(notebookName: string): Promise<string> {
     const resourceCard = new DataResourceCard(this.page);
     const notebookCard = await resourceCard.findCard(notebookName, ResourceCard.Notebook);
-    await notebookCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: false});
+    await notebookCard.selectSnowmanMenu(Option.Duplicate, {waitForNavi: false});
     await waitWhileLoading(this.page);
     return `Duplicate of ${notebookName}`; // name of clone notebook
   }
@@ -106,7 +106,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
     // Open Copy modal.s
     const resourceCard = new DataResourceCard(this.page);
     const notebookCard = await resourceCard.findCard(notebookName, ResourceCard.Notebook);
-    await notebookCard.selectSnowmanMenu(Option.CopyToAnotherWorkspace, {waitForNav: false});
+    await notebookCard.selectSnowmanMenu(Option.CopyToAnotherWorkspace, {waitForNavi: false});
     // Fill out modal fields.
     const copyModal = await new CopyModal(this.page);
     await copyModal.waitForLoad();

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -2,7 +2,7 @@ import CopyModal from 'app/component/copy-modal';
 import DataResourceCard from 'app/component/data-resource-card';
 import NewNotebookModal from 'app/component/new-notebook-modal';
 import Link from 'app/element/link';
-import {Option, Language, LinkText, ResourceCard} from 'app/text-labels';
+import {MenuOption, Language, LinkText, ResourceCard} from 'app/text-labels';
 import {Page} from 'puppeteer';
 import {getPropValue} from 'utils/element-utils';
 import {waitForDocumentTitle, waitWhileLoading} from 'utils/waits-utils';
@@ -91,7 +91,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
   async duplicateNotebook(notebookName: string): Promise<string> {
     const resourceCard = new DataResourceCard(this.page);
     const notebookCard = await resourceCard.findCard(notebookName, ResourceCard.Notebook);
-    await notebookCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: false});
+    await notebookCard.selectSnowmanMenu(MenuOption.Duplicate, {waitForNav: false});
     await waitWhileLoading(this.page);
     return `Duplicate of ${notebookName}`; // name of clone notebook
   }
@@ -106,7 +106,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
     // Open Copy modal.s
     const resourceCard = new DataResourceCard(this.page);
     const notebookCard = await resourceCard.findCard(notebookName, ResourceCard.Notebook);
-    await notebookCard.selectSnowmanMenu(Option.CopyToAnotherWorkspace, {waitForNav: false});
+    await notebookCard.selectSnowmanMenu(MenuOption.CopyToAnotherWorkspace, {waitForNav: false});
     // Fill out modal fields.
     const copyModal = await new CopyModal(this.page);
     await copyModal.waitForLoad();

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -91,7 +91,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
   async duplicateNotebook(notebookName: string): Promise<string> {
     const resourceCard = new DataResourceCard(this.page);
     const notebookCard = await resourceCard.findCard(notebookName, ResourceCard.Notebook);
-    await notebookCard.selectSnowmanMenu(Option.Duplicate, {waitForNavi: false});
+    await notebookCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: false});
     await waitWhileLoading(this.page);
     return `Duplicate of ${notebookName}`; // name of clone notebook
   }
@@ -106,7 +106,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
     // Open Copy modal.s
     const resourceCard = new DataResourceCard(this.page);
     const notebookCard = await resourceCard.findCard(notebookName, ResourceCard.Notebook);
-    await notebookCard.selectSnowmanMenu(Option.CopyToAnotherWorkspace, {waitForNavi: false});
+    await notebookCard.selectSnowmanMenu(Option.CopyToAnotherWorkspace, {waitForNav: false});
     // Fill out modal fields.
     const copyModal = await new CopyModal(this.page);
     await copyModal.waitForLoad();

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -4,7 +4,7 @@ import Modal from 'app/component/modal';
 import Link from 'app/element/link';
 import Textarea from 'app/element/textarea';
 import Textbox from 'app/element/textbox';
-import {LinkText, Option, ResourceCard} from 'app/text-labels';
+import {LinkText, MenuOption, ResourceCard} from 'app/text-labels';
 import {buildXPath} from 'app/xpath-builders';
 import {ElementType} from 'app/xpath-options';
 import {waitForAttributeEquality, waitWhileLoading} from 'utils/waits-utils';
@@ -128,7 +128,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
       throw new Error(`Failed to find ${resourceType} card "${resourceName}"`);
     }
 
-    await card.selectSnowmanMenu(Option.Delete, {waitForNav: false});
+    await card.selectSnowmanMenu(MenuOption.Delete, {waitForNav: false});
 
     const modal = new Modal(this.page);
     await modal.waitForLoad();
@@ -149,7 +149,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
         link = LinkText.DeleteNotebook;
         break;
       case ResourceCard.CohortReview:
-        link = Option.Delete;
+        link = MenuOption.Delete;
         break;
       default:
         throw new Error(`Case ${resourceType} handling is not defined.`);
@@ -175,13 +175,13 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
       throw new Error(`Failed to find ${resourceType} card "${resourceName}"`);
     }
 
-    let option: Option;
+    let option: MenuOption;
     switch (resourceType) {
       case ResourceCard.Dataset:
-        option = Option.RenameDataset;
+        option = MenuOption.RenameDataset;
         break;
       default:
-        option = Option.Rename;
+        option = MenuOption.Rename;
         break;
     }
     await card.selectSnowmanMenu(option, {waitForNav: false});
@@ -230,10 +230,10 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
 
   /**
    * Select Workspace action snowman menu option.
-   * @param {Option} option
+   * @param {MenuOption} option
    * @param opts
    */
-  async selectWorkspaceAction(option: Option, opts?: { waitForNav: false }): Promise<void> {
+  async selectWorkspaceAction(option: MenuOption, opts?: { waitForNav: false }): Promise<void> {
     const iconXpath = './/*[@data-test-id="workspace-menu-button"]';
     await this.page.waitForXPath(iconXpath, {visible: true}).then(icon => icon.click());
     const snowmanMenu = new SnowmanMenu(this.page);
@@ -244,7 +244,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * Delete workspace via Workspace Actions snowman menu "Delete" option.
    */
   async deleteWorkspace(): Promise<string[]> {
-    await this.selectWorkspaceAction(Option.Delete, { waitForNav: false });
+    await this.selectWorkspaceAction(MenuOption.Delete, { waitForNav: false });
     // Handle Delete Confirmation modal
     return this.dismissDeleteWorkspaceModal();
   }
@@ -267,7 +267,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
     * Edit workspace via Workspace Actions snowman menu "Edit" option.
     */
   async editWorkspace(): Promise<void> {
-    await this.selectWorkspaceAction(Option.Edit);
+    await this.selectWorkspaceAction(MenuOption.Edit);
   }
 
   async getCdrVersion(): Promise<string> {
@@ -285,7 +285,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * Share workspace via Workspace Actions snowman menu "Share" option.
    */
   async shareWorkspace(): Promise<ShareModal> {
-    await this.selectWorkspaceAction(Option.Share, { waitForNav: false });
+    await this.selectWorkspaceAction(MenuOption.Share, { waitForNav: false });
     const modal = new ShareModal(this.page);
     await modal.waitForLoad();
     return modal;

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -128,7 +128,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
       throw new Error(`Failed to find ${resourceType} card "${resourceName}"`);
     }
 
-    await card.selectSnowmanMenu(Option.Delete, {waitForNav: false});
+    await card.selectSnowmanMenu(Option.Delete, {waitForNavi: false});
 
     const modal = new Modal(this.page);
     await modal.waitForLoad();
@@ -184,7 +184,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
         option = Option.Rename;
         break;
     }
-    await card.selectSnowmanMenu(option, {waitForNav: false});
+    await card.selectSnowmanMenu(option, {waitForNavi: false});
 
     const modal = new Modal(this.page);
     await modal.waitForLoad();
@@ -233,7 +233,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * @param {Option} option
    * @param opts
    */
-  async selectWorkspaceAction(option: Option, opts?: { waitForNav: false }): Promise<void> {
+  async selectWorkspaceAction(option: Option, opts?: { waitForNavi: false }): Promise<void> {
     const iconXpath = './/*[@data-test-id="workspace-menu-button"]';
     await this.page.waitForXPath(iconXpath, {visible: true}).then(icon => icon.click());
     const snowmanMenu = new SnowmanMenu(this.page);
@@ -244,7 +244,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * Delete workspace via Workspace Actions snowman menu "Delete" option.
    */
   async deleteWorkspace(): Promise<string[]> {
-    await this.selectWorkspaceAction(Option.Delete, { waitForNav: false });
+    await this.selectWorkspaceAction(Option.Delete, { waitForNavi: false });
     // Handle Delete Confirmation modal
     return this.dismissDeleteWorkspaceModal();
   }
@@ -283,7 +283,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * Share workspace via Workspace Actions snowman menu "Share" option.
    */
   async shareWorkspace(): Promise<ShareModal> {
-    await this.selectWorkspaceAction(Option.Share, { waitForNav: false });
+    await this.selectWorkspaceAction(Option.Share);
     const modal = new ShareModal(this.page);
     await modal.waitUntilVisible();
     return modal;

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -258,6 +258,8 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
     const contentText = await modal.getTextContent();
     await modal.clickButton(clickButtonText, {waitForClose: true});
     await waitWhileLoading(this.page);
+    const workspaceName = contentText[0].split('Workspace: ')[1].replace('?','');
+    console.log(`Deleted workspace "${workspaceName}"`);
     return contentText;
   }
 

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -128,7 +128,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
       throw new Error(`Failed to find ${resourceType} card "${resourceName}"`);
     }
 
-    await card.selectSnowmanMenu(Option.Delete, {waitForNavi: false});
+    await card.selectSnowmanMenu(Option.Delete, {waitForNav: false});
 
     const modal = new Modal(this.page);
     await modal.waitForLoad();
@@ -184,7 +184,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
         option = Option.Rename;
         break;
     }
-    await card.selectSnowmanMenu(option, {waitForNavi: false});
+    await card.selectSnowmanMenu(option, {waitForNav: false});
 
     const modal = new Modal(this.page);
     await modal.waitForLoad();
@@ -233,7 +233,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * @param {Option} option
    * @param opts
    */
-  async selectWorkspaceAction(option: Option, opts?: { waitForNavi: false }): Promise<void> {
+  async selectWorkspaceAction(option: Option, opts?: { waitForNav: false }): Promise<void> {
     const iconXpath = './/*[@data-test-id="workspace-menu-button"]';
     await this.page.waitForXPath(iconXpath, {visible: true}).then(icon => icon.click());
     const snowmanMenu = new SnowmanMenu(this.page);
@@ -244,7 +244,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * Delete workspace via Workspace Actions snowman menu "Delete" option.
    */
   async deleteWorkspace(): Promise<string[]> {
-    await this.selectWorkspaceAction(Option.Delete, { waitForNavi: false });
+    await this.selectWorkspaceAction(Option.Delete, { waitForNav: false });
     // Handle Delete Confirmation modal
     return this.dismissDeleteWorkspaceModal();
   }

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -285,9 +285,9 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    * Share workspace via Workspace Actions snowman menu "Share" option.
    */
   async shareWorkspace(): Promise<ShareModal> {
-    await this.selectWorkspaceAction(Option.Share);
+    await this.selectWorkspaceAction(Option.Share, { waitForNav: false });
     const modal = new ShareModal(this.page);
-    await modal.waitUntilVisible();
+    await modal.waitForLoad();
     return modal;
   }
 }

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -66,7 +66,7 @@ export default class WorkspaceDataPage extends WorkspaceBase {
   async exportToNotebook(datasetName: string, notebookName: string): Promise<void> {
     const resourceCard = new DataResourceCard(this.page);
     const datasetCard = await resourceCard.findCard(datasetName, ResourceCard.Dataset);
-    await datasetCard.selectSnowmanMenu([Option.ExportToNotebook], {waitForNavi: false});
+    await datasetCard.selectSnowmanMenu([Option.ExportToNotebook], {waitForNav: false});
     console.log(`Exported Dataset "${datasetName}" to notebook "${notebookName}"`);
   }
 

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -2,7 +2,7 @@ import ConceptDomainCard, {Domain} from 'app/component/concept-domain-card';
 import Link from 'app/element/link';
 import DataResourceCard from 'app/component/data-resource-card';
 import ClrIconLink from 'app/element/clr-icon-link';
-import {Option, Language, ResourceCard} from 'app/text-labels';
+import {MenuOption, Language, ResourceCard} from 'app/text-labels';
 import {ElementHandle, Page} from 'puppeteer';
 import {makeRandomName} from 'utils/str-utils';
 import {waitForDocumentTitle, waitWhileLoading} from 'utils/waits-utils';
@@ -66,7 +66,7 @@ export default class WorkspaceDataPage extends WorkspaceBase {
   async exportToNotebook(datasetName: string, notebookName: string): Promise<void> {
     const resourceCard = new DataResourceCard(this.page);
     const datasetCard = await resourceCard.findCard(datasetName, ResourceCard.Dataset);
-    await datasetCard.selectSnowmanMenu([Option.ExportToNotebook], {waitForNav: false});
+    await datasetCard.selectSnowmanMenu([MenuOption.ExportToNotebook], {waitForNav: false});
     console.log(`Exported Dataset "${datasetName}" to notebook "${notebookName}"`);
   }
 

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -66,7 +66,7 @@ export default class WorkspaceDataPage extends WorkspaceBase {
   async exportToNotebook(datasetName: string, notebookName: string): Promise<void> {
     const resourceCard = new DataResourceCard(this.page);
     const datasetCard = await resourceCard.findCard(datasetName, ResourceCard.Dataset);
-    await datasetCard.selectSnowmanMenu([MenuOption.ExportToNotebook], {waitForNav: false});
+    await datasetCard.selectSnowmanMenu(MenuOption.ExportToNotebook, {waitForNav: false});
     console.log(`Exported Dataset "${datasetName}" to notebook "${notebookName}"`);
   }
 

--- a/e2e/app/page/workspace-data-page.ts
+++ b/e2e/app/page/workspace-data-page.ts
@@ -66,7 +66,7 @@ export default class WorkspaceDataPage extends WorkspaceBase {
   async exportToNotebook(datasetName: string, notebookName: string): Promise<void> {
     const resourceCard = new DataResourceCard(this.page);
     const datasetCard = await resourceCard.findCard(datasetName, ResourceCard.Dataset);
-    await datasetCard.selectSnowmanMenu(Option.exportToNotebook, {waitForNav: false});
+    await datasetCard.selectSnowmanMenu([Option.ExportToNotebook], {waitForNavi: false});
     console.log(`Exported Dataset "${datasetName}" to notebook "${notebookName}"`);
   }
 

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -417,6 +417,7 @@ export default class WorkspaceEditPage extends WorkspaceBase {
 
     // confirm create in pop-up modal
     const modal = new Modal(this.page);
+    await modal.waitForLoad();
     const modalTextContent = await modal.getTextContent();
     await modal.clickButton(LinkText.Confirm, {waitForClose: true, waitForNav: true});
     await waitWhileLoading(this.page);

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -13,7 +13,7 @@ export enum WorkspaceAccessLevel {
 }
 
 // Options in dropdown select.
-export enum Option {
+export enum MenuOption {
    Age = 'Age',
    Conditions = 'Conditions',
    CopyToAnotherWorkspace = 'Copy to another Workspace',

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -14,15 +14,27 @@ export enum WorkspaceAccessLevel {
 
 // Options in dropdown select.
 export enum Option {
+   Age = 'Age',
+   Conditions = 'Conditions',
    CopyToAnotherWorkspace = 'Copy to another Workspace',
+   Deceased = 'Deceased',
    Delete = 'Delete',
+   DeleteGroup = 'Delete group',
+   Demographics = 'Demographics',
+   Drugs = 'Drugs',
    Duplicate  = 'Duplicate',
    Edit = 'Edit',
+   EditGroupName  = 'Edit group name',
+   Ethnicity  = 'Ethnicity',
+   ExportToNotebook = 'Export to Notebook',
+   PhysicalMeasurements = 'Physical Measurements',
    Rename = 'Rename',
    RenameDataset = 'Rename Dataset',
    Review = 'Review',
+   Save = 'Save',
    Share = 'Share',
-   exportToNotebook = 'Export to Notebook',
+   SuppressGroupFromTotalCount = 'Suppress group from total count',
+   Visits = 'Visits',
 }
 
 // Button or link text labels.

--- a/e2e/app/xpath-builders.ts
+++ b/e2e/app/xpath-builders.ts
@@ -67,7 +67,7 @@ export function buildXPath(xOpts: XPathOptions, container?: Container): string {
     selector = `${textExpr}//${type}`;
     break;
   case ElementType.Dropdown:
-    selector = `${textExpr}${nodeLevel}//*[contains(concat(" ", normalize-space(@class), " "), " p-dropdown ")]`;
+    selector = `${textExpr}//*[contains(concat(" ", normalize-space(@class), " "), " p-dropdown ")]`;
     break;
   case ElementType.Tab:
     selector = `//*[(@aria-selected | @tabindex) and @role="button" and text()="${name}"]`;

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -2,7 +2,7 @@ const { defaults } = require('jest-config');
 const { TEST_MODE } = process.env;
 
 module.exports = {
-  "verbose": true,
+  "verbose": false,
   "bail": 1,  // Stop running tests after `n` failures
   "preset": "jest-puppeteer",
   "testTimeout": 600000,

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
     "impersonate-test-user": "env-cmd -x ../api/project.rb generate-impersonated-user-token --impersonated-user=\\$USER_NAME --output-token-filename=../e2e/puppeteer-access-token.txt",
     "_test": "yarn impersonate-test-user && jest",
     "_test:debugTest": "yarn impersonate-test-user && node --inspect-brk node_modules/.bin/jest",
-    "test": "cross-env yarn _test --maxWorkers=1",
+    "test": "cross-env yarn _test --maxWorkers=5",
     "test:debugTest": "cross-env PUPPETEER_HEADLESS=false DEBUG=true yarn _test:debugTest",
     "test:debug": "cross-env PUPPETEER_HEADLESS=false DEBUG=true yarn _test --detectOpenHandles",
     "test-local": "cross-env WORKBENCH_ENV=local DEBUG=true yarn _test --maxWorkers=3",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
     "impersonate-test-user": "env-cmd -x ../api/project.rb generate-impersonated-user-token --impersonated-user=\\$USER_NAME --output-token-filename=../e2e/puppeteer-access-token.txt",
     "_test": "yarn impersonate-test-user && jest",
     "_test:debugTest": "yarn impersonate-test-user && node --inspect-brk node_modules/.bin/jest",
-    "test": "cross-env yarn _test --maxWorkers=5",
+    "test": "cross-env yarn _test --maxWorkers=1",
     "test:debugTest": "cross-env PUPPETEER_HEADLESS=false DEBUG=true yarn _test:debugTest",
     "test:debug": "cross-env PUPPETEER_HEADLESS=false DEBUG=true yarn _test --detectOpenHandles",
     "test-local": "cross-env WORKBENCH_ENV=local DEBUG=true yarn _test --maxWorkers=3",

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -190,7 +190,7 @@ describe('User can create new Cohorts', () => {
     let cohortCard = await DataResourceCard.findCard(page, `${cohortName}`);
   
     // Edit cohort using Ellipsis menu
-    await cohortCard.selectSnowmanMenu(Option.Edit, {waitForNav: false});
+    await cohortCard.selectSnowmanMenu(Option.Edit, {waitForNavi: false});
     await cohortBuildPage.waitForLoad();
     await waitWhileLoading(page);
 
@@ -215,7 +215,7 @@ describe('User can create new Cohorts', () => {
     // Duplicate cohort using Ellipsis menu.
     const origCardsCount = (await DataResourceCard.findAllCards(page)).length;
     cohortCard = await DataResourceCard.findCard(page, `${cohortName}`);
-    await cohortCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: false});
+    await cohortCard.selectSnowmanMenu(Option.Duplicate, {waitForNavi: false});
     await waitWhileLoading(page);
     const newCardsCount = (await DataResourceCard.findAllCards(page)).length;
     // cards count increase by 1.

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -190,7 +190,7 @@ describe('User can create new Cohorts', () => {
     let cohortCard = await DataResourceCard.findCard(page, `${cohortName}`);
   
     // Edit cohort using Ellipsis menu
-    await cohortCard.selectSnowmanMenu(Option.Edit, {waitForNavi: false});
+    await cohortCard.selectSnowmanMenu(Option.Edit, {waitForNav: false});
     await cohortBuildPage.waitForLoad();
     await waitWhileLoading(page);
 
@@ -215,7 +215,7 @@ describe('User can create new Cohorts', () => {
     // Duplicate cohort using Ellipsis menu.
     const origCardsCount = (await DataResourceCard.findAllCards(page)).length;
     cohortCard = await DataResourceCard.findCard(page, `${cohortName}`);
-    await cohortCard.selectSnowmanMenu(Option.Duplicate, {waitForNavi: false});
+    await cohortCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: false});
     await waitWhileLoading(page);
     const newCardsCount = (await DataResourceCard.findAllCards(page)).length;
     // cards count increase by 1.

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -4,7 +4,7 @@ import DataResourceCard from 'app/component/data-resource-card';
 import Button from 'app/element/button';
 import ClrIconLink from 'app/element/clr-icon-link';
 import Link from 'app/element/link';
-import {Option, LinkText, ResourceCard} from 'app/text-labels';
+import {MenuOption, LinkText, ResourceCard} from 'app/text-labels';
 import CohortBuildPage, {FieldSelector} from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {findOrCreateWorkspace, signInWithAccessToken} from 'utils/test-utils';
@@ -190,7 +190,7 @@ describe('User can create new Cohorts', () => {
     let cohortCard = await DataResourceCard.findCard(page, `${cohortName}`);
   
     // Edit cohort using Ellipsis menu
-    await cohortCard.selectSnowmanMenu(Option.Edit, {waitForNav: false});
+    await cohortCard.selectSnowmanMenu(MenuOption.Edit, {waitForNav: false});
     await cohortBuildPage.waitForLoad();
     await waitWhileLoading(page);
 
@@ -215,7 +215,7 @@ describe('User can create new Cohorts', () => {
     // Duplicate cohort using Ellipsis menu.
     const origCardsCount = (await DataResourceCard.findAllCards(page)).length;
     cohortCard = await DataResourceCard.findCard(page, `${cohortName}`);
-    await cohortCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: false});
+    await cohortCard.selectSnowmanMenu(MenuOption.Duplicate, {waitForNav: false});
     await waitWhileLoading(page);
     const newCardsCount = (await DataResourceCard.findAllCards(page)).length;
     // cards count increase by 1.

--- a/e2e/tests/cohorts/cohorts-create.spec.ts
+++ b/e2e/tests/cohorts/cohorts-create.spec.ts
@@ -211,22 +211,21 @@ describe('User can create new Cohorts', () => {
 
     // navigate back to the data page and open Cohorts sub tab
     await dataPage.openCohortsSubtab();
+    await waitWhileLoading(page);
 
     // Duplicate cohort using Ellipsis menu.
-    const origCardsCount = (await DataResourceCard.findAllCards(page)).length;
     cohortCard = await DataResourceCard.findCard(page, `${cohortName}`);
     await cohortCard.selectSnowmanMenu(MenuOption.Duplicate, {waitForNav: false});
     await waitWhileLoading(page);
-    const newCardsCount = (await DataResourceCard.findAllCards(page)).length;
-    // cards count increase by 1.
-    expect(newCardsCount).toBe(origCardsCount + 1);
 
+    const duplCohortName = `Duplicate of ${cohortName}`;
+    console.log(`Duplicated Cohort "${cohortName}": "${duplCohortName}"`)
     // Delete duplicated cohort.
-    const modalTextContent = await dataPage.deleteResource(`Duplicate of ${cohortName}`, ResourceCard.Cohort);
-    expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: Duplicate of ${cohortName}?`);
+    const modalTextContent = await dataPage.deleteResource(duplCohortName, ResourceCard.Cohort);
+    expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: ${duplCohortName}?`);
 
     // Verify Delete successful.
-    expect(await DataResourceCard.findCard(page, `Duplicate of ${cohortName}`, 5000)).toBeFalsy();
+    expect(await DataResourceCard.findCard(page, duplCohortName, 5000)).toBeFalsy();
 
     // find the original new cohortCard
     cohortCard = await DataResourceCard.findCard(page, `${cohortName}`);

--- a/e2e/tests/cohorts/cohorts-review.spec.ts
+++ b/e2e/tests/cohorts/cohorts-review.spec.ts
@@ -40,7 +40,7 @@ describe('Cohort review tests', () => {
     const cohortName = await cohortCard.getResourceName();
     console.log(`Created Cohort: "${cohortName}"`);
 
-    await cohortCard.selectSnowmanMenu(Option.Review);
+    await cohortCard.selectSnowmanMenu(Option.Review, {waitForNavi: true});
     const modal = new CohortReviewModal(page);
     await modal.fillInNumberOfPartcipants(reviewSetNumberOfParticipants);
     await modal.clickButton(LinkText.CreateSet);

--- a/e2e/tests/cohorts/cohorts-review.spec.ts
+++ b/e2e/tests/cohorts/cohorts-review.spec.ts
@@ -40,7 +40,7 @@ describe('Cohort review tests', () => {
     const cohortName = await cohortCard.getResourceName();
     console.log(`Created Cohort: "${cohortName}"`);
 
-    await cohortCard.selectSnowmanMenu(Option.Review, {waitForNavi: true});
+    await cohortCard.selectSnowmanMenu(Option.Review, {waitForNav: true});
     const modal = new CohortReviewModal(page);
     await modal.fillInNumberOfPartcipants(reviewSetNumberOfParticipants);
     await modal.clickButton(LinkText.CreateSet);

--- a/e2e/tests/cohorts/cohorts-review.spec.ts
+++ b/e2e/tests/cohorts/cohorts-review.spec.ts
@@ -1,5 +1,5 @@
 import {createWorkspace, isValidDate, signInWithAccessToken} from 'utils/test-utils';
-import {Option, LinkText, ResourceCard} from 'app/text-labels';
+import {MenuOption, LinkText, ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import CohortBuildPage from 'app/page/cohort-build-page';
 import CohortParticipantDetailPage from 'app/page/cohort-participant-detail-page';
@@ -40,7 +40,7 @@ describe('Cohort review tests', () => {
     const cohortName = await cohortCard.getResourceName();
     console.log(`Created Cohort: "${cohortName}"`);
 
-    await cohortCard.selectSnowmanMenu(Option.Review, {waitForNav: true});
+    await cohortCard.selectSnowmanMenu(MenuOption.Review, {waitForNav: true});
     const modal = new CohortReviewModal(page);
     await modal.fillInNumberOfPartcipants(reviewSetNumberOfParticipants);
     await modal.clickButton(LinkText.CreateSet);

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -72,7 +72,7 @@ describe('Dataset test', () => {
 
     // Edit the dataset to include "All Participants".
     const datasetCard = await resourceCard.findCard(datasetName)
-    await datasetCard.selectSnowmanMenu(Option.Edit);
+    await datasetCard.selectSnowmanMenu(Option.Edit, {waitForNavi: true});
     await waitWhileLoading(page);
 
     const datasetEditPage = new DatasetEditPage(page);

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -2,7 +2,7 @@ import DataResourceCard from 'app/component/data-resource-card';
 import ClrIconLink from 'app/element/clr-icon-link';
 import CohortBuildPage from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {Option, ResourceCard} from 'app/text-labels';
+import {MenuOption, ResourceCard} from 'app/text-labels';
 import {findOrCreateWorkspace, signInWithAccessToken} from 'utils/test-utils';
 import {waitForText, waitWhileLoading} from 'utils/waits-utils';
 import DatasetEditPage from 'app/page/dataset-edit-page';
@@ -72,7 +72,7 @@ describe('Dataset test', () => {
 
     // Edit the dataset to include "All Participants".
     const datasetCard = await resourceCard.findCard(datasetName)
-    await datasetCard.selectSnowmanMenu(Option.Edit, {waitForNav: true});
+    await datasetCard.selectSnowmanMenu(MenuOption.Edit, {waitForNav: true});
     await waitWhileLoading(page);
 
     const datasetEditPage = new DatasetEditPage(page);

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -72,7 +72,7 @@ describe('Dataset test', () => {
 
     // Edit the dataset to include "All Participants".
     const datasetCard = await resourceCard.findCard(datasetName)
-    await datasetCard.selectSnowmanMenu(Option.Edit, {waitForNavi: true});
+    await datasetCard.selectSnowmanMenu(Option.Edit, {waitForNav: true});
     await waitWhileLoading(page);
 
     const datasetEditPage = new DatasetEditPage(page);

--- a/e2e/tests/datasets/export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/export-py-notebook.spec.ts
@@ -94,7 +94,7 @@ describe('Create Dataset', () => {
 
     const resourceCard = new DataResourceCard(page);
     const datasetCard = await resourceCard.findCard(datasetName, ResourceCard.Dataset);
-    await datasetCard.selectSnowmanMenu(Option.exportToNotebook, {waitForNav: false});
+    await datasetCard.selectSnowmanMenu(Option.ExportToNotebook, {waitForNavi: false});
 
     const exportModal = new ExportToNotebookModal(page);
     await exportModal.waitForLoad();

--- a/e2e/tests/datasets/export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/export-py-notebook.spec.ts
@@ -94,7 +94,7 @@ describe('Create Dataset', () => {
 
     const resourceCard = new DataResourceCard(page);
     const datasetCard = await resourceCard.findCard(datasetName, ResourceCard.Dataset);
-    await datasetCard.selectSnowmanMenu(Option.ExportToNotebook, {waitForNavi: false});
+    await datasetCard.selectSnowmanMenu(Option.ExportToNotebook, {waitForNav: false});
 
     const exportModal = new ExportToNotebookModal(page);
     await exportModal.waitForLoad();

--- a/e2e/tests/datasets/export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/export-py-notebook.spec.ts
@@ -2,7 +2,7 @@ import DataResourceCard from 'app/component/data-resource-card';
 import ExportToNotebookModal from 'app/component/export-to-notebook-modal';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {Option, ResourceCard} from 'app/text-labels';
+import {MenuOption, ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findOrCreateWorkspace, signInWithAccessToken} from 'utils/test-utils';
 import {waitForText, waitWhileLoading} from 'utils/waits-utils';
@@ -94,7 +94,7 @@ describe('Create Dataset', () => {
 
     const resourceCard = new DataResourceCard(page);
     const datasetCard = await resourceCard.findCard(datasetName, ResourceCard.Dataset);
-    await datasetCard.selectSnowmanMenu(Option.ExportToNotebook, {waitForNav: false});
+    await datasetCard.selectSnowmanMenu(MenuOption.ExportToNotebook, {waitForNav: false});
 
     const exportModal = new ExportToNotebookModal(page);
     await exportModal.waitForLoad();

--- a/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
+++ b/e2e/tests/notebook/reader-copy-to-workspace.spec.ts
@@ -5,7 +5,7 @@ import Link from 'app/element/link';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {Option, Language, LinkText, ResourceCard, WorkspaceAccessLevel} from 'app/text-labels';
+import {MenuOption, Language, LinkText, ResourceCard, WorkspaceAccessLevel} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
 import {makeRandomName} from 'utils/str-utils';
 import {createWorkspace, findOrCreateWorkspace, signInWithAccessToken, signInAs, signOut} from 'utils/test-utils';
@@ -84,11 +84,11 @@ describe('Workspace reader Jupyter notebook action tests', () => {
     let notebookCard = await dataResourceCard.findCard(notebookName, ResourceCard.Notebook);
     // open Snowman menu.
     const snowmanMenu = await notebookCard.getSnowmanMenu();
-    expect(await snowmanMenu.isOptionDisabled(Option.Rename)).toBe(true);
-    expect(await snowmanMenu.isOptionDisabled(Option.Duplicate)).toBe(true);
-    expect(await snowmanMenu.isOptionDisabled(Option.Delete)).toBe(true);
+    expect(await snowmanMenu.isOptionDisabled(MenuOption.Rename)).toBe(true);
+    expect(await snowmanMenu.isOptionDisabled(MenuOption.Duplicate)).toBe(true);
+    expect(await snowmanMenu.isOptionDisabled(MenuOption.Delete)).toBe(true);
     // But the Copy to another Workspace action is available for click.
-    expect(await snowmanMenu.isOptionDisabled(Option.CopyToAnotherWorkspace)).toBe(false);
+    expect(await snowmanMenu.isOptionDisabled(MenuOption.CopyToAnotherWorkspace)).toBe(false);
     await notebookCard.clickSnowmanIcon(); // close Snowman menu.
 
     // Copy notebook to another Workspace and give notebook a new name.
@@ -119,10 +119,10 @@ describe('Workspace reader Jupyter notebook action tests', () => {
 
     // Notebook actions Rename, Duplicate, Delete and Copy to another Workspace actions are avaliable to click.
     const copyNotebookCardMenu = await notebookCard.getSnowmanMenu();
-    expect(await copyNotebookCardMenu.isOptionDisabled(Option.Rename)).toBe(false);
-    expect(await copyNotebookCardMenu.isOptionDisabled(Option.Duplicate)).toBe(false);
-    expect(await copyNotebookCardMenu.isOptionDisabled(Option.Delete)).toBe(false);
-    expect(await copyNotebookCardMenu.isOptionDisabled(Option.CopyToAnotherWorkspace)).toBe(false);
+    expect(await copyNotebookCardMenu.isOptionDisabled(MenuOption.Rename)).toBe(false);
+    expect(await copyNotebookCardMenu.isOptionDisabled(MenuOption.Duplicate)).toBe(false);
+    expect(await copyNotebookCardMenu.isOptionDisabled(MenuOption.Delete)).toBe(false);
+    expect(await copyNotebookCardMenu.isOptionDisabled(MenuOption.CopyToAnotherWorkspace)).toBe(false);
     await notebookCard.clickSnowmanIcon(); // close menu
 
     await newAnalysisPage.deleteResource(copiedNotebookName, ResourceCard.Notebook);

--- a/e2e/tests/runtime/runtime-status-update.spec.ts
+++ b/e2e/tests/runtime/runtime-status-update.spec.ts
@@ -13,7 +13,7 @@ import NotebookPreviewPage from 'app/page/notebook-preview-page';
 // This one is going to take a long time.
 jest.setTimeout(60 * 30 * 1000);
 
-describe('Updating runtime parameters', () => {
+describe.skip('Updating runtime parameters', () => {
   beforeEach(async () => {
     await signInWithAccessToken(page);
     const workspaceCard = await createWorkspace(page, config.altCdrVersionName);

--- a/e2e/tests/runtime/runtime-status-update.spec.ts
+++ b/e2e/tests/runtime/runtime-status-update.spec.ts
@@ -13,7 +13,7 @@ import NotebookPreviewPage from 'app/page/notebook-preview-page';
 // This one is going to take a long time.
 jest.setTimeout(60 * 30 * 1000);
 
-describe.skip('Updating runtime parameters', () => {
+describe('Updating runtime parameters', () => {
   beforeEach(async () => {
     await signInWithAccessToken(page);
     const workspaceCard = await createWorkspace(page, config.altCdrVersionName);

--- a/e2e/tests/runtime/runtime-status-update.spec.ts
+++ b/e2e/tests/runtime/runtime-status-update.spec.ts
@@ -129,7 +129,7 @@ describe('Updating runtime parameters', () => {
 
     // Wait until status shows green in side-nav
     await page.waitForTimeout(2000);
-    await helpSidebar.toggleRuntimePanel();;
+    await helpSidebar.toggleRuntimePanel();
     await runtimePanel.waitForStartStopIconState(StartStopIconState.Starting);
     await runtimePanel.waitForStartStopIconState(StartStopIconState.Running);
 

--- a/e2e/tests/workspace/old-cdr-version-modal.spec.ts
+++ b/e2e/tests/workspace/old-cdr-version-modal.spec.ts
@@ -39,7 +39,7 @@ describe('OldCdrVersion Modal restrictions', () => {
 
         await workspaceCard.asElementHandle().hover();
         // Click on Ellipsis menu "Duplicate" option.
-        await workspaceCard.selectSnowmanMenu(Option.Duplicate);
+        await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNavi: true});
 
         // Fill out Workspace Name should be just enough for successful duplication
         const workspaceEditPage = new WorkspaceEditPage(page);

--- a/e2e/tests/workspace/old-cdr-version-modal.spec.ts
+++ b/e2e/tests/workspace/old-cdr-version-modal.spec.ts
@@ -1,7 +1,7 @@
 import {createWorkspace, signInWithAccessToken} from 'utils/test-utils';
 import WorkspaceCard from 'app/component/workspace-card';
 import {config} from 'resources/workbench-config';
-import {Option} from 'app/text-labels';
+import {MenuOption} from 'app/text-labels';
 import WorkspacesPage from 'app/page/workspaces-page';
 import {makeWorkspaceName} from 'utils/str-utils';
 import OldCdrVersionModal from 'app/page/old-cdr-version-modal';
@@ -39,7 +39,7 @@ describe('OldCdrVersion Modal restrictions', () => {
 
         await workspaceCard.asElementHandle().hover();
         // Click on Ellipsis menu "Duplicate" option.
-        await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: true});
+        await workspaceCard.selectSnowmanMenu(MenuOption.Duplicate, {waitForNav: true});
 
         // Fill out Workspace Name should be just enough for successful duplication
         const workspaceEditPage = new WorkspaceEditPage(page);

--- a/e2e/tests/workspace/old-cdr-version-modal.spec.ts
+++ b/e2e/tests/workspace/old-cdr-version-modal.spec.ts
@@ -39,7 +39,7 @@ describe('OldCdrVersion Modal restrictions', () => {
 
         await workspaceCard.asElementHandle().hover();
         // Click on Ellipsis menu "Duplicate" option.
-        await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNavi: true});
+        await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: true});
 
         // Fill out Workspace Name should be just enough for successful duplication
         const workspaceEditPage = new WorkspaceEditPage(page);

--- a/e2e/tests/workspace/workspace-card-share.spec.ts
+++ b/e2e/tests/workspace/workspace-card-share.spec.ts
@@ -4,7 +4,7 @@ import Link from 'app/element/link';
 import HomePage from 'app/page/home-page';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import WorkspacesPage from 'app/page/workspaces-page';
-import {Option, LinkText, WorkspaceAccessLevel} from 'app/text-labels';
+import {MenuOption, LinkText, WorkspaceAccessLevel} from 'app/text-labels';
 import {config} from 'resources/workbench-config';
 import {createWorkspace, findOrCreateWorkspace, signInWithAccessToken, signInAs, signOut} from 'utils/test-utils';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
@@ -62,7 +62,7 @@ describe('Share workspace', () => {
       const workspaceName = await workspaceCard.getWorkspaceName();
 
       // Open the Share modal
-      await workspaceCard.selectSnowmanMenu(Option.Share, {waitForNav: false});
+      await workspaceCard.selectSnowmanMenu(MenuOption.Share, {waitForNav: false});
 
       const shareModal = new ShareModal(page);
       await shareModal.waitUntilVisible();

--- a/e2e/tests/workspace/workspace-card-share.spec.ts
+++ b/e2e/tests/workspace/workspace-card-share.spec.ts
@@ -62,7 +62,7 @@ describe('Share workspace', () => {
       const workspaceName = await workspaceCard.getWorkspaceName();
 
       // Open the Share modal
-      await workspaceCard.selectSnowmanMenu(Option.Share, {waitForNav: false});
+      await workspaceCard.selectSnowmanMenu(Option.Share, {waitForNavi: false});
 
       const shareModal = new ShareModal(page);
       await shareModal.waitUntilVisible();

--- a/e2e/tests/workspace/workspace-card-share.spec.ts
+++ b/e2e/tests/workspace/workspace-card-share.spec.ts
@@ -62,7 +62,7 @@ describe('Share workspace', () => {
       const workspaceName = await workspaceCard.getWorkspaceName();
 
       // Open the Share modal
-      await workspaceCard.selectSnowmanMenu(Option.Share, {waitForNavi: false});
+      await workspaceCard.selectSnowmanMenu(Option.Share, {waitForNav: false});
 
       const shareModal = new ShareModal(page);
       await shareModal.waitUntilVisible();

--- a/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
@@ -1,7 +1,7 @@
 import {createWorkspace, signInWithAccessToken} from 'utils/test-utils';
 import WorkspaceCard from 'app/component/workspace-card';
 import {config} from 'resources/workbench-config';
-import {Option} from 'app/text-labels';
+import {MenuOption} from 'app/text-labels';
 import OldCdrVersionModal from 'app/page/old-cdr-version-modal';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import Navigation, {NavLink} from 'app/component/navigation';
@@ -19,7 +19,7 @@ describe('Duplicate workspace, changing CDR versions', () => {
 
         await workspaceCard.asElementHandle().hover();
         // Click on Ellipsis menu "Duplicate" option.
-        await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: true});
+        await workspaceCard.selectSnowmanMenu(MenuOption.Duplicate, {waitForNav: true});
 
         // Fill out Workspace Name should be just enough for successful duplication
         const workspaceEditPage = new WorkspaceEditPage(page);
@@ -63,7 +63,7 @@ describe('Duplicate workspace, changing CDR versions', () => {
 
         await workspaceCard.asElementHandle().hover();
         // Click on Ellipsis menu "Duplicate" option.
-        await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: true});
+        await workspaceCard.selectSnowmanMenu(MenuOption.Duplicate, {waitForNav: true});
 
         // Fill out Workspace Name should be just enough for successful duplication
         const workspaceEditPage = new WorkspaceEditPage(page);

--- a/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
@@ -19,7 +19,7 @@ describe('Duplicate workspace, changing CDR versions', () => {
 
         await workspaceCard.asElementHandle().hover();
         // Click on Ellipsis menu "Duplicate" option.
-        await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNavi: true});
+        await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: true});
 
         // Fill out Workspace Name should be just enough for successful duplication
         const workspaceEditPage = new WorkspaceEditPage(page);
@@ -63,7 +63,7 @@ describe('Duplicate workspace, changing CDR versions', () => {
 
         await workspaceCard.asElementHandle().hover();
         // Click on Ellipsis menu "Duplicate" option.
-        await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNavi: true});
+        await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: true});
 
         // Fill out Workspace Name should be just enough for successful duplication
         const workspaceEditPage = new WorkspaceEditPage(page);

--- a/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
@@ -19,7 +19,7 @@ describe('Duplicate workspace, changing CDR versions', () => {
 
         await workspaceCard.asElementHandle().hover();
         // Click on Ellipsis menu "Duplicate" option.
-        await workspaceCard.selectSnowmanMenu(Option.Duplicate);
+        await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNavi: true});
 
         // Fill out Workspace Name should be just enough for successful duplication
         const workspaceEditPage = new WorkspaceEditPage(page);
@@ -63,7 +63,7 @@ describe('Duplicate workspace, changing CDR versions', () => {
 
         await workspaceCard.asElementHandle().hover();
         // Click on Ellipsis menu "Duplicate" option.
-        await workspaceCard.selectSnowmanMenu(Option.Duplicate);
+        await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNavi: true});
 
         // Fill out Workspace Name should be just enough for successful duplication
         const workspaceEditPage = new WorkspaceEditPage(page);

--- a/e2e/tests/workspace/workspace-duplicate.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate.spec.ts
@@ -23,7 +23,7 @@ describe('Duplicate workspace', () => {
 
       await workspaceCard.asElementHandle().hover();
       // Click on Ellipsis menu "Duplicate" option.
-      await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNavi: true});
+      await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: true});
 
       // Fill out Workspace Name should be just enough for successful duplication
       const workspaceEditPage = new WorkspaceEditPage(page);

--- a/e2e/tests/workspace/workspace-duplicate.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate.spec.ts
@@ -1,5 +1,5 @@
 import {findOrCreateWorkspace, signInWithAccessToken} from 'utils/test-utils';
-import {Option} from 'app/text-labels';
+import {MenuOption} from 'app/text-labels';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import Navigation, {NavLink} from 'app/component/navigation';
 import WorkspaceCard from 'app/component/workspace-card';
@@ -23,7 +23,7 @@ describe('Duplicate workspace', () => {
 
       await workspaceCard.asElementHandle().hover();
       // Click on Ellipsis menu "Duplicate" option.
-      await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNav: true});
+      await workspaceCard.selectSnowmanMenu(MenuOption.Duplicate, {waitForNav: true});
 
       // Fill out Workspace Name should be just enough for successful duplication
       const workspaceEditPage = new WorkspaceEditPage(page);
@@ -55,7 +55,7 @@ describe('Duplicate workspace', () => {
       await workspaceCard.clickWorkspaceName();
 
       const dataPage = new WorkspaceDataPage(page);
-      await dataPage.selectWorkspaceAction(Option.Duplicate);
+      await dataPage.selectWorkspaceAction(MenuOption.Duplicate);
 
       const workspaceEditPage = new WorkspaceEditPage(page);
 

--- a/e2e/tests/workspace/workspace-duplicate.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate.spec.ts
@@ -23,7 +23,7 @@ describe('Duplicate workspace', () => {
 
       await workspaceCard.asElementHandle().hover();
       // Click on Ellipsis menu "Duplicate" option.
-      await workspaceCard.selectSnowmanMenu(Option.Duplicate);
+      await workspaceCard.selectSnowmanMenu(Option.Duplicate, {waitForNavi: true});
 
       // Fill out Workspace Name should be just enough for successful duplication
       const workspaceEditPage = new WorkspaceEditPage(page);

--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -25,7 +25,7 @@ describe('Editing workspace via workspace card snowman menu', () => {
   test('User as OWNER can edit workspace', async () => {
     const workspaceCard = await createWorkspace(page);
     workspaceName = await workspaceCard.getWorkspaceName();
-    await workspaceCard.selectSnowmanMenu(Option.Edit);
+    await workspaceCard.selectSnowmanMenu(Option.Edit, {waitForNavi: true});
 
     const workspaceEditPage = new WorkspaceEditPage(page);
 
@@ -106,11 +106,11 @@ describe('Editing workspace via workspace card snowman menu', () => {
     const workspaceEditPage = new WorkspaceEditPage(page);
 
      // CDR Version Select is readonly. Get selected value.
-     const selectedOption = await workspaceEditPage.selectCdrVersion();
-     const cdrVersionSelect = await workspaceEditPage.getCdrVersionSelect();
-     const selectedValue = await cdrVersionSelect.getOptionValue(selectedOption);
+    const selectedOption = await workspaceEditPage.selectCdrVersion();
+    const cdrVersionSelect = await workspaceEditPage.getCdrVersionSelect();
+    const selectedValue = await cdrVersionSelect.getOptionValue(selectedOption);
 
-     // Change question #2 answer
+    // Change question #2 answer
      await performActions(page, testData.defaultAnswersResearchPurposeSummary);
 
      const updateButton = await workspaceEditPage.getUpdateWorkspaceButton();

--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -25,7 +25,7 @@ describe('Editing workspace via workspace card snowman menu', () => {
   test('User as OWNER can edit workspace', async () => {
     const workspaceCard = await createWorkspace(page);
     workspaceName = await workspaceCard.getWorkspaceName();
-    await workspaceCard.selectSnowmanMenu(Option.Edit, {waitForNavi: true});
+    await workspaceCard.selectSnowmanMenu(Option.Edit, {waitForNav: true});
 
     const workspaceEditPage = new WorkspaceEditPage(page);
 

--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -1,5 +1,5 @@
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {Option, WorkspaceAccessLevel} from 'app/text-labels';
+import {MenuOption, WorkspaceAccessLevel} from 'app/text-labels';
 import * as testData from 'resources/data/workspace-data';
 import {createWorkspace, findOrCreateWorkspace, performActions, signInWithAccessToken} from 'utils/test-utils';
 import WorkspaceAboutPage from 'app/page/workspace-about-page';
@@ -25,7 +25,7 @@ describe('Editing workspace via workspace card snowman menu', () => {
   test('User as OWNER can edit workspace', async () => {
     const workspaceCard = await createWorkspace(page);
     workspaceName = await workspaceCard.getWorkspaceName();
-    await workspaceCard.selectSnowmanMenu(Option.Edit, {waitForNav: true});
+    await workspaceCard.selectSnowmanMenu(MenuOption.Edit, {waitForNav: true});
 
     const workspaceEditPage = new WorkspaceEditPage(page);
 

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -261,7 +261,7 @@ export async function waitForText(page: Page,
  * It usually indicates the page is ready for user interaction.
  * </pre>
  */
-export async function waitWhileLoading(page: Page, timeout: number = 150000): Promise<void> {
+export async function waitWhileLoading(page: Page, timeout: number = (2 * 60 * 1000)): Promise<void> {
   const notBlankPageSelector = '[data-test-id="sign-in-container"], title:not(empty), div.spinner, svg[viewBox]';
   const spinElementsSelector = '[style*="running spin"], .spinner:empty, [style*="running rotation"]:not([aria-hidden="true"])';
 

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -39,7 +39,7 @@ export async function waitForDocumentTitle(page: Page, titleSubstr: string): Pro
     const jsHandle = await page.waitForFunction(t => {
       const actualTitle = document.title;
       return actualTitle.includes(t);
-    }, {timeout: 30000}, titleSubstr);
+    }, {timeout: 60000}, titleSubstr);
     return (await jsHandle.jsonValue()) as boolean;
   } catch (e) {
     console.error(`waitForDocumentTitle contains "${titleSubstr}" failed. ${e}`);
@@ -261,7 +261,7 @@ export async function waitForText(page: Page,
  * It usually indicates the page is ready for user interaction.
  * </pre>
  */
-export async function waitWhileLoading(page: Page, timeout: number = 90000): Promise<void> {
+export async function waitWhileLoading(page: Page, timeout: number = 150000): Promise<void> {
   const notBlankPageSelector = '[data-test-id="sign-in-container"], title:not(empty), div.spinner, svg[viewBox]';
   const spinElementsSelector = '[style*="running spin"], .spinner:empty, [style*="running rotation"]:not([aria-hidden="true"])';
 

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -39,7 +39,7 @@ export async function waitForDocumentTitle(page: Page, titleSubstr: string): Pro
     const jsHandle = await page.waitForFunction(t => {
       const actualTitle = document.title;
       return actualTitle.includes(t);
-    }, {timeout: 60000}, titleSubstr);
+    }, {timeout: 10 * 60 * 1000}, titleSubstr);
     return (await jsHandle.jsonValue()) as boolean;
   } catch (e) {
     console.error(`waitForDocumentTitle contains "${titleSubstr}" failed. ${e}`);


### PR DESCRIPTION
`tiered-menu`, `select-menu` and `snowman-menu` classes have some duplicate functions. To avoid duplication and simplify code, create a common abstract `base-menu` class which to be extended by `tiered-menu`, `select-menu` and `snowman-menu` classes.

Additionally, found and fixed some imperfect xpath selectors and increased general timeouts.