### PR TITLE
[no ticket][risk=no] Puppeteer fix nightly tests

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -20,7 +20,7 @@
     "test-staging:debug": "cross-env WORKBENCH_ENV=staging PUPPETEER_HEADLESS=false DEBUG=true yarn _test --maxWorkers=1",
     "test:ci": "yarn _test --ci --maxWorkers=2 --forceExit",
     "test:ci:debug": "yarn _test --ci --debug --maxWorkers=1 --bail 1",
-    "test-nightly": "cross-env TEST_MODE=nightly-integration yarn _test --maxWorkers=1",
+    "test-nightly": "cross-env WORKBENCH_ENV=test TEST_MODE=nightly-integration yarn _test --maxWorkers=2",
     "test-nightly-local-devup": "cross-env TEST_MODE=nightly-integration yarn jest --maxWorkers=1",
     "test-nightly-local-devup:debug": "cross-env TEST_MODE=nightly-integration PUPPETEER_HEADLESS=false DEBUG=true yarn jest --maxWorkers=1",
     "compile": "tsc -p tsconfig.json",

--- a/e2e/tests/nightly/dataproc-to-gce.spec.ts
+++ b/e2e/tests/nightly/dataproc-to-gce.spec.ts
@@ -87,5 +87,6 @@ describe('Updating runtime compute type', () => {
     // Delete notebook
     const workspaceAnalysisPage = await notebookPreviewPage.goAnalysisPage();
     await workspaceAnalysisPage.deleteResource(notebookName, ResourceCard.Notebook);
+    await workspaceAnalysisPage.deleteWorkspace();
   });
 });

--- a/e2e/tests/nightly/gce-to-dataproc.spec.ts
+++ b/e2e/tests/nightly/gce-to-dataproc.spec.ts
@@ -90,5 +90,6 @@ describe('Updating runtime compute type', () => {
     // Delete notebook
     const workspaceAnalysisPage = await notebookPreviewPage.goAnalysisPage();
     await workspaceAnalysisPage.deleteResource(notebookName, ResourceCard.Notebook);
+    await workspaceAnalysisPage.deleteWorkspace();
   });
 });


### PR DESCRIPTION
CircleCi [failure](https://app.circleci.com/pipelines/github/all-of-us/workbench/8878/workflows/8007c2e1-e329-40c1-a8e5-1e467862f23c/jobs/129727).
Failure were caused by waiting for the runtime status spinner to stop in this [call](https://github.com/all-of-us/workbench/blob/283b78a4e82e3e12fa558a95be4eabcad4c722ea/e2e/app/page/notebook-page.ts#L255). The fix is to exclude runtime status spinner while for page to load.

ran on localhost:

<img width="402" alt="Screen Shot 2021-04-02 at 11 44 06 AM" src="https://user-images.githubusercontent.com/35533885/113430791-c131fe80-93a8-11eb-8e1d-7c61066aa1e1.png">
