### PR TITLE
[RW-5818][risk=no] Fix domain card text alignment on concept homepage

### DIFF
--- a/ui/src/app/components/card.tsx
+++ b/ui/src/app/components/card.tsx
@@ -25,6 +25,7 @@ export const styles = reactStyles({
   },
   domainCard: {
     ...baseStyles.card,
+    justifyContent: 'space-between',
     minWidth: '300px', maxWidth: '300px',
     minHeight: '223px', maxHeight: '223px',
   },

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -81,7 +81,7 @@ const DomainCard: React.FunctionComponent<{conceptDomainInfo: DomainInfo, browse
            data-test-id='domain-box-name'>{conceptDomainInfo.name}</Clickable>
       <div style={styles.conceptText}>
         {updating ? <Spinner size={42}/> : <React.Fragment>
-          <span style={{fontSize: 30}}>{conceptCount.toLocaleString()}</span> concepts in this domain. <p/>
+          <span style={{fontSize: 30}}>{conceptCount.toLocaleString()}</span> concepts in this domain.
         </React.Fragment>}
         <div><b>{conceptDomainInfo.participantCount.toLocaleString()}</b> participants in domain.</div>
       </div>


### PR DESCRIPTION
- Make text spacing on domain cards consistent with survey cards
- Fix alignment of "Select Concepts" links on survey cards

Before:
![all-of-us-workbench-test appspot com_](https://user-images.githubusercontent.com/40036095/107263216-18e66600-6a07-11eb-85ae-9b7e3b3d7f92.png)

After:
![localhost_4200_workspaces_aou-rw-test-06d57f05_synthv3ws_data_concepts](https://user-images.githubusercontent.com/40036095/107263252-24d22800-6a07-11eb-8fdf-dc79762badfc.png)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
