### PR TITLE
[RW-6148][risk=no] Increase default GCE disk from 50 -> 100 GB

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -747,15 +747,15 @@ describe('RuntimePanel', () => {
     expect(runningCost().text()).toEqual('$0.40/hr');
     expect(storageCost().text()).toEqual('$0.02/hr');
 
-    // Selecting the General Analysis preset should bring the machine back to n1-standard-4 with 50GB storage.
+    // Selecting the General Analysis preset should bring the machine back to n1-standard-4 with 100GB storage.
     await pickPreset(wrapper, {displayName: 'General Analysis'});
     expect(runningCost().text()).toEqual('$0.20/hr');
     expect(storageCost().text()).toEqual('< $0.01/hr');
 
-    // After selecting Dataproc, the Dataproc defaults should make the running cost 71 cents an hour. The storage cost should remain unchanged.
+    // After selecting Dataproc, the Dataproc defaults should make the running cost 71 cents an hour. The storage cost increases due to worker disk.
     await pickComputeType(wrapper, ComputeType.Dataproc);
     expect(runningCost().text()).toEqual('$0.71/hr');
-    expect(storageCost().text()).toEqual('< $0.01/hr');
+    expect(storageCost().text()).toEqual('$0.01/hr');
 
     // Bump up all the worker values to increase the price on everything.
     await pickNumWorkers(wrapper, 4);
@@ -764,7 +764,7 @@ describe('RuntimePanel', () => {
     await pickWorkerRam(wrapper, 30);
     await pickWorkerDiskSize(wrapper, 300);
     expect(runningCost().text()).toEqual('$2.87/hr');
-    expect(storageCost().text()).toEqual('$0.13/hr');
+    expect(storageCost().text()).toEqual('$0.14/hr');
   });
 
   it('should update the cost estimator when master machine changes', async() => {

--- a/ui/src/app/utils/runtime-presets.ts
+++ b/ui/src/app/utils/runtime-presets.ts
@@ -11,7 +11,7 @@ export const runtimePresets: {
       // TODO: Support specifying toolDockerImage here.
       gceConfig: {
         machineType: 'n1-standard-4',
-        diskSize: 50
+        diskSize: 100
       },
     }
   },
@@ -21,9 +21,9 @@ export const runtimePresets: {
       configurationType: RuntimeConfigurationType.HailGenomicAnalysis,
       dataprocConfig: {
         masterMachineType: 'n1-standard-4',
-        masterDiskSize: 50,
+        masterDiskSize: 100,
         workerMachineType: 'n1-standard-4',
-        workerDiskSize: 50,
+        workerDiskSize: 100,
         numberOfWorkers: 2,
         numberOfPreemptibleWorkers: 0
       }


### PR DESCRIPTION
Preemptively sending this out so we can have this ready to go for next week's release, if desired.

**DO NOT MERGE**: Until getting Shimon's sign-off (question pending to him).

Note: this also updates Dataproc settings for consistency. Only the single GCE change will actually affect production users, since test env genomics is the only place where you can use Dataproc.