### PR TITLE
[risk=no] Block initial render on CDR load

### DIFF
--- a/ui/src/app/pages/signed-in/component.html
+++ b/ui/src/app/pages/signed-in/component.html
@@ -27,7 +27,9 @@
 
   <div class="content-container">
     <div class="background-image"></div>
-    <div class="app-container" [class.minimize-chrome]="minimizeChrome">
+    <div *ngIf="cdrVersionsInitialized"
+         class="app-container"
+         [class.minimize-chrome]="minimizeChrome">
       <!--
         Angular's builtin Router module will attach specific views here
         based on clicking routerLink elements (above) or router.navigate calls.

--- a/ui/src/app/pages/signed-in/component.ts
+++ b/ui/src/app/pages/signed-in/component.ts
@@ -56,6 +56,7 @@ export class SignedInComponent implements OnInit, OnDestroy, AfterViewInit {
   shouldShowDisplayTag = environment.shouldShowDisplayTag;
   enableSignedInFooter = environment.enableFooter;
   minimizeChrome = false;
+  cdrVersionsInitialized = false;
   // True if the user tried to open the Zendesk support widget and an error
   // occurred.
   zendeskLoadError = false;
@@ -94,8 +95,15 @@ export class SignedInComponent implements OnInit, OnDestroy, AfterViewInit {
         setInstitutionCategoryState(this.profile.verifiedInstitutionalAffiliation);
         if (hasRegisteredAccess(this.profile.dataAccessLevel)) {
           cdrVersionsApi().getCdrVersions().then(resp => {
+            // cdrVersionsInitialized blocks app rendering so that route
+            // components don't try to lookup CDR data before it's available.
+            // This will need to be a step in the React bootstrapping as well.
+            // See discussion on https://github.com/all-of-us/workbench/pull/4713
             cdrVersionStore.set(resp);
+            this.cdrVersionsInitialized = true;
           });
+        } else {
+          this.cdrVersionsInitialized = true;
         }
       });
     });

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -389,10 +389,7 @@ export const withRouteConfigData = () => {
   return connectBehaviorSubject(routeConfigDataStore, 'routeConfigData');
 };
 
-// HOC that provides a 'cdrVersionListResponse' prop with the CDR version
-// information. Rendering of the connected component is blocked on initial load
-// of the CDR versions. This should only affect initial page loads, this HOC can
-// be included last (if multiple HOCs are in use) to minimize this impact.
+// HOC that provides a 'cdrVersionListResponse' prop with the CDR version information.
 export const withCdrVersions = () => {
   return withStore(cdrVersionStore, 'cdrVersionListResponse');
 };


### PR DESCRIPTION
This is approach (3) per https://github.com/all-of-us/workbench/pull/4713/files#r603670272 . The idea of this fix is that we block all routes from even rendering until we've loaded the CDR versions (if we need to load them). When CDR are access via the stores in lower components, the value will be available.

This is a bit of blunt approach to blocking the initial routing/navigation. It causes some slight visual impact during the initial load (a flash of a white page after the initial spinner, but before the dashboard spinner). This is probably acceptable for the remainder of Angular's lifetime in the project. As an alternative to this, we can try to revert https://github.com/all-of-us/workbench/pull/4713 - which will likely involve reverting https://github.com/all-of-us/workbench/pull/4721 too.