### PR TITLE
[RW-6460][risk=no] Bump test heap override in gradle

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -551,8 +551,8 @@ tasks.withType(Test) {
       html.enabled = true
     }
   }
-  // The default max heap size was reduced in Gradle 5; override.
-  maxHeapSize = "1g"
+  // As of Q1 2021, API unit tests need a larger heap due to memory retention across individual test cases.
+  maxHeapSize = "2g"
 }
 
 appengine {  // App Engine tasks configuration


### PR DESCRIPTION
Forgot about this option. From ssh'ing in, I observed that the actual -Xmx value was 1g. Then found this setting in the docs and in our gradle config.

Try 2G for now. Follow-up: the -Xmx3g in circle may be doing nothing. Will remove or update comments there accordingly.