### PR TITLE
[no ticket][risk=no] revert commit #4792

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -67,7 +67,7 @@ ENVIRONMENTS = {
     :config_json => "config_staging.json",
     :cdr_config_json => "cdr_config_staging.json",
     :featured_workspaces_json => "featured_workspaces_staging.json",
-    :gae_vars => make_gae_vars(0, 4),
+    :gae_vars => make_gae_vars,
     :source_cdr_project => "all-of-us-ehr-dev",
     :source_wgv_project => "all-of-us-workbench-test"
   },


### PR DESCRIPTION
revert commit [4792](https://github.com/all-of-us/workbench/pull/4792) because it doesn't with improving Puppeteer testing in Staging env.