### PR TITLE
[RW-6461][risk=low]: Add index on status for billing_project_buffer_entry table

### DIFF
--- a/api/db/changelog/db.changelog-155-add-ras-link-entries.xml
+++ b/api/db/changelog/db.changelog-155-add-ras-link-entries.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-  <changeSet author="yonghao" id="db.changelog-155-add-ras-link-entries">
+  <changeSet author="yonghao" id="db.changelog-153-add-ras-link-entries">
     <addColumn tableName="user">
       <column name="ras_link_login_gov_username" type="varchar(255)"/>
       <column name="ras_link_login_gov_completion_time" type="datetime"/>

--- a/api/db/changelog/db.changelog-155-add-ras-link-entries.xml
+++ b/api/db/changelog/db.changelog-155-add-ras-link-entries.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-  <changeSet author="yonghao" id="db.changelog-153-add-ras-link-entries">
+  <changeSet author="yonghao" id="db.changelog-155-add-ras-link-entries">
     <addColumn tableName="user">
       <column name="ras_link_login_gov_username" type="varchar(255)"/>
       <column name="ras_link_login_gov_completion_time" type="datetime"/>

--- a/api/db/changelog/db.changelog-156-billing-buffer-entry-status-index.xml
+++ b/api/db/changelog/db.changelog-156-billing-buffer-entry-status-index.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="yonghao" id="changelog-156-billing-buffer-entry-status-index">
+    <createIndex tableName="billing_project_buffer_entry" indexName="billing_project_buffer_entry_status_idx" unique="false">
+      <column name="status"/>
+    </createIndex>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -165,6 +165,7 @@
   <include file="changelog/db.changelog-153-cdr-version-addDefaultValue-data_access_level.xml"/>
   <include file="changelog/db.changelog-154-wgs-cromwell-extract-submission.xml"/>
   <include file="changelog/db.changelog-155-add-ras-link-entries.xml"/>
+  <include file="changelog/db.changelog-156-billing-buffer-entry-status-index.xml"/>
 
   <!--
    Note: to update the DB locally, do the following:


### PR DESCRIPTION
Description:
Background: post workspace times out if too many request comes at the same time. Adding index would speed up the query time.

```
mysql> SHOW INDEX FROM billing_project_buffer_entry;
+------------------------------+------------+-----------------------------------------------+--------------+---------------------------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| Table                        | Non_unique | Key_name                                      | Seq_in_index | Column_name                     | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+------------------------------+------------+-----------------------------------------------+--------------+---------------------------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| billing_project_buffer_entry |          0 | PRIMARY                                       |            1 | billing_project_buffer_entry_id | A         |          17 |     NULL | NULL   |      | BTREE      |         |               |
| billing_project_buffer_entry |          0 | firecloud_project_name                        |            1 | firecloud_project_name          | A         |          17 |     NULL | NULL   |      | BTREE      |         |               |
| billing_project_buffer_entry |          1 | fk_billing_project_buffer_entry_assigned_user |            1 | assigned_user_id                | A         |           2 |     NULL | NULL   | YES  | BTREE      |         |               |
| billing_project_buffer_entry |          1 | fk_billing_buffer_tier                        |            1 | access_tier                     | A         |           1 |     NULL | NULL   | YES  | BTREE      |         |               |
| billing_project_buffer_entry |          1 | billing_project_buffer_entry_status_idx       |            1 | status                          | A         |           3 |     NULL | NULL   |      | BTREE      |         |               |
+------------------------------+------------+-----------------------------------------------+--------------+---------------------------------+-----------+-------------+----------+--------+------+------------+---------+---------------+

```
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
