### PR TITLE
[RW-6318][risk=no] Reactify WorkspaceEditComponent

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -20,7 +20,6 @@ import {ConceptSetActionsComponent} from './pages/data/concept/concept-set-actio
 import {ProfilePageComponent} from './pages/profile/profile-page';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceAboutComponent} from './pages/workspace/workspace-about';
-import {WorkspaceEditComponent, WorkspaceEditMode} from './pages/workspace/workspace-edit';
 import {WorkspaceListComponent} from './pages/workspace/workspace-list';
 import {WorkspaceWrapperComponent} from './pages/workspace/workspace-wrapper/component';
 

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -97,6 +97,13 @@ const routes: Routes = [
             path: 'workspaces',
             canActivateChild: [WorkspaceGuard],
             children: [
+              // legacy / duplicated routes go HERE
+              {
+                path: 'build',
+                component: AppRouting,
+                data: {}
+              },
+              // non-migrated routes go HERE
               {
                 path: '',
                 component: WorkspaceListComponent,
@@ -113,6 +120,18 @@ const routes: Routes = [
                 component: WorkspaceWrapperComponent,
                 runGuardsAndResolvers: 'always',
                 children: [
+                  // legacy / duplicated routes go HERE
+                  {
+                    path: 'edit',
+                    component: AppRouting,
+                    data: {}
+                  },
+                  {
+                    path: 'duplicate',
+                    component: AppRouting,
+                    data: {}
+                  },
+                  // non-migrated routes go HERE
                   {
                     path: 'about',
                     component: WorkspaceAboutComponent,
@@ -120,26 +139,6 @@ const routes: Routes = [
                       title: 'View Workspace Details',
                       breadcrumb: BreadcrumbType.Workspace,
                       helpContentKey: 'about'
-                    }
-                  },
-                  {
-                    path: 'edit',
-                    component: WorkspaceEditComponent,
-                    data: {
-                      title: 'Edit Workspace',
-                      mode: WorkspaceEditMode.Edit,
-                      breadcrumb: BreadcrumbType.WorkspaceEdit,
-                      helpContentKey: 'edit'
-                    }
-                  },
-                  {
-                    path: 'duplicate',
-                    component: WorkspaceEditComponent,
-                    data: {
-                      title: 'Duplicate Workspace',
-                      mode: WorkspaceEditMode.Duplicate,
-                      breadcrumb: BreadcrumbType.WorkspaceDuplicate,
-                      helpContentKey: 'duplicate'
                     }
                   },
                   {
@@ -309,11 +308,6 @@ const routes: Routes = [
             path: 'profile',
             component: ProfilePageComponent,
             data: {title: 'Profile'}
-          },
-          {
-            path: 'workspaces/build',
-            component: WorkspaceEditComponent,
-            data: {title: 'Create Workspace', mode: WorkspaceEditMode.Create}
           }
         ]
       },

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -28,10 +28,10 @@ import {NotebookList} from './pages/analysis/notebook-list';
 import {NotebookRedirect} from './pages/analysis/notebook-redirect';
 import {Homepage} from './pages/homepage/homepage';
 import {SignIn} from './pages/login/sign-in';
+import {WorkspaceEdit, WorkspaceEditMode} from './pages/workspace/workspace-edit';
 import {WorkspaceLibrary} from './pages/workspace/workspace-library';
 import {AnalyticsTracker} from './utils/analytics';
 import {BreadcrumbType} from './utils/navigation';
-import {WorkspaceEdit, WorkspaceEditMode} from "./pages/workspace/workspace-edit";
 
 
 const signInGuard: Guard = {

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -31,6 +31,7 @@ import {SignIn} from './pages/login/sign-in';
 import {WorkspaceLibrary} from './pages/workspace/workspace-library';
 import {AnalyticsTracker} from './utils/analytics';
 import {BreadcrumbType} from './utils/navigation';
+import {WorkspaceEdit, WorkspaceEditMode} from "./pages/workspace/workspace-edit";
 
 
 const signInGuard: Guard = {
@@ -63,6 +64,7 @@ const UserAuditPage = withRouteData(UserAudit);
 const UserDisabledPage = withRouteData(UserDisabled);
 const WorkspaceAdminPage = withRouteData(AdminWorkspace);
 const WorkspaceAuditPage = withRouteData(WorkspaceAudit);
+const WorkspaceEditPage = withRouteData(WorkspaceEdit);
 const WorkspaceSearchAdminPage = withRouteData(AdminWorkspaceSearch);
 const WorkspaceLibraryPage = withRouteData(WorkspaceLibrary);
 
@@ -176,6 +178,35 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
         <AppRoute
           path='/library'
           component={() => <WorkspaceLibraryPage routeData={{title: 'Workspace Library', minimizeChrome: false}}/>}
+        />
+        <AppRoute
+            path='/workspaces/build'
+            component={() => <WorkspaceEditPage
+                routeData={{title: 'Create Workspace'}}
+                workspaceEditMode={WorkspaceEditMode.Create}
+            />}
+        />
+        <AppRoute
+            path='/workspaces/:ns/:wsid/duplicate'
+            component={() => <WorkspaceEditPage
+                routeData={{
+                  title: 'Duplicate Workspace',
+                  breadcrumb: BreadcrumbType.WorkspaceDuplicate,
+                  helpContentKey: 'duplicate'
+                }}
+                workspaceEditMode={WorkspaceEditMode.Duplicate}
+            />}
+        />
+        <AppRoute
+            path='/workspaces/:ns/:wsid/edit'
+            component={() => <WorkspaceEditPage
+                routeData={{
+                  title: 'Edit Workspace',
+                  breadcrumb: BreadcrumbType.WorkspaceEdit,
+                  helpContentKey: 'edit'
+                }}
+                workspaceEditMode={WorkspaceEditMode.Edit}
+            />}
         />
         <AppRoute
           path='/workspaces/:ns/:wsid/notebooks'

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -38,7 +38,6 @@ import {InitialErrorComponent} from './pages/initial-error/component';
 import {ProfilePageComponent} from './pages/profile/profile-page';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceAboutComponent} from './pages/workspace/workspace-about';
-import {WorkspaceEditComponent} from './pages/workspace/workspace-edit';
 import {WorkspaceListComponent} from './pages/workspace/workspace-list';
 import {WorkspaceNavBarComponent} from './pages/workspace/workspace-nav-bar';
 import {WorkspaceShareComponent} from './pages/workspace/workspace-share';
@@ -138,7 +137,6 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     TablePage,
     TextModalComponent,
     WorkspaceAboutComponent,
-    WorkspaceEditComponent,
     WorkspaceListComponent,
     WorkspaceNavBarComponent,
     WorkspaceShareComponent,

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
 
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
-import {cdrVersionStore, currentWorkspaceStore, navigate, routeConfigDataStore, serverConfigStore} from 'app/utils/navigation';
+import {cdrVersionStore, currentWorkspaceStore, navigate, serverConfigStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {DisseminateResearchEnum, ResearchOutcomeEnum, SpecificPopulationEnum,UserApi, WorkspaceAccessLevel, WorkspacesApi} from 'generated/fetch';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
@@ -33,9 +33,10 @@ describe('WorkspaceEdit', () => {
   let workspacesApi: WorkspacesApiStub;
   let userApi: UserApiStub;
   let workspace: WorkspaceData;
+  let workspaceEditMode: WorkspaceEditMode;
 
   const component = () => {
-    return mount(<WorkspaceEdit cancel={() => {}} />);
+    return mount(<WorkspaceEdit cancel={() => {}} workspaceEditMode={workspaceEditMode}/>);
   };
 
   beforeEach(() => {
@@ -58,6 +59,8 @@ describe('WorkspaceEdit', () => {
       }
     };
 
+    workspaceEditMode = WorkspaceEditMode.Create;
+
     userApi = new UserApiStub();
     registerApiClient(UserApi, userApi);
 
@@ -66,7 +69,6 @@ describe('WorkspaceEdit', () => {
 
     currentWorkspaceStore.next(workspace);
     cdrVersionStore.next(cdrVersionListResponse);
-    routeConfigDataStore.next({mode: WorkspaceEditMode.Create});
     serverConfigStore.next({enableBillingUpgrade: true, defaultFreeCreditsDollarLimit: 100.0, gsuiteDomain: ''});
   });
 
@@ -85,7 +87,7 @@ describe('WorkspaceEdit', () => {
   });
 
   it('displays workspaces duplicate page', async () => {
-    routeConfigDataStore.next({mode: WorkspaceEditMode.Duplicate});
+    workspaceEditMode = WorkspaceEditMode.Duplicate;
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find(WorkspaceEditSection).first().text()).toContain(`Duplicate workspace "${workspace.name}"`);
@@ -96,7 +98,7 @@ describe('WorkspaceEdit', () => {
   });
 
   it('displays workspaces edit page', async () => {
-    routeConfigDataStore.next({mode: WorkspaceEditMode.Edit});
+    workspaceEditMode = WorkspaceEditMode.Edit;
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find(WorkspaceEditSection).first().text()).toContain('Edit workspace');
@@ -111,7 +113,7 @@ describe('WorkspaceEdit', () => {
     // specific population group.
     workspace.researchPurpose.populationDetails = [SpecificPopulationEnum.AGECHILDREN];
 
-    routeConfigDataStore.next({mode: WorkspaceEditMode.Edit});
+    workspaceEditMode = WorkspaceEditMode.Edit;
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
 
@@ -129,7 +131,7 @@ describe('WorkspaceEdit', () => {
     workspace.researchPurpose.populationDetails = [SpecificPopulationEnum.AGECHILDREN,
       SpecificPopulationEnum.RACEMENA, SpecificPopulationEnum.DISABILITYSTATUS];
 
-    routeConfigDataStore.next({mode: WorkspaceEditMode.Edit});
+    workspaceEditMode = WorkspaceEditMode.Edit
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
 
@@ -188,7 +190,7 @@ describe('WorkspaceEdit', () => {
   });
 
   it('supports disable save button if Research Outcome is not answered', async () => {
-    routeConfigDataStore.next({mode: WorkspaceEditMode.Duplicate});
+    workspaceEditMode = WorkspaceEditMode.Duplicate;
     workspace.researchPurpose.researchOutcomeList = []
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
@@ -201,7 +203,7 @@ describe('WorkspaceEdit', () => {
   });
 
   it('supports successful duplication', async() => {
-    routeConfigDataStore.next({mode: WorkspaceEditMode.Duplicate});
+    workspaceEditMode = WorkspaceEditMode.Duplicate;
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
 
@@ -224,7 +226,7 @@ describe('WorkspaceEdit', () => {
     currentWorkspaceStore.next(altCdrWorkspace);
 
     // duplication will involve a CDR version upgrade by default
-    routeConfigDataStore.next({mode: WorkspaceEditMode.Duplicate});
+    workspaceEditMode = WorkspaceEditMode.Duplicate;
 
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
@@ -246,7 +248,7 @@ describe('WorkspaceEdit', () => {
     const defaultCdrWorkspace = {...workspace, cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID}
     currentWorkspaceStore.next(defaultCdrWorkspace);
 
-    routeConfigDataStore.next({mode: WorkspaceEditMode.Duplicate});
+    workspaceEditMode = WorkspaceEditMode.Duplicate;
 
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
@@ -260,7 +262,7 @@ describe('WorkspaceEdit', () => {
 
   // regression test for RW-5132
   it('prevents multiple Workspace creations via the same confirmation dialog', async() => {
-    routeConfigDataStore.next({mode: WorkspaceEditMode.Duplicate});
+    workspaceEditMode = WorkspaceEditMode.Duplicate;
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
 
@@ -285,7 +287,7 @@ describe('WorkspaceEdit', () => {
   });
 
   it('supports waiting on access delays', async () => {
-    routeConfigDataStore.next({mode: WorkspaceEditMode.Duplicate});
+    workspaceEditMode = WorkspaceEditMode.Duplicate;
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
 
@@ -317,7 +319,7 @@ describe('WorkspaceEdit', () => {
   });
 
   it('shows confirmation on extended access delays', async() => {
-    routeConfigDataStore.next({mode: WorkspaceEditMode.Duplicate});
+    workspaceEditMode = WorkspaceEditMode.Duplicate;
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
 

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -233,6 +233,7 @@ export interface WorkspaceEditProps {
   profileState: {
     profile: Profile;
   };
+  workspaceEditMode: WorkspaceEditMode;
 }
 
 export interface WorkspaceEditState {
@@ -251,7 +252,7 @@ export interface WorkspaceEditState {
   workspace: Workspace;
   workspaceCreationConflictError: boolean;
   workspaceCreationError: boolean;
-  workspaceCreationErrorMessage: string;
+  workspaceCreationErrorMessage: string
   workspaceNewAclDelayed: boolean;
   workspaceNewAclDelayedContinueFn: Function;
 }
@@ -280,6 +281,10 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
         workspaceNewAclDelayed: false,
         workspaceNewAclDelayedContinueFn: () => {},
       };
+    }
+
+    cancel(): void {
+      history.back();
     }
 
     async fetchBillingAccounts() {
@@ -615,8 +620,8 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
     renderHeader() {
       // use workspace name from props instead of state here
       // because it's a record of the initial value
-      const {routeConfigData: {mode}, workspace} = this.props;
-      switch (mode) {
+      const {workspace, workspaceEditMode} = this.props;
+      switch (workspaceEditMode) {
         case WorkspaceEditMode.Create:
           return 'Create a new workspace';
         case WorkspaceEditMode.Edit:
@@ -627,7 +632,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
     }
 
     renderButtonText() {
-      switch (this.props.routeConfigData.mode) {
+      switch (this.props.workspaceEditMode) {
         case WorkspaceEditMode.Create: return 'Create Workspace';
         case WorkspaceEditMode.Edit: return 'Update Workspace';
         case WorkspaceEditMode.Duplicate: return 'Duplicate Workspace';
@@ -787,7 +792,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             errorMsg = error.message;
           } else {
             errorMsg = `Could not
-            ${this.props.routeConfigData.mode === WorkspaceEditMode.Create ?
+            ${this.props.workspaceEditMode === WorkspaceEditMode.Create ?
                 ' create ' : ' update '} workspace.`;
           }
 
@@ -807,7 +812,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
     }
 
     isMode(mode) {
-      return this.props.routeConfigData.mode === mode;
+      return this.props.workspaceEditMode === mode;
     }
 
     buildBillingAccountOptions() {
@@ -1334,7 +1339,7 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
         <div>
           <FlexRow style={{marginTop: '1rem', marginBottom: '1rem'}}>
             <Button type='secondary' style={{marginRight: '1rem'}}
-                    onClick = {() => this.props.cancel()}>
+                    onClick = {() => this.cancel()}>
               Cancel
             </Button>
             <TooltipTrigger content={
@@ -1378,10 +1383,10 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
             { workspaceCreationErrorMessage }
           </ModalBody>
           <ModalFooter>
-            <Button onClick = {() => this.props.cancel()}
+            <Button onClick = {() => this.cancel()}
                 type='secondary' style={{marginRight: '2rem'}}>
               Cancel
-              {this.props.routeConfigData.mode === WorkspaceEditMode.Create ?
+              {this.props.workspaceEditMode === WorkspaceEditMode.Create ?
                 ' Creation' : ' Update'}
                 </Button>
             <Button type='primary' onClick={() => this.resetWorkspaceEditor()}>Keep Editing</Button>
@@ -1392,17 +1397,17 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
           <CreateBillingAccountModal onClose={() => this.setState({showCreateBillingAccountModal: false})} />}
         {workspaceCreationConflictError &&
         <Modal>
-          <ModalTitle>{this.props.routeConfigData.mode === WorkspaceEditMode.Create ?
+          <ModalTitle>{this.props.workspaceEditMode === WorkspaceEditMode.Create ?
               'Error: ' : 'Conflicting update:'}</ModalTitle>
           <ModalBody>
-            {this.props.routeConfigData.mode === WorkspaceEditMode.Create ?
+            {this.props.workspaceEditMode === WorkspaceEditMode.Create ?
               'You already have a workspace named ' + name +
               ' Please choose another name' :
               'Another client has modified this workspace since the beginning of this editing ' +
               'session. Please reload to avoid overwriting those changes.'}
           </ModalBody>
           <ModalFooter>
-            <Button type='secondary' onClick = {() => this.props.cancel()}
+            <Button type='secondary' onClick = {() => this.cancel()}
                     style={{marginRight: '2rem'}}>Cancel Creation</Button>
             <Button type='primary' onClick={() => this.resetWorkspaceEditor()}>Keep Editing</Button>
           </ModalFooter>
@@ -1470,18 +1475,3 @@ export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace
     }
 
   });
-
-@Component({
-  template: '<div #root></div>'
-})
-export class WorkspaceEditComponent extends ReactWrapperBase {
-
-  constructor(private _location: Location) {
-    super(WorkspaceEdit, ['cancel']);
-    this.cancel = this.cancel.bind(this);
-  }
-
-  cancel(): void {
-    this._location.back();
-  }
-}

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -2,8 +2,6 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 import * as validate from 'validate.js';
 
-import {Location} from '@angular/common';
-import {Component} from '@angular/core';
 import {Button, Clickable, Link, StyledAnchorTag} from 'app/components/buttons';
 import {FadeBox} from 'app/components/containers';
 import {FlexColumn, FlexRow} from 'app/components/flex';
@@ -39,7 +37,6 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {
   formatFreeCreditsUSD,
   reactStyles,
-  ReactWrapperBase,
   sliceByHalfLength,
   withCdrVersions,
   withCurrentWorkspace,
@@ -252,7 +249,7 @@ export interface WorkspaceEditState {
   workspace: Workspace;
   workspaceCreationConflictError: boolean;
   workspaceCreationError: boolean;
-  workspaceCreationErrorMessage: string
+  workspaceCreationErrorMessage: string;
   workspaceNewAclDelayed: boolean;
   workspaceNewAclDelayedContinueFn: Function;
 }

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -40,7 +40,6 @@ import {
   sliceByHalfLength,
   withCdrVersions,
   withCurrentWorkspace,
-  withRouteConfigData,
   withUserProfile
 } from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
@@ -223,7 +222,6 @@ const CdrVersionUpgrade = (props: UpgradeProps) => {
 };
 
 export interface WorkspaceEditProps {
-  routeConfigData: any;
   cdrVersionListResponse: CdrVersionListResponse;
   workspace: WorkspaceData;
   cancel: Function;
@@ -254,7 +252,7 @@ export interface WorkspaceEditState {
   workspaceNewAclDelayedContinueFn: Function;
 }
 
-export const WorkspaceEdit = fp.flow(withRouteConfigData(), withCurrentWorkspace(), withCdrVersions(), withUserProfile())(
+export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), withUserProfile())(
   class WorkspaceEditCmp extends React.Component<WorkspaceEditProps, WorkspaceEditState> {
     constructor(props: WorkspaceEditProps) {
       super(props);


### PR DESCRIPTION
Moved workspaceEditMode to props from routeData because this is the only component to use that concept.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
