### PR TITLE
[no ticket][risk=no] fixing Multiple entries with same key error

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
@@ -48,7 +48,7 @@ public class ConceptBigQueryServiceTest extends BigQueryBaseTest {
     DbConceptSetConceptId dbConceptSetConceptId1 =
         DbConceptSetConceptId.builder().addConceptId(6L).addStandard(true).build();
     DbConceptSetConceptId dbConceptSetConceptId2 =
-        DbConceptSetConceptId.builder().addConceptId(9L).addStandard(false).build();
+        DbConceptSetConceptId.builder().addConceptId(10L).addStandard(false).build();
     assertThat(
             conceptBigQueryService.getParticipantCountForConcepts(
                 Domain.CONDITION, ImmutableSet.of(dbConceptSetConceptId1, dbConceptSetConceptId2)))

--- a/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cdr/ConceptBigQueryServiceTest.java
@@ -45,11 +45,13 @@ public class ConceptBigQueryServiceTest extends BigQueryBaseTest {
 
   @Test
   public void testGetConceptCountNoConceptsSaved() {
-    DbConceptSetConceptId dbConceptSetConceptId =
+    DbConceptSetConceptId dbConceptSetConceptId1 =
         DbConceptSetConceptId.builder().addConceptId(6L).addStandard(true).build();
+    DbConceptSetConceptId dbConceptSetConceptId2 =
+        DbConceptSetConceptId.builder().addConceptId(9L).addStandard(false).build();
     assertThat(
             conceptBigQueryService.getParticipantCountForConcepts(
-                Domain.CONDITION, ImmutableSet.of(dbConceptSetConceptId)))
+                Domain.CONDITION, ImmutableSet.of(dbConceptSetConceptId1, dbConceptSetConceptId2)))
         .isEqualTo(1);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
@@ -90,7 +90,7 @@ public class ConceptBigQueryService {
     paramMap.put(standardParam, QueryParameterValue.int64(standardOrSource));
     if (CHILD_LOOKUP_DOMAINS.contains(domain)) {
       String domainParam = (standardOrSource == 1 ? "standardDomain" : "sourceDomain");
-      String rankParam = "rankParam";
+      String rankParam = (standardOrSource == 1 ? "standardRank" : "sourceRank");
       sqlBuilder.append(
           String.format(
               Domain.DRUG.equals(domain) ? DRUG_CHILD_LOOKUP_SQL : CHILD_LOOKUP_SQL,


### PR DESCRIPTION
Code is adding a query parameter for both source and standard concepts and was using the same key name producing the error below. Also updated unit test to include this breaking scenario:

org.pmiops.workbench.exceptions.ExceptionAdvice serverError: ErrorId c7b3caa2-2a25-472e-aad0-98f99919ef87: java.lang.IllegalArgumentException
java.lang.IllegalArgumentException: Multiple entries with same key: rankParam=QueryParameterValue{value=%[procedure_rank1]%, arrayValuesInner=null, structValuesInner=null, type=STRING, arrayType=null, structTypesInner=null} and rankParam=QueryParameterValue{value=%[procedure_rank1]%, arrayValuesInner=null, structValuesInner=null, type=STRING, arrayType=null, structTypesInner=null}
	at com.google.common.collect.ImmutableMap.conflictException(ImmutableMap.java:215)
	at com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:209)
	at com.google.common.collect.RegularImmutableMap.checkNoConflictInKeyBucket(RegularImmutableMap.java:146)
	at com.google.common.collect.RegularImmutableMap.fromEntryArray(RegularImmutableMap.java:109)
	at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:394)
	at org.pmiops.workbench.cdr.ConceptBigQueryService.getParticipantCountForConcepts(ConceptBigQueryService.java:70)
	at org.pmiops.workbench.conceptset.mapper.ConceptSetMapper.afterMappingDbModelToClient(ConceptSetMapper.java:47)
	at org.pmiops.workbench.conceptset.mapper.ConceptSetMapperImpl.dbModelToClient(ConceptSetMapperImpl.java:68)
	at org.pmiops.workbench.conceptset.ConceptSetService.getConceptSet(ConceptSetService.java:204)