### PR TITLE
[risk=low][no ticket] Expose db port during connect-to-cloud-db to allow usage of other SQL tools

### DIFF
--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -28,6 +28,10 @@ x-api-defaults: &api-defaults
 services:
   scripts:
     <<: *api-defaults
+  ports-scripts:
+    <<: *api-defaults
+    ports:
+      - 127.0.0.1:3307:3307
   db:
     image: mysql:5.7.27
     env_file:

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -145,7 +145,7 @@ def ensure_docker(cmd_name, args=nil)
   args = (args or [])
   unless Workbench.in_docker?
     ensure_docker_sync()
-    exec(*(%W{docker-compose run --service-ports --rm scripts ./project.rb #{cmd_name}} + args))
+    exec(*(%W{docker-compose run --rm scripts ./project.rb #{cmd_name}} + args))
   end
 end
 

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -145,7 +145,15 @@ def ensure_docker(cmd_name, args=nil)
   args = (args or [])
   unless Workbench.in_docker?
     ensure_docker_sync()
-    exec(*(%W{docker-compose run --rm scripts ./project.rb #{cmd_name}} + args))
+    exec(*(%W{docker-compose run --service-ports --rm scripts ./project.rb #{cmd_name}} + args))
+  end
+end
+
+def ensure_docker_with_ports(cmd_name, args=nil)
+  args = (args or [])
+  unless Workbench.in_docker?
+    ensure_docker_sync()
+    exec(*(%W{docker-compose run --service-ports --rm ports-scripts ./project.rb #{cmd_name}} + args))
   end
 end
 
@@ -171,19 +179,22 @@ def ensure_docker_api(cmd_name, args)
   exit 1
 end
 
+def gcs_vars_path(project)
+  return "gs://#{project}-credentials/vars.env"
+end
+
 def read_db_vars(gcc)
   Workbench.assert_in_docker
-  vars_path = "gs://#{gcc.project}-credentials/vars.env"
   vars = Workbench.read_vars(Common.new.capture_stdout(%W{
-    gsutil cat #{vars_path}
+    gsutil cat #{gcs_vars_path(gcc.project)}
   }))
   if vars.empty?
-    Common.new.error "Failed to read #{vars_path}"
+    Common.new.error "Failed to read #{gcs_vars_path(gcc.project)}"
     exit 1
   end
   # Note: CDR project and target project may be the same.
   cdr_project = get_cdr_sql_project(gcc.project)
-  cdr_vars_path = "gs://#{cdr_project}-credentials/vars.env"
+  cdr_vars_path = gcs_vars_path(cdr_project)
   cdr_vars = Workbench.read_vars(Common.new.capture_stdout(%W{
     gsutil cat #{cdr_vars_path}
   }))
@@ -2379,7 +2390,7 @@ Common.register_command({
 })
 
 def connect_to_cloud_db(cmd_name, *args)
-  ensure_docker cmd_name, args
+  ensure_docker_with_ports cmd_name, args
   common = Common.new
   op = WbOptionsParser.new(cmd_name, args)
   op.add_option(
@@ -2388,6 +2399,7 @@ def connect_to_cloud_db(cmd_name, *args)
     "Optional database user to connect as, defaults to 'dev-readonly'. " +
     "To perform mutations use 'workbench'. Avoid using 'root' unless " +
     "absolutely necessary.")
+
   gcc = GcloudContextV2.new(op)
   op.parse.validate
   gcc.validate
@@ -2415,11 +2427,13 @@ def connect_to_cloud_db(cmd_name, *args)
       common.status "Database session will be read-only; use --db-user to change this"
       common.status ""
     end
+    common.status "Fetch credentials from #{gcs_vars_path(gcc.project)} to connect through a different SQL tool"
     common.run_inline %W{
       mysql --host=127.0.0.1 --port=3307 --user=#{op.opts.db_user}
       --database=#{env["DB_NAME"]} --password=#{db_password}},
       db_password
   end
+
 end
 
 Common.register_command({


### PR DESCRIPTION
Description:
Setting this up so I can use Datagrip

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
