### PR TITLE
[noTicket][risk=no]Correct validate check for DataSet

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -63,6 +63,7 @@ import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -126,19 +127,14 @@ public class DataSetController implements DataSetApiDelegate {
         Optional.ofNullable(dataSetRequest.getIncludesAllParticipants()).orElse(false);
     if (Strings.isNullOrEmpty(dataSetRequest.getName())) {
       throw new BadRequestException("Missing name");
-    } else if (dataSetRequest.getConceptSetIds() == null
-        || (dataSetRequest.getConceptSetIds().isEmpty()
-            && (dataSetRequest.getPrePackagedConceptSet().size() == 1
-                && dataSetRequest
-                    .getPrePackagedConceptSet()
-                    .get(0)
-                    .equals(PrePackagedConceptSetEnum.NONE)))) {
+    } else if (CollectionUtils.isEmpty(dataSetRequest.getConceptSetIds())
+        && dataSetRequest
+            .getPrePackagedConceptSet()
+            .containsAll(ImmutableList.of(PrePackagedConceptSetEnum.NONE))) {
       throw new BadRequestException("Missing concept set ids");
-    } else if ((dataSetRequest.getCohortIds() == null || dataSetRequest.getCohortIds().isEmpty())
-        && !includesAllParticipants) {
+    } else if (CollectionUtils.isEmpty(dataSetRequest.getCohortIds()) && !includesAllParticipants) {
       throw new BadRequestException("Missing cohort ids");
-    } else if (dataSetRequest.getDomainValuePairs() == null
-        || dataSetRequest.getDomainValuePairs().isEmpty()) {
+    } else if (CollectionUtils.isEmpty(dataSetRequest.getDomainValuePairs())) {
       throw new BadRequestException("Missing values");
     }
   }

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -128,7 +128,11 @@ public class DataSetController implements DataSetApiDelegate {
       throw new BadRequestException("Missing name");
     } else if (dataSetRequest.getConceptSetIds() == null
         || (dataSetRequest.getConceptSetIds().isEmpty()
-            && dataSetRequest.getPrePackagedConceptSet().equals(PrePackagedConceptSetEnum.NONE))) {
+            && (dataSetRequest.getPrePackagedConceptSet().size() == 1
+                && dataSetRequest
+                    .getPrePackagedConceptSet()
+                    .get(0)
+                    .equals(PrePackagedConceptSetEnum.NONE)))) {
       throw new BadRequestException("Missing concept set ids");
     } else if ((dataSetRequest.getCohortIds() == null || dataSetRequest.getCohortIds().isEmpty())
         && !includesAllParticipants) {


### PR DESCRIPTION
PrePackagedSet is no longer contains a single entity, it is actually a list now. So for validating a dataset, throw an exception if there not concept set selected and Prepackaged list contains just one element i.e NONE


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
