### PR TITLE
[risk=medium][RW-6187] Migrate UI registration checking to accessTierShortNames

### DIFF
--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -50,7 +50,7 @@ const signInGuard: Guard = {
 };
 
 const registrationGuard: Guard = {
-  allowed: (): boolean => hasRegisteredAccess(profileStore.get().profile.dataAccessLevel),
+  allowed: (): boolean => hasRegisteredAccess(profileStore.get().profile.accessTierShortNames),
   redirectPath: '/'
 };
 

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -8,7 +8,7 @@ import {SessionExpired} from 'app/pages/session-expired';
 import {SignInAgain} from 'app/pages/sign-in-again';
 import {UserDisabled} from 'app/pages/user-disabled';
 import {SignInService} from 'app/services/sign-in.service';
-import {hasRegisteredAccess, ReactWrapperBase} from 'app/utils';
+import {ReactWrapperBase} from 'app/utils';
 import {authStore, profileStore, useStore} from 'app/utils/stores';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
@@ -40,6 +40,7 @@ import {WorkspaceAbout} from './pages/workspace/workspace-about';
 import {WorkspaceEdit, WorkspaceEditMode} from './pages/workspace/workspace-edit';
 import {WorkspaceLibrary} from './pages/workspace/workspace-library';
 import {WorkspaceList} from './pages/workspace/workspace-list';
+import {hasRegisteredAccess} from './utils/access-tiers';
 import {AnalyticsTracker} from './utils/analytics';
 import {BreadcrumbType} from './utils/navigation';
 

--- a/ui/src/app/components/side-nav.spec.tsx
+++ b/ui/src/app/components/side-nav.spec.tsx
@@ -27,8 +27,7 @@ describe('SideNav', () => {
   });
 
   it('disables options when user not registered', () => {
-    const wrapper = mount(<SideNav {...props} profile={{...ProfileStubVariables.PROFILE_STUB,
-      dataAccessLevel: DataAccessLevel.Unregistered}}/>);
+    const wrapper = mount(<SideNav {...props} profile={{...ProfileStubVariables.PROFILE_STUB, accessTierShortNames: []}}/>);
     wrapper.setState({showUserOptions: true});
     // These are our expected items to be disabled when you are not registered
     let disabledItemText = ['Profile', 'Your Workspaces', 'Featured Workspaces', 'User Support Hub'];

--- a/ui/src/app/components/side-nav.spec.tsx
+++ b/ui/src/app/components/side-nav.spec.tsx
@@ -3,8 +3,6 @@ import * as React from 'react';
 
 import {SideNav, SideNavItem, SideNavProps} from './side-nav';
 import {ProfileStubVariables} from "../../testing/stubs/profile-api-stub";
-import {DataAccessLevel} from "../../generated/fetch";
-
 
 describe('SideNav', () => {
   const props: SideNavProps = {

--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -1,12 +1,13 @@
 import {Clickable} from 'app/components/buttons';
 import {ClrIcon} from 'app/components/icons';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
-import {hasRegisteredAccess, reactStyles} from 'app/utils';
+import {reactStyles} from 'app/utils';
 import {AuthorityGuardedAction, hasAuthorityForAction} from 'app/utils/authorities';
 import {navigate, navigateSignOut, signInStore} from 'app/utils/navigation';
 import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
 import {Profile} from 'generated/fetch';
 import * as React from 'react';
+import {hasRegisteredAccess} from 'app/utils/access-tiers';
 
 const styles = reactStyles({
   flex: {

--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -2,12 +2,12 @@ import {Clickable} from 'app/components/buttons';
 import {ClrIcon} from 'app/components/icons';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
+import {hasRegisteredAccess} from 'app/utils/access-tiers';
 import {AuthorityGuardedAction, hasAuthorityForAction} from 'app/utils/authorities';
 import {navigate, navigateSignOut, signInStore} from 'app/utils/navigation';
 import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
 import {Profile} from 'generated/fetch';
 import * as React from 'react';
-import {hasRegisteredAccess} from 'app/utils/access-tiers';
 
 const styles = reactStyles({
   flex: {

--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -272,7 +272,7 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
           onToggleSideNav={() => this.props.onToggleSideNav()}
           href='/profile'
           active={this.props.profileActive}
-          disabled={!hasRegisteredAccess(profile.dataAccessLevel)}
+          disabled={!hasRegisteredAccess(profile.accessTierShortNames)}
         />
       }
       {
@@ -295,7 +295,7 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
         onToggleSideNav={() => this.props.onToggleSideNav()}
         href={'/workspaces'}
         active={this.props.workspacesActive}
-        disabled={!hasRegisteredAccess(profile.dataAccessLevel)}
+        disabled={!hasRegisteredAccess(profile.accessTierShortNames)}
       />
       <SideNavItem
         icon='star'
@@ -303,14 +303,14 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
         onToggleSideNav={() => this.props.onToggleSideNav()}
         href={'/library'}
         active={this.props.libraryActive}
-        disabled={!hasRegisteredAccess(profile.dataAccessLevel)}
+        disabled={!hasRegisteredAccess(profile.accessTierShortNames)}
       />
       <SideNavItem
         icon='help'
         content={'User Support Hub'}
         onToggleSideNav={() => this.props.onToggleSideNav()}
         parentOnClick={() => this.redirectToZendesk()}
-        disabled={!hasRegisteredAccess(profile.dataAccessLevel)}
+        disabled={!hasRegisteredAccess(profile.accessTierShortNames)}
       />
       <SideNavItem
         icon='envelope'

--- a/ui/src/app/guards/registration-guard.service.ts
+++ b/ui/src/app/guards/registration-guard.service.ts
@@ -19,7 +19,7 @@ export class RegistrationGuard implements CanActivate, CanActivateChild {
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
     return this.profileStorageService.profile$.flatMap((profile) => {
-      if (hasRegisteredAccess(profile.dataAccessLevel)) {
+      if (hasRegisteredAccess(profile.accessTierShortNames)) {
         return Observable.from([true]);
       } else {
         this.router.navigate(['/']);

--- a/ui/src/app/guards/registration-guard.service.ts
+++ b/ui/src/app/guards/registration-guard.service.ts
@@ -8,8 +8,7 @@ import {
 import {Observable} from 'rxjs/Observable';
 
 import {ProfileStorageService} from 'app/services/profile-storage.service';
-import {hasRegisteredAccess} from 'app/utils';
-
+import {hasRegisteredAccess} from 'app/utils/access-tiers';
 
 @Injectable()
 export class RegistrationGuard implements CanActivate, CanActivateChild {

--- a/ui/src/app/pages/admin/admin-user.tsx
+++ b/ui/src/app/pages/admin/admin-user.tsx
@@ -512,9 +512,14 @@ export const AdminUser = withUrlParams()(class extends React.Component<Props, St
                 containerStyle={styles.textInputContainer}
             />
             <TextInputWithLabel
-                labelText={'Registration state'}
-                placeholder={fp.capitalize(updatedProfile.dataAccessLevel.toString())}
-                inputId={'registrationState'}
+                labelText={'Access tiers'}
+                placeholder={
+                  fp.flow(
+                    fp.map(fp.capitalize),
+                    fp.join(', '))
+                  (updatedProfile.accessTierShortNames)
+                }
+                inputId={'accessTiers'}
                 disabled={true}
                 inputStyle={{...styles.textInput, ...styles.backgroundColorDark}}
                 containerStyle={styles.textInputContainer}

--- a/ui/src/app/pages/homepage/homepage.spec.tsx
+++ b/ui/src/app/pages/homepage/homepage.spec.tsx
@@ -19,7 +19,7 @@ import {cdrVersionListResponse} from "../../../testing/stubs/cdr-versions-api-st
 
 describe('HomepageComponent', () => {
 
-  const profile = ProfileStubVariables.PROFILE_STUB as unknown as Profile;
+  const profile = ProfileStubVariables.PROFILE_STUB;
   let profileApi: ProfileApiStub;
 
   const component = () => {
@@ -91,7 +91,7 @@ describe('HomepageComponent', () => {
   it('should show access tasks dashboard if the user is not registered', async () => {
     const newProfile = {
       ...profile,
-      dataAccessLevel: DataAccessLevel.Unregistered
+      accessTierShortNames: [],   // unregistered
     };
     serverConfigStore.next({...serverConfigStore.getValue()});
     userProfileStore.next({profile: newProfile, reload, updateCache});
@@ -106,7 +106,7 @@ describe('HomepageComponent', () => {
       dataUseAgreementBypassTime: null,
       dataUseAgreementCompletionTime: 1000,
       dataUseAgreementSignedVersion: 2, // Old version
-      dataAccessLevel: DataAccessLevel.Unregistered
+      accessTierShortNames: [],   // unregistered
     };
     serverConfigStore.next({...serverConfigStore.getValue()});
     userProfileStore.next({profile: newProfile, reload, updateCache});
@@ -123,7 +123,7 @@ describe('HomepageComponent', () => {
       dataUseAgreementBypassTime: null,
       dataUseAgreementCompletionTime: 1000,
       dataUseAgreementSignedVersion: 3, // Live version
-      dataAccessLevel: DataAccessLevel.Unregistered
+      accessTierShortNames: [],   // unregistered
     };
     serverConfigStore.next({...serverConfigStore.getValue()});
     userProfileStore.next({profile: newProfile, reload, updateCache});
@@ -137,7 +137,7 @@ describe('HomepageComponent', () => {
   it('should not display the quick tour if registration dashboard is open', async () => {
     const newProfile = {
       ...profile,
-      dataAccessLevel: DataAccessLevel.Unregistered
+      accessTierShortNames: [],   // unregistered
     };
     serverConfigStore.next({...serverConfigStore.getValue()});
     userProfileStore.next({profile: newProfile, reload, updateCache});

--- a/ui/src/app/pages/homepage/homepage.spec.tsx
+++ b/ui/src/app/pages/homepage/homepage.spec.tsx
@@ -2,7 +2,7 @@ import {mount} from 'enzyme';
 import * as React from 'react';
 
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
-import {DataAccessLevel, Profile, ProfileApi} from 'generated/fetch';
+import {ProfileApi} from 'generated/fetch';
 import {ProfileApiStub, ProfileStubVariables} from 'testing/stubs/profile-api-stub';
 import {serverConfigStore, userProfileStore} from 'app/utils/navigation';
 

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -242,7 +242,7 @@ export const Homepage = withUserProfile()(class extends React.Component<Props, S
       this.setState({betaAccessGranted: !!profile.betaAccessBypassTime});
 
       const {workbenchAccessTasks} = queryParamsStore.getValue();
-      const hasAccess = hasRegisteredAccess(profile.dataAccessLevel);
+      const hasAccess = hasRegisteredAccess(profile.accessTierShortNames);
       if (!hasAccess || workbenchAccessTasks) {
         await this.syncCompliance();
       }

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -22,12 +22,12 @@ import {getRegistrationTasksMap, RegistrationDashboard} from 'app/pages/homepage
 import {profileApi, workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors, {addOpacity} from 'app/styles/colors';
 import {reactStyles, withUserProfile} from 'app/utils';
+import {hasRegisteredAccess} from 'app/utils/access-tiers';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {buildRasRedirectUrl} from 'app/utils/ras';
 import {fetchWithGlobalErrorHandler} from 'app/utils/retry';
 import {supportUrls} from 'app/utils/zendesk';
 import {Profile, WorkspaceResponseListResponse} from 'generated/fetch';
-import {hasRegisteredAccess} from 'app/utils/access-tiers';
 
 export const styles = reactStyles({
   bottomBanner: {

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -21,12 +21,13 @@ import {RecentWorkspaces} from 'app/pages/homepage/recent-workspaces';
 import {getRegistrationTasksMap, RegistrationDashboard} from 'app/pages/homepage/registration-dashboard';
 import {profileApi, workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors, {addOpacity} from 'app/styles/colors';
-import {hasRegisteredAccess, reactStyles, withUserProfile} from 'app/utils';
+import {reactStyles, withUserProfile} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {buildRasRedirectUrl} from 'app/utils/ras';
 import {fetchWithGlobalErrorHandler} from 'app/utils/retry';
 import {supportUrls} from 'app/utils/zendesk';
 import {Profile, WorkspaceResponseListResponse} from 'generated/fetch';
+import {hasRegisteredAccess} from 'app/utils/access-tiers';
 
 export const styles = reactStyles({
   bottomBanner: {

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -130,6 +130,7 @@ export const createEmptyProfile = (): Profile => {
     // profile creation, this field is populated with the full email address.
     username: '',
     dataAccessLevel: DataAccessLevel.Unregistered,
+    accessTierShortNames: [],
     givenName: '',
     familyName: '',
     contactEmail: '',

--- a/ui/src/app/pages/signed-in/component.ts
+++ b/ui/src/app/pages/signed-in/component.ts
@@ -9,6 +9,7 @@ import {cdrVersionsApi} from 'app/services/swagger-fetch-clients';
 
 import {FooterTypeEnum} from 'app/components/footer';
 import {debouncer} from 'app/utils';
+import {hasRegisteredAccess} from 'app/utils/access-tiers';
 import Timeout = NodeJS.Timeout;
 import {setInstitutionCategoryState} from 'app/utils/analytics';
 import {navigateSignOut, routeConfigDataStore} from 'app/utils/navigation';
@@ -16,7 +17,6 @@ import {cdrVersionStore, compoundRuntimeOpStore, routeDataStore} from 'app/utils
 import {initializeZendeskWidget} from 'app/utils/zendesk';
 import {environment} from 'environments/environment';
 import {Profile as FetchProfile} from 'generated/fetch';
-import {hasRegisteredAccess} from 'app/utils/access-tiers';
 
 /*
  * The user's last known active timestamp is stored in localStorage with the key of

--- a/ui/src/app/pages/signed-in/component.ts
+++ b/ui/src/app/pages/signed-in/component.ts
@@ -93,7 +93,7 @@ export class SignedInComponent implements OnInit, OnDestroy, AfterViewInit {
       this.profileLoadingSub = this.profileStorageService.profile$.subscribe((profile) => {
         this.profile = profile as unknown as FetchProfile;
         setInstitutionCategoryState(this.profile.verifiedInstitutionalAffiliation);
-        if (hasRegisteredAccess(this.profile.dataAccessLevel)) {
+        if (hasRegisteredAccess(this.profile.accessTierShortNames)) {
           cdrVersionsApi().getCdrVersions().then(resp => {
             // cdrVersionsInitialized blocks app rendering so that route
             // components don't try to lookup CDR data before it's available.

--- a/ui/src/app/pages/signed-in/component.ts
+++ b/ui/src/app/pages/signed-in/component.ts
@@ -8,7 +8,7 @@ import {SignInService} from 'app/services/sign-in.service';
 import {cdrVersionsApi} from 'app/services/swagger-fetch-clients';
 
 import {FooterTypeEnum} from 'app/components/footer';
-import {debouncer, hasRegisteredAccess} from 'app/utils';
+import {debouncer} from 'app/utils';
 import Timeout = NodeJS.Timeout;
 import {setInstitutionCategoryState} from 'app/utils/analytics';
 import {navigateSignOut, routeConfigDataStore} from 'app/utils/navigation';
@@ -16,6 +16,7 @@ import {cdrVersionStore, compoundRuntimeOpStore, routeDataStore} from 'app/utils
 import {initializeZendeskWidget} from 'app/utils/zendesk';
 import {environment} from 'environments/environment';
 import {Profile as FetchProfile} from 'generated/fetch';
+import {hasRegisteredAccess} from 'app/utils/access-tiers';
 
 /*
  * The user's last known active timestamp is stored in localStorage with the key of

--- a/ui/src/app/utils/access-tiers.tsx
+++ b/ui/src/app/utils/access-tiers.tsx
@@ -1,0 +1,14 @@
+export enum AccessTierShortNames {
+    Registered = 'registered',
+    Controlled = 'controlled',
+}
+
+/**
+ * Determine whether the given access level is Registered. This is required to do most things in the Workbench app
+ * (outside of local/test development).
+ *
+ * TODO: make separate evaluations by tier
+ */
+export function hasRegisteredAccess(accessTierShortNames: Array<string>): boolean {
+  return !!accessTierShortNames && accessTierShortNames.includes(AccessTierShortNames.Registered);
+}

--- a/ui/src/app/utils/access-tiers.tsx
+++ b/ui/src/app/utils/access-tiers.tsx
@@ -1,3 +1,5 @@
+import * as fp from 'lodash/fp';
+
 export enum AccessTierShortNames {
     Registered = 'registered',
     Controlled = 'controlled',
@@ -10,5 +12,5 @@ export enum AccessTierShortNames {
  * TODO: make separate evaluations by tier
  */
 export function hasRegisteredAccess(accessTierShortNames: Array<string>): boolean {
-  return !!accessTierShortNames && accessTierShortNames.includes(AccessTierShortNames.Registered);
+  return fp.includes(AccessTierShortNames.Registered, accessTierShortNames);
 }

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -1,11 +1,4 @@
 import {ElementRef, OnChanges, OnDestroy, OnInit, ViewChild} from '@angular/core';
-import * as fp from 'lodash/fp';
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
-import {ReplaySubject} from 'rxjs/ReplaySubject';
-const {useEffect, useState} = React;
-
 import {colorWithWhiteness} from 'app/styles/colors';
 import {
   currentCohortCriteriaStore,
@@ -21,11 +14,15 @@ import {
   urlParamsStore,
   userProfileStore
 } from 'app/utils/navigation';
-import {
-  ConfigResponse,
-  Domain,
-} from 'generated/fetch';
+import {ConfigResponse, Domain, } from 'generated/fetch';
+import * as fp from 'lodash/fp';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import {ReplaySubject} from 'rxjs/ReplaySubject';
 import {cdrVersionStore, withStore} from './stores';
+
+const {useEffect, useState} = React;
 
 export const WINDOW_REF = 'window-ref';
 
@@ -39,18 +36,6 @@ export function isBlank(toTest: String): boolean {
     toTest = toTest.trim();
     return toTest === '';
   }
-}
-
-export const REGISTERED_TIER_SHORT_NAME = 'registered';
-/**
- * Determine whether the given access level is >= registered. This is the
- * minimum required level to do most things in the Workbench app (outside of
- * local/test development).
- *
- * TODO: make separate evaluations by tier
- */
-export function hasRegisteredAccess(accessTierShortNames: Array<string>): boolean {
-  return !!accessTierShortNames && accessTierShortNames.includes(REGISTERED_TIER_SHORT_NAME);
 }
 
 

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -23,7 +23,6 @@ import {
 } from 'app/utils/navigation';
 import {
   ConfigResponse,
-  DataAccessLevel,
   Domain,
 } from 'generated/fetch';
 import {cdrVersionStore, withStore} from './stores';
@@ -42,16 +41,16 @@ export function isBlank(toTest: String): boolean {
   }
 }
 
+export const REGISTERED_TIER_SHORT_NAME = 'registered';
 /**
  * Determine whether the given access level is >= registered. This is the
  * minimum required level to do most things in the Workbench app (outside of
  * local/test development).
+ *
+ * TODO: make separate evaluations by tier
  */
-export function hasRegisteredAccess(access: DataAccessLevel): boolean {
-  return [
-    DataAccessLevel.Registered,
-    DataAccessLevel.Protected
-  ].includes(access);
+export function hasRegisteredAccess(accessTierShortNames: Array<string>): boolean {
+  return !!accessTierShortNames && accessTierShortNames.includes(REGISTERED_TIER_SHORT_NAME);
 }
 
 

--- a/ui/src/testing/stubs/cdr-versions-api-stub.ts
+++ b/ui/src/testing/stubs/cdr-versions-api-stub.ts
@@ -1,4 +1,4 @@
-import {REGISTERED_TIER_SHORT_NAME} from 'app/utils';
+import {AccessTierShortNames} from 'app/utils/access-tiers';
 import {ArchivalStatus, CdrVersion, CdrVersionListResponse, CdrVersionsApi} from 'generated/fetch';
 import {stubNotImplementedError} from 'testing/stubs/stub-utils';
 
@@ -15,7 +15,7 @@ export const cdrVersionListResponse: CdrVersionListResponse = {
     {
       name: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION,
       cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
-      accessTierShortName: REGISTERED_TIER_SHORT_NAME,
+      accessTierShortName: AccessTierShortNames.Registered,
       archivalStatus: ArchivalStatus.LIVE,
       hasMicroarrayData: true,
       creationTime: 0
@@ -23,7 +23,7 @@ export const cdrVersionListResponse: CdrVersionListResponse = {
     {
       name: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION,
       cdrVersionId: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION_ID,
-      accessTierShortName: REGISTERED_TIER_SHORT_NAME,
+      accessTierShortName: AccessTierShortNames.Registered,
       archivalStatus: ArchivalStatus.LIVE,
       hasMicroarrayData: false,
       creationTime: 0

--- a/ui/src/testing/stubs/cdr-versions-api-stub.ts
+++ b/ui/src/testing/stubs/cdr-versions-api-stub.ts
@@ -1,10 +1,10 @@
+import {REGISTERED_TIER_SHORT_NAME} from 'app/utils';
 import {ArchivalStatus, CdrVersion, CdrVersionListResponse, CdrVersionsApi} from 'generated/fetch';
 import {stubNotImplementedError} from 'testing/stubs/stub-utils';
 
 export class CdrVersionsStubVariables {
   static DEFAULT_WORKSPACE_CDR_VERSION = 'Fake CDR Version';
   static DEFAULT_WORKSPACE_CDR_VERSION_ID = 'fakeCdrVersion';
-  static DEFAULT_ACCESS_TIER_SHORT_NAME = 'registered';
   static ALT_WORKSPACE_CDR_VERSION = 'Alternative CDR Version';
   static ALT_WORKSPACE_CDR_VERSION_ID = 'altCdrVersion';
 }
@@ -15,7 +15,7 @@ export const cdrVersionListResponse: CdrVersionListResponse = {
     {
       name: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION,
       cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
-      accessTierShortName: CdrVersionsStubVariables.DEFAULT_ACCESS_TIER_SHORT_NAME,
+      accessTierShortName: REGISTERED_TIER_SHORT_NAME,
       archivalStatus: ArchivalStatus.LIVE,
       hasMicroarrayData: true,
       creationTime: 0
@@ -23,7 +23,7 @@ export const cdrVersionListResponse: CdrVersionListResponse = {
     {
       name: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION,
       cdrVersionId: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION_ID,
-      accessTierShortName: CdrVersionsStubVariables.DEFAULT_ACCESS_TIER_SHORT_NAME,
+      accessTierShortName: REGISTERED_TIER_SHORT_NAME,
       archivalStatus: ArchivalStatus.LIVE,
       hasMicroarrayData: false,
       creationTime: 0

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -3,13 +3,13 @@ import {
   AccessModule,
   AdminTableUser,
   CreateAccountRequest,
-  DataAccessLevel,
   InstitutionalRole,
   NihToken,
   Profile,
   ProfileApi,
 } from 'generated/fetch';
 
+import {REGISTERED_TIER_SHORT_NAME} from 'app/utils';
 import {EmptyResponse} from 'generated/fetch/api';
 import {stubNotImplementedError} from 'testing/stubs/stub-utils';
 
@@ -17,7 +17,7 @@ export class ProfileStubVariables {
   static PROFILE_STUB = <Profile>{
     username: 'tester@fake-research-aou.org',
     contactEmail: 'tester@mactesterson.edu><script>alert("hello");</script>',
-    dataAccessLevel: DataAccessLevel.Registered,
+    accessTierShortNames: [REGISTERED_TIER_SHORT_NAME],
     givenName: 'Tester!@#$%^&*()><script>alert("hello");</script>',
     familyName: 'MacTesterson!@#$%^&*()><script>alert("hello");</script>',
     phoneNumber: '999-999-9999',

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -9,7 +9,7 @@ import {
   ProfileApi,
 } from 'generated/fetch';
 
-import {REGISTERED_TIER_SHORT_NAME} from 'app/utils';
+import {AccessTierShortNames} from 'app/utils/access-tiers';
 import {EmptyResponse} from 'generated/fetch/api';
 import {stubNotImplementedError} from 'testing/stubs/stub-utils';
 
@@ -17,7 +17,7 @@ export class ProfileStubVariables {
   static PROFILE_STUB = <Profile>{
     username: 'tester@fake-research-aou.org',
     contactEmail: 'tester@mactesterson.edu><script>alert("hello");</script>',
-    accessTierShortNames: [REGISTERED_TIER_SHORT_NAME],
+    accessTierShortNames: [AccessTierShortNames.Registered],
     givenName: 'Tester!@#$%^&*()><script>alert("hello");</script>',
     familyName: 'MacTesterson!@#$%^&*()><script>alert("hello");</script>',
     phoneNumber: '999-999-9999',

--- a/ui/src/testing/stubs/workspaces.tsx
+++ b/ui/src/testing/stubs/workspaces.tsx
@@ -1,4 +1,4 @@
-import {REGISTERED_TIER_SHORT_NAME} from 'app/utils';
+import {AccessTierShortNames} from 'app/utils/access-tiers';
 import {
   RecentWorkspace,
   RecentWorkspaceResponse,
@@ -21,7 +21,7 @@ export function buildWorkspaceStub(suffix = ''): Workspace {
     id: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID + suffix,
     namespace: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS + suffix,
     cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID + suffix,
-    accessTierShortName: REGISTERED_TIER_SHORT_NAME,
+    accessTierShortName: AccessTierShortNames.Registered,
     creationTime: new Date().getTime(),
     lastModifiedTime: new Date().getTime(),
     researchPurpose: {

--- a/ui/src/testing/stubs/workspaces.tsx
+++ b/ui/src/testing/stubs/workspaces.tsx
@@ -1,3 +1,4 @@
+import {REGISTERED_TIER_SHORT_NAME} from 'app/utils';
 import {
   RecentWorkspace,
   RecentWorkspaceResponse,
@@ -6,7 +7,6 @@ import {
   WorkspaceAccessLevel
 } from 'generated/fetch';
 import {CdrVersionsStubVariables} from './cdr-versions-api-stub';
-
 
 export class WorkspaceStubVariables {
   static DEFAULT_WORKSPACE_NS = 'defaultNamespace';
@@ -21,7 +21,7 @@ export function buildWorkspaceStub(suffix = ''): Workspace {
     id: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID + suffix,
     namespace: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS + suffix,
     cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID + suffix,
-    accessTierShortName: CdrVersionsStubVariables.DEFAULT_ACCESS_TIER_SHORT_NAME,
+    accessTierShortName: REGISTERED_TIER_SHORT_NAME,
     creationTime: new Date().getTime(),
     lastModifiedTime: new Date().getTime(),
     researchPurpose: {


### PR DESCRIPTION
Description:

UI counterpart to https://github.com/all-of-us/workbench/pull/4755

Final cleanup of dataAccessTierFields will be done in RW-6189.

TODO and out of scope: make tier-specific access and display determinations instead of always looking for Registered Tier access.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
