### PR TITLE
[RW-6156][risk=no]  Delete the old data_dictionary_entry table in workbenchdb (Data Dictionary)

### DIFF
--- a/api/db/changelog/db.changelog-159-delete-data-dictionary-entry-table.xml
+++ b/api/db/changelog/db.changelog-159-delete-data-dictionary-entry-table.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-    <changeSet author="nsaxena" id="changelog-160-delete-data-dictionary-entry-table">
+    <changeSet author="nsaxena" id="changelog-159-delete-data-dictionary-entry-table">
         <dropTable tableName="data_dictionary_entry"/>
     </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-160-delete-data-dictionary-entry-table.xml
+++ b/api/db/changelog/db.changelog-160-delete-data-dictionary-entry-table.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+    <changeSet author="nsaxena" id="changelog-160-delete-data-dictionary-entry-table">
+        <dropTable tableName="data_dictionary_entry"/>
+    </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -168,6 +168,7 @@
   <include file="changelog/db.changelog-156-billing-buffer-entry-status-index.xml"/>
   <include file="changelog/db.changelog-157-add-user-access-tier.xml"/>
   <include file="changelog/db.changelog-158-workspace-add-google-project.xml"/>
+  <include file="changelog/db.changelog-160-delete-data-dictionary-entry-table.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -168,7 +168,7 @@
   <include file="changelog/db.changelog-156-billing-buffer-entry-status-index.xml"/>
   <include file="changelog/db.changelog-157-add-user-access-tier.xml"/>
   <include file="changelog/db.changelog-158-workspace-add-google-project.xml"/>
-  <include file="changelog/db.changelog-160-delete-data-dictionary-entry-table.xml"/>
+  <include file="changelog/db.changelog-159-delete-data-dictionary-entry-table.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`


### PR DESCRIPTION
workbench.data_dictionary_entry table is no longer being used to get dictionary information, this information is now being saved in cloud table.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
