### PR TITLE
[noTicket][risk=nO]Update existing services that read from data_dictionary entry (Data Dictionary) 

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/DSDataDictionaryDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/DSDataDictionaryDao.java
@@ -1,8 +1,27 @@
 package org.pmiops.workbench.cdr.dao;
 
 import org.pmiops.workbench.cdr.model.DbDSDataDictionary;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface DSDataDictionaryDao extends CrudRepository<DbDSDataDictionary, Long> {
-  DbDSDataDictionary findFirstByFieldNameAndDomain(String field_name, String domain);
+  @Query(
+      value =
+          "select * from \n"
+              + "(\n"
+              + "select * \n"
+              + "from ds_data_dictionary \n"
+              + "where field_name = :name \n"
+              + "and domain = :domain\n"
+              + "and relevant_omop_table not like 'ds_%'\n"
+              + "UNION\n"
+              + "select * \n"
+              + "from ds_data_dictionary \n"
+              + "where field_name = :name \n"
+              + "and domain = :domain\n"
+              + "and relevant_omop_table like 'ds_%') d limit 1",
+      nativeQuery = true)
+  DbDSDataDictionary findFirstByFieldNameAndDomain(
+      @Param("name") String name, @Param("domain") String domain);
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/model/DbDSDataDictionary.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/model/DbDSDataDictionary.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.cdr.model;
 
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -101,6 +102,36 @@ public class DbDSDataDictionary {
 
   public void setDomain(String domain) {
     this.domain = domain;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DbDSDataDictionary that = (DbDSDataDictionary) o;
+    return id == that.id
+        && fieldName.equals(that.fieldName)
+        && relevantOmopTable.equals(that.relevantOmopTable)
+        && description.equals(that.description)
+        && fieldType.equals(that.fieldType)
+        && omopCdmStandardOrCustomField.equals(that.omopCdmStandardOrCustomField)
+        && dataProvenance.equals(that.dataProvenance)
+        && sourcePpiModule.equals(that.sourcePpiModule)
+        && domain.equals(that.domain);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        fieldName,
+        relevantOmopTable,
+        description,
+        fieldType,
+        omopCdmStandardOrCustomField,
+        dataProvenance,
+        sourcePpiModule,
+        domain);
   }
 
   public static DbDSDataDictionary.Builder builder() {

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/DSDataDictionaryDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/DSDataDictionaryDaoTest.java
@@ -25,7 +25,7 @@ public class DSDataDictionaryDaoTest {
 
   @Before
   public void setUp() {
-    dbDSDataDictionaryCondition =
+    dbDSDataDictionaryCondition_ds =
         dsDataDictionaryDao.save(
             DbDSDataDictionary.builder()
                 .addDataProvenance("Mock Data Provenance")
@@ -34,7 +34,7 @@ public class DSDataDictionaryDaoTest {
                 .addFieldName("Mock Condition Field")
                 .addFieldType("Integer")
                 .addOmopCdmStandardOrCustomField("Custom")
-                .addRelevantOmopTable("condition")
+                .addRelevantOmopTable("ds_condition")
                 .addSourcePpiModule("ppi")
                 .build());
     dbDSDataDictionaryPerson =
@@ -49,7 +49,7 @@ public class DSDataDictionaryDaoTest {
                 .addRelevantOmopTable("ds_person")
                 .addSourcePpiModule("ppi")
                 .build());
-    dbDSDataDictionaryCondition_ds =
+    dbDSDataDictionaryCondition =
         dsDataDictionaryDao.save(
             DbDSDataDictionary.builder()
                 .addDataProvenance("Mock Data Provenance")
@@ -58,7 +58,7 @@ public class DSDataDictionaryDaoTest {
                 .addFieldName("Mock Condition Field")
                 .addFieldType("Integer")
                 .addOmopCdmStandardOrCustomField("Custom")
-                .addRelevantOmopTable("ds_condition")
+                .addRelevantOmopTable("condition")
                 .addSourcePpiModule("ppi")
                 .build());
   }

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/DSDataDictionaryDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/DSDataDictionaryDaoTest.java
@@ -19,11 +19,13 @@ public class DSDataDictionaryDaoTest {
 
   @Autowired private DSDataDictionaryDao dsDataDictionaryDao;
 
-  private DbDSDataDictionary dbDSDataDictionary_Condition;
+  private DbDSDataDictionary dbDSDataDictionaryCondition_ds;
+  private DbDSDataDictionary dbDSDataDictionaryCondition;
+  private DbDSDataDictionary dbDSDataDictionaryPerson;
 
   @Before
   public void setUp() {
-    dbDSDataDictionary_Condition =
+    dbDSDataDictionaryCondition =
         dsDataDictionaryDao.save(
             DbDSDataDictionary.builder()
                 .addDataProvenance("Mock Data Provenance")
@@ -32,29 +34,51 @@ public class DSDataDictionaryDaoTest {
                 .addFieldName("Mock Condition Field")
                 .addFieldType("Integer")
                 .addOmopCdmStandardOrCustomField("Custom")
-                .addRelevantOmopTable("omop")
+                .addRelevantOmopTable("condition")
                 .addSourcePpiModule("ppi")
                 .build());
-    dsDataDictionaryDao.save(
-        DbDSDataDictionary.builder()
-            .addDataProvenance("Mock Data Provenance")
-            .addDescription("Mock description for Condition")
-            .addDomain(Domain.CONDITION.toString())
-            .addFieldName("Mock Condition Field")
-            .addFieldType("Integer")
-            .addOmopCdmStandardOrCustomField("Custom")
-            .addRelevantOmopTable("omop_2")
-            .addSourcePpiModule("ppi")
-            .build());
+    dbDSDataDictionaryPerson =
+        dsDataDictionaryDao.save(
+            DbDSDataDictionary.builder()
+                .addDataProvenance("Mock Data Provenance")
+                .addDescription("Mock description for Person")
+                .addDomain(Domain.PERSON.toString())
+                .addFieldName("Mock Person Field")
+                .addFieldType("Integer")
+                .addOmopCdmStandardOrCustomField("Custom")
+                .addRelevantOmopTable("ds_person")
+                .addSourcePpiModule("ppi")
+                .build());
+    dbDSDataDictionaryCondition_ds =
+        dsDataDictionaryDao.save(
+            DbDSDataDictionary.builder()
+                .addDataProvenance("Mock Data Provenance")
+                .addDescription("Mock description for Condition")
+                .addDomain(Domain.CONDITION.toString())
+                .addFieldName("Mock Condition Field")
+                .addFieldType("Integer")
+                .addOmopCdmStandardOrCustomField("Custom")
+                .addRelevantOmopTable("ds_condition")
+                .addSourcePpiModule("ppi")
+                .build());
   }
 
   @Test
-  public void findByFieldNameAndDomain() {
+  public void findByFieldNameAndDomain_twoEntries() {
     DbDSDataDictionary mockConditionDictionary =
         dsDataDictionaryDao.findFirstByFieldNameAndDomain(
             "Mock Condition Field", Domain.CONDITION.toString());
     assertThat(mockConditionDictionary).isNotNull();
-    assertThat(mockConditionDictionary).isEqualTo(dbDSDataDictionary_Condition);
+    assertThat(mockConditionDictionary).isEqualTo(dbDSDataDictionaryCondition);
+  }
+
+  @Test
+  public void findByFieldNameAndDomain_oneEntry() {
+    DbDSDataDictionary mockPersonDictionary =
+        dsDataDictionaryDao.findFirstByFieldNameAndDomain(
+            "Mock Person Field", Domain.PERSON.toString());
+    assertThat(mockPersonDictionary).isNotNull();
+    assertThat(mockPersonDictionary).isEqualTo(dbDSDataDictionaryPerson);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/DataSetServiceTest.java
@@ -554,6 +554,7 @@ public class DataSetServiceTest {
     dsDataDictionary.setFieldName("gender");
     dsDataDictionary.setDescription("Gender testing");
     dsDataDictionary.setFieldType("string");
+    dsDataDictionary.setRelevantOmopTable("person");
     dsDataDictionaryDao.save(dsDataDictionary);
   }
 }


### PR DESCRIPTION
Update query to pick just one entry (referring to the correct omop table rather than ds_) from ds_Data_dictionary. 


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
