### PR TITLE
[no ticket][risk=no] CircleCI config: add check to exit e2e test job early

### DIFF
--- a/.circleci/skip-e2e-pr-checks.sh
+++ b/.circleci/skip-e2e-pr-checks.sh
@@ -15,7 +15,7 @@ fi
 # Get the commit message. Exiting job early if the commit message contains 'skip e2e' string.
 COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s")
 
-# Double comma is "Parameter Expansion". It converts string to lowercase letters
+# Double comma is "Parameter Expansion". It converts string to lowercase letters.
 if [[ "${COMMIT_MESSAGE,,}" == *"skip e2e"* ]]; then
   echo "Skip e2e text found in commit message"
   circleci-agent step halt
@@ -23,7 +23,7 @@ else
   echo "not found skip e2e text"
 fi
 
-# Exiting on PR branch when files matching ignore patterns are the only changed files in the last commit.
+# Exiting CI job when files matching ignore patterns are the only changed files in the last commit.
 # The grep command exits with '0' status when it's successful (match were found).
 # While it exits with status '1' when no match was found.
 git diff --name-only HEAD^ HEAD | grep -qvFf .circleci/e2e-job-ignore-patterns.txt

--- a/.circleci/skip-e2e-pr-checks.sh
+++ b/.circleci/skip-e2e-pr-checks.sh
@@ -23,8 +23,17 @@ else
   echo "not found skip e2e text"
 fi
 
+# Exiting on PR branch when files matching ignore patterns are the only changed files in the last commit.
+# The grep command exits with '0' status when it's successful (match were found).
+# While it exits with status '1' when no match was found.
+git diff --name-only HEAD^ HEAD | grep -qvFf .circleci/e2e-job-ignore-patterns.txt
+STATUS=$?
+if [[ "$STATUS" -eq 1 ]]; then
+  echo "Files matching ignore patterns are the only changed files made in the last commit. Exiting job."
+  circleci-agent step halt
+fi
+
 # Exiting on PR branch when all (changed) file names matched ignore pattern.
-# The grep command exits with '0' status when it's successful (match were found). While it exits with status '1' when no match was found.
 git diff --name-only $(git merge-base origin/master ${CIRCLE_BRANCH}) | grep -qvFf .circleci/e2e-job-ignore-patterns.txt
 STATUS=$?
 if [[ "$STATUS" -eq 1 ]]; then

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -2,6 +2,7 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
 
+
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {cdrVersionStore, currentWorkspaceStore, navigate, serverConfigStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -2,7 +2,6 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
 
-
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {cdrVersionStore, currentWorkspaceStore, navigate, serverConfigStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';


### PR DESCRIPTION
Exit CircleCI e2e (puppeteer) job if changed files in the last commit match ignore patterns are the only changed files in the last commit.

Before:
In this [CI run](https://app.circleci.com/pipelines/github/all-of-us/workbench/8210/workflows/e969afc0-6789-40ff-b6a7-903963c86a95), only one UI test were changed in the last commit. It's okay to skip running Puppeteer tests because UI test name is one of many ignore patterns.

After (e2e job exited early due to the check):
[CI run](https://app.circleci.com/pipelines/github/all-of-us/workbench/8235/workflows/8d800e2f-7a81-4ff4-9581-30336499a70d)