### PR TITLE
[noTicket][risk=no]Cleaning up Physical Measurement code

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -287,17 +287,6 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
 
   @Query(
       value =
-          "select count(*) from concept c "
-              + "where (c.count_value > 0 or c.source_count_value > 0) "
-              + "and match(c.concept_name, c.concept_code, c.vocabulary_id, c.synonyms) against(:term in boolean mode) "
-              + "and c.vocabulary_id = 'PPI' "
-              + "and c.concept_class_id = 'Clinical Observation' "
-              + "and c.standard_concept IN ('')",
-      nativeQuery = true)
-  Long findPhysicalMeasurementCount(@Param("term") String term);
-
-  @Query(
-      value =
           "select count from cb_criteria c "
               + "join(select substring_index(path,'.',1) as survey_version_concept_id, count(*) as count "
               + "       from cb_criteria "

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -344,9 +344,6 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   @Override
   public Long findDomainCount(String domain, String term) {
     Domain domainToCount = Domain.valueOf(domain);
-    if (domainToCount.equals(Domain.PHYSICAL_MEASUREMENT)) {
-      return cbCriteriaDao.findPhysicalMeasurementCount(modifyTermMatch(term));
-    }
     Long count = cbCriteriaDao.findDomainCountOnCode(term, domain);
     return count == 0 ? cbCriteriaDao.findDomainCount(modifyTermMatch(term), domain) : count;
   }


### PR DESCRIPTION
This PR will remove the if condition which will never hit since domain PHYSICAL_MEASUREMENT is not used any more, the domain being used now is PHYSICAL_MEASUREMENT_CSS

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
