### PR TITLE
[RW-6162] [risk=no] Extend wait timeout for runtime status changes

### DIFF
--- a/e2e/app/component/runtime-panel.ts
+++ b/e2e/app/component/runtime-panel.ts
@@ -1,11 +1,11 @@
-import Container from 'app/container';
-import {LinkText} from 'app/text-labels';
-import Button from 'app/element/button';
-import {Page} from 'puppeteer';
-import {waitForAttributeEquality, waitWhileLoading} from 'utils/waits-utils';
-import PrimereactInputNumber from 'app/element/primereact-input-number';
 import SelectMenu from 'app/component/select-menu';
+import Container from 'app/container';
+import Button from 'app/element/button';
+import PrimereactInputNumber from 'app/element/primereact-input-number';
+import {LinkText} from 'app/text-labels';
+import {Page} from 'puppeteer';
 import {savePageToFile, takeScreenshot} from 'utils/save-file-utils';
+import {waitForAttributeEquality, waitWhileLoading} from 'utils/waits-utils';
 
 const defaultXpath = '//*[@id="runtime-panel"]';
 const statusIconXpath = '//*[@data-test-id="runtime-status-icon"]';
@@ -164,7 +164,9 @@ export default class RuntimePanel extends Container {
         {xpath: statusIconXpath},
         'src',
         this.buildStatusIconSrc(startStopIconState),
-        600000
+        // Wait up to 20 minutes before timing out here. We expect runtime changes to be quite
+        // slow, so we want to give a generous amount of time before failing the test.
+        20 * 60 * 1000
     )
   }
 

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -164,6 +164,7 @@ export async function waitForHidden(page: Page, cssSelector: string): Promise<bo
  * @param {string} cssSelector - The selector for the element on the page
  * @param {string} attribute - The attribute name
  * @param {string} value - The attribute value to match
+ * @param {number} timeout - the timeout in msecs
  */
 export async function waitForAttributeEquality(page: Page,
                                                selector: {xpath?: string, css?: string},


### PR DESCRIPTION
This is a low-effort attempt to fix flakiness we're seeing in notebook runtime tests. If the longer timeout seems to help with flakiness, it will be a reasonably good signal that we should split out our notebook runtime tests to run less frequently but allow longer timeouts and durations.