### PR TITLE
[no ticket][risk=no] Puppeteer remove password login test

### DIFF
--- a/e2e/tests/user/login.spec.ts
+++ b/e2e/tests/user/login.spec.ts
@@ -1,7 +1,6 @@
 import CookiePolicyPage from 'app/page/cookie-policy';
-import GoogleLoginPage, { FieldSelector } from 'app/page/google-login';
+import GoogleLoginPage from 'app/page/google-login';
 import { config } from 'resources/workbench-config';
-import { waitForText } from 'utils/waits-utils';
 
 describe('Login tests:', () => {
   test('Cookie banner visible on login page', async () => {
@@ -25,23 +24,4 @@ describe('Login tests:', () => {
     expect(await loginPage.loginButton()).toBeTruthy();
   });
 
-  test('Entered wrong password', async () => {
-    const INCORRECT_PASSWORD = 'wrongpassword123';
-    const loginPage = new GoogleLoginPage(page);
-    await loginPage.load();
-
-    const naviPromise = page.waitForNavigation({ waitUntil: 'networkidle0' });
-    const googleButton = await loginPage.loginButton();
-    await googleButton.click();
-    await naviPromise;
-
-    await loginPage.enterEmail(config.userEmail);
-    await loginPage.enterPassword(INCORRECT_PASSWORD);
-
-    const button = await page.waitForXPath(FieldSelector.NextButton, { visible: true });
-    await button.click();
-
-    const err = await waitForText(page, 'Wrong password. Try again');
-    expect(err).toBeTruthy();
-  });
 });

--- a/e2e/tests/user/login.spec.ts
+++ b/e2e/tests/user/login.spec.ts
@@ -23,5 +23,4 @@ describe('Login tests:', () => {
     const loginPage = new GoogleLoginPage(page);
     expect(await loginPage.loginButton()).toBeTruthy();
   });
-
 });


### PR DESCRIPTION
Puppeteer automated tests cannot workaround Google login Captcha. Removing one login test because sometimes it encounters the Captcha page.

<img width="396" alt="Screen Shot 2021-04-02 at 1 53 53 PM" src="https://user-images.githubusercontent.com/35533885/113446128-2d226000-93c5-11eb-8053-18ceb520dc2b.png">
