### PR TITLE
[no ticket][risk=no] Puppeteer rework fillOutRequiredCreationFields func

### DIFF
--- a/e2e/app/element/select.ts
+++ b/e2e/app/element/select.ts
@@ -59,4 +59,30 @@ export default class Select extends BaseElement {
     }, selectElement);
     return selectedOption;
   }
+
+  /**
+   * Wait until value of Selected option equals to expected option.
+   */
+  async waitForSelectedValue(expectedOption: string, timeout = 30000): Promise<void> {
+    const selectElement = await this.page.waitForXPath(this.getXpath(), { visible: true });
+    await this.page
+      .waitForFunction(
+        (select, text) => {
+          for (const option of select.options) {
+            if (option.selected) {
+              console.log(option.textContent);
+              return option.textContent === text;
+            }
+          }
+        },
+        { timeout },
+        selectElement,
+        expectedOption
+      )
+      .catch((err) => {
+        console.error(`waitForSelectedValue() failed. Expected selected option is ${expectedOption}`);
+        console.error(err);
+        throw new Error(err);
+      });
+  }
 }

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -268,6 +268,7 @@ export default class WorkspaceEditPage extends WorkspaceBase {
     await Promise.all([waitForDocumentTitle(this.page, PageTitle), waitWhileLoading(this.page)]);
     const selectXpath = buildXPath(FIELD.billingAccountSelect.textOption);
     const select = new Select(this.page, selectXpath);
+    // Wait for Workspace name text-field, Billing Account Select and Create Workspace button
     await Promise.all([
       this.getWorkspaceNameTextbox().asElementHandle(),
       select.asElementHandle(),

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -4,7 +4,7 @@ import { Language, LinkText, PageUrl } from 'app/text-labels';
 import WorkspaceEditPage, { FIELD as EDIT_FIELD } from 'app/page/workspace-edit-page';
 import RadioButton from 'app/element/radiobutton';
 import { findOrCreateWorkspace } from 'utils/test-utils';
-import { waitForDocumentTitle, waitForText, waitWhileLoading } from 'utils/waits-utils';
+import { waitForDocumentTitle, waitWhileLoading } from 'utils/waits-utils';
 import ReactSelect from 'app/element/react-select';
 import WorkspaceDataPage from './workspace-data-page';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
@@ -108,8 +108,9 @@ export default class WorkspacesPage extends AuthenticatedPage {
     reviewRequest = false
   ): Promise<WorkspaceEditPage> {
     const editPage = await this.clickCreateNewWorkspace();
-    // wait for Billing Account default selected value
-    await waitForText(this.page, UseFreeCredits);
+    // wait for Billing Account default selected value to appear
+    const selectBilling = editPage.getBillingAccountSelect();
+    await selectBilling.waitForSelectedValue(UseFreeCredits);
 
     await editPage.getWorkspaceNameTextbox().type(workspaceName);
     await editPage.getWorkspaceNameTextbox().pressTab();

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -326,9 +326,9 @@ export async function waitForText(
       await page.waitForSelector(selector.css, { visible: true, timeout });
       const jsHandle = await page.waitForFunction(
         (css, expText) => {
-          const element = document.querySelector(css);
           const regExp = new RegExp(expText);
-          return element != null && regExp.test(element.textContent);
+          const element = document.querySelector(css);
+          return element && regExp.test(element.textContent);
         },
         { timeout },
         selector.css,
@@ -346,10 +346,10 @@ export async function waitForText(
       await page.waitForXPath(selector.xpath, { visible: true, timeout });
       const jsHandle = await page.waitForFunction(
         (xpath, expText) => {
+          const regExp = new RegExp(expText);
           const element = document.evaluate(xpath, document.body, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)
             .singleNodeValue;
-          const regExp = new RegExp(expText);
-          return element != null && regExp.test(element.textContent);
+          return element && regExp.test(element.textContent);
         },
         { timeout },
         selector.xpath,


### PR DESCRIPTION
`waitForText` used for checking Billing Account selected value is not reliable. It failed [here](https://app.circleci.com/pipelines/github/all-of-us/workbench/9155/workflows/b04bb6a3-87ea-489b-ac92-8153c0b5e825/jobs/131814).

Replace it with new `waitForSelectedValue()` in `select` class.