### PR TITLE
[RW-6242][risk=no] Puppeteer click not working sporadically

### DIFF
--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -143,11 +143,11 @@ export default class BaseElement extends Container {
   async click(options?: ClickOptions): Promise<void> {
     return this.asElementHandle()
       .then(async element => {
-        // experienment: click workaround
+        // Experienment: click workaround
         // Wait for x,y to stop changing within specified time
         const startTime = Date.now();
-        let prevX;
-        let prevY;
+        let previousX;
+        let previousY;
         let i = 0;
         while ((Date.now() - startTime) < (30 * 1000)) {
           const viewport = await element.isIntersectingViewport();
@@ -155,18 +155,17 @@ export default class BaseElement extends Container {
             const box = await element.boundingBox();
             const x = box.x + (box.width / 2);
             const y = box.y + (box.height / 2);
-            if (prevX === x || prevY === y) {
+            if (i > 0) {
+              console.warn(`Detected changing boundingBox: i=${i} prevX=${previousX} x=${x} prevY=${previousY} y=${y}`);
+            }
+            if (previousX === x || previousY === y) {
               break;
             }
-            if (i > 0) {
-              console.warn(`Detected changing boundingBox. prevX=${prevX} x=${x}  prevY=${prevY} y=${y}`);
-            }
-            prevX = x;
-            prevY = y;
+            previousX = x;
+            previousY = y;
             i++;
-          } else {
-            await element.hover();
           }
+          await element.hover();
           await this.page.waitForTimeout(200);
         }
         return element.click(options);

--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -143,25 +143,31 @@ export default class BaseElement extends Container {
   async click(options?: ClickOptions): Promise<void> {
     return this.asElementHandle()
       .then(async element => {
-        // Wait for x,y to stop changing within specified time.
+        // experienment: click workaround
+        // Wait for x,y to stop changing within specified time
         const startTime = Date.now();
         let prevX;
         let prevY;
         let i = 0;
         while ((Date.now() - startTime) < (30 * 1000)) {
-          const box = await element.boundingBox();
-          const x = box.x + (box.width/2);
-          const y = box.y + (box.height/2);
-          if (prevX === x || prevY === y) {
-            break;
+          const viewport = await element.isIntersectingViewport();
+          if (viewport) {
+            const box = await element.boundingBox();
+            const x = box.x + (box.width / 2);
+            const y = box.y + (box.height / 2);
+            if (prevX === x || prevY === y) {
+              break;
+            }
+            if (i > 0) {
+              console.warn(`Detected changing boundingBox. prevX=${prevX} x=${x}  prevY=${prevY} y=${y}`);
+            }
+            prevX = x;
+            prevY = y;
+            i++;
+          } else {
+            await element.hover();
           }
-          if (i > 0) {
-            console.warn(`Detected changing boundingBox. prevX=${prevX} x=${x}  prevY=${prevY} y=${y}`);
-          }
-          prevX = x;
-          prevY = y;
-          await this.page.waitForTimeout(100);
-          i++;
+          await this.page.waitForTimeout(200);
         }
         return element.click(options);
       });

--- a/e2e/app/modal/base-modal.ts
+++ b/e2e/app/modal/base-modal.ts
@@ -59,10 +59,10 @@ export default abstract class BaseModal extends Container {
       if (waitForNav) {
          await Promise.all([
             this.page.waitForNavigation({waitUntil: ['load', 'networkidle0']}),
-            button.click(),
+            button.click({delay: 10}),
          ]);
       } else {
-         await button.click();
+         await button.click({delay: 10});
       }
 
       if (waitForClose) {


### PR DESCRIPTION
Sometimes, click the `Confirm` button in `Create Workspace` modal is not working. The button was not clicked, so the modal remains open then the test fails. I did some investigation, I cannot find any failed requests or page errors after it happened.

Experimental Workaround: before click, check element's position (x,y) is constant, viewport visibility and short delay in click option.

Failure: https://app.circleci.com/pipelines/github/all-of-us/workbench/7185/workflows/46317864-3cf4-4bea-93c5-c7a2b79f3d37/jobs/118435/parallel-runs/1?filterBy=FAILED