### PR TITLE
[RW-6079] [risk=no] Turn on Jupyter debug-level logs for newly-created clusters

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -42,7 +42,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
-  private static final String WORKSPACE_CDR = "WORKSPACE_CDR";
+  private static final String WORKSPACE_CDR_ENV_KEY = "WORKSPACE_CDR";
+  private static final String JUPYTER_DEBUG_LOGGING_ENV_KEY = "JUPYTER_DEBUG_LOGGING";
+
 
   private static final Logger log = Logger.getLogger(LeonardoNotebooksClientImpl.class.getName());
 
@@ -170,11 +172,17 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     // i.e. is NEW or MIGRATED
     if (!workspace.getBillingMigrationStatusEnum().equals(BillingMigrationStatus.OLD)) {
       customEnvironmentVariables.put(
-          WORKSPACE_CDR,
+          WORKSPACE_CDR_ENV_KEY,
           workspace.getCdrVersion().getBigqueryProject()
               + "."
               + workspace.getCdrVersion().getBigqueryDataset());
     }
+
+    // See RW-6079
+    customEnvironmentVariables.put(
+        JUPYTER_DEBUG_LOGGING_ENV_KEY,
+      "true"
+    );
 
     leonardoRetryHandler.run(
         (context) -> {

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -45,7 +45,6 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   private static final String WORKSPACE_CDR_ENV_KEY = "WORKSPACE_CDR";
   private static final String JUPYTER_DEBUG_LOGGING_ENV_KEY = "JUPYTER_DEBUG_LOGGING";
 
-
   private static final Logger log = Logger.getLogger(LeonardoNotebooksClientImpl.class.getName());
 
   private final Provider<RuntimesApi> runtimesApiProvider;
@@ -179,10 +178,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     }
 
     // See RW-6079
-    customEnvironmentVariables.put(
-        JUPYTER_DEBUG_LOGGING_ENV_KEY,
-      "true"
-    );
+    customEnvironmentVariables.put(JUPYTER_DEBUG_LOGGING_ENV_KEY, "true");
 
     leonardoRetryHandler.run(
         (context) -> {


### PR DESCRIPTION
This makes a change to use the feature enabled by https://github.com/DataBiosphere/terra-docker/pull/193

It would be possible (and maybe safer) to add a feature flag to control this. My instinct was that a feature flag would add more boilerplate without much benefit – we could simply push out a rollback PR if needed.

No explicit coordination is required with the Terra-docker push; even if this change ends up in production first, the new env var shouldn't break anything on its own.