### PR TITLE
[RW-6257][risk=no] Puppeteer fix test failure

### DIFF
--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -41,6 +41,7 @@ export enum MenuOption {
 export enum LinkText {
    AddSelection = 'Add Selection',
    AddThis = 'ADD THIS',
+   AllSurveys = 'All Surveys',
    ApplyModifiers = 'APPLY MODIFIERS',
    ApplyRecreate = 'APPLY & RECREATE',
    BackToCohort = 'Back to cohort',
@@ -70,6 +71,7 @@ export enum LinkText {
    DeleteEnvironment = 'Delete Environment',
    DeleteNotebook = 'Delete Notebook',
    DeleteWorkspace = 'Delete Workspace',
+   Demographics = 'Demographics',
    DiscardChanges = 'Discard Changes',
    DuplicateWorkspace = 'Duplicate Workspace',
    Edit = 'Edit',

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -43,10 +43,10 @@ beforeEach(async () => {
         if (request.url().includes('api-dot-all-of-us')){
           responseBody = await response.buffer();
           if (responseBody !== undefined) {
-            responseBody = JSON.stringify(responseBody.toString());
+            responseBody = JSON.stringify(JSON.parse(responseBody.toString()), null, 2);
           }
           const method = request.method();
-          console.debug(`❗Request finished: ${status} ${method} ${request.url()}  \n ${responseBody}`);
+          console.debug(`❗Request finished: ${status} ${method} ${request.url()}  \n ${responseBody}`, {depth: null, colors: true});
         }
       }
       await request.continue();
@@ -83,7 +83,7 @@ beforeEach(async () => {
       console.debug(`❗Page error: ${error}`);
     }
   })
-  
+
 });
 
 afterEach(async () => {

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -43,13 +43,13 @@ beforeEach(async () => {
         // response body can only be accessed for non-redirect responses.
         if (request.url().includes('api-dot-all-of-us')){
           responseBody = await response.buffer();
+          if (responseBody !== undefined) {
+            responseBody = JSON.stringify(responseBody.toString());
+          }
+          const method = request.method();
+          console.debug(`❗Request finished: ${status} ${method} ${request.url()}  \n ${responseBody}`);
         }
       }
-      if (responseBody !== undefined) {
-        responseBody = JSON.stringify(responseBody);
-      }
-      const method = request.method();
-      console.debug(`❗Request finished: ${status} ${method} ${request.url()}  \n ${responseBody}`);
       await request.continue();
       // tslint:disable-next-line:no-empty
     } catch (e) {

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -20,7 +20,6 @@ beforeEach(async () => {
 
   await page.setRequestInterception(true);
 
-  // Note: A request could be still
   page.on('request', (request) => {
     try {
       if (request.url().includes('api-dot-all-of-us')) {
@@ -84,30 +83,7 @@ beforeEach(async () => {
       console.debug(`❗Page error: ${error}`);
     }
   })
-  /*
-  .on('response', async(response) => {
-    try {
-      const request = response.request();
-      const requestUrl = request.url();
-
-      // Long only responses from AoU-app requests
-      if (requestUrl.includes('api-dot-all-of-us')) {
-        const failure = request.failure();
-        const method = request.method().trim();
-        if (method !== 'OPTIONS') {
-          if (failure !== null) {
-            // This log sometimes duplicate log from requestfailed.
-            console.debug(`❗ Failed Request: ${response.status()} ${method} ${requestUrl} \n ${failure.errorText}`);
-          } else {
-            console.debug(`❗ Request: ${response.status()} ${method} ${requestUrl}`);
-          }
-        }
-      }
-      // tslint:disable-next-line:no-empty
-    } catch (err) {
-    }
-  });
-  */
+  
 });
 
 afterEach(async () => {

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -20,51 +20,72 @@ beforeEach(async () => {
 
   await page.setRequestInterception(true);
 
+  // Note: A request could be still
   page.on('request', (request) => {
     try {
+      if (request.url().includes('api-dot-all-of-us')) {
+        const method = request.method();
+        if (method !== 'OPTIONS') {
+          console.debug(`❗Request issued: ${request.url()}`);
+        }
+      }
       request.continue();
       // tslint:disable-next-line:no-empty
     } catch (e) {
     }
-  });
-
-  page.on('console', message => {
-    if (message != null) {
-      // Don't log "log", "info" or "debug"
-      if (['ERROR', 'WARNING'].includes(message.type().toUpperCase())) {
-        console.debug(`❗ Console Message: ${message.type()}: ${message.text()}`);
+  })
+  .on('requestfinished', async (request) => {
+    try {
+      const response = await request.response();
+      const status = request.response().status();
+      let responseBody;
+      if (request.redirectChain().length === 0) {
+        // response body can only be accessed for non-redirect responses.
+        if (request.url().includes('api-dot-all-of-us')){
+          responseBody = await response.buffer();
+        }
       }
+      if (responseBody !== undefined) {
+        responseBody = JSON.stringify(responseBody);
+      }
+      const method = request.method();
+      console.debug(`❗Request finished: ${status} ${method} ${request.url()}  \n ${responseBody}`);
+      await request.continue();
+      // tslint:disable-next-line:no-empty
+    } catch (e) {
     }
-  });
-
-  // Emitted when the page crashed
-  page.on('error', error => {
-    console.debug(`❗ Page Crashed: ${error}`);
-  });
-
-  // Emitted when a script has uncaught exception
-  page.on('pageerror', error => {
-    if (error != null) {
-      console.debug(`❗ Page Error: ${error}`);
-    }
-  });
-
-  // Emitted when a request failed. Warning: blocked requests from above will be logged as failed requests, safe to ignore these.
-  page.on('requestfailed', async request => {
+  })
+  .on('requestfailed', async (request) => {
     try {
       const response = request.response();
       if (response !== null) {
         const status = response.status();
         const responseText = await response.text();
         const failureError = request.failure().errorText;
-        console.debug(`❗ Failed Request: ${status} ${request.method()} ${request.url()}  \n ${failureError} \n ${responseText}`);
+        console.debug(`❗Request failed: ${status} ${request.method()} ${request.url()}  \n ${failureError} \n ${responseText}`);
       }
       // tslint:disable-next-line:no-empty
     } catch (err) {
     }
-  });
-
-  page.on('response', async(response) => {
+  })
+  .on('console', (message) => {
+    if (message != null) {
+      // Don't log "log", "info" or "debug"
+      if (['ERROR', 'WARNING'].includes(message.type().toUpperCase())) {
+        console.debug(`❗Page console: ${message.type()}: ${message.text()}`);
+      }
+    }
+  })
+  .on('error', (error) => {
+    console.debug(`❗Page error: ${error}`);
+  })
+  .on('pageerror', (error) => {
+    if (error != null) {
+      console.debug(`❗Page error: ${error}`);
+    }
+  })
+  /*
+  .on('response', async(response) => {
     try {
       const request = response.request();
       const requestUrl = request.url();
@@ -86,7 +107,7 @@ beforeEach(async () => {
     } catch (err) {
     }
   });
-  
+  */
 });
 
 afterEach(async () => {

--- a/e2e/tests/datasets/create-r-notebook.spec.ts
+++ b/e2e/tests/datasets/create-r-notebook.spec.ts
@@ -7,9 +7,9 @@ import {findOrCreateWorkspace, signInWithAccessToken} from 'utils/test-utils';
 import {waitForText, waitWhileLoading} from 'utils/waits-utils';
 import CohortActionsPage from 'app/page/cohort-actions-page';
 import {Ethnicity} from 'app/page/cohort-search-page';
-import {Language, ResourceCard} from 'app/text-labels';
+import {Language, LinkText, ResourceCard} from 'app/text-labels';
 
-describe('Create Dataset', () => {
+describe('Create dataset and export to notebook at same time', () => {
 
   beforeEach(async () => {
     await signInWithAccessToken(page);
@@ -20,7 +20,7 @@ describe('Create Dataset', () => {
    * Create new Dataset with Cohort, then export to notebook in R language.
    * Delete Cohort, Dataset, and Notebook.
    */
-  test('Export dataset to notebook in R language', async () => {
+  test('Jupyter Notebook for R programming language can be created', async () => {
     const workspaceCard = await findOrCreateWorkspace(page);
     const workspaceName = await workspaceCard.clickWorkspaceName();
 
@@ -52,7 +52,7 @@ describe('Create Dataset', () => {
     await cohortActionsPage.clickCreateDatasetButton();
 
     await datasetBuildPage.selectCohorts([newCohortName]);
-    await datasetBuildPage.selectConceptSets(['Demographics']);
+    await datasetBuildPage.selectConceptSets([LinkText.Demographics]);
     const saveModal = await datasetBuildPage.clickSaveAndAnalyzeButton();
     const newNotebookName = makeRandomName();
     const newDatasetName = await saveModal.saveDataset({

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -2,7 +2,7 @@ import DataResourceCard from 'app/component/data-resource-card';
 import ClrIconLink from 'app/element/clr-icon-link';
 import CohortBuildPage from 'app/page/cohort-build-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {MenuOption, ResourceCard} from 'app/text-labels';
+import {LinkText, MenuOption, ResourceCard} from 'app/text-labels';
 import {findOrCreateWorkspace, signInWithAccessToken} from 'utils/test-utils';
 import {waitForText, waitWhileLoading} from 'utils/waits-utils';
 import DatasetEditPage from 'app/page/dataset-edit-page';
@@ -22,7 +22,7 @@ describe('Dataset test', () => {
    * - Edit dataset. Save dataset without Export to Notebook.
    * - Delete Dataset.
    */
-  test('Can create Dataset with user-defined Cohorts', async () => {
+  test('Create Dataset from user-defined Cohorts', async () => {
     const workspaceCard = await findOrCreateWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
@@ -59,7 +59,7 @@ describe('Dataset test', () => {
     const datasetPage = await dataPage.clickAddDatasetButton();
 
     await datasetPage.selectCohorts([cohortName]);
-    await datasetPage.selectConceptSets(['Demographics']);
+    await datasetPage.selectConceptSets([LinkText.Demographics]);
     const saveModal = await datasetPage.clickSaveAndAnalyzeButton();
     let datasetName = await saveModal.saveDataset({exportToNotebook: false});
 
@@ -79,7 +79,7 @@ describe('Dataset test', () => {
     await datasetEditPage.waitForLoad();
     await datasetEditPage.selectCohorts(['All Participants']);
     await datasetEditPage.clickAnalyzeButton();
-    
+
     // Save Dataset in a new name.
     await saveModal.waitForLoad();
     datasetName = await saveModal.saveDataset({exportToNotebook: false}, true);

--- a/e2e/tests/datasets/dataset-rename.spec.ts
+++ b/e2e/tests/datasets/dataset-rename.spec.ts
@@ -1,6 +1,6 @@
 import DataResourceCard from 'app/component/data-resource-card';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import {ResourceCard} from 'app/text-labels';
+import {LinkText, ResourceCard} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
 import {findOrCreateWorkspace, signInWithAccessToken} from 'utils/test-utils';
 
@@ -27,7 +27,7 @@ describe('Dataset test', () => {
     const datasetPage = await dataPage.clickAddDatasetButton();
 
     await datasetPage.selectCohorts(['All Participants']);
-    await datasetPage.selectConceptSets(['Demographics', 'All Surveys']);
+    await datasetPage.selectConceptSets([LinkText.Demographics, LinkText.AllSurveys]);
     const saveModal = await datasetPage.clickSaveAndAnalyzeButton();
     const datasetName = await saveModal.saveDataset();
 

--- a/e2e/tests/datasets/export-to-notebook.spec.ts
+++ b/e2e/tests/datasets/export-to-notebook.spec.ts
@@ -1,0 +1,64 @@
+import DataResourceCard from 'app/component/data-resource-card';
+import ExportToNotebookModal from 'app/modal/export-to-notebook-modal';
+import NotebookPreviewPage from 'app/page/notebook-preview-page';
+import WorkspaceDataPage from 'app/page/workspace-data-page';
+import {LinkText, MenuOption, ResourceCard} from 'app/text-labels';
+import {makeRandomName} from 'utils/str-utils';
+import {createWorkspace, signInWithAccessToken} from 'utils/test-utils';
+import {waitWhileLoading} from 'utils/waits-utils';
+
+describe('Export to notebook from dataset', () => {
+
+  beforeEach(async () => {
+    await signInWithAccessToken(page);
+  });
+
+  /**
+   * Test:
+   * - Create dataset.
+   * - Export dataset to notebook thru snowman menu.
+   */
+  test('Create Jupyter notebook for Python programming language from existing dataset', async () => {
+    await createWorkspace(page).then(card => card.clickWorkspaceName());
+
+    // Click Add Datasets button.
+    const dataPage = new WorkspaceDataPage(page);
+    const datasetBuildPage = await dataPage.clickAddDatasetButton();
+
+    await datasetBuildPage.selectCohorts(['All Participants']);
+    await datasetBuildPage.selectConceptSets([LinkText.Demographics]);
+    const saveModal = await datasetBuildPage.clickSaveAndAnalyzeButton();
+    const datasetName = await saveModal.saveDataset({exportToNotebook: false});
+    await waitWhileLoading(page);
+
+    const resourceCard = new DataResourceCard(page);
+    const datasetCard = await resourceCard.findCard(datasetName, ResourceCard.Dataset);
+    await datasetCard.selectSnowmanMenu(MenuOption.ExportToNotebook, {waitForNav: false});
+
+    const exportModal = new ExportToNotebookModal(page);
+    await exportModal.waitForLoad();
+
+    const notebookName = makeRandomName('test-notebook');
+    await exportModal.fillInModal(notebookName);
+
+    // Verify notebook created successfully. Not going to start the Jupyter notebook.
+    const notebookPreviewPage = new NotebookPreviewPage(page);
+    await notebookPreviewPage.waitForLoad();
+    const currentPageUrl = page.url();
+    expect(currentPageUrl).toContain(`notebooks/preview/${notebookName}.ipynb`);
+
+    // Navigate to Workpace Notebooks page.
+    const analysisPage = await notebookPreviewPage.goAnalysisPage();
+
+    // Delete notebook
+    await analysisPage.deleteResource(notebookName, ResourceCard.Notebook);
+
+    // Delete Dataset
+    await analysisPage.openDatasetsSubtab();
+    await analysisPage.deleteResource(datasetName, ResourceCard.Dataset);
+
+    // Delete workspace
+    await dataPage.deleteWorkspace();
+  });
+
+});

--- a/e2e/tests/notebook/notebook-r.spec.ts
+++ b/e2e/tests/notebook/notebook-r.spec.ts
@@ -1,7 +1,7 @@
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {Language} from 'app/text-labels';
 import {makeRandomName} from 'utils/str-utils';
-import {findOrCreateWorkspace, signInWithAccessToken} from 'utils/test-utils';
+import {createWorkspace, signInWithAccessToken} from 'utils/test-utils';
 
 describe('Jupyter notebook tests in R language', () => {
 
@@ -10,7 +10,7 @@ describe('Jupyter notebook tests in R language', () => {
   });
 
   test('Run code from file', async () => {
-    const workspaceCard = await findOrCreateWorkspace(page);
+    const workspaceCard = await createWorkspace(page);
     await workspaceCard.clickWorkspaceName();
 
     const notebookName = makeRandomName('r-notebook');

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -268,9 +268,11 @@ export async function waitForText(page: Page,
  * It usually indicates the page is ready for user interaction.
  * </pre>
  */
-export async function waitWhileLoading(page: Page, timeout: number = (2 * 60 * 1000)): Promise<void> {
+export async function waitWhileLoading(page: Page, timeout: number = (2 * 60 * 1000), opts: {waitForRuntime?: boolean} = {}): Promise<void> {
+  const {waitForRuntime = false}  = opts;
+
   const notBlankPageSelector = '[data-test-id="sign-in-container"], title:not(empty), div.spinner, svg[viewBox]';
-  const spinElementsSelector = '[style*="running spin"], .spinner:empty, [style*="running rotation"]';
+  const spinElementsSelector = `[style*="running spin"], .spinner:empty, [style*="running rotation"]${waitForRuntime ? ':not([aria-hidden="true"])' : ''}`;
 
   // To prevent checking on blank page, wait for elements exist in DOM.
   await Promise.race([


### PR DESCRIPTION
[CI job 119002](https://app.circleci.com/pipelines/github/all-of-us/workbench/7272/workflows/feb10550-2b29-4fa2-924e-fd2e2a0a9d22/jobs/119002) failed. Caused by multiple test suites were using same workspace concurrently. The runtime spinner was running and caused `waitWhileLoading` function to timeout after 2 minutes.

Fixes:
- `waitWhileLoading` function to handle the runtime spinner on sidebar runtime tab (icon).
- Refactored `jest.test-setup.ts`: Make debug log easier to read and enable user to find out if any request still is in progress ( never finished ) when test is failing.
- Refactored failed `export-py-notebook.spec.ts`: externalize hard-coded strings, force create new workspaces and split the single test suite into two smaller test suites.
