### PR TITLE
[risk=low][RW-6566] Stopgap solution to resume populating first_registration_completion_time

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -190,7 +190,8 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "  u.era_commons_bypass_time,\n"
                 + "  u.era_commons_completion_time,\n"
                 + "  u.family_name,\n"
-                + "  u.first_registration_completion_time,\n"
+                // temporary solution to RW-6566
+                + "  uat.first_enabled AS first_registration_completion_time,\n"
                 + "  u.first_sign_in_time,\n"
                 + "  u.free_tier_credits_limit_days_override,\n"
                 + "  u.free_tier_credits_limit_dollars_override,\n"
@@ -255,6 +256,14 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "      WHERE uat.access_status = 1 " // ENABLED
                 + "      GROUP BY u.user_id"
                 + "  ) as t ON t.user_id = u.user_id "
+                // temporary solution to RW-6566: retrieve first_enabled from user_access_tier
+                // for 'registered' entries as a substitute for first_registration_completion_time
+                + "  LEFT OUTER JOIN ( "
+                + "    SELECT uat.user_id, uat.first_enabled FROM user_access_tier uat "
+                + "    JOIN access_tier at ON at.access_tier_id = uat.access_tier_id "
+                + "    WHERE uat.access_status = 1 AND at.short_name = 'registered' "
+                + "  ) uat ON u.user_id = uat.user_id "
+                // end temporary solution for RW-6566
                 + "  ORDER BY u.user_id"
                 + "  LIMIT %d\n"
                 + "  OFFSET %d",

--- a/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
@@ -73,8 +73,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
   public static final Timestamp USER__ERA_COMMONS_COMPLETION_TIME =
       Timestamp.from(Instant.parse("2015-05-20T00:00:00.00Z"));
   public static final String USER__FAMILY_NAME = "foo_16";
-  public static final Timestamp USER__FIRST_REGISTRATION_COMPLETION_TIME =
-      Timestamp.from(Instant.parse("2015-05-22T00:00:00.00Z"));
   public static final Timestamp USER__FIRST_SIGN_IN_TIME =
       Timestamp.from(Instant.parse("2015-05-23T00:00:00.00Z"));
   public static final Short USER__FREE_TIER_CREDITS_LIMIT_DAYS_OVERRIDE = 19;
@@ -137,8 +135,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
     assertTimeApprox(user.getEraCommonsBypassTime(), USER__ERA_COMMONS_BYPASS_TIME);
     assertTimeApprox(user.getEraCommonsCompletionTime(), USER__ERA_COMMONS_COMPLETION_TIME);
     assertThat(user.getFamilyName()).isEqualTo(USER__FAMILY_NAME);
-    assertTimeApprox(
-        user.getFirstRegistrationCompletionTime(), USER__FIRST_REGISTRATION_COMPLETION_TIME);
     assertTimeApprox(user.getFirstSignInTime(), USER__FIRST_SIGN_IN_TIME);
     assertThat(user.getFreeTierCreditsLimitDaysOverride())
         .isEqualTo(USER__FREE_TIER_CREDITS_LIMIT_DAYS_OVERRIDE);
@@ -184,7 +180,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
     user.setEraCommonsBypassTime(USER__ERA_COMMONS_BYPASS_TIME);
     user.setEraCommonsCompletionTime(USER__ERA_COMMONS_COMPLETION_TIME);
     user.setFamilyName(USER__FAMILY_NAME);
-    user.setFirstRegistrationCompletionTime(USER__FIRST_REGISTRATION_COMPLETION_TIME);
     user.setFirstSignInTime(USER__FIRST_SIGN_IN_TIME);
     user.setFreeTierCreditsLimitDaysOverride(USER__FREE_TIER_CREDITS_LIMIT_DAYS_OVERRIDE);
     user.setFreeTierCreditsLimitDollarsOverride(USER__FREE_TIER_CREDITS_LIMIT_DOLLARS_OVERRIDE);
@@ -223,8 +218,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
         .eraCommonsBypassTime(offsetDateTimeUtc(USER__ERA_COMMONS_BYPASS_TIME))
         .eraCommonsCompletionTime(offsetDateTimeUtc(USER__ERA_COMMONS_COMPLETION_TIME))
         .familyName(USER__FAMILY_NAME)
-        .firstRegistrationCompletionTime(
-            offsetDateTimeUtc(USER__FIRST_REGISTRATION_COMPLETION_TIME))
         .firstSignInTime(offsetDateTimeUtc(USER__FIRST_SIGN_IN_TIME))
         .freeTierCreditsLimitDaysOverride(
             USER__FREE_TIER_CREDITS_LIMIT_DAYS_OVERRIDE.intValue()) // manual adjustment


### PR DESCRIPTION
Description:

We can do better than this ... but I've been unable to whip something up quickly.  This will unblock the reporting team while we think of something better.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
