### PR TITLE
[RW-6291][risk=med] Add extract tables -> VCF -> researcher buckets to extraction workflow

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -57,7 +57,7 @@
     "extractionPetServiceAccount": "pet-118217329794842274136@aou-wgs-cohort-extraction.iam.gserviceaccount.com",
     "extractionMethodConfigurationNamespace": "aouwgscohortextraction",
     "extractionMethodConfigurationName": "HelloWorld",
-    "extractionMethodConfigurationVersion": 51,
+    "extractionMethodConfigurationVersion": 52,
     "extractionCohortsDataset": "fc-aou-cdr-synth-test.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test.wgs_extracted_cohorts",
     "extractionTempTablesDataset": "fc-aou-cdr-synth-test.wgs_extraction_temp_tables"

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -57,7 +57,7 @@
     "extractionPetServiceAccount": "pet-118217329794842274136@aou-wgs-cohort-extraction.iam.gserviceaccount.com",
     "extractionMethodConfigurationNamespace": "aouwgscohortextraction",
     "extractionMethodConfigurationName": "HelloWorld",
-    "extractionMethodConfigurationVersion": 52,
+    "extractionMethodConfigurationVersion": 54,
     "extractionCohortsDataset": "fc-aou-cdr-synth-test.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test.wgs_extracted_cohorts",
     "extractionTempTablesDataset": "fc-aou-cdr-synth-test.wgs_extraction_temp_tables"

--- a/api/genomics/wdl/WgsCohortExtractPrep.wdl
+++ b/api/genomics/wdl/WgsCohortExtractPrep.wdl
@@ -170,6 +170,7 @@ task CreateCohortExtractTable {
     bootDiskSizeGb: "15"
     disks: "local-disk 10 HDD"
     preemptible: 3
+	  # Temporary GATK that I'm using to get unblocked. We will realign with the mainstream GATK ah_var_store branch
     docker: "gcr.io/all-of-us-workbench-test/variantstore-extract-prep:2"
   }
 } 
@@ -214,11 +215,9 @@ task ExtractTask {
         set -e
         export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
 
-        bq query --project_id ~{read_project_id} --max_rows=10000000 --format=csv --nouse_legacy_sql \
-          'select sample_id, sample_name FROM `~{fq_sample_table}`' | sed -e 1d \
-          > sample_map.csv
-
-        cat sample_map.csv
+        #bq query --project_id ~{read_project_id} --max_rows=10000000 --format=csv --nouse_legacy_sql \
+        #  'select sample_id, sample_name FROM `~{fq_sample_table}`' | sed -e 1d \
+        #  > sample_map.csv
 
         gatk --java-options "-Xmx9g" \
             ExtractCohort \
@@ -226,7 +225,7 @@ task ExtractTask {
                 -R "~{reference}" \
                 -O "~{output_file}" \
                 --local-sort-max-records-in-ram ~{local_sort_max_records_in_ram} \
-                --sample-file sample_map.csv \
+                --sample-table ~{fq_sample_table} \
                 --cohort-extract-table ~{fq_cohort_extract_table} \
                 -L ~{intervals} \
                 --project-id ~{read_project_id} \

--- a/api/genomics/wdl/WgsCohortExtractPrep.wdl
+++ b/api/genomics/wdl/WgsCohortExtractPrep.wdl
@@ -1,5 +1,8 @@
 version 1.0
 
+# This is just temporarily here for review. The final version of this will be
+# merged into the GATK branch and we will pull the workflows from there.
+
 workflow WgsCohortExtract {
 
   input {
@@ -10,9 +13,24 @@ workflow WgsCohortExtract {
     String wgs_extraction_destination_dataset
     String wgs_extraction_temp_tables_dataset
     String extraction_uuid
+    String output_gcs_dir
+    
+    # Extract parameters
+    File wgs_intervals
+    Int scatter_count
+       
+    File reference
+    File reference_index
+    File reference_dict
+        
+    String output_file_base_name
+    
+    String? fq_filter_set_table
+    String? filter_set_name
+    File? gatk_override
   }
 
-  call CreateCohortTable {
+  call CreateCohortSampleTable {
     input:
       participant_ids = participant_ids,
       wgs_dataset = wgs_dataset,
@@ -24,20 +42,48 @@ workflow WgsCohortExtract {
   call CreateCohortExtractTable {
     input:
       cohort_uuid = extraction_uuid,
+      fq_cohort_sample_table = CreateCohortSampleTable.fq_cohort_sample_table,
       query_project = query_project,
       wgs_dataset = wgs_dataset,
       wgs_extraction_cohorts_dataset = wgs_extraction_cohorts_dataset,
       wgs_extraction_destination_dataset = wgs_extraction_destination_dataset,
       wgs_extraction_temp_tables_dataset = wgs_extraction_temp_tables_dataset
   }
+  
+  call SplitIntervals {
+    input:
+        intervals = wgs_intervals,
+        ref_fasta = reference,
+        ref_fai = reference_index,
+        ref_dict = reference_dict,
+        scatter_count = scatter_count
+  }
+    
+  scatter(i in range(scatter_count) ) {
+    call ExtractTask {
+      input:
+        gatk_override            = gatk_override,
+        reference                = reference,
+        reference_index          = reference_index,
+        reference_dict           = reference_dict,
+        fq_sample_table          = CreateCohortSampleTable.fq_cohort_sample_table,
+        intervals                = SplitIntervals.interval_files[i],
+        fq_cohort_extract_table  = CreateCohortExtractTable.fq_cohort_extract_table,
+        read_project_id          = query_project,
+        fq_filter_set_table      = fq_filter_set_table,
+        filter_set_name          = filter_set_name,
+        output_file              = "${output_file_base_name}_${i}.vcf.gz",
+        output_gcs_dir           = output_gcs_dir
+    }
+  }
 
   output {
-    String cohort_extract_table = CreateCohortExtractTable.cohort_extract_table
+    String fq_cohort_extract_table = CreateCohortExtractTable.fq_cohort_extract_table
   }
 
 }
 
-task CreateCohortTable {
+task CreateCohortSampleTable {
 
   input {
     File participant_ids
@@ -46,7 +92,7 @@ task CreateCohortTable {
     String query_project
     String table_name
   }
-
+  
   command <<<
     echo "SELECT
       sample_id,
@@ -58,18 +104,22 @@ task CreateCohortTable {
 
     PARTICIPANT_IDS=$(cat ~{participant_ids} | awk '{print "\""$0"\""}' | paste -sd ",")
     echo "($PARTICIPANT_IDS)" >> create_cohort.sql
-
-    DESTINATION_TABLE=$(echo ~{wgs_extraction_cohorts_dataset} | tr '.' ':')
+    
+    DESTINATION_DATASET=$(echo ~{wgs_extraction_cohorts_dataset} | tr '.' ':')
 
     bq query \
       --project_id ~{query_project} \
-      --destination_table ${DESTINATION_TABLE}.~{table_name} \
+      --destination_table ${DESTINATION_DATASET}.~{table_name} \
       --use_legacy_sql=false \
       --max_rows=10000000 \
       --allow_large_results < create_cohort.sql
+    
+    echo "~{wgs_extraction_cohorts_dataset}.~{table_name}" > fq_cohort_sample_table.txt
   >>>
-
-  output { }
+  
+  output {
+    String fq_cohort_sample_table = read_string("fq_cohort_sample_table.txt")
+  }
 
   runtime {
     memory: "3.75 GB"
@@ -78,23 +128,24 @@ task CreateCohortTable {
     preemptible: 3
     docker: "us.gcr.io/broad-gatk/gatk:4.1.8.0"
   }
-}
+} 
 
 
 task CreateCohortExtractTable {
 
   input {
     String cohort_uuid
+    String fq_cohort_sample_table
     String wgs_dataset
     String wgs_extraction_cohorts_dataset
     String wgs_extraction_destination_dataset
     String wgs_extraction_temp_tables_dataset
     String query_project
   }
-
+  
   command <<<
     set -e
-
+    
     echo "Exporting to ~{wgs_extraction_destination_dataset}.~{cohort_uuid}"
 
     python /app/ngs_cohort_extract.py \
@@ -102,16 +153,16 @@ task CreateCohortExtractTable {
       --fq_temp_table_dataset ~{wgs_extraction_temp_tables_dataset} \
       --fq_destination_dataset ~{wgs_extraction_destination_dataset} \
       --destination_table ~{cohort_uuid} \
-      --fq_cohort_sample_names ~{wgs_extraction_cohorts_dataset}.~{cohort_uuid} \
+      --fq_cohort_sample_names ~{fq_cohort_sample_table} \
       --min_variant_samples 0 \
       --query_project ~{query_project} \
       --fq_sample_mapping_table ~{wgs_dataset}.metadata
-
-    echo ~{wgs_extraction_destination_dataset}.~{cohort_uuid} > cohort_extract_table.txt
+    
+    echo ~{wgs_extraction_destination_dataset}.~{cohort_uuid} > fq_cohort_extract_table.txt
   >>>
-
+  
   output {
-    String cohort_extract_table = read_string("cohort_extract_table.txt")
+    String fq_cohort_extract_table = read_string("fq_cohort_extract_table.txt")
   }
 
   runtime {
@@ -119,9 +170,131 @@ task CreateCohortExtractTable {
     bootDiskSizeGb: "15"
     disks: "local-disk 10 HDD"
     preemptible: 3
-    # Temporary GATK that I'm using to get unblocked. We will realign with the mainstream GATK ah_var_store branch
-    # once they incorporate my changes.
     docker: "gcr.io/all-of-us-workbench-test/variantstore-extract-prep:2"
   }
-}
+} 
+
+task ExtractTask {
+    # indicates that this task should NOT be call cached
+    meta {
+       volatile: true
+    }
+
+    input {
+        # ------------------------------------------------
+        # Input args:
+        File reference
+        File reference_index
+        File reference_dict
+    
+        String fq_sample_table
+
+        File intervals
+
+        String fq_cohort_extract_table
+        String read_project_id
+        String output_file
+        String output_gcs_dir
+        
+        String? fq_filter_set_table
+        String? filter_set_name
+        
+        # Runtime Options:
+        File? gatk_override
+        
+        Int? local_sort_max_records_in_ram = 5000000
+    }
+    
+    String outdir = sub(output_gcs_dir, "/$", "")
+
+
+    # ------------------------------------------------
+    # Run our command:
+    command <<<
+        set -e
+        export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
+
+        bq query --project_id ~{read_project_id} --max_rows=10000000 --format=csv --nouse_legacy_sql \
+          'select sample_id, sample_name FROM `~{fq_sample_table}`' | sed -e 1d \
+          > sample_map.csv
+
+        cat sample_map.csv
+
+        gatk --java-options "-Xmx9g" \
+            ExtractCohort \
+                --mode GENOMES --ref-version 38 --query-mode LOCAL_SORT \
+                -R "~{reference}" \
+                -O "~{output_file}" \
+                --local-sort-max-records-in-ram ~{local_sort_max_records_in_ram} \
+                --sample-file sample_map.csv \
+                --cohort-extract-table ~{fq_cohort_extract_table} \
+                -L ~{intervals} \
+                --project-id ~{read_project_id} \
+                ~{"--variant-filter-table " + fq_filter_set_table} \
+                ~{"--filter-set-name " + filter_set_name}
+        
+        gsutil cp ~{output_file} ~{output_gcs_dir}/
+        gsutil cp ~{output_file}.tbi ~{output_gcs_dir}/
+    >>>
+
+    # ------------------------------------------------
+    # Runtime settings:
+    runtime {
+        docker: "us.gcr.io/broad-gatk/gatk:4.1.8.0"
+        memory: "10 GB"
+        disks: "local-disk 100 HDD"
+        bootDiskSizeGb: 15
+        preemptible: 3
+        cpu: 2
+    }
+
+    # ------------------------------------------------
+    # Outputs:
+    output {
+        String sample_csv = "sample_map.csv"
+        File output_vcf = "~{output_file}"
+        File output_vcf_index = "~{output_file}.tbi"
+    }
+ }
+
+ task SplitIntervals {
+     input {
+       File? intervals
+       File ref_fasta
+       File ref_fai
+       File ref_dict
+       Int scatter_count
+       String? split_intervals_extra_args
+
+       File? gatk_override
+     }
+
+     command {
+         set -e
+         export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
+
+         mkdir interval-files
+         gatk --java-options "-Xmx5g" SplitIntervals \
+             -R ~{ref_fasta} \
+             ~{"-L " + intervals} \
+             -scatter ~{scatter_count} \
+             -O interval-files \
+             ~{split_intervals_extra_args}
+         cp interval-files/*.interval_list .
+     }
+
+     runtime {
+         docker: "us.gcr.io/broad-gatk/gatk:4.1.8.0"
+         bootDiskSizeGb: 15
+         memory: "6 GB"
+         disks: "local-disk 10 HDD"
+         preemptible: 3
+         cpu: 1
+     }
+
+     output {
+         Array[File] interval_files = glob("*.interval_list")
+     }
+ }
+
 

--- a/api/src/main/java/org/pmiops/workbench/genomics/WgsCohortExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/WgsCohortExtractionService.java
@@ -31,7 +31,7 @@ public class WgsCohortExtractionService {
 
   private final CohortService cohortService;
   private final FireCloudService fireCloudService;
-  private final Provider<CloudStorageClient> cloudStorageClientProvider;
+  private final Provider<CloudStorageClient> extractionServiceAccountCloudStorageClientProvider;
   private final Provider<SubmissionsApi> submissionApiProvider;
   private final Provider<MethodConfigurationsApi> methodConfigurationsApiProvider;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
@@ -41,14 +41,14 @@ public class WgsCohortExtractionService {
       CohortService cohortService,
       FireCloudService fireCloudService,
       @Qualifier(StorageConfig.WGS_EXTRACTION_STORAGE_CLIENT)
-          Provider<CloudStorageClient> cloudStorageClientProvider,
+          Provider<CloudStorageClient> extractionServiceAccountCloudStorageClientProvider,
       Provider<SubmissionsApi> submissionsApiProvider,
       Provider<MethodConfigurationsApi> methodConfigurationsApiProvider,
       Provider<WorkbenchConfig> workbenchConfigProvider) {
     this.cohortService = cohortService;
     this.fireCloudService = fireCloudService;
     this.submissionApiProvider = submissionsApiProvider;
-    this.cloudStorageClientProvider = cloudStorageClientProvider;
+    this.extractionServiceAccountCloudStorageClientProvider = extractionServiceAccountCloudStorageClientProvider;
     this.methodConfigurationsApiProvider = methodConfigurationsApiProvider;
     this.workbenchConfigProvider = workbenchConfigProvider;
   }
@@ -80,13 +80,13 @@ public class WgsCohortExtractionService {
     WorkbenchConfig.WgsCohortExtractionConfig cohortExtractionConfig =
         workbenchConfigProvider.get().wgsCohortExtraction;
 
-    FirecloudWorkspace fcWorkspace = fireCloudService.getWorkspace(workspace).get().getWorkspace();
+    FirecloudWorkspace fcUserWorkspace = fireCloudService.getWorkspace(workspace).get().getWorkspace();
 
     String extractionUuid = UUID.randomUUID().toString();
     String extractionFolder = "wgs-cohort-extractions/" + extractionUuid;
 
     Blob personIdsFile =
-        cloudStorageClientProvider
+        extractionServiceAccountCloudStorageClientProvider
             .get()
             .writeFile(
                 // It is critical that this file is written to a bucket that the user cannot write
@@ -153,13 +153,13 @@ public class WgsCohortExtractionService {
                             .put(
                                 "WgsCohortExtract.output_gcs_dir",
                                 "\"gs://"
-                                    + fcWorkspace.getBucketName()
+                                    + fcUserWorkspace.getBucketName()
                                     + "/"
                                     + extractionFolder
                                     + "/vcfs/\"")
                             .put(
                                 "WgsCohortExtract.gatk_override",
-                                "\"gs://all-of-us-workbench-test-genomics/wgs/gatk-package-4.1.9.0-200-gfabc915-SNAPSHOT-local.jar\"")
+                                "\"gs://all-of-us-workbench-test-genomics/wgs/gatk-package-4.1.9.0-204-g6449d52-SNAPSHOT-local.jar\"")
                             .build())
                     .methodConfigVersion(
                         cohortExtractionConfig.extractionMethodConfigurationVersion)

--- a/api/src/main/java/org/pmiops/workbench/genomics/WgsCohortExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/WgsCohortExtractionService.java
@@ -133,14 +133,36 @@ public class WgsCohortExtractionService {
                             .put(
                                 "WgsCohortExtract.wgs_extraction_temp_tables_dataset",
                                 "\"" + cohortExtractionConfig.extractionTempTablesDataset + "\"")
-                            .put("WgsCohortExtract.wgs_intervals", "\"gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.interval_list\"")
-                            .put("WgsCohortExtract.scatter_count", "1000") // This value will need to be dynamically adjusted through testing.
-                            .put("WgsCohortExtract.reference", "\"gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta\"")
-                            .put("WgsCohortExtract.reference_index", "\"gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai\"")
-                            .put("WgsCohortExtract.reference_dict", "\"gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict\"")
-                            .put("WgsCohortExtract.output_file_base_name", "\"interval\"") // Will produce files named "interval_1.vcf.gz", "interval_32.vcf.gz", etc
-                            .put("WgsCohortExtract.output_gcs_dir", "\"gs://" + fcWorkspace.getBucketName() + "/" + extractionFolder + "/vcfs/\"")
-                            .put("WgsCohortExtract.gatk_override", "\"gs://all-of-us-workbench-test-genomics/wgs/gatk-package-4.1.9.0-200-gfabc915-SNAPSHOT-local.jar\"")
+                            .put(
+                                "WgsCohortExtract.wgs_intervals",
+                                "\"gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.interval_list\"")
+                            .put(
+                                "WgsCohortExtract.scatter_count",
+                                "1000") // This value will need to be dynamically adjusted through
+                            // testing.
+                            .put(
+                                "WgsCohortExtract.reference",
+                                "\"gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta\"")
+                            .put(
+                                "WgsCohortExtract.reference_index",
+                                "\"gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai\"")
+                            .put(
+                                "WgsCohortExtract.reference_dict",
+                                "\"gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict\"")
+                            .put(
+                                "WgsCohortExtract.output_file_base_name",
+                                "\"interval\"") // Will produce files named "interval_1.vcf.gz",
+                            // "interval_32.vcf.gz", etc
+                            .put(
+                                "WgsCohortExtract.output_gcs_dir",
+                                "\"gs://"
+                                    + fcWorkspace.getBucketName()
+                                    + "/"
+                                    + extractionFolder
+                                    + "/vcfs/\"")
+                            .put(
+                                "WgsCohortExtract.gatk_override",
+                                "\"gs://all-of-us-workbench-test-genomics/wgs/gatk-package-4.1.9.0-200-gfabc915-SNAPSHOT-local.jar\"")
                             .build())
                     .methodConfigVersion(
                         cohortExtractionConfig.extractionMethodConfigurationVersion)

--- a/api/src/main/java/org/pmiops/workbench/genomics/WgsCohortExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/WgsCohortExtractionService.java
@@ -48,7 +48,8 @@ public class WgsCohortExtractionService {
     this.cohortService = cohortService;
     this.fireCloudService = fireCloudService;
     this.submissionApiProvider = submissionsApiProvider;
-    this.extractionServiceAccountCloudStorageClientProvider = extractionServiceAccountCloudStorageClientProvider;
+    this.extractionServiceAccountCloudStorageClientProvider =
+        extractionServiceAccountCloudStorageClientProvider;
     this.methodConfigurationsApiProvider = methodConfigurationsApiProvider;
     this.workbenchConfigProvider = workbenchConfigProvider;
   }
@@ -80,7 +81,8 @@ public class WgsCohortExtractionService {
     WorkbenchConfig.WgsCohortExtractionConfig cohortExtractionConfig =
         workbenchConfigProvider.get().wgsCohortExtraction;
 
-    FirecloudWorkspace fcUserWorkspace = fireCloudService.getWorkspace(workspace).get().getWorkspace();
+    FirecloudWorkspace fcUserWorkspace =
+        fireCloudService.getWorkspace(workspace).get().getWorkspace();
 
     String extractionUuid = UUID.randomUUID().toString();
     String extractionFolder = "wgs-cohort-extractions/" + extractionUuid;

--- a/api/src/main/java/org/pmiops/workbench/genomics/WgsCohortExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/WgsCohortExtractionService.java
@@ -136,10 +136,8 @@ public class WgsCohortExtractionService {
                             .put(
                                 "WgsCohortExtract.wgs_intervals",
                                 "\"gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.interval_list\"")
-                            .put(
-                                "WgsCohortExtract.scatter_count",
-                                "1000") // This value will need to be dynamically adjusted through
-                            // testing.
+                            // This value will need to be dynamically adjusted through testing
+                            .put("WgsCohortExtract.scatter_count", "1000")
                             .put(
                                 "WgsCohortExtract.reference",
                                 "\"gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta\"")
@@ -149,10 +147,9 @@ public class WgsCohortExtractionService {
                             .put(
                                 "WgsCohortExtract.reference_dict",
                                 "\"gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict\"")
-                            .put(
-                                "WgsCohortExtract.output_file_base_name",
-                                "\"interval\"") // Will produce files named "interval_1.vcf.gz",
-                            // "interval_32.vcf.gz", etc
+                            // Will produce files named "interval_1.vcf.gz", "interval_32.vcf.gz",
+                            // etc
+                            .put("WgsCohortExtract.output_file_base_name", "\"interval\"")
                             .put(
                                 "WgsCohortExtract.output_gcs_dir",
                                 "\"gs://"

--- a/api/src/main/java/org/pmiops/workbench/genomics/WgsCohortExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/WgsCohortExtractionService.java
@@ -83,6 +83,8 @@ public class WgsCohortExtractionService {
     FirecloudWorkspace fcWorkspace = fireCloudService.getWorkspace(workspace).get().getWorkspace();
 
     String extractionUuid = UUID.randomUUID().toString();
+    String extractionFolder = "wgs-cohort-extractions/" + extractionUuid;
+
     Blob personIdsFile =
         cloudStorageClientProvider
             .get()
@@ -91,7 +93,7 @@ public class WgsCohortExtractionService {
                 // to because its contents will feed into a SQL query with the cohort
                 // extraction SA's permissions
                 cohortExtractionConfig.operationalTerraWorkspaceBucket,
-                "wgs-cohort-extractions/" + extractionUuid + "/person_ids.txt",
+                extractionFolder + "/person_ids.txt",
                 String.join("\n", cohortService.getPersonIds(cohortId))
                     .getBytes(StandardCharsets.UTF_8));
 
@@ -132,12 +134,12 @@ public class WgsCohortExtractionService {
                                 "WgsCohortExtract.wgs_extraction_temp_tables_dataset",
                                 "\"" + cohortExtractionConfig.extractionTempTablesDataset + "\"")
                             .put("WgsCohortExtract.wgs_intervals", "\"gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.interval_list\"")
-                            .put("WgsCohortExtract.scatter_count", "100")
+                            .put("WgsCohortExtract.scatter_count", "1000") // This value will need to be dynamically adjusted through testing.
                             .put("WgsCohortExtract.reference", "\"gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta\"")
                             .put("WgsCohortExtract.reference_index", "\"gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai\"")
                             .put("WgsCohortExtract.reference_dict", "\"gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict\"")
-                            .put("WgsCohortExtract.output_file_base_name", "\"cohort_" + cohortId + "\"")
-                            .put("WgsCohortExtract.output_gcs_dir", "\"gs://" + fcWorkspace.getBucketName() + "/cohort-" + cohortId + "_vcfs/\"")
+                            .put("WgsCohortExtract.output_file_base_name", "\"interval\"") // Will produce files named "interval_1.vcf.gz", "interval_32.vcf.gz", etc
+                            .put("WgsCohortExtract.output_gcs_dir", "\"gs://" + fcWorkspace.getBucketName() + "/" + extractionFolder + "/vcfs/\"")
                             .put("WgsCohortExtract.gatk_override", "\"gs://all-of-us-workbench-test-genomics/wgs/gatk-package-4.1.9.0-200-gfabc915-SNAPSHOT-local.jar\"")
                             .build())
                     .methodConfigVersion(

--- a/api/src/test/java/org/pmiops/workbench/genomics/WgsCohortExtractionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/genomics/WgsCohortExtractionServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.google.cloud.storage.Blob;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,8 +38,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.Optional;
-
 @RunWith(SpringRunner.class)
 public class WgsCohortExtractionServiceTest {
 
@@ -52,7 +51,12 @@ public class WgsCohortExtractionServiceTest {
 
   @TestConfiguration
   @Import({WgsCohortExtractionService.class})
-  @MockBean({CohortService.class, FireCloudService.class, MethodConfigurationsApi.class, SubmissionsApi.class})
+  @MockBean({
+    CohortService.class,
+    FireCloudService.class,
+    MethodConfigurationsApi.class,
+    SubmissionsApi.class
+  })
   static class Configuration {
     @Bean
     @Scope("prototype")
@@ -82,10 +86,9 @@ public class WgsCohortExtractionServiceTest {
     workbenchConfig.wgsCohortExtraction.extractionMethodConfigurationNamespace = "methodNamespace";
     workbenchConfig.wgsCohortExtraction.extractionMethodConfigurationVersion = 1;
 
-    FirecloudWorkspace fcWorkspace = new FirecloudWorkspace()
-            .bucketName("user-bucket");
-    FirecloudWorkspaceResponse fcWorkspaceResponse = new FirecloudWorkspaceResponse()
-            .workspace(fcWorkspace);
+    FirecloudWorkspace fcWorkspace = new FirecloudWorkspace().bucketName("user-bucket");
+    FirecloudWorkspaceResponse fcWorkspaceResponse =
+        new FirecloudWorkspaceResponse().workspace(fcWorkspace);
     doReturn(Optional.of(fcWorkspaceResponse)).when(fireCloudService).getWorkspace(any());
 
     FirecloudMethodConfiguration firecloudMethodConfiguration = new FirecloudMethodConfiguration();
@@ -119,12 +122,14 @@ public class WgsCohortExtractionServiceTest {
   public void submitExtractionJob_outputVcfsInCorrectBucket() throws ApiException {
     wgsCohortExtractionService.submitGenomicsCohortExtractionJob(mockWorkspace(), 1l);
 
-    ArgumentCaptor<FirecloudMethodConfiguration> argument = ArgumentCaptor.forClass(FirecloudMethodConfiguration.class);
+    ArgumentCaptor<FirecloudMethodConfiguration> argument =
+        ArgumentCaptor.forClass(FirecloudMethodConfiguration.class);
 
     verify(methodConfigurationsApi).createWorkspaceMethodConfig(any(), any(), argument.capture());
     String actualOutputDir = argument.getValue().getInputs().get("WgsCohortExtract.output_gcs_dir");
 
-    assertThat(actualOutputDir).matches("\"gs:\\/\\/user-bucket\\/wgs-cohort-extractions\\/.*\\/vcfs\\/\"");
+    assertThat(actualOutputDir)
+        .matches("\"gs:\\/\\/user-bucket\\/wgs-cohort-extractions\\/.*\\/vcfs\\/\"");
   }
 
   private DbWorkspace mockWorkspace() {


### PR DESCRIPTION
Description:

Invoking an extraction job will now put VCF files into the researcher bucket.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
