### PR TITLE
[RW-6200][risk=no] adding PM to concept set search

### DIFF
--- a/api/config/cdr_config_perf.json
+++ b/api/config/cdr_config_perf.json
@@ -48,7 +48,7 @@
       "creationTime": "2019-09-30 00:00:00Z",
       "releaseNumber": 3,
       "numParticipants": 234525,
-      "cdrDbName": "synth_r_2019q4_10",
+      "cdrDbName": "synth_r_2019q4_11",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"

--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -43,7 +43,7 @@
       "creationTime": "2019-09-30 00:00:00Z",
       "releaseNumber": 3,
       "numParticipants": 234525,
-      "cdrDbName": "synth_r_2019q4_10",
+      "cdrDbName": "synth_r_2019q4_11",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"
@@ -58,7 +58,7 @@
       "creationTime": "2020-10-20 00:00:00Z",
       "releaseNumber": 5,
       "numParticipants": 315297,
-      "cdrDbName": "r_2020q4_2",
+      "cdrDbName": "r_2020q4_3",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"

--- a/api/config/cdr_config_prod.json
+++ b/api/config/cdr_config_prod.json
@@ -84,7 +84,7 @@
       "creationTime": "2020-10-20 00:00:00Z",
       "releaseNumber": 4,
       "numParticipants": 315297,
-      "cdrDbName": "r_2020q4_2",
+      "cdrDbName": "r_2020q4_3",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"

--- a/api/config/cdr_config_stable.json
+++ b/api/config/cdr_config_stable.json
@@ -75,7 +75,7 @@
       "creationTime": "2019-09-30 00:00:00Z",
       "releaseNumber": 3,
       "numParticipants": 234525,
-      "cdrDbName": "synth_r_2019q4_10",
+      "cdrDbName": "synth_r_2019q4_11",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"
@@ -90,7 +90,7 @@
       "creationTime": "2019-09-30 00:00:00Z",
       "releaseNumber": 4,
       "numParticipants": 234525,
-      "cdrDbName": "synth_r_2019q4_10",
+      "cdrDbName": "synth_r_2019q4_11",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"

--- a/api/config/cdr_config_staging.json
+++ b/api/config/cdr_config_staging.json
@@ -75,7 +75,7 @@
       "creationTime": "2019-09-30 00:00:00Z",
       "releaseNumber": 3,
       "numParticipants": 234525,
-      "cdrDbName": "synth_r_2019q4_10",
+      "cdrDbName": "synth_r_2019q4_11",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"
@@ -90,7 +90,7 @@
       "creationTime": "2019-09-30 00:00:00Z",
       "releaseNumber": 4,
       "numParticipants": 234525,
-      "cdrDbName": "synth_r_2019q4_10",
+      "cdrDbName": "synth_r_2019q4_11",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"

--- a/api/config/cdr_config_test.json
+++ b/api/config/cdr_config_test.json
@@ -56,7 +56,7 @@
       "creationTime": "2019-09-30 00:00:00Z",
       "releaseNumber": 3,
       "numParticipants": 234525,
-      "cdrDbName": "synth_r_2019q4_10",
+      "cdrDbName": "synth_r_2019q4_11",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"
@@ -72,7 +72,7 @@
       "creationTime": "2020-08-26 00:09:51Z",
       "releaseNumber": 3,
       "numParticipants": 234525,
-      "cdrDbName": "synth_r_2019q4_10",
+      "cdrDbName": "synth_r_2019q4_11",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"

--- a/api/db-cdr/generate-cdr/make-bq-data.sh
+++ b/api/db-cdr/generate-cdr/make-bq-data.sh
@@ -87,7 +87,7 @@ VALUES
 (21,4,'Measurement','MEASUREMENT','Labs and Measurements','Labs and Measurements',0,0,0),
 (10,6,'Procedure','PROCEDURE','Procedures','Procedure',0,0,0),
 (27,5,'Observation','OBSERVATION','Observations','Observation',0,0,0),
-(0,10,'Physical Measurements','PHYSICAL_MEASUREMENT','Physical Measurements','Participants have the option to provide a standard set of physical measurements as part of the enrollment process',0,0,0)"
+(0,19,'Physical Measurements','PHYSICAL_MEASUREMENT_CSS','Physical Measurements','Participants have the option to provide a standard set of physical measurements as part of the enrollment process',0,0,0)"
 
 # Populate survey_module
 #################
@@ -469,7 +469,7 @@ set d.all_concept_count = c.all_concept_count, d.standard_concept_count = c.stan
 FROM \`$OUTPUT_PROJECT.$OUTPUT_DATASET.cb_criteria\`
 WHERE type = 'PPI'
 AND domain_id = 'PHYSICAL_MEASUREMENT_CSS') c
-where d.domain = 10"
+where d.domain = 19"
 
 # Set participant counts for Condition domain
 bq --quiet --project_id=$BQ_PROJECT query --nouse_legacy_sql \
@@ -521,9 +521,8 @@ WHERE measurement_source_concept_id IN (
 SELECT concept_id
 FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
 WHERE type = 'PPI'
-AND domain_id = 'PHYSICAL_MEASUREMENT'
-AND is_selectable = 1)) as r
-where d.domain = 10"
+AND domain_id = 'PHYSICAL_MEASUREMENT_CSS')) as r
+where d.domain = 19"
 
 ##########################################
 # survey count updates                   #

--- a/api/db-cdr/generate-cdr/make-bq-data.sh
+++ b/api/db-cdr/generate-cdr/make-bq-data.sh
@@ -465,12 +465,10 @@ where d.domain_enum = c.domain_id"
 bq --quiet --project_id=$BQ_PROJECT query --nouse_legacy_sql \
 "update \`$OUTPUT_PROJECT.$OUTPUT_DATASET.domain_info\` d
 set d.all_concept_count = c.all_concept_count, d.standard_concept_count = c.standard_concept_count from
-(SELECT count(distinct concept_id) as all_concept_count, SUM(CASE WHEN standard_concept IN ('S', 'C') THEN 1 ELSE 0 END) as standard_concept_count
-FROM \`$OUTPUT_PROJECT.$OUTPUT_DATASET.concept\`
-WHERE vocabulary_id = 'PPI'
-AND domain_id = 'Measurement'
-AND (count_value > 0 or source_count_value > 0)
-AND concept_class_id = 'Clinical Observation') c
+(SELECT count(distinct concept_id) as all_concept_count, 0 as standard_concept_count
+FROM \`$OUTPUT_PROJECT.$OUTPUT_DATASET.cb_criteria\`
+WHERE type = 'PPI'
+AND domain_id = 'PHYSICAL_MEASUREMENT_CSS') c
 where d.domain = 10"
 
 # Set participant counts for Condition domain

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -473,7 +473,11 @@ public class DataSetController implements DataSetApiDelegate {
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
     DomainValuesResponse response = new DomainValuesResponse();
 
-    FieldList fieldList = bigQueryService.getTableFieldsFromDomain(Domain.valueOf(domainValue));
+    Domain domain =
+        Domain.PHYSICAL_MEASUREMENT_CSS.equals(Domain.valueOf(domainValue))
+            ? Domain.MEASUREMENT
+            : Domain.valueOf(domainValue);
+    FieldList fieldList = bigQueryService.getTableFieldsFromDomain(domain);
     response.setItems(
         fieldList.stream()
             .map(field -> new DomainValue().value(field.getName().toLowerCase()))

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -472,8 +472,15 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   private String modifyTermMatch(String term) {
     if (MYSQL_FULL_TEXT_CHARS.stream().anyMatch(term::contains)) {
       return Arrays.stream(term.split("\\s+"))
-          .map(s -> (!s.startsWith("+") && !s.startsWith("-")) ? "+" + s : s)
-          .collect(Collectors.joining());
+          .map(
+              s -> {
+                if (s.startsWith("(")
+                    || (!s.startsWith("+") && !s.startsWith("-") && !s.endsWith(")"))) {
+                  return "+" + s;
+                }
+                return s;
+              })
+          .collect(Collectors.joining(" "));
     }
 
     String[] keywords = term.split("\\W+");

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -149,14 +149,16 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
         standardConceptIds.stream().map(l -> l.toString()).collect(Collectors.toList());
     if (!sourceIds.isEmpty()) {
       criteriaList.addAll(
-          cbCriteriaDao.findCriteriaByDomainIdAndStandardAndConceptIds(domainId, false, sourceIds)
+          cbCriteriaDao
+              .findCriteriaByDomainIdAndStandardAndConceptIds(domainId, false, sourceIds)
               .stream()
               .map(cohortBuilderMapper::dbModelToClient)
               .collect(Collectors.toList()));
     }
     if (!standardConceptIds.isEmpty()) {
       criteriaList.addAll(
-          cbCriteriaDao.findCriteriaByDomainIdAndStandardAndConceptIds(domainId, true, standardIds)
+          cbCriteriaDao
+              .findCriteriaByDomainIdAndStandardAndConceptIds(domainId, true, standardIds)
               .stream()
               .map(cohortBuilderMapper::dbModelToClient)
               .collect(Collectors.toList()));
@@ -267,7 +269,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
                   .collect(Collectors.toList()))
           .totalCount(dbCriteriaPage.getTotalElements());
     }
-    if (Domain.fromValue(domain).equals(Domain.PHYSICAL_MEASUREMENT)) {
+    if (Domain.fromValue(domain).equals(Domain.PHYSICAL_MEASUREMENT_CSS)) {
       Page<DbConcept> dbConcepts = conceptDao.findPMConcepts(modifyTermMatch(term), pageRequest);
       List<Criteria> criteriaList =
           dbConcepts.getContent().stream()

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -13,6 +13,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Ordering;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -28,11 +29,9 @@ import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.cdr.dao.CBCriteriaAttributeDao;
 import org.pmiops.workbench.cdr.dao.CBCriteriaDao;
 import org.pmiops.workbench.cdr.dao.CBDataFilterDao;
-import org.pmiops.workbench.cdr.dao.ConceptDao;
 import org.pmiops.workbench.cdr.dao.DomainInfoDao;
 import org.pmiops.workbench.cdr.dao.PersonDao;
 import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
-import org.pmiops.workbench.cdr.model.DbConcept;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbCriteriaAttribute;
 import org.pmiops.workbench.cdr.model.DbMenuOption;
@@ -68,21 +67,18 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
 
   private static final Integer DEFAULT_TREE_SEARCH_LIMIT = 100;
   private static final Integer DEFAULT_CRITERIA_SEARCH_LIMIT = 250;
-  private static final String MEASUREMENT = "Measurement";
   private static final ImmutableList<String> MYSQL_FULL_TEXT_CHARS =
       ImmutableList.of("\"", "+", "-", "*", "(", ")");
-  private static final ImmutableList<String> STANDARD_CONCEPTS = ImmutableList.of("S", "C");
 
-  private BigQueryService bigQueryService;
-  private CohortQueryBuilder cohortQueryBuilder;
-  private CBCriteriaAttributeDao cbCriteriaAttributeDao;
-  private CBCriteriaDao cbCriteriaDao;
-  private ConceptDao conceptDao;
-  private CBDataFilterDao cbDataFilterDao;
-  private DomainInfoDao domainInfoDao;
-  private PersonDao personDao;
-  private SurveyModuleDao surveyModuleDao;
-  private CohortBuilderMapper cohortBuilderMapper;
+  private final BigQueryService bigQueryService;
+  private final CohortQueryBuilder cohortQueryBuilder;
+  private final CBCriteriaAttributeDao cbCriteriaAttributeDao;
+  private final CBCriteriaDao cbCriteriaDao;
+  private final CBDataFilterDao cbDataFilterDao;
+  private final DomainInfoDao domainInfoDao;
+  private final PersonDao personDao;
+  private final SurveyModuleDao surveyModuleDao;
+  private final CohortBuilderMapper cohortBuilderMapper;
 
   @Autowired
   public CohortBuilderServiceImpl(
@@ -90,7 +86,6 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
       CohortQueryBuilder cohortQueryBuilder,
       CBCriteriaAttributeDao cbCriteriaAttributeDao,
       CBCriteriaDao cbCriteriaDao,
-      ConceptDao conceptDao,
       CBDataFilterDao cbDataFilterDao,
       DomainInfoDao domainInfoDao,
       PersonDao personDao,
@@ -100,7 +95,6 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
     this.cohortQueryBuilder = cohortQueryBuilder;
     this.cbCriteriaAttributeDao = cbCriteriaAttributeDao;
     this.cbCriteriaDao = cbCriteriaDao;
-    this.conceptDao = conceptDao;
     this.cbDataFilterDao = cbDataFilterDao;
     this.domainInfoDao = domainInfoDao;
     this.personDao = personDao;
@@ -144,9 +138,9 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
       String domainId, Collection<Long> sourceConceptIds, Collection<Long> standardConceptIds) {
     List<Criteria> criteriaList = new ArrayList<>();
     List<String> sourceIds =
-        sourceConceptIds.stream().map(l -> l.toString()).collect(Collectors.toList());
+        sourceConceptIds.stream().map(Object::toString).collect(Collectors.toList());
     List<String> standardIds =
-        standardConceptIds.stream().map(l -> l.toString()).collect(Collectors.toList());
+        standardConceptIds.stream().map(Object::toString).collect(Collectors.toList());
     if (!sourceIds.isEmpty()) {
       criteriaList.addAll(
           cbCriteriaDao
@@ -233,23 +227,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
     PageRequest pageRequest =
         new PageRequest(0, Optional.ofNullable(limit).orElse(DEFAULT_CRITERIA_SEARCH_LIMIT));
     if (term == null || term.trim().isEmpty()) {
-      // return top counts
-      if (Domain.fromValue(domain).equals(Domain.PHYSICAL_MEASUREMENT)) {
-        Page<DbConcept> dbConcepts = conceptDao.findPMConcepts(pageRequest);
-        List<Criteria> criteriaList =
-            dbConcepts.getContent().stream()
-                .map(
-                    c -> {
-                      boolean isStandard = STANDARD_CONCEPTS.contains(c.getStandardConcept());
-                      return cohortBuilderMapper.dbModelToClient(
-                          c, isStandard, isStandard ? c.getCountValue() : c.getSourceCountValue());
-                    })
-                .collect(Collectors.toList());
-        return new CriteriaListWithCountResponse()
-            .items(criteriaList)
-            .totalCount(dbConcepts.getTotalElements());
-      }
-      if (Domain.fromValue(domain).equals(Domain.SURVEY)) {
+      if (Domain.SURVEY.equals(Domain.fromValue(domain))) {
         Long id = cbCriteriaDao.findIdByDomainAndName(domain, surveyName);
         Page<DbCriteria> dbCriteriaPage =
             cbCriteriaDao.findSurveyQuestionCriteriaByDomainAndIdAndFullText(
@@ -269,23 +247,8 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
                   .collect(Collectors.toList()))
           .totalCount(dbCriteriaPage.getTotalElements());
     }
-    if (Domain.fromValue(domain).equals(Domain.PHYSICAL_MEASUREMENT_CSS)) {
-      Page<DbConcept> dbConcepts = conceptDao.findPMConcepts(modifyTermMatch(term), pageRequest);
-      List<Criteria> criteriaList =
-          dbConcepts.getContent().stream()
-              .map(
-                  c -> {
-                    boolean isStandard = STANDARD_CONCEPTS.contains(c.getStandardConcept());
-                    return cohortBuilderMapper.dbModelToClient(
-                        c, isStandard, isStandard ? c.getCountValue() : c.getSourceCountValue());
-                  })
-              .collect(Collectors.toList());
-      return new CriteriaListWithCountResponse()
-          .items(criteriaList)
-          .totalCount(dbConcepts.getTotalElements());
-    }
 
-    if (Domain.fromValue(domain).equals(Domain.SURVEY)) {
+    if (Domain.SURVEY.equals(Domain.fromValue(domain))) {
       Page<DbCriteria> dbCriteriaPage;
       if (surveyName.equals("All")) {
         dbCriteriaPage =
@@ -306,7 +269,8 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
     }
 
     Page<DbCriteria> dbCriteriaPage =
-        cbCriteriaDao.findCriteriaByDomainAndTypeAndCode(domain, term, pageRequest);
+        cbCriteriaDao.findCriteriaByDomainAndTypeAndCode(
+            domain, term.replaceAll("[()+\"*-]", ""), pageRequest);
     if (dbCriteriaPage.getContent().isEmpty() && !term.contains(".")) {
       dbCriteriaPage =
           cbCriteriaDao.findCriteriaByDomainAndFullText(domain, modifyTermMatch(term), pageRequest);
@@ -395,6 +359,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   @Override
   public List<DomainInfo> findDomainInfos() {
     return domainInfoDao.findByOrderByDomainId().stream()
+        .filter(dbDomainInfo -> dbDomainInfo.getAllConceptCount() > 0)
         .map(cohortBuilderMapper::dbModelToClient)
         .collect(Collectors.toList());
   }
@@ -505,17 +470,13 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   }
 
   private String modifyTermMatch(String term) {
-    if (!MYSQL_FULL_TEXT_CHARS.stream()
-        .filter(term::contains)
-        .collect(Collectors.toList())
-        .isEmpty()) {
-      return term;
+    if (MYSQL_FULL_TEXT_CHARS.stream().anyMatch(term::contains)) {
+      return Arrays.stream(term.split("\\s+"))
+          .map(s -> (!s.startsWith("+") && !s.startsWith("-")) ? "+" + s : s)
+          .collect(Collectors.joining());
     }
 
     String[] keywords = term.split("\\W+");
-    if (keywords.length == 1 && keywords[0].length() <= 3) {
-      return "+\"" + keywords[0] + "+\"";
-    }
 
     return IntStream.range(0, keywords.length)
         .filter(i -> keywords[i].length() > 2)

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -143,16 +143,14 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
         standardConceptIds.stream().map(Object::toString).collect(Collectors.toList());
     if (!sourceIds.isEmpty()) {
       criteriaList.addAll(
-          cbCriteriaDao
-              .findCriteriaByDomainIdAndStandardAndConceptIds(domainId, false, sourceIds)
+          cbCriteriaDao.findCriteriaByDomainIdAndStandardAndConceptIds(domainId, false, sourceIds)
               .stream()
               .map(cohortBuilderMapper::dbModelToClient)
               .collect(Collectors.toList()));
     }
     if (!standardConceptIds.isEmpty()) {
       criteriaList.addAll(
-          cbCriteriaDao
-              .findCriteriaByDomainIdAndStandardAndConceptIds(domainId, true, standardIds)
+          cbCriteriaDao.findCriteriaByDomainIdAndStandardAndConceptIds(domainId, true, standardIds)
               .stream()
               .map(cohortBuilderMapper::dbModelToClient)
               .collect(Collectors.toList()));

--- a/api/src/main/java/org/pmiops/workbench/dataset/BigQueryDataSetTableInfo.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/BigQueryDataSetTableInfo.java
@@ -40,6 +40,11 @@ public enum BigQueryDataSetTableInfo {
       " measurement_source_concept_id in "
           + String.format(
               CHILD_LOOKUP_SQL, "'MEASUREMENT'", 0, "@sourceConceptIds", "'MEASUREMENT'", 0)),
+  PHYSICAL_MEASUREMENT_CSS(
+      Domain.PHYSICAL_MEASUREMENT_CSS,
+      "ds_measurement",
+      " measurement_concept_id in unnest(@standardConceptIds)",
+      " measurement_source_concept_id in unnest(@sourceConceptIds)"),
   SURVEY(Domain.SURVEY, "ds_survey", null, " question_concept_id in unnest(@sourceConceptIds)"),
   PERSON(Domain.PERSON, "ds_person", null, null),
   OBSERVATION(

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -260,7 +260,10 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     Map<String, QueryParameterValue> mergedQueryParameterValues = new HashMap<>();
 
     final List<String> domainValues =
-        bigQueryService.getTableFieldsFromDomain(domain).stream()
+        bigQueryService
+            .getTableFieldsFromDomain(
+                Domain.PHYSICAL_MEASUREMENT_CSS.equals(domain) ? Domain.MEASUREMENT : domain)
+            .stream()
             .map(field -> field.getName().toLowerCase())
             .collect(Collectors.toList());
 
@@ -288,7 +291,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                   .filter(
                       cs ->
                           cs.getDomainEnum().equals(domain)
-                              || (cs.getDomainEnum().equals(Domain.PHYSICAL_MEASUREMENT)
+                              || (cs.getDomainEnum().equals(Domain.PHYSICAL_MEASUREMENT_CSS)
                                   && domain.equals(Domain.MEASUREMENT)))
                   .flatMap(cs -> cs.getConceptSetConceptIds().stream())
                   .collect(Collectors.toList());
@@ -1000,7 +1003,11 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
             .collect(Collectors.toList()));
 
     final String domainName = domainMaybe.get().toString();
-    final String domainFirstCharacterCapitalized = capitalizeFirstCharacterOnly(domainName);
+    final String domainFirstCharacterCapitalized =
+        capitalizeFirstCharacterOnly(
+            Domain.PHYSICAL_MEASUREMENT_CSS.toString().equals(domainName)
+                ? Domain.MEASUREMENT.toString()
+                : domainName);
 
     final List<DbDSLinking> valuesLinkingTableResult =
         dsLinkingDao.findByDomainAndDenormalizedNameIn(

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -279,6 +279,7 @@ public final class DbStorageEnums {
           .put(Domain.FITBIT_HEART_RATE_LEVEL, (short) 16)
           .put(Domain.FITBIT_ACTIVITY, (short) 17)
           .put(Domain.FITBIT_INTRADAY_STEPS, (short) 18)
+          .put(Domain.PHYSICAL_MEASUREMENT_CSS, (short) 19)
           .build();
 
   // A mapping from our Domain enum to OMOP domain ID values.
@@ -303,6 +304,7 @@ public final class DbStorageEnums {
           .put(Domain.FITBIT_HEART_RATE_LEVEL, "Fitbit: Heart Rate - Minute-Level")
           .put(Domain.FITBIT_ACTIVITY, "Fitbit: Activity - Daily Summary")
           .put(Domain.FITBIT_INTRADAY_STEPS, "Fitbit: Intraday Steps - Minute-Level")
+          .put(Domain.PHYSICAL_MEASUREMENT_CSS, "Physical Measurement CSS")
           .build();
 
   public static Domain domainFromStorage(Short domain) {

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3568,6 +3568,7 @@ definitions:
     - SURVEY
     - PERSON
     - PHYSICAL_MEASUREMENT
+    - PHYSICAL_MEASUREMENT_CSS
     - ALL_EVENTS
     - LAB
     - VITAL

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3568,7 +3568,6 @@ definitions:
     - SURVEY
     - PERSON
     - PHYSICAL_MEASUREMENT
-    - PHYSICAL_MEASUREMENT_CSS
     - ALL_EVENTS
     - LAB
     - VITAL
@@ -3577,6 +3576,7 @@ definitions:
     - FITBIT_HEART_RATE_LEVEL
     - FITBIT_ACTIVITY
     - FITBIT_INTRADAY_STEPS
+    - PHYSICAL_MEASUREMENT_CSS
   Surveys:
     type: string
     description: a survey for concepts

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -116,7 +116,7 @@ public class CohortBuilderControllerTest {
                 .domainId("CONDITION")
                 .name("Conditions")
                 .description("descr")
-                .allConceptCount(0)
+                .allConceptCount(10)
                 .standardConceptCount(0)
                 .participantCount(1000));
 
@@ -124,7 +124,7 @@ public class CohortBuilderControllerTest {
     assertThat(domainInfo.getName()).isEqualTo(dbDomainInfo.getName());
     assertThat(domainInfo.getDescription()).isEqualTo(dbDomainInfo.getDescription());
     assertThat(domainInfo.getParticipantCount()).isEqualTo(dbDomainInfo.getParticipantCount());
-    assertThat(domainInfo.getAllConceptCount()).isEqualTo(0);
+    assertThat(domainInfo.getAllConceptCount()).isEqualTo(10);
     assertThat(domainInfo.getStandardConceptCount()).isEqualTo(0);
   }
 

--- a/ui/src/app/cohort-search/utils.ts
+++ b/ui/src/app/cohort-search/utils.ts
@@ -64,6 +64,9 @@ export function domainToTitle(domain: any): string {
     case Domain.PHYSICALMEASUREMENT:
       domain = 'Physical Measurements';
       break;
+    case Domain.PHYSICALMEASUREMENTCSS:
+      domain = 'Physical Measurements';
+      break;
     case Domain.VISIT:
       domain = 'Visits';
       break;

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -21,7 +21,6 @@ import {
 } from 'app/utils';
 import {currentCohortSearchContextStore, currentConceptStore, NavStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {environment} from 'environments/environment';
 import {Concept, Domain, DomainInfo, SurveyModule} from 'generated/fetch';
 import {Key} from 'ts-key-enum';
 

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -279,8 +279,8 @@ export const ConceptHomepage = fp.flow(withCurrentCohortSearchContext(), withCur
     render() {
       const {conceptDomainList, conceptSurveysList, currentInputString, currentSearchString, domainInfoError, domainsLoading, inputErrors,
         loadingDomains, surveyInfoError, showSearchError, surveysLoading} = this.state;
-      const conceptDomainCards = conceptDomainList.filter(domain => domain.domain !== Domain.PHYSICALMEASUREMENT);
-      const physicalMeasurementsCard = conceptDomainList.find(domain => domain.domain === Domain.PHYSICALMEASUREMENT);
+      const conceptDomainCards = conceptDomainList.filter(domain => domain.domain !== Domain.PHYSICALMEASUREMENTCSS);
+      const physicalMeasurementsCard = conceptDomainList.find(domain => domain.domain === Domain.PHYSICALMEASUREMENTCSS);
       return <React.Fragment>
         <FadeBox style={{margin: 'auto', paddingTop: '1rem', width: '95.7%'}}>
           <div style={{display: 'flex', alignItems: 'center'}}>
@@ -348,13 +348,13 @@ export const ConceptHomepage = fp.flow(withCurrentCohortSearchContext(), withCur
                 <div style={{...styles.cardList, marginBottom: '1rem'}}>
                   {domainInfoError
                     ? this.errorMessage()
-                    : domainsLoading.includes(Domain.PHYSICALMEASUREMENT)
+                    : domainsLoading.includes(Domain.PHYSICALMEASUREMENTCSS)
                       ? <Spinner size={42}/>
                       : physicalMeasurementsCard.allConceptCount === 0
                         ? 'No Program Physical Measurement Results. Please type in a new search term.'
                         : <PhysicalMeasurementsCard physicalMeasurement={physicalMeasurementsCard}
-                                                    browsePhysicalMeasurements={() => this.browseDomain(Domain.PHYSICALMEASUREMENT)}
-                                                    updating={domainsLoading.includes(Domain.PHYSICALMEASUREMENT)}/>
+                                                    browsePhysicalMeasurements={() => this.browseDomain(Domain.PHYSICALMEASUREMENTCSS)}
+                                                    updating={domainsLoading.includes(Domain.PHYSICALMEASUREMENTCSS)}/>
                   }
                 </div>
               </React.Fragment>}

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -341,7 +341,7 @@ export const ConceptHomepage = fp.flow(withCurrentCohortSearchContext(), withCur
                                                      updating={surveysLoading.includes(survey.name)}/>)
                 }
               </div>
-              {environment.enableNewConceptTabs && !!physicalMeasurementsCard && <React.Fragment>
+              {!!physicalMeasurementsCard && <React.Fragment>
                 <div style={styles.sectionHeader}>
                   Program Physical Measurements
                 </div>

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -234,7 +234,8 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
 
     get displayDomainName() {
       const {conceptSet} = this.state;
-      return conceptSet.domain === Domain.PHYSICALMEASUREMENT ? 'Physical Measurements' : fp.capitalize(conceptSet.domain.toString()) ;
+      return (conceptSet.domain === Domain.PHYSICALMEASUREMENT ||
+        conceptSet.domain === Domain.PHYSICALMEASUREMENTCSS) ? 'Physical Measurements' : fp.capitalize(conceptSet.domain.toString()) ;
     }
 
     async showUnsavedModal() {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -13,11 +13,7 @@ import {TooltipTrigger} from 'app/components/popups';
 import {Spinner} from 'app/components/spinners';
 import {CircleWithText} from 'app/icons/circleWithText';
 import {NewDataSetModal} from 'app/pages/data/data-set/new-dataset-modal';
-import {
-  cohortsApi,
-  conceptSetsApi,
-  dataSetApi
-} from 'app/services/swagger-fetch-clients';
+import {cohortsApi, conceptSetsApi, dataSetApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {
   formatDomain,
@@ -32,10 +28,7 @@ import {
 } from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {getCdrVersion} from 'app/utils/cdr-versions';
-import {
-  currentWorkspaceStore,
-  navigateAndPreventDefaultIfNoKeysPressed
-} from 'app/utils/navigation';
+import {currentWorkspaceStore, navigateAndPreventDefaultIfNoKeysPressed} from 'app/utils/navigation';
 import {apiCallWithGatewayTimeoutRetries} from 'app/utils/retry';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
@@ -312,7 +305,7 @@ export class ValueListItem extends React.Component<
 
     dataSetApi().getDataDictionaryEntry(
       parseInt(currentWorkspaceStore.getValue().cdrVersionId, 10),
-      domain.toString(),
+      domain === Domain.PHYSICALMEASUREMENTCSS ? Domain.MEASUREMENT.toString() : domain.toString(),
       domainValue.value).then(dataDictionaryEntry => {
         this.setState({dataDictionaryEntry});
       }).catch(e => {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -1181,8 +1181,9 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
               <FlexColumn>
                 <FlexRow style={{paddingTop: '0.5rem'}}>
                   {fp.toPairs(previewList).map((value) => {
-                    // Strip underscores so we get the correct enum value below
-                    const domain: string = value[0].replace(/_/g, '');
+                    const domain: string = value[0];
+                    // Strip underscores so we get the correct enum value
+                    const domainEnumValue = Domain[domain.replace(/_/g, '')];
                     const previewRow: DataSetPreviewInfo = value[1];
                     return <TooltipTrigger key={domain}
                                            content={
@@ -1194,8 +1195,8 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
                                            side='top'>
                       <Clickable
                                  disabled={previewRow.isLoading}
-                                 onClick={() => this.setState({selectedPreviewDomain: Domain[domain]})}
-                                 style={stylesFunction.selectDomainForPreviewButton(selectedPreviewDomain === Domain[domain])}>
+                                 onClick={() => this.setState({selectedPreviewDomain: domainEnumValue})}
+                                 style={stylesFunction.selectDomainForPreviewButton(selectedPreviewDomain === domainEnumValue)}>
                         <FlexRow style={{alignItems: 'center', overflow: 'auto', wordBreak: 'break-all'}}>
                           {formatDomainString(domain)}
                           {previewRow.isLoading &&

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -1188,7 +1188,8 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
               <FlexColumn>
                 <FlexRow style={{paddingTop: '0.5rem'}}>
                   {fp.toPairs(previewList).map((value) => {
-                    const domain: string = value[0];
+                    // Strip underscores so we get the correct enum value below
+                    const domain: string = value[0].replace(/_/g, '');
                     const previewRow: DataSetPreviewInfo = value[1];
                     return <TooltipTrigger key={domain}
                                            content={
@@ -1200,11 +1201,10 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
                                            side='top'>
                       <Clickable
                                  disabled={previewRow.isLoading}
-                                 onClick={() =>
-                                   this.setState({selectedPreviewDomain: Domain[domain]})}
+                                 onClick={() => this.setState({selectedPreviewDomain: Domain[domain]})}
                                  style={stylesFunction.selectDomainForPreviewButton(selectedPreviewDomain === Domain[domain])}>
                         <FlexRow style={{alignItems: 'center', overflow: 'auto', wordBreak: 'break-all'}}>
-                          {domain.toString()}
+                          {formatDomainString(domain)}
                           {previewRow.isLoading &&
                           <Spinner style={{marginLeft: '4px', height: '18px', width: '18px'}}/>}
                         </FlexRow>

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -453,8 +453,7 @@ export function formatWorkspaceResourceDisplayDate(time: string): string {
 }
 
 export function formatDomainString(domainString: string): string {
-  return fp.capitalize(domainString ===
-  Domain.PHYSICALMEASUREMENTCSS.toString() ? Domain.PHYSICALMEASUREMENT.toString() : domainString);
+  return fp.capitalize(domainString === 'PHYSICALMEASUREMENTCSS' ? Domain.PHYSICALMEASUREMENT.toString() : domainString);
 }
 
 export function formatDomain(domain: FetchDomain): string {

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -453,7 +453,8 @@ export function formatWorkspaceResourceDisplayDate(time: string): string {
 }
 
 export function formatDomainString(domainString: string): string {
-  return fp.capitalize(domainString === 'PHYSICALMEASUREMENTCSS' ? Domain.PHYSICALMEASUREMENT.toString() : domainString);
+  return fp.capitalize(domainString === Domain.PHYSICALMEASUREMENTCSS.toString()
+    ? Domain.PHYSICALMEASUREMENT.toString() : domainString);
 }
 
 export function formatDomain(domain: FetchDomain): string {

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -453,7 +453,8 @@ export function formatWorkspaceResourceDisplayDate(time: string): string {
 }
 
 export function formatDomainString(domainString: string): string {
-  return fp.capitalize(domainString);
+  return fp.capitalize(domainString ===
+  Domain.PHYSICALMEASUREMENTCSS.toString() ? Domain.PHYSICALMEASUREMENT.toString() : domainString);
 }
 
 export function formatDomain(domain: FetchDomain): string {


### PR DESCRIPTION
adding PM to concept set search and dataset preview and export to notebook. This PR also bumps the synth/preprod/prod cloud CDR indices to new version that includes the new PM criteria rows.

![Screen Shot 2021-02-17 at 10 27 46 AM](https://user-images.githubusercontent.com/3904919/108234809-c7c32a00-710a-11eb-813c-63759ddb5312.png)
