### PR TITLE
[RW-6080][risk=no] Suppress logspam from 404s when checking or polling for runtime

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoRetryHandler.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoRetryHandler.java
@@ -4,6 +4,7 @@ import java.net.SocketTimeoutException;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletResponse;
 import org.pmiops.workbench.exceptions.ExceptionUtils;
+import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.utils.ResponseCodeRetryPolicy;
 import org.pmiops.workbench.utils.RetryHandler;
@@ -36,12 +37,20 @@ public class LeonardoRetryHandler extends RetryHandler<ApiException> {
     @Override
     protected void logNoRetry(Throwable t, int responseCode) {
       if (t instanceof ApiException) {
-        logger.log(
-            getLogLevel(responseCode),
-            String.format(
-                "Exception calling Leonardo API with response: %s",
-                ((ApiException) t).getResponseBody()),
-            t);
+        if (responseCode == 404) {
+          logger.log(
+              getLogLevel(responseCode),
+              String.format(
+                  "Exception calling Leonardo API with response: %s. This is likely because a runtime has not yet been created and is being polled for. Surpressing stack trace.",
+                  responseCode));
+        } else {
+          logger.log(
+              getLogLevel(responseCode),
+              String.format(
+                  "Exception calling Leonardo API with response: %s",
+                  ((ApiException) t).getResponseBody()),
+              t);
+        }
       } else {
         super.logNoRetry(t, responseCode);
       }

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoRetryHandler.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoRetryHandler.java
@@ -4,7 +4,6 @@ import java.net.SocketTimeoutException;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletResponse;
 import org.pmiops.workbench.exceptions.ExceptionUtils;
-import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.utils.ResponseCodeRetryPolicy;
 import org.pmiops.workbench.utils.RetryHandler;
@@ -41,7 +40,8 @@ public class LeonardoRetryHandler extends RetryHandler<ApiException> {
           logger.log(
               getLogLevel(responseCode),
               String.format(
-                  "Exception calling Leonardo API with response: %s. This is likely because a runtime has not yet been created and is being polled for. Surpressing stack trace.",
+                  "Exception calling Leonardo API with response: %s. This is likely because a runtime "
+                      + "has not yet been created and is being polled for. Suppressing stack trace.",
                   responseCode));
         } else {
           logger.log(


### PR DESCRIPTION
No before image because you'd have to scroll for several hours to get past it
I fixed the spelling in a commit after taking this screenshot
<img width="1156" alt="Screen Shot 2021-01-25 at 3 21 29 PM" src="https://user-images.githubusercontent.com/1847690/105761324-00fbe600-5f21-11eb-94ef-b5ef53d980b3.png">


Theoretically I could have threaded through a `suppress_404s` variable of some sort but all these functions override a stack of turtles that ultimately ends in Spring and I legitimately can't think of any 404 case from our interactions with Leonardo that is a case of 'the runtime isn't there and that is bad' vs 'the runtime isn't there yet cause you didn't make one and Swagger throws when this happens'

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI + API server with `yarn test-local`
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
