### PR TITLE
[DO NOT MERGE][RW-6440][risk=no]API - cleanup unused columns in cb_criteria table

### DIFF
--- a/api/db-cdr/changelog-schema/db.changelog-master.xml
+++ b/api/db-cdr/changelog-schema/db.changelog-master.xml
@@ -9,4 +9,5 @@
     <runningAs username="liquibase"/>
   </preConditions>
   <include file="changelog-schema/db.changelog-v2-1.xml"/>
+  <include file="changelog-schema/db.changelog-v2-2.xml"/>
 </databaseChangeLog>

--- a/api/db-cdr/changelog-schema/db.changelog-v2-2.xml
+++ b/api/db-cdr/changelog-schema/db.changelog-v2-2.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+    <changeSet author="nsaxena" id="changelog-v2-2">
+        <dropColumn columnName="synonyms" tableName="cb_criteria"/>
+    </changeSet>
+</databaseChangeLog>

--- a/api/db-cdr/generate-cdr/bq-schemas/cb_criteria.json
+++ b/api/db-cdr/generate-cdr/bq-schemas/cb_criteria.json
@@ -86,11 +86,6 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "synonyms",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "rollup_count",
     "type": "INTEGER"
   },

--- a/api/db-cdr/generate-cdr/make-bq-criteria-tables.sh
+++ b/api/db-cdr/generate-cdr/make-bq-criteria-tables.sh
@@ -58,7 +58,6 @@ bq --quiet --project_id=$BQ_PROJECT query --nouse_legacy_sql \
     has_hierarchy       INT64,
     has_ancestor_data   INT64,
     path                STRING,
-    synonyms            STRING,
     full_text           STRING,
     display_synonyms    STRING
 )"
@@ -5830,13 +5829,12 @@ WHERE REGEXP_CONTAINS(name, r'[\"]')"
 
 
 ###############################################
-# FULL_TEXT and SYNONYMS
+# FULL_TEXT
 ###############################################
-echo "FULL_TEXT and SYNONYMS - adding data"
+echo "FULL_TEXT - adding data"
 bq --quiet --project_id=$BQ_PROJECT query --nouse_legacy_sql \
 "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
 SET   x.full_text = y.full_text
-    , x.synonyms = y.full_text
     , x.display_synonyms = y.display_synonyms
 FROM
     (
@@ -5866,7 +5864,6 @@ echo "FULL_TEXT - add [rank1]"
 bq --quiet --project_id=$BQ_PROJECT query --nouse_legacy_sql \
 "UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\` x
 SET x.full_text = CONCAT(x.full_text, '|', y.rnk)
-   ,x.synonyms = CONCAT(x.full_text, '|', y.rnk)
 FROM
     (
         SELECT MIN(id) as id, CONCAT('[', LOWER(domain_id), '_rank1]') as rnk

--- a/api/db-cdr/generate-cdr/make-bq-data.sh
+++ b/api/db-cdr/generate-cdr/make-bq-data.sh
@@ -139,8 +139,8 @@ if [[ $tables =~ $cb_cri_table_check ]]; then
     echo "Inserting cb_criteria"
     bq --quiet --project_id=$BQ_PROJECT query --nouse_legacy_sql \
     "INSERT INTO \`$OUTPUT_PROJECT.$OUTPUT_DATASET.cb_criteria\`
-     (id, parent_id, domain_id, type, subtype, is_standard, code, name, value, is_group, is_selectable, est_count, concept_id, has_attribute, has_hierarchy, has_ancestor_data, path, synonyms, rollup_count, item_count, full_text, display_synonyms)
-    SELECT id, parent_id, domain_id, type, subtype, is_standard, code, name, value, is_group, is_selectable, est_count, concept_id, has_attribute, has_hierarchy, has_ancestor_data, path, synonyms, rollup_count, item_count, full_text, display_synonyms
+     (id, parent_id, domain_id, type, subtype, is_standard, code, name, value, is_group, is_selectable, est_count, concept_id, has_attribute, has_hierarchy, has_ancestor_data, path, rollup_count, item_count, full_text, display_synonyms)
+    SELECT id, parent_id, domain_id, type, subtype, is_standard, code, name, value, is_group, is_selectable, est_count, concept_id, has_attribute, has_hierarchy, has_ancestor_data, path, rollup_count, item_count, full_text, display_synonyms
     FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`"
 fi
 

--- a/api/src/bigquerytest/resources/bigquery/cbdata/cb_criteria_data.json
+++ b/api/src/bigquerytest/resources/bigquery/cbdata/cb_criteria_data.json
@@ -15,7 +15,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "1.5.6",
-    "synonyms": "Cholera|Cholera|Cholera|[condition_rank1]",
     "full_text": "Cholera|Cholera|Cholera|[condition_rank1]"
   },
   {
@@ -34,7 +33,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "1.5.6",
-    "synonyms": "Cholera|Cholera|Cholera",
     "full_text": "Cholera|Cholera|Cholera|[condition_rank1]"
   },
   {
@@ -53,7 +51,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "1.5.6.1413",
-    "synonyms": "Cholera|Cholera|Cholera",
     "full_text": "Cholera|Cholera|Cholera|[condition_rank1]"
   },
   {
@@ -72,7 +69,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "1.5.6.1414",
-    "synonyms": "Cholera due to vibrio cholerae|Cholera d/t vib cholerae|Cholera d/t vib cholerae|Cholera due to vibrio cholerae|Cholera due to vibrio cholerae|[condition_rank1]",
     "full_text": "Cholera due to vibrio cholerae|Cholera d/t vib cholerae|Cholera d/t vib cholerae|Cholera due to vibrio cholerae|Cholera due to vibrio cholerae|[condition_rank1]"
   },
   {
@@ -91,7 +87,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "23670.23679.35652.35665",
-    "synonyms": "Aortic aneurysm of unspecified site",
     "full_text": "[condition_rank1]"
   },
   {
@@ -110,7 +105,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "23670.23679.35653.35666",
-    "synonyms": "Aortic aneurysm of unspecified site",
     "full_text": "Aortic aneurysm of unspecified site|[condition_rank1]"
   },
   {
@@ -129,7 +123,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 1,
     "path": "2994175.2994225",
-    "synonyms": "Gynecological antiinfectives and antiseptics",
     "full_text": "Gynecological antiinfectives and antiseptics|[drug_rank1]"
   },
   {
@@ -148,7 +141,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 1,
     "path": "2994174.2994224",
-    "synonyms": "Gynecological antiinfectives and antiseptics",
     "full_text": "Gynecological antiinfectives and antiseptics|[drug_rank1]"
   },
   {
@@ -167,7 +159,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 1,
     "path": "2994179.2994253.2994426.2994929.2996787",
-    "synonyms": "Amobarbital|Amobarbital|Amobarbital|[drug_rank1]",
     "full_text": "Amobarbital|Amobarbital|Amobarbital|[drug_rank1]"
   },
   {
@@ -186,7 +177,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "1297944.1297957.1298239.1300274.1306695.1322640.1361587.1453546.1623752.1871061",
-    "synonyms": "Cervical disc disorder with myelopathy|Cervical disc disorder with myelopathy|Cervical disc disorder with myelopathy|Cervical disc disorder with myelopathy (disorder)",
     "full_text": "Cervical disc disorder with myelopathy|Cervical disc disorder with myelopathy|Cervical disc disorder with myelopathy|Cervical disc disorder with myelopathy (disorder)|[condition_rank1]"
   },
   {
@@ -205,7 +195,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "99999.1871888",
-    "synonyms": "Obstetric procedure|[procedure_rank1]",
     "full_text": "Obstetric procedure|[procedure_rank1]"
   },
   {
@@ -224,7 +213,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "99999.1871888.1871889",
-    "synonyms": "Termination of pregnancy|[procedure_rank1]",
     "full_text": "Termination of pregnancy|[procedure_rank1]"
   },
   {
@@ -243,7 +231,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "2985961.2985995.2986079.2986708.2988049.2989968.2991522",
-    "synonyms": "Ampicillin [Susceptibility] by Disk diffusion (KB)",
     "full_text": "Ampicillin [Susceptibility] by Disk diffusion (KB)|[measurement_rank1]"
   },
   {
@@ -262,7 +249,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "311096.311122.311454.313124.316493.321152",
-    "synonyms": "Excision or curettage of bone cyst or benign tumor, tibia or fibula",
     "full_text": "Excision or curettage of bone cyst or benign tumor, tibia or fibula|[procedure_rank1]"
   },
   {
@@ -281,7 +267,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "3211944.3211943",
-    "synonyms": "Excision or curettage of bone cyst or benign tumor, tibia or fibula",
     "full_text": "Excision or curettage of bone cyst or benign tumor, tibia or fibula|[condition_rank1]"
   },
   {
@@ -300,7 +285,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "23487234",
-    "synonyms": "Survey",
     "full_text": "[survey_rank1]"
   },
   {
@@ -319,7 +303,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "23487234.23487235",
-    "synonyms": "Question",
     "full_text": "[survey_rank1]"
   },
   {
@@ -338,7 +321,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "23487234.23487235.23487236",
-    "synonyms": "Answer",
     "full_text": "[survey_rank1]"
   },
   {
@@ -357,7 +339,6 @@
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
     "path": "1.5.6.23746",
-    "synonyms": "Cholera due to vibrio cholerae|Cholera d/t vib cholerae|Cholera d/t vib cholerae|Cholera due to vibrio cholerae|Cholera due to vibrio cholerae|[procedure_rank1]",
     "full_text": "Cholera due to vibrio cholerae|Cholera d/t vib cholerae|Cholera d/t vib cholerae|Cholera due to vibrio cholerae|Cholera due to vibrio cholerae|[procedure_rank1]"
   }
 ]

--- a/api/src/bigquerytest/resources/bigquery/materializeddata/cb_criteria_data.json
+++ b/api/src/bigquerytest/resources/bigquery/materializeddata/cb_criteria_data.json
@@ -14,7 +14,6 @@
     "has_attribute": 0,
     "has_hierarchy": 1,
     "has_ancestor_data": 0,
-    "path": "1.5.6",
-    "synonyms": "Cholera|Cholera|Cholera"
+    "path": "1.5.6"
   }
 ]

--- a/api/src/bigquerytest/resources/bigquery/schema/cb_criteria.json
+++ b/api/src/bigquerytest/resources/bigquery/schema/cb_criteria.json
@@ -86,11 +86,6 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "synonyms",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "full_text",
     "type": "STRING"
   }


### PR DESCRIPTION
Removing the column 'synonyms' from liquibase, make-bq-data (while creating table in bq), inserting data into bq.

No changes has been made to 'existing' big query dataset

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
