### PR TITLE
[risk=no][no-ticket]Refactor of the profile step component

### DIFF
--- a/ui/src/app/pages/profile/profile-page.tsx
+++ b/ui/src/app/pages/profile/profile-page.tsx
@@ -590,9 +590,9 @@ export const ProfilePage = fp.flow(
             </div>
             <hr style={{...styles.verticalLine, width: '15.8rem'}}/>
             <div style={{display: 'grid', gap: '10px', gridAutoRows: '225px', gridTemplateColumns: '220px 220px'}}>
-            <ProfileRegistrationStepStatus
+              <ProfileRegistrationStepStatus
                 title='Turn on Google 2-Step Verification'
-                wasBypassed={!!profile.twoFactorAuthBypassTime} 
+                wasBypassed={!!profile.twoFactorAuthBypassTime}
                 incompleteButtonText='Set Up'
                 completedButtonText={getRegistrationTasksMap()['twoFactorAuth'].completedText}
                 isComplete={!!(getRegistrationTasksMap()['twoFactorAuth'].completionTimestamp(profile))}
@@ -601,7 +601,7 @@ export const ProfilePage = fp.flow(
                 >
               </ProfileRegistrationStepStatus>
               {enableEraCommons && <ProfileRegistrationStepStatus
-                  title='Connect Your eRA Commons Account' 
+                  title='Connect Your eRA Commons Account'
                   wasBypassed={!!profile.eraCommonsBypassTime}
                   incompleteButtonText='Link'
                   completedButtonText={getRegistrationTasksMap()['eraCommons'].completedText}
@@ -627,7 +627,7 @@ export const ProfilePage = fp.flow(
                   completedButtonText={getRegistrationTasksMap()['dataUserCodeOfConduct'].completedText}
                   isComplete={!!(getRegistrationTasksMap()['dataUserCodeOfConduct'].completionTimestamp(profile))}
                   completeStep={getRegistrationTasksMap()['dataUserCodeOfConduct'].onClick}
-                  childrenStyle={{marginLeft: '0rem'}}
+                  childrenStyle={{marginLeft: 0}}
                   content={this.getDataUseAgreementText(profile)}
                 >
               </ProfileRegistrationStepStatus>}

--- a/ui/src/app/pages/profile/profile-page.tsx
+++ b/ui/src/app/pages/profile/profile-page.tsx
@@ -589,53 +589,49 @@ export const ProfilePage = fp.flow(
               Requirements for <AoU/> Workbench access
             </div>
             <hr style={{...styles.verticalLine, width: '15.8rem'}}/>
-            <FlexRow>
-              <ProfileRegistrationStepStatus
+            <div style={{display: 'grid', gap: '10px', gridAutoRows: '225px', gridTemplateColumns: '220px 220px'}}>
+            <ProfileRegistrationStepStatus
                 title='Turn on Google 2-Step Verification'
-                wasBypassed={!!profile.twoFactorAuthBypassTime}
+                wasBypassed={!!profile.twoFactorAuthBypassTime} 
                 incompleteButtonText='Set Up'
                 completedButtonText={getRegistrationTasksMap()['twoFactorAuth'].completedText}
-                completionTimestamp={getRegistrationTasksMap()['twoFactorAuth'].completionTimestamp(profile)}
                 isComplete={!!(getRegistrationTasksMap()['twoFactorAuth'].completionTimestamp(profile))}
-                completeStep={getRegistrationTasksMap()['twoFactorAuth'].onClick}>
-                {this.getTwoFactorAuthCardText(profile)}
+                completeStep={getRegistrationTasksMap()['twoFactorAuth'].onClick}
+                content={this.getTwoFactorAuthCardText(profile)}
+                >
               </ProfileRegistrationStepStatus>
               {enableEraCommons && <ProfileRegistrationStepStatus
-                  containerStylesOverride={{marginLeft: '0.5rem'}}
-                  title='Connect Your eRA Commons Account'
+                  title='Connect Your eRA Commons Account' 
                   wasBypassed={!!profile.eraCommonsBypassTime}
                   incompleteButtonText='Link'
                   completedButtonText={getRegistrationTasksMap()['eraCommons'].completedText}
-                  completionTimestamp={getRegistrationTasksMap()['eraCommons'].completionTimestamp(profile)}
                   isComplete={!!(getRegistrationTasksMap()['eraCommons'].completionTimestamp(profile))}
-                  completeStep={getRegistrationTasksMap()['eraCommons'].onClick}>
-                {this.getEraCommonsCardText(profile)}
+                  completeStep={getRegistrationTasksMap()['eraCommons'].onClick}
+                  content={this.getEraCommonsCardText(profile)}
+                >
               </ProfileRegistrationStepStatus>}
-            </FlexRow>
-            <FlexRow style={{marginTop: 3}}>
               {enableComplianceTraining && <ProfileRegistrationStepStatus
-                  title={<span><i>All of Us</i> Responsible Conduct of Research Training'</span>}
+                  title={<span><i>All of Us</i> Responsible Conduct of Research Training</span>}
                   wasBypassed={!!profile.complianceTrainingBypassTime}
                   incompleteButtonText='Access Training'
                   completedButtonText={getRegistrationTasksMap()['complianceTraining'].completedText}
-                  completionTimestamp={getRegistrationTasksMap()['complianceTraining'].completionTimestamp(profile)}
                   isComplete={!!(getRegistrationTasksMap()['complianceTraining'].completionTimestamp(profile))}
-                  completeStep={getRegistrationTasksMap()['complianceTraining'].onClick}>
-                {this.getComplianceTrainingText(profile)}
+                  completeStep={getRegistrationTasksMap()['complianceTraining'].onClick}
+                  content={this.getComplianceTrainingText(profile)}
+                >
               </ProfileRegistrationStepStatus>}
               {enableDataUseAgreement && <ProfileRegistrationStepStatus
-                  containerStylesOverride={{marginLeft: '0.5rem'}}
                   title='Sign Data User Code Of Conduct'
                   wasBypassed={!!profile.dataUseAgreementBypassTime}
                   incompleteButtonText='Sign'
                   completedButtonText={getRegistrationTasksMap()['dataUserCodeOfConduct'].completedText}
-                  completionTimestamp={getRegistrationTasksMap()['dataUserCodeOfConduct'].completionTimestamp(profile)}
                   isComplete={!!(getRegistrationTasksMap()['dataUserCodeOfConduct'].completionTimestamp(profile))}
                   completeStep={getRegistrationTasksMap()['dataUserCodeOfConduct'].onClick}
-                  childrenStyle={{marginLeft: '0rem'}}>
-                {this.getDataUseAgreementText(profile)}
+                  childrenStyle={{marginLeft: '0rem'}}
+                  content={this.getDataUseAgreementText(profile)}
+                >
               </ProfileRegistrationStepStatus>}
-            </FlexRow>
+            </div>
             <div style={{marginTop: '1rem', marginLeft: '1rem'}}>
 
               <div style={styles.title}>Optional Demographics Survey</div>

--- a/ui/src/app/pages/profile/profile-registration-step-status.tsx
+++ b/ui/src/app/pages/profile/profile-registration-step-status.tsx
@@ -40,8 +40,8 @@ interface Props {
   incompleteButtonText: string;
   completedButtonText: string;
   completeStep: Function;
-  completionTimestamp: string;
   childrenStyle?: React.CSSProperties;
+  content?: JSX.Element | JSX.Element[]; 
 }
 
 const ProfileRegistrationStepStatus: React.FunctionComponent<Props> =
@@ -53,7 +53,9 @@ const ProfileRegistrationStepStatus: React.FunctionComponent<Props> =
       incompleteButtonText,
       completedButtonText,
       completeStep,
-      children
+      childrenStyle,
+      children,
+      content
     } = props;
 
     return (
@@ -61,32 +63,20 @@ const ProfileRegistrationStepStatus: React.FunctionComponent<Props> =
         <div style={styles.title}>
           { title }
         </div>
-        <FlexColumn style={{justifyContent: 'space-between', flex: '1 1 auto'}}>
-
-          { isComplete ? (
-            <React.Fragment>
-              <div style={props.childrenStyle}>
-                { children }
-              </div>
-              <Button disabled={true} data-test-id='completed-button'
-                      style={{...styles.button, backgroundColor: colors.success,
-                        width: 'max-content', cursor: 'default'}}>
-                <ClrIcon shape='check' style={{marginRight: '0.3rem'}}/>{wasBypassed ? 'Bypassed' : completedButtonText}
-              </Button>
-            </React.Fragment>
-          ) : (
-            <React.Fragment>
-              {/*This div exists to ensure spacing is consistent. We want to put the button at the bottom of the flex box*/}
-              <div/>
-              <Button
-                type='purplePrimary'
-                style={ styles.button }
-                onClick={ completeStep }
-              >
-                { incompleteButtonText }
-              </Button>
-            </React.Fragment>
-          ) }
+        <FlexColumn style={{
+          justifyContent: isComplete && children ? 'flex-end' : 'space-between', 
+          flex: '1 1 auto',
+          alignItems: 'baseline'
+          }}>
+          {isComplete && <div style={childrenStyle}>{ content }</div>}
+          {children}
+          {isComplete && <Button disabled={true} 
+                                data-test-id='completed-button' 
+                                style={{...styles.button, backgroundColor: colors.success, width: 'max-content', cursor: 'default'}}>
+              <ClrIcon shape='check' style={{marginRight: '0.3rem'}}/>{wasBypassed ? 'Bypassed' : completedButtonText}
+            </Button>
+          }
+          {!isComplete && <Button type='purplePrimary' style={ styles.button } onClick={ completeStep }>{ incompleteButtonText }</Button>}
         </FlexColumn>
       </FlexColumn>
     );

--- a/ui/src/app/pages/profile/profile-registration-step-status.tsx
+++ b/ui/src/app/pages/profile/profile-registration-step-status.tsx
@@ -41,7 +41,7 @@ interface Props {
   completedButtonText: string;
   completeStep: Function;
   childrenStyle?: React.CSSProperties;
-  content?: JSX.Element | JSX.Element[]; 
+  content?: JSX.Element | JSX.Element[];
 }
 
 const ProfileRegistrationStepStatus: React.FunctionComponent<Props> =
@@ -64,19 +64,19 @@ const ProfileRegistrationStepStatus: React.FunctionComponent<Props> =
           { title }
         </div>
         <FlexColumn style={{
-          justifyContent: isComplete && children ? 'flex-end' : 'space-between', 
+          justifyContent: isComplete && children ? 'flex-end' : 'space-between',
           flex: '1 1 auto',
           alignItems: 'baseline'
-          }}>
+        }}>
           {isComplete && <div style={childrenStyle}>{ content }</div>}
           {children}
-          {isComplete && <Button disabled={true} 
-                                data-test-id='completed-button' 
+          {isComplete && <Button disabled={ true }
+                                data-test-id='completed-button'
                                 style={{...styles.button, backgroundColor: colors.success, width: 'max-content', cursor: 'default'}}>
               <ClrIcon shape='check' style={{marginRight: '0.3rem'}}/>{wasBypassed ? 'Bypassed' : completedButtonText}
             </Button>
           }
-          {!isComplete && <Button type='purplePrimary' style={ styles.button } onClick={ completeStep }>{ incompleteButtonText }</Button>}
+          {!isComplete && <Button type='purplePrimary' style={styles.button} onClick={completeStep}>{incompleteButtonText}</Button>}
         </FlexColumn>
       </FlexColumn>
     );


### PR DESCRIPTION
Description:
This is a refactor of the profile step component in preparation for the controlled tier card.
This refactor cleans up some code by:
1. Removing unused props
2. Making the render function a bit more straightforward
3. Always renders children - moving conditionally rendered content to a prop
4. Converts the cards to a CSS grid - this removes the need for some markup and styling specific to the position of the card. It also allows us to add cards dynamically without disrupting the flow or having to stick the cards into rigid 2 item flex rows.

It looks odd in JSX to have child tags that do not get rendered because the sub component conditionally bypasses the rendering of the children - hence the move to a "content" property.

This also makes it easier to fulfill the design of the CT card

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
