### PR TITLE
[RW-6180][risk=medium] update Workspace logic for Multi Tier 

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultAccessTier;
 
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.common.collect.ImmutableList;
@@ -33,6 +34,7 @@ import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;
 import org.pmiops.workbench.cohortbuilder.SearchGroupItemQueryBuilder;
 import org.pmiops.workbench.cohortbuilder.mapper.CohortBuilderMapperImpl;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
@@ -125,6 +127,8 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Autowired private TestWorkbenchConfig testWorkbenchConfig;
 
+  @Autowired private AccessTierDao accessTierDao;
+
   @Mock private Provider<WorkbenchConfig> configProvider;
 
   private DbCriteria drugNode1;
@@ -183,6 +187,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     cdrVersion.setCdrVersionId(1L);
     cdrVersion.setBigqueryDataset(testWorkbenchConfig.bigquery.dataSetId);
     cdrVersion.setBigqueryProject(testWorkbenchConfig.bigquery.projectId);
+    cdrVersion.setAccessTier(createDefaultAccessTier(accessTierDao));
     CdrVersionContext.setCdrVersionNoCheckAuthDomain(cdrVersion);
 
     cdrVersion = cdrVersionDao.save(cdrVersion);

--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
@@ -35,6 +35,7 @@ import org.pmiops.workbench.cohortreview.AnnotationQueryBuilder;
 import org.pmiops.workbench.concept.ConceptService;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.dao.CohortReviewDao;
@@ -61,6 +62,7 @@ import org.pmiops.workbench.test.TestBigQueryCdrSchemaConfig;
 import org.pmiops.workbench.testconfig.TestJpaConfig;
 import org.pmiops.workbench.testconfig.TestWorkbenchConfig;
 import org.pmiops.workbench.utils.PaginationToken;
+import org.pmiops.workbench.utils.TestMockFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
@@ -83,6 +85,8 @@ public class CohortMaterializationServiceBQTest extends BigQueryBaseTest {
   private static final String STANDARD_CONCEPT_CODE = "S";
 
   @Autowired private TestWorkbenchConfig testWorkbenchConfig;
+
+  @Autowired private AccessTierDao accessTierDao;
 
   @Autowired private CdrVersionDao cdrVersionDao;
 
@@ -121,7 +125,7 @@ public class CohortMaterializationServiceBQTest extends BigQueryBaseTest {
 
   @Before
   public void setUp() {
-    DbCdrVersion cdrVersion = new DbCdrVersion();
+    DbCdrVersion cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
     cdrVersion.setBigqueryDataset(testWorkbenchConfig.bigquery.dataSetId);
     cdrVersion.setBigqueryProject(testWorkbenchConfig.bigquery.projectId);
     cdrVersion = cdrVersionDao.save(cdrVersion);

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -448,7 +448,10 @@ public class WorkspacesController implements WorkspacesApiDelegate {
 
     DbAccessTier accessTier = fromWorkspace.getCdrVersion().getAccessTier();
 
-    // Clone CDR version from the source, by default.
+    // When specifying a CDR Version in the request, it must be live and
+    // in the same Access Tier as the source Workspace's CDR Version.
+    //
+    // If the request is lacking a CDR Version, use the source's.
 
     final DbCdrVersion toCdrVersion;
     String reqCdrVersionId = body.getWorkspace().getCdrVersionId();

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
@@ -71,15 +71,18 @@ public class DbCdrVersion {
     return dataAccessLevel;
   }
 
+  @Deprecated // soon to be replaced by accessTier
   public void setDataAccessLevel(Short dataAccessLevel) {
     this.dataAccessLevel = dataAccessLevel;
   }
 
   @Transient
+  @Deprecated // soon to be replaced by accessTier
   public DataAccessLevel getDataAccessLevelEnum() {
     return DbStorageEnums.dataAccessLevelFromStorage(getDataAccessLevel());
   }
 
+  @Deprecated // soon to be replaced by accessTier
   public void setDataAccessLevelEnum(DataAccessLevel dataAccessLevel) {
     setDataAccessLevel(DbStorageEnums.dataAccessLevelToStorage(dataAccessLevel));
   }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
@@ -180,19 +180,23 @@ public class DbWorkspace {
   }
 
   @Column(name = "data_access_level")
+  @Deprecated // soon to be replaced by accessTier
   public Short getDataAccessLevel() {
     return dataAccessLevel;
   }
 
+  @Deprecated // soon to be replaced by accessTier
   public void setDataAccessLevel(Short dataAccessLevel) {
     this.dataAccessLevel = dataAccessLevel;
   }
 
   @Transient
+  @Deprecated // soon to be replaced by accessTier
   public DataAccessLevel getDataAccessLevelEnum() {
     return DbStorageEnums.dataAccessLevelFromStorage(getDataAccessLevel());
   }
 
+  @Deprecated // soon to be replaced by accessTier
   public void setDataAccessLevelEnum(DataAccessLevel dataAccessLevel) {
     setDataAccessLevel(DbStorageEnums.dataAccessLevelToStorage(dataAccessLevel));
   }

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -66,10 +66,11 @@ public interface FireCloudService {
       String ownerEmailToRemove, String projectName, Optional<String> callerAccessToken);
 
   /** Creates a new FC workspace. */
-  FirecloudWorkspace createWorkspace(String projectName, String workspaceName);
+  FirecloudWorkspace createWorkspace(
+      String projectName, String workspaceName, String authDomainName);
 
   FirecloudWorkspace cloneWorkspace(
-      String fromProject, String fromName, String toProject, String toName);
+      String fromProject, String fromName, String toProject, String toName, String authDomainName);
 
   /** Retrieves all billing project memberships for the user from FireCloud. */
   List<FirecloudBillingProjectMembership> getBillingProjectMemberships();

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -314,23 +314,22 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public FirecloudWorkspace createWorkspace(String projectName, String workspaceName) {
+  public FirecloudWorkspace createWorkspace(
+      String projectName, String workspaceName, String authDomainName) {
     WorkspacesApi workspacesApi = endUserWorkspacesApiProvider.get();
     FirecloudWorkspaceIngest workspaceIngest =
         new FirecloudWorkspaceIngest()
             .namespace(projectName)
             .name(workspaceName)
             .authorizationDomain(
-                ImmutableList.of(
-                    new FirecloudManagedGroupRef()
-                        .membersGroupName(configProvider.get().firecloud.registeredDomainName)));
+                ImmutableList.of(new FirecloudManagedGroupRef().membersGroupName(authDomainName)));
 
     return retryHandler.run((context) -> workspacesApi.createWorkspace(workspaceIngest));
   }
 
   @Override
   public FirecloudWorkspace cloneWorkspace(
-      String fromProject, String fromName, String toProject, String toName) {
+      String fromProject, String fromName, String toProject, String toName, String authDomainName) {
     WorkspacesApi workspacesApi = endUserWorkspacesApiProvider.get();
     FirecloudWorkspaceRequestClone cloneRequest =
         new FirecloudWorkspaceRequestClone()
@@ -340,9 +339,7 @@ public class FireCloudServiceImpl implements FireCloudService {
             // propagating copies of large data files elswhere in the bucket.
             .copyFilesWithPrefix("notebooks/")
             .authorizationDomain(
-                ImmutableList.of(
-                    new FirecloudManagedGroupRef()
-                        .membersGroupName(configProvider.get().firecloud.registeredDomainName)));
+                ImmutableList.of(new FirecloudManagedGroupRef().membersGroupName(authDomainName)));
 
     return retryHandler.run(
         (context) -> workspacesApi.cloneWorkspace(fromProject, fromName, cloneRequest));

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5191,7 +5191,6 @@ definitions:
     type: object
     required:
     - username
-    - dataAccessLevel
     properties:
       userId:
         description: researchallofus userId

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3541,7 +3541,7 @@ definitions:
     - ARCHIVED
   DataAccessLevel:
     type: string
-    description: levels of access to data in the curated data repository
+    description: DEPRECATED.  Will be replaced by Access Tiers.  Was -> levels of access to data in the curated data repository
     enum:
     - unregistered
     - registered
@@ -3694,6 +3694,7 @@ definitions:
         type: string
       dataAccessLevel:
         "$ref": "#/definitions/DataAccessLevel"
+        description: DEPRECATED.  Use accessTierShortName.
       archivalStatus:
         "$ref": "#/definitions/ArchivalStatus"
       hasMicroarrayData:
@@ -4147,6 +4148,7 @@ definitions:
         type: string
       dataAccessLevel:
         "$ref": "#/definitions/DataAccessLevel"
+        description: DEPRECATED.  Use accessTierShortName.
       researchPurpose:
         "$ref": "#/definitions/ResearchPurpose"
       billingStatus:
@@ -5126,6 +5128,7 @@ definitions:
         type: string
       dataAccessLevel:
         "$ref": "#/definitions/DataAccessLevel"
+        description: DEPRECATED.  Will be replaced by Access Tiers.
       givenName:
         type: string
       familyName:
@@ -5218,7 +5221,7 @@ definitions:
         type: integer
         format: int64
       dataAccessLevel:
-        description: what level of data access the user has
+        description: DEPRECATED.  Will be replaced by Access Tiers.  Was -> what level of data access the user has
         "$ref": "#/definitions/DataAccessLevel"
       degrees:
         type: array
@@ -8172,6 +8175,7 @@ definitions:
         description: User's current role/position.
       dataAccessLevel:
         description: |-
+          DEPRECATED.  Will be replaced by Ascess Tiers.
           An indication of whether the user has completed the requirements for access to the
           registered tier.
         "$ref": "#/definitions/DataAccessLevel"

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8175,7 +8175,7 @@ definitions:
         description: User's current role/position.
       dataAccessLevel:
         description: |-
-          DEPRECATED.  Will be replaced by Ascess Tiers.
+          DEPRECATED.  Will be replaced by Access Tiers.
           An indication of whether the user has completed the requirements for access to the
           registered tier.
         "$ref": "#/definitions/DataAccessLevel"

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -51,6 +51,7 @@ import org.pmiops.workbench.conceptset.mapper.ConceptSetMapperImpl;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.dataset.DataSetService;
 import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
+import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.dao.CohortReviewDao;
@@ -175,21 +176,24 @@ public class CohortsControllerTest {
   String cohortCriteria;
   String badCohortCriteria;
   private TestMockFactory testMockFactory;
+
+  @Autowired CdrVersionService cdrVersionService;
+  @Autowired CloudStorageService cloudStorageService;
+  @Autowired CohortMaterializationService cohortMaterializationService;
+  @Autowired ComplianceService complianceService;
+  @Autowired FireCloudService fireCloudService;
+  @Autowired UserRecentResourceService userRecentResourceService;
+  @Autowired UserService userService;
   @Autowired WorkspaceService workspaceService;
+
+  @Autowired AccessTierDao accessTierDao;
   @Autowired CdrVersionDao cdrVersionDao;
   @Autowired CohortDao cohortDao;
-  @Autowired ConceptSetDao conceptSetDao;
-  @Autowired ConceptDao conceptDao;
   @Autowired CohortReviewDao cohortReviewDao;
+  @Autowired ConceptDao conceptDao;
+  @Autowired ConceptSetDao conceptSetDao;
   @Autowired DataSetService dataSetService;
-  @Autowired UserRecentResourceService userRecentResourceService;
   @Autowired UserDao userDao;
-  @Autowired CohortMaterializationService cohortMaterializationService;
-  @Autowired FireCloudService fireCloudService;
-  @Autowired UserService userService;
-  @Autowired CloudStorageService cloudStorageService;
-  @Autowired CdrVersionService cdrVersionService;
-  @Autowired ComplianceService complianceService;
 
   @TestConfiguration
   @Import({
@@ -285,7 +289,7 @@ public class CohortsControllerTest {
     user = userDao.save(user);
     currentUser = user;
 
-    cdrVersion = new DbCdrVersion();
+    cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
     cdrVersion.setName(CDR_VERSION_NAME);
     cdrVersionDao.save(cdrVersion);
 

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -42,6 +42,7 @@ import org.pmiops.workbench.conceptset.mapper.ConceptSetMapperImpl;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.dataset.DataSetService;
 import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
+import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
@@ -170,6 +171,8 @@ public class ConceptSetsControllerTest {
 
   @Autowired BillingProjectBufferService billingProjectBufferService;
 
+  @Autowired AccessTierDao accessTierDao;
+
   @Autowired CdrVersionDao cdrVersionDao;
 
   @Autowired CBCriteriaDao cbCriteriaDao;
@@ -271,12 +274,7 @@ public class ConceptSetsControllerTest {
     user = userDao.save(user);
     currentUser = user;
 
-    DbCdrVersion cdrVersion = new DbCdrVersion();
-    cdrVersion.setName("1");
-    // set the db name to be empty since test cases currently
-    // run in the workbench schema only.
-    cdrVersion.setCdrDbName("");
-    cdrVersion = cdrVersionDao.save(cdrVersion);
+    DbCdrVersion cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
 
     workspace = new Workspace();
     workspace.setName(WORKSPACE_NAME);

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -80,6 +80,7 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.dataset.DataSetServiceImpl;
 import org.pmiops.workbench.dataset.DatasetConfig;
 import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
+import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
@@ -185,6 +186,7 @@ public class DataSetControllerTest {
   private static DbUser currentUser;
   private Workspace workspace;
 
+  @Autowired private AccessTierDao accessTierDao;
   @Autowired private CdrVersionDao cdrVersionDao;
   @Autowired private CohortsController cohortsController;
   @Autowired private ConceptSetsController conceptSetsController;
@@ -314,11 +316,7 @@ public class DataSetControllerTest {
     user = userDao.save(user);
     currentUser = user;
 
-    DbCdrVersion cdrVersion = new DbCdrVersion();
-    cdrVersion.setName("1");
-    // set the db name to be empty since test cases currently
-    // run in the workbench schema only.
-    cdrVersion.setCdrDbName("");
+    DbCdrVersion cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
     cdrVersion.setMicroarrayBigqueryDataset("microarray");
     cdrVersion = cdrVersionDao.save(cdrVersion);
 

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -19,10 +19,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-import static org.pmiops.workbench.billing.GoogleApisConfig.END_USER_CLOUD_BILLING;
-import static org.pmiops.workbench.billing.GoogleApisConfig.SERVICE_ACCOUNT_CLOUD_BILLING;
-import static org.pmiops.workbench.config.WorkbenchConfig.createEmptyConfig;
-import static org.pmiops.workbench.utils.TestMockFactory.createDefaultAccessTier;
 
 import com.google.api.services.cloudbilling.Cloudbilling;
 import com.google.api.services.cloudbilling.model.BillingAccount;
@@ -66,6 +62,7 @@ import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditor;
 import org.pmiops.workbench.actionaudit.auditors.WorkspaceAuditor;
 import org.pmiops.workbench.billing.BillingProjectBufferService;
 import org.pmiops.workbench.billing.FreeTierBillingService;
+import org.pmiops.workbench.billing.GoogleApisConfig;
 import org.pmiops.workbench.cdr.CdrVersionContext;
 import org.pmiops.workbench.cdr.CdrVersionService;
 import org.pmiops.workbench.cdr.ConceptBigQueryService;
@@ -269,11 +266,11 @@ public class WorkspacesControllerTest {
 
   @MockBean FreeTierBillingService mockFreeTierBillingService;
 
-  @Qualifier(END_USER_CLOUD_BILLING)
+  @Qualifier(GoogleApisConfig.END_USER_CLOUD_BILLING)
   @Autowired
   private Provider<Cloudbilling> endUserCloudbillingProvider;
 
-  @Qualifier(SERVICE_ACCOUNT_CLOUD_BILLING)
+  @Qualifier(GoogleApisConfig.SERVICE_ACCOUNT_CLOUD_BILLING)
   @Autowired
   private Provider<Cloudbilling> serviceAccountCloudbillingProvider;
 
@@ -334,13 +331,13 @@ public class WorkspacesControllerTest {
   })
   static class Configuration {
 
-    @Bean(END_USER_CLOUD_BILLING)
+    @Bean(GoogleApisConfig.END_USER_CLOUD_BILLING)
     @Scope("prototype")
     Cloudbilling endUserCloudbilling() {
       return endUserCloudbilling;
     }
 
-    @Bean(SERVICE_ACCOUNT_CLOUD_BILLING)
+    @Bean(GoogleApisConfig.SERVICE_ACCOUNT_CLOUD_BILLING)
     @Scope("prototype")
     Cloudbilling serviceAccountCloudbilling() {
       return serviceAccountCloudbilling;
@@ -398,7 +395,7 @@ public class WorkspacesControllerTest {
 
   @Before
   public void setUp() {
-    workbenchConfig = createEmptyConfig();
+    workbenchConfig = WorkbenchConfig.createEmptyConfig();
     workbenchConfig.featureFlags.enableBillingUpgrade = true;
     workbenchConfig.firecloud.registeredDomainName = "allUsers";
     workbenchConfig.billing.accountId = "free-tier";
@@ -406,7 +403,7 @@ public class WorkspacesControllerTest {
     testMockFactory = new TestMockFactory();
     currentUser = createUser(LOGGED_IN_USER_EMAIL);
 
-    accessTier = createDefaultAccessTier(accessTierDao);
+    accessTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
 
     cdrVersion = new DbCdrVersion();
     cdrVersion.setName("1");

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -1336,9 +1336,6 @@ public class WorkspacesControllerTest {
     Workspace originalWorkspace = createWorkspace();
     originalWorkspace = workspacesController.createWorkspace(originalWorkspace).getBody();
 
-    endUserCloudbilling = TestMockFactory.createMockedCloudbilling();
-    serviceAccountCloudbilling = TestMockFactory.createMockedCloudbilling();
-
     DbAccessTier altAccessTier =
         new DbAccessTier()
             .setAccessTierId(2)
@@ -1367,17 +1364,10 @@ public class WorkspacesControllerTest {
 
     final CloneWorkspaceRequest req = new CloneWorkspaceRequest();
     req.setWorkspace(modWorkspace);
-    final FirecloudWorkspace clonedFirecloudWorkspace =
-        stubCloneWorkspace(
-            modWorkspace.getNamespace(), modWorkspace.getName(), LOGGED_IN_USER_EMAIL);
-
-    mockBillingProjectBuffer("cloned-ns");
+    stubCloneWorkspace(modWorkspace.getNamespace(), modWorkspace.getName(), LOGGED_IN_USER_EMAIL);
 
     workspacesController.cloneWorkspace(
         originalWorkspace.getNamespace(), originalWorkspace.getId(), req);
-
-    verifyZeroInteractions(endUserCloudbillingProvider.get());
-    verifyZeroInteractions(serviceAccountCloudbillingProvider.get());
   }
 
   private void sortPopulationDetails(ResearchPurpose researchPurpose) {

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.billing.GoogleApisConfig.END_USER_CLOUD_BILLING;
 import static org.pmiops.workbench.billing.GoogleApisConfig.SERVICE_ACCOUNT_CLOUD_BILLING;
 import static org.pmiops.workbench.config.WorkbenchConfig.createEmptyConfig;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultAccessTier;
 
 import com.google.api.services.cloudbilling.Cloudbilling;
 import com.google.api.services.cloudbilling.model.BillingAccount;
@@ -261,8 +262,6 @@ public class WorkspacesControllerTest {
   private static final String BUCKET_URI =
       String.format("gs://%s/", TestMockFactory.WORKSPACE_BUCKET_NAME);
 
-  private static final String TEST_AUTH_DOMAIN = "test-tier-users";
-
   @Autowired private BillingProjectBufferService billingProjectBufferService;
   @Autowired private WorkspaceAuditor mockWorkspaceAuditor;
   @Autowired private CohortAnnotationDefinitionController cohortAnnotationDefinitionController;
@@ -407,15 +406,7 @@ public class WorkspacesControllerTest {
     testMockFactory = new TestMockFactory();
     currentUser = createUser(LOGGED_IN_USER_EMAIL);
 
-    accessTier =
-        new DbAccessTier()
-            .setAccessTierId(1)
-            .setShortName("test")
-            .setDisplayName("Test Tier")
-            .setAuthDomainName(TEST_AUTH_DOMAIN)
-            .setAuthDomainGroupEmail("test-tier-users@fake-research-aou.org")
-            .setServicePerimeter("test/tier/perimeter");
-    accessTier = accessTierDao.save(accessTier);
+    accessTier = createDefaultAccessTier(accessTierDao);
 
     cdrVersion = new DbCdrVersion();
     cdrVersion.setName("1");
@@ -616,7 +607,8 @@ public class WorkspacesControllerTest {
     Workspace workspace = createWorkspace();
     workspace = workspacesController.createWorkspace(workspace).getBody();
     verify(fireCloudService)
-        .createWorkspace(workspace.getNamespace(), workspace.getName(), TEST_AUTH_DOMAIN);
+        .createWorkspace(
+            workspace.getNamespace(), workspace.getName(), accessTier.getAuthDomainName());
 
     stubGetWorkspace(
         workspace.getNamespace(),

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -18,7 +18,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import org.pmiops.workbench.billing.BillingProjectBufferService;
+import org.pmiops.workbench.db.dao.AccessTierDao;
+import org.pmiops.workbench.db.dao.CdrVersionDao;
+import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbBillingProjectBufferEntry;
+import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
@@ -204,5 +208,28 @@ public class TestMockFactory {
     dbWorkspace.setIntendedStudy(researchPurpose.getIntendedStudy());
     dbWorkspace.setAnticipatedFindings(researchPurpose.getAnticipatedFindings());
     return dbWorkspace;
+  }
+
+  public static DbAccessTier createDefaultAccessTier(AccessTierDao accessTierDao) {
+    final DbAccessTier accessTier =
+        new DbAccessTier()
+            .setAccessTierId(1)
+            .setShortName("test")
+            .setDisplayName("Test Tier")
+            .setAuthDomainName("Test Auth Domain")
+            .setAuthDomainGroupEmail("test-tier-users@fake-research-aou.org")
+            .setServicePerimeter("test/tier/perimeter");
+    return accessTierDao.save(accessTier);
+  }
+
+  public static DbCdrVersion createDefaultCdrVersion(
+      CdrVersionDao cdrVersionDao, AccessTierDao accessTierDao) {
+    final DbCdrVersion cdrVersion = new DbCdrVersion();
+    cdrVersion.setName("1");
+    // set the db name to be empty since test cases currently
+    // run in the workbench schema only.
+    cdrVersion.setCdrDbName("");
+    cdrVersion.setAccessTier(createDefaultAccessTier(accessTierDao));
+    return cdrVersionDao.save(cdrVersion);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -124,7 +124,7 @@ public class TestMockFactory {
               return fcWorkspace;
             })
         .when(fireCloudService)
-        .createWorkspace(anyString(), anyString());
+        .createWorkspace(anyString(), anyString(), anyString());
   }
 
   public void stubBufferBillingProject(BillingProjectBufferService billingProjectBufferService) {


### PR DESCRIPTION
Description:

Partial completion of RW-6180
* (already completed in #4576) Choose tier-appropriate Billing Buffer for workspace create and clone/duplicate
* Choose tier-appropriate Auth Domain for workspace create and clone/duplicate
* Rejects CDR Tier mismatch when cloning/duplicating workspace
* Deprecates/removes DataAccessLevel fields

Does not cover
* Reporting changes for RW-6180
* Friendly UI when a user violates tier equality on Workspace Duplicate (TODO: will commit to not enabling in Preprod/Prod until then)

Also includes
* WorkspacesController refactoring regarding common code between Create and Clone/Duplicate

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
