### PR TITLE
[RW-6153][risk=no]  Update existing services that read from data_dictionary entry (Data Dictionary)

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/DSDataDictionaryDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/DSDataDictionaryDao.java
@@ -4,5 +4,5 @@ import org.pmiops.workbench.cdr.model.DbDSDataDictionary;
 import org.springframework.data.repository.CrudRepository;
 
 public interface DSDataDictionaryDao extends CrudRepository<DbDSDataDictionary, Long> {
-  DbDSDataDictionary findByFieldNameAndDomain(String field_name, String domain);
+  DbDSDataDictionary findFirstByFieldNameAndDomain(String field_name, String domain);
 }

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -999,7 +999,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
   @Override
   public DataDictionaryEntry findDataDictionaryEntry(String fieldName, String domain) {
     DbDSDataDictionary dbDSDataDictionary =
-        dsDataDictionaryDao.findByFieldNameAndDomain(fieldName, domain);
+        dsDataDictionaryDao.findFirstByFieldNameAndDomain(fieldName, domain);
     if (dbDSDataDictionary == null) {
       throw new NotFoundException(
           "No Data Dictionary Entry found for field " + fieldName + "and domain: " + domain);

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -861,11 +861,11 @@ public class DataSetControllerTest {
   public void getDataDictionaryEntry() {
     when(cdrVersionService.findByCdrVersionId(2l))
         .thenReturn(Optional.ofNullable(new DbCdrVersion()));
-    when(mockDSDataDictionaryDao.findByFieldNameAndDomain(anyString(), anyString()))
+    when(mockDSDataDictionaryDao.findFirstByFieldNameAndDomain(anyString(), anyString()))
         .thenReturn(new DbDSDataDictionary());
 
     dataSetController.getDataDictionaryEntry(2l, "PERSON", "MockValue");
-    verify(mockDSDataDictionaryDao, times(1)).findByFieldNameAndDomain("MockValue", "PERSON");
+    verify(mockDSDataDictionaryDao, times(1)).findFirstByFieldNameAndDomain("MockValue", "PERSON");
   }
 
   DataSetExportRequest setUpValidDataSetExportRequest() {

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/DSDataDictionaryDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/DSDataDictionaryDaoTest.java
@@ -26,7 +26,7 @@ public class DSDataDictionaryDaoTest {
     dbDSDataDictionary_Condition =
         dsDataDictionaryDao.save(
             DbDSDataDictionary.builder()
-                .addDataProvenance("Mock Data Provance")
+                .addDataProvenance("Mock Data Provenance")
                 .addDescription("Mock description for Condition")
                 .addDomain(Domain.CONDITION.toString())
                 .addFieldName("Mock Condition Field")
@@ -35,12 +35,23 @@ public class DSDataDictionaryDaoTest {
                 .addRelevantOmopTable("omop")
                 .addSourcePpiModule("ppi")
                 .build());
+    dsDataDictionaryDao.save(
+        DbDSDataDictionary.builder()
+            .addDataProvenance("Mock Data Provenance")
+            .addDescription("Mock description for Condition")
+            .addDomain(Domain.CONDITION.toString())
+            .addFieldName("Mock Condition Field")
+            .addFieldType("Integer")
+            .addOmopCdmStandardOrCustomField("Custom")
+            .addRelevantOmopTable("omop_2")
+            .addSourcePpiModule("ppi")
+            .build());
   }
 
   @Test
   public void findByFieldNameAndDomain() {
     DbDSDataDictionary mockConditionDictionary =
-        dsDataDictionaryDao.findByFieldNameAndDomain(
+        dsDataDictionaryDao.findFirstByFieldNameAndDomain(
             "Mock Condition Field", Domain.CONDITION.toString());
     assertThat(mockConditionDictionary).isNotNull();
     assertThat(mockConditionDictionary).isEqualTo(dbDSDataDictionary_Condition);
@@ -49,7 +60,8 @@ public class DSDataDictionaryDaoTest {
   @Test
   public void findByFieldNameAndDomainDoesNotExist() {
     DbDSDataDictionary mockNotFoundDictionary =
-        dsDataDictionaryDao.findByFieldNameAndDomain("Does not exist", Domain.CONDITION.toString());
+        dsDataDictionaryDao.findFirstByFieldNameAndDomain(
+            "Does not exist", Domain.CONDITION.toString());
     assertThat(mockNotFoundDictionary).isNull();
   }
 }


### PR DESCRIPTION
The call to retrieve data dictionary is failing in case of multiple entries in DB for same field_name and domain eg

Person id has 2 entries with same domain 1 referring to the omop table person, the other to ds_person. 

As of now getting the first entry will solve the issue,  however this is a temporary solution, and it would be better to use the relevant_omop_mapping as well to get the data dictionary.
---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
