### PR TITLE
DRAFT [risk=medium][RW-6187] Update services to read from user/access tier table

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
@@ -1,12 +1,12 @@
 package org.pmiops.workbench.access;
 
 import java.util.List;
-import java.util.Optional;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 
 public interface AccessTierService {
+  // TODO remove once we are no longer special-casing the Registered Tier
   String REGISTERED_TIER_SHORT_NAME = "registered";
 
   /**
@@ -17,16 +17,9 @@ public interface AccessTierService {
   List<DbAccessTier> getAllTiers();
 
   /**
-   * Return the access tier referred to by the shortName in the database
-   *
-   * @param shortName the short name of the access tier to look up in the database
-   * @return an {@code Optional<DbAccessTier>} if one matches the shortName passed in, EMPTY
-   *     otherwise
-   */
-  Optional<DbAccessTier> getAccessTier(String shortName);
-
-  /**
    * Return the Registered Tier if it exists in the database
+   *
+   * <p>TODO remove once we are no longer special-casing the Registered Tier
    *
    * @return a DbAccessTier representing the Registered Tier
    * @throws ServerErrorException if there is no Registered Tier
@@ -42,6 +35,24 @@ public interface AccessTierService {
   void addUserToAllTiers(DbUser user);
 
   /**
+   * Add a tier membership to a user if none exists by inserting a DB row set to ENABLED. If such a
+   * membership exists and is DISABLED, set it to ENABLED.
+   *
+   * @param user the DbUser in the user-accessTier mapping we're updating
+   * @param accessTier the DbAccessTier in the user-accessTier mapping we're updating
+   */
+  void addUserToTier(DbUser user, DbAccessTier accessTier);
+
+  /**
+   * Remove a tier membership from a user if one exists and is ENABLED by marking that membership as
+   * DISABLED. Do nothing if no membership exists.
+   *
+   * @param user the DbUser in the user-accessTier mapping we're updating
+   * @param accessTier the DbAccessTier in the user-accessTier mapping we're updating
+   */
+  void removeUserFromTier(DbUser user, DbAccessTier accessTier);
+
+  /**
    * Remove a Registered Tier membership from a user if one exists and is ENABLED by marking that
    * membership as DISABLED. Do nothing if no membership exists.
    *
@@ -49,6 +60,8 @@ public interface AccessTierService {
    * when the user_access_tier table is the source of truth for tier membership. The existing method
    * UserServiceImpl.removeFromRegisteredTierGroupIdempotent() continues to handle group membership
    * until then.
+   *
+   * <p>TODO remove once we are no longer special-casing the Registered Tier
    *
    * @param user the DbUser in the user-accessTier mapping we're updating
    */
@@ -63,17 +76,15 @@ public interface AccessTierService {
    * UserServiceImpl.addToRegisteredTierGroupIdempotent() continues to handle group membership until
    * then.
    *
+   * <p>TODO remove once we are no longer special-casing the Registered Tier
+   *
    * @param user the DbUser in the user-accessTier mapping we're updating
    */
   void addUserToRegisteredTier(DbUser user);
 
   /**
-   * A placeholder implementation until we establish userAccessTierDao as the source of truth for
-   * access tier membership.
-   *
-   * <p>For registered users, return the registered tier or all tiers if we're in an environment
-   * which has enabled all tiers for registered users. Return no access tiers for unregistered
-   * users.
+   * Return the list of tiers a user has access to: those where a DbUserAccessTier exists with
+   * status ENABLED
    *
    * @param user the user whose access we're checking
    * @return The List of DbAccessTiers the DbUser has access to in this environment

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
@@ -15,7 +15,6 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.CdrVersionListResponse;
 import org.pmiops.workbench.model.CdrVersionTier;
 import org.pmiops.workbench.model.CdrVersionTiersResponse;
-import org.pmiops.workbench.model.DataAccessLevel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -56,7 +55,7 @@ public class CdrVersionService {
         .getAccessTiersForUser(userProvider.get())
         .contains(version.getAccessTier())) {
       throw new ForbiddenException(
-          "Requester does not have access to tier  "
+          "Requester does not have access to tier "
               + version.getAccessTier().getShortName()
               + ", cannot access CDR");
     }
@@ -103,16 +102,18 @@ public class CdrVersionService {
 
   @Deprecated // only handles the Registered Tier
   public CdrVersionListResponse getCdrVersions() {
-    DataAccessLevel accessLevel = userProvider.get().getDataAccessLevelEnum();
-    if (accessLevel == DataAccessLevel.REGISTERED) {
-      CdrVersionTier registeredTierVersions =
-          getVersionsForTier(accessTierService.getRegisteredTier());
-      return new CdrVersionListResponse()
-          .items(registeredTierVersions.getVersions())
-          .defaultCdrVersionId(String.valueOf(registeredTierVersions.getDefaultCdrVersionId()));
-    } else {
-      throw new ForbiddenException("User does not have access to any CDR versions");
-    }
+    DbAccessTier registeredTier =
+        accessTierService.getAccessTiersForUser(userProvider.get()).stream()
+            .filter(
+                tier -> tier.getShortName().equals(AccessTierService.REGISTERED_TIER_SHORT_NAME))
+            .findFirst()
+            .orElseThrow(
+                () -> new ForbiddenException("User does not have access to any CDR versions"));
+
+    CdrVersionTier registeredTierVersions = getVersionsForTier(registeredTier);
+    return new CdrVersionListResponse()
+        .items(registeredTierVersions.getVersions())
+        .defaultCdrVersionId(String.valueOf(registeredTierVersions.getDefaultCdrVersionId()));
   }
 
   public CdrVersionTiersResponse getCdrVersionsByTier() {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserAccessTierDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserAccessTierDao.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.db.dao;
 
+import java.util.List;
 import java.util.Optional;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
@@ -8,4 +9,6 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface UserAccessTierDao extends CrudRepository<DbUserAccessTier, Long> {
   Optional<DbUserAccessTier> getByUserAndAccessTier(DbUser user, DbAccessTier accessTier);
+
+  List<DbUserAccessTier> getAllByUser(DbUser user);
 }

--- a/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
@@ -138,32 +138,21 @@ public class AccessTierServiceTest {
   @Test
   public void test_getAccessTiersForUser_registered() {
     final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
-    userAccessTierDao.save(
-        new DbUserAccessTier()
-            .setUser(user)
-            .setAccessTier(registeredTier)
-            .setTierAccessStatus(TierAccessStatus.ENABLED)
-            .setFirstEnabled(now())
-            .setLastUpdated(now()));
+    addDaoEntry(user, registeredTier, TierAccessStatus.ENABLED);
     assertThat(accessTierService.getAccessTiersForUser(user)).containsExactly(registeredTier);
   }
 
   @Test
   public void test_getAccessTiersForUser_registered_disabled() {
     final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
-    userAccessTierDao.save(
-        new DbUserAccessTier()
-            .setUser(user)
-            .setAccessTier(registeredTier)
-            .setTierAccessStatus(TierAccessStatus.DISABLED)
-            .setFirstEnabled(now())
-            .setLastUpdated(now()));
+    addDaoEntry(user, registeredTier, TierAccessStatus.DISABLED);
     assertThat(accessTierService.getAccessTiersForUser(user)).isEmpty();
   }
 
   @Test
   public void test_getAccessTiersForUser_registered_controlled() {
     final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    addDaoEntry(user, registeredTier, TierAccessStatus.ENABLED);
 
     final DbAccessTier controlledTier =
         accessTierDao.save(
@@ -174,21 +163,7 @@ public class AccessTierServiceTest {
                 .setAuthDomainName("Controlled Tier Auth Domain")
                 .setAuthDomainGroupEmail("ct-users@fake-research-aou.org")
                 .setServicePerimeter("controlled/tier/perimeter"));
-
-    userAccessTierDao.save(
-        new DbUserAccessTier()
-            .setUser(user)
-            .setAccessTier(registeredTier)
-            .setTierAccessStatus(TierAccessStatus.ENABLED)
-            .setFirstEnabled(now())
-            .setLastUpdated(now()));
-    userAccessTierDao.save(
-        new DbUserAccessTier()
-            .setUser(user)
-            .setAccessTier(controlledTier)
-            .setTierAccessStatus(TierAccessStatus.ENABLED)
-            .setFirstEnabled(now())
-            .setLastUpdated(now()));
+    addDaoEntry(user, controlledTier, TierAccessStatus.ENABLED);
 
     assertThat(accessTierService.getAccessTiersForUser(user))
         .containsExactly(registeredTier, controlledTier);
@@ -435,6 +410,16 @@ public class AccessTierServiceTest {
     assertThat(controlledMembership.getUser()).isEqualTo(user);
     assertThat(controlledMembership.getAccessTier()).isEqualTo(controlledTier);
     assertThat(controlledMembership.getTierAccessStatusEnum()).isEqualTo(TierAccessStatus.ENABLED);
+  }
+
+  private DbUserAccessTier addDaoEntry(DbUser user, DbAccessTier tier, TierAccessStatus status) {
+    return userAccessTierDao.save(
+        new DbUserAccessTier()
+            .setUser(user)
+            .setAccessTier(tier)
+            .setTierAccessStatus(status)
+            .setFirstEnabled(now())
+            .setLastUpdated(now()));
   }
 
   private Timestamp now() {

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbUser;
@@ -50,7 +51,11 @@ public class OfflineUserControllerTest {
 
   @TestConfiguration
   @Import({OfflineUserController.class})
-  @MockBean({CloudResourceManagerService.class, UserService.class})
+  @MockBean({
+    AccessTierService.class,
+    CloudResourceManagerService.class,
+    UserService.class,
+  })
   static class Configuration {
     @Bean
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)

--- a/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
@@ -17,10 +17,12 @@ import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
+import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
@@ -30,7 +32,6 @@ import org.pmiops.workbench.model.CdrVersion;
 import org.pmiops.workbench.model.CdrVersionListResponse;
 import org.pmiops.workbench.model.CdrVersionTier;
 import org.pmiops.workbench.model.CdrVersionTiersResponse;
-import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
@@ -54,10 +55,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class CdrVersionServiceTest {
 
   @Autowired private AccessTierDao accessTierDao;
+  @Autowired private AccessTierService accessTierService;
   @Autowired private CdrVersionDao cdrVersionDao;
   @Autowired private CdrVersionMapper cdrVersionMapper;
   @Autowired private CdrVersionService cdrVersionService;
   @Autowired private FireCloudService fireCloudService;
+  @Autowired private UserDao userDao;
 
   private static DbUser user;
   private static final FakeClock CLOCK = new FakeClock(Instant.now(), ZoneId.systemDefault());
@@ -76,7 +79,9 @@ public class CdrVersionServiceTest {
     CdrVersionService.class,
     CdrVersionMapperImpl.class,
   })
-  @MockBean({FireCloudService.class})
+  @MockBean({
+    FireCloudService.class,
+  })
   static class Configuration {
     @Bean
     @Scope("prototype")
@@ -97,11 +102,12 @@ public class CdrVersionServiceTest {
 
   @Before
   public void setUp() {
+    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+
     user = new DbUser();
     user.setUsername("user");
-    user.setDataAccessLevelEnum(DataAccessLevel.REGISTERED);
+    user = userDao.save(user);
 
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
     defaultCdrVersion =
         makeCdrVersion(
             1L,
@@ -139,75 +145,99 @@ public class CdrVersionServiceTest {
 
   @Test
   public void testSetCdrVersionDefault() {
-    when(fireCloudService.isUserMemberOfGroup(
-            user.getUsername(), registeredTier.getAuthDomainName()))
-        .thenReturn(true);
+    addMembershipForTest(registeredTier);
     cdrVersionService.setCdrVersion(defaultCdrVersion);
     assertThat(CdrVersionContext.getCdrVersion()).isEqualTo(defaultCdrVersion);
   }
 
   @Test
   public void testSetCdrVersionDefaultId() {
-    when(fireCloudService.isUserMemberOfGroup(
-            user.getUsername(), registeredTier.getAuthDomainName()))
-        .thenReturn(true);
+    addMembershipForTest(registeredTier);
     cdrVersionService.setCdrVersion(defaultCdrVersion.getCdrVersionId());
     assertThat(CdrVersionContext.getCdrVersion()).isEqualTo(defaultCdrVersion);
   }
 
+  @Test(expected = ForbiddenException.class)
+  public void testSetCdrVersionDefaultForbiddenNotInTier() {
+    cdrVersionService.setCdrVersion(defaultCdrVersion);
+  }
+
+  @Test(expected = ForbiddenException.class)
+  public void testSetCdrVersionDefaultIdForbiddenNotInTier() {
+    cdrVersionService.setCdrVersion(defaultCdrVersion.getCdrVersionId());
+  }
+
+  // these tests fail because the user is in the right tier according to the AoU DB
+  // but the user is not in the right auth domain according to Terra
+
+  @Test(expected = ForbiddenException.class)
+  public void testSetCdrVersionDefaultForbiddenNotInGroup() {
+    accessTierService.addUserToTier(user, registeredTier);
+
+    when(fireCloudService.isUserMemberOfGroup(
+            user.getUsername(), registeredTier.getAuthDomainName()))
+        .thenReturn(false);
+
+    cdrVersionService.setCdrVersion(defaultCdrVersion);
+  }
+
+  @Test(expected = ForbiddenException.class)
+  public void testSetCdrVersionDefaultIdForbiddenNotInGroup() {
+    accessTierService.addUserToTier(user, registeredTier);
+
+    when(fireCloudService.isUserMemberOfGroup(
+            user.getUsername(), registeredTier.getAuthDomainName()))
+        .thenReturn(false);
+
+    cdrVersionService.setCdrVersion(defaultCdrVersion.getCdrVersionId());
+  }
+
   @Test
   public void testSetCdrVersionControlled() {
-    when(fireCloudService.isUserMemberOfGroup(
-            user.getUsername(), controlledTier.getAuthDomainName()))
-        .thenReturn(true);
-    config.featureFlags.unsafeAllowAccessToAllTiersForRegisteredUsers = true;
+    addMembershipForTest(controlledTier);
     cdrVersionService.setCdrVersion(controlledCdrVersion);
     assertThat(CdrVersionContext.getCdrVersion()).isEqualTo(controlledCdrVersion);
   }
 
   @Test
   public void testSetCdrVersionControlledId() {
-    when(fireCloudService.isUserMemberOfGroup(
-            user.getUsername(), controlledTier.getAuthDomainName()))
-        .thenReturn(true);
-    config.featureFlags.unsafeAllowAccessToAllTiersForRegisteredUsers = true;
+    addMembershipForTest(controlledTier);
     cdrVersionService.setCdrVersion(controlledCdrVersion.getCdrVersionId());
     assertThat(CdrVersionContext.getCdrVersion()).isEqualTo(controlledCdrVersion);
   }
 
   @Test(expected = ForbiddenException.class)
   public void testSetCdrVersionControlledForbiddenNotInTier() {
-    when(fireCloudService.isUserMemberOfGroup(
-            user.getUsername(), controlledTier.getAuthDomainName()))
-        .thenReturn(true);
-    config.featureFlags.unsafeAllowAccessToAllTiersForRegisteredUsers = false;
     cdrVersionService.setCdrVersion(controlledCdrVersion);
   }
 
   @Test(expected = ForbiddenException.class)
   public void testSetCdrVersionControlledIdForbiddenNotInTier() {
-    when(fireCloudService.isUserMemberOfGroup(
-            user.getUsername(), controlledTier.getAuthDomainName()))
-        .thenReturn(true);
-    config.featureFlags.unsafeAllowAccessToAllTiersForRegisteredUsers = false;
     cdrVersionService.setCdrVersion(controlledCdrVersion.getCdrVersionId());
   }
 
+  // these tests fail because the user is in the right tier according to the AoU DB
+  // but the user is not in the right auth domain according to Terra
+
   @Test(expected = ForbiddenException.class)
   public void testSetCdrVersionControlledForbiddenNotInGroup() {
+    accessTierService.addUserToTier(user, controlledTier);
+
     when(fireCloudService.isUserMemberOfGroup(
             user.getUsername(), controlledTier.getAuthDomainName()))
         .thenReturn(false);
-    config.featureFlags.unsafeAllowAccessToAllTiersForRegisteredUsers = true;
+
     cdrVersionService.setCdrVersion(controlledCdrVersion);
   }
 
   @Test(expected = ForbiddenException.class)
   public void testSetCdrVersionControlledIdForbiddenNotInGroup() {
+    accessTierService.addUserToTier(user, controlledTier);
+
     when(fireCloudService.isUserMemberOfGroup(
             user.getUsername(), controlledTier.getAuthDomainName()))
         .thenReturn(false);
-    config.featureFlags.unsafeAllowAccessToAllTiersForRegisteredUsers = true;
+
     cdrVersionService.setCdrVersion(controlledCdrVersion.getCdrVersionId());
   }
 
@@ -215,22 +245,9 @@ public class CdrVersionServiceTest {
 
   @Test
   public void testGetCdrVersionsRegisteredOnly() {
-    config.featureFlags.unsafeAllowAccessToAllTiersForRegisteredUsers = false;
-
+    addMembershipForTest(registeredTier);
     CdrVersionListResponse response = cdrVersionService.getCdrVersions();
-    assertDefaultCdrOnly(response);
-  }
 
-  @Test
-  public void testGetCdrVersionsRegisteredAllTiers() {
-    // this flag does not affect the deprecated version, so the result is the same
-    config.featureFlags.unsafeAllowAccessToAllTiersForRegisteredUsers = true;
-
-    CdrVersionListResponse response = cdrVersionService.getCdrVersions();
-    assertDefaultCdrOnly(response);
-  }
-
-  private void assertDefaultCdrOnly(CdrVersionListResponse response) {
     List<CdrVersion> expected =
         ImmutableList.of(cdrVersionMapper.dbModelToClient(defaultCdrVersion));
     assertThat(response.getItems()).containsExactlyElementsIn(expected);
@@ -241,7 +258,6 @@ public class CdrVersionServiceTest {
 
   @Test(expected = ForbiddenException.class)
   public void testGetCdrVersionsUnregistered() {
-    user.setDataAccessLevelEnum(DataAccessLevel.UNREGISTERED);
     cdrVersionService.getCdrVersions();
   }
 
@@ -249,14 +265,15 @@ public class CdrVersionServiceTest {
 
   @Test
   public void testGetCdrVersionsByTierRegisteredOnly() {
-    config.featureFlags.unsafeAllowAccessToAllTiersForRegisteredUsers = false;
+    addMembershipForTest(registeredTier);
     CdrVersionTiersResponse response = cdrVersionService.getCdrVersionsByTier();
     assertResponseMultiTier(response, ImmutableList.of("registered"), defaultCdrVersion);
   }
 
   @Test
   public void testGetCdrVersionsByTierAllTiers() {
-    config.featureFlags.unsafeAllowAccessToAllTiersForRegisteredUsers = true;
+    addMembershipForTest(registeredTier);
+    addMembershipForTest(controlledTier);
     CdrVersionTiersResponse response = cdrVersionService.getCdrVersionsByTier();
     assertResponseMultiTier(
         response,
@@ -267,7 +284,6 @@ public class CdrVersionServiceTest {
 
   @Test(expected = ForbiddenException.class)
   public void testGetCdrVersionsByTierUnregistered() {
-    user.setDataAccessLevelEnum(DataAccessLevel.UNREGISTERED);
     cdrVersionService.getCdrVersionsByTier();
   }
 
@@ -312,6 +328,7 @@ public class CdrVersionServiceTest {
   }
 
   private void testGetCdrVersionsHasDataType(Predicate<CdrVersion> hasType) {
+    addMembershipForTest(registeredTier);
     final List<CdrVersion> cdrVersions =
         parseRegisteredTier(cdrVersionService.getCdrVersionsByTier());
     // hasFitBitData, hasCopeSurveyData, hasMicroarrayData, and hasWgsData are false by default
@@ -373,5 +390,19 @@ public class CdrVersionServiceTest {
     cdrVersion.setHasFitbitData(hasFitbit);
     cdrVersion.setHasCopeSurveyData(hasCopeSurveyData);
     return cdrVersionDao.save(cdrVersion);
+  }
+
+  private void addMembershipForTest(DbAccessTier tier) {
+    accessTierService.addUserToTier(user, tier);
+
+    when(fireCloudService.isUserMemberOfGroup(user.getUsername(), tier.getAuthDomainName()))
+        .thenReturn(true);
+  }
+
+  private void removeMembershipForTest(DbAccessTier tier) {
+    accessTierService.removeUserFromTier(user, tier);
+
+    when(fireCloudService.isUserMemberOfGroup(user.getUsername(), tier.getAuthDomainName()))
+        .thenReturn(false);
   }
 }


### PR DESCRIPTION
Description:

AccessTierService and CdrVersionService rely on the user_access_table as the source of truth for user access decisions instead of `user.data_access_level`.

`UserServiceImpl.updateDataAccessLevel()` and related UserService access changes still interact with `user.data_access_level` here but I hope to follow up with a PR to update that soon.  I might end up folding that in here if it's not too complex.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
