### PR TITLE
[no-ticket][risk=no] Remove extraneous modal

### DIFF
--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -145,7 +145,6 @@ interface WorkspaceCardState {
   // The list of user roles associated with this workspace. Lazily populated
   // only when the workspace share dialog is opened.
   userRoles?: UserRole[];
-  workspaceDeletionError: boolean;
 }
 
 interface WorkspaceCardProps {
@@ -167,8 +166,7 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
       loadingData: false,
       sharing: false,
       showResearchPurposeReviewModal: false,
-      userRoles: null,
-      workspaceDeletionError: false
+      userRoles: null
     };
   }
 
@@ -182,7 +180,7 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
       this.setState({loadingData: false});
       await this.props.reload();
     } catch (e) {
-      this.setState({workspaceDeletionError: true, loadingData: false});
+      this.setState({bugReportOpen: true, bugReportError: 'Could not delete workspace', loadingData: false});
     }
   }
 
@@ -213,13 +211,6 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
     this.reloadData();
   }
 
-  submitWorkspaceDeletionError(): void {
-    this.setState({
-      bugReportOpen: true,
-      bugReportError: 'Could not delete workspace.',
-      workspaceDeletionError: false});
-  }
-
   // Reloads data by calling the callback from the owning component. This
   // currently causes the workspace-list to reload the entire list of recentWorkspaces.
   async reloadData() {
@@ -247,7 +238,7 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
   render() {
     const {userEmail, workspace, accessLevel} = this.props;
     const {bugReportError, bugReportOpen, confirmDeleting, loadingData,
-      sharing, showResearchPurposeReviewModal, userRoles, workspaceDeletionError} = this.state;
+      sharing, showResearchPurposeReviewModal, userRoles} = this.state;
 
     return <React.Fragment>
       <WorkspaceCardBase>
@@ -311,17 +302,6 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
           </FlexColumn>
         </FlexRow>
       </WorkspaceCardBase>
-      {workspaceDeletionError && <Modal>
-        <ModalTitle>Error: Could not delete workspace '{workspace.name}'</ModalTitle>
-        <ModalBody style={{display: 'flex', flexDirection: 'row'}}>
-          Please{' '}
-          <Link onClick={() => this.submitWorkspaceDeletionError()}>submit a bug report.</Link>
-        </ModalBody>
-        <ModalFooter>
-          <Button type='secondary'
-                  onClick={() => this.setState({workspaceDeletionError: false})}>Close</Button>
-        </ModalFooter>
-      </Modal>}
       {confirmDeleting &&
       <ConfirmDeleteModal data-test-id='confirm-delete-modal'
                           resourceType={ResourceType.WORKSPACE}

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {ResourceType, UserRole, Workspace, WorkspaceAccessLevel} from 'generated/fetch';
 
 import {BugReportModal} from 'app/components/bug-report';
-import {Button, Clickable, Link, MenuItem} from 'app/components/buttons';
+import {Button, Clickable, MenuItem} from 'app/components/buttons';
 import {WorkspaceCardBase} from 'app/components/card';
 import {ConfirmDeleteModal} from 'app/components/confirm-delete-modal';
 import {FlexColumn, FlexRow} from 'app/components/flex';


### PR DESCRIPTION
Description:

Two different error modals were showing up when there was a deletion error. One linked to the next. Removed the extra modal.
I confirmed with Lou that this was not the intended UX.

I found this while working on the CT workspace changes

### Original UX
![original](https://user-images.githubusercontent.com/50371603/114400990-81b99e00-9b70-11eb-85eb-e861fe45e09f.gif)

### Updated UX
![corrected](https://user-images.githubusercontent.com/50371603/114400997-83836180-9b70-11eb-9c2b-92818aa1ca54.gif)

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests
- [X] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
