### PR TITLE
[risk=low][RW-6187] Populate a new DbUserAccessTier whenever Registration status is updated

### DIFF
--- a/api/db/changelog/db.changelog-157-add-user-access-tier.xml
+++ b/api/db/changelog/db.changelog-157-add-user-access-tier.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="thibault" id="changelog-157-add-user-access-tier">
+
+    <createTable tableName="user_access_tier">
+      <column name="user_access_tier_id" type="bigint" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="user_id" type="bigint">
+        <constraints nullable="false"
+          foreignKeyName="fk_user_access_tier_user"
+          references="user(user_id)"
+          deleteCascade="true"/>
+      </column>
+      <column name="access_tier_id" type="bigint">
+        <constraints nullable="false"
+          foreignKeyName="fk_user_access_tier_access_tier"
+          references="access_tier(access_tier_id)"
+          deleteCascade="true"/>
+      </column>
+      <column name="access_status" type="tinyint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="first_enabled" type="datetime">
+       <constraints nullable="false"/>
+      </column>
+      <column name="last_updated" type="datetime">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <addUniqueConstraint
+      columnNames="user_id, access_tier_id"
+      constraintName="user_access_tier_pair"
+      tableName="user_access_tier"
+    />
+
+    <!--
+    migration from user.data_access_level:
+    Populate this table with a Registered Tier entry for all users who are Registered.
+    There are no Protected or Controlled Tier users to migrate.
+    -->
+
+    <sql>
+      INSERT INTO user_access_tier
+      (user_id, access_tier_id, access_status, first_enabled, last_updated)
+
+      SELECT
+      u.user_id,
+      a.access_tier_id,
+      1 AS access_status, -- TierAccessStatus.ENABLED
+      u.first_registration_completion_time AS first_enabled,
+      NOW() AS last_updated
+
+      FROM user u, access_tier a
+      WHERE a.short_name = 'registered'
+
+      -- Registered and Protected; no Protected users exist in Prod
+      AND u.data_access_level IN (1, 2)
+
+      -- valid dates exist for all Registered users in Prod
+      AND u.first_registration_completion_time IS NOT NULL
+    </sql>
+
+    <!--
+    A step in the migration away from data_access_level before we can delete it: when we remove
+    accessors to a column but not the column itself, Hibernate requires a default value.
+    Set it to DataAccessLevel.UNREGISTERED (0)
+     -->
+    <addDefaultValue tableName="user" columnName="data_access_level" defaultValue="0"/>
+
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -166,7 +166,7 @@
   <include file="changelog/db.changelog-154-wgs-cromwell-extract-submission.xml"/>
   <include file="changelog/db.changelog-155-add-ras-link-entries.xml"/>
   <include file="changelog/db.changelog-156-billing-buffer-entry-status-index.xml"/>
-
+  <include file="changelog/db.changelog-157-add-user-access-tier.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -4,7 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static org.pmiops.workbench.utils.TestMockFactory.createDefaultAccessTier;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTierForTests;
 
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.common.collect.ImmutableList;
@@ -194,7 +194,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     cdrVersion.setCdrVersionId(1L);
     cdrVersion.setBigqueryDataset(testWorkbenchConfig.bigquery.dataSetId);
     cdrVersion.setBigqueryProject(testWorkbenchConfig.bigquery.projectId);
-    cdrVersion.setAccessTier(createDefaultAccessTier(accessTierDao));
+    cdrVersion.setAccessTier(createRegisteredTierForTests(accessTierDao));
     CdrVersionContext.setCdrVersionNoCheckAuthDomain(cdrVersion);
 
     cdrVersion = cdrVersionDao.save(cdrVersion);

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
@@ -7,12 +7,17 @@ import org.pmiops.workbench.db.model.DbUser;
 public interface AccessTierService {
   String REGISTERED_TIER_SHORT_NAME = "registered";
 
-  List<DbAccessTier> getAccessTiersForUser(DbUser user);
-
-  // currently the required tier in some contexts
-  DbAccessTier getRegisteredTier();
+  List<DbAccessTier> getAllTiers();
 
   DbAccessTier getAccessTier(String shortName);
 
-  List<DbAccessTier> getAllTiers();
+  DbAccessTier getRegisteredTier();
+
+  void addUserToAllTiers(DbUser user);
+
+  void removeUserFromRegisteredTier(DbUser user);
+
+  void addUserToRegisteredTier(DbUser user);
+
+  List<DbAccessTier> getAccessTiersForUser(DbUser user);
 }

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
@@ -20,7 +20,7 @@ public interface AccessTierService {
    * Return the access tier referred to by the shortName in the database
    *
    * @param shortName the short name of the access tier to look up in the database
-   * @return an {@code Option<DbAccessTier>} if one matches the shortName passed in, EMPTY otherwise
+   * @return an {@code Optional<DbAccessTier>} if one matches the shortName passed in, EMPTY otherwise
    */
   Optional<DbAccessTier> getAccessTier(String shortName);
 

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
@@ -20,7 +20,8 @@ public interface AccessTierService {
    * Return the access tier referred to by the shortName in the database
    *
    * @param shortName the short name of the access tier to look up in the database
-   * @return an {@code Optional<DbAccessTier>} if one matches the shortName passed in, EMPTY otherwise
+   * @return an {@code Optional<DbAccessTier>} if one matches the shortName passed in, EMPTY
+   *     otherwise
    */
   Optional<DbAccessTier> getAccessTier(String shortName);
 

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
@@ -33,16 +33,16 @@ public interface AccessTierService {
   DbAccessTier getRegisteredTier();
 
   /**
-   * Add memberships to all tiers for a user if they don't exist by inserting DB row(s). For any
-   * memberships which exist, update them (whether enabled or not) set them to ENABLED.
+   * Add memberships to all tiers for a user if they don't exist by inserting DB row(s) set to
+   * ENABLED. For any memberships which exist and are DISABLED, set them to ENABLED.
    *
    * @param user the DbUser in the user-accessTier mappings we're updating
    */
   void addUserToAllTiers(DbUser user);
 
   /**
-   * Remove a Registered Tier membership from a user if one exists by marking that membership as
-   * DISABLED. Do nothing if no membership exists.
+   * Remove a Registered Tier membership from a user if one exists and is ENABLED by marking that
+   * membership as DISABLED. Do nothing if no membership exists.
    *
    * <p>Currently, this does not synchronize Terra Auth Domain group membership, but it will do so
    * when the user_access_tier table is the source of truth for tier membership. The existing method
@@ -54,8 +54,8 @@ public interface AccessTierService {
   void removeUserFromRegisteredTier(DbUser user);
 
   /**
-   * Add a Registered Tier membership to a user if none exists by inserting a DB row. If such a
-   * membership exists (whether enabled or not) set it to ENABLED.
+   * Add a Registered Tier membership to a user if none exists by inserting a DB row set to ENABLED.
+   * If such a membership exists and is DISABLED, set it to ENABLED.
    *
    * <p>Currently, this does not synchronize Terra Auth Domain group membership, but it will do so
    * when the user_access_tier table is the source of truth for tier membership. The existing method

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
@@ -20,7 +20,7 @@ public interface AccessTierService {
    * Return the access tier referred to by the shortName in the database
    *
    * @param shortName the short name of the access tier to look up in the database
-   * @return an Option\<DbAccessTier\> if one matches the shortName passed in, EMPTY otherwise
+   * @return an {@code Option<DbAccessTier>} if one matches the shortName passed in, EMPTY otherwise
    */
   Optional<DbAccessTier> getAccessTier(String shortName);
 

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
@@ -1,23 +1,71 @@
 package org.pmiops.workbench.access;
 
 import java.util.List;
+import java.util.Optional;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.exceptions.ServerErrorException;
 
 public interface AccessTierService {
   String REGISTERED_TIER_SHORT_NAME = "registered";
 
+  /**
+   * Return all access tiers in the database
+   *
+   * @return the List of all DbAccessTiers in the database
+   */
   List<DbAccessTier> getAllTiers();
 
-  DbAccessTier getAccessTier(String shortName);
+  /**
+   * Return the access tier referred to by the shortName in the database
+   *
+   * @param shortName the short name of the access tier to look up in the database
+   * @return an Option\<DbAccessTier\> if one matches the shortName passed in, EMPTY otherwise
+   */
+  Optional<DbAccessTier> getAccessTier(String shortName);
 
+  /**
+   * Return the Registered Tier if it exists in the database
+   *
+   * @return a DbAccessTier representing the Registered Tier
+   * @throws ServerErrorException if there is no Registered Tier
+   */
   DbAccessTier getRegisteredTier();
 
+  /**
+   * Add memberships to all tiers for a user if they don't exist by inserting DB row(s). For any
+   * memberships which exist, update them (whether enabled or not) set them to ENABLED.
+   *
+   * @param user the DbUser in the user-accessTier mappings we're updating
+   */
   void addUserToAllTiers(DbUser user);
 
+  /**
+   * Remove a Registered Tier membership from a user if one exists by marking that membership as
+   * DISABLED. Do nothing if no membership exists.
+   *
+   * @param user the DbUser in the user-accessTier mapping we're updating
+   */
   void removeUserFromRegisteredTier(DbUser user);
 
+  /**
+   * Add a Registered Tier membership to a user if none exists by inserting a DB row. If such a
+   * membership exists (whether enabled or not) set it to ENABLED.
+   *
+   * @param user the DbUser in the user-accessTier mapping we're updating
+   */
   void addUserToRegisteredTier(DbUser user);
 
+  /**
+   * A placeholder implementation until we establish userAccessTierDao as the source of truth for
+   * access tier membership.
+   *
+   * <p>For registered users, return the registered tier or all tiers if we're in an environment
+   * which has enabled all tiers for registered users. Return no access tiers for unregistered
+   * users.
+   *
+   * @param user the user whose access we're checking
+   * @return The List of DbAccessTiers the DbUser has access to in this environment
+   */
   List<DbAccessTier> getAccessTiersForUser(DbUser user);
 }

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
@@ -44,6 +44,11 @@ public interface AccessTierService {
    * Remove a Registered Tier membership from a user if one exists by marking that membership as
    * DISABLED. Do nothing if no membership exists.
    *
+   * <p>Currently, this does not synchronize Terra Auth Domain group membership, but it will do so
+   * when the user_access_tier table is the source of truth for tier membership. The existing method
+   * UserServiceImpl.removeFromRegisteredTierGroupIdempotent() continues to handle group membership
+   * until then.
+   *
    * @param user the DbUser in the user-accessTier mapping we're updating
    */
   void removeUserFromRegisteredTier(DbUser user);
@@ -51,6 +56,11 @@ public interface AccessTierService {
   /**
    * Add a Registered Tier membership to a user if none exists by inserting a DB row. If such a
    * membership exists (whether enabled or not) set it to ENABLED.
+   *
+   * <p>Currently, this does not synchronize Terra Auth Domain group membership, but it will do so
+   * when the user_access_tier table is the source of truth for tier membership. The existing method
+   * UserServiceImpl.addToRegisteredTierGroupIdempotent() continues to handle group membership until
+   * then.
    *
    * @param user the DbUser in the user-accessTier mapping we're updating
    */

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
@@ -48,7 +48,8 @@ public class AccessTierServiceImpl implements AccessTierService {
    * Return the access tier referred to by the shortName in the database
    *
    * @param shortName the short name of the access tier to look up in the database
-   * @return an {@code Optional<DbAccessTier>} if one matches the shortName passed in, EMPTY otherwise
+   * @return an {@code Optional<DbAccessTier>} if one matches the shortName passed in, EMPTY
+   *     otherwise
    */
   public Optional<DbAccessTier> getAccessTier(String shortName) {
     return accessTierDao.findOneByShortName(shortName);

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
@@ -121,7 +121,7 @@ public class AccessTierServiceImpl implements AccessTierService {
 
       // don't update if already ENABLED
       if (entryToUpdate.getTierAccessStatusEnum() == TierAccessStatus.DISABLED) {
-         userAccessTierDao.save(
+        userAccessTierDao.save(
             entryToUpdate.setTierAccessStatus(TierAccessStatus.ENABLED).setLastUpdated());
       }
     } else {

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
@@ -48,7 +48,7 @@ public class AccessTierServiceImpl implements AccessTierService {
    * Return the access tier referred to by the shortName in the database
    *
    * @param shortName the short name of the access tier to look up in the database
-   * @return an {@code Option<DbAccessTier>} if one matches the shortName passed in, EMPTY otherwise
+   * @return an {@code Optional<DbAccessTier>} if one matches the shortName passed in, EMPTY otherwise
    */
   public Optional<DbAccessTier> getAccessTier(String shortName) {
     return accessTierDao.findOneByShortName(shortName);

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
@@ -3,12 +3,16 @@ package org.pmiops.workbench.access;
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import javax.inject.Provider;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.AccessTierDao;
+import org.pmiops.workbench.db.dao.UserAccessTierDao;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserAccessTier;
 import org.pmiops.workbench.model.DataAccessLevel;
+import org.pmiops.workbench.model.TierAccessStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -18,16 +22,106 @@ public class AccessTierServiceImpl implements AccessTierService {
   private final Provider<WorkbenchConfig> configProvider;
 
   private final AccessTierDao accessTierDao;
+  private final UserAccessTierDao userAccessTierDao;
 
   @Autowired
   public AccessTierServiceImpl(
-      Provider<WorkbenchConfig> configProvider, AccessTierDao accessTierDao) {
+      Provider<WorkbenchConfig> configProvider,
+      AccessTierDao accessTierDao,
+      UserAccessTierDao userAccessTierDao) {
     this.configProvider = configProvider;
     this.accessTierDao = accessTierDao;
+    this.userAccessTierDao = userAccessTierDao;
+  }
+
+  public List<DbAccessTier> getAllTiers() {
+    return accessTierDao.findAll();
+  }
+
+  public DbAccessTier getAccessTier(String shortName) {
+    return accessTierDao.findOneByShortName(shortName);
+  }
+
+  public DbAccessTier getRegisteredTier() {
+    return getAccessTier(REGISTERED_TIER_SHORT_NAME);
   }
 
   /**
-   * A placeholder implementation until we complete the Controlled Tier access modules.
+   * Add memberships to all tiers for a user if they don't exist by inserting DB row(s). For any
+   * memberships which exist, update them (whether enabled or not) set them to ENABLED.
+   *
+   * @param user the DbUser in the user-accessTier mappings we're updating
+   */
+  public void addUserToAllTiers(DbUser user) {
+    getAllTiers().forEach(tier -> addUserToTier(user, tier));
+  }
+
+  /**
+   * Add a Registered Tier membership to a user if none exists by inserting a DB row. If such a
+   * membership exists (whether enabled or not) set it to ENABLED.
+   *
+   * @param user the DbUser in the user-accessTier mapping we're updating
+   */
+  public void addUserToRegisteredTier(DbUser user) {
+    addUserToTier(user, getRegisteredTier());
+  }
+
+  /**
+   * Remove a Registered Tier membership from a user if one exists by marking that membership as
+   * DISABLED. Do nothing if no membership exists.
+   *
+   * @param user the DbUser in the user-accessTier mapping we're updating
+   */
+  public void removeUserFromRegisteredTier(DbUser user) {
+    removeUserFromTier(user, getRegisteredTier());
+  }
+
+  /**
+   * Add a tier membership to a user if none exists by inserting a DB row. If such a membership
+   * exists (whether enabled or not) set it to ENABLED.
+   *
+   * @param user the DbUser in the user-accessTier mapping we're updating
+   * @param accessTier the DbAccessTier in the user-accessTier mapping we're updating
+   */
+  private void addUserToTier(DbUser user, DbAccessTier accessTier) {
+    Optional<DbUserAccessTier> existingEntryMaybe =
+        userAccessTierDao.getByUserAndAccessTier(user, accessTier);
+
+    if (existingEntryMaybe.isPresent()) {
+      final DbUserAccessTier entryToUpdate =
+          existingEntryMaybe.get().setAccessStatus(TierAccessStatus.ENABLED).setLastUpdated();
+      userAccessTierDao.save(entryToUpdate);
+    } else {
+      final DbUserAccessTier entryToInsert =
+          new DbUserAccessTier()
+              .setUser(user)
+              .setAccessTier(accessTier)
+              .setAccessStatus(TierAccessStatus.ENABLED)
+              .setFirstEnabled()
+              .setLastUpdated();
+      userAccessTierDao.save(entryToInsert);
+    }
+  }
+
+  /**
+   * Remove a tier membership from a user if one exists by marking that membership as DISABLED. Do
+   * nothing if no membership exists.
+   *
+   * @param user the DbUser in the user-accessTier mapping we're updating
+   * @param accessTier the DbAccessTier in the user-accessTier mapping we're updating
+   */
+  private void removeUserFromTier(DbUser user, DbAccessTier accessTier) {
+    userAccessTierDao
+        .getByUserAndAccessTier(user, accessTier)
+        .ifPresent(
+            entryToSoftDelete ->
+                userAccessTierDao.save(
+                    entryToSoftDelete.setAccessStatus(TierAccessStatus.DISABLED).setLastUpdated()));
+  }
+
+  /**
+   * A placeholder implementation until we establish userAccessTierDao as the source of truth for
+   * user - access tier membership.
    *
    * <p>For registered users, return the registered tier or all tiers if we're in an environment
    * which has enabled all tiers for registered users. Return no access tiers for unregistered
@@ -46,17 +140,5 @@ public class AccessTierServiceImpl implements AccessTierService {
     } else {
       return Collections.emptyList();
     }
-  }
-
-  public DbAccessTier getRegisteredTier() {
-    return getAccessTier(REGISTERED_TIER_SHORT_NAME);
-  }
-
-  public DbAccessTier getAccessTier(String shortName) {
-    return accessTierDao.findOneByShortName(shortName);
-  }
-
-  public List<DbAccessTier> getAllTiers() {
-    return accessTierDao.findAll();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
@@ -48,7 +48,7 @@ public class AccessTierServiceImpl implements AccessTierService {
    * Return the access tier referred to by the shortName in the database
    *
    * @param shortName the short name of the access tier to look up in the database
-   * @return an Option\<DbAccessTier\> if one matches the shortName passed in, EMPTY otherwise
+   * @return an {@code Option<DbAccessTier>} if one matches the shortName passed in, EMPTY otherwise
    */
   public Optional<DbAccessTier> getAccessTier(String shortName) {
     return accessTierDao.findOneByShortName(shortName);

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
@@ -35,20 +35,34 @@ public class AccessTierServiceImpl implements AccessTierService {
     this.userAccessTierDao = userAccessTierDao;
   }
 
+  /**
+   * Return all access tiers in the database
+   *
+   * @return the List of all DbAccessTiers in the database
+   */
   public List<DbAccessTier> getAllTiers() {
     return accessTierDao.findAll();
   }
 
-  public DbAccessTier getAccessTier(String shortName) {
+  /**
+   * Return the access tier referred to by the shortName in the database
+   *
+   * @param shortName the short name of the access tier to look up in the database
+   * @return an Option\<DbAccessTier\> if one matches the shortName passed in, EMPTY otherwise
+   */
+  public Optional<DbAccessTier> getAccessTier(String shortName) {
     return accessTierDao.findOneByShortName(shortName);
   }
 
+  /**
+   * Return the Registered Tier if it exists in the database
+   *
+   * @return a DbAccessTier representing the Registered Tier
+   * @throws ServerErrorException if there is no Registered Tier
+   */
   public DbAccessTier getRegisteredTier() {
-    final DbAccessTier registeredTier = getAccessTier(REGISTERED_TIER_SHORT_NAME);
-    if (registeredTier == null) {
-      throw new ServerErrorException("Cannot find Registered Tier in database.");
-    }
-    return registeredTier;
+    return getAccessTier(REGISTERED_TIER_SHORT_NAME)
+        .orElseThrow(() -> new ServerErrorException("Cannot find Registered Tier in database."));
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
@@ -79,6 +79,11 @@ public class AccessTierServiceImpl implements AccessTierService {
    * Add a Registered Tier membership to a user if none exists by inserting a DB row. If such a
    * membership exists (whether enabled or not) set it to ENABLED.
    *
+   * <p>Currently, this does not synchronize Terra Auth Domain group membership, but it will do so
+   * when the user_access_tier table is the source of truth for tier membership. The existing method
+   * UserServiceImpl.addToRegisteredTierGroupIdempotent() continues to handle group membership until
+   * then.
+   *
    * @param user the DbUser in the user-accessTier mapping we're updating
    */
   public void addUserToRegisteredTier(DbUser user) {
@@ -88,6 +93,11 @@ public class AccessTierServiceImpl implements AccessTierService {
   /**
    * Remove a Registered Tier membership from a user if one exists by marking that membership as
    * DISABLED. Do nothing if no membership exists.
+   *
+   * <p>Currently, this does not synchronize Terra Auth Domain group membership, but it will do so
+   * when the user_access_tier table is the source of truth for tier membership. The existing method
+   * UserServiceImpl.removeFromRegisteredTierGroupIdempotent() continues to handle group membership
+   * until then.
    *
    * @param user the DbUser in the user-accessTier mapping we're updating
    */

--- a/api/src/main/java/org/pmiops/workbench/db/dao/AccessTierDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/AccessTierDao.java
@@ -1,11 +1,12 @@
 package org.pmiops.workbench.db.dao;
 
 import java.util.List;
+import java.util.Optional;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.springframework.data.repository.CrudRepository;
 
 public interface AccessTierDao extends CrudRepository<DbAccessTier, Long> {
   List<DbAccessTier> findAll();
 
-  DbAccessTier findOneByShortName(String shortName);
+  Optional<DbAccessTier> findOneByShortName(String shortName);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserAccessTierDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserAccessTierDao.java
@@ -1,0 +1,11 @@
+package org.pmiops.workbench.db.dao;
+
+import java.util.Optional;
+import org.pmiops.workbench.db.model.DbAccessTier;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserAccessTier;
+import org.springframework.data.repository.CrudRepository;
+
+public interface UserAccessTierDao extends CrudRepository<DbUserAccessTier, Long> {
+  Optional<DbUserAccessTier> getByUserAndAccessTier(DbUser user, DbAccessTier accessTier);
+}

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Provider;
 import org.hibernate.exception.GenericJDBCException;
+import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.actionaudit.targetproperties.BypassTimeTargetProperty;
@@ -93,6 +94,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   private final FireCloudService fireCloudService;
   private final ComplianceService complianceService;
   private final DirectoryService directoryService;
+  private final AccessTierService accessTierService;
 
   private static final Logger log = Logger.getLogger(UserServiceImpl.class.getName());
 
@@ -110,7 +112,8 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao,
       FireCloudService fireCloudService,
       ComplianceService complianceService,
-      DirectoryService directoryService) {
+      DirectoryService directoryService,
+      AccessTierService accessTierService) {
     this.configProvider = configProvider;
     this.userProvider = userProvider;
     this.clock = clock;
@@ -124,6 +127,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     this.fireCloudService = fireCloudService;
     this.complianceService = complianceService;
     this.directoryService = directoryService;
+    this.accessTierService = accessTierService;
   }
 
   @VisibleForTesting
@@ -200,6 +204,10 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       addToRegisteredTierGroupIdempotent(dbUser);
       newDataAccessLevel = DataAccessLevel.REGISTERED;
 
+      // record the user as having Registered Tier membership in user_access_tier
+      // which will eventually serve as the source of truth (TODO)
+      accessTierService.addUserToRegisteredTier(dbUser);
+
       // if this is the first time the user has completed registration, record it
       // this starts the Free Tier Credits countdown clock
       if (dbUser.getFirstRegistrationCompletionTime() == null) {
@@ -208,6 +216,10 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     } else {
       removeFromRegisteredTierGroupIdempotent(dbUser);
       newDataAccessLevel = DataAccessLevel.UNREGISTERED;
+
+      // record the user as lacking Registered Tier membership in user_access_tier
+      // which will eventually serve as the source of truth (TODO)
+      accessTierService.removeUserFromRegisteredTier(dbUser);
     }
     if (!newDataAccessLevel.equals(previousDataAccessLevel)) {
       dbUser.setDataAccessLevelEnum(newDataAccessLevel);
@@ -283,7 +295,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     user.setDisabled(false);
     user.setEmailVerificationStatusEnum(EmailVerificationStatus.UNVERIFIED);
     try {
-      return userDao.save(user);
+      user = userDao.save(user);
     } catch (DataIntegrityViolationException e) {
       // For certain test workflows, it's possible to have concurrent user creation.
       // We attempt to handle that gracefully here.
@@ -307,9 +319,15 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
                     + "indicating possible concurrent creation.",
                 username, userByUserName.getUserId()),
             e);
-        return userByUserName;
+        user = userByUserName;
       }
     }
+
+    // record the Service Account's access level as belonging to all tiers in user_access_tier
+    // which will eventually serve as the source of truth (TODO)
+    // this needs to occur after the user has been saved to the DB
+    accessTierService.addUserToAllTiers(user);
+    return user;
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -137,17 +137,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   /**
-   * Updates the currently-authenticated user with a modifier function.
-   *
-   * <p>Ensures that the data access level for the user reflects the state of other fields on the
-   * user; handles conflicts with concurrent updates by retrying.
-   */
-  private DbUser updateUserWithRetries(Function<DbUser, DbUser> modifyUser) {
-    DbUser user = userProvider.get();
-    return updateUserWithRetries(modifyUser, user, Agent.asUser(user));
-  }
-
-  /**
    * Updates a user record with a modifier function.
    *
    * <p>Ensures that the data access level for the user reflects the state of other fields on the

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -29,6 +29,7 @@ import org.pmiops.workbench.model.ReviewStatus;
 import org.pmiops.workbench.model.SexAtBirth;
 import org.pmiops.workbench.model.SpecificPopulationEnum;
 import org.pmiops.workbench.model.Surveys;
+import org.pmiops.workbench.model.TierAccessStatus;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
 
 /**
@@ -583,6 +584,12 @@ public final class DbStorageEnums {
           .put(Disability.PREFER_NO_ANSWER, (short) 3)
           .build();
 
+  private static final BiMap<TierAccessStatus, Short> CLIENT_TO_STORAGE_TIER_ACCESS_STATUS =
+      ImmutableBiMap.<TierAccessStatus, Short>builder()
+          .put(TierAccessStatus.DISABLED, (short) 0)
+          .put(TierAccessStatus.ENABLED, (short) 1)
+          .build();
+
   public static Race raceFromStorage(Short race) {
     return CLIENT_TO_STORAGE_RACE.inverse().get(race);
   }
@@ -629,5 +636,13 @@ public final class DbStorageEnums {
 
   public static Disability disabilityFromStorage(Short disability) {
     return CLIENT_TO_STORAGE_DISABILITY.inverse().get(disability);
+  }
+
+  public static Short tierAccessStatusToStorage(TierAccessStatus tierAccessStatus) {
+    return CLIENT_TO_STORAGE_TIER_ACCESS_STATUS.get(tierAccessStatus);
+  }
+
+  public static TierAccessStatus tierAccessStatusFromStorage(Short tierAccessStatus) {
+    return CLIENT_TO_STORAGE_TIER_ACCESS_STATUS.inverse().get(tierAccessStatus);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserAccessTier.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserAccessTier.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.db.model;
 
 import java.sql.Timestamp;
-import java.time.Instant;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -89,10 +88,6 @@ public class DbUserAccessTier {
     return this;
   }
 
-  public DbUserAccessTier setFirstEnabled() {
-    return setFirstEnabled(Timestamp.from(Instant.now()));
-  }
-
   @Column(name = "last_updated", nullable = false)
   public Timestamp getLastUpdated() {
     return lastUpdated;
@@ -101,9 +96,5 @@ public class DbUserAccessTier {
   public DbUserAccessTier setLastUpdated(Timestamp lastUpdated) {
     this.lastUpdated = lastUpdated;
     return this;
-  }
-
-  public DbUserAccessTier setLastUpdated() {
-    return setLastUpdated(Timestamp.from(Instant.now()));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserAccessTier.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserAccessTier.java
@@ -1,0 +1,91 @@
+package org.pmiops.workbench.db.model;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import org.pmiops.workbench.model.TierAccessStatus;
+
+@Entity
+@Table(name = "user_access_tier")
+public class DbUserAccessTier {
+
+  private long userAccessTierId;
+  private DbUser user;
+  private DbAccessTier accessTier;
+  private Short tierAccessStatus;
+  private Timestamp firstEnabled;
+  private Timestamp lastUpdated;
+
+  public DbUserAccessTier() {}
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "user_access_tier_id")
+  public long getUserAccessTierId() {
+    return userAccessTierId;
+  }
+
+  public DbUserAccessTier setUserAccessTierId(long userAccessTierId) {
+    this.userAccessTierId = userAccessTierId;
+    return this;
+  }
+
+  @ManyToOne()
+  @JoinColumn(name = "user_id", nullable = false)
+  public DbUser getUser() {
+    return user;
+  }
+
+  public DbUserAccessTier setUser(DbUser user) {
+    this.user = user;
+    return this;
+  }
+
+  @ManyToOne()
+  @JoinColumn(name = "access_tier_id", nullable = false)
+  public DbAccessTier getAccessTier() {
+    return accessTier;
+  }
+
+  public DbUserAccessTier setAccessTier(DbAccessTier accessTier) {
+    this.accessTier = accessTier;
+    return this;
+  }
+
+  @Column(name = "access_status", nullable = false)
+  public TierAccessStatus getAccessStatus() {
+    return DbStorageEnums.tierAccessStatusFromStorage(tierAccessStatus);
+  }
+
+  public DbUserAccessTier setAccessStatus(TierAccessStatus status) {
+    this.tierAccessStatus = DbStorageEnums.tierAccessStatusToStorage(status);
+    return this;
+  }
+
+  @Column(name = "first_enabled", nullable = false)
+  public Timestamp getFirstEnabled() {
+    return firstEnabled;
+  }
+
+  public DbUserAccessTier setFirstEnabled() {
+    this.firstEnabled = Timestamp.from(Instant.now());
+    return this;
+  }
+
+  @Column(name = "last_updated", nullable = false)
+  public Timestamp getLastUpdated() {
+    return lastUpdated;
+  }
+
+  public DbUserAccessTier setLastUpdated() {
+    this.lastUpdated = Timestamp.from(Instant.now());
+    return this;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserAccessTier.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserAccessTier.java
@@ -10,6 +10,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import org.pmiops.workbench.model.TierAccessStatus;
 
 @Entity
@@ -60,12 +61,21 @@ public class DbUserAccessTier {
   }
 
   @Column(name = "access_status", nullable = false)
-  public TierAccessStatus getAccessStatus() {
-    return DbStorageEnums.tierAccessStatusFromStorage(tierAccessStatus);
+  public Short getTierAccessStatus() {
+    return tierAccessStatus;
   }
 
-  public DbUserAccessTier setAccessStatus(TierAccessStatus status) {
-    this.tierAccessStatus = DbStorageEnums.tierAccessStatusToStorage(status);
+  @Transient
+  public TierAccessStatus getTierAccessStatusEnum() {
+    return DbStorageEnums.tierAccessStatusFromStorage(getTierAccessStatus());
+  }
+
+  public DbUserAccessTier setTierAccessStatus(TierAccessStatus status) {
+    return setTierAccessStatus(DbStorageEnums.tierAccessStatusToStorage(status));
+  }
+
+  public DbUserAccessTier setTierAccessStatus(Short tierAccessStatus) {
+    this.tierAccessStatus = tierAccessStatus;
     return this;
   }
 
@@ -74,9 +84,13 @@ public class DbUserAccessTier {
     return firstEnabled;
   }
 
-  public DbUserAccessTier setFirstEnabled() {
-    this.firstEnabled = Timestamp.from(Instant.now());
+  public DbUserAccessTier setFirstEnabled(Timestamp firstEnabled) {
+    this.firstEnabled = firstEnabled;
     return this;
+  }
+
+  public DbUserAccessTier setFirstEnabled() {
+    return setFirstEnabled(Timestamp.from(Instant.now()));
   }
 
   @Column(name = "last_updated", nullable = false)
@@ -84,8 +98,12 @@ public class DbUserAccessTier {
     return lastUpdated;
   }
 
-  public DbUserAccessTier setLastUpdated() {
-    this.lastUpdated = Timestamp.from(Instant.now());
+  public DbUserAccessTier setLastUpdated(Timestamp lastUpdated) {
+    this.lastUpdated = lastUpdated;
     return this;
+  }
+
+  public DbUserAccessTier setLastUpdated() {
+    return setLastUpdated(Timestamp.from(Instant.now()));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/tools/cdrconfig/CdrConfigVOMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/tools/cdrconfig/CdrConfigVOMapper.java
@@ -40,7 +40,9 @@ public interface CdrConfigVOMapper {
       CdrVersionVO localVersion,
       @MappingTarget DbCdrVersion dbCdrVersion,
       @Context AccessTierDao accessTierDao) {
-    dbCdrVersion.setAccessTier(accessTierDao.findOneByShortName(localVersion.accessTier));
+    accessTierDao
+        .findOneByShortName(localVersion.accessTier)
+        .ifPresent(dbCdrVersion::setAccessTier);
   }
 
   List<DbCdrVersion> toDbVersions(

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8806,3 +8806,9 @@ definitions:
       - RUNNING
       - FAILED
       - SUCCEEDED
+  TierAccessStatus:
+    type: string
+    description: 'Whether a user currently has access to a tier'
+    enum:
+      - DISABLED
+      - ENABLED

--- a/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
@@ -90,20 +90,20 @@ public class AccessTierServiceTest {
 
   @Test
   public void test_getAccessTier_empty() {
-    assertThat(accessTierService.getAccessTier("n/a")).isNull();
+    assertThat(accessTierService.getAccessTier("n/a")).isEmpty();
   }
 
   @Test
   public void test_getAccessTier_registered() {
     final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
     assertThat(accessTierService.getAccessTier(registeredTier.getShortName()))
-        .isEqualTo(registeredTier);
+        .hasValue(registeredTier);
   }
 
   @Test
   public void test_getAccessTier_missing() {
     final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
-    assertThat(accessTierService.getAccessTier("some other tier")).isNull();
+    assertThat(accessTierService.getAccessTier("some other tier")).isEmpty();
   }
 
   @Test
@@ -121,9 +121,9 @@ public class AccessTierServiceTest {
                 .setServicePerimeter("controlled/tier/perimeter"));
 
     assertThat(accessTierService.getAccessTier(registeredTier.getShortName()))
-        .isEqualTo(registeredTier);
+        .hasValue(registeredTier);
     assertThat(accessTierService.getAccessTier(controlledTier.getShortName()))
-        .isEqualTo(controlledTier);
+        .hasValue(controlledTier);
   }
 
   @Test(expected = ServerErrorException.class)

--- a/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
@@ -1,0 +1,332 @@
+package org.pmiops.workbench.access;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+
+import java.sql.Timestamp;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.AccessTierDao;
+import org.pmiops.workbench.db.dao.UserAccessTierDao;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.model.DbAccessTier;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserAccessTier;
+import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.model.DataAccessLevel;
+import org.pmiops.workbench.model.TierAccessStatus;
+import org.pmiops.workbench.utils.TestMockFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+public class AccessTierServiceTest {
+  @Autowired private AccessTierDao accessTierDao;
+  @Autowired private AccessTierService accessTierService;
+  @Autowired private UserAccessTierDao userAccessTierDao;
+  @Autowired private UserDao userDao;
+
+  private static DbUser user;
+  private static WorkbenchConfig config;
+
+  @Import({
+    AccessTierServiceImpl.class,
+  })
+  @TestConfiguration
+  static class Configuration {
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public DbUser user() {
+      return user;
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public WorkbenchConfig config() {
+      return config;
+    }
+  }
+
+  @Before
+  public void setup() {
+    user = new DbUser();
+    user.setUsername("user");
+    user = userDao.save(user);
+
+    config = WorkbenchConfig.createEmptyConfig();
+  }
+
+  @Test
+  public void test_getAllTiers_empty() {
+    assertThat(accessTierService.getAllTiers()).isEmpty();
+  }
+
+  @Test
+  public void test_getAllTiers_2() {
+    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+
+    final DbAccessTier controlledTier =
+        accessTierDao.save(
+            new DbAccessTier()
+                .setAccessTierId(2)
+                .setShortName("controlled")
+                .setDisplayName("Controlled Tier")
+                .setAuthDomainName("Controlled Tier Auth Domain")
+                .setAuthDomainGroupEmail("ct-users@fake-research-aou.org")
+                .setServicePerimeter("controlled/tier/perimeter"));
+
+    assertThat(accessTierService.getAllTiers()).containsExactly(registeredTier, controlledTier);
+  }
+
+  @Test
+  public void test_getAccessTier_empty() {
+    assertThat(accessTierService.getAccessTier("n/a")).isNull();
+  }
+
+  @Test
+  public void test_getAccessTier_registered() {
+    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    assertThat(accessTierService.getAccessTier(registeredTier.getShortName()))
+        .isEqualTo(registeredTier);
+  }
+
+  @Test
+  public void test_getAccessTier_missing() {
+    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    assertThat(accessTierService.getAccessTier("some other tier")).isNull();
+  }
+
+  @Test
+  public void test_getAccessTier_multi() {
+    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+
+    final DbAccessTier controlledTier =
+        accessTierDao.save(
+            new DbAccessTier()
+                .setAccessTierId(2)
+                .setShortName("controlled")
+                .setDisplayName("Controlled Tier")
+                .setAuthDomainName("Controlled Tier Auth Domain")
+                .setAuthDomainGroupEmail("ct-users@fake-research-aou.org")
+                .setServicePerimeter("controlled/tier/perimeter"));
+
+    assertThat(accessTierService.getAccessTier(registeredTier.getShortName()))
+        .isEqualTo(registeredTier);
+    assertThat(accessTierService.getAccessTier(controlledTier.getShortName()))
+        .isEqualTo(controlledTier);
+  }
+
+  @Test(expected = ServerErrorException.class)
+  public void test_getRegisteredTier_empty() {
+    accessTierService.getRegisteredTier();
+  }
+
+  @Test
+  public void test_getRegisteredTier_registered() {
+    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    assertThat(accessTierService.getRegisteredTier()).isEqualTo(registeredTier);
+  }
+
+  @Test(expected = ServerErrorException.class)
+  public void test_getRegisteredTier_missing() {
+    final DbAccessTier controlledTier =
+        accessTierDao.save(
+            new DbAccessTier()
+                .setAccessTierId(2)
+                .setShortName("controlled")
+                .setDisplayName("Controlled Tier")
+                .setAuthDomainName("Controlled Tier Auth Domain")
+                .setAuthDomainGroupEmail("ct-users@fake-research-aou.org")
+                .setServicePerimeter("controlled/tier/perimeter"));
+    accessTierService.getRegisteredTier();
+  }
+
+  // we expect to see the Registered Tier in the DB
+  // but we have not defined it for this test
+
+  @Test(expected = ServerErrorException.class)
+  public void test_getAccessTiersForUser_registered_empty() {
+    user.setDataAccessLevelEnum(DataAccessLevel.REGISTERED);
+    accessTierService.getAccessTiersForUser(user);
+  }
+
+  @Test
+  public void test_getAccessTiersForUser_unregistered_empty() {
+    user.setDataAccessLevelEnum(DataAccessLevel.UNREGISTERED);
+    assertThat(accessTierService.getAccessTiersForUser(user)).isEmpty();
+  }
+
+  @Test
+  public void test_getAccessTiersForUser_registered() {
+    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    user.setDataAccessLevelEnum(DataAccessLevel.REGISTERED);
+    assertThat(accessTierService.getAccessTiersForUser(user)).containsExactly(registeredTier);
+  }
+
+  @Test
+  public void test_getAccessTiersForUser_unregistered() {
+    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    assertThat(accessTierService.getAccessTiersForUser(user)).isEmpty();
+  }
+
+  @Test(expected = ServerErrorException.class)
+  public void test_addUserToRegisteredTier_missing() {
+    accessTierService.addUserToRegisteredTier(user);
+  }
+
+  @Test
+  public void test_addUserToRegisteredTier_new() {
+    assertThat(userAccessTierDao.findAll()).isEmpty();
+
+    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+
+    // simply to show a non-Registered tier exists but we don't add the user to it
+    final DbAccessTier controlledTier =
+        accessTierDao.save(
+            new DbAccessTier()
+                .setAccessTierId(2)
+                .setShortName("controlled")
+                .setDisplayName("Controlled Tier")
+                .setAuthDomainName("Controlled Tier Auth Domain")
+                .setAuthDomainGroupEmail("ct-users@fake-research-aou.org")
+                .setServicePerimeter("controlled/tier/perimeter"));
+
+    accessTierService.addUserToRegisteredTier(user);
+
+    Iterable<DbUserAccessTier> userAccessTiers = userAccessTierDao.findAll();
+    assertThat(userAccessTiers).hasSize(1);
+
+    Optional<DbUserAccessTier> uat = userAccessTierDao.getByUserAndAccessTier(user, registeredTier);
+    assertThat(uat).isPresent();
+
+    assertThat(uat.get().getUser()).isEqualTo(user);
+    assertThat(uat.get().getAccessTier()).isEqualTo(registeredTier);
+    assertThat(uat.get().getTierAccessStatusEnum()).isEqualTo(TierAccessStatus.ENABLED);
+  }
+
+  @Test
+  public void test_addUserToRegisteredTier_twice() {
+    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+
+    accessTierService.addUserToRegisteredTier(user);
+
+    assertThat(userAccessTierDao.findAll()).hasSize(1);
+
+    Optional<DbUserAccessTier> uat = userAccessTierDao.getByUserAndAccessTier(user, registeredTier);
+    assertThat(uat).isPresent();
+    assertThat(uat.get().getUser()).isEqualTo(user);
+    assertThat(uat.get().getAccessTier()).isEqualTo(registeredTier);
+    assertThat(uat.get().getTierAccessStatusEnum()).isEqualTo(TierAccessStatus.ENABLED);
+    final Timestamp firstEnabled = uat.get().getFirstEnabled();
+    final Timestamp lastUpdated = uat.get().getLastUpdated();
+
+    // wait a second
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    accessTierService.addUserToRegisteredTier(user);
+
+    // no change
+
+    assertThat(userAccessTierDao.findAll()).hasSize(1);
+
+    uat = userAccessTierDao.getByUserAndAccessTier(user, registeredTier);
+    assertThat(uat).isPresent();
+    assertThat(uat.get().getUser()).isEqualTo(user);
+    assertThat(uat.get().getAccessTier()).isEqualTo(registeredTier);
+    assertThat(uat.get().getTierAccessStatusEnum()).isEqualTo(TierAccessStatus.ENABLED);
+
+    // firstEnabled does not change but lastUpdated does
+
+    assertThat(uat.get().getFirstEnabled()).isEqualTo(firstEnabled);
+    assertThat(uat.get().getLastUpdated().after(lastUpdated)).isTrue();
+  }
+
+  @Test
+  public void test_removeUserFromRegisteredTier_new() {
+    assertThat(userAccessTierDao.findAll()).isEmpty();
+
+    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+
+    // does nothing
+    accessTierService.removeUserFromRegisteredTier(user);
+    assertThat(userAccessTierDao.findAll()).isEmpty();
+  }
+
+  @Test
+  public void test_removeUserFromRegisteredTier_existing() {
+    assertThat(userAccessTierDao.findAll()).isEmpty();
+
+    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+
+    // adds a DB entry for (user, registered)
+    accessTierService.addUserToRegisteredTier(user);
+
+    // updates the DB entry by setting it to DISABLED
+    accessTierService.removeUserFromRegisteredTier(user);
+
+    assertThat(userAccessTierDao.findAll()).hasSize(1);
+
+    Optional<DbUserAccessTier> uat = userAccessTierDao.getByUserAndAccessTier(user, registeredTier);
+    assertThat(uat).isPresent();
+    assertThat(uat.get().getUser()).isEqualTo(user);
+    assertThat(uat.get().getAccessTier()).isEqualTo(registeredTier);
+    assertThat(uat.get().getTierAccessStatusEnum()).isEqualTo(TierAccessStatus.DISABLED);
+  }
+
+  @Test
+  public void test_addUserToAllTiers_empty() {
+    accessTierService.addUserToAllTiers(user);
+    assertThat(userAccessTierDao.findAll()).isEmpty();
+  }
+
+  @Test
+  public void test_addUserToAllTiers_two() {
+    assertThat(userAccessTierDao.findAll()).isEmpty();
+
+    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+
+    final DbAccessTier controlledTier =
+        accessTierDao.save(
+            new DbAccessTier()
+                .setAccessTierId(2)
+                .setShortName("controlled")
+                .setDisplayName("Controlled Tier")
+                .setAuthDomainName("Controlled Tier Auth Domain")
+                .setAuthDomainGroupEmail("ct-users@fake-research-aou.org")
+                .setServicePerimeter("controlled/tier/perimeter"));
+
+    accessTierService.addUserToAllTiers(user);
+
+    assertThat(userAccessTierDao.findAll()).hasSize(2);
+
+    Optional<DbUserAccessTier> uat_r =
+        userAccessTierDao.getByUserAndAccessTier(user, registeredTier);
+    assertThat(uat_r).isPresent();
+    final DbUserAccessTier registeredMembership = uat_r.get();
+    assertThat(registeredMembership.getUser()).isEqualTo(user);
+    assertThat(registeredMembership.getAccessTier()).isEqualTo(registeredTier);
+    assertThat(registeredMembership.getTierAccessStatusEnum()).isEqualTo(TierAccessStatus.ENABLED);
+
+    Optional<DbUserAccessTier> uat_c =
+        userAccessTierDao.getByUserAndAccessTier(user, controlledTier);
+    assertThat(uat_c).isPresent();
+    final DbUserAccessTier controlledMembership = uat_c.get();
+    assertThat(controlledMembership.getUser()).isEqualTo(user);
+    assertThat(controlledMembership.getAccessTier()).isEqualTo(controlledTier);
+    assertThat(controlledMembership.getTierAccessStatusEnum()).isEqualTo(TierAccessStatus.ENABLED);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
@@ -73,7 +73,7 @@ public class AccessTierServiceTest {
 
   @Test
   public void test_getAllTiers_2() {
-    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     final DbAccessTier controlledTier =
         accessTierDao.save(
@@ -95,20 +95,20 @@ public class AccessTierServiceTest {
 
   @Test
   public void test_getAccessTier_registered() {
-    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
     assertThat(accessTierService.getAccessTier(registeredTier.getShortName()))
         .isEqualTo(registeredTier);
   }
 
   @Test
   public void test_getAccessTier_missing() {
-    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
     assertThat(accessTierService.getAccessTier("some other tier")).isNull();
   }
 
   @Test
   public void test_getAccessTier_multi() {
-    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     final DbAccessTier controlledTier =
         accessTierDao.save(
@@ -133,7 +133,7 @@ public class AccessTierServiceTest {
 
   @Test
   public void test_getRegisteredTier_registered() {
-    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
     assertThat(accessTierService.getRegisteredTier()).isEqualTo(registeredTier);
   }
 
@@ -168,14 +168,14 @@ public class AccessTierServiceTest {
 
   @Test
   public void test_getAccessTiersForUser_registered() {
-    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
     user.setDataAccessLevelEnum(DataAccessLevel.REGISTERED);
     assertThat(accessTierService.getAccessTiersForUser(user)).containsExactly(registeredTier);
   }
 
   @Test
   public void test_getAccessTiersForUser_unregistered() {
-    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
     assertThat(accessTierService.getAccessTiersForUser(user)).isEmpty();
   }
 
@@ -188,7 +188,7 @@ public class AccessTierServiceTest {
   public void test_addUserToRegisteredTier_new() {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
-    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     // simply to show a non-Registered tier exists but we don't add the user to it
     final DbAccessTier controlledTier =
@@ -216,7 +216,7 @@ public class AccessTierServiceTest {
 
   @Test
   public void test_addUserToRegisteredTier_twice() {
-    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     accessTierService.addUserToRegisteredTier(user);
 
@@ -259,7 +259,7 @@ public class AccessTierServiceTest {
   public void test_removeUserFromRegisteredTier_new() {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
-    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     // does nothing
     accessTierService.removeUserFromRegisteredTier(user);
@@ -270,7 +270,7 @@ public class AccessTierServiceTest {
   public void test_removeUserFromRegisteredTier_existing() {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
-    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     // adds a DB entry for (user, registered)
     accessTierService.addUserToRegisteredTier(user);
@@ -297,7 +297,7 @@ public class AccessTierServiceTest {
   public void test_addUserToAllTiers_two() {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
-    final DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     final DbAccessTier controlledTier =
         accessTierDao.save(

--- a/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
@@ -303,11 +303,12 @@ public class AccessTierServiceTest {
 
     accessTierService.removeUserFromRegisteredTier(user);
 
+    // no change
+
+    assertThat(userAccessTierDao.findAll()).hasSize(1);
+
     uat = userAccessTierDao.getByUserAndAccessTier(user, registeredTier);
     assertThat(uat).isPresent();
-
-    // unchanged
-
     assertThat(uat.get().getLastUpdated()).isEqualTo(lastUpdated);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.actionaudit.auditors.AuthDomainAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.compliance.ComplianceService;
@@ -51,15 +52,17 @@ public class AuthDomainControllerTest {
   private static final String CURRENT_POSITION = "Tester";
   private static final String RESEARCH_PURPOSE = "To test things";
 
+  @Autowired private UserDao userDao;
+
+  @Mock private AccessTierService accessTierService;
   @Mock private AdminActionHistoryDao adminActionHistoryDao;
-  @Mock private FireCloudService fireCloudService;
-  @Mock private Provider<DbUser> userProvider;
+  @Mock private AuthDomainAuditor mockAuthDomainAuditAdapter;
   @Mock private ComplianceService complianceService;
   @Mock private DirectoryService directoryService;
-  @Mock private UserServiceAuditor mockUserServiceAuditAdapter;
-  @Mock private AuthDomainAuditor mockAuthDomainAuditAdapter;
-  @Autowired private UserDao userDao;
+  @Mock private FireCloudService fireCloudService;
+  @Mock private Provider<DbUser> userProvider;
   @Mock private UserDataUseAgreementDao userDataUseAgreementDao;
+  @Mock private UserServiceAuditor mockUserServiceAuditAdapter;
   @Mock private UserTermsOfServiceDao userTermsOfServiceDao;
   @Mock private VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
 
@@ -93,7 +96,8 @@ public class AuthDomainControllerTest {
             verifiedInstitutionalAffiliationDao,
             fireCloudService,
             complianceService,
-            directoryService);
+            directoryService,
+            accessTierService);
     this.authDomainController =
         new AuthDomainController(
             fireCloudService, userService, userDao, mockAuthDomainAuditAdapter);

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -22,6 +22,7 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.actionaudit.auditors.WorkspaceAuditor;
@@ -218,6 +219,7 @@ public class CohortsControllerTest {
     WorkspaceResourcesServiceImpl.class,
     WorkspaceServiceImpl.class,
     WorkspacesController.class,
+    AccessTierServiceImpl.class,
   })
   @MockBean({
     BigQueryService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.actionaudit.auditors.WorkspaceAuditor;
@@ -201,6 +202,7 @@ public class ConceptSetsControllerTest {
     WorkspaceResourcesServiceImpl.class,
     WorkspaceServiceImpl.class,
     WorkspacesController.class,
+    AccessTierServiceImpl.class,
   })
   @MockBean({
     BigQueryService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -49,6 +49,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.invocation.InvocationOnMock;
+import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.actionaudit.auditors.WorkspaceAuditor;
@@ -229,6 +230,7 @@ public class DataSetControllerTest {
     WorkspaceResourcesServiceImpl.class,
     WorkspaceServiceImpl.class,
     WorkspacesController.class,
+    AccessTierServiceImpl.class,
   })
   @MockBean({
     BigQueryService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -31,6 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
+import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.actionaudit.ActionAuditQueryServiceImpl;
 import org.pmiops.workbench.actionaudit.auditors.ProfileAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
@@ -42,6 +43,7 @@ import org.pmiops.workbench.captcha.ApiException;
 import org.pmiops.workbench.captcha.CaptchaVerificationService;
 import org.pmiops.workbench.compliance.ComplianceServiceImpl;
 import org.pmiops.workbench.config.CommonConfig;
+import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserDataUseAgreementDao;
 import org.pmiops.workbench.db.dao.UserService;
@@ -98,6 +100,7 @@ import org.pmiops.workbench.shibboleth.ShibbolethService;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.test.FakeLongRandom;
 import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
+import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.AuditLogEntryMapperImpl;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -148,6 +151,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   @MockBean private UserServiceAuditor mockUserServiceAuditor;
   @MockBean private RasLinkService mockRasLinkService;
 
+  @Autowired private AccessTierDao accessTierDao;
   @Autowired private InstitutionService institutionService;
   @Autowired private ProfileController profileController;
   @Autowired private ProfileService profileService;
@@ -184,6 +188,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     UserServiceImpl.class,
     UserServiceTestConfiguration.class,
     VerifiedInstitutionalAffiliationMapperImpl.class,
+    AccessTierServiceImpl.class,
   })
   @MockBean({BigQueryService.class})
   static class Configuration {
@@ -218,6 +223,9 @@ public class ProfileControllerTest extends BaseControllerTest {
     super.setUp();
 
     config.googleDirectoryService.gSuiteDomain = GSUITE_DOMAIN;
+
+    // key UserService logic depends on the existence of the Registered Tier
+    TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     Profile profile = new Profile();
     profile.setContactEmail(CONTACT_EMAIL);

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.actionaudit.auditors.LeonardoRuntimeAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.cohortreview.mapper.CohortReviewMapperImpl;
@@ -160,7 +161,8 @@ public class RuntimeControllerTest {
     LeonardoNotebooksClientImpl.class,
     NotebooksRetryHandler.class,
     LeonardoRetryHandler.class,
-    NoBackOffPolicy.class
+    NoBackOffPolicy.class,
+    AccessTierServiceImpl.class,
   })
   @MockBean({ConceptSetService.class, CohortService.class})
   static class Configuration {

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -20,6 +20,7 @@ import org.apache.commons.collections4.ListUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.compliance.ComplianceService;
@@ -68,6 +69,7 @@ public class UserControllerTest {
   @Import({
     UserController.class,
     UserServiceTestConfiguration.class,
+    AccessTierServiceImpl.class,
   })
   @MockBean({
     FireCloudService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -408,7 +408,7 @@ public class WorkspacesControllerTest {
     testMockFactory = new TestMockFactory();
     currentUser = createUser(LOGGED_IN_USER_EMAIL);
 
-    accessTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    accessTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao, 1);
     cdrVersion.setName("1");

--- a/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
@@ -101,7 +101,7 @@ public class CdrVersionServiceTest {
     user.setUsername("user");
     user.setDataAccessLevelEnum(DataAccessLevel.REGISTERED);
 
-    registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
     defaultCdrVersion =
         makeCdrVersion(
             1L,

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessTierDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessTierDaoTest.java
@@ -1,0 +1,103 @@
+package org.pmiops.workbench.db.dao;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.db.model.DbAccessTier;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserAccessTier;
+import org.pmiops.workbench.model.TierAccessStatus;
+import org.pmiops.workbench.utils.TestMockFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class UserAccessTierDaoTest {
+  @Autowired private UserDao userDao;
+  @Autowired private AccessTierDao accessTierDao;
+  @Autowired private UserAccessTierDao userAccessTierDao;
+
+  DbUser user;
+  DbAccessTier registeredTier;
+  DbAccessTier controlledTier;
+
+  @Before
+  public void setup() {
+    user = new DbUser();
+    user.setUserId(100);
+    user = userDao.save(user);
+
+    registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+
+    controlledTier =
+        accessTierDao.save(
+            new DbAccessTier()
+                .setAccessTierId(2)
+                .setShortName("controlled")
+                .setDisplayName("Controlled Tier")
+                .setAuthDomainName("Controlled Tier Auth Domain")
+                .setAuthDomainGroupEmail("ct-users@fake-research-aou.org")
+                .setServicePerimeter("controlled/tier/perimeter"));
+  }
+
+  @Test
+  public void test_getByUserAndAccessTier_empty() {
+    assertThat(userAccessTierDao.getByUserAndAccessTier(user, registeredTier)).isEmpty();
+  }
+
+  @Test
+  public void test_getByUserAndAccessTier_RT() {
+    final Instant testStart = Instant.now();
+
+    userAccessTierDao.save(
+        new DbUserAccessTier()
+            .setUser(user)
+            .setAccessTier(registeredTier)
+            .setAccessStatus(TierAccessStatus.ENABLED));
+
+    Optional<DbUserAccessTier> entryMaybe =
+        userAccessTierDao.getByUserAndAccessTier(user, registeredTier);
+    assertThat(entryMaybe).isPresent();
+    DbUserAccessTier entry = entryMaybe.get();
+    assertThat(entry.getUser()).isEqualTo(user);
+    assertThat(entry.getAccessTier()).isEqualTo(registeredTier);
+    assertThat(entry.getAccessStatus()).isEqualTo(TierAccessStatus.ENABLED);
+    assertThat(entry.getFirstEnabled().toInstant().isAfter(testStart)).isTrue();
+    assertThat(entry.getLastUpdated().toInstant().isAfter(testStart)).isTrue();
+  }
+
+  @Test
+  public void test_getByUserAndAccessTier_RT_disabled() {
+    userAccessTierDao.save(
+        new DbUserAccessTier()
+            .setUser(user)
+            .setAccessTier(registeredTier)
+            .setAccessStatus(TierAccessStatus.DISABLED));
+
+    Optional<DbUserAccessTier> entryMaybe =
+        userAccessTierDao.getByUserAndAccessTier(user, registeredTier);
+    assertThat(entryMaybe).isPresent();
+    DbUserAccessTier entry = entryMaybe.get();
+    assertThat(entry.getAccessStatus()).isEqualTo(TierAccessStatus.DISABLED);
+  }
+
+  @Test
+  public void test_getByUserAndAccessTier_CT_no_access() {
+    userAccessTierDao.save(
+        new DbUserAccessTier()
+            .setUser(user)
+            .setAccessTier(registeredTier)
+            .setAccessStatus(TierAccessStatus.ENABLED));
+
+    assertThat(userAccessTierDao.getByUserAndAccessTier(user, controlledTier)).isEmpty();
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessTierDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessTierDaoTest.java
@@ -26,9 +26,9 @@ public class UserAccessTierDaoTest {
   @Autowired private AccessTierDao accessTierDao;
   @Autowired private UserAccessTierDao userAccessTierDao;
 
-  DbUser user;
-  DbAccessTier registeredTier;
-  DbAccessTier controlledTier;
+  private DbUser user;
+  private DbAccessTier registeredTier;
+  private DbAccessTier controlledTier;
 
   @Before
   public void setup() {
@@ -56,13 +56,16 @@ public class UserAccessTierDaoTest {
 
   @Test
   public void test_getByUserAndAccessTier_RT() {
-    final Instant testStart = Instant.now();
+    // arbitrary nonzero time amount
+    final Instant recently = Instant.now().minusSeconds(10);
 
     userAccessTierDao.save(
         new DbUserAccessTier()
             .setUser(user)
             .setAccessTier(registeredTier)
-            .setAccessStatus(TierAccessStatus.ENABLED));
+            .setTierAccessStatus(TierAccessStatus.ENABLED)
+            .setFirstEnabled()
+            .setLastUpdated());
 
     Optional<DbUserAccessTier> entryMaybe =
         userAccessTierDao.getByUserAndAccessTier(user, registeredTier);
@@ -70,9 +73,9 @@ public class UserAccessTierDaoTest {
     DbUserAccessTier entry = entryMaybe.get();
     assertThat(entry.getUser()).isEqualTo(user);
     assertThat(entry.getAccessTier()).isEqualTo(registeredTier);
-    assertThat(entry.getAccessStatus()).isEqualTo(TierAccessStatus.ENABLED);
-    assertThat(entry.getFirstEnabled().toInstant().isAfter(testStart)).isTrue();
-    assertThat(entry.getLastUpdated().toInstant().isAfter(testStart)).isTrue();
+    assertThat(entry.getTierAccessStatusEnum()).isEqualTo(TierAccessStatus.ENABLED);
+    assertThat(entry.getFirstEnabled().toInstant().isAfter(recently)).isTrue();
+    assertThat(entry.getLastUpdated().toInstant().isAfter(recently)).isTrue();
   }
 
   @Test
@@ -81,13 +84,15 @@ public class UserAccessTierDaoTest {
         new DbUserAccessTier()
             .setUser(user)
             .setAccessTier(registeredTier)
-            .setAccessStatus(TierAccessStatus.DISABLED));
+            .setTierAccessStatus(TierAccessStatus.DISABLED)
+            .setFirstEnabled()
+            .setLastUpdated());
 
     Optional<DbUserAccessTier> entryMaybe =
         userAccessTierDao.getByUserAndAccessTier(user, registeredTier);
     assertThat(entryMaybe).isPresent();
     DbUserAccessTier entry = entryMaybe.get();
-    assertThat(entry.getAccessStatus()).isEqualTo(TierAccessStatus.DISABLED);
+    assertThat(entry.getTierAccessStatusEnum()).isEqualTo(TierAccessStatus.DISABLED);
   }
 
   @Test
@@ -96,7 +101,9 @@ public class UserAccessTierDaoTest {
         new DbUserAccessTier()
             .setUser(user)
             .setAccessTier(registeredTier)
-            .setAccessStatus(TierAccessStatus.ENABLED));
+            .setTierAccessStatus(TierAccessStatus.ENABLED)
+            .setFirstEnabled()
+            .setLastUpdated());
 
     assertThat(userAccessTierDao.getByUserAndAccessTier(user, controlledTier)).isEmpty();
   }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessTierDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessTierDaoTest.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.db.dao;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Optional;
 import org.junit.Before;
@@ -64,8 +65,8 @@ public class UserAccessTierDaoTest {
             .setUser(user)
             .setAccessTier(registeredTier)
             .setTierAccessStatus(TierAccessStatus.ENABLED)
-            .setFirstEnabled()
-            .setLastUpdated());
+            .setFirstEnabled(now())
+            .setLastUpdated(now()));
 
     Optional<DbUserAccessTier> entryMaybe =
         userAccessTierDao.getByUserAndAccessTier(user, registeredTier);
@@ -85,8 +86,8 @@ public class UserAccessTierDaoTest {
             .setUser(user)
             .setAccessTier(registeredTier)
             .setTierAccessStatus(TierAccessStatus.DISABLED)
-            .setFirstEnabled()
-            .setLastUpdated());
+            .setFirstEnabled(now())
+            .setLastUpdated(now()));
 
     Optional<DbUserAccessTier> entryMaybe =
         userAccessTierDao.getByUserAndAccessTier(user, registeredTier);
@@ -102,9 +103,13 @@ public class UserAccessTierDaoTest {
             .setUser(user)
             .setAccessTier(registeredTier)
             .setTierAccessStatus(TierAccessStatus.ENABLED)
-            .setFirstEnabled()
-            .setLastUpdated());
+            .setFirstEnabled(now())
+            .setLastUpdated(now()));
 
     assertThat(userAccessTierDao.getByUserAndAccessTier(user, controlledTier)).isEmpty();
+  }
+
+  private Timestamp now() {
+    return Timestamp.from(Instant.now());
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessTierDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessTierDaoTest.java
@@ -36,7 +36,7 @@ public class UserAccessTierDaoTest {
     user.setUserId(100);
     user = userDao.save(user);
 
-    registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     controlledTier =
         accessTierDao.save(

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -19,17 +20,23 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
+import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.actionaudit.targetproperties.BypassTimeTargetProperty;
 import org.pmiops.workbench.compliance.ComplianceService;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserAccessTier;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.model.Authority;
+import org.pmiops.workbench.model.DataAccessLevel;
+import org.pmiops.workbench.model.EmailVerificationStatus;
+import org.pmiops.workbench.model.TierAccessStatus;
 import org.pmiops.workbench.moodle.ApiException;
 import org.pmiops.workbench.moodle.model.BadgeDetailsV2;
 import org.pmiops.workbench.test.FakeClock;
@@ -61,6 +68,7 @@ public class UserServiceTest {
   private static final int CLOCK_INCREMENT_MILLIS = 1000;
   private static DbUser providedDbUser;
   private static WorkbenchConfig providedWorkbenchConfig;
+  private static DbAccessTier registeredTier;
 
   @MockBean private FireCloudService mockFireCloudService;
   @MockBean private ComplianceService mockComplianceService;
@@ -71,6 +79,7 @@ public class UserServiceTest {
   @Autowired private UserService userService;
   @Autowired private UserDao userDao;
   @Autowired private AccessTierDao accessTierDao;
+  @Autowired private UserAccessTierDao userAccessTierDao;
 
   @Import({
     UserServiceTestConfiguration.class,
@@ -105,13 +114,13 @@ public class UserServiceTest {
   public void setUp() {
     DbUser user = new DbUser();
     user.setUsername(USERNAME);
-    userDao.save(user);
+    user = userDao.save(user);
     providedDbUser = user;
 
     providedWorkbenchConfig = WorkbenchConfig.createEmptyConfig();
 
     // key UserService logic depends on the existence of the Registered Tier
-    TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     // Since we're injecting the same static instance of this FakeClock,
     // increments and other mutations will carry across tests if we don't reset it here.
@@ -425,5 +434,87 @@ public class UserServiceTest {
     for (Authority auth : Authority.values()) {
       assertThat(userService.hasAuthority(user.getUserId(), auth)).isTrue();
     }
+  }
+
+  @Test
+  public void test_updateUserWithRetries_register() {
+    DbUser dbUser = userDao.save(new DbUser());
+    assertThat(userAccessTierDao.findAll()).isEmpty();
+
+    dbUser = userService.updateUserWithRetries(this::registerUser, dbUser, Agent.asUser(dbUser));
+
+    assertThat(dbUser.getDataAccessLevelEnum()).isEqualTo(DataAccessLevel.REGISTERED);
+
+    assertThat(userAccessTierDao.findAll()).hasSize(1);
+    Optional<DbUserAccessTier> userAccessMaybe =
+        userAccessTierDao.getByUserAndAccessTier(dbUser, registeredTier);
+    assertThat(userAccessMaybe).isPresent();
+    assertThat(userAccessMaybe.get().getTierAccessStatusEnum()).isEqualTo(TierAccessStatus.ENABLED);
+  }
+
+  @Test
+  public void test_updateUserWithRetries_unregister() {
+    DbUser dbUser = new DbUser();
+    assertThat(userAccessTierDao.findAll()).isEmpty();
+
+    dbUser = userService.updateUserWithRetries(this::unregisterUser, dbUser, Agent.asUser(dbUser));
+
+    assertThat(dbUser.getDataAccessLevelEnum()).isEqualTo(DataAccessLevel.UNREGISTERED);
+
+    // the user has never been registered so they have no DbUserAccessTier entry
+
+    assertThat(userAccessTierDao.findAll()).hasSize(0);
+    Optional<DbUserAccessTier> userAccessMaybe =
+        userAccessTierDao.getByUserAndAccessTier(dbUser, registeredTier);
+    assertThat(userAccessMaybe).isEmpty();
+  }
+
+  @Test
+  public void test_updateUserWithRetries_register_then_unregister() {
+    DbUser dbUser = new DbUser();
+    assertThat(userAccessTierDao.findAll()).isEmpty();
+
+    dbUser = userService.updateUserWithRetries(this::registerUser, dbUser, Agent.asUser(dbUser));
+    dbUser = userService.updateUserWithRetries(this::unregisterUser, dbUser, Agent.asUser(dbUser));
+
+    assertThat(dbUser.getDataAccessLevelEnum()).isEqualTo(DataAccessLevel.UNREGISTERED);
+
+    // The user received a DbUserAccessTier when they were registered.
+    // They still have it after unregistering but now it is DISABLED.
+
+    assertThat(userAccessTierDao.findAll()).hasSize(1);
+    Optional<DbUserAccessTier> userAccessMaybe =
+        userAccessTierDao.getByUserAndAccessTier(dbUser, registeredTier);
+    assertThat(userAccessMaybe).isPresent();
+    assertThat(userAccessMaybe.get().getTierAccessStatusEnum())
+        .isEqualTo(TierAccessStatus.DISABLED);
+  }
+
+  private DbUser registerUser(DbUser user) {
+    // shouldUserBeRegistered logic:
+    //    return !user.getDisabled()
+    //        && complianceTrainingCompliant
+    //        && eraCommonsCompliant
+    //        && betaAccessGranted
+    //        && twoFactorAuthComplete
+    //        && dataUseAgreementCompliant
+    //        && EmailVerificationStatus.SUBSCRIBED.equals(user.getEmailVerificationStatusEnum());
+
+    Timestamp now = Timestamp.from(Instant.now());
+
+    user.setDisabled(false);
+    user.setEmailVerificationStatusEnum(EmailVerificationStatus.SUBSCRIBED);
+    user.setComplianceTrainingBypassTime(now);
+    user.setEraCommonsBypassTime(now);
+    user.setBetaAccessBypassTime(now);
+    user.setTwoFactorAuthBypassTime(now);
+    user.setDataUseAgreementBypassTime(now);
+
+    return userDao.save(user);
+  }
+
+  private DbUser unregisterUser(DbUser user) {
+    user.setDisabled(true);
+    return userDao.save(user);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.compliance.ComplianceService;
@@ -103,6 +104,7 @@ public class RasLinkServiceTest {
     UserServiceAuditor.class,
     FreeTierBillingService.class,
     HttpTransport.class,
+    AccessTierService.class,
   })
   static class Configuration {
     @Bean

--- a/api/src/test/java/org/pmiops/workbench/tools/cdrconfig/CdrConfigVOMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/tools/cdrconfig/CdrConfigVOMapperTest.java
@@ -108,7 +108,7 @@ public class CdrConfigVOMapperTest {
 
   @Test
   public void test_populateAccessTier() {
-    DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     CdrVersionVO cdrVersionVO = new CdrVersionVO();
     cdrVersionVO.accessTier = registeredTier.getShortName();
@@ -123,7 +123,7 @@ public class CdrConfigVOMapperTest {
 
   @Test
   public void test_populateAccessTier_missing() {
-    DbAccessTier registeredTier = TestMockFactory.createDefaultAccessTier(accessTierDao);
+    DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     CdrVersionVO cdrVersionVO = new CdrVersionVO();
     cdrVersionVO.accessTier = "a tier which doesn't exist";

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -209,7 +209,7 @@ public class TestMockFactory {
     return dbWorkspace;
   }
 
-  public static DbAccessTier createDefaultAccessTier(AccessTierDao accessTierDao) {
+  public static DbAccessTier createRegisteredTierForTests(AccessTierDao accessTierDao) {
     final DbAccessTier accessTier =
         new DbAccessTier()
             .setAccessTierId(1)
@@ -234,7 +234,7 @@ public class TestMockFactory {
     // set the db name to be empty since test cases currently
     // run in the workbench schema only.
     cdrVersion.setCdrDbName("");
-    cdrVersion.setAccessTier(createDefaultAccessTier(accessTierDao));
+    cdrVersion.setAccessTier(createRegisteredTierForTests(accessTierDao));
     return cdrVersionDao.save(cdrVersion);
   }
 }


### PR DESCRIPTION
Description:

Another step in the migration from using dataAccessLevel to check access to querying a new table user_access_tier / DbUserAccessTier for ENABLED status.

Several parts of RW-6187 are complete and deployed to Production: Workspace and CDR Version entities have been transitioned to this model, and we are now Reporting tier membership (in addition to DataAccessLevel).

This PR involves creating and updating DbUserAccessTier whenever we also set a user's DataAccessLevel in UserServiceImpl.  It does not remove any DataAccessLevel setting or change any access checks to use DbUserAccessTier.  My thought is that we should deploy this parallel source of truth and leave it in this state for one release cycle while confirming that everything looks correct.  After the next release, we can apply an additional PR to remove all user interaction with DataAccessLevel and rely on the new table as the source of truth.

After another release beyond that, we can clean up any stray references to DataAccessLevel in places like CDR Config files.

Also includes https://github.com/all-of-us/workbench/pull/4722 - fix CdrConfigVOMapper and add tests.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
