### PR TITLE
[risk=low][no ticket] Check whether the user_access_tier mapping is ENABLED in native queries

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -78,6 +78,7 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + "  FROM user u "
               + "  JOIN user_access_tier uat ON u.user_id = uat.user_id "
               + "  JOIN access_tier a ON a.access_tier_id = uat.access_tier_id "
+              + "  WHERE uat.access_status = 1 " // ENABLED
               + "  GROUP BY u.user_id"
               + ") as t ON t.user_id = u.user_id "
               + "GROUP BY u.disabled, t.access_tier_short_names ")
@@ -166,6 +167,7 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + "  FROM user u "
               + "  JOIN user_access_tier uat ON u.user_id = uat.user_id "
               + "  JOIN access_tier a ON a.access_tier_id = uat.access_tier_id "
+              + "  WHERE uat.access_status = 1 " // ENABLED
               + "  GROUP BY u.user_id"
               + ") as t ON t.user_id = u.user_id")
   List<DbAdminTableUser> getAdminTableUsers();

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -253,6 +253,7 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "    FROM user u "
                 + "      JOIN user_access_tier uat ON u.user_id = uat.user_id "
                 + "      JOIN access_tier a ON a.access_tier_id = uat.access_tier_id "
+                + "      WHERE uat.access_status = 1 " // ENABLED
                 + "      GROUP BY u.user_id"
                 + "  ) as t ON t.user_id = u.user_id "
                 + "  ORDER BY u.user_id"


### PR DESCRIPTION
Description:

It's not enough to simply JOIN on user_access_tier.  You must also check that it is ENABLED.

Added regression tests for the 3 queries which all fail on the previous versions.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
