### PR TITLE
[no ticket][risk=no] adding new command to build prep tables from csv files

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -830,6 +830,35 @@ Common.register_command({
   :fn => ->(*args) { circle_build_cdr_indices("circle-build-cdr-indices", args) }
 })
 
+def make_prep_tables_from_csv(cmd_name, *args)
+  op = WbOptionsParser.new(cmd_name, args)
+  op.opts.cdr_version = "!_prep_tables_!"
+  op.opts.bucket = "all-of-us-workbench-private-cloudsql"
+  op.add_option(
+    "--bq-project [bq-project]",
+    ->(opts, v) { opts.bq_project = v},
+    "BQ Project. Required."
+  )
+  op.add_option(
+    "--bq-dataset [bq-dataset]",
+    ->(opts, v) { opts.bq_dataset = v},
+    "BQ dataset. Required."
+  )
+  op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset }
+  op.parse.validate
+
+  common = Common.new
+  Dir.chdir('db-cdr') do
+    common.run_inline %W{./generate-cdr/validate-prerequisites-exist.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.cdr_version} #{op.opts.bucket}}
+  end
+end
+
+Common.register_command({
+  :invocation => "make-prep-tables-from-csv",
+  :description => "Generates criteria prep tables from csv files.",
+  :fn => ->(*args) { make_prep_tables_from_csv("make-prep-tables-from-csv", *args) }
+})
+
 def make_bq_denormalized_tables(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
   date = Time.new


### PR DESCRIPTION
This is a new intermediate command that will build all the prep tables in a specified `project:dataset`. This command will only create prep tables, the backup commands are ignored(backups are only run in full CDR indices build).

Example run: 
`./project.rb make-prep-tables-from-csv --bq-project all-of-us-workbench-test --bq-dataset test_R2019q4r3`

This will produce:

1. `all-of-us-workbench-test:test_R2019q4r3.prep_criteria`
2. `all-of-us-workbench-test:test_R2019q4r3.prep_criteria_ancestor`
3. `all-of-us-workbench-test:test_R2019q4r3.prep_clinical_terms_nc`
4. `all-of-us-workbench-test:test_R2019q4r3.prep_concept`
5. `all-of-us-workbench-test:test_R2019q4r3.prep_concept_relationship`