### PR TITLE
[RW-6460][risk=no] Bump API unit test VM size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,6 +322,7 @@ commands:
 jobs:
   api-unit-test:
     parallelism: 4
+    resource_class: medium+
     executor: api-unit-test-executor
     steps:
       - run-api-test:

--- a/api/src/test/java/org/pmiops/workbench/config/WorkbenchConfigTest.java
+++ b/api/src/test/java/org/pmiops/workbench/config/WorkbenchConfigTest.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Bean;
 
 public class WorkbenchConfigTest {
 
+  // XXX: trigger CI - revert.
   @Test
   public void testUnsafeEndpointsDisabledInProd() throws FileNotFoundException {
     WorkbenchConfig workbenchConfig = getConfigFromFile("../api/config/config_prod.json");


### PR DESCRIPTION
Heap dump size is still 1.4GB after increasing the GC size, suggesting the 3GB increase didn't do much, possibly because the process didn't have sufficient memory to begin with
