### PR TITLE
[RW-6441][risk=no] Generate prep tables for csv files

### DIFF
--- a/api/db-cdr/generate-cdr/bq-schemas/prep_clinical_terms_nc.json
+++ b/api/db-cdr/generate-cdr/bq-schemas/prep_clinical_terms_nc.json
@@ -1,0 +1,12 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "parent",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "concept_id",
+    "type": "INTEGER"
+  }
+]

--- a/api/db-cdr/generate-cdr/bq-schemas/prep_criteria.json
+++ b/api/db-cdr/generate-cdr/bq-schemas/prep_criteria.json
@@ -1,0 +1,87 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "parent_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "domain_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_standard",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "subtype",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "concept_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "value",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "est_count",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_group",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_selectable",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "has_attribute",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "has_hierarchy",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "synonyms",
+    "type": "STRING"
+  }
+]

--- a/api/db-cdr/generate-cdr/bq-schemas/prep_criteria_ancestor.json
+++ b/api/db-cdr/generate-cdr/bq-schemas/prep_criteria_ancestor.json
@@ -1,0 +1,12 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "ancestor_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "descendant_id",
+    "type": "INTEGER"
+  }
+]

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-tables.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-tables.sh
@@ -22,7 +22,6 @@ else
     echo "Validation failed!"
     exit 1
 fi
-exit 1
 
 echo ""
 echo 'Making denormalized search events table'

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-tables.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-tables.sh
@@ -22,6 +22,7 @@ else
     echo "Validation failed!"
     exit 1
 fi
+exit 1
 
 echo ""
 echo 'Making denormalized search events table'

--- a/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
+++ b/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
@@ -23,54 +23,71 @@ if [[ ${INCOMPATIBLE_DATASETS[@]} =~ $BQ_DATASET ]];
   exit 1
 fi
 
+# Purge all backup csv files except for the last 10 versions
+fileCount=$(gsutil ls gs://all-of-us-workbench-private-cloudsql/DummySR/cdr_csv_files/backup | wc -l)
+numberToDelete=$(($fileCount - ${#All_FILES[@]} * 10))
+if [[ $numberToDelete > 0 ]];
+then
+  echo "Purging backup files"
+  while IFS= read -r line; do
+    ts=$(echo $line | cut -d_ -f1)
+    if [[ ${#ts} > 0 ]];
+    then
+      echo "Removing $line"
+      gsutil rm gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/backup/$line
+    fi
+  # This lists all the files in the backup bucket sorted by timestamp and gets only the number to delete
+  done < <(gsutil ls gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/backup | rev | cut -d/ -f1 | rev | sort | head -$numberToDelete)
+fi
+
 rm -rf $TEMP_FILE_DIR
 mkdir $TEMP_FILE_DIR
 
 if gsutil -m cp gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/*.csv $TEMP_FILE_DIR
  then
+  timestamp=$(date +%s)
   for file in ${All_FILES[@]}; do
     read -r header < $TEMP_FILE_DIR/$file
     IFS=',' read -r -a columns <<< $header
     case $file in
       $CRITERIA_MENU)
-        echo "Processing $CRITERIA_MENU"
+        echo "Processing $file"
         if [[ $columns =~ id ]];
         then
-          echo "Removing $CRITERIA_MENU header"
-          # remove the first line of file
+          echo "Removing $file header"
+          # Remove the first line of file
           sed 1d $TEMP_FILE_DIR/$file > $TEMP_FILE_DIR/temp_$file
-          # zip the file
+          # Zip the file
           gzip -cvf $TEMP_FILE_DIR/temp_$file > $TEMP_FILE_DIR/$file.gz
         else
-          # zip the file
+          # Zip the file
           gzip $TEMP_FILE_DIR/$file
         fi
-        # copy it back to bucket
+        # Copy it back to bucket
         gsutil cp $TEMP_FILE_DIR/$file.gz gs://$BUCKET/$BQ_DATASET/$CDR_VERSION/
+        # Backup the csv file
+        echo "Backing up $file"
+        gsutil cp $TEMP_FILE_DIR/$file.gz gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/backup/"$timestamp"_"$file".gz
       ;;
     $PREP_CRITERIA|$PREP_CRITERIA_ANCESTOR|$PREP_CLINICAL_TERMS)
-      echo "Processing $file"
       tableName=${file%.*}
       if [[ $columns =~ id || $columns =~ ancestor_id || $columns =~ parent ]];
       then
         echo "Removing $file header"
-        # remove the first line of file
+        # Remove the first line of file
         sed 1d $TEMP_FILE_DIR/$file > $TEMP_FILE_DIR/temp_$file
-        # rename file
+        # Rename file
         mv $TEMP_FILE_DIR/temp_$file $TEMP_FILE_DIR/$file
-        # copy it back to bucket
+        # Copy it back to bucket
         echo "Copying $file"
         gsutil cp $TEMP_FILE_DIR/$file gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/
       fi
 
-      # backup the csv file
+      # Backup the csv file
       echo "Backing up $file"
-      timestamp=$(date +%s)
-      # cutoffTimestamp=$(date -d "2019-10-01 23:29:40" +%s)
-      echo "$cutoffTimestamp"
       bq extract --project_id=$BQ_PROJECT --compression GZIP --print_header=false $BQ_DATASET.$tableName gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/backup/"$timestamp"_"$file".gz
 
-      # load the csv file into table
+      # Load the csv file into table
       echo "Starting load of $file"
       schema_path=generate-cdr/bq-schemas
       bq --project_id=$BQ_PROJECT rm -f $BQ_DATASET.$tableName
@@ -84,4 +101,3 @@ if gsutil -m cp gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/*.csv $TEMP_FILE_DIR
 fi
 
 rm -rf $TEMP_FILE_DIR
-# More validation to come in future stories

--- a/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
+++ b/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
@@ -25,7 +25,8 @@ fi
 
 # Purge all backup csv files except for the last 10 versions
 fileCount=$(gsutil ls gs://all-of-us-workbench-private-cloudsql/DummySR/cdr_csv_files/backup | wc -l)
-numberToDelete=$(($fileCount - ${#All_FILES[@]} * 10))
+allFilesCount=${#All_FILES[@]}
+numberToDelete=$((fileCount - allFilesCount * 10))
 if [[ $numberToDelete > 0 ]];
 then
   echo "Purging backup files"

--- a/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
+++ b/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
@@ -8,7 +8,8 @@ export BQ_DATASET=$2        # CDR dataset
 export CDR_VERSION=$3       # CDR version
 export BUCKET=$4            # Bucket
 
-FILE_DIR="csv"
+TEMP_FILE_DIR="csv"
+CSV_HOME_DIR="cdr_csv_files"
 CRITERIA_MENU="cb_criteria_menu.csv"
 PREP_CRITERIA="prep_criteria.csv"
 PREP_CRITERIA_ANCESTOR="prep_criteria_ancestor.csv"
@@ -22,34 +23,53 @@ if [[ "${INCOMPATIBLE_DATASETS[@]}" =~ "$BQ_DATASET" ]];
   exit 1
 fi
 
-rm -rf "$FILE_DIR"
-mkdir "$FILE_DIR"
+rm -rf "$TEMP_FILE_DIR"
+mkdir "$TEMP_FILE_DIR"
 
-if gsutil -m cp gs://"$BUCKET"/"$BQ_DATASET"/cdr_csv_files/*.csv "$FILE_DIR"
+if gsutil -m cp gs://"$BUCKET"/"$BQ_DATASET"/"$CSV_HOME_DIR"/*.csv "$TEMP_FILE_DIR"
  then
   for file in ${All_FILES[@]}; do
-    read -r header < "$FILE_DIR"/"$file"
+    read -r header < "$TEMP_FILE_DIR"/"$file"
     IFS=',' read -r -a columns <<< "$header"
     case "$file" in
       "$CRITERIA_MENU")
         echo "Processing $CRITERIA_MENU"
         if [[ "$columns" =~ id ]];
-        echo "Removing header"
         then
+          echo "Removing $CRITERIA_MENU header"
           # remove the first line of file
-          sed 1d "$FILE_DIR"/"$file" > "$FILE_DIR"/temp_"$file"
+          sed 1d "$TEMP_FILE_DIR"/"$file" > "$TEMP_FILE_DIR"/temp_"$file"
           # zip the file
-          gzip -cvf "$FILE_DIR"/temp_"$file" > "$FILE_DIR"/"$file".gz
+          gzip -cvf "$TEMP_FILE_DIR"/temp_"$file" > "$TEMP_FILE_DIR"/"$file".gz
         else
           # zip the file
-          gzip "$FILE_DIR"/"$file"
+          gzip "$TEMP_FILE_DIR"/"$file"
         fi
         # copy it back to bucket
-        gsutil cp "$FILE_DIR"/"$file".gz gs://"$BUCKET"/"$BQ_DATASET"/"$CDR_VERSION"/
+        gsutil cp "$TEMP_FILE_DIR"/"$file".gz gs://"$BUCKET"/"$BQ_DATASET"/"$CDR_VERSION"/
       ;;
     "$PREP_CRITERIA")
       # TODO: RW-6441
       echo "Processing $PREP_CRITERIA"
+      tableName=${file%.*}
+      if [[ "$columns" =~ id ]];
+      then
+        echo "Removing $PREP_CRITERIA header"
+        # remove the first line of file
+        sed 1d "$TEMP_FILE_DIR"/"$file" > "$TEMP_FILE_DIR"/temp_"$file"
+        # rename file
+        mv "$TEMP_FILE_DIR"/temp_"$file" "$TEMP_FILE_DIR"/"$file"
+      fi
+      # copy it back to bucket
+      gsutil cp "$TEMP_FILE_DIR"/"$file" gs://"$BUCKET"/"$BQ_DATASET"/"$CSV_HOME_DIR"/
+
+      # Create bq tables we have json schema for
+      schema_path=generate-cdr/bq-schemas
+
+      bq --project_id=$BQ_PROJECT rm -f $BQ_DATASET."$tableName"
+      bq load --project_id=$BQ_PROJECT --source_format=CSV $BQ_DATASET."$tableName" gs://"$BUCKET"/"$BQ_DATASET"/"$CSV_HOME_DIR"/"$PREP_CRITERIA" $schema_path/"$tableName".json
+      echo "Finished loading $PREP_CRITERIA"
+
     ;;
     "$PREP_CRITERIA_ANCESTOR")
       # TODO: RW-6441
@@ -65,5 +85,5 @@ if gsutil -m cp gs://"$BUCKET"/"$BQ_DATASET"/cdr_csv_files/*.csv "$FILE_DIR"
   done
 fi
 
-rm -rf "$FILE_DIR"
+rm -rf "$TEMP_FILE_DIR"
 # More validation to come in future stories

--- a/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
+++ b/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
@@ -14,70 +14,68 @@ CRITERIA_MENU="cb_criteria_menu.csv"
 PREP_CRITERIA="prep_criteria.csv"
 PREP_CRITERIA_ANCESTOR="prep_criteria_ancestor.csv"
 PREP_CLINICAL_TERMS="prep_clinical_terms_nc.csv"
-All_FILES=("$CRITERIA_MENU" "$PREP_CRITERIA" "$PREP_CRITERIA_ANCESTOR" "$PREP_CLINICAL_TERMS")
+All_FILES=($CRITERIA_MENU $PREP_CRITERIA $PREP_CRITERIA_ANCESTOR $PREP_CLINICAL_TERMS)
 INCOMPATIBLE_DATASETS=("R2019Q4R3" "R2019Q4R4")
 
-if [[ "${INCOMPATIBLE_DATASETS[@]}" =~ "$BQ_DATASET" ]];
+if [[ ${INCOMPATIBLE_DATASETS[@]} =~ $BQ_DATASET ]];
   then
   echo "Can't run CDR build indices against "$BQ_DATASET"!"
   exit 1
 fi
 
-rm -rf "$TEMP_FILE_DIR"
-mkdir "$TEMP_FILE_DIR"
+rm -rf $TEMP_FILE_DIR
+mkdir $TEMP_FILE_DIR
 
-if gsutil -m cp gs://"$BUCKET"/"$BQ_DATASET"/"$CSV_HOME_DIR"/*.csv "$TEMP_FILE_DIR"
+if gsutil -m cp gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/*.csv $TEMP_FILE_DIR
  then
   for file in ${All_FILES[@]}; do
-    read -r header < "$TEMP_FILE_DIR"/"$file"
-    IFS=',' read -r -a columns <<< "$header"
-    case "$file" in
-      "$CRITERIA_MENU")
+    read -r header < $TEMP_FILE_DIR/$file
+    IFS=',' read -r -a columns <<< $header
+    case $file in
+      $CRITERIA_MENU)
         echo "Processing $CRITERIA_MENU"
-        if [[ "$columns" =~ id ]];
+        if [[ $columns =~ id ]];
         then
           echo "Removing $CRITERIA_MENU header"
           # remove the first line of file
-          sed 1d "$TEMP_FILE_DIR"/"$file" > "$TEMP_FILE_DIR"/temp_"$file"
+          sed 1d $TEMP_FILE_DIR/$file > $TEMP_FILE_DIR/temp_$file
           # zip the file
-          gzip -cvf "$TEMP_FILE_DIR"/temp_"$file" > "$TEMP_FILE_DIR"/"$file".gz
+          gzip -cvf $TEMP_FILE_DIR/temp_$file > $TEMP_FILE_DIR/$file.gz
         else
           # zip the file
-          gzip "$TEMP_FILE_DIR"/"$file"
+          gzip $TEMP_FILE_DIR/$file
         fi
         # copy it back to bucket
-        gsutil cp "$TEMP_FILE_DIR"/"$file".gz gs://"$BUCKET"/"$BQ_DATASET"/"$CDR_VERSION"/
+        gsutil cp $TEMP_FILE_DIR/$file.gz gs://$BUCKET/$BQ_DATASET/$CDR_VERSION/
       ;;
-    "$PREP_CRITERIA")
-      # TODO: RW-6441
-      echo "Processing $PREP_CRITERIA"
+    $PREP_CRITERIA|$PREP_CRITERIA_ANCESTOR|$PREP_CLINICAL_TERMS)
+      echo "Processing $file"
       tableName=${file%.*}
-      if [[ "$columns" =~ id ]];
+      if [[ $columns =~ id || $columns =~ ancestor_id || $columns =~ parent ]];
       then
-        echo "Removing $PREP_CRITERIA header"
+        echo "Removing $file header"
         # remove the first line of file
-        sed 1d "$TEMP_FILE_DIR"/"$file" > "$TEMP_FILE_DIR"/temp_"$file"
+        sed 1d $TEMP_FILE_DIR/$file > $TEMP_FILE_DIR/temp_$file
         # rename file
-        mv "$TEMP_FILE_DIR"/temp_"$file" "$TEMP_FILE_DIR"/"$file"
+        mv $TEMP_FILE_DIR/temp_$file $TEMP_FILE_DIR/$file
+        # copy it back to bucket
+        echo "Copying $file"
+        gsutil cp $TEMP_FILE_DIR/$file gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/
       fi
-      # copy it back to bucket
-      gsutil cp "$TEMP_FILE_DIR"/"$file" gs://"$BUCKET"/"$BQ_DATASET"/"$CSV_HOME_DIR"/
 
-      # Create bq tables we have json schema for
+      # backup the csv file
+      echo "Backing up $file"
+      timestamp=$(date +%s)
+      # cutoffTimestamp=$(date -d "2019-10-01 23:29:40" +%s)
+      echo "$cutoffTimestamp"
+      bq extract --project_id=$BQ_PROJECT --compression GZIP --print_header=false $BQ_DATASET.$tableName gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/backup/"$timestamp"_"$file".gz
+
+      # load the csv file into table
+      echo "Starting load of $file"
       schema_path=generate-cdr/bq-schemas
-
-      bq --project_id=$BQ_PROJECT rm -f $BQ_DATASET."$tableName"
-      bq load --project_id=$BQ_PROJECT --source_format=CSV $BQ_DATASET."$tableName" gs://"$BUCKET"/"$BQ_DATASET"/"$CSV_HOME_DIR"/"$PREP_CRITERIA" $schema_path/"$tableName".json
-      echo "Finished loading $PREP_CRITERIA"
-
-    ;;
-    "$PREP_CRITERIA_ANCESTOR")
-      # TODO: RW-6441
-      echo "Processing $PREP_CRITERIA_ANCESTOR"
-    ;;
-    "$PREP_CLINICAL_TERMS")
-      # TODO: RW-6441
-      echo "Processing $PREP_CLINICAL_TERMS"
+      bq --project_id=$BQ_PROJECT rm -f $BQ_DATASET.$tableName
+      bq load --project_id=$BQ_PROJECT --source_format=CSV $BQ_DATASET.$tableName gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/$file $schema_path/$tableName.json
+      echo "Finished loading $file"
     ;;
 
     esac
@@ -85,5 +83,5 @@ if gsutil -m cp gs://"$BUCKET"/"$BQ_DATASET"/"$CSV_HOME_DIR"/*.csv "$TEMP_FILE_D
   done
 fi
 
-rm -rf "$TEMP_FILE_DIR"
+rm -rf $TEMP_FILE_DIR
 # More validation to come in future stories

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -845,16 +845,6 @@ def make_bq_denormalized_tables(cmd_name, *args)
     "BQ dataset. Required."
   )
   op.add_option(
-    "--wgv-project [wgv-project]",
-    ->(opts, v) { opts.wgv_project = v},
-    "Whole Genome Variant Project. Required."
-  )
-  op.add_option(
-    "--wgv-dataset [wgv-dataset]",
-    ->(opts, v) { opts.wgv_dataset = v},
-    "Whole Genome Variant Dataset. Required."
-  )
-  op.add_option(
     "--cdr-version [cdr-version]",
     ->(opts, v) { opts.cdr_version = v},
     "CDR version. Required."
@@ -870,9 +860,19 @@ def make_bq_denormalized_tables(cmd_name, *args)
     "GCS bucket. Required."
   )
   op.add_option(
+    "--wgv-project [wgv-project]",
+    ->(opts, v) { opts.wgv_project = v},
+    "Whole Genome Variant Project. Optional."
+  )
+  op.add_option(
+    "--wgv-dataset [wgv-dataset]",
+    ->(opts, v) { opts.wgv_dataset = v},
+    "Whole Genome Variant Dataset. Optional."
+  )
+  op.add_option(
     "--data-browser [data-browser]",
     ->(opts, v) { opts.data_browser = v},
-    "Is this run for data browser. Default is false"
+    "Is this run for data browser. Optional - Default is false"
   )
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset and opts.cdr_version and opts.bucket }
   op.parse.validate


### PR DESCRIPTION
This PR adds validation and load functionality for the CB prep tables used by the CDR indices build. The following has been added when running `circle-build-cdr-indices` command:

1. Create prep_criteria, prep_criteria_ancestor and prep_clinical_terms_nc from csv files
2. Create backups gzip files from prep tables prior to  step 1 and put them in gs://all-of-us-workbench-private-cloudsql/R20XXQXRX/cdr_csv_files/backup
3. Purge old versions of the csv files.