### PR TITLE
[no ticket][risk=low]Skip build uploading user request from uploadSnapshot

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
@@ -246,12 +246,6 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
             fixedValues,
             batchSize));
     resultBuilder.addAll(
-        userRequestBuilder.buildBatchedRequests(
-            getTableId(UserColumnValueExtractor.class),
-            reportingSnapshot.getUsers(),
-            fixedValues,
-            batchSize));
-    resultBuilder.addAll(
         workspaceFreeTierUsageRequestBuilder.buildBatchedRequests(
             getTableId(WorkspaceFreeTierUsageColumnValueExtractor.class),
             reportingSnapshot.getWorkspaceFreeTierUsage(),

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8007,14 +8007,6 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/ReportingInstitution"
-      users:
-        type: array
-        items:
-          "$ref": "#/definitions/ReportingUser"
-      workspaces:
-        type: array
-        items:
-          "$ref": "#/definitions/ReportingWorkspace"
       workspaceFreeTierUsage:
         type: array
         items:

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingUploadServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingUploadServiceTest.java
@@ -46,6 +46,7 @@ import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.ReportingCohort;
+import org.pmiops.workbench.model.ReportingDatasetCohort;
 import org.pmiops.workbench.model.ReportingSnapshot;
 import org.pmiops.workbench.model.ReportingUser;
 import org.pmiops.workbench.model.ReportingWorkspace;
@@ -257,15 +258,12 @@ public class ReportingUploadServiceTest {
     final ReportingSnapshot largeSnapshot =
         createEmptySnapshot()
             .captureTimestamp(NOW.toEpochMilli())
-            .users(
+            .datasetCohorts(
                 IntStream.range(0, 21)
                     .mapToObj(
                         id ->
-                            new ReportingUser()
-                                .username("bill@aou.biz")
-                                .givenName("Bill")
-                                .disabled(false)
-                                .userId((long) id))
+                            new ReportingDatasetCohort()
+                                .cohortId((long) id))
                     .collect(ImmutableList.toImmutableList()))
             .cohorts(ImmutableList.of(ReportingTestUtils.createReportingCohort()))
             .institutions(ImmutableList.of(ReportingTestUtils.createReportingInstitution()));

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingUploadServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingUploadServiceTest.java
@@ -260,10 +260,7 @@ public class ReportingUploadServiceTest {
             .captureTimestamp(NOW.toEpochMilli())
             .datasetCohorts(
                 IntStream.range(0, 21)
-                    .mapToObj(
-                        id ->
-                            new ReportingDatasetCohort()
-                                .cohortId((long) id))
+                    .mapToObj(id -> new ReportingDatasetCohort().cohortId((long) id))
                     .collect(ImmutableList.toImmutableList()))
             .cohorts(ImmutableList.of(ReportingTestUtils.createReportingCohort()))
             .institutions(ImmutableList.of(ReportingTestUtils.createReportingInstitution()));

--- a/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
@@ -334,8 +334,7 @@ public class ReportingTestUtils {
         + oneForNonEmpty(reportingSnapshot.getDatasetCohorts())
         + oneForNonEmpty(reportingSnapshot.getDatasetConceptSets())
         + oneForNonEmpty(reportingSnapshot.getDatasetDomainIdValues())
-        + oneForNonEmpty(reportingSnapshot.getInstitutions())
-        + oneForNonEmpty(reportingSnapshot.getUsers());
+        + oneForNonEmpty(reportingSnapshot.getInstitutions());
   }
 
   public static ReportingInstitution createReportingInstitution() {
@@ -414,7 +413,6 @@ public class ReportingTestUtils {
         .datasetDomainIdValues(new ArrayList<>())
         .datasetCohorts(new ArrayList<>())
         .institutions(new ArrayList<>())
-        .users(new ArrayList<>())
         .workspaceFreeTierUsage(new ArrayList<>());
   }
 }


### PR DESCRIPTION
Background: Now user is loaded/uploaded in batch, it is not part of snapshot.  
```
org.pmiops.workbench.exceptions.ExceptionAdvice serverError: ErrorId fd797199-8b95-4399-81b5-31a65e6f64e9: java.lang.NullPointerException
java.lang.NullPointerException
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:878)
	at com.google.common.collect.Lists.partition(Lists.java:659)
	at org.pmiops.workbench.reporting.insertion.InsertAllRequestPayloadTransformer.buildBatchedRequests(InsertAllRequestPayloadTransformer.java:40)
	at org.pmiops.workbench.reporting.ReportingUploadServiceImpl.getInsertAllRequests(ReportingUploadServiceImpl.java:249)
	at org.pmiops.workbench.reporting.ReportingUploadServiceImpl.uploadSnapshot(ReportingUploadServiceImpl.java:102)
	at org.pmiops.workbench.reporting.ReportingServiceImpl.collectRecordsAndUpload(ReportingServiceImpl.java:59)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:333)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:190)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157)
	at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:99)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:283)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213)
	at com.sun.proxy.$Proxy187.collectRecordsAndUpload(Unknown Source)
	at org.pmiops.workbench.utils.ResponseEntities.noContentRun(ResponseEntities.java:14)
	at org.pmiops.workbench.api.OfflineReportingController.uploadReportingSnapshot(OfflineReportingController.java:20)
	at org.pmiops.workbench.api.OfflineReportingApiController.uploadReportingSnapshot(OfflineReportingApiController.java:35)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
