### PR TITLE
[risk=no] RW-6387 Cleanup: remove single-tier bufferCapacity config param

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -26,7 +26,6 @@
     "projectNamePrefix": "aou-rw-local1-",
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 2,
-    "bufferCapacity": 10,
     "bufferCapacityPerTier": {
       "registered": 10,
       "controlled_test": 10

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -26,7 +26,6 @@
     "projectNamePrefix": "aou-rw-perf-",
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 4,
-    "bufferCapacity": 300,
     "bufferCapacityPerTier": {
       "registered": 300
     },

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -26,7 +26,6 @@
     "projectNamePrefix": "aou-rw-preprod-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 4,
-    "bufferCapacity": 20,
     "bufferCapacityPerTier": {
       "registered": 20
     },

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -26,7 +26,6 @@
     "projectNamePrefix": "aou-rw-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 4,
-    "bufferCapacity": 200,
     "bufferCapacityPerTier": {
       "registered": 200
     },

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -26,7 +26,6 @@
     "projectNamePrefix": "aou-rw-stable-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 2,
-    "bufferCapacity": 10,
     "bufferCapacityPerTier": {
       "registered": 10
     },

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -26,7 +26,6 @@
     "projectNamePrefix": "aou-rw-staging-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
     "retryCount": 2,
-    "bufferCapacity": 50,
     "bufferCapacityPerTier": {
       "registered": 50
     },

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -26,7 +26,6 @@
     "projectNamePrefix": "aou-rw-test-",
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 2,
-    "bufferCapacity": 300,
     "bufferCapacityPerTier": {
       "registered": 300,
       "controlled_test": 100

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -61,10 +61,6 @@ public class WorkbenchConfig {
   public static class BillingConfig {
     // This config variable seems to be unused.
     public Integer retryCount;
-    // The total capacity of the GCP project buffer, assuming a single tier.
-    // Scheduled to be removed after bufferCapacityPerTier is enabled in all environments.
-    // https://precisionmedicineinitiative.atlassian.net/browse/RW-6387
-    @Deprecated public Integer bufferCapacity;
     // The total capacity of the GCP project buffer, per access tier. The buffering system will not
     // attempt to create any new projects in a tier when the total number of in-progress & ready
     // projects is at or above this level.


### PR DESCRIPTION
Removes bufferCapacity from WorkbenchConfig

**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
