### PR TITLE
[risk=no] Log runtime error messages when we observe the error status

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -171,8 +171,7 @@ public class RuntimeController implements RuntimeApiDelegate {
 
     try {
       LeonardoGetRuntimeResponse leoRuntimeResponse =
-          leonardoNotebooksClient.getRuntime(
-              googleProject, userProvider.get().getRuntimeName());
+          leonardoNotebooksClient.getRuntime(googleProject, userProvider.get().getRuntimeName());
       if (LeonardoRuntimeStatus.ERROR.equals(leoRuntimeResponse.getStatus())) {
         log.warning(
             String.format(

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.api;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -13,6 +12,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import javax.inject.Provider;
 import org.json.JSONObject;
 import org.pmiops.workbench.actionaudit.auditors.LeonardoRuntimeAuditor;
@@ -28,6 +28,7 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
+import org.pmiops.workbench.leonardo.model.LeonardoClusterError;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeStatus;
@@ -176,12 +177,21 @@ public class RuntimeController implements RuntimeApiDelegate {
         log.warning(
             String.format(
                 "Observed Leonardo runtime with unexpected error status:\n%s",
-                Joiner.on('\n').join(leoRuntimeResponse.getErrors())));
+                formatRuntimeErrors(leoRuntimeResponse.getErrors())));
       }
       return ResponseEntity.ok(leonardoMapper.toApiRuntime(leoRuntimeResponse));
     } catch (NotFoundException e) {
       return ResponseEntity.ok(getOverrideFromListRuntimes(googleProject));
     }
+  }
+
+  private String formatRuntimeErrors(@Nullable List<LeonardoClusterError> errors) {
+    if (errors == null || errors.isEmpty()) {
+      return "no error messages";
+    }
+    return errors.stream()
+        .map(err -> String.format("error %d: %s", err.getErrorCode(), err.getErrorMessage()))
+        .collect(Collectors.joining("\n"));
   }
 
   private Runtime getOverrideFromListRuntimes(String googleProject) {

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -64,6 +64,7 @@ import org.pmiops.workbench.leonardo.ApiException;
 import org.pmiops.workbench.leonardo.LeonardoRetryHandler;
 import org.pmiops.workbench.leonardo.api.RuntimesApi;
 import org.pmiops.workbench.leonardo.model.LeonardoAuditInfo;
+import org.pmiops.workbench.leonardo.model.LeonardoClusterError;
 import org.pmiops.workbench.leonardo.model.LeonardoCreateRuntimeRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoGceConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
@@ -390,6 +391,28 @@ public class RuntimeControllerTest {
         .thenReturn(testLeoRuntime);
 
     assertThat(runtimeController.getRuntime(WORKSPACE_NS).getBody()).isEqualTo(testRuntime);
+  }
+
+  @Test
+  public void testGetRuntime_error() throws ApiException {
+    when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
+        .thenReturn(
+            testLeoRuntime
+                .status(LeonardoRuntimeStatus.ERROR)
+                .errors(
+                    ImmutableList.of(
+                        new LeonardoClusterError().errorCode(1).errorMessage("foo"),
+                        new LeonardoClusterError().errorCode(2).errorMessage(null))));
+
+    assertThat(runtimeController.getRuntime(BILLING_PROJECT_ID).getBody()).isEqualTo(testRuntime);
+  }
+
+  @Test
+  public void testGetRuntime_errorNoMessages() throws ApiException {
+    when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
+        .thenReturn(testLeoRuntime.status(LeonardoRuntimeStatus.ERROR).errors(null));
+
+    assertThat(runtimeController.getRuntime(BILLING_PROJECT_ID).getBody()).isEqualTo(testRuntime);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -404,7 +404,8 @@ public class RuntimeControllerTest {
                         new LeonardoClusterError().errorCode(1).errorMessage("foo"),
                         new LeonardoClusterError().errorCode(2).errorMessage(null))));
 
-    assertThat(runtimeController.getRuntime(BILLING_PROJECT_ID).getBody()).isEqualTo(testRuntime);
+    assertThat(runtimeController.getRuntime(BILLING_PROJECT_ID).getBody())
+        .isEqualTo(testRuntime.status(RuntimeStatus.ERROR));
   }
 
   @Test
@@ -412,7 +413,8 @@ public class RuntimeControllerTest {
     when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
         .thenReturn(testLeoRuntime.status(LeonardoRuntimeStatus.ERROR).errors(null));
 
-    assertThat(runtimeController.getRuntime(BILLING_PROJECT_ID).getBody()).isEqualTo(testRuntime);
+    assertThat(runtimeController.getRuntime(BILLING_PROJECT_ID).getBody())
+        .isEqualTo(testRuntime.status(RuntimeStatus.ERROR));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -395,7 +395,7 @@ public class RuntimeControllerTest {
 
   @Test
   public void testGetRuntime_error() throws ApiException {
-    when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
+    when(userRuntimesApi.getRuntime(GOOGLE_PROJECT_ID, getRuntimeName()))
         .thenReturn(
             testLeoRuntime
                 .status(LeonardoRuntimeStatus.ERROR)
@@ -404,16 +404,16 @@ public class RuntimeControllerTest {
                         new LeonardoClusterError().errorCode(1).errorMessage("foo"),
                         new LeonardoClusterError().errorCode(2).errorMessage(null))));
 
-    assertThat(runtimeController.getRuntime(BILLING_PROJECT_ID).getBody())
+    assertThat(runtimeController.getRuntime(WORKSPACE_NS).getBody())
         .isEqualTo(testRuntime.status(RuntimeStatus.ERROR));
   }
 
   @Test
   public void testGetRuntime_errorNoMessages() throws ApiException {
-    when(userRuntimesApi.getRuntime(BILLING_PROJECT_ID, getRuntimeName()))
+    when(userRuntimesApi.getRuntime(GOOGLE_PROJECT_ID, getRuntimeName()))
         .thenReturn(testLeoRuntime.status(LeonardoRuntimeStatus.ERROR).errors(null));
 
-    assertThat(runtimeController.getRuntime(BILLING_PROJECT_ID).getBody())
+    assertThat(runtimeController.getRuntime(WORKSPACE_NS).getBody())
         .isEqualTo(testRuntime.status(RuntimeStatus.ERROR));
   }
 


### PR DESCRIPTION
This is a long standing issue that we don't capture runtime errors when we see them - typically by the time we go to debug these issues, the runtimes have been automatically deleted. Log this in the server logs so we have some record of what happened.

This should make e2e test debugging easier as well.