### PR TITLE
DRAFT strawman: what if CdrVersionContext never returns null and CdrDbConfig doesn't need to store a default

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionContext.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionContext.java
@@ -1,6 +1,8 @@
 package org.pmiops.workbench.cdr;
 
+import javax.validation.constraints.NotNull;
 import org.pmiops.workbench.db.model.DbCdrVersion;
+import org.pmiops.workbench.exceptions.ServerErrorException;
 
 /** Maintains state of what CDR version is being used in the context of the current request. */
 public class CdrVersionContext {
@@ -24,7 +26,12 @@ public class CdrVersionContext {
     cdrVersion.remove();
   }
 
+  @NotNull
   public static DbCdrVersion getCdrVersion() {
-    return cdrVersion.get();
+    DbCdrVersion version = cdrVersion.get();
+    if (version == null) {
+      throw new ServerErrorException("No CDR version specified!");
+    }
+    return version;
   }
 }


### PR DESCRIPTION
Description:

Stop storing a default CDR Version in CdrDbConfig; instead, rely on CdrVersionContext having a correctly set CDR Version for every request where it's needed.

Confirmed that I can access the test CDR SQL DB via Cohort Builder and Dataset Builder, but my understanding is that this testing is far from exhaustive.  This would involve checking every endpoint which ultimately calls any `cdr.dao` method.  I made a brief attempt to do so but after ~ 1 hour in, I stopped after realizing the huge time investment this would be.  Can we think of a better way?

Filed https://precisionmedicineinitiative.atlassian.net/browse/RW-6432 for investigation.

#4661 is the alternative temporary solution that I plan to adopt to unblock Controlled Tier work (as part of #4649); without one of these, CdrDbConfig prevents the application from starting up correctly, complaining of multiple default CDR Versions.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
