### PR TITLE
RW-6550 adding check for dependent OMOP tables

### DIFF
--- a/api/db-cdr/generate-cdr/make-bq-criteria-tables.sh
+++ b/api/db-cdr/generate-cdr/make-bq-criteria-tables.sh
@@ -12,26 +12,6 @@ export BQ_PROJECT=$1        # project
 export BQ_DATASET=$2        # dataset
 export DATA_BROWSER=$3      # data browser flag
 
-# Test that dependant tables exist
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.cb_search_all_events")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept_ancestor")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept_relationship")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept_synonym")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.condition_occurrence")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.death")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.drug_exposure")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.measurement")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.observation")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.person")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.prep_criteria")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.prep_criteria_ancestor")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.prep_clinical_terms_nc")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.procedure_occurrence")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.relationship")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.visit_occurrence")
-echo "$test"
-
 ################################################
 # CREATE TABLES
 ################################################

--- a/api/db-cdr/generate-cdr/make-bq-dataset-linking.sh
+++ b/api/db-cdr/generate-cdr/make-bq-dataset-linking.sh
@@ -7,9 +7,6 @@ set -ex
 export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
 
-# Test that datset exists
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET")
-
 ################################################
 # CREATE LINKING TABLE
 ################################################

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-dataset.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-dataset.sh
@@ -7,19 +7,6 @@ set -ex
 export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
 
-# Test that dependant tables exist
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.cb_criteria")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.prep_concept_ancestor")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.condition_occurrence")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.procedure_occurrence")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.drug_exposure")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.measurement")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.observation")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.visit_occurrence")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.person")
-echo "$test"
-
 ################################################
 # CREATE TABLES
 ################################################

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-review.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-review.sh
@@ -7,19 +7,6 @@ set -ex
 export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
 
-# Test that dependant tables exist
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.observation")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.prep_concept_ancestor")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.cb_criteria")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.condition_occurrence")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.procedure_occurrence")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.drug_exposure")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.measurement")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.visit_occurrence")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.person")
-echo "$test"
-
 # Create bq tables we have json schema for
 schema_path=generate-cdr/bq-schemas
 

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-search-events.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-search-events.sh
@@ -8,18 +8,6 @@ export BQ_PROJECT=$1        # project
 export BQ_DATASET=$2        # dataset
 export DATA_BROWSER=$3      # data browser flag
 
-# Test that dependant tables exist
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.person")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.condition_occurrence")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.procedure_occurrence")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.drug_exposure")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.observation")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.observation_ext")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.measurement")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.visit_occurrence")
-echo "$test"
-
 # Create bq tables we have json schema for
 schema_path=generate-cdr/bq-schemas
 

--- a/api/db-cdr/generate-cdr/make-bq-denormalized-search-person.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-search-person.sh
@@ -9,28 +9,6 @@ export BQ_DATASET=$2        # CDR dataset
 export WGV_PROJECT=$3       # whole genome variant project
 export WGV_DATASET=$4       # whole genome variant dataset
 
-# Test that dependant tables exist
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.prep_concept_ancestor")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.person")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.concept")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.cb_criteria")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.condition_occurrence")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.procedure_occurrence")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.device_exposure")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.drug_exposure")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.observation")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.measurement")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.visit_occurrence")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.condition_occurrence_ext")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.procedure_occurrence_ext")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.device_exposure_ext")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.drug_exposure_ext")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.observation_ext")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.measurement_ext")
-test=$(bq show "$BQ_PROJECT:$BQ_DATASET.visit_occurrence_ext")
-test=$(bq show "$WGV_PROJECT:$WGV_DATASET.metadata")
-echo "$test"
-
 # Create bq tables we have json schema for
 schema_path=generate-cdr/bq-schemas
 

--- a/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
+++ b/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
@@ -30,7 +30,7 @@ PREP_FILES=($PREP_CDR_DATE
            $PREP_CONCEPT
            $PREP_CONCEPT_RELATIONSHIP)
 ALL_FILES=("${NON_PREP_FILES[@]}" "${PREP_FILES[@]}")
-DEPENDANT_TABLES=("activity_summary"
+DEPENDENT_TABLES=("activity_summary"
             "concept"
             "concept_ancestor"
             "concept_relationship"
@@ -112,7 +112,7 @@ if [[ ${INCOMPATIBLE_DATASETS[@]} =~ $BQ_DATASET ]];
   exit 1
 fi
 
-for table in ${DEPENDANT_TABLES[@]}; do
+for table in ${DEPENDENT_TABLES[@]}; do
   echo "Validating that $table exists!"
   tableInfo=$(bq show "$BQ_PROJECT:$BQ_DATASET.$table")
   echo $tableInfo

--- a/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
+++ b/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
@@ -30,6 +30,33 @@ PREP_FILES=($PREP_CDR_DATE
            $PREP_CONCEPT
            $PREP_CONCEPT_RELATIONSHIP)
 ALL_FILES=("${NON_PREP_FILES[@]}" "${PREP_FILES[@]}")
+DEPENDANT_TABLES=("activity_summary"
+            "concept"
+            "concept_ancestor"
+            "concept_relationship"
+            "concept_synonym"
+            "condition_occurrence"
+            "condition_occurrence_ext"
+            "death"
+            "device_exposure"
+            "device_exposure_ext"
+            "domain"
+            "drug_exposure"
+            "drug_exposure_ext"
+            "heart_rate_minute_level"
+            "heart_rate_summary"
+            "measurement"
+            "measurement_ext"
+            "observation"
+            "observation_ext"
+            "person"
+            "procedure_occurrence"
+            "procedure_occurrence_ext"
+            "relationship"
+            "steps_intraday"
+            "visit_occurrence"
+            "visit_occurrence_ext"
+            "vocabulary")
 INCOMPATIBLE_DATASETS=("R2019Q4R3" "R2019Q4R4")
 
 function removeHeaderIfExist() {
@@ -84,6 +111,12 @@ if [[ ${INCOMPATIBLE_DATASETS[@]} =~ $BQ_DATASET ]];
   echo "Can't run CDR build indices against "$BQ_DATASET"!"
   exit 1
 fi
+
+for table in ${DEPENDANT_TABLES[@]}; do
+  echo "Validating that $table exists!"
+  tableInfo=$(bq show "$BQ_PROJECT:$BQ_DATASET.$table")
+  echo $tableInfo
+done
 
 rm -rf $TEMP_FILE_DIR
 mkdir $TEMP_FILE_DIR


### PR DESCRIPTION
This PR contains

1. Removal of bq show checks in individual scripts of CDR indices
2. Adds check that all dependent OMOP tables exist in the validation script.