### PR TITLE
[RW-6197][risk=no] Better handling for DataSet Save/Export errors

### DIFF
--- a/ui/src/app/pages/data/data-set/new-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/new-dataset-modal.tsx
@@ -133,7 +133,7 @@ class NewDataSetModal extends React.Component<Props, State> {
         };
         await dataSetApi().updateDataSet(workspaceNamespace, workspaceId, dataSet.id, updateReq);
       } else {
-        await dataSetApi().createDataSet(workspaceNamespace, workspaceId, request);
+        await dataSetApi().createDataSet(workspaceNamespace, workspaceId, null);
       }
       if (this.state.exportToNotebook) {
         await dataSetApi().exportToNotebook(
@@ -154,6 +154,7 @@ class NewDataSetModal extends React.Component<Props, State> {
         window.history.back();
       }
     } catch (e) {
+      console.error(e);
       if (e.status === 409) {
         this.setState({conflictDataSetName: true, loading: false});
       } else if (e.status === 400) {


### PR DESCRIPTION
- Handle all errors to avoid infinite spinner on modal that requires page refresh
- Separate save/update and export error handling to show specific messaging for export failures

Name conflict:
![Screen Shot 2021-02-17 at 11 30 19 AM](https://user-images.githubusercontent.com/40036095/108247525-5ee2ae80-7118-11eb-95fe-548959918ecd.png)
Save failed:
![Screen Shot 2021-02-17 at 11 28 41 AM](https://user-images.githubusercontent.com/40036095/108247551-67d38000-7118-11eb-84db-21fda31875ca.png)
Export failed:
![Screen Shot 2021-02-17 at 11 32 01 AM](https://user-images.githubusercontent.com/40036095/108247573-71f57e80-7118-11eb-9a32-6c432d5dbc4a.png)


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
