### PR TITLE
[RW-6303][risk=no] Datasets - remove all concept ids from SQL generated when selecting All Surveys

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
@@ -25,7 +25,7 @@ public class ConceptBigQueryService {
   private final BigQueryService bigQueryService;
   private static final ImmutableList<Domain> CHILD_LOOKUP_DOMAINS =
       ImmutableList.of(Domain.CONDITION, Domain.PROCEDURE, Domain.MEASUREMENT, Domain.DRUG);
-  private static final String SURVEY_QUESTION_CONCEPT_ID_SQL_TEMPLATE =
+  public static final String SURVEY_QUESTION_CONCEPT_ID_SQL_TEMPLATE =
       "select DISTINCT(question_concept_id) as concept_id \n"
           + "from `${projectId}.${dataSetId}.ds_survey`\n";
 

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -677,7 +677,8 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
   }
 
   private boolean preDefinedSurveyConceptSet(List<DbConceptSet> dbConceptSets) {
-    return dbConceptSets.stream().anyMatch(c -> c.getConceptSetId() == 0);
+    return dbConceptSets.stream()
+        .anyMatch(c -> c.getConceptSetId() == 0 && Domain.SURVEY.equals(c.getDomainEnum()));
   }
 
   private QueryJobConfiguration buildQueryJobConfiguration(

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -47,6 +47,7 @@ import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbConceptSetConceptId;
 import org.pmiops.workbench.db.model.DbDataDictionaryEntry;
 import org.pmiops.workbench.db.model.DbDataset;
+import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
@@ -434,6 +435,12 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     final ImmutableList.Builder<DbConceptSet> selectedConceptSetsBuilder = ImmutableList.builder();
     selectedConceptSetsBuilder.addAll(initialSelectedConceptSets);
 
+    // If pre packaged all survey concept set is selected create a temp concept set with concept ids
+    // of all survey questions
+    if (prePackagedConceptSet.contains(SURVEY)
+        || prePackagedConceptSet.contains(PrePackagedConceptSetEnum.BOTH)) {
+      selectedConceptSetsBuilder.add(buildPrePackagedSurveyConceptSet());
+    }
     return selectedConceptSetsBuilder.build();
   }
 
@@ -684,6 +691,9 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
   @VisibleForTesting
   public boolean conceptSetSelectionIsNonemptyAndEachDomainHasAtLeastOneConcept(
       List<DbConceptSet> conceptSetsSelected) {
+    if (preDefinedSurveyConceptSet(conceptSetsSelected)) {
+      return true;
+    }
     if (conceptSetsSelected.isEmpty()) {
       return false;
     }
@@ -1170,5 +1180,12 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
 
   private static boolean getBuiltinBooleanFromNullable(Boolean boo) {
     return Optional.ofNullable(boo).orElse(false);
+  }
+
+  private DbConceptSet buildPrePackagedSurveyConceptSet() {
+    final DbConceptSet surveyConceptSet = new DbConceptSet();
+    surveyConceptSet.setName("All Surveys");
+    surveyConceptSet.setDomain(DbStorageEnums.domainToStorage(Domain.SURVEY));
+    return surveyConceptSet;
   }
 }


### PR DESCRIPTION
Datasets - remove all concept ids from SQL generated when selecting All Surveys using a sub-select.

![Screen Shot 2021-02-19 at 3 01 19 PM](https://user-images.githubusercontent.com/3904919/108561120-537fb680-72c3-11eb-8754-742128bb0b13.png)

Old implementation:
![Screen Shot 2021-02-19 at 3 04 06 PM](https://user-images.githubusercontent.com/3904919/108561345-b709e400-72c3-11eb-97a6-d30b9837dc52.png)


