### PR TITLE
[no ticket][risk=no] Enable Puppeteer testing in staging env

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -67,7 +67,7 @@ ENVIRONMENTS = {
     :config_json => "config_staging.json",
     :cdr_config_json => "cdr_config_staging.json",
     :featured_workspaces_json => "featured_workspaces_staging.json",
-    :gae_vars => make_gae_vars(3, 10, 'F1'),
+    :gae_vars => make_gae_vars(0, 10, 'F2'),
     :source_cdr_project => "all-of-us-ehr-dev",
     :source_wgv_project => "all-of-us-workbench-test"
   },

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -67,7 +67,7 @@ ENVIRONMENTS = {
     :config_json => "config_staging.json",
     :cdr_config_json => "cdr_config_staging.json",
     :featured_workspaces_json => "featured_workspaces_staging.json",
-    :gae_vars => make_gae_vars,
+    :gae_vars => make_gae_vars(0, 10, 'F2'),
     :source_cdr_project => "all-of-us-ehr-dev",
     :source_wgv_project => "all-of-us-workbench-test"
   },

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -67,7 +67,7 @@ ENVIRONMENTS = {
     :config_json => "config_staging.json",
     :cdr_config_json => "cdr_config_staging.json",
     :featured_workspaces_json => "featured_workspaces_staging.json",
-    :gae_vars => make_gae_vars(5, 10, 'F1'),
+    :gae_vars => make_gae_vars(3, 10, 'F1'),
     :source_cdr_project => "all-of-us-ehr-dev",
     :source_wgv_project => "all-of-us-workbench-test"
   },

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -67,7 +67,7 @@ ENVIRONMENTS = {
     :config_json => "config_staging.json",
     :cdr_config_json => "cdr_config_staging.json",
     :featured_workspaces_json => "featured_workspaces_staging.json",
-    :gae_vars => make_gae_vars(0, 10, 'F2'),
+    :gae_vars => make_gae_vars(5, 10, 'F1'),
     :source_cdr_project => "all-of-us-ehr-dev",
     :source_wgv_project => "all-of-us-workbench-test"
   },

--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -49,5 +49,6 @@
     <min-idle-instances>automatic</min-idle-instances>
     <min-pending-latency>automatic</min-pending-latency>
     <max-pending-latency>10s</max-pending-latency>
+    <max-concurrent-requests>5</max-concurrent-requests>
   </automatic-scaling>
 </appengine-web-app>

--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -46,9 +46,7 @@
     <min-idle-instances>${GAE_MIN_IDLE_INSTANCES}</min-idle-instances>
     <max-instances>${GAE_MAX_INSTANCES}</max-instances>
     <max-idle-instances>1</max-idle-instances>
-    <min-idle-instances>automatic</min-idle-instances>
     <min-pending-latency>automatic</min-pending-latency>
     <max-pending-latency>10s</max-pending-latency>
-    <max-concurrent-requests>5</max-concurrent-requests>
   </automatic-scaling>
 </appengine-web-app>

--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -45,8 +45,7 @@
   <automatic-scaling>
     <min-idle-instances>${GAE_MIN_IDLE_INSTANCES}</min-idle-instances>
     <max-instances>${GAE_MAX_INSTANCES}</max-instances>
-    <max-idle-instances>1</max-idle-instances>
-    <min-pending-latency>automatic</min-pending-latency>
+    <min-pending-latency>6s</min-pending-latency>
     <max-pending-latency>10s</max-pending-latency>
   </automatic-scaling>
 </appengine-web-app>

--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -45,5 +45,9 @@
   <automatic-scaling>
     <min-idle-instances>${GAE_MIN_IDLE_INSTANCES}</min-idle-instances>
     <max-instances>${GAE_MAX_INSTANCES}</max-instances>
+    <max-idle-instances>1</max-idle-instances>
+    <min-idle-instances>automatic</min-idle-instances>
+    <min-pending-latency>automatic</min-pending-latency>
+    <max-pending-latency>10s</max-pending-latency>
   </automatic-scaling>
 </appengine-web-app>

--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -45,7 +45,5 @@
   <automatic-scaling>
     <min-idle-instances>${GAE_MIN_IDLE_INSTANCES}</min-idle-instances>
     <max-instances>${GAE_MAX_INSTANCES}</max-instances>
-    <min-pending-latency>6s</min-pending-latency>
-    <max-pending-latency>10s</max-pending-latency>
   </automatic-scaling>
 </appengine-web-app>


### PR DESCRIPTION
Issue: Puppeteer tests fail randomly in staging with the default appengine settings in staging:
- Default is `min_idle_instances = 0, max_instances = 10, instance_class = 'F1'` [devstart.rb#L70](https://github.com/all-of-us/workbench/blob/25b429cfb3b1cad7d2363dee64bce03d3bfe9f8c/api/libproject/devstart.rb#L70)

Google Cloud Console error is `Request was aborted after waiting too long to attempt to service your request.`

Experimented with some different appengine settings, following two works (no Puppeteer tests failures):
- `(4, 10, 'F1')`
- `(0, 10, 'F2')`

Increasing number of idle instances or increasing class type to `F2` both works. 

Difference in cost per hour per usage between `F1` and `F2` class is $0.05. Idle `F1` instance costs per hour is $0.05. Having a higher number of idle instances cost $ every hour (used or not). A higher class type (F2) costs 5 cents per hour only when used. I think changing to F2 makes sense because it's cost-effective.

