### PR TITLE
[risk=no][RW-6608] Fix rare concurrency bug between updateRecentWorkspace and deleteWorkspace

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentWorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentWorkspaceDao.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.pmiops.workbench.db.model.DbUserRecentWorkspace;
-import org.pmiops.workbench.db.model.DbWorkspace;
 import org.springframework.data.repository.CrudRepository;
 
 public interface UserRecentWorkspaceDao extends CrudRepository<DbUserRecentWorkspace, Long> {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentWorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentWorkspaceDao.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.pmiops.workbench.db.model.DbUserRecentWorkspace;
+import org.pmiops.workbench.db.model.DbWorkspace;
 import org.springframework.data.repository.CrudRepository;
 
 public interface UserRecentWorkspaceDao extends CrudRepository<DbUserRecentWorkspace, Long> {
@@ -12,4 +13,6 @@ public interface UserRecentWorkspaceDao extends CrudRepository<DbUserRecentWorks
   Optional<DbUserRecentWorkspace> findFirstByWorkspaceIdAndUserId(long workspaceId, long userId);
 
   void deleteByUserIdAndWorkspaceIdIn(long userId, Collection<Long> ids);
+
+  void deleteByWorkspaceId(long workspaceId);
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -230,8 +230,7 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
         dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
     dbWorkspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
     dbWorkspace = workspaceDao.saveWithLastModified(dbWorkspace);
-    userRecentWorkspaceDao.deleteByUserIdAndWorkspaceIdIn(
-        userProvider.get().getUserId(), Collections.singletonList(dbWorkspace.getWorkspaceId()));
+    userRecentWorkspaceDao.deleteByWorkspaceId(dbWorkspace.getWorkspaceId());
 
     String billingProjectName = dbWorkspace.getWorkspaceNamespace();
     try {

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -217,6 +217,7 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
     return workspaceResponse;
   }
 
+  @Transactional
   @Override
   public void deleteWorkspace(DbWorkspace dbWorkspace) {
     // This deletes all Firecloud and google resources, however saves all references


### PR DESCRIPTION
Very rarely, we will get an "ObjectOptimisticLockingFailureException" while deleting a workspace. It's happened 5 times in test according to stackdriver.

It seems to be because of a concurrency bug that will arise if a UserRecentWorkspace is updated while a delete workspace operation is taking place. Specifically, if the UserRecentWorkspace is updated in between the find() and delete() calls in this function, https://github.com/all-of-us/workbench/blob/fc41e9cf8f685f84a1feb2e56a71d0482327a403/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java#L429.

I was unable to reproduce it locally because I couldn't find a way to run Spring locally with multiple threads but I think we can fix it by just running the delete command and foregoing the find check.

The bug happens so rarely that it doesn’t have a big user impact but it does cause our puppeteer tests to fail every now and then so it’s worth fixing IMO.