### PR TITLE
[risk=no][RW-6608] Don't delete recent workspaces on delete workspace

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentWorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentWorkspaceDao.java
@@ -12,5 +12,4 @@ public interface UserRecentWorkspaceDao extends CrudRepository<DbUserRecentWorks
   Optional<DbUserRecentWorkspace> findFirstByWorkspaceIdAndUserId(long workspaceId, long userId);
 
   void deleteByUserIdAndWorkspaceIdIn(long userId, Collection<Long> ids);
-
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentWorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentWorkspaceDao.java
@@ -13,5 +13,4 @@ public interface UserRecentWorkspaceDao extends CrudRepository<DbUserRecentWorks
 
   void deleteByUserIdAndWorkspaceIdIn(long userId, Collection<Long> ids);
 
-  void deleteByWorkspaceId(long workspaceId);
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -226,7 +226,6 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
         dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
     dbWorkspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
     dbWorkspace = workspaceDao.saveWithLastModified(dbWorkspace);
-    userRecentWorkspaceDao.deleteByWorkspaceId(dbWorkspace.getWorkspaceId());
 
     String billingProjectName = dbWorkspace.getWorkspaceNamespace();
     try {

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -2,7 +2,6 @@ package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -762,24 +762,6 @@ public class WorkspacesControllerTest extends SpringTest {
     }
   }
 
-  @Transactional
-  @Test
-  public void testDeleteWorkspace_recentWorkspace() {
-    Workspace workspace = createWorkspace();
-    workspace = workspacesController.createWorkspace(workspace).getBody();
-
-    workspacesController.updateRecentWorkspaces(workspace.getNamespace(), workspace.getName());
-    long workspaceId =
-        workspaceDao.get(workspace.getNamespace(), workspace.getName()).getWorkspaceId();
-
-    workspacesController.deleteWorkspace(workspace.getNamespace(), workspace.getName());
-
-    assertFalse(
-        userRecentWorkspaceDao
-            .findFirstByWorkspaceIdAndUserId(workspaceId, currentUser.getUserId())
-            .isPresent());
-  }
-
   @Test
   public void testApproveWorkspace() {
     Workspace ws = createWorkspace();


### PR DESCRIPTION
Description:
Running into concurrency issues while deleting all recent workspaces upon deleting a workspace. We can just opt to not delete them at all since RecentWorkspace was designed to handle that case.