### PR TITLE
[RW-6317][risk=no] Reactify remaining admin routes

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -323,7 +323,7 @@ const routes: Routes = [
           {
             path: 'banner',
             component: AppRouting,
-            data: {title: 'Create Banner'}
+            data: {}
           },
           {
             path: 'institution',

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -9,8 +9,6 @@ import {SignInGuard} from './guards/sign-in-guard.service';
 import {DataPageComponent} from 'app/pages/data/data-page';
 import {DataSetPageComponent} from 'app/pages/data/data-set/dataset-page';
 import {CohortPageComponent} from './cohort-search/cohort-page/cohort-page.component';
-import {AdminBannerComponent} from './pages/admin/admin-banner';
-import {AdminReviewWorkspaceComponent} from './pages/admin/admin-review-workspace';
 import {CohortReviewComponent} from './pages/data/cohort-review/cohort-review';
 import {DetailPageComponent} from './pages/data/cohort-review/detail-page';
 import {QueryReportComponent} from './pages/data/cohort-review/query-report.component';
@@ -322,7 +320,11 @@ const routes: Routes = [
       {
         path: 'admin',
         children: [
-          // legacy / duplicated routes go HERE
+          {
+            path: 'banner',
+            component: AppRouting,
+            data: {title: 'Create Banner'}
+          },
           {
             path: 'institution',
             component: AppRouting,
@@ -337,6 +339,11 @@ const routes: Routes = [
             path: 'institution/edit/:institutionId',
             component: AppRouting,
             data: {},
+          },
+          {
+            path: 'review-workspace',
+            component: AppRouting,
+            data: {}
           },
           {
             path: 'user', // included for backwards compatibility
@@ -417,17 +424,6 @@ const routes: Routes = [
             path: 'workspaces/:workspaceNamespace',
             component: AppRouting,
             data: {}
-          },
-          // non-migrated routes go HERE
-          {
-            path: 'review-workspace',
-            component: AdminReviewWorkspaceComponent,
-            data: {title: 'Review Workspaces'}
-          },
-          {
-            path: 'banner',
-            component: AdminBannerComponent,
-            data: {title: 'Create Banner'}
           }
         ]
       },

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -359,6 +359,36 @@ const routes: Routes = [
             data: {}
           },
           {
+            path: 'institution/add',
+            component: AppRouting,
+            data: {},
+          },
+          {
+            path: 'institution/edit/:institutionId',
+            component: AppRouting,
+            data: {},
+          },
+          {
+            path: 'user', // included for backwards compatibility
+            component: AppRouting,
+            data: {}
+          },
+          {
+            path: 'users',
+            component: AppRouting,
+            data: {}
+          },
+          {
+            path: 'users/:usernameWithoutGsuiteDomain',
+            component: AppRouting,
+            data: {title: 'User Admin'}
+          },
+          {
+            path: 'user-audit',
+            component: AppRouting,
+            data: {}
+          },
+          {
             path: 'user-audit/:username',
             component: AppRouting,
             data: {}

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -29,6 +29,10 @@ import {SignIn} from './pages/login/sign-in';
 import {WorkspaceLibrary} from './pages/workspace/workspace-library';
 import {AnalyticsTracker} from './utils/analytics';
 import {BreadcrumbType} from './utils/navigation';
+import {AdminUser} from "./pages/admin/admin-user";
+import {AdminUsers} from "./pages/admin/admin-users";
+import {AdminWorkspace} from "./pages/admin/admin-workspace";
+import {AdminWorkspaceSearch} from "./pages/admin/admin-workspace-search";
 
 
 const signInGuard: Guard = {

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -29,8 +29,6 @@ import {SignIn} from './pages/login/sign-in';
 import {WorkspaceLibrary} from './pages/workspace/workspace-library';
 import {AnalyticsTracker} from './utils/analytics';
 import {BreadcrumbType} from './utils/navigation';
-import {AdminUser} from "./pages/admin/admin-user";
-import {AdminUsers} from "./pages/admin/admin-users";
 
 
 const signInGuard: Guard = {

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -29,6 +29,8 @@ import {SignIn} from './pages/login/sign-in';
 import {WorkspaceLibrary} from './pages/workspace/workspace-library';
 import {AnalyticsTracker} from './utils/analytics';
 import {BreadcrumbType} from './utils/navigation';
+import { AdminBanner } from './pages/admin/admin-banner';
+import {AdminReviewWorkspace} from "./pages/admin/admin-review-workspace";
 
 
 const signInGuard: Guard = {
@@ -41,7 +43,9 @@ const registrationGuard: Guard = {
   redirectPath: '/'
 };
 
+const AdminBannerPage = withRouteData(AdminBanner);
 const AdminNotebookViewPage = withRouteData(AdminNotebookView);
+const AdminReviewWorkspacePage = withRouteData(AdminReviewWorkspace);
 const CookiePolicyPage = withRouteData(CookiePolicy);
 const DataUserCodeOfConductPage = fp.flow(withRouteData, withFullHeight)(DataUserCodeOfConduct);
 const HomepagePage = withRouteData(Homepage); // this name is bad i am sorry
@@ -97,6 +101,10 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
           component={() => <HomepagePage routeData={{title: 'Homepage'}}/>}
       />
       <AppRoute
+          path='/admin/banner'
+          component={() => <AdminBannerPage routeData={{title: 'Create Banner'}}/>}
+      />
+      <AppRoute
           path='/admin/institution'
           component={() => <InstitutionAdminPage routeData={{title: 'Institution Admin'}}/>}
       />
@@ -111,6 +119,10 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
       <AppRoute
           path='/admin/user' // included for backwards compatibility
           component={() => <UsersAdminPage routeData={{title: 'User Admin Table'}}/>}
+      />
+      <AppRoute
+          path='/admin/review-workspace'
+          component={() => <AdminReviewWorkspacePage routeData={{title: 'Review Workspaces'}}/>}
       />
       <AppRoute
           path='/admin/users'

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -14,9 +14,11 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 import {Redirect} from 'react-router';
 import {NOTEBOOK_HELP_CONTENT} from './components/help-sidebar';
+import { AdminBanner } from './pages/admin/admin-banner';
 import {AdminInstitution} from './pages/admin/admin-institution';
 import {AdminInstitutionEdit} from './pages/admin/admin-institution-edit';
 import {AdminNotebookView} from './pages/admin/admin-notebook-view';
+import {AdminReviewWorkspace} from './pages/admin/admin-review-workspace';
 import {AdminUser} from './pages/admin/admin-user';
 import {AdminUsers} from './pages/admin/admin-users';
 import {AdminWorkspace} from './pages/admin/admin-workspace';
@@ -29,8 +31,6 @@ import {SignIn} from './pages/login/sign-in';
 import {WorkspaceLibrary} from './pages/workspace/workspace-library';
 import {AnalyticsTracker} from './utils/analytics';
 import {BreadcrumbType} from './utils/navigation';
-import { AdminBanner } from './pages/admin/admin-banner';
-import {AdminReviewWorkspace} from "./pages/admin/admin-review-workspace";
 
 
 const signInGuard: Guard = {

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -29,6 +29,8 @@ import {SignIn} from './pages/login/sign-in';
 import {WorkspaceLibrary} from './pages/workspace/workspace-library';
 import {AnalyticsTracker} from './utils/analytics';
 import {BreadcrumbType} from './utils/navigation';
+import {AdminUser} from "./pages/admin/admin-user";
+import {AdminUsers} from "./pages/admin/admin-users";
 
 
 const signInGuard: Guard = {

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -29,10 +29,6 @@ import {SignIn} from './pages/login/sign-in';
 import {WorkspaceLibrary} from './pages/workspace/workspace-library';
 import {AnalyticsTracker} from './utils/analytics';
 import {BreadcrumbType} from './utils/navigation';
-import {AdminUser} from "./pages/admin/admin-user";
-import {AdminUsers} from "./pages/admin/admin-users";
-import {AdminWorkspace} from "./pages/admin/admin-workspace";
-import {AdminWorkspaceSearch} from "./pages/admin/admin-workspace-search";
 
 
 const signInGuard: Guard = {

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -25,8 +25,6 @@ import {BugReportComponent} from './components/bug-report';
 import {ConfirmDeleteModalComponent} from './components/confirm-delete-modal';
 import {HelpSidebarComponent} from './components/help-sidebar';
 import {RoutingSpinnerComponent} from './components/routing-spinner/component';
-import {AdminBannerComponent} from './pages/admin/admin-banner';
-import {AdminReviewWorkspaceComponent} from './pages/admin/admin-review-workspace';
 import {AppComponent, overriddenUrlKey} from './pages/app/component';
 import {CohortReviewComponent} from './pages/data/cohort-review/cohort-review';
 import {DetailPageComponent} from './pages/data/cohort-review/detail-page';
@@ -116,8 +114,6 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     ClarityModule,
   ],
   declarations: [
-    AdminBannerComponent,
-    AdminReviewWorkspaceComponent,
     AppComponent,
     AppRouting,
     BugReportComponent,

--- a/ui/src/app/pages/admin/admin-banner.tsx
+++ b/ui/src/app/pages/admin/admin-banner.tsx
@@ -1,10 +1,8 @@
-import {Component} from '@angular/core';
 import {BoldHeader, Header} from 'app/components/headers';
 import {TextArea, TextInput} from 'app/components/inputs';
 import {TooltipTrigger} from 'app/components/popups';
 import {statusAlertApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
-import {ReactWrapperBase} from 'app/utils';
 import * as React from 'react';
 import ReactSwitch from 'react-switch';
 import * as validate from 'validate.js';

--- a/ui/src/app/pages/admin/admin-banner.tsx
+++ b/ui/src/app/pages/admin/admin-banner.tsx
@@ -127,12 +127,3 @@ export class AdminBanner extends React.Component<{}, AdminBannerState> {
     </div>;
   }
 }
-
-@Component({
-  template: '<div #root></div>'
-})
-export class AdminBannerComponent extends ReactWrapperBase {
-  constructor() {
-    super(AdminBanner, []);
-  }
-}

--- a/ui/src/app/pages/admin/admin-review-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-review-workspace.tsx
@@ -124,13 +124,3 @@ export const AdminReviewWorkspace = withUserProfile()(class extends React.Compon
     </div>;
   }
 });
-
-
-@Component({
-  template: '<div #root></div>'
-})
-export class AdminReviewWorkspaceComponent extends ReactWrapperBase {
-  constructor() {
-    super(AdminReviewWorkspace, []);
-  }
-}

--- a/ui/src/app/pages/admin/admin-review-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-review-workspace.tsx
@@ -1,4 +1,3 @@
-import {Component} from '@angular/core';
 import {Column} from 'primereact/column';
 import {DataTable} from 'primereact/datatable';
 import * as React from 'react';
@@ -7,7 +6,7 @@ import {BugReportModal} from 'app/components/bug-report';
 import {Button} from 'app/components/buttons';
 import {Spinner, SpinnerOverlay} from 'app/components/spinners';
 import {workspacesApi} from 'app/services/swagger-fetch-clients';
-import {reactStyles, ReactWrapperBase, withUserProfile} from 'app/utils';
+import {reactStyles, withUserProfile} from 'app/utils';
 import {Profile, Workspace} from 'generated/fetch';
 
 const styles = reactStyles({


### PR DESCRIPTION
This is based on `as/reactify-user-admin-routes` because I don't want to cause a huge rebase kerfuffle  with several branches editing the same files at the same time

--

**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
