### PR TITLE
[no ticket][risk=no] Puppeteer getSelectedValue function fix

### DIFF
--- a/e2e/app/element/select.ts
+++ b/e2e/app/element/select.ts
@@ -26,7 +26,7 @@ export default class Select extends BaseElement {
   async selectOption(value: string): Promise<string> {
     const disabled = await this.isDisabled();
     if (disabled) {
-      console.warn(`Select is disabled. Cannot select option value: "${value}".`);
+      throw new Error(`Select is disabled. Cannot select option value: "${value}".`);
     }
     const selector = `${this.xpath}/option[text()="${value}"]`;
     await this.page.waitForXPath(selector);

--- a/e2e/app/element/select.ts
+++ b/e2e/app/element/select.ts
@@ -11,7 +11,7 @@ import {buildXPath} from 'app/xpath-builders';
 export default class Select extends BaseElement {
 
   private selectedOption: string;
-   
+
   static async findByName(page: Page, xOpt: XPathOptions, container?: Container): Promise<Select> {
     xOpt.type = ElementType.Select;
     const selectXpath = buildXPath(xOpt, container);
@@ -47,11 +47,17 @@ export default class Select extends BaseElement {
   }
 
   /**
-   *
+   * Returns value of Selected option.
    */
   async getSelectedValue(): Promise<string> {
-    const selectedValue = await this.page.waitForXPath(`${this.getXpath()}/label`, {visible: true});
-    const baseElement = await BaseElement.asBaseElement(this.page, selectedValue);
-    return await baseElement.getTextContent();
+    const selectElement = await this.page.waitForXPath(this.getXpath(), {visible: true});
+    const selectedOption = await this.page.evaluate(select => {
+      for(const option of select.options) {
+        if(option.selected) {
+          return option.value;
+        }
+      }
+    }, selectElement);
+    return selectedOption;
   }
 }

--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -30,9 +30,8 @@ describe('Editing workspace via workspace card snowman menu', () => {
     const workspaceEditPage = new WorkspaceEditPage(page);
 
     // CDR Version Select is readonly. Get selected value.
-    const selectedOption = await workspaceEditPage.selectCdrVersion();
     const cdrVersionSelect = await workspaceEditPage.getCdrVersionSelect();
-    const selectedValue = await cdrVersionSelect.getOptionValue(selectedOption);
+    const selectedValue = await cdrVersionSelect.getSelectedValue();
 
     // Change question #2 answer
     await performActions(page, testData.defaultAnswersResearchPurposeSummary);
@@ -105,10 +104,9 @@ describe('Editing workspace via workspace card snowman menu', () => {
 
     const workspaceEditPage = new WorkspaceEditPage(page);
 
-     // CDR Version Select is readonly. Get selected value.
-    const selectedOption = await workspaceEditPage.selectCdrVersion();
+    // CDR Version Select is readonly. Get selected value.
     const cdrVersionSelect = await workspaceEditPage.getCdrVersionSelect();
-    const selectedValue = await cdrVersionSelect.getOptionValue(selectedOption);
+    const selectedValue = await cdrVersionSelect.getSelectedValue();
 
     // Change question #2 answer
      await performActions(page, testData.defaultAnswersResearchPurposeSummary);


### PR DESCRIPTION
Issue: `getSelectedValue` is not working when working inside a disabled `select` element. An workaround was used but it works with following annoying error every time.

```
console.warn
      Select is disabled. Cannot select option value: "Synthetic Dataset v3".

      27 |     const disabled = await this.isDisabled();
      28 |     if (disabled) {
    > 29 |       console.warn(`Select is disabled. Cannot select option value: "${value}".`);
         |               ^
      30 |     }
      31 |     const selector = `${this.xpath}/option[text()="${value}"]`;
      32 |     await this.page.waitForXPath(selector);

      at Select.selectOption (app/element/select.ts:29:15)
      at Object.<anonymous> (tests/workspace/workspace-edit.spec.ts:33:28)`
```
