### PR TITLE
[RW-6460][risk=no] Bump heap size for API unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ anchors:
     # See: https://support.circleci.com/hc/en-us/articles/360021812453-Common-Android-memory-issues
     GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
     TERM: dumb
-
+    
   env-db: &env-db
     MYSQL_ROOT_PASSWORD: ubuntu
     MYSQL_USER: ubuntu
@@ -66,12 +66,24 @@ anchors:
 # -------------------------
 executors:
   # Default workbench docker image environment which is used in all jobs
-  workbench-executor:
+  workbench-executor: &workbench-executor
     environment:
       <<: *env-default
     docker:
       - image: << pipeline.parameters.workbench-image >>
     working_directory: ~/workbench
+  
+  # Variant of the default executor with a higher heap size. This is currently needed as Junit4 does not
+  # release test memory across unit test runs, and certain combinations of tests will trigger OOM errors
+  # due to garbage collection timeout. This should be reassessed after upgrading to Junit 5. See RW-6460.
+  api-unit-test-executor:
+    <<: *workbench-executor
+    environment:
+      <<: *env-default
+      # This still assumes a 4G (medium) machine. This increase is possible for unit tests as they are run
+      # as a ~single-process workflow - in other cases using 3GB may starve other processes. For example,
+      # this should not be used for the Local API integration test (which starts both a server, and a test process).
+      JAVA_TOOL_OPTIONS: -Xmx3g
 
   # Default workbench environment plus MySQL database docker image
   db-executor:
@@ -310,7 +322,7 @@ commands:
 jobs:
   api-unit-test:
     parallelism: 4
-    executor: workbench-executor
+    executor: api-unit-test-executor
     steps:
       - run-api-test:
           additional_steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ anchors:
     # See: https://support.circleci.com/hc/en-us/articles/360021812453-Common-Android-memory-issues
     GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
     TERM: dumb
-    
+
   env-db: &env-db
     MYSQL_ROOT_PASSWORD: ubuntu
     MYSQL_USER: ubuntu

--- a/api/src/test/java/org/pmiops/workbench/genomics/WgsCohortExtractionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/genomics/WgsCohortExtractionServiceTest.java
@@ -93,6 +93,7 @@ public class WgsCohortExtractionServiceTest {
       return cloudStorageClient;
     }
 
+    // XXX: revert - CI trigger
     @Bean
     @Scope("prototype")
     DbUser user() {

--- a/api/src/test/java/org/pmiops/workbench/genomics/WgsCohortExtractionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/genomics/WgsCohortExtractionServiceTest.java
@@ -93,7 +93,6 @@ public class WgsCohortExtractionServiceTest {
       return cloudStorageClient;
     }
 
-    // XXX: revert - CI trigger
     @Bean
     @Scope("prototype")
     DbUser user() {


### PR DESCRIPTION
2GB -> 3GB. UPdating https://precisionmedicineinitiative.atlassian.net/browse/RW-6460 with working theory. Capturing heap dump wasn't too useful, but did show some things.