### PR TITLE
[risk=no] Switch integration test away from unused invite key

### DIFF
--- a/api/src/integration/java/org/pmiops/workbench/google/CloudStorageServiceImplIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/google/CloudStorageServiceImplIntegrationTest.java
@@ -19,6 +19,6 @@ public class CloudStorageServiceImplIntegrationTest extends BaseIntegrationTest 
 
   @Test
   public void testCanReadFile() {
-    assertThat(service.readInvitationKey().length() > 4).isTrue();
+    assertThat(service.getCaptchaServerKey()).isNotEmpty();
   }
 }


### PR DESCRIPTION
Follow-up PR will remove the remaining code that references the invite key.