### PR TITLE
[no ticket][risk=no] Puppeteer Fix Registration test

### DIFF
--- a/e2e/app/page/create-account-page.ts
+++ b/e2e/app/page/create-account-page.ts
@@ -55,12 +55,12 @@ export const FieldSelector = {
   },
   EducationLevelSelect: {
     textOption: {
-      type: ElementType.Dropdown, name: LabelAlias.EducationLevel, ancestorLevel: 1
+      type: ElementType.Dropdown, name: LabelAlias.EducationLevel, ancestorLevel: 2
     }
   },
   BirthYearSelect: {
     textOption: {
-      type: ElementType.Dropdown, name: LabelAlias.YearOfBirth, ancestorLevel: 1
+      type: ElementType.Dropdown, name: LabelAlias.YearOfBirth, ancestorLevel: 2
     }
   },
   InstitutionSelect: {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -20,6 +20,7 @@
     "test-staging:debug": "cross-env WORKBENCH_ENV=staging PUPPETEER_HEADLESS=false DEBUG=true yarn _test --maxWorkers=1",
     "test:ci": "yarn _test --no-color --ci --maxWorkers=2",
     "test:ci:debug": "yarn _test --ci --debug --maxWorkers=1 --bail 1",
+    "test-nightly": "cross-env TEST_MODE=nightly-integration yarn _test --maxWorkers=1",
     "lint": "tslint --project tsconfig.json",
     "lint:fix": "yarn compile && yarn run lint --fix",
     "tsc-build": "tsc --build --clean && tsc --skipLibCheck --project tsconfig.json",


### PR DESCRIPTION
`registration.spec.ts` nightly test is broken due to bad xpath selector. Broken by recent commit https://github.com/all-of-us/workbench/pull/4486.

Updated xpath selector and test passed okay.
<img width="494" alt="Screen Shot 2021-01-25 at 3 08 56 PM" src="https://user-images.githubusercontent.com/35533885/105760288-90a09500-5f1f-11eb-9b89-de95cc256a04.png">
