### PR TITLE
[RW-5741][risk=no] Fix "undefined" in the window title

### DIFF
--- a/ui/src/app/pages/app/component.ts
+++ b/ui/src/app/pages/app/component.ts
@@ -124,7 +124,6 @@ export class AppComponent implements OnInit {
         currentRoute.data.subscribe(value => {
           const routeTitle = value.title || this.titleFromPathElement(currentRoute, value.pathElementForTitle);
           this.titleService.setTitle(buildPageTitleForEnvironment(routeTitle));
-          console.log(value, `ng route: ${routeTitle}, ${buildPageTitleForEnvironment(routeTitle)}`)
         });
       }
     }
@@ -136,7 +135,6 @@ export class AppComponent implements OnInit {
       currentRoute.data.subscribe(() => {
         const routeTitle = title || this.titleFromPathElement(currentRoute, pathElementForTitle);
         this.titleService.setTitle(buildPageTitleForEnvironment(routeTitle));
-        console.log(`react route: ${buildPageTitleForEnvironment(routeTitle)}`)
       });
     }
   }

--- a/ui/src/app/pages/app/component.ts
+++ b/ui/src/app/pages/app/component.ts
@@ -1,6 +1,5 @@
 import {Component, OnInit} from '@angular/core';
 import {Title} from '@angular/platform-browser';
-import {buildPageTitleForEnvironment} from 'app/utils/title';
 import {
   ActivatedRoute,
   Event as RouterEvent,
@@ -8,6 +7,7 @@ import {
   NavigationError,
   Router,
 } from '@angular/router';
+import {buildPageTitleForEnvironment} from 'app/utils/title';
 
 
 import {ServerConfigService} from 'app/services/server-config.service';

--- a/ui/src/app/utils/title.ts
+++ b/ui/src/app/utils/title.ts
@@ -4,11 +4,11 @@ import {BASE_TITLE} from 'app/utils/strings';
 
 export function buildPageTitleForEnvironment(pageTitle?: string) {
   let title = BASE_TITLE;
+  if (pageTitle) {
+    title = `${pageTitle} | ${title}`;
+  }
   if (environment.shouldShowDisplayTag) {
     title = `[${environment.displayTag}] ${title}`;
-    if (pageTitle) {
-      title = `${pageTitle} | ${title}`;
-    }
   }
   return title;
 }


### PR DESCRIPTION
- Window title flashed in "undefined | " during initial load. Fix this by properly handling unset values in the route parameters
- Switched code to use dead utility function for building page titles
- Updated page title logic to always place the environment first; most people are unlikely to notice/care the tab title, but this feels more consistent to me