### PR TITLE
[RW-6564][risk=low] Optimize bulkSyncTwoFactorAuth by using a batch gsuite lookup

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -176,16 +176,16 @@ public class OfflineUserController implements OfflineUserApiDelegate {
     Map<String, Boolean> twoFactorAuthStatuses = directoryService.getAllTwoFactorAuthStatuses();
     for (DbUser user : userService.getAllUsersExcludingDisabled()) {
       userCount++;
+      if (!twoFactorAuthStatuses.containsKey(user.getUsername())) {
+        log.warning(
+            String.format("user %s does not exist in gsuite, skipping", user.getUsername()));
+        errorCount++;
+        continue;
+      }
       try {
+
         Timestamp oldTime = user.getTwoFactorAuthCompletionTime();
         List<String> oldTiers = accessTierService.getAccessTierShortNamesForUser(user);
-
-        if (!twoFactorAuthStatuses.containsKey(user.getUsername())) {
-          log.warning(
-              String.format("user %s does not exist in gsuite, skipping", user.getUsername()));
-          errorCount++;
-          continue;
-        }
         DbUser updatedUser =
             userService.syncTwoFactorAuthStatus(
                 user, Agent.asSystem(), twoFactorAuthStatuses.get(user.getUsername()));

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -180,8 +180,15 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         Timestamp oldTime = user.getTwoFactorAuthCompletionTime();
         List<String> oldTiers = accessTierService.getAccessTierShortNamesForUser(user);
 
+        if (!twoFactorAuthStatuses.containsKey(user.getUsername())) {
+          log.warning(
+              String.format("user %s does not exist in gsuite, skipping", user.getUsername()));
+          errorCount++;
+          continue;
+        }
         DbUser updatedUser =
-            userService.syncTwoFactorAuthStatus(user, Agent.asSystem(), twoFactorAuthStatuses);
+            userService.syncTwoFactorAuthStatus(
+                user, Agent.asSystem(), twoFactorAuthStatuses.get(user.getUsername()));
 
         Timestamp newTime = updatedUser.getTwoFactorAuthCompletionTime();
         List<String> newTiers = accessTierService.getAccessTierShortNamesForUser(user);

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -183,7 +183,6 @@ public class OfflineUserController implements OfflineUserApiDelegate {
         continue;
       }
       try {
-
         Timestamp oldTime = user.getTwoFactorAuthCompletionTime();
         List<String> oldTiers = accessTierService.getAccessTierShortNamesForUser(user);
         DbUser updatedUser =

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -4,11 +4,9 @@ import com.google.api.services.oauth2.model.Userinfoplus;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
@@ -115,10 +113,30 @@ public interface UserService {
   DbUser syncEraCommonsStatusUsingImpersonation(DbUser user, Agent agent)
       throws IOException, org.pmiops.workbench.firecloud.ApiException;
 
+  /**
+   * Synchronize the 2FA enablement status of the currently signed-in user between the Workbench
+   * database and the gsuite directory API. This may affect the user's enabled access tiers. This
+   * can only be called within the context of a user-authenticated API request.
+   */
   void syncTwoFactorAuthStatus();
 
-  DbUser syncTwoFactorAuthStatus(
-      DbUser targetUser, Agent agent, @Nullable Map<String, Boolean> twoFactorAuthEnabledLookup);
+  /**
+   * Synchronize the 2FA enablement status of the target user between the Workbench database and the
+   * gsuite directory API, acting as the provided agent type. This may affect the user's enabled
+   * access tiers. This can be called administratively, or from an offline cron.
+   */
+  DbUser syncTwoFactorAuthStatus(DbUser targetUser, Agent agent);
+
+  /**
+   * Synchronize the 2FA enablement status of the target user between the Workbench database and the
+   * provided 2FA status, acting as the provided agent type. This may affect the user's enabled
+   * access tiers. This can be called administratively, or from an offline cron.
+   *
+   * <p>This method is provided to allow for optimization to the lookup of the enrolled 2FA status,
+   * enables batch 2FA synchronization to be implemented without repeated calls to Gsuite. The
+   * source value for isEnrolledIn2FA should always be Gsuite.
+   */
+  DbUser syncTwoFactorAuthStatus(DbUser targetUser, Agent agent, boolean isEnrolledIn2FA);
 
   int getCurrentDuccVersion();
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -4,9 +4,11 @@ import com.google.api.services.oauth2.model.Userinfoplus;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
@@ -115,7 +117,8 @@ public interface UserService {
 
   void syncTwoFactorAuthStatus();
 
-  DbUser syncTwoFactorAuthStatus(DbUser targetUser, Agent agent);
+  DbUser syncTwoFactorAuthStatus(
+      DbUser targetUser, Agent agent, @Nullable Map<String, Boolean> twoFactorAuthEnabledLookup);
 
   int getCurrentDuccVersion();
 

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.google;
 
 import com.google.api.services.directory.model.User;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -22,6 +23,8 @@ public interface DirectoryService {
 
   /** Returns a user via username lookup. Returns null if no user was found. */
   User getUser(String username);
+
+  Map<String, Boolean> getAllTwoFactorAuthStatuses();
 
   /** Looks up a user by username and returns their stored contact email address, if available. */
   Optional<String> getContactEmail(String username);

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
@@ -24,6 +24,10 @@ public interface DirectoryService {
   /** Returns a user via username lookup. Returns null if no user was found. */
   User getUser(String username);
 
+  /**
+   * Returns a mapping of researcher username (e.g. foo@researchallofus.org) to that user's 2FA
+   * enablement status in Gsuite.
+   */
   Map<String, Boolean> getAllTwoFactorAuthStatuses();
 
   /** Looks up a user by username and returns their stored contact email address, if available. */

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -169,7 +169,6 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
     final String domain = gSuiteDomain();
     Map<String, Boolean> statuses = Maps.newHashMap();
     Users response = null;
-    int pageCount = 0;
     do {
       final String pageToken =
           Optional.ofNullable(response).map(r -> r.getNextPageToken()).orElse(null);
@@ -190,9 +189,7 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
       for (User u : response.getUsers()) {
         statuses.put(u.getPrimaryEmail(), u.getIsEnrolledIn2Sv());
       }
-      pageCount++;
     } while (!Strings.isNullOrEmpty(response.getNextPageToken()));
-    log.info(String.format("processed %d pages from gsuite", pageCount));
     return statuses;
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
@@ -1,7 +1,9 @@
 package org.pmiops.workbench.api;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -10,12 +12,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.services.cloudresourcemanager.model.Project;
+import com.google.common.base.Functions;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,6 +32,7 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.google.CloudResourceManagerService;
+import org.pmiops.workbench.google.DirectoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -43,7 +49,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class OfflineUserControllerTest extends SpringTest {
   @Autowired private CloudResourceManagerService cloudResourceManagerService;
-  @Autowired private UserService userService;
+  @Autowired private UserService mockUserService;
+  @Autowired private DirectoryService mockDirectoryService;
   @Autowired private OfflineUserController offlineUserController;
 
   private Long incrementedUserId = 1L;
@@ -56,6 +63,7 @@ public class OfflineUserControllerTest extends SpringTest {
     AccessTierService.class,
     CloudResourceManagerService.class,
     UserService.class,
+    DirectoryService.class
   })
   static class Configuration {
     @Bean
@@ -67,8 +75,8 @@ public class OfflineUserControllerTest extends SpringTest {
 
   @Before
   public void setUp() {
-    when(userService.getAllUsersExcludingDisabled()).thenReturn(getUsers());
-    when(userService.getAllUsers()).thenReturn(getUsers());
+    when(mockUserService.getAllUsersExcludingDisabled()).thenReturn(getUsers());
+    when(mockUserService.getAllUsers()).thenReturn(getUsers());
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
   }
 
@@ -99,32 +107,69 @@ public class OfflineUserControllerTest extends SpringTest {
   public void testBulkSyncTrainingStatusV2()
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
     // Mock out the service under test to simply return the passed user argument.
-    doAnswer(i -> i.getArgument(0)).when(userService).syncComplianceTrainingStatusV2(any(), any());
+    doAnswer(i -> i.getArgument(0))
+        .when(mockUserService)
+        .syncComplianceTrainingStatusV2(any(), any());
     offlineUserController.bulkSyncComplianceTrainingStatus();
-    verify(userService, times(4)).syncComplianceTrainingStatusV2(any(), any());
+    verify(mockUserService, times(4)).syncComplianceTrainingStatusV2(any(), any());
   }
 
   @Test(expected = ServerErrorException.class)
   public void testBulkSyncTrainingStatusWithSingleUserErrorV2()
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
-    doAnswer(i -> i.getArgument(0)).when(userService).syncComplianceTrainingStatusV2(any(), any());
+    doAnswer(i -> i.getArgument(0))
+        .when(mockUserService)
+        .syncComplianceTrainingStatusV2(any(), any());
     doThrow(new org.pmiops.workbench.moodle.ApiException("Unknown error"))
-        .when(userService)
+        .when(mockUserService)
         .syncComplianceTrainingStatusV2(
             argThat(user -> user.getUsername().equals("a@fake-research-aou.org")), any());
     offlineUserController.bulkSyncComplianceTrainingStatus();
     // Even when a single call throws an exception, we call the service for all users.
-    verify(userService, times(4)).syncComplianceTrainingStatusV2(any(), any());
+    verify(mockUserService, times(4)).syncComplianceTrainingStatusV2(any(), any());
+  }
+
+  @Test
+  public void testBulkSyncTwoFactorAuthSync() {
+    Map<String, Boolean> allTwoFactorEnabled =
+        getUsers().stream()
+            .collect(Collectors.toMap(DbUser::getUsername, Functions.constant(true)));
+    doReturn(allTwoFactorEnabled).when(mockDirectoryService).getAllTwoFactorAuthStatuses();
+    doAnswer(i -> i.getArgument(0))
+        .when(mockUserService)
+        .syncTwoFactorAuthStatus(any(), any(), anyBoolean());
+
+    offlineUserController.bulkSyncTwoFactorAuthStatus();
+    verify(mockUserService, times(4)).syncTwoFactorAuthStatus(any(), any(), eq(true));
+  }
+
+  @Test
+  public void testBulkSyncTwoFactorAuthSyncMissingUsers() {
+    Map<String, Boolean> allTwoFactorEnabled =
+        getUsers().stream()
+            .limit(2)
+            .collect(Collectors.toMap(DbUser::getUsername, Functions.constant(false)));
+    doReturn(allTwoFactorEnabled).when(mockDirectoryService).getAllTwoFactorAuthStatuses();
+    doAnswer(i -> i.getArgument(0))
+        .when(mockUserService)
+        .syncTwoFactorAuthStatus(any(), any(), anyBoolean());
+
+    try {
+      offlineUserController.bulkSyncTwoFactorAuthStatus();
+    } catch (ServerErrorException e) {
+      // expected
+    }
+    verify(mockUserService, times(2)).syncTwoFactorAuthStatus(any(), any(), eq(false));
   }
 
   @Test
   public void testBulkSyncEraCommonsStatus()
       throws IOException, org.pmiops.workbench.firecloud.ApiException {
     doAnswer(i -> i.getArgument(0))
-        .when(userService)
+        .when(mockUserService)
         .syncEraCommonsStatusUsingImpersonation(any(), any());
     offlineUserController.bulkSyncEraCommonsStatus();
-    verify(userService, times(3)).syncEraCommonsStatusUsingImpersonation(any(), any());
+    verify(mockUserService, times(3)).syncEraCommonsStatusUsingImpersonation(any(), any());
   }
 
   @Test(expected = ServerErrorException.class)
@@ -132,15 +177,15 @@ public class OfflineUserControllerTest extends SpringTest {
       throws ApiException, NotFoundException, IOException,
           org.pmiops.workbench.firecloud.ApiException {
     doAnswer(i -> i.getArgument(0))
-        .when(userService)
+        .when(mockUserService)
         .syncEraCommonsStatusUsingImpersonation(any(), any());
     doThrow(new org.pmiops.workbench.firecloud.ApiException("Unknown error"))
-        .when(userService)
+        .when(mockUserService)
         .syncEraCommonsStatusUsingImpersonation(
             argThat(user -> user.getUsername().equals("a@fake-research-aou.org")), any());
     offlineUserController.bulkSyncEraCommonsStatus();
     // Even when a single call throws an exception, we call the service for all users.
-    verify(userService, times(3)).syncEraCommonsStatusUsingImpersonation(any(), any());
+    verify(mockUserService, times(3)).syncEraCommonsStatusUsingImpersonation(any(), any());
   }
 
   @Test


### PR DESCRIPTION
Previous approach:

```
for u in users:
  2fa = get_2fa_from_gsuite(u)
  maybe_write_to_db(u, 2fa)
```

New approach:
```
2fa_map = get_all_2fa_from_gsuite()
for u in users:
  maybe_write_to_db(u, 2fa_map[u])
```

Note: this approach still may result in many serial repeated writes to the DB in a worst case scenario. On average though, we expect to rarely need to make writes here - and eventually the cron should converge if this scenario were to arise.

Possible future work:
- Move the read/write/access level checks into a cloud scheduler task, partition into groups of users