### PR TITLE
[RW-6107][risk=low] Escape user instructions on render, use alternate escaping library

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionUserInstructionsMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionUserInstructionsMapper.java
@@ -2,8 +2,6 @@ package org.pmiops.workbench.institution;
 
 import com.google.common.base.Strings;
 import org.mapstruct.Mapper;
-import org.owasp.html.HtmlPolicyBuilder;
-import org.owasp.html.PolicyFactory;
 import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbInstitutionUserInstructions;
 import org.pmiops.workbench.exceptions.BadRequestException;
@@ -16,19 +14,13 @@ public interface InstitutionUserInstructionsMapper {
       InstitutionUserInstructions modelObject, DbInstitution institution) {
 
     // don't store empty or null instructions
-    // sanitize() converts null to empty string, so we can't rely on it for this check
-
     final String instructions = modelObject.getInstructions();
     if (Strings.isNullOrEmpty(instructions)) {
       throw new BadRequestException(
           "Cannot save InstitutionUserInstructions because the instructions are missing.");
     }
-
-    final PolicyFactory removeAllTags = new HtmlPolicyBuilder().toFactory();
-    final String sanitizedInstructions = removeAllTags.sanitize(instructions).trim();
-
     return new DbInstitutionUserInstructions()
         .setInstitution(institution)
-        .setUserInstructions(sanitizedInstructions);
+        .setUserInstructions(instructions);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.mail;
 
 import com.google.api.services.directory.model.User;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.html.HtmlEscapers;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -98,10 +99,16 @@ public class MailServiceImpl implements MailService {
   @Override
   public void sendInstitutionUserInstructions(String contactEmail, String userInstructions)
       throws MessagingException {
+    // TODO(RW-6482): Use a templating system rather than manual oneoff escaping.
+    // These institutional instructions are stored unescaped. Though they are input by admins,
+    // the strings should note be trusted as HTML.
+    String escapedUserInstructions = HtmlEscapers.htmlEscaper().escape(userInstructions);
     final MandrillMessage msg =
         new MandrillMessage()
             .to(Collections.singletonList(validatedRecipient(contactEmail)))
-            .html(buildHtml(INSTRUCTIONS_RESOURCE, instructionsSubstitutionMap(userInstructions)))
+            .html(
+                buildHtml(
+                    INSTRUCTIONS_RESOURCE, instructionsSubstitutionMap(escapedUserInstructions)))
             .subject("Instructions from your institution on using the Researcher Workbench")
             .fromEmail(workbenchConfigProvider.get().mandrill.fromEmail);
 

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -101,7 +101,7 @@ public class MailServiceImpl implements MailService {
       throws MessagingException {
     // TODO(RW-6482): Use a templating system rather than manual oneoff escaping.
     // These institutional instructions are stored unescaped. Though they are input by admins,
-    // the strings should note be trusted as HTML.
+    // the strings should not be trusted as HTML.
     String escapedUserInstructions = HtmlEscapers.htmlEscaper().escape(userInstructions);
     final MandrillMessage msg =
         new MandrillMessage()

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -870,28 +870,21 @@ public class ProfileControllerTest extends BaseControllerTest {
   }
 
   @Test
-  public void sendUserInstructions_sanitized() throws MessagingException {
+  public void sendUserInstructions_withInstructions() throws MessagingException {
     final VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation =
         createVerifiedInstitutionalAffiliation();
-
-    final String rawInstructions =
-        "<html><script>window.alert('hacked');</script></html>"
-            + "Wash your hands for 20 seconds"
-            + "<STYLE type=\"text/css\">BODY{background:url(\"javascript:alert('XSS')\")} "
-            + "div {color: 'red'}</STYLE>\n"
-            + "<img src=\"https://eviltrackingpixel.com\" />\n";
-
-    final String sanitizedInstructions = "Wash your hands for 20 seconds";
 
     final InstitutionUserInstructions instructions =
         new InstitutionUserInstructions()
             .institutionShortName(verifiedInstitutionalAffiliation.getInstitutionShortName())
-            .instructions(rawInstructions);
+            .instructions(
+                "Wash your hands for 20 seconds <img src=\"https://this.is.escaped.later.com\" />");
     institutionService.setInstitutionUserInstructions(instructions);
 
     createAccountAndDbUserWithAffiliation(verifiedInstitutionalAffiliation);
     verify(mockMailService).sendWelcomeEmail(any(), any(), any());
-    verify(mockMailService).sendInstitutionUserInstructions(CONTACT_EMAIL, sanitizedInstructions);
+    verify(mockMailService)
+        .sendInstitutionUserInstructions(CONTACT_EMAIL, instructions.getInstructions());
   }
 
   @Test


### PR DESCRIPTION
Backfill / migration should not be necessary, admins can just re-save as needed.