### PR TITLE
[RW-5824][risk=no] Change concept set and cohort builder search result column order

### DIFF
--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -191,14 +191,9 @@ const columns = [
     style: {...styles.columnNameHeader, width: '31%', borderLeft: 0},
   },
   {
-    name: 'Code',
-    tooltip: 'Code from vocabulary',
-    style: columnHeaderStyle,
-  },
-  {
-    name: 'Vocab',
-    tooltip: 'Vocabulary for concept',
-    style: {...columnHeaderStyle, paddingLeft: '0'},
+    name: 'Concept Id',
+    tooltip: 'Unique ID for concept in OMOP',
+    style: {...styles.columnNameHeader, width: '10%', paddingLeft: '0', paddingRight: '0.5rem'},
   },
   {
     name: 'Source/Standard',
@@ -206,9 +201,14 @@ const columns = [
     style: {...styles.columnNameHeader, width: '10%', paddingLeft: '0', paddingRight: '0.5rem'},
   },
   {
-    name: 'Concept Id',
-    tooltip: 'Unique ID for concept in OMOP',
-    style: {...styles.columnNameHeader, width: '10%', paddingLeft: '0', paddingRight: '0.5rem'},
+    name: 'Vocab',
+    tooltip: 'Vocabulary for concept',
+    style: {...columnHeaderStyle, paddingLeft: '0'},
+  },
+  {
+    name: 'Code',
+    tooltip: 'Code from vocabulary',
+    style: columnHeaderStyle,
   },
   {
     name: 'Roll-up Count',
@@ -484,6 +484,9 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
             </div>
           </TooltipTrigger>
         </td>
+        <td style={{...columnBodyStyle, width: '10%', paddingRight: '0.5rem'}}>{row.conceptId}</td>
+        <td style={{...columnBodyStyle, width: '10%', paddingRight: '0.5rem'}}>{row.isStandard ? 'Standard' : 'Source'}</td>
+        <td style={{...columnBodyStyle}}>{!brand && row.type}</td>
         <td style={{...columnBodyStyle, paddingLeft: '0.2rem', paddingRight: '0.5rem'}}>
           <TooltipTrigger disabled={hoverId !== elementId} content={<div>{row.code}</div>}>
             <div data-test-id='code-column-value'
@@ -493,9 +496,6 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
               {row.code}
             </div>
           </TooltipTrigger></td>
-        <td style={{...columnBodyStyle}}>{!brand && row.type}</td>
-        <td style={{...columnBodyStyle, width: '10%', paddingRight: '0.5rem'}}>{row.isStandard ? 'Standard' : 'Source'}</td>
-        <td style={{...columnBodyStyle, width: '10%', paddingRight: '0.5rem'}}>{row.conceptId}</td>
         <td style={{...columnBodyStyle, paddingLeft: '0.2rem'}}>{row.parentCount > -1 && row.parentCount.toLocaleString()}</td>
         <td style={{...columnBodyStyle, paddingLeft: '0.2rem'}}>{row.childCount > -1 && row.childCount.toLocaleString()}</td>
         <td style={{...columnBodyStyle, textAlign: 'center', width: '12%'}}>


### PR DESCRIPTION

<img width="1680" alt="Screen Shot 2021-01-19 at 3 47 30 PM" src="https://user-images.githubusercontent.com/34481816/105091559-0616ec00-5a6e-11eb-9125-69f2f53dc7c4.png">

<img width="1550" alt="Screen Shot 2021-01-19 at 3 47 36 PM" src="https://user-images.githubusercontent.com/34481816/105091567-07e0af80-5a6e-11eb-8908-68f5344efe7e.png">



---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
