### PR TITLE
[risk=low][RW-6908] Add a PREFER_NO_ANSWER enum val to Demographic Survey Disability

### DIFF
--- a/api/db/changelog/db.changelog-149-demographic-survey-add-disability-prefer-no-answer.xml
+++ b/api/db/changelog/db.changelog-149-demographic-survey-add-disability-prefer-no-answer.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="thibault" id="changelog-149-demographic-survey-add-disability-prefer-no-answer">
+    <!-- changing from a nullable boolean type (null = prefer not to answer) to a [TRUE, FALSE, PREFER_NO_ANSWER] enum -->
+    <sql>
+      UPDATE demographic_survey
+      SET disability = 3
+      WHERE disability IS NULL
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -158,6 +158,7 @@
   <include file="changelog/db.changelog-146-access-tier-table-and-cdr-version.xml"/>
   <include file="changelog/db.changelog-147-remove-cluster-create-retries.xml"/>
   <include file="changelog/db.changelog-148-remove-cluster-config.xml"/>
+  <include file="changelog/db.changelog-149-demographic-survey-add-disability-prefer-no-answer.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -576,6 +576,7 @@ public final class DbStorageEnums {
       ImmutableBiMap.<Disability, Short>builder()
           .put(Disability.TRUE, (short) 1)
           .put(Disability.FALSE, (short) 2)
+          .put(Disability.PREFER_NO_ANSWER, (short) 3)
           .build();
 
   public static Race raceFromStorage(Short race) {

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -622,25 +622,7 @@ public final class DbStorageEnums {
     return CLIENT_TO_STORAGE_DISABILITY.get(disability);
   }
 
-  public static Short disabilityToStorage(Boolean disability) {
-    if (disability != null) {
-      return disability ? (short) 1 : (short) 2;
-    } else {
-      return null;
-    }
-  }
-
   public static Disability disabilityFromStorage(Short disability) {
     return CLIENT_TO_STORAGE_DISABILITY.inverse().get(disability);
-  }
-
-  // named such for MapStruct, which will automatically pick up on a function with this signature.
-  // can't be named disabilityFromStorage because it would have the same args as the other one.
-  public static Boolean boolyDisabilityFromStorage(Short disability) {
-    if (disability != null) {
-      return disability == 1;
-    } else {
-      return null;
-    }
   }
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3638,8 +3638,9 @@ definitions:
   Disability:
     type: string
     enum:
-    - true
-    - false
+    - TRUE
+    - FALSE
+    - PREFER_NO_ANSWER
   FeaturedWorkspaceCategory:
     type: string
     enum:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5304,8 +5304,7 @@ definitions:
       education:
         "$ref": "#/definitions/Education"
       disability:
-        type: boolean
-        default: null
+        "$ref": "#/definitions/Disability"
   Address:
     type: object
     properties:

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditorTest.kt
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditorTest.kt
@@ -16,6 +16,7 @@ import org.pmiops.workbench.actionaudit.TargetType
 import org.pmiops.workbench.db.model.DbUser
 import org.pmiops.workbench.model.DataAccessLevel
 import org.pmiops.workbench.model.DemographicSurvey
+import org.pmiops.workbench.model.Disability
 import org.pmiops.workbench.model.Education
 import org.pmiops.workbench.model.Ethnicity
 import org.pmiops.workbench.model.InstitutionalRole
@@ -75,7 +76,7 @@ class ProfileAuditorTest {
                 .apply { institutionalRoleEnum = InstitutionalRole.ADMIN }
 
         val demographicSurvey1 = DemographicSurvey()
-                .apply { disability = false }
+                .apply { disability = Disability.FALSE }
                 .apply { ethnicity = Ethnicity.NOT_HISPANIC }
                 .apply { yearOfBirth = BigDecimal.valueOf(1999) }
                 .apply { race = listOf(Race.PREFER_NO_ANSWER) }

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -70,6 +70,7 @@ import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.CreateAccountRequest;
 import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.DemographicSurvey;
+import org.pmiops.workbench.model.Disability;
 import org.pmiops.workbench.model.DuaType;
 import org.pmiops.workbench.model.Education;
 import org.pmiops.workbench.model.EmailVerificationStatus;
@@ -1024,7 +1025,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     demographicSurvey.addSexAtBirthItem(SexAtBirth.FEMALE);
     demographicSurvey.setYearOfBirth(new BigDecimal(2000));
     demographicSurvey.setEducation(Education.NO_EDUCATION);
-    demographicSurvey.setDisability(false);
+    demographicSurvey.setDisability(Disability.FALSE);
 
     profile.setDemographicSurvey(demographicSurvey);
 

--- a/api/src/test/java/org/pmiops/workbench/db/model/StorageEnumsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/model/StorageEnumsTest.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.db.model;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.api.client.util.Sets;
 import java.lang.reflect.Field;
@@ -15,7 +14,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Test;
-import org.pmiops.workbench.model.Disability;
 import org.pmiops.workbench.model.Domain;
 
 public class StorageEnumsTest {
@@ -57,32 +55,6 @@ public class StorageEnumsTest {
       String storageValue = DbStorageEnums.domainToDomainId(domainValue);
       assertWithMessage("unmapped enum value: " + domainValue).that(storageValue).isNotNull();
       assertThat(DbStorageEnums.domainIdToDomain(storageValue)).isEqualTo(domainValue);
-    }
-  }
-
-  // special-case test for Disability Short/Boolean methods
-
-  @Test
-  public void test_disability() {
-    for (Disability disabilityValue : Disability.values()) {
-      Short shortValue = DbStorageEnums.disabilityToStorage(disabilityValue);
-      assertWithMessage("unmapped enum value (Disability -> Short): " + disabilityValue)
-          .that(shortValue)
-          .isNotNull();
-      Boolean boolValue = DbStorageEnums.boolyDisabilityFromStorage(shortValue);
-      assertWithMessage("unmapped enum value (Short -> Boolean): " + disabilityValue)
-          .that(boolValue)
-          .isNotNull();
-      Short shortValue2 = DbStorageEnums.disabilityToStorage(boolValue);
-      assertWithMessage("unmapped enum value (Boolean -> Short): " + disabilityValue)
-          .that(shortValue2)
-          .isNotNull();
-      assertThat(shortValue2).isEqualTo(shortValue);
-      Disability roundTrip = DbStorageEnums.disabilityFromStorage(shortValue);
-      assertWithMessage("unmapped enum value (Short -> Disability): " + disabilityValue)
-          .that(roundTrip)
-          .isNotNull();
-      assertThat(roundTrip).isEqualTo(disabilityValue);
     }
   }
 

--- a/api/src/test/java/org/pmiops/workbench/db/model/StorageEnumsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/model/StorageEnumsTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.db.model;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.api.client.util.Sets;
 import java.lang.reflect.Field;

--- a/ui/src/app/pages/profile/demographic-survey.tsx
+++ b/ui/src/app/pages/profile/demographic-survey.tsx
@@ -15,7 +15,7 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, toggleIncludes} from 'app/utils';
 
 import {environment} from 'environments/environment';
-import {GenderIdentity, Profile, Race, SexAtBirth } from 'generated/fetch';
+import {Disability, GenderIdentity, Profile, Race, SexAtBirth} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 import ReCAPTCHA from 'react-google-recaptcha';
@@ -140,7 +140,7 @@ export class DemographicSurvey extends React.Component<Props, State> {
       identifiesAsLgbtq: { nullBoolean: {} },
       sexAtBirth: { presence: { allowEmpty: false } },
       yearOfBirth: { presence: { allowEmpty: false } },
-      disability: { nullBoolean: {} },
+      disability: { presence: { allowEmpty: false } },
       education: { presence: { allowEmpty: false } },
       lgbtqIdentity: {
         length: {
@@ -252,19 +252,19 @@ or another sexual and/or gender minority?'>
           <FlexRow style={{alignItems: 'baseline'}}>
             <RadioButton id='radio-disability-yes' onChange={
               (e) => this.updateDemographicAttribute('disability', true)}
-                         checked={!!demographicSurvey ? demographicSurvey.disability === true : false}
+                         checked={!!demographicSurvey ? demographicSurvey.disability === Disability.True : false}
                          style={{marginRight: '0.5rem'}}/>
             <label htmlFor='radio-disability-yes' style={{paddingRight: '3rem', color: colors.primary}}>Yes</label>
           </FlexRow>
           <FlexRow style={{alignItems: 'baseline'}}>
             <RadioButton id='radio-disability-no' onChange={(e) => this.updateDemographicAttribute('disability', false)}
-                         checked={!!demographicSurvey ? demographicSurvey.disability === false : false}
+                         checked={!!demographicSurvey ? demographicSurvey.disability === Disability.False : false}
                          style={{marginRight: '0.5rem'}}/>
             <label htmlFor='radio-disability-no' style={{color: colors.primary}}>No</label>
           </FlexRow>
           <FlexRow style={{alignItems: 'baseline'}}>
             <RadioButton id='radio-disability-pnta' onChange={(e) => this.updateDemographicAttribute('disability', null)}
-                         checked={!!demographicSurvey ? demographicSurvey.disability === null : false}
+                         checked={!!demographicSurvey ? demographicSurvey.disability === Disability.PREFERNOANSWER : false}
                          style={{marginRight: '0.5rem'}}/>
             <label htmlFor='radio-disability-pnta' style={{color: colors.primary}}>Prefer not to answer</label>
           </FlexRow>

--- a/ui/src/app/pages/profile/demographic-survey.tsx
+++ b/ui/src/app/pages/profile/demographic-survey.tsx
@@ -204,20 +204,25 @@ export class DemographicSurvey extends React.Component<Props, State> {
 or another sexual and/or gender minority?'>
         <FlexColumn>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton data-test-id='radio-lgbtq-yes' id='radio-lgbtq-yes' onChange={
-              (e) => this.updateDemographicAttribute('identifiesAsLgbtq', true)}
+            <RadioButton data-test-id='radio-lgbtq-yes'
+                         id='radio-lgbtq-yes'
+                         onChange={(e) => this.updateDemographicAttribute('identifiesAsLgbtq', true)}
                          checked={!!demographicSurvey ? demographicSurvey.identifiesAsLgbtq === true : false}
                          style={{marginRight: '0.5rem'}}/>
             <label htmlFor='radio-lgbtq-yes' style={{paddingRight: '3rem', color: colors.primary}}>Yes</label>
           </FlexRow>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton data-test-id='radio-lgbtq-no' id='radio-lgbtq-no' onChange={(e) => this.updateDemographicAttribute('identifiesAsLgbtq', false)}
+            <RadioButton data-test-id='radio-lgbtq-no'
+                         id='radio-lgbtq-no'
+                         onChange={(e) => this.updateDemographicAttribute('identifiesAsLgbtq', false)}
                          checked={!!demographicSurvey ? demographicSurvey.identifiesAsLgbtq === false : false}
                          style={{marginRight: '0.5rem'}}/>
             <label htmlFor='radio-lgbtq-no' style={{color: colors.primary}}>No</label>
           </FlexRow>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton data-test-id='radio-lgbtq-pnta' id='radio-lgbtq-pnta' onChange={(e) => this.updateDemographicAttribute('identifiesAsLgbtq', null)}
+            <RadioButton data-test-id='radio-lgbtq-pnta'
+                         id='radio-lgbtq-pnta'
+                         onChange={(e) => this.updateDemographicAttribute('identifiesAsLgbtq', null)}
                          checked={!!demographicSurvey ? demographicSurvey.identifiesAsLgbtq === null : false}
                          style={{marginRight: '0.5rem'}}/>
             <label htmlFor='radio-lgbtq-pnta' style={{color: colors.primary}}>Prefer not to answer</label>
@@ -250,20 +255,22 @@ or another sexual and/or gender minority?'>
       <Section header='Do you have a physical or cognitive disability?'>
         <FlexColumn>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton id='radio-disability-yes' onChange={
-              (e) => this.updateDemographicAttribute('disability', true)}
+            <RadioButton id='radio-disability-yes'
+                         onChange={(e) => this.updateDemographicAttribute('disability', e)}
                          checked={!!demographicSurvey ? demographicSurvey.disability === Disability.True : false}
                          style={{marginRight: '0.5rem'}}/>
             <label htmlFor='radio-disability-yes' style={{paddingRight: '3rem', color: colors.primary}}>Yes</label>
           </FlexRow>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton id='radio-disability-no' onChange={(e) => this.updateDemographicAttribute('disability', false)}
+            <RadioButton id='radio-disability-no'
+                         onChange={(e) => this.updateDemographicAttribute('disability', e)}
                          checked={!!demographicSurvey ? demographicSurvey.disability === Disability.False : false}
                          style={{marginRight: '0.5rem'}}/>
             <label htmlFor='radio-disability-no' style={{color: colors.primary}}>No</label>
           </FlexRow>
           <FlexRow style={{alignItems: 'baseline'}}>
-            <RadioButton id='radio-disability-pnta' onChange={(e) => this.updateDemographicAttribute('disability', null)}
+            <RadioButton id='radio-disability-pnta'
+                         onChange={(e) => this.updateDemographicAttribute('disability', e)}
                          checked={!!demographicSurvey ? demographicSurvey.disability === Disability.PREFERNOANSWER : false}
                          style={{marginRight: '0.5rem'}}/>
             <label htmlFor='radio-disability-pnta' style={{color: colors.primary}}>Prefer not to answer</label>


### PR DESCRIPTION
Description:

Following up on DbStorageEnums cleanup in #4531 and #4544, and PNTA updates in #4516, add a PNTA enum value for Disability in Demographics Survey.  Migrate exiting NULL Db values to the new enum value.

Clean up related DbStorageEnums code.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
