### PR TITLE
[RW-6166][risk=no] Set character limit, add "Show more" for concept set descriptions

### DIFF
--- a/e2e/app/page/conceptset-page.ts
+++ b/e2e/app/page/conceptset-page.ts
@@ -59,7 +59,7 @@ export default class ConceptSetPage extends AuthenticatedPage {
     }
     // edit description
     if (newDescription !== undefined) {
-      const descInputXpath = '//*[@data-test-id="edit-description"]';
+      const descInputXpath = '//*[@id="edit-description"]';
       const descInput = new Textbox(this.page, descInputXpath);
       await descInput.paste(newDescription);
     }

--- a/ui/src/app/components/resource-card.tsx
+++ b/ui/src/app/components/resource-card.tsx
@@ -39,7 +39,7 @@ const styles = reactStyles({
   },
   resourceDescription: {
     textOverflow: 'ellipsis', overflow: 'hidden', display: '-webkit-box',
-    WebkitLineClamp: 4, WebkitBoxOrient: 'vertical'
+    WebkitLineClamp: 4, WebkitBoxOrient: 'vertical', overflowWrap: 'anywhere'
   },
   lastModified: {
     color: colors.primary,

--- a/ui/src/app/pages/data/concept/concept-search.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.spec.tsx
@@ -53,7 +53,8 @@ describe('ConceptSearch', () => {
     wrapper.find('[data-test-id="edit-concept-set"]').first().simulate('click');
     await waitOneTickAndUpdate(wrapper);
     wrapper.find('[data-test-id="edit-name"]').first().simulate('change', {target: {value: newName}});
-    wrapper.find('[data-test-id="edit-description"]').first().simulate('change', {target: {value: newDesc}});
+    const editDescription = wrapper.find('[id="edit-description"]');
+    editDescription.find('textarea#edit-description').simulate('change', {target: {value: newDesc}});
     wrapper.find('[data-test-id="save-edit-concept-set"]').first().simulate('click');
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find('[data-test-id="concept-set-title"]').text()).toContain(newName);
@@ -84,7 +85,8 @@ describe('ConceptSearch', () => {
     wrapper.find('[data-test-id="edit-concept-set"]').first().simulate('click');
     await waitOneTickAndUpdate(wrapper);
     wrapper.find('[data-test-id="edit-name"]').first().simulate('change', {target: {value: newName}});
-    wrapper.find('[data-test-id="edit-description"]').first().simulate('change', {target: {value: newDesc}});
+    const editDescription = wrapper.find('[id="edit-description"]');
+    editDescription.find('textarea#edit-description').simulate('change', {target: {value: newDesc}});
     wrapper.find('[data-test-id="cancel-edit-concept-set"]').first().simulate('click');
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find('[data-test-id="concept-set-title"]').text()).toContain(conceptSet.name);

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -318,10 +318,13 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
                                                                tooLongWarningCharacters={950}
                                                                onChange={v => this.setState({editDescription: v})}/>
                           <div style={{margin: '0.5rem 0'}}>
+                            <TooltipTrigger content={<span>Description cannot exceed 1000 characters</span>}
+                                            disabled={!errors || !errors.editDescription}>
                             <Button type='primary' style={{marginRight: '0.5rem'}}
                                     data-test-id='save-edit-concept-set'
                                     disabled={editSaving || errors}
                                     onClick={() => this.submitEdits()}>Save</Button>
+                            </TooltipTrigger>
                             <Button type='secondary' disabled={editSaving}
                                     data-test-id='cancel-edit-concept-set'
                                     onClick={() => this.setState({

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -10,7 +10,7 @@ import {FadeBox} from 'app/components/containers';
 import {CopyModal} from 'app/components/copy-modal';
 import {FlexColumn, FlexRow} from 'app/components/flex';
 import {SnowmanIcon} from 'app/components/icons';
-import {TextAreaWithLengthValidationMessage, TextInput, ValidationError} from 'app/components/inputs';
+import {TextAreaWithLengthValidationMessage, TextInput} from 'app/components/inputs';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {PopupTrigger, TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
@@ -21,7 +21,6 @@ import colors from 'app/styles/colors';
 import {
   reactStyles,
   ReactWrapperBase,
-  summarizeErrors,
   withCurrentCohortSearchContext,
   withCurrentConcept,
   withCurrentWorkspace,
@@ -281,6 +280,13 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
       }
     }
 
+    tooltipContent(errors) {
+      return !!errors ? <ul>
+        {errors.editName && <li>Name cannot be blank</li>}
+        {errors.editDescription && <li>Description cannot exceed 1000 characters</li>}
+      </ul> : '';
+    }
+
     render() {
       const {cohortContext, workspace: {accessLevel, cdrVersionId, id, namespace}} = this.props;
       const {copying, conceptSet, editing, editDescription, editName, error, errorMessage, editSaving, deleting, loading,
@@ -308,9 +314,6 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
                                      id='edit-name'
                                      style={{marginBottom: '0.5rem'}} data-test-id='edit-name'
                                      onChange={v => this.setState({editName: v})}/>
-                          {errors && <ValidationError>
-                            {summarizeErrors( errors && errors.editName)}
-                          </ValidationError>}
                           <TextAreaWithLengthValidationMessage initialText={editDescription}
                                                                id='edit-description'
                                                                textBoxStyleOverrides={{width: '100%'}}
@@ -318,8 +321,8 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
                                                                tooLongWarningCharacters={950}
                                                                onChange={v => this.setState({editDescription: v})}/>
                           <div style={{margin: '0.5rem 0'}}>
-                            <TooltipTrigger content={<span>Description cannot exceed 1000 characters</span>}
-                                            disabled={!errors || !errors.editDescription}>
+                            <TooltipTrigger content={this.tooltipContent(errors)}
+                                            disabled={!errors}>
                             <Button type='primary' style={{marginRight: '0.5rem'}}
                                     data-test-id='save-edit-concept-set'
                                     disabled={editSaving || errors}

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -10,7 +10,7 @@ import {FadeBox} from 'app/components/containers';
 import {CopyModal} from 'app/components/copy-modal';
 import {FlexColumn, FlexRow} from 'app/components/flex';
 import {SnowmanIcon} from 'app/components/icons';
-import {TextArea, TextAreaWithLengthValidationMessage, TextInput, ValidationError} from 'app/components/inputs';
+import {TextAreaWithLengthValidationMessage, TextInput, ValidationError} from 'app/components/inputs';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {PopupTrigger, TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
@@ -312,8 +312,8 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
                             {summarizeErrors( errors && errors.editName)}
                           </ValidationError>}
                           <TextAreaWithLengthValidationMessage initialText={editDescription}
-                                                               data-test-id='edit-description'
-                                                               maxCharacters={1000} id={''}
+                                                               id='edit-description'
+                                                               maxCharacters={1000}
                                                                tooLongWarningCharacters={950}
                                                                onChange={v => this.setState({editDescription: v})}/>
                           <div style={{margin: '0.5rem 0'}}>

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -313,6 +313,7 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
                           </ValidationError>}
                           <TextAreaWithLengthValidationMessage initialText={editDescription}
                                                                id='edit-description'
+                                                               textBoxStyleOverrides={{width: '100%'}}
                                                                maxCharacters={1000}
                                                                tooLongWarningCharacters={950}
                                                                onChange={v => this.setState({editDescription: v})}/>

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -10,7 +10,7 @@ import {FadeBox} from 'app/components/containers';
 import {CopyModal} from 'app/components/copy-modal';
 import {FlexColumn, FlexRow} from 'app/components/flex';
 import {SnowmanIcon} from 'app/components/icons';
-import {TextArea, TextInput, ValidationError} from 'app/components/inputs';
+import {TextArea, TextAreaWithLengthValidationMessage, TextInput, ValidationError} from 'app/components/inputs';
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {PopupTrigger, TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
@@ -41,7 +41,7 @@ import {ConceptSet, CopyRequest, Criteria, Domain, ResourceType, WorkspaceAccess
 
 const styles = reactStyles({
   conceptSetHeader: {
-    display: 'flex', flexDirection: 'row', justifyContent: 'space-between', paddingBottom: '1.5rem'
+    display: 'flex', flexDirection: 'row', justifyContent: 'space-between'
   },
   conceptSetTitle: {
     color: colors.primary, fontSize: 20, fontWeight: 600, marginBottom: '0.5rem',
@@ -286,8 +286,8 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
       const {copying, conceptSet, editing, editDescription, editName, error, errorMessage, editSaving, deleting, loading,
         showMoreDescription, showUnsavedModal} = this.state;
       const errors = validate(
-        {editName: editName},
-        {editName: {presence: {allowEmpty: false}}}
+        {editDescription, editName},
+        {editName: {presence: {allowEmpty: false}}, editDescription: {length: {maximum: 1000}}}
       );
       return <React.Fragment>
         <FadeBox style={{margin: 'auto', paddingTop: '1rem', width: '95.7%'}}>
@@ -311,10 +311,12 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
                           {errors && <ValidationError>
                             {summarizeErrors( errors && errors.editName)}
                           </ValidationError>}
-                          <TextArea value={editDescription} disabled={editSaving}
-                                    style={{marginBottom: '0.5rem'}} data-test-id='edit-description'
-                                    onChange={v => this.setState({editDescription: v})}/>
-                          <div style={{marginBottom: '0.5rem'}}>
+                          <TextAreaWithLengthValidationMessage initialText={editDescription}
+                                                               data-test-id='edit-description'
+                                                               maxCharacters={1000} id={''}
+                                                               tooLongWarningCharacters={950}
+                                                               onChange={v => this.setState({editDescription: v})}/>
+                          <div style={{margin: '0.5rem 0'}}>
                             <Button type='primary' style={{marginRight: '0.5rem'}}
                                     data-test-id='save-edit-concept-set'
                                     disabled={editSaving || errors}

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -52,7 +52,13 @@ const styles = reactStyles({
   },
   conceptSetData: {
     display: 'flex', flexDirection: 'row', color: colors.primary, fontWeight: 600
-  }
+  },
+  showMore: {
+    background: colors.white,
+    color: colors.accent,
+    cursor: 'pointer',
+    marginLeft: '0.25rem'
+  },
 });
 
 export interface ConceptSetMenuProps {
@@ -119,6 +125,7 @@ interface State {
   error: boolean;
   errorMessage: string;
   loading: boolean;
+  showMoreDescription: boolean;
   // Show if trying to navigate away with unsaved changes
   showUnsavedModal: boolean;
   unsavedChanges: boolean;
@@ -142,6 +149,7 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
         errorMessage: '',
         deleting: false,
         loading: this.isDetailPage,
+        showMoreDescription: false,
         showUnsavedModal: false,
         unsavedChanges: false
       };
@@ -275,8 +283,8 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
 
     render() {
       const {cohortContext, workspace: {accessLevel, cdrVersionId, id, namespace}} = this.props;
-      const {copying, conceptSet, editing, editDescription, editName, error, errorMessage, editSaving, deleting, loading, showUnsavedModal}
-        = this.state;
+      const {copying, conceptSet, editing, editDescription, editName, error, errorMessage, editSaving, deleting, loading,
+        showMoreDescription, showUnsavedModal} = this.state;
       const errors = validate(
         {editName: editName},
         {editName: {presence: {allowEmpty: false}}}
@@ -333,7 +341,16 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
                             </Clickable>
                           </div>
                           <div style={{marginBottom: '1.5rem', color: colors.primary}} data-test-id='concept-set-description'>
-                            {conceptSet.description}
+                            {showMoreDescription ?
+                              conceptSet.description :
+                              conceptSet.description.slice(0, 250)
+                            }
+                            {conceptSet.description.length > 250 &&
+                              <span style={styles.showMore}
+                                    onClick={() => this.setState({showMoreDescription: !showMoreDescription})}>
+                                Show {showMoreDescription ? 'less' : 'more'}
+                              </span>
+                            }
                           </div>
                         </React.Fragment>}
                       <div style={styles.conceptSetData}>


### PR DESCRIPTION
- Set 1000 character limit for concept set description text area


https://user-images.githubusercontent.com/40036095/109837678-0aa4f780-7c0b-11eb-849a-dcd50b758235.mov

- Add "Show more" button for descriptions over 250 characters

https://user-images.githubusercontent.com/40036095/109707975-6cf4ee00-7b60-11eb-995c-1d4a2ca2dd57.mov

- Prevent long words from overflowing on concept set cards

Before & After:
<img width="245" alt="Screen Shot 2021-03-02 at 2 37 37 PM" src="https://user-images.githubusercontent.com/40036095/109717912-4937a500-7b6c-11eb-8660-87220dde43ff.png"> ===> <img width="232" alt="Screen Shot 2021-03-02 at 2 37 48 PM" src="https://user-images.githubusercontent.com/40036095/109717943-518fe000-7b6c-11eb-8b67-b5f5f1072e0c.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
