### PR TITLE
[RW-6234][risk=no] Log requests and console errors when running Puppeteer tests

### DIFF
--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -1,4 +1,3 @@
-const url = require('url');
 const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36';
 
 const isDebugMode = process.argv.includes('--debug');
@@ -13,6 +12,7 @@ const isDebugMode = process.argv.includes('--debug');
 beforeEach(async () => {
 
   await jestPuppeteer.resetPage();
+  await jestPuppeteer.resetBrowser();
 
   await page.setUserAgent(userAgent);
   await page.setViewport({width: 1300, height: 0});

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -53,12 +53,14 @@ beforeEach(async () => {
   });
 
   // Emitted when a request failed. Warning: blocked requests from above will be logged as failed requests, safe to ignore these.
-  page.on('requestfailed', request => {
+  page.on('requestfailed', async request => {
     try {
       const response = request.response();
       if (response !== null) {
         const status = response.status();
-        console.error(`❌ ${status} ${request.method()} ${request.url()}  \n ${request.failure().errorText} \n ${response.text()}`);
+        const responseText = await response.text();
+        const failureError = request.failure().errorText;
+        console.error(`❌ ${status} ${request.method()} ${request.url()}  \n ${failureError} \n ${responseText}`);
       }
       // tslint:disable-next-line:no-empty
     } catch (err) {

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -1,7 +1,5 @@
 const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36';
 
-const isDebugMode = process.argv.includes('--debug');
-
 /**
  * Set up page common properties:
  * - Page view port

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -33,20 +33,20 @@ beforeEach(async () => {
       const msg = message.type().toUpperCase();
       // Don't log "log", "info" or "debug"
       if (msg.includes('ERROR') || msg.includes('WARNING')) {
-        console.debug(`${message.type()}: ${message.text()}`);
+        console.debug(`❗ ${message.type()}: ${message.text()}`);
       }
     }
   });
 
   // Emitted when the page crashed
   page.on('error', error => {
-    console.debug(`❌ ${error}`);
+    console.debug(`❗ ${error}`);
   });
 
   // Emitted when a script has uncaught exception
   page.on('pageerror', error => {
     if (error != null) {
-      console.debug(`❌ ${error}`);
+      console.debug(`❗ ${error}`);
     }
   });
 
@@ -58,7 +58,7 @@ beforeEach(async () => {
         const status = response.status();
         const responseText = await response.text();
         const failureError = request.failure().errorText;
-        console.debug(`❌ ${status} ${request.method()} ${request.url()}  \n ${failureError} \n ${responseText}`);
+        console.debug(`❗ ${status} ${request.method()} ${request.url()}  \n ${failureError} \n ${responseText}`);
       }
       // tslint:disable-next-line:no-empty
     } catch (err) {
@@ -76,9 +76,9 @@ beforeEach(async () => {
         const method = request.method().trim();
         if (method !== 'OPTIONS') {
           if (failure !== null) {
-            console.debug(`${response.status()} ${method} ${requestUrl} \n ${failure.errorText}`);
+            console.debug(`❗ ${response.status()} ${method} ${requestUrl} \n ${failure.errorText}`);
           } else {
-            console.debug(`${response.status()} ${request.method()} ${requestUrl}`);
+            console.debug(`❗ ${response.status()} ${request.method()} ${requestUrl}`);
           }
         }
       }

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -35,20 +35,20 @@ beforeEach(async () => {
       const msg = message.type().toUpperCase();
       // Don't log "log", "info" or "debug"
       if (msg.includes('ERROR') || msg.includes('WARNING')) {
-        console.error(`${message.type()}: ${message.text()}`);
+        console.debug(`${message.type()}: ${message.text()}`);
       }
     }
   });
 
   // Emitted when the page crashed
   page.on('error', error => {
-    console.error(`❌ ${error}`);
+    console.debug(`❌ ${error}`);
   });
 
   // Emitted when a script has uncaught exception
   page.on('pageerror', error => {
     if (error != null) {
-      console.error(`❌ ${error}`);
+      console.debug(`❌ ${error}`);
     }
   });
 
@@ -60,7 +60,7 @@ beforeEach(async () => {
         const status = response.status();
         const responseText = await response.text();
         const failureError = request.failure().errorText;
-        console.error(`❌ ${status} ${request.method()} ${request.url()}  \n ${failureError} \n ${responseText}`);
+        console.debug(`❌ ${status} ${request.method()} ${request.url()}  \n ${failureError} \n ${responseText}`);
       }
       // tslint:disable-next-line:no-empty
     } catch (err) {
@@ -76,16 +76,12 @@ beforeEach(async () => {
       if (requestUrl.includes('api-dot-all-of-us')) {
         const failure = request.failure();
         if (failure !== null) {
-          console.info(`${status} ${request.method()} ${requestUrl} \n ${failure}`);
+          console.debug(`${status} ${request.method()} ${requestUrl} \n ${failure}`);
         }
-        /*
-        // Do not remove.
         if (failure === null) {
-          const text = await response.text();
           const status = response.status();
-          console.info(`${status} ${request.method()} ${requestUrl} \n ${text}`);
+          console.debug(`${status} ${request.method()} ${requestUrl}`);
         }
-        */
       }
       // tslint:disable-next-line:no-empty
     } catch (err) {

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -28,25 +28,24 @@ beforeEach(async () => {
     }
   });
 
-  page.on('console', async(message) => {
+  page.on('console', message => {
     if (message != null) {
-      const msg = message.type().toUpperCase();
       // Don't log "log", "info" or "debug"
-      if (msg.includes('ERROR') || msg.includes('WARNING')) {
-        console.debug(`❗ ${message.type()}: ${message.text()}`);
+      if (['ERROR', 'WARNING'].includes(message.type().toUpperCase())) {
+        console.debug(`❗ Console Message: ${message.type()}: ${message.text()}`);
       }
     }
   });
 
   // Emitted when the page crashed
   page.on('error', error => {
-    console.debug(`❗ ${error}`);
+    console.debug(`❗ Page Crashed: ${error}`);
   });
 
   // Emitted when a script has uncaught exception
   page.on('pageerror', error => {
     if (error != null) {
-      console.debug(`❗ ${error}`);
+      console.debug(`❗ Page Error: ${error}`);
     }
   });
 
@@ -58,7 +57,7 @@ beforeEach(async () => {
         const status = response.status();
         const responseText = await response.text();
         const failureError = request.failure().errorText;
-        console.debug(`❗ ${status} ${request.method()} ${request.url()}  \n ${failureError} \n ${responseText}`);
+        console.debug(`❗ Failed Request: ${status} ${request.method()} ${request.url()}  \n ${failureError} \n ${responseText}`);
       }
       // tslint:disable-next-line:no-empty
     } catch (err) {
@@ -76,9 +75,10 @@ beforeEach(async () => {
         const method = request.method().trim();
         if (method !== 'OPTIONS') {
           if (failure !== null) {
-            console.debug(`❗ ${response.status()} ${method} ${requestUrl} \n ${failure.errorText}`);
+            // This log sometimes duplicate log from requestfailed.
+            console.debug(`❗ Failed Request: ${response.status()} ${method} ${requestUrl} \n ${failure.errorText}`);
           } else {
-            console.debug(`❗ ${response.status()} ${request.method()} ${requestUrl}`);
+            console.debug(`❗ Request: ${response.status()} ${method} ${requestUrl}`);
           }
         }
       }

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -11,60 +11,87 @@ const isDebugMode = process.argv.includes('--debug');
  * - waitFor functions timeout
  */
 beforeEach(async () => {
+
+  await jestPuppeteer.resetPage();
+
   await page.setUserAgent(userAgent);
-  await page.setViewport({width: 1280, height: 0});
+  await page.setViewport({width: 1300, height: 0});
+
   page.setDefaultNavigationTimeout(60000); // Puppeteer default timeout is 30 seconds.
   page.setDefaultTimeout(30000);
-});
 
-/**
- * At the end of each test completion, do:
- * - Disable network interception.
- * - Delete broswer cookies.
- * - Reset global page and browser variables.
- */
-afterEach(async () => {
-  await page.deleteCookie(...await page.cookies());
-  await jestPuppeteer.resetPage();
-  await jestPuppeteer.resetBrowser();
-});
-
-/**
- * Enable network interception in new page and block unwanted requests.
- */
-beforeAll(async () => {
   await page.setRequestInterception(true);
+
   page.on('request', (request) => {
-    const requestUrl = url.parse(request.url(), true);
-    const host = requestUrl.hostname;
-    // to improve page load performance, block network requests unrelated to application.
     try {
-      if (host === 'www.google-analytics.com'
-           || host === 'accounts.youtube.com'
-           || host === 'static.zdassets.com'
-           || host === 'play.google.com'
-           || request.url().endsWith('content-security-index-report')) {
-        request.abort();
-      } else {
-        request.continue();
-      }
-    } catch (err) {
-      console.error(err);
+      request.continue();
+      // tslint:disable-next-line:no-empty
+    } catch (e) {
     }
   });
-  if (isDebugMode) {
-    // Emitted when a request failed. Warning: blocked requests from above will be logged as failed requests, safe to ignore these.
-    page.on('requestfailed', request => {
-      console.error(`❌ Failed request => ${request.method()} ${request.url()}`);
-      request.continue();
-    });
-    // Emitted when the page crashed
-    page.on('error', error => console.error(`❌ ${error}`));
-    // Emitted when a script has uncaught exception
-    page.on('pageerror', error => console.error(`❌ ${error}`));
-  }
+
+  page.on('console', async(message) => {
+    if (message != null) {
+      const msg = message.type().toUpperCase();
+      // Don't log "log", "info" or "debug"
+      if (msg.includes('ERROR') || msg.includes('WARNING')) {
+        console.error(`${message.type()}: ${message.text()}`);
+      }
+    }
+  });
+
+  // Emitted when the page crashed
+  page.on('error', error => {
+    console.error(`❌ ${error}`);
+  });
+
+  // Emitted when a script has uncaught exception
+  page.on('pageerror', error => {
+    if (error != null) {
+      console.error(`❌ ${error}`);
+    }
+  });
+
+  // Emitted when a request failed. Warning: blocked requests from above will be logged as failed requests, safe to ignore these.
+  page.on('requestfailed', request => {
+    try {
+      const response = request.response();
+      if (response !== null) {
+        const status = response.status();
+        console.error(`❌ ${status} ${request.method()} ${request.url()}  \n ${request.failure().errorText} \n ${response.text()}`);
+      }
+      // tslint:disable-next-line:no-empty
+    } catch (err) {
+    }
+  });
+
+  page.on('response', async(response) => {
+    try {
+      const request = response.request();
+      const requestUrl = request.url();
+
+      // Long only responses from AoU-app requests
+      if (requestUrl.includes('api-dot-all-of-us')) {
+        const failure = request.failure();
+        if (failure !== null) {
+          console.info(`${status} ${request.method()} ${requestUrl} \n ${failure}`);
+        }
+        /*
+        // Do not remove.
+        if (failure === null) {
+          const text = await response.text();
+          const status = response.status();
+          console.info(`${status} ${request.method()} ${requestUrl} \n ${text}`);
+        }
+        */
+      }
+      // tslint:disable-next-line:no-empty
+    } catch (err) {
+    }
+  });
+  
 });
 
-afterAll(async () => {
+afterEach(async () => {
   await page.setRequestInterception(false);
 });

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -75,12 +75,13 @@ beforeEach(async () => {
       // Long only responses from AoU-app requests
       if (requestUrl.includes('api-dot-all-of-us')) {
         const failure = request.failure();
-        if (failure !== null) {
-          console.debug(`${status} ${request.method()} ${requestUrl} \n ${failure}`);
-        }
-        if (failure === null) {
-          const status = response.status();
-          console.debug(`${status} ${request.method()} ${requestUrl}`);
+        const method = request.method().trim();
+        if (method !== 'OPTIONS') {
+          if (failure !== null) {
+            console.debug(`${response.status()} ${method} ${requestUrl} \n ${failure.errorText}`);
+          } else {
+            console.debug(`${response.status()} ${request.method()} ${requestUrl}`);
+          }
         }
       }
       // tslint:disable-next-line:no-empty


### PR DESCRIPTION
log failed requests, console errors, warnings. exclude OPTIONS and non `api-dot-all-of-us` requests. 
To keep secrets, response contents are not logged.