### PR TITLE
[no ticket][risk=no] Puppeteer CI nightly job fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -631,6 +631,7 @@ workflows:
       - puppeteer-test:
           <<: *filter-pr-branch
           env_name: "local"
+          test_mode: "nightly-integration"
           parallel_num: 4
           optional_steps:
             - halt-puppeteer-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,7 +632,7 @@ workflows:
           <<: *filter-pr-branch
           env_name: "local"
           test_mode: "nightly-integration"
-          parallel_num: 4
+          parallel_num: 1
           optional_steps:
             - halt-puppeteer-check
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,9 @@ commands:
     description: "Run puppeteer end-to-end integration test"
     steps:
       - run:
-          command: echo "Environment parameter WORKBENCH_ENV=${WORKBENCH_ENV}"
+          command: |
+            echo "WORKBENCH_ENV=${WORKBENCH_ENV}"
+            echo "TEST_MODE=${TEST_MODE}"
       - gcloud-auth-login:
           # Needed for yarn test, which invokes generate-impersonated-user-token
           with_application_default_credentials: true
@@ -549,6 +551,11 @@ jobs:
         default: "test"
         type: enum
         enum: ["test", "staging", "local"]
+      test_mode:
+        description: Switching between "nightly-integration" and normal "integration" test mode
+        default: "integration"
+        type: enum
+        enum: [ "integration", "nightly-integration" ]
       parallel_num:
         type: integer
         default: 1
@@ -557,6 +564,7 @@ jobs:
         default: []
     environment:
       WORKBENCH_ENV: << parameters.env_name >>
+      TEST_MODE: << parameters.test_mode >>
     parallelism: << parameters.parallel_num >>
     steps:
       - attach_workspace:
@@ -578,14 +586,6 @@ jobs:
 
   puppeteer-env-setup:
     executor: puppeteer-executor
-    parameters:
-      test_mode:
-        description: Switching between "nightly-integration" and normal "integration" test mode
-        default: "integration"
-        type: enum
-        enum: [ "integration", "nightly-integration" ]
-    environment:
-      TEST_MODE: << parameters.test_mode >>
     steps:
       - checkout-code
       - store-commit-message
@@ -701,11 +701,11 @@ workflows:
                 - master
     jobs:
       - api-bigquery-test
-      - puppeteer-env-setup:
-          test_mode: "nightly-integration"
+      - puppeteer-env-setup
       - puppeteer-test:
           parallel_num: 1
           env_name: "test"
+          test_mode: "nightly-integration"
           requires:
             - puppeteer-env-setup
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -631,8 +631,7 @@ workflows:
       - puppeteer-test:
           <<: *filter-pr-branch
           env_name: "local"
-          test_mode: "nightly-integration"
-          parallel_num: 1
+          parallel_num: 4
           optional_steps:
             - halt-puppeteer-check
           requires:

--- a/e2e/app/page/create-account-page.ts
+++ b/e2e/app/page/create-account-page.ts
@@ -225,7 +225,7 @@ export default class CreateAccountPage extends BasePage {
 
   // Step 4: Fill out demographic survey information with default values
   async fillOutDemographicSurvey(): Promise<void> {
-    await waitForText(this.page, 'Optional Demographics Survey');
+    await waitForText(this.page, 'Demographics Survey');
     // Find and check on all checkboxes with same label: Prefer not to answer
     const targetXpath = '//*[normalize-space(text())="Prefer not to answer"]/ancestor::node()[1]/input[@type="checkbox" or @type="radio"]';
     await this.page.waitForXPath(targetXpath, { visible: true });


### PR DESCRIPTION
Nightly job ran all tests instead tests inside the nightly folder.
CI job [122068](https://app.circleci.com/pipelines/github/all-of-us/workbench/7792/workflows/86f1df0b-b458-4226-b236-02fa50763f94/jobs/122068)

Cause: `puppeteer-executor` override `test_mode` value (`nightly-integration`) in `puppeteer-test` to `integration`. 
Fix by moving `test_mode` parameter from `puppeteer-env-setup` job to `puppeteer-test` job.