### PR TITLE
[RW-6442][risk=no] removing cdr-date and bucket parameters and adding new table

### DIFF
--- a/api/db-cdr/generate-cdr/bq-schemas/cb_cdr_date.json
+++ b/api/db-cdr/generate-cdr/bq-schemas/cb_cdr_date.json
@@ -1,0 +1,12 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "bq_dataset",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "cdr_date",
+    "type": "STRING"
+  }
+]

--- a/api/db-cdr/generate-cdr/generate-private-cdr-counts.sh
+++ b/api/db-cdr/generate-cdr/generate-private-cdr-counts.sh
@@ -6,9 +6,9 @@ export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
 export WORKBENCH_PROJECT=$3 # workbench project
 export CDR_VERSION=$4 # cdr version
-export BUCKET=$5 # GCS bucket
 
 WORKBENCH_DATASET=$CDR_VERSION
+BUCKET="all-of-us-workbench-private-cloudsql"
 
 startDate=$(date)
 echo $(date) " Starting generate-private-cdr-counts $startDate"

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-search-person.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-search-person.sh
@@ -8,7 +8,6 @@ export BQ_PROJECT=$1        # CDR project
 export BQ_DATASET=$2        # CDR dataset
 export WGV_PROJECT=$3       # whole genome variant project
 export WGV_DATASET=$4       # whole genome variant dataset
-export CDR_DATE=$5          # cdr date
 
 # Test that dependant tables exist
 test=$(bq show "$BQ_PROJECT:$BQ_DATASET.prep_concept_ancestor")
@@ -192,7 +191,7 @@ FROM
             SELECT a.person_id
                 , date(a.birth_datetime) as date_of_birth
                 , coalesce(b.observation_date, c.observation_date, d.observation_date) as date_of_consent
-                , date('$CDR_DATE') as date_of_cdr
+                , date((select cdr_date from \`$BQ_PROJECT.$BQ_DATASET.cb_cdr_date\` where bq_dataset = '$BQ_DATASET')) as date_of_cdr
             FROM \`$BQ_PROJECT.$BQ_DATASET.person\` a
             LEFT JOIN
             (

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-tables.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-tables.sh
@@ -9,13 +9,11 @@ export BQ_DATASET=$2        # CDR dataset
 export WGV_PROJECT=$3       # whole genome variant project
 export WGV_DATASET=$4       # whole genome variant dataset
 export CDR_VERSION=$5       # CDR version
-export CDR_DATE=$6          # cdr date
-export BUCKET=$7            # bucket
 export DATA_BROWSER=$8      # data browser flag
 
 echo ""
 echo 'Validating that all prerequisites exist'
-if ./generate-cdr/validate-prerequisites-exist.sh $BQ_PROJECT $BQ_DATASET $CDR_VERSION $BUCKET
+if ./generate-cdr/validate-prerequisites-exist.sh $BQ_PROJECT $BQ_DATASET $CDR_VERSION
 then
     echo "Validation is complete"
 else
@@ -48,7 +46,7 @@ then
 
   echo ""
   echo 'Making denormalized search person table'
-  if ./generate-cdr/make-bq-denormalized-search-person.sh $BQ_PROJECT $BQ_DATASET $WGV_PROJECT $WGV_DATASET $CDR_DATE
+  if ./generate-cdr/make-bq-denormalized-search-person.sh $BQ_PROJECT $BQ_DATASET $WGV_PROJECT $WGV_DATASET
   then
       echo "Making denormalized search person table complete"
   else

--- a/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
+++ b/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
@@ -107,6 +107,16 @@ fi
 
 rm -rf $TEMP_FILE_DIR
 
+# Validate that a cdr cutoff date exists
+echo "Validating that a CDR cutoff date exists..."
+q="select count(*) as count from \`$BQ_PROJECT.$BQ_DATASET.cb_cdr_date\` where bq_dataset = '$BQ_DATASET'"
+cdrDate=$(bq --quiet --project_id=$BQ_PROJECT query --nouse_legacy_sql "$q" | tr -dc '0-9')
+if [[ $cdrDate != 1 ]];
+then
+  echo "CDR cutoff date doesn't exist in $BQ_PROJECT.$BQ_DATASET.cb_cdr_date!"
+  exit 1
+fi
+
 # Purge all backup csv files except for the last 10 versions
 if [[ $CDR_VERSION != $PREP_TABLE_RUN ]];
 then

--- a/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
+++ b/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
@@ -6,46 +6,26 @@ set -e
 export BQ_PROJECT=$1        # CDR project
 export BQ_DATASET=$2        # CDR dataset
 export CDR_VERSION=$3       # CDR version
-export BUCKET=$4            # Bucket
 
 PREP_TABLE_RUN="!_prep_tables_!"
+BUCKET="all-of-us-workbench-private-cloudsql"
 TEMP_FILE_DIR="csv"
 CSV_HOME_DIR="cdr_csv_files"
 CRITERIA_MENU="cb_criteria_menu.csv"
+DS_DATA_DICTIONARY="ds_data_dictionary.csv"
+CB_CDR_DATE="cb_cdr_date.csv"
 PREP_CRITERIA="prep_criteria.csv"
 PREP_CRITERIA_ANCESTOR="prep_criteria_ancestor.csv"
 PREP_CLINICAL_TERMS="prep_clinical_terms_nc.csv"
-DS_DATA_DICTIONARY="ds_data_dictionary.csv"
 PREP_CONCEPT="prep_concept.csv"
 PREP_CONCEPT_RELATIONSHIP="prep_concept_relationship.csv"
-All_FILES=($CRITERIA_MENU $PREP_CRITERIA $PREP_CRITERIA_ANCESTOR $PREP_CLINICAL_TERMS $DS_DATA_DICTIONARY $PREP_CONCEPT $PREP_CONCEPT_RELATIONSHIP)
+All_FILES=($CRITERIA_MENU $DS_DATA_DICTIONARY $CB_CDR_DATE $PREP_CRITERIA $PREP_CRITERIA_ANCESTOR $PREP_CLINICAL_TERMS $PREP_CONCEPT $PREP_CONCEPT_RELATIONSHIP)
 INCOMPATIBLE_DATASETS=("R2019Q4R3" "R2019Q4R4")
 
 if [[ ${INCOMPATIBLE_DATASETS[@]} =~ $BQ_DATASET ]];
   then
   echo "Can't run CDR build indices against "$BQ_DATASET"!"
   exit 1
-fi
-
-# Purge all backup csv files except for the last 10 versions
-if [[ $CDR_VERSION != $PREP_TABLE_RUN ]];
-then
-  fileCount=$(gsutil ls gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/backup | wc -l)
-  allFilesCount=${#All_FILES[@]}
-  numberToDelete=$((fileCount - allFilesCount * 10))
-  if [[ $numberToDelete > 0 ]];
-  then
-    echo "Purging backup files"
-    while IFS= read -r line; do
-      ts=$(echo $line | cut -d_ -f1)
-      if [[ ${#ts} > 0 ]];
-      then
-        echo "Removing $line"
-        gsutil rm gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/backup/$line
-      fi
-    # This lists all the files in the backup bucket sorted by timestamp and gets only the number to delete
-    done < <(gsutil ls gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/backup | rev | cut -d/ -f1 | rev | sort | head -$numberToDelete)
-  fi
 fi
 
 rm -rf $TEMP_FILE_DIR
@@ -81,9 +61,14 @@ if gsutil -m cp gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/*.csv $TEMP_FILE_DIR
           gsutil cp $TEMP_FILE_DIR/$file.gz gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/backup/"$timestamp"_"$file".gz
         fi
       ;;
-    $PREP_CRITERIA|$PREP_CRITERIA_ANCESTOR|$PREP_CLINICAL_TERMS|$PREP_CONCEPT|$PREP_CONCEPT_RELATIONSHIP)
+    $CB_CDR_DATE|$PREP_CRITERIA|$PREP_CRITERIA_ANCESTOR|$PREP_CLINICAL_TERMS|$PREP_CONCEPT|$PREP_CONCEPT_RELATIONSHIP)
       tableName=${file%.*}
-      if [[ $firstColumn == id || $firstColumn == ancestor_id || $firstColumn == parent || $firstColumn == concept_id || $firstColumn == concept_id_1 ]];
+      if [[ $firstColumn == id || \
+            $firstColumn == ancestor_id || \
+            $firstColumn == parent || \
+            $firstColumn == concept_id || \
+            $firstColumn == concept_id_1 || \
+            $firstColumn == bq_dataset ]];
       then
         echo "Removing $file header"
         # Remove the first line of file
@@ -116,10 +101,25 @@ if gsutil -m cp gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/*.csv $TEMP_FILE_DIR
       bq load --project_id=$BQ_PROJECT --source_format=CSV $BQ_DATASET.$tableName gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/$file $schema_path/$tableName.json
       echo "Finished loading $file"
     ;;
-
     esac
-
   done
 fi
 
 rm -rf $TEMP_FILE_DIR
+
+# Purge all backup csv files except for the last 10 versions
+if [[ $CDR_VERSION != $PREP_TABLE_RUN ]];
+then
+  fileCount=$(gsutil ls gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/backup | wc -l)
+  allFilesCount=${#All_FILES[@]}
+  numberToDelete=$(($((fileCount - 1)) - $((allFilesCount * 10))))
+  if [[ $numberToDelete > 0 ]];
+  then
+    echo "Purging $numberToDelete backup files"
+    while IFS= read -r line; do
+      echo "Removing $line"
+      gsutil rm gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/backup/$line
+    # This lists all the files in the backup bucket sorted by timestamp and gets only the number to delete
+    done < <(gsutil ls gs://$BUCKET/$BQ_DATASET/$CSV_HOME_DIR/backup | rev | cut -d/ -f1 | rev | sort | awk 'NF' | head -$numberToDelete)
+  fi
+fi


### PR DESCRIPTION
This PR adds the following:

1. Removing cdr-date and bucket parameters
2. Creation of cb_cdr_dates table to hold the cutoff date for each CDR

Example command:
./project.rb circle-build-cdr-indices --project all-of-us-ehr-dev --bq-dataset test_R2019q4r3 --wgv-dataset 1kg_wgs --cdr-version synth_r_2019q4_14