### PR TITLE
[RW-6320][risk=no] Move concept homepage and actions page to React router

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -14,7 +14,6 @@ import {DetailPageComponent} from './pages/data/cohort-review/detail-page';
 import {QueryReportComponent} from './pages/data/cohort-review/query-report.component';
 import {TablePage} from './pages/data/cohort-review/table-page';
 import {ConceptSearchComponent} from './pages/data/concept/concept-search';
-import {ConceptSetActionsComponent} from './pages/data/concept/concept-set-actions';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceWrapperComponent} from './pages/workspace/workspace-wrapper/component';
 
@@ -276,12 +275,8 @@ const routes: Routes = [
                           },
                         }, {
                           path: ':csid/actions',
-                          component: ConceptSetActionsComponent,
-                          data: {
-                            title: 'Concept Set Actions',
-                            breadcrumb: BreadcrumbType.ConceptSet,
-                            helpContentKey: 'conceptSets'
-                          },
+                          component: AppRouting,
+                          data: {},
                         }, ]
                       }
                     ]

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -13,7 +13,6 @@ import {CohortReviewComponent} from './pages/data/cohort-review/cohort-review';
 import {DetailPageComponent} from './pages/data/cohort-review/detail-page';
 import {QueryReportComponent} from './pages/data/cohort-review/query-report.component';
 import {TablePage} from './pages/data/cohort-review/table-page';
-import {ConceptHomepageComponent} from './pages/data/concept/concept-homepage';
 import {ConceptSearchComponent} from './pages/data/concept/concept-search';
 import {ConceptSetActionsComponent} from './pages/data/concept/concept-set-actions';
 import {SignedInComponent} from './pages/signed-in/component';
@@ -251,12 +250,8 @@ const routes: Routes = [
                         path: 'concepts',
                         children: [{
                           path: '',
-                          component: ConceptHomepageComponent,
-                          data: {
-                            title: 'Search Concepts',
-                            breadcrumb: BreadcrumbType.SearchConcepts,
-                            helpContentKey: 'conceptSets'
-                          }
+                          component: AppRouting,
+                          data: {}
                         }, {
                           path: ':domain',
                           component: ConceptSearchComponent,

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -27,6 +27,7 @@ import {InteractiveNotebook} from './pages/analysis/interactive-notebook';
 import {NotebookList} from './pages/analysis/notebook-list';
 import {NotebookRedirect} from './pages/analysis/notebook-redirect';
 import {CohortActions} from './pages/data/cohort/cohort-actions';
+import {ConceptHomepage} from './pages/data/concept/concept-homepage';
 import {Homepage} from './pages/homepage/homepage';
 import {SignIn} from './pages/login/sign-in';
 import {ProfilePage} from './pages/profile/profile-page';
@@ -50,8 +51,9 @@ const registrationGuard: Guard = {
 
 const AdminBannerPage = withRouteData(AdminBanner);
 const AdminNotebookViewPage = withRouteData(AdminNotebookView);
-const CohortActionsPage = withRouteData(CohortActions);
 const AdminReviewWorkspacePage = withRouteData(AdminReviewWorkspace);
+const CohortActionsPage = withRouteData(CohortActions);
+const ConceptHomepagePage = withRouteData(ConceptHomepage);
 const CookiePolicyPage = withRouteData(CookiePolicy);
 const DataUserCodeOfConductPage = fp.flow(withRouteData, withFullHeight)(DataUserCodeOfConduct);
 const HomepagePage = withRouteData(Homepage); // this name is bad i am sorry
@@ -277,6 +279,14 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
             title: 'Cohort Actions',
             breadcrumb: BreadcrumbType.Cohort,
             helpContentKey: 'cohortBuilder'
+          }}/>}
+        />
+        <AppRoute
+          path='/workspaces/:ns/:wsid/data/concepts'
+          component={() => <ConceptHomepagePage routeData={{
+            title: 'Search Concepts',
+            breadcrumb: BreadcrumbType.SearchConcepts,
+            helpContentKey: 'conceptSets'
           }}/>}
         />
       </ProtectedRoutes>

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -28,6 +28,7 @@ import {NotebookList} from './pages/analysis/notebook-list';
 import {NotebookRedirect} from './pages/analysis/notebook-redirect';
 import {CohortActions} from './pages/data/cohort/cohort-actions';
 import {ConceptHomepage} from './pages/data/concept/concept-homepage';
+import {ConceptSetActions} from './pages/data/concept/concept-set-actions';
 import {Homepage} from './pages/homepage/homepage';
 import {SignIn} from './pages/login/sign-in';
 import {ProfilePage} from './pages/profile/profile-page';
@@ -54,6 +55,7 @@ const AdminNotebookViewPage = withRouteData(AdminNotebookView);
 const AdminReviewWorkspacePage = withRouteData(AdminReviewWorkspace);
 const CohortActionsPage = withRouteData(CohortActions);
 const ConceptHomepagePage = withRouteData(ConceptHomepage);
+const ConceptSetActionsPage = withRouteData(ConceptSetActions);
 const CookiePolicyPage = withRouteData(CookiePolicy);
 const DataUserCodeOfConductPage = fp.flow(withRouteData, withFullHeight)(DataUserCodeOfConduct);
 const HomepagePage = withRouteData(Homepage); // this name is bad i am sorry
@@ -286,6 +288,14 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
           component={() => <ConceptHomepagePage routeData={{
             title: 'Search Concepts',
             breadcrumb: BreadcrumbType.SearchConcepts,
+            helpContentKey: 'conceptSets'
+          }}/>}
+        />
+        <AppRoute
+          path='/workspaces/:ns/:wsid/data/concepts/sets/:csid/actions'
+          component={() => <ConceptSetActionsPage routeData={{
+            title: 'Concept Set Actions',
+            breadcrumb: BreadcrumbType.ConceptSet,
             helpContentKey: 'conceptSets'
           }}/>}
         />

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -30,7 +30,6 @@ import {CohortReviewComponent} from './pages/data/cohort-review/cohort-review';
 import {DetailPageComponent} from './pages/data/cohort-review/detail-page';
 import {QueryReportComponent} from './pages/data/cohort-review/query-report.component';
 import {TablePage} from './pages/data/cohort-review/table-page';
-import {ConceptHomepageComponent} from './pages/data/concept/concept-homepage';
 import {ConceptSearchComponent} from './pages/data/concept/concept-search';
 import {ConceptSetActionsComponent} from './pages/data/concept/concept-set-actions';
 import {InitialErrorComponent} from './pages/initial-error/component';
@@ -113,7 +112,6 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     CohortPageComponent,
     CohortReviewComponent,
     ConceptSetActionsComponent,
-    ConceptHomepageComponent,
     ConceptSearchComponent,
     ConfirmDeleteModalComponent,
     DataPageComponent,

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -31,7 +31,6 @@ import {DetailPageComponent} from './pages/data/cohort-review/detail-page';
 import {QueryReportComponent} from './pages/data/cohort-review/query-report.component';
 import {TablePage} from './pages/data/cohort-review/table-page';
 import {ConceptSearchComponent} from './pages/data/concept/concept-search';
-import {ConceptSetActionsComponent} from './pages/data/concept/concept-set-actions';
 import {InitialErrorComponent} from './pages/initial-error/component';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceNavBarComponent} from './pages/workspace/workspace-nav-bar';
@@ -111,7 +110,6 @@ export function getLeoConfiguration(signInService: SignInService): LeoConfigurat
     BugReportComponent,
     CohortPageComponent,
     CohortReviewComponent,
-    ConceptSetActionsComponent,
     ConceptSearchComponent,
     ConfirmDeleteModalComponent,
     DataPageComponent,

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -12,7 +12,6 @@ import {cohortBuilderApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {
   reactStyles,
-  ReactWrapperBase,
   validateInputForMySQL,
   withCurrentCohortSearchContext,
   withCurrentConcept,

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -1,4 +1,3 @@
-import {Component} from '@angular/core';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 
@@ -364,12 +363,3 @@ export const ConceptHomepage = fp.flow(withCurrentCohortSearchContext(), withCur
     }
   }
 );
-
-@Component({
-  template: '<div #root></div>'
-})
-export class ConceptHomepageComponent extends ReactWrapperBase {
-  constructor() {
-    super(ConceptHomepage, []);
-  }
-}

--- a/ui/src/app/pages/data/concept/concept-set-actions.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-actions.tsx
@@ -1,4 +1,3 @@
-import {Component} from '@angular/core';
 import {Button} from 'app/components/buttons';
 import {ActionCardBase} from 'app/components/card';
 import {FadeBox} from 'app/components/containers';
@@ -6,7 +5,7 @@ import {FlexColumn, FlexRow} from 'app/components/flex';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {conceptSetsApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
-import {reactStyles, ReactWrapperBase, withCurrentWorkspace} from 'app/utils';
+import {reactStyles, withCurrentWorkspace} from 'app/utils';
 import {conceptSetUpdating, navigate, navigateByUrl, urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {ConceptSet} from 'generated/fetch';
@@ -155,13 +154,3 @@ export const ConceptSetActions = withCurrentWorkspace()(
     }
   }
 );
-
-@Component({
-  template: '<div #root></div>'
-})
-export class ConceptSetActionsComponent extends ReactWrapperBase {
-
-  constructor() {
-    super(ConceptSetActions, []);
-  }
-}


### PR DESCRIPTION
Moves routes for `ConceptHomepage` and `ConceptSetActions` components from Angular to React router

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] I have run and tested this change locally
