### PR TITLE
[RW-6152][risk=low]  Integrate data dictionary load into the CDR indices build (Data Dictionary) Part I

### DIFF
--- a/api/db-cdr/generate-cdr/bq-schemas/ds_data_dictionary.json
+++ b/api/db-cdr/generate-cdr/bq-schemas/ds_data_dictionary.json
@@ -1,0 +1,47 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "ID",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "FIELD_NAME",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "RELEVANT_OMOP_SQL",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "DESCRIPTION",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "FIELD_TYPE",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "OMOP_CDM_STANDARD_OR_CUSTOM_FIELD",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "DATA_PROVENANCE",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "SOURCE_PPI_MODULE",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "DOMAIN",
+    "type": "STRING"
+  }
+]

--- a/api/db-cdr/generate-cdr/make-bq-data-dictionary.sh
+++ b/api/db-cdr/generate-cdr/make-bq-data-dictionary.sh
@@ -9,11 +9,12 @@ export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
 export DRY_RUN=$3     # dry run
 
+archiveList=$(gsutil ls gs://all-of-us-workbench-private-cloudsql/$BQ_DATASET/data_dictionary/archive/*.csv) > /dev/null || true;
+dataDictionaryList=$(gsutil ls gs://all-of-us-workbench-private-cloudsql/$BQ_DATASET/data_dictionary/*.csv) > /dev/null || true;
+
 if [ "$DRY_RUN" == true ]
 then
   echo "Check if data dictionary file exists"
-  archiveList=$(gsutil ls gs://all-of-us-workbench-private-cloudsql/$BQ_DATASET/data_dictionary/archive/*.csv) > /dev/null || true;
-  dataDictionaryList=$(gsutil ls gs://all-of-us-workbench-private-cloudsql/$BQ_DATASET/data_dictionary/*.csv) > /dev/null || true;
   if [ -z "$dataDictionaryList" ] && [ -z "$archiveList" ]
   then
     echo "Error: Data Dictionary file is missing!"
@@ -24,8 +25,6 @@ fi
 
 # Throw error if there is no data_dictionary file for CDR release
 echo "Check if data dictionary file exists"
-archiveList=$(gsutil ls gs://all-of-us-workbench-private-cloudsql/$BQ_DATASET/data_dictionary/archive/*.csv) > /dev/null || true;
-dataDictionaryList=$(gsutil ls gs://all-of-us-workbench-private-cloudsql/$BQ_DATASET/data_dictionary/*.csv) > /dev/null || true;
 if [ -z "$dataDictionaryList" ] && [ -z "$archiveList" ]
 then
   echo "Error: Data Dictionary file is missing!"

--- a/api/db-cdr/generate-cdr/make-bq-data-dictionary.sh
+++ b/api/db-cdr/generate-cdr/make-bq-data-dictionary.sh
@@ -3,6 +3,10 @@
 # This generates the big query data dictionary tables by importing data from
 # csv at gs://all-of-us-workbench-private-cloudsql/$BQ_DATASET/data_dictionary.
 
+# This script is meant to be run as part of CDR process only. However if its being run individually,
+# parameters required for this scripts are:
+# BQ_PROJECT: workbench-project (eg all-of-us-rw-preprod) and required dataSet
+# eg ./project.rb make_bq_data_dictionary --bq-project all-of-us-workbench-test --bq-dataset synth_r_2019q4_11
 set -ex
 
 export BQ_PROJECT=$1  # project

--- a/api/db-cdr/generate-cdr/make-bq-data-dictionary.sh
+++ b/api/db-cdr/generate-cdr/make-bq-data-dictionary.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# This generates the big query data dictionary tables by importing data from
+# csv at gs://all-of-us-workbench-private-cloudsql/$BQ_DATASET/data_dictionary.
+
+set -ex
+
+export BQ_PROJECT=$1  # project
+export BQ_DATASET=$2  # dataset
+export DRY_RUN=$3     # dry run
+
+if [ "$DRY_RUN" == true ]
+then
+  echo "Check if data dictionary file exists"
+  archiveList=$(gsutil ls gs://all-of-us-workbench-private-cloudsql/$BQ_DATASET/data_dictionary/archive/*.csv) > /dev/null || true;
+  dataDictionaryList=$(gsutil ls gs://all-of-us-workbench-private-cloudsql/$BQ_DATASET/data_dictionary/*.csv) > /dev/null || true;
+  if [ -z "$dataDictionaryList" ] && [ -z "$archiveList" ]
+  then
+    echo "Error: Data Dictionary file is missing!"
+    exit 1;
+  fi
+  exit 0
+fi
+
+# Throw error if there is no data_dictionary file for CDR release
+echo "Check if data dictionary file exists"
+archiveList=$(gsutil ls gs://all-of-us-workbench-private-cloudsql/$BQ_DATASET/data_dictionary/archive/*.csv) > /dev/null || true;
+dataDictionaryList=$(gsutil ls gs://all-of-us-workbench-private-cloudsql/$BQ_DATASET/data_dictionary/*.csv) > /dev/null || true;
+if [ -z "$dataDictionaryList" ] && [ -z "$archiveList" ]
+then
+  echo "Error: Data Dictionary file is missing!"
+  exit 1;
+fi
+
+tableCreated=false;
+
+for filename in $dataDictionaryList; do
+  if (! $tableCreated)
+  then
+    echo "CREATE TABLE - ds_data_dictionary"
+    bq --quiet --project_id=$BQ_PROJECT query --nouse_legacy_sql \
+    "CREATE OR REPLACE TABLE \`$BQ_PROJECT.$BQ_DATASET.ds_data_dictionary\`
+    (
+      FIELD_NAME               STRING,
+      RELEVANT_OMOP_SQL        STRING,
+      DESCRIPTION              STRING,
+      FIELD_TYPE               STRING,
+      OMOP_CDM_STANDARD_OR_CUSTOM_FIELD  STRING,
+      DATA_PROVENANCE          STRING,
+      SOURCE_PPI_MODULE        STRING,
+      DOMAIN                   STRING
+    )"
+    tableCreated=true;
+  fi
+  echo "Load ${filename} into ds_data_dictionary"
+
+  bq load --skip_leading_rows=1  --project_id=$BQ_PROJECT --source_format=CSV \
+  $BQ_DATASET.ds_data_dictionary $filename
+
+  echo "move ${filename} to archive folder"
+  gsutil mv $filename \
+  "gs://all-of-us-workbench-private-cloudsql/$BQ_DATASET/data_dictionary/archive"
+done
+echo "The end"

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1052,6 +1052,40 @@ Must be run once when a new cdr is released",
   :fn => ->(*args) { make_bq_dataset_linking("make-bq-dataset-linking", *args) }
 })
 
+def make_bq_data_dictionary(cmd_name, *args)
+  ensure_docker_sync()
+  op = WbOptionsParser.new(cmd_name, args)
+  op.opts.dry_run = false
+  op.add_option(
+    "--bq-project [bq-project]",
+    ->(opts, v) { opts.bq_project = v},
+    "BQ Project. Required."
+  )
+  op.add_option(
+    "--bq-dataset [bq-dataset]",
+    ->(opts, v) { opts.bq_dataset = v},
+    "BQ dataset. Required."
+  )
+  op.add_option(
+    "--dry-run [dry-run]",
+    ->(opts, v) { opts.dry_run = v},
+    "Is this dry run. Default is false"
+  )
+  op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset }
+  op.parse.validate
+
+  common = Common.new
+  common.run_inline %W{docker-compose run --rm db-make-bq-tables ./generate-cdr/make-bq-data-dictionary.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.dry_run}}
+end
+
+Common.register_command({
+  :invocation => "make_bq_data_dictionary",
+  :description => "make_bq_data_dictionary --bq-project <PROJECT> --bq-dataset <DATASET>
+Generates big query data dictionary tables. Used by Data Set Builder to show values details.
+Must be run once when a new cdr is released",
+  :fn => ->(*args) { make_bq_data_dictionary("make-bq-data-dictionary", *args) }
+})
+
 def generate_cb_criteria_tables(cmd_name, *args)
   ensure_docker_sync()
   op = WbOptionsParser.new(cmd_name, args)


### PR DESCRIPTION
This PR is for a new script make_bq_data_dictionary, thats added to ./project.rb to create and load data into BQ table **ds_data_dictionary**

This script will take in the inputs **bq-project  and bq-dataset**. 

- It will check/pick the csv file under bucket /all-of-us-workbench-private-cloudsql/bq-dataSet. If there are no files under the bucket, it will throw an error.
- Create the table ds_data_dictionary and dump CSV in the table
- Move the executed CSV under the archive folder.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
