### PR TITLE
[RW-6279][risk=no] Puppeteer gce-to-dataproc test fix

### DIFF
--- a/e2e/app/component/runtime-panel.ts
+++ b/e2e/app/component/runtime-panel.ts
@@ -179,7 +179,7 @@ export default class RuntimePanel extends BaseHelpSidebar {
     // Runtime panel automatically close after click Create button.
     // Reopen panel in order to check icon status.
     await this.open();
-    await this.waitForStartStopIconState(StartStopIconState.Starting, 60 * 1000);
+    await this.waitForStartStopIconState(StartStopIconState.Starting, 10 * 60 * 1000);
     await this.waitForStartStopIconState(StartStopIconState.Running);
     await this.close();
     console.log('Runtime is running');


### PR DESCRIPTION
Failed CI [job 119558](https://app.circleci.com/pipelines/github/all-of-us/workbench/7362/workflows/33e94ae6-8cff-466f-a32b-11508b0327cc/jobs/119558/steps).

Increase wait time for notebook runtime to start.