### PR TITLE
[no ticket][risk=no] CircleCI "skip e2e" check not working

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -561,7 +561,7 @@ jobs:
           at: .
       - steps: << parameters.optional_steps >>
       - run:
-          name: "Update environment variables for e2e test"
+          name: "Export e2e test user to environment variable"
           command: bash .circleci/export-e2e-test-user-vars.sh << parameters.env_name >>
       - when:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,7 +298,6 @@ commands:
               \"circleNodeIndex\": ${CIRCLE_NODE_INDEX} \
               }" \
               > ./logs/circleci_parameters.json
-          when: always
       - store_artifacts:
           path: e2e/logs
           destination: logs
@@ -577,13 +576,8 @@ jobs:
 
   puppeteer-env-setup:
     executor: puppeteer-executor
-    parameters:
-      optional_steps:
-        type: steps
-        default: []
     steps:
       - checkout-code
-      - steps: << parameters.optional_steps >>
       - browser-tools/install-browser-tools
       - restore_cache:
           keys:
@@ -622,9 +616,7 @@ workflows:
           requires:
             - ui-unit-test
       # Deploy local UI server connected to "test" API server. Run Puppeteer tests for PR commits only
-      - puppeteer-env-setup:
-          optional_steps:
-            - halt-puppeteer-check
+      - puppeteer-env-setup
       - puppeteer-test:
           <<: *filter-pr-branch
           env_name: "local"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,15 +306,6 @@ commands:
       - store_test_results:
           path: ~/workbench/e2e/logs
 
-  store-commit-message:
-    description: "Export Git commit message to environment variable"
-    steps:
-      - run:
-          command: |
-            echo 'export COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s")' >> $BASH_ENV
-            source $BASH_ENV
-          name: "Export COMMIT_MESSAGE environment variable"
-
   ui-cache:
     description: "workbench/ui: yarn install, save and restore cache"
     steps:
@@ -586,9 +577,13 @@ jobs:
 
   puppeteer-env-setup:
     executor: puppeteer-executor
+    parameters:
+      optional_steps:
+        type: steps
+        default: []
     steps:
       - checkout-code
-      - store-commit-message
+      - steps: << parameters.optional_steps >>
       - browser-tools/install-browser-tools
       - restore_cache:
           keys:
@@ -627,7 +622,9 @@ workflows:
           requires:
             - ui-unit-test
       # Deploy local UI server connected to "test" API server. Run Puppeteer tests for PR commits only
-      - puppeteer-env-setup
+      - puppeteer-env-setup:
+          optional_steps:
+            - halt-puppeteer-check
       - puppeteer-test:
           <<: *filter-pr-branch
           env_name: "local"

--- a/.circleci/skip-e2e-pr-checks.sh
+++ b/.circleci/skip-e2e-pr-checks.sh
@@ -12,7 +12,9 @@ else
   exit 0
 fi
 
-# Exiting if the commit message contains 'skip e2e' string
+# Get the commit message. Exiting job early if the commit message contains 'skip e2e' string
+COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s")
+
 # Double comma is "Parameter Expansion". It converts string to lowercase letters
 if [[ "${COMMIT_MESSAGE,,}" == *"skip e2e"* ]]; then
   echo "Skip e2e text found in commit message"

--- a/.circleci/skip-e2e-pr-checks.sh
+++ b/.circleci/skip-e2e-pr-checks.sh
@@ -12,7 +12,7 @@ else
   exit 0
 fi
 
-# Get the commit message. Exiting job early if the commit message contains 'skip e2e' string
+# Get the commit message. Exiting job early if the commit message contains 'skip e2e' string.
 COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s")
 
 # Double comma is "Parameter Expansion". It converts string to lowercase letters
@@ -23,7 +23,7 @@ else
   echo "not found skip e2e text"
 fi
 
-# Exiting on PR branch when all (changed) file names matched ignore pattern
+# Exiting on PR branch when all (changed) file names matched ignore pattern.
 # The grep command exits with '0' status when it's successful (match were found). While it exits with status '1' when no match was found.
 git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep -qvFf .circleci/e2e-job-ignore-patterns.txt
 STATUS=$?

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -18,7 +18,7 @@
     "test-local-devup:debug": "cross-env WORKBENCH_ENV=local PUPPETEER_HEADLESS=false DEBUG=true node --inspect-brk node_modules/.bin/jest --maxWorkers=3",
     "test-staging": "cross-env WORKBENCH_ENV=staging yarn _test --maxWorkers=3",
     "test-staging:debug": "cross-env WORKBENCH_ENV=staging PUPPETEER_HEADLESS=false DEBUG=true yarn _test --maxWorkers=1",
-    "test:ci": "yarn _test --no-color --ci --maxWorkers=2",
+    "test:ci": "yarn _test --no-color --ci --maxWorkers=2 --forceExit",
     "test:ci:debug": "yarn _test --ci --debug --maxWorkers=1 --bail 1",
     "test-nightly": "cross-env TEST_MODE=nightly-integration yarn _test --maxWorkers=1",
     "test-nightly-local-devup": "cross-env TEST_MODE=nightly-integration yarn jest --maxWorkers=1",


### PR DESCRIPTION
Cause: `persiste_to_workspace` does not save environment variables. Thus env variable `$COMMIT_MESSAGE` was lost in `puppeteer-test` job.