### PR TITLE
[risk=no][RW-6187] stop populating dataAccessLevel in user reporting

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
-import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.model.ReportingCohort;
 import org.pmiops.workbench.model.ReportingDataset;
@@ -272,11 +271,6 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 .contactEmail(rs.getString("contact_email"))
                 .creationTime(offsetDateTimeUtc(rs.getTimestamp("creation_time")))
                 .currentPosition(rs.getString("current_position"))
-                // TODO remove in RW-6189
-                // until then, what we're interested in is registered vs not
-                .dataAccessLevel(
-                    AccessTierService.temporaryDataAccessLevelKluge(
-                        rs.getString("access_tier_short_names")))
                 .accessTierShortNames(rs.getString("access_tier_short_names"))
                 .dataUseAgreementBypassTime(
                     offsetDateTimeUtc(rs.getTimestamp("data_use_agreement_bypass_time")))

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -10,7 +10,6 @@ import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.BillingAccountType;
 import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.CohortStatus;
-import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.Disability;
 import org.pmiops.workbench.model.DisseminateResearchEnum;
@@ -190,22 +189,6 @@ public final class DbStorageEnums {
 
   public static Short cohortStatusToStorage(CohortStatus s) {
     return CLIENT_TO_STORAGE_COHORT_STATUS.get(s);
-  }
-
-  // DataAccessLevel
-  private static final BiMap<DataAccessLevel, Short> CLIENT_TO_STORAGE_DATA_ACCESS_LEVEL =
-      ImmutableBiMap.<DataAccessLevel, Short>builder()
-          .put(DataAccessLevel.UNREGISTERED, (short) 0)
-          .put(DataAccessLevel.REGISTERED, (short) 1)
-          .put(DataAccessLevel.PROTECTED, (short) 2)
-          .build();
-
-  public static DataAccessLevel dataAccessLevelFromStorage(Short level) {
-    return CLIENT_TO_STORAGE_DATA_ACCESS_LEVEL.inverse().get(level);
-  }
-
-  public static Short dataAccessLevelToStorage(DataAccessLevel level) {
-    return CLIENT_TO_STORAGE_DATA_ACCESS_LEVEL.get(level);
   }
 
   // Degree

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
@@ -27,7 +27,6 @@ public enum UserColumnValueExtractor implements ColumnValueExtractor<ReportingUs
   CONTACT_EMAIL("contact_email", ReportingUser::getContactEmail),
   CREATION_TIME("creation_time", u -> toInsertRowString(u.getCreationTime())),
   CURRENT_POSITION("current_position", ReportingUser::getCurrentPosition),
-  DATA_ACCESS_LEVEL("data_access_level", u -> enumToString(u.getDataAccessLevel())),
   DATA_USE_AGREEMENT_BYPASS_TIME(
       "data_use_agreement_bypass_time", u -> toInsertRowString(u.getDataUseAgreementBypassTime())),
   DATA_USE_AGREEMENT_COMPLETION_TIME(

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8284,12 +8284,6 @@ definitions:
       currentPosition:
         type: string
         description: User's current role/position.
-      dataAccessLevel:
-        description: |-
-          DEPRECATED.  Will be replaced by Access Tiers.
-          An indication of whether the user has completed the requirements for access to the
-          registered tier.
-        "$ref": "#/definitions/DataAccessLevel"
       dataUseAgreementBypassTime:
         type: string
         format: date-time

--- a/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
@@ -14,7 +14,6 @@ import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.Disability;
 import org.pmiops.workbench.model.Education;
@@ -61,8 +60,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
   public static final String USER__CURRENT_POSITION = "foo_7";
   public static final String USER__ACCESS_TIER_SHORT_NAMES =
       AccessTierService.REGISTERED_TIER_SHORT_NAME;
-  public static final DataAccessLevel USER__DATA_ACCESS_LEVEL =
-      AccessTierService.temporaryDataAccessLevelKluge(USER__ACCESS_TIER_SHORT_NAMES);
   public static final Timestamp USER__DATA_USE_AGREEMENT_BYPASS_TIME =
       Timestamp.from(Instant.parse("2015-05-14T00:00:00.00Z"));
   public static final Timestamp USER__DATA_USE_AGREEMENT_COMPLETION_TIME =
@@ -128,7 +125,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
     assertThat(user.getContactEmail()).isEqualTo(USER__CONTACT_EMAIL);
     assertTimeApprox(user.getCreationTime(), USER__CREATION_TIME);
     assertThat(user.getCurrentPosition()).isEqualTo(USER__CURRENT_POSITION);
-    assertThat(user.getDataAccessLevel()).isEqualTo(USER__DATA_ACCESS_LEVEL); // manual adjustment
     assertThat(user.getAccessTierShortNames()).isEqualTo(USER__ACCESS_TIER_SHORT_NAMES);
     assertTimeApprox(user.getDataUseAgreementBypassTime(), USER__DATA_USE_AGREEMENT_BYPASS_TIME);
     assertTimeApprox(


### PR DESCRIPTION
Description:

Now that we're populating accessTierShortNames, we can stop populating the dataAccessLevel field in User Reporting.

Jonathan and Francis in Reporting know that this change is coming.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
