### PR TITLE
[no ticket][risk=no] Puppeteer test log improvement

### DIFF
--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -73,14 +73,23 @@ beforeEach(async () => {
   // Api response won't be logged.
   const skipApiResponseBody = (request: Request): boolean => {
     const filters = [
-      '/readonly', '/chartinfo/', 'page-visits', '/generateCode/', '/criteria/CONDITION/search/', '/criteria/'
+      '/readonly',
+      '/chartinfo/',
+      'page-visits',
+      '/generateCode/',
+      '/criteria/CONDITION/search/',
+      '/criteria/',
+      '/cdrVersions',
+      '/config',
+      '/user-recent-workspaces',
+      '/profile'
     ];
     return filters.some((partialUrl) => request && request.url().includes(partialUrl));
   }
 
-  // Make log less cluttered: truncate long Api response.
+  // Truncate long Api response.
   const shouldTruncateResponse = (request: Request): boolean => {
-    return request && (request.url().endsWith('/v1/workspaces') || request.url().endsWith('/v1/cdrVersions'));
+    return request && (request.url().endsWith('/v1/workspaces'));
   }
 
   const isApiFailure = (request: Request): boolean => {

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -71,7 +71,7 @@ beforeEach(async () => {
   }
 
   // Api response won't be logged.
-  const skipApiResponseBody = (request: Request): boolean => {
+  const shouldSkipApiResponseBody = (request: Request): boolean => {
     const filters = [
       '/readonly',
       '/chartinfo/',
@@ -157,7 +157,7 @@ beforeEach(async () => {
     let status;
     try {
       if (canLogResponse(request)) {
-        // Try find out what the request was if exception thrown.
+        // Save data for log in catch block when exception is thrown.
         method = request.method();
         const resp = request.response();
         url = resp.url();
@@ -166,13 +166,11 @@ beforeEach(async () => {
         if (isApiFailure(request)) {
           await logError(request);
         } else {
-          const responseBody = await transformResponseBody(request);
-          if (skipApiResponseBody(request)) {
-            console.debug('❗ Request finished: ' +
-               `${request.response().status()} ${request.method()} ${request.url()}`);
+          if (shouldSkipApiResponseBody(request)) {
+            console.debug(`❗ Request finished: ${status} ${method} ${url}`);
           } else {
             console.debug('❗ Request finished: ' +
-               `${request.response().status()} ${request.method()} ${request.url()}\n${responseBody}`);
+               `${status} ${method} ${url}\n${await transformResponseBody(request)}`);
           }
         }
       }
@@ -205,16 +203,16 @@ beforeEach(async () => {
     try {
       console.error(`❗ ${title}\nError message: ${error.message}\nStack: ${error.stack}`);
     } catch (err) {
-      console.error(`❗ ${title}\nException occurred when getting page error.\n${err}`);
+      console.error(`❗ ${title}\nException occurred when getting error.\n${err}`);
     }
   });
 
   page.on('pageerror', async (error) => {
     const title = await getTitle();
     try {
-      console.error(`❗ ${title}\nError message: ${error.message}\nStack: ${error.stack}`);
+      console.error(`❗ ${title}\nPage error message: ${error.message}\nStack: ${error.stack}`);
     } catch (err) {
-      console.error(`❗ ${title}\nException occurred when getting pageerror.\n${err}`);
+      console.error(`❗ ${title}\nPage exception occurred when getting pageerror.\n${err}`);
     }
   })
 

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -70,6 +70,7 @@ beforeEach(async () => {
        : null;
   }
 
+  // Api response won't be logged.
   const skipApiResponseBody = (request: Request): boolean => {
     const filters = [
       '/readonly', '/chartinfo/', 'page-visits', '/generateCode/', '/criteria/CONDITION/search/', '/criteria/'
@@ -77,8 +78,8 @@ beforeEach(async () => {
     return filters.some((partialUrl) => request && request.url().includes(partialUrl));
   }
 
-  // Api "/workspaces" or "/cdrVersions" response can be truncated
-  const isApiTruncateResponse = (request: Request): boolean => {
+  // Make log less cluttered: truncate long Api response.
+  const shouldTruncateResponse = (request: Request): boolean => {
     return request && (request.url().endsWith('/v1/workspaces') || request.url().endsWith('/v1/cdrVersions'));
   }
 
@@ -114,7 +115,7 @@ beforeEach(async () => {
   const transformResponseBody = async (request: Request): Promise<string> => {
     if (request) {
       let responseText = stringifyData(await getResponseText(request));
-      if (isApiTruncateResponse(request)) {
+      if (shouldTruncateResponse(request)) {
         // truncate long response. get first two workspace details.
         responseText = fp.isEmpty(JSON.parse(responseText).items)
            ? responseText

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -25,7 +25,6 @@ beforeEach(async () => {
 
   const describeJsHandle = async (jsHandle)  => {
     return jsHandle.executionContext().evaluate(obj => {
-      // serialize |obj| however you want
       return obj.toString();
     }, jsHandle);
   }


### PR DESCRIPTION
Parsing/reading page console message could fail sometimes or/and throw exception if unable to parse. Throw exception would cause tests to fail.

[log](https://circleci.com/api/v1.1/project/github/all-of-us/workbench/122328/output/107/3?file=true&allocation-id=6035c3c60e4b2a7a29e510d2-3-build%2F226CF0A0)