### PR TITLE
[RW-6244][risk=no] Fix flaky automatic scroll in criteria search tree view

### DIFF
--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -288,7 +288,7 @@ export const CriteriaSearch = fp.flow(withUrlParams(), withCurrentWorkspace())(c
     const nodeId = `node${id}`;
     const node = document.getElementById(nodeId);
     if (node) {
-      setTimeout(() => node.scrollIntoView({behavior: 'smooth', block: 'center'}), 200);
+      node.scrollIntoView({behavior: 'smooth', block: 'start'});
     }
     this.setState({loadingSubtree: false});
   }


### PR DESCRIPTION
Changing `scrollIntoView` option from `block: 'center'` to `block: 'start'` fixes the issue. Also, removed `setTimeout` since it's no longer needed (IIRC it was necessary for Angular).

For some reason, when set to `block: 'center'`, subsequent automatic scrolls won't work if the position of the main page scrollbar was unchanged since the last automatic scroll. If the main page is moved up or down in between automatic scrolls, it seems to work fine. Setting to `block: 'start'` seems work either way.

https://user-images.githubusercontent.com/40036095/108747734-68e32380-7503-11eb-91af-2ce6226d9966.mov

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
