### PR TITLE
[RW-5241][risk=no] Temporarily restore the integer config value bufferCapacity

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -26,7 +26,8 @@
     "projectNamePrefix": "aou-rw-local1-",
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 2,
-    "bufferCapacity": {
+    "bufferCapacity": 10,
+    "bufferCapacityPerTier": {
       "registered": 10,
       "controlled_test": 10
     },

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -26,7 +26,8 @@
     "projectNamePrefix": "aou-rw-perf-",
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 4,
-    "bufferCapacity": {
+    "bufferCapacity": 300,
+    "bufferCapacityPerTier": {
       "registered": 300
     },
     "bufferRefillProjectsPerTask": 5,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -26,7 +26,8 @@
     "projectNamePrefix": "aou-rw-preprod-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 4,
-    "bufferCapacity": {
+    "bufferCapacity": 20,
+    "bufferCapacityPerTier": {
       "registered": 20
     },
     "bufferRefillProjectsPerTask": 1,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -26,7 +26,8 @@
     "projectNamePrefix": "aou-rw-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 4,
-    "bufferCapacity": {
+    "bufferCapacity": 200,
+    "bufferCapacityPerTier": {
       "registered": 200
     },
     "bufferRefillProjectsPerTask": 1,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -26,7 +26,8 @@
     "projectNamePrefix": "aou-rw-stable-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 2,
-    "bufferCapacity": {
+    "bufferCapacity": 10,
+    "bufferCapacityPerTier": {
       "registered": 10
     },
     "bufferRefillProjectsPerTask": 1,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -26,7 +26,8 @@
     "projectNamePrefix": "aou-rw-staging-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 2,
-    "bufferCapacity": {
+    "bufferCapacity": 50,
+    "bufferCapacityPerTier": {
       "registered": 50
     },
     "bufferRefillProjectsPerTask": 1,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -26,7 +26,8 @@
     "projectNamePrefix": "aou-rw-test-",
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 2,
-    "bufferCapacity": {
+    "bufferCapacity": 300,
+    "bufferCapacityPerTier": {
       "registered": 300,
       "controlled_test": 100
     },

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -325,7 +325,7 @@ public class BillingProjectBufferService implements GaugeDataCollector {
   }
 
   private int getBufferMaxCapacity(String accessTierShortName) {
-    return workbenchConfigProvider.get().billing.bufferCapacity.get(accessTierShortName);
+    return workbenchConfigProvider.get().billing.bufferCapacityPerTier.get(accessTierShortName);
   }
 
   public BillingProjectBufferStatus getStatus() {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -61,10 +61,14 @@ public class WorkbenchConfig {
   public static class BillingConfig {
     // This config variable seems to be unused.
     public Integer retryCount;
+    // The total capacity of the GCP project buffer, assuming a single tier.
+    // Scheduled to be removed after bufferCapacityPerTier is enabled in all environments.
+    // https://precisionmedicineinitiative.atlassian.net/browse/RW-6387
+    @Deprecated public Integer bufferCapacity;
     // The total capacity of the GCP project buffer, per access tier. The buffering system will not
     // attempt to create any new projects in a tier when the total number of in-progress & ready
     // projects is at or above this level.
-    public Map<String, Integer> bufferCapacity;
+    public Map<String, Integer> bufferCapacityPerTier;
     // The number of times to attempt project creation per cron task execution. This effectively
     // controls the max rate of project refill. If the cron task is configured to run once per
     // minute and this param is set to 5, then the buffer system will create up to approximately

--- a/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/BillingProjectBufferServiceTest.java
@@ -144,7 +144,7 @@ public class BillingProjectBufferServiceTest {
   public void setUp() {
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
     workbenchConfig.billing.projectNamePrefix = "test-prefix";
-    workbenchConfig.billing.bufferCapacity =
+    workbenchConfig.billing.bufferCapacityPerTier =
         Collections.singletonMap(REGISTERED_TIER_NAME, REGISTERED_TIER_BUFFER_CAPACITY);
     workbenchConfig.billing.bufferRefillProjectsPerTask = 1;
     workbenchConfig.billing.bufferStatusChecksPerTask = 10;
@@ -213,7 +213,7 @@ public class BillingProjectBufferServiceTest {
             .setServicePerimeter(controlledTierServicePerimeter);
     controlledTier = accessTierDao.save(controlledTier);
 
-    workbenchConfig.billing.bufferCapacity =
+    workbenchConfig.billing.bufferCapacityPerTier =
         ImmutableMap.of(REGISTERED_TIER_NAME, 1, controlledTierName, 1);
 
     billingProjectBufferService.bufferBillingProjects();
@@ -224,7 +224,7 @@ public class BillingProjectBufferServiceTest {
     // one project per tier, per bufferRefillProjectsPerTask
     final int expectedCreationCount =
         workbenchConfig.billing.bufferRefillProjectsPerTask
-            * workbenchConfig.billing.bufferCapacity.size();
+            * workbenchConfig.billing.bufferCapacityPerTier.size();
 
     ArgumentCaptor<String> projectCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> perimeterCaptor = ArgumentCaptor.forClass(String.class);
@@ -293,7 +293,7 @@ public class BillingProjectBufferServiceTest {
 
     // increase buffer capacity
     expectedCallCount++;
-    workbenchConfig.billing.bufferCapacity =
+    workbenchConfig.billing.bufferCapacityPerTier =
         Collections.singletonMap(REGISTERED_TIER_NAME, REGISTERED_TIER_BUFFER_CAPACITY + 1);
     billingProjectBufferService.bufferBillingProjects();
     verify(mockFireCloudService, times((int) REGISTERED_TIER_BUFFER_CAPACITY + expectedCallCount))
@@ -312,7 +312,7 @@ public class BillingProjectBufferServiceTest {
       billingProjectBufferService.bufferBillingProjects();
     }
 
-    workbenchConfig.billing.bufferCapacity =
+    workbenchConfig.billing.bufferCapacityPerTier =
         Collections.singletonMap(REGISTERED_TIER_NAME, REGISTERED_TIER_BUFFER_CAPACITY - 2);
 
     // should no op since we're at capacity + 2
@@ -527,7 +527,8 @@ public class BillingProjectBufferServiceTest {
     // test demonstrates that with an appropriate set of configuration values, a 300-project
     // buffer can recover almost immediately after the first non-error project is ready.
 
-    workbenchConfig.billing.bufferCapacity = Collections.singletonMap(REGISTERED_TIER_NAME, 300);
+    workbenchConfig.billing.bufferCapacityPerTier =
+        Collections.singletonMap(REGISTERED_TIER_NAME, 300);
     workbenchConfig.billing.bufferRefillProjectsPerTask = 5;
     workbenchConfig.billing.bufferStatusChecksPerTask = 10;
 


### PR DESCRIPTION
Description:

#4576 changed the type of a config value instead of deprecating it, which can cause release problems.

Restore the original value but mark it as deprecated.  Remove it after a release cycle: https://precisionmedicineinitiative.atlassian.net/browse/RW-6387

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
