### PR TITLE
[RW-6535][risk=no] Update stale FAQ link for "trouble signing in?"

### DIFF
--- a/ui/src/app/pages/login/login.tsx
+++ b/ui/src/app/pages/login/login.tsx
@@ -55,7 +55,7 @@ export const LoginReactComponent: React.FunctionComponent<{
           </div>
           <StyledAnchorTag
             target='_blank'
-            href='https://www.researchallofus.org/frequently-asked-questions/#login-help'
+            href='https://www.researchallofus.org/frequently-asked-questions/#workbench-faqs'
             style={{marginTop: '0.625rem', lineHeight: '0.75rem'}}>
               Trouble Signing In?
           </StyledAnchorTag>

--- a/ui/src/app/pages/login/login.tsx
+++ b/ui/src/app/pages/login/login.tsx
@@ -55,7 +55,7 @@ export const LoginReactComponent: React.FunctionComponent<{
           </div>
           <StyledAnchorTag
             target='_blank'
-            href='https://www.researchallofus.org/frequently-asked-questions/#workbench-faqs'
+            href='https://www.researchallofus.org/faq/what-if-i-have-trouble-signing-in-to-the-workbench'
             style={{marginTop: '0.625rem', lineHeight: '0.75rem'}}>
               Trouble Signing In?
           </StyledAnchorTag>


### PR DESCRIPTION
Old anchor was removed. This is the new direct link to the FAQ details.