### PR TITLE
[risk=low] [RW-6190] rm penultimate use of WorkbenchConfig.firecloud.registeredDomainName

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -102,7 +102,6 @@ public class UserController implements UserApiDelegate {
     // See discussion on RW-2894. This may not be strictly necessary, especially if researchers
     // details will be published publicly, but it prevents arbitrary unregistered users from seeing
     // limited researcher profile details.
-
     WorkbenchConfig config = configProvider.get();
     if (!fireCloudService.isUserMemberOfGroup(
         userProvider.get().getUsername(), config.firecloud.registeredDomainName)) {

--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -102,6 +102,7 @@ public class UserController implements UserApiDelegate {
     // See discussion on RW-2894. This may not be strictly necessary, especially if researchers
     // details will be published publicly, but it prevents arbitrary unregistered users from seeing
     // limited researcher profile details.
+
     WorkbenchConfig config = configProvider.get();
     if (!fireCloudService.isUserMemberOfGroup(
         userProvider.get().getUsername(), config.firecloud.registeredDomainName)) {

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -47,7 +47,6 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.exceptions.TooManyRequestsException;
 import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupWithMembers;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
 import org.pmiops.workbench.google.CloudStorageClient;
@@ -842,20 +841,15 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   @AuthorityRequired({Authority.FEATURED_WORKSPACE_ADMIN})
   public ResponseEntity<EmptyResponse> publishWorkspace(
       String workspaceNamespace, String workspaceId) {
-    return setPublished(workspaceNamespace, workspaceId, true);
+    workspaceService.setPublished(workspaceNamespace, workspaceId, true);
+    return ResponseEntity.ok(new EmptyResponse());
   }
 
   @Override
   @AuthorityRequired({Authority.FEATURED_WORKSPACE_ADMIN})
   public ResponseEntity<EmptyResponse> unpublishWorkspace(
       String workspaceNamespace, String workspaceId) {
-    return setPublished(workspaceNamespace, workspaceId, false);
-  }
-
-  private ResponseEntity<EmptyResponse> setPublished(
-      String workspaceNamespace, String workspaceId, boolean publish) {
-    final DbWorkspace dbWorkspace = workspaceDao.getRequired(workspaceNamespace, workspaceId);
-    workspaceService.setPublished(dbWorkspace, publish);
+    workspaceService.setPublished(workspaceNamespace, workspaceId, false);
     return ResponseEntity.ok(new EmptyResponse());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -43,7 +43,7 @@ public interface WorkspaceService {
 
   List<UserRole> getFirecloudUserRoles(String workspaceNamespace, String firecloudName);
 
-  DbWorkspace setPublished(DbWorkspace workspace, String publishedWorkspaceGroup, boolean publish);
+  DbWorkspace setPublished(DbWorkspace workspace, boolean publish);
 
   List<DbUserRecentWorkspace> getRecentWorkspaces();
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -43,7 +43,7 @@ public interface WorkspaceService {
 
   List<UserRole> getFirecloudUserRoles(String workspaceNamespace, String firecloudName);
 
-  DbWorkspace setPublished(DbWorkspace workspace, boolean publish);
+  DbWorkspace setPublished(String workspaceNamespace, String firecloudName, boolean publish);
 
   List<DbUserRecentWorkspace> getRecentWorkspaces();
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceFakeImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceFakeImpl.java
@@ -43,8 +43,7 @@ public class WorkspaceServiceFakeImpl implements WorkspaceService {
   }
 
   @Override
-  public DbWorkspace setPublished(
-      DbWorkspace workspace, String publishedWorkspaceGroup, boolean publish) {
+  public DbWorkspace setPublished(DbWorkspace workspace, boolean publish) {
     return null;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceFakeImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceFakeImpl.java
@@ -43,7 +43,8 @@ public class WorkspaceServiceFakeImpl implements WorkspaceService {
   }
 
   @Override
-  public DbWorkspace setPublished(DbWorkspace workspace, boolean publish) {
+  public DbWorkspace setPublished(
+      String workspaceNamespace, String firecloudName, boolean publish) {
     return null;
   }
 


### PR DESCRIPTION
Description:

Part of RW-6190.  Use the DbAccessTier's Auth Domain Name instead of WorkbenchConfig.

One use of `registeredDomainName` will exist after this change, which will require a little bit of thought beyond this quick one-off PR.  See the notes in RW-6190 for details.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
