### PR TITLE
[risk=no] Fix unsafeAllowAccessToAllTiersForRegisteredUsers config value location

### DIFF
--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -107,7 +107,6 @@
   },
   "access": {
     "enableComplianceTraining": true,
-    "unsafeAllowAccessToAllTiersForRegisteredUsers": false,
     "enableEraCommons": true,
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
@@ -117,6 +116,7 @@
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,
+    "unsafeAllowAccessToAllTiersForRegisteredUsers": false,
     "enableRdrExport": true,
     "enableBillingUpgrade": true,
     "enableV3DataUserCodeOfConduct": true,


### PR DESCRIPTION
Seems this was just a typo in this particular config - other environments look fine. This caused a failure on deploy because the config JSON wasn't recognized.

A very old ticket is still the correct fix for this issue, which is to add a test to cover config correctness: https://precisionmedicineinitiative.atlassian.net/browse/RW-2408