### PR TITLE
[no ticket][risk=no] Run Puppeteer tests in staging

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -67,7 +67,7 @@ ENVIRONMENTS = {
     :config_json => "config_staging.json",
     :cdr_config_json => "cdr_config_staging.json",
     :featured_workspaces_json => "featured_workspaces_staging.json",
-    :gae_vars => make_gae_vars,
+    :gae_vars => make_gae_vars(0, 10, 'F4'),
     :source_cdr_project => "all-of-us-ehr-dev",
     :source_wgv_project => "all-of-us-workbench-test"
   },

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -67,7 +67,7 @@ ENVIRONMENTS = {
     :config_json => "config_staging.json",
     :cdr_config_json => "cdr_config_staging.json",
     :featured_workspaces_json => "featured_workspaces_staging.json",
-    :gae_vars => make_gae_vars(0, 10, 'F4'),
+    :gae_vars => make_gae_vars(0, 4, 'F1'),
     :source_cdr_project => "all-of-us-ehr-dev",
     :source_wgv_project => "all-of-us-workbench-test"
   },

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -67,7 +67,7 @@ ENVIRONMENTS = {
     :config_json => "config_staging.json",
     :cdr_config_json => "cdr_config_staging.json",
     :featured_workspaces_json => "featured_workspaces_staging.json",
-    :gae_vars => make_gae_vars(0, 4, 'F1'),
+    :gae_vars => make_gae_vars(0, 4),
     :source_cdr_project => "all-of-us-ehr-dev",
     :source_wgv_project => "all-of-us-workbench-test"
   },


### PR DESCRIPTION
Increase GAE CPU and memory in staging to run Puppeteer e2e tests. Same GAE settings as in test env.
GAE [instance_class](https://cloud.google.com/appengine/docs/standard#second-gen-runtimes) setting.