### PR TITLE
[no ticket][risk=no] Puppeteer fix getSelectedValue func

### DIFF
--- a/e2e/app/element/select.ts
+++ b/e2e/app/element/select.ts
@@ -53,7 +53,7 @@ export default class Select extends BaseElement {
     const selectedOption = await this.page.evaluate((select) => {
       for (const option of select.options) {
         if (option.selected) {
-          return option.value;
+          return option.textContent;
         }
       }
     }, selectElement);


### PR DESCRIPTION
Found a bug during testing in staging env. `getSelectedValue` function should returns displayed texts instead of attribute `value`.

<img width="354" alt="Screen Shot 2021-03-29 at 3 59 32 PM" src="https://user-images.githubusercontent.com/35533885/112892814-d1479680-90a7-11eb-89ba-b3ccbf4482b4.png">
