### PR TITLE
[RW-6187][risk=low] Report "registered" or "none" for user access tiers

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.ReportingCohort;
 import org.pmiops.workbench.model.ReportingDataset;
 import org.pmiops.workbench.model.ReportingDatasetCohort;
@@ -268,6 +269,12 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 .creationTime(offsetDateTimeUtc(rs.getTimestamp("creation_time")))
                 .currentPosition(rs.getString("current_position"))
                 .dataAccessLevel(dataAccessLevelFromStorage(rs.getShort("data_access_level")))
+                // TODO placeholder until we have a proper association of users to tiers
+                .accessTierShortNames(
+                    dataAccessLevelFromStorage(rs.getShort("data_access_level"))
+                            == DataAccessLevel.REGISTERED
+                        ? "registered"
+                        : "none")
                 .dataUseAgreementBypassTime(
                     offsetDateTimeUtc(rs.getTimestamp("data_use_agreement_bypass_time")))
                 .dataUseAgreementCompletionTime(

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
@@ -13,6 +13,7 @@ import org.pmiops.workbench.model.ReportingUser;
  */
 public enum UserColumnValueExtractor implements ColumnValueExtractor<ReportingUser> {
   ABOUT_YOU("about_you", ReportingUser::getAboutYou),
+  ACCESS_TIER_SHORT_NAMES("access_tier_short_names", ReportingUser::getAccessTierShortNames),
   AREA_OF_RESEARCH("area_of_research", ReportingUser::getAreaOfResearch),
   COMPLIANCE_TRAINING_BYPASS_TIME(
       "compliance_training_bypass_time",

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8145,6 +8145,10 @@ definitions:
       aboutYou:
         type: string
         description: User's description of themselves.
+      accessTierShortNames:
+        description: |-
+          Short names of access tiers available to the user, comma-delimited if multiple.
+        type: string
       areaOfResearch:
         type: string
         description: ''

--- a/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
@@ -98,6 +98,7 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
   public static final InstitutionalRole USER__INSTITUTIONAL_ROLE_ENUM =
       InstitutionalRole.UNDERGRADUATE;
   public static final String USER__INSTITUTIONAL_ROLE_OTHER_TEXT = "foo_2";
+  public static final String USER__ACCESS_TIER_SHORT_NAMES = "registered";
 
   // Those enums are manually added
   public static Ethnicity USER__ETHNICITY = Ethnicity.PREFER_NO_ANSWER;
@@ -127,6 +128,7 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
         .isEqualTo(
             DbStorageEnums.dataAccessLevelFromStorage(
                 USER__DATA_ACCESS_LEVEL)); // manual adjustment
+    assertThat(user.getAccessTierShortNames()).isEqualTo(USER__ACCESS_TIER_SHORT_NAMES);
     assertTimeApprox(user.getDataUseAgreementBypassTime(), USER__DATA_USE_AGREEMENT_BYPASS_TIME);
     assertTimeApprox(
         user.getDataUseAgreementCompletionTime(), USER__DATA_USE_AGREEMENT_COMPLETION_TIME);


### PR DESCRIPTION
Description:

Similar to https://github.com/all-of-us/workbench/pull/4627 - this is the first part of RW-6187.

When we enable CT membership for users, we will report RT and CT membership for users as appropriate.  However that is complex and won't be ready for a while.  For now, unblock reporting updates with this simple binary check for Registered/Unregistered.
  
Terraform module update is all-of-us/workbench-terraform-modules#21
Devops update is forthcoming.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
