### PR TITLE
[risk=no] rm deprecated requireInviteKey flag (2/2)

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -109,8 +109,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": true,
-    "unsafeAllowUserCreationFromGSuiteData": true,
-    "requireInvitationKey": false
+    "unsafeAllowUserCreationFromGSuiteData": true
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -111,8 +111,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": true,
-    "unsafeAllowUserCreationFromGSuiteData": false,
-    "requireInvitationKey": false
+    "unsafeAllowUserCreationFromGSuiteData": false
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -108,8 +108,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
-    "unsafeAllowUserCreationFromGSuiteData": false,
-    "requireInvitationKey": false
+    "unsafeAllowUserCreationFromGSuiteData": false
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -108,8 +108,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
-    "unsafeAllowUserCreationFromGSuiteData": false,
-    "requireInvitationKey": false
+    "unsafeAllowUserCreationFromGSuiteData": false
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -108,8 +108,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
-    "unsafeAllowUserCreationFromGSuiteData": false,
-    "requireInvitationKey": false
+    "unsafeAllowUserCreationFromGSuiteData": false
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -108,8 +108,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
-    "unsafeAllowUserCreationFromGSuiteData": false,
-    "requireInvitationKey": false
+    "unsafeAllowUserCreationFromGSuiteData": false
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -109,8 +109,7 @@
     "enableDataUseAgreement": true,
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": true,
-    "unsafeAllowUserCreationFromGSuiteData": true,
-    "requireInvitationKey": false
+    "unsafeAllowUserCreationFromGSuiteData": true
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,

--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -37,7 +37,6 @@ public class ConfigController implements ConfigApiDelegate {
             .enableDataUseAgreement(config.access.enableDataUseAgreement)
             .enableBetaAccess(config.access.enableBetaAccess)
             .unsafeAllowSelfBypass(config.access.unsafeAllowSelfBypass)
-            .requireInvitationKey(config.access.requireInvitationKey)
             .enableBillingUpgrade(config.featureFlags.enableBillingUpgrade)
             .enableV3DataUserCodeOfConduct(config.featureFlags.enableV3DataUserCodeOfConduct)
             .enableEventDateModifier(config.featureFlags.enableEventDateModifier)

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -254,9 +254,6 @@ public class WorkbenchConfig {
     public boolean enableEraCommons;
     public boolean enableDataUseAgreement;
     public boolean enableBetaAccess;
-
-    // TODO(calbach): Remove after https://github.com/all-of-us/workbench/pull/4623 is released.
-    @Deprecated public boolean requireInvitationKey;
   }
 
   public static class FeatureFlagsConfig {

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3967,10 +3967,6 @@ definitions:
         default: false
         description: Whether a user is allowed to self-bypass. Only enabled in test
           environments.
-      requireInvitationKey:
-        type: boolean
-        default: false
-        description: Whether the current environment requires an invitation key for signup.
       defaultFreeCreditsDollarLimit:
         type: number
         format: double


### PR DESCRIPTION
Follow-up to https://github.com/all-of-us/workbench/pull/4623