### PR TITLE
[RW-6192] [risk=no] Improve project buffer recovery time

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -27,6 +27,7 @@
     "retryCount": 2,
     "bufferCapacity": 10,
     "bufferRefillProjectsPerTask": 1,
+    "bufferStatusChecksPerTask": 10,
     "defaultFreeCreditsDollarLimit": 300.0,
     "freeTierCostAlertThresholds": [
       0.5,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -27,6 +27,7 @@
     "retryCount": 4,
     "bufferCapacity": 300,
     "bufferRefillProjectsPerTask": 5,
+    "bufferStatusChecksPerTask": 10,
     "defaultFreeCreditsDollarLimit": 300.0,
     "freeTierCostAlertThresholds": [
       0.5,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -27,6 +27,7 @@
     "retryCount": 4,
     "bufferCapacity": 20,
     "bufferRefillProjectsPerTask": 1,
+    "bufferStatusChecksPerTask": 10,
     "defaultFreeCreditsDollarLimit": 300.0,
     "freeTierCostAlertThresholds": [
       0.5,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -27,6 +27,7 @@
     "retryCount": 4,
     "bufferCapacity": 200,
     "bufferRefillProjectsPerTask": 1,
+    "bufferStatusChecksPerTask": 10,
     "defaultFreeCreditsDollarLimit": 300.0,
     "freeTierCostAlertThresholds": [
       0.5,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -27,6 +27,7 @@
     "retryCount": 2,
     "bufferCapacity": 10,
     "bufferRefillProjectsPerTask": 1,
+    "bufferStatusChecksPerTask": 10,
     "defaultFreeCreditsDollarLimit": 300.0,
     "freeTierCostAlertThresholds": [
       0.5,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -27,6 +27,7 @@
     "retryCount": 2,
     "bufferCapacity": 50,
     "bufferRefillProjectsPerTask": 1,
+    "bufferStatusChecksPerTask": 10,
     "defaultFreeCreditsDollarLimit": 300.0,
     "freeTierCostAlertThresholds": [
       0.5,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -27,6 +27,7 @@
     "retryCount": 2,
     "bufferCapacity": 300,
     "bufferRefillProjectsPerTask": 1,
+    "bufferStatusChecksPerTask": 10,
     "defaultFreeCreditsDollarLimit": 300.0,
     "freeTierCostAlertThresholds": [
       0.5,

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -69,7 +69,7 @@ public class BillingProjectBufferService implements GaugeDataCollector {
   }
 
   private Timestamp getCurrentTimestamp() {
-    return new Timestamp(clock.instant().toEpochMilli());
+    return Timestamp.from(clock.instant());
   }
 
   /** Makes a configurable number of project creation attempts. */
@@ -121,7 +121,11 @@ public class BillingProjectBufferService implements GaugeDataCollector {
     final DbBillingProjectBufferEntry bufferEntry = new DbBillingProjectBufferEntry();
     bufferEntry.setFireCloudProjectName(createBillingProjectName());
     bufferEntry.setCreationTime(Timestamp.from(clock.instant()));
-
+    // Note: we set the lastSyncRequestTime column to the current timestamp as an optimization.
+    // If we leave this column as NULL, the sync process will prioritize this entry for immediate
+    // synchronization with Terra. Instead, we populate this column with the current timestamp
+    // since we know with high confidence that the initial status is CREATING. See RW-6192 for
+    // more context.
     bufferEntry.setLastSyncRequestTime(Timestamp.from(clock.instant()));
     bufferEntry.setStatusEnum(BufferEntryStatus.CREATING, this::getCurrentTimestamp);
     return billingProjectBufferEntryDao.save(bufferEntry);
@@ -138,7 +142,6 @@ public class BillingProjectBufferService implements GaugeDataCollector {
 
     int successfulSyncCount = 0;
     for (DbBillingProjectBufferEntry bufferEntry : creatingEntriesToSync) {
-      log.info("Syncing buffer entry");
       //noinspection UnusedAssignment
       bufferEntry = syncBufferEntry(bufferEntry);
       successfulSyncCount += 1;

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -71,6 +71,15 @@ public class WorkbenchConfig {
     // of project creation to a number less than 1 per second. In practice, a reasonable aggressive
     // value for this parameter would be 5-10 project refills per minute.
     public Integer bufferRefillProjectsPerTask;
+    // The number of projects whose status should be checked per cron task execution. This controls
+    // the maximum rate of API calls to Terra's getBillingProjectStatus endpoint. This value has
+    // little impact during normal operation, when the number of CREATING projects which need to be
+    // synced is quite small, but can impact system behavior during outages and after recovery.
+    //
+    // A higher number ensures that projects are kept in sync more quickly, at the cost of greater
+    // load on Terra's endpoints. Historically this number was hard-coded to 5, but a larger value
+    // (between 10-20) significantly speeds the Workbench's recovery from an outage.
+    public Integer bufferStatusChecksPerTask;
     // The environment-driven prefix to apply to GCP projects created in the buffer. Example:
     // "aou-rw-perf-" causes the buffer to create projects named like "aou-rw-perf-8aec175b".
     public String projectNamePrefix;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectBufferEntryDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/BillingProjectBufferEntryDao.java
@@ -28,7 +28,14 @@ public interface BillingProjectBufferEntryDao
   List<DbBillingProjectBufferEntry> findAllByStatusAndLastStatusChangedTimeLessThan(
       short status, Timestamp timestamp);
 
-  List<DbBillingProjectBufferEntry> findTop5ByStatusOrderByLastSyncRequestTimeAsc(short status);
+  @Query(
+      value =
+          "SELECT * FROM billing_project_buffer_entry "
+              + "  WHERE status = 0 "
+              + "  ORDER BY last_sync_request_time ASC "
+              + "  LIMIT ?1",
+      nativeQuery = true)
+  List<DbBillingProjectBufferEntry> getCreatingEntriesToSync(int limit);
 
   DbBillingProjectBufferEntry findFirstByStatusOrderByCreationTimeAsc(short status);
 

--- a/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
@@ -111,7 +111,7 @@ public class BillingProjectBufferServiceTest {
   @Autowired private Clock clock;
   @Autowired private UserDao userDao;
   @Autowired private Provider<WorkbenchConfig> workbenchConfigProvider;
-  // Put a spy on the buffer entry DAO since we might want to intercept some calls.
+  // Put a spy on the buffer entry DAO to allow us to intercept calls for the buffer recovery test.
   @Autowired @SpyBean private BillingProjectBufferEntryDao billingProjectBufferEntryDao;
   @Autowired private FireCloudService mockFireCloudService;
   @Autowired private MonitoringService mockMonitoringService;
@@ -126,6 +126,7 @@ public class BillingProjectBufferServiceTest {
     workbenchConfig.billing.projectNamePrefix = "test-prefix";
     workbenchConfig.billing.bufferCapacity = (int) BUFFER_CAPACITY;
     workbenchConfig.billing.bufferRefillProjectsPerTask = 1;
+    workbenchConfig.billing.bufferStatusChecksPerTask = 10;
 
     CLOCK.setInstant(NOW);
 
@@ -434,10 +435,23 @@ public class BillingProjectBufferServiceTest {
   }
 
   @Test
-  public void testOutageRecoveryTimePeriod() {
+  public void testOutageRecoveryTime() {
+    // This test runs through a simulated outage-and-recovery scenario, checking the time
+    // it takes Workbench to recover with a project in the READY state after an extended
+    // Terra outage.
+    //
+    // See RW-6192 for more context on the issue that motivated this test. When that issue
+    // was filed, it took a 300-project buffer ~1-2 hours to reach a recovery state. This
+    // test demonstrates that with an appropriate set of configuration values, a 300-project
+    // buffer can recover almost immediately after the first non-error project is ready.
+
     workbenchConfig.billing.bufferCapacity = (int) 300;
     workbenchConfig.billing.bufferRefillProjectsPerTask = 5;
+    workbenchConfig.billing.bufferStatusChecksPerTask = 10;
 
+    // Set up the core Terra mock. All projects will return CREATING status for 15 minutes after
+    // their creation time. After 15 minutes, they will return ERROR by default, or SUCCESS if
+    // the project name has been added to the HashSet.
     Set<String> successProjectNames = new HashSet<>();
     doAnswer(
             invocation -> {
@@ -446,7 +460,8 @@ public class BillingProjectBufferServiceTest {
                   billingProjectBufferEntryDao.findByFireCloudProjectName(projectName);
               Duration timeSinceCreation =
                   Duration.between(entry.getCreationTime().toInstant(), CLOCK.instant());
-
+              log.fine(String.format("%s is %s mins old (%s project)", projectName, timeSinceCreation.toMinutes(),
+                  successProjectNames.contains(projectName) ? "SUCCESS" : "ERROR"));
               CreationStatusEnum status = null;
               if (timeSinceCreation.toMinutes() < 15) {
                 status = CreationStatusEnum.CREATING;
@@ -462,7 +477,8 @@ public class BillingProjectBufferServiceTest {
         .when(mockFireCloudService)
         .getBillingProjectStatus(anyString());
 
-    Instant startingTime = CLOCK.instant();
+    // This lambda simulates the passage of time, with the clock incrementing and each of the
+    // buffer and sync cron jobs executing every minute.
     Runnable tick =
         () -> {
           CLOCK.setInstant(CLOCK.instant().plus(Duration.ofMinutes(1)));
@@ -470,7 +486,9 @@ public class BillingProjectBufferServiceTest {
           billingProjectBufferService.syncBillingProjectStatus();
         };
 
-    // Outage simulation: create a bunch of projects which will error-out after 15 minutes.
+    Instant startingTime = CLOCK.instant();
+
+    // Simulate a Terra outage: create a bunch of projects which will error-out after 15 minutes.
     while (billingProjectBufferEntryDao.count() < 300) {
       tick.run();
       if (Duration.between(startingTime, CLOCK.instant()).toHours() > 3) {
@@ -479,16 +497,25 @@ public class BillingProjectBufferServiceTest {
       }
     }
 
+    // Sanity check: there shouldn't be any AVAILABLE projects.
     assertThat(billingProjectBufferEntryDao.getCountByStatusMap().get(BufferEntryStatus.AVAILABLE))
         .isEqualTo(null);
-    assertThat(billingProjectBufferEntryDao.getCountByStatusMap().get(BufferEntryStatus.ERROR))
+    // Sanity check: there should be non-zero CREATING projects.
+    assertThat(billingProjectBufferEntryDao.getCountByStatusMap().get(BufferEntryStatus.CREATING))
         .isGreaterThan(0L);
 
-    // Recovery: start creating projects which will be READY after 15 minutes.
+    // Simulate a Terra system recovery.
+    //
+    // Add a new mock to the buffer entry DAO, which will take any newly-created buffer entries
+    // and add them to the successProjectNames list, so they will become SUCCESS status after 15
+    // minutes.
     doAnswer(
             invocation -> {
               DbBillingProjectBufferEntry entry = invocation.getArgument(0);
-              successProjectNames.add(entry.getFireCloudProjectName());
+              // Use a nonexistent ID as a signal that the current entry is being newly-created.
+              if (entry.getId() == 0) {
+                successProjectNames.add(entry.getFireCloudProjectName());
+              }
               return invocation.callRealMethod();
             })
         .when(billingProjectBufferEntryDao)
@@ -501,21 +528,23 @@ public class BillingProjectBufferServiceTest {
 
       Long availableCount =
           billingProjectBufferEntryDao.getCountByStatusMap().get(BufferEntryStatus.AVAILABLE);
+      // Recovery is defined as "time to first project available"
       if (availableCount != null && availableCount >= 1) {
         workbenchRecoveryTime = CLOCK.instant();
         break;
       }
       if (Duration.between(startingTime, CLOCK.instant()).toHours() > 4) {
-        log.info("Took too long, bailing out");
+        // To avoid looping forever, bail out after 4 "hours" if this keeps running.
+        log.severe("Took too long recovering, bailing out");
         break;
       }
     }
 
-    log.info(
-        String.format(
-            "Workbench recovered after %s minutes",
-            Duration.between(terraRecoveryTime, workbenchRecoveryTime).toMinutes()));
     assertThat(workbenchRecoveryTime).isNotNull();
+    long workbenchRecoveryMinutes = Duration.between(terraRecoveryTime, workbenchRecoveryTime)
+        .toMinutes();
+    log.info(String.format("Workbench recovered in %s minutes", workbenchRecoveryMinutes));
+    assertThat(workbenchRecoveryMinutes).isLessThan(30l);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
@@ -460,8 +460,12 @@ public class BillingProjectBufferServiceTest {
                   billingProjectBufferEntryDao.findByFireCloudProjectName(projectName);
               Duration timeSinceCreation =
                   Duration.between(entry.getCreationTime().toInstant(), CLOCK.instant());
-              log.fine(String.format("%s is %s mins old (%s project)", projectName, timeSinceCreation.toMinutes(),
-                  successProjectNames.contains(projectName) ? "SUCCESS" : "ERROR"));
+              log.fine(
+                  String.format(
+                      "%s is %s mins old (%s project)",
+                      projectName,
+                      timeSinceCreation.toMinutes(),
+                      successProjectNames.contains(projectName) ? "SUCCESS" : "ERROR"));
               CreationStatusEnum status = null;
               if (timeSinceCreation.toMinutes() < 15) {
                 status = CreationStatusEnum.CREATING;
@@ -541,8 +545,8 @@ public class BillingProjectBufferServiceTest {
     }
 
     assertThat(workbenchRecoveryTime).isNotNull();
-    long workbenchRecoveryMinutes = Duration.between(terraRecoveryTime, workbenchRecoveryTime)
-        .toMinutes();
+    long workbenchRecoveryMinutes =
+        Duration.between(terraRecoveryTime, workbenchRecoveryTime).toMinutes();
     log.info(String.format("Workbench recovered in %s minutes", workbenchRecoveryMinutes));
     assertThat(workbenchRecoveryMinutes).isLessThan(30l);
   }


### PR DESCRIPTION
This PR makes two changes to the project buffer system:

1) Parameterizes the "number of projects to sync per cron job execution". This had previously been hard-coded to 5, but is now a WorkbenchConfig entry with a standard value of 10.
2) Populates the "lastSyncRequestTime" for newly-created buffer entries to the current timestamp.

See the associated ticket for more context, and code comments for more details. The new unit test is especially interesting; it is effectively a simulation of an outage-and-recovery scenario which allowed me to test whether the above changes would have an impact on our real-world time to recovery.