### PR TITLE
[no ticket][risk=no] Always create circleci_parameters.json in CircleCI Puppeteer job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,6 +566,7 @@ jobs:
               \"circleBuildUrl\": \"${CIRCLE_BUILD_URL}\", \
               \"circleNodeIndex\": ${CIRCLE_NODE_INDEX} \
               }" > ./logs/circleci_parameters.json
+          when: always
       - store_artifacts:
           path: ~/workbench/e2e/logs
           destination: logs


### PR DESCRIPTION
Noticed today "Create circleci_parameters.json" step were skipped if previous step (run puppeteer tests) has failed. subsequently, test results upload fails.