### PR TITLE
[risk=low][RW-6300] transition from getCdrVersions() to getCdrVersionsByTier()

### DIFF
--- a/ui/src/app/cohort-search/cohort-page/cohort-page.component.spec.tsx
+++ b/ui/src/app/cohort-search/cohort-page/cohort-page.component.spec.tsx
@@ -5,7 +5,7 @@ import {cohortsApi, registerApiClient} from 'app/services/swagger-fetch-clients'
 import {currentWorkspaceStore, queryParamsStore} from 'app/utils/navigation';
 import {CohortBuilderApi, CohortsApi} from 'generated/fetch';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
-import {cdrVersionListResponse} from 'testing/stubs/cdr-versions-api-stub';
+import {cdrVersionTiersResponse} from 'testing/stubs/cdr-versions-api-stub';
 import {CohortBuilderServiceStub} from 'testing/stubs/cohort-builder-service-stub';
 import {CohortsApiStub} from 'testing/stubs/cohorts-api-stub';
 import {workspaceDataStub} from 'testing/stubs/workspaces';
@@ -15,7 +15,7 @@ import {cdrVersionStore} from "app/utils/stores";
 describe('CohortPage', () => {
   beforeEach(() => {
     currentWorkspaceStore.next(workspaceDataStub);
-    cdrVersionStore.set(cdrVersionListResponse);
+    cdrVersionStore.set(cdrVersionTiersResponse);
     registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     registerApiClient(CohortsApi, new CohortsApiStub());
   });

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -15,6 +15,7 @@ import {cohortBuilderApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, validateInputForMySQL, withCdrVersions, withCurrentConcept, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
+import {findCdrVersion} from 'app/utils/cdr-versions';
 import {
   attributesSelectionStore,
   currentCohortSearchContextStore,
@@ -23,7 +24,7 @@ import {
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {
   CdrVersion,
-  CdrVersionListResponse,
+  CdrVersionTiersResponse,
   Criteria,
   CriteriaSubType,
   CriteriaType,
@@ -230,7 +231,7 @@ const columns = [
 const searchTrigger = 2;
 
 interface Props {
-  cdrVersionListResponse: CdrVersionListResponse;
+  cdrVersionTiersResponse: CdrVersionTiersResponse;
   concept?: Array<Criteria>;
   hierarchy: Function;
   searchContext: any;
@@ -284,9 +285,8 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
       };
     }
     componentDidMount(): void {
-      const {cdrVersionListResponse, searchTerms, searchContext: {source}, workspace: {cdrVersionId}} = this.props;
-      const cdrVersions = cdrVersionListResponse.items;
-      this.setState({cdrVersion: cdrVersions.find(cdr => cdr.cdrVersionId === cdrVersionId)});
+      const {cdrVersionTiersResponse, searchTerms, searchContext: {source}, workspace: {cdrVersionId}} = this.props;
+      this.setState({cdrVersion: findCdrVersion(cdrVersionId, cdrVersionTiersResponse)});
       if (source === 'conceptSetDetails') {
         this.setState({data: this.props.concept});
       } else {

--- a/ui/src/app/cohort-search/overview/overview.component.spec.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.spec.tsx
@@ -3,7 +3,6 @@ import {shallow} from 'enzyme';
 import * as React from 'react';
 import {ListOverview} from './overview.component';
 
-
 describe('ListOverview', () => {
   it('should render', () => {
     const wrapper = shallow(<ListOverview searchRequest={{}} update={0}/>);

--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -22,7 +22,7 @@ import {currentWorkspaceStore, navigate, navigateByUrl, urlParamsStore} from 'ap
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {
   AgeType,
-  CdrVersionListResponse,
+  CdrVersionTiersResponse,
   Cohort,
   GenderOrSexType,
   ResourceType,
@@ -144,7 +144,7 @@ interface Props {
   updateCount: any;
   updating: Function;
   workspace: WorkspaceData;
-  cdrVersionListResponse: CdrVersionListResponse;
+  cdrVersionTiersResponse: CdrVersionTiersResponse;
 }
 
 interface State {

--- a/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
+++ b/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
@@ -13,7 +13,7 @@ import {reactStyles, withCdrVersions, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {currentWorkspaceStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {CdrVersionListResponse, CriteriaMenu, Domain, SearchRequest} from 'generated/fetch';
+import {CdrVersionTiersResponse, CriteriaMenu, Domain, SearchRequest} from 'generated/fetch';
 
 function initItem(id: string, type: string) {
   return {
@@ -137,7 +137,7 @@ interface Props {
   updated: number;
   updateRequest: Function;
   workspace: WorkspaceData;
-  cdrVersionListResponse: CdrVersionListResponse;
+  cdrVersionTiersResponse: CdrVersionTiersResponse;
 }
 
 interface State {

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -14,7 +14,7 @@ import {getCdrVersion} from 'app/utils/cdr-versions';
 import {currentCohortCriteriaStore, currentWorkspaceStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {
-  CdrVersionListResponse,
+  CdrVersionTiersResponse,
   Criteria,
   CriteriaSubType,
   CriteriaType,
@@ -130,7 +130,7 @@ interface Props {
   setSearchTerms: Function;
   concept: Array<any>;
   workspace: WorkspaceData;
-  cdrVersionListResponse: CdrVersionListResponse;
+  cdrVersionTiersResponse: CdrVersionTiersResponse;
 }
 
 interface State {
@@ -309,9 +309,9 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
 
   // Hides the tree node for COPE survey if config hasCopeSurveyData is set to false
   showNode(node: Criteria) {
-    const {workspace, cdrVersionListResponse} = this.props;
+    const {workspace, cdrVersionTiersResponse} = this.props;
     return node.subtype === CriteriaSubType.SURVEY.toString() && node.name.includes('COPE')
-        ? getCdrVersion(workspace, cdrVersionListResponse).hasCopeSurveyData
+        ? getCdrVersion(workspace, cdrVersionTiersResponse).hasCopeSurveyData
         : true;
   }
 

--- a/ui/src/app/components/copy-modal.spec.tsx
+++ b/ui/src/app/components/copy-modal.spec.tsx
@@ -10,7 +10,7 @@ import {dropNotebookFileSuffix} from 'app/pages/analysis/util';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
 import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
-import {cdrVersionListResponse, CdrVersionsStubVariables} from 'testing/stubs/cdr-versions-api-stub';
+import {cdrVersionTiersResponse, CdrVersionsStubVariables} from 'testing/stubs/cdr-versions-api-stub';
 
 import {CopyModalComponent, CopyModalProps, CopyModalState} from './copy-modal';
 
@@ -85,7 +85,7 @@ describe('CopyModal', () => {
     registerApiClient(WorkspacesApi, wsApiStub);
 
     props = {
-      cdrVersionListResponse: cdrVersionListResponse,
+      cdrVersionTiersResponse: cdrVersionTiersResponse,
       fromWorkspaceNamespace: fromWorkspaceNamespace,
       fromWorkspaceFirecloudName: fromWorkspaceFirecloudName,
       fromResourceName: fromResourceName,

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -5,12 +5,19 @@ import { Button } from 'app/components/buttons';
 import { styles as headerStyles } from 'app/components/headers';
 import { Select, TextInput, ValidationError } from 'app/components/inputs';
 import { Modal, ModalBody, ModalFooter, ModalTitle } from 'app/components/modals';
-import {CdrVersionListResponse, ConceptSet, FileDetail, ResourceType, Workspace} from 'generated/fetch';
+import {
+  CdrVersionTiersResponse,
+  ConceptSet,
+  FileDetail,
+  ResourceType,
+  Workspace
+} from 'generated/fetch';
 
 import { Spinner } from 'app/components/spinners';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, withCdrVersions} from 'app/utils';
+import {findCdrVersion} from 'app/utils/cdr-versions';
 import { navigate } from 'app/utils/navigation';
 import {toDisplay} from 'app/utils/resources';
 import { WorkspacePermissions } from 'app/utils/workspace-permissions';
@@ -26,7 +33,7 @@ const ResourceTypeHomeTabs = new Map()
   .set(ResourceType.DATASET, 'data');
 
 export interface Props {
-  cdrVersionListResponse: CdrVersionListResponse;
+  cdrVersionTiersResponse: CdrVersionTiersResponse;
   fromWorkspaceNamespace: string;
   fromWorkspaceFirecloudName: string;
   fromResourceName: string;
@@ -130,8 +137,8 @@ class CopyModalComponent extends React.Component<Props, State> {
   }
 
   cdrName(cdrVersionId: string): string {
-    const {cdrVersionListResponse} = this.props;
-    const version = cdrVersionListResponse.items.find(v => v.cdrVersionId === cdrVersionId);
+    const {cdrVersionTiersResponse} = this.props;
+    const version = findCdrVersion(cdrVersionId, cdrVersionTiersResponse);
     return version ? version.name : '[CDR version not found]';
   }
 

--- a/ui/src/app/components/side-nav.spec.tsx
+++ b/ui/src/app/components/side-nav.spec.tsx
@@ -2,7 +2,7 @@ import {mount} from 'enzyme';
 import * as React from 'react';
 
 import {SideNav, SideNavItem, SideNavProps} from './side-nav';
-import {ProfileStubVariables} from "../../testing/stubs/profile-api-stub";
+import {ProfileStubVariables} from 'testing/stubs/profile-api-stub';
 
 describe('SideNav', () => {
   const props: SideNavProps = {

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -17,7 +17,7 @@ import {RuntimeConfigurationType, RuntimeStatus, WorkspaceAccessLevel, Workspace
 import {RuntimeApi} from 'generated/fetch/api';
 import defaultServerConfig from 'testing/default-server-config';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
-import {cdrVersionListResponse, CdrVersionsStubVariables} from 'testing/stubs/cdr-versions-api-stub';
+import {cdrVersionTiersResponse, CdrVersionsStubVariables} from 'testing/stubs/cdr-versions-api-stub';
 import {defaultGceConfig, defaultDataprocConfig, RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
 import {workspaceStubs} from 'testing/stubs/workspaces';
 import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
@@ -58,7 +58,7 @@ describe('RuntimePanel', () => {
         billingAccountType: BillingAccountType.FREETIER,
         cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID
       },
-      cdrVersionListResponse,
+      cdrVersionTiersResponse,
       onClose
     };
 

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -40,7 +40,7 @@ describe('RuntimePanel', () => {
   };
 
   beforeEach(() => {
-    cdrVersionStore.set(cdrVersionListResponse);
+    cdrVersionStore.set(cdrVersionTiersResponse);
     serverConfigStore.next({...defaultServerConfig});
 
     runtimeApiStub = new RuntimeApiStub();

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -45,7 +45,8 @@ import {AoU} from 'app/components/text-wrappers';
 import {findCdrVersion} from 'app/utils/cdr-versions';
 import {
   BillingAccountType,
-  BillingStatus, CdrVersionTiersResponse,
+  BillingStatus,
+  CdrVersionTiersResponse,
   DataprocConfig,
   Runtime,
   RuntimeConfigurationType,

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -42,10 +42,10 @@ import {
 import {WorkspaceData} from 'app/utils/workspace-data';
 
 import {AoU} from 'app/components/text-wrappers';
+import {findCdrVersion} from 'app/utils/cdr-versions';
 import {
   BillingAccountType,
-  BillingStatus,
-  CdrVersionListResponse,
+  BillingStatus, CdrVersionTiersResponse,
   DataprocConfig,
   Runtime,
   RuntimeConfigurationType,
@@ -176,7 +176,7 @@ enum PanelContent {
 // this is only used in the test.
 export interface Props {
   workspace: WorkspaceData;
-  cdrVersionListResponse?: CdrVersionListResponse;
+  cdrVersionTiersResponse?: CdrVersionTiersResponse;
   onClose: () => void;
 }
 
@@ -797,12 +797,12 @@ export const RuntimePanel = fp.flow(
   withCdrVersions(),
   withCurrentWorkspace(),
   withUserProfile()
-)(({cdrVersionListResponse, workspace, profileState, onClose = () => {}}) => {
+)(({ cdrVersionTiersResponse, workspace, profileState, onClose = () => {}}) => {
   const {namespace, id, cdrVersionId, googleProject} = workspace;
 
   const {profile} = profileState;
 
-  const {hasMicroarrayData} = fp.find({cdrVersionId}, cdrVersionListResponse.items) || {hasMicroarrayData: false};
+  const {hasMicroarrayData} = findCdrVersion(cdrVersionId, cdrVersionTiersResponse) || {hasMicroarrayData: false};
   let [{currentRuntime, pendingRuntime}, setRequestedRuntime] = useCustomRuntime(namespace);
 
   // If the runtime has been deleted, it's possible that the default preset values have changed since its creation

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -14,7 +14,7 @@ import {
   WorkspaceAccessLevel
 } from 'generated/fetch';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
-import {cdrVersionListResponse, CdrVersionsApiStub} from 'testing/stubs/cdr-versions-api-stub';
+import {cdrVersionTiersResponse, CdrVersionsApiStub} from 'testing/stubs/cdr-versions-api-stub';
 import {CohortsApiStub, exampleCohortStubs} from 'testing/stubs/cohorts-api-stub';
 import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
 import {DataSetApiStub} from 'testing/stubs/data-set-api-stub';
@@ -354,21 +354,21 @@ describe('DataSetPage', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find('[data-test-id="prePackage-concept-set-item"]').length).toBe(7);
 
-    cdrVersionListResponse.items[0].hasWgsData = false;
+    cdrVersionTiersResponse.tiers[0].versions[0].hasWgsData = false;
     wrapper = mount(<DataSetPage/>);
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find('[data-test-id="prePackage-concept-set-item"]').length).toBe(6);
 
 
-    cdrVersionListResponse.items[0].hasFitbitData = false;
-    cdrVersionListResponse.items[0].hasWgsData = true;
+    cdrVersionTiersResponse.tiers[0].versions[0].hasFitbitData = false;
+    cdrVersionTiersResponse.tiers[0].versions[0].hasWgsData = true;
     wrapper = mount(<DataSetPage/>);
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find('[data-test-id="prePackage-concept-set-item"]').length).toBe(3);
 
 
-    cdrVersionListResponse.items[0].hasFitbitData = false;
-    cdrVersionListResponse.items[0].hasWgsData = false;
+    cdrVersionTiersResponse.tiers[0].versions[0].hasFitbitData = false;
+    cdrVersionTiersResponse.tiers[0].versions[0].hasWgsData = false;
     wrapper = mount(<DataSetPage/>);
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.find('[data-test-id="prePackage-concept-set-item"]').length).toBe(2);

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -32,7 +32,7 @@ describe('DataSetPage', () => {
       wsid: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
     });
     currentWorkspaceStore.next(workspaceDataStub);
-    cdrVersionStore.set(cdrVersionListResponse);
+    cdrVersionStore.set(cdrVersionTiersResponse);
   });
 
   it('should render', async() => {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -35,7 +35,7 @@ import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
 import {
   BillingStatus,
-  CdrVersionListResponse,
+  CdrVersionTiersResponse,
   Cohort,
   ConceptSet,
   DataDictionaryEntry,
@@ -422,7 +422,7 @@ interface DataSetPreviewInfo {
 
 interface Props {
   workspace: WorkspaceData;
-  cdrVersionListResponse: CdrVersionListResponse;
+  cdrVersionTiersResponse: CdrVersionTiersResponse;
   urlParams: any;
   profileState: {
     profile: Profile,
@@ -487,13 +487,13 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
     async componentDidMount() {
       const {namespace, id} = this.props.workspace;
       const resourcesPromise = this.loadResources();
-      if (getCdrVersion(this.props.workspace, this.props.cdrVersionListResponse).hasFitbitData) {
+      if (getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).hasFitbitData) {
         PREPACKAGED_DOMAINS =   {
           ...PREPACKAGED_SURVEY_PERSON_DOMAIN,
           ...PREPACKAGED_WITH_FITBIT_DOMAINS
         };
       }
-      if (getCdrVersion(this.props.workspace, this.props.cdrVersionListResponse).hasWgsData) {
+      if (getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).hasWgsData) {
         PREPACKAGED_DOMAINS = {
           ...PREPACKAGED_DOMAINS,
           ...PREPACKAGED_WITH_WHOLE_GENOME
@@ -640,11 +640,11 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
 
     getPrePackagedList() {
       let prepackagedList = Object.keys(PrepackagedConceptSet);
-      if (!getCdrVersion(this.props.workspace, this.props.cdrVersionListResponse).hasFitbitData) {
+      if (!getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).hasFitbitData) {
         prepackagedList = prepackagedList
             .filter(prepack => !fp.startsWith('FITBIT', prepack));
       }
-      if (!getCdrVersion(this.props.workspace, this.props.cdrVersionListResponse).hasWgsData) {
+      if (!getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).hasWgsData) {
         prepackagedList = prepackagedList.filter(prepack => prepack !== 'WHOLEGENOME');
       }
       return prepackagedList;
@@ -1267,7 +1267,7 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
                                            workspaceId={id}
                                            billingLocked={this.props.workspace.billingStatus === BillingStatus.INACTIVE}
                                            displayMicroarrayOptions={
-                                             getCdrVersion(this.props.workspace, this.props.cdrVersionListResponse).hasMicroarrayData}
+                                             getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).hasMicroarrayData}
                                            prePackagedConceptSet={this.getPrePackagedConceptSetApiEnum()}
                                            dataSet={dataSet ? dataSet : undefined}
                                            closeFunction={() => {

--- a/ui/src/app/pages/homepage/homepage.spec.tsx
+++ b/ui/src/app/pages/homepage/homepage.spec.tsx
@@ -53,7 +53,7 @@ describe('HomepageComponent', () => {
       enableEraCommons: true,
       enableV3DataUserCodeOfConduct: true
     });
-    cdrVersionStore.set(cdrVersionListResponse);
+    cdrVersionStore.set(cdrVersionTiersResponse);
   });
 
   it('should render the homepage', () => {

--- a/ui/src/app/pages/homepage/homepage.spec.tsx
+++ b/ui/src/app/pages/homepage/homepage.spec.tsx
@@ -13,12 +13,10 @@ import {UserMetricsApiStub} from 'testing/stubs/user-metrics-api-stub';
 import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
 import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
-import {cdrVersionStore} from "../../utils/stores";
-import {cdrVersionListResponse} from "../../../testing/stubs/cdr-versions-api-stub";
-
+import {cdrVersionStore} from 'app/utils/stores';
+import {cdrVersionTiersResponse} from "testing/stubs/cdr-versions-api-stub";
 
 describe('HomepageComponent', () => {
-
   const profile = ProfileStubVariables.PROFILE_STUB;
   let profileApi: ProfileApiStub;
 

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -16,7 +16,7 @@ import {getCdrVersion} from 'app/utils/cdr-versions';
 import {navigateAndPreventDefaultIfNoKeysPressed} from 'app/utils/navigation';
 import {getDisplayName, isNotebook} from 'app/utils/resources';
 import {
-  CdrVersionListResponse,
+  CdrVersionTiersResponse,
   Workspace,
   WorkspaceResource,
   WorkspaceResourceResponse,
@@ -73,7 +73,7 @@ interface TableData {
 }
 
 interface Props {
-  cdrVersionListResponse: CdrVersionListResponse;
+  cdrVersionTiersResponse: CdrVersionTiersResponse;
   workspaces: WorkspaceResponse[];
 }
 
@@ -113,8 +113,8 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
     };
 
     const getCdrVersionName = (r: WorkspaceResource) => {
-      const {cdrVersionListResponse} = props;
-      return getCdrVersion(getWorkspace(r), cdrVersionListResponse).name;
+      const {cdrVersionTiersResponse} = props;
+      return getCdrVersion(getWorkspace(r), cdrVersionTiersResponse).name;
     };
 
     if (resources && wsMap) {

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -107,7 +107,6 @@ export const StepToImageConfig: Map<SignInStep, BackgroundImageConfig> = new Map
   }]]
 );
 
-
 export interface SignInProps extends ServerConfigProps, WindowSizeProps {
   initialStep?: SignInStep;
   onSignIn: () => void;

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -107,6 +107,7 @@ export const StepToImageConfig: Map<SignInStep, BackgroundImageConfig> = new Map
   }]]
 );
 
+
 export interface SignInProps extends ServerConfigProps, WindowSizeProps {
   initialStep?: SignInStep;
   onSignIn: () => void;

--- a/ui/src/app/pages/profile/profile-page.spec.tsx
+++ b/ui/src/app/pages/profile/profile-page.spec.tsx
@@ -12,7 +12,6 @@ import {InstitutionApiStub} from 'testing/stubs/institution-api-stub';
 import {ProfileApiStub} from 'testing/stubs/profile-api-stub';
 import {ProfileStubVariables} from 'testing/stubs/profile-api-stub';
 
-
 describe('ProfilePageComponent', () => {
   function getSubmitButton(wrapper: ReactWrapper): ReactWrapper {
     return wrapper.find('[data-test-id="submit-button"]');

--- a/ui/src/app/pages/profile/profile-page.spec.tsx
+++ b/ui/src/app/pages/profile/profile-page.spec.tsx
@@ -12,6 +12,7 @@ import {InstitutionApiStub} from 'testing/stubs/institution-api-stub';
 import {ProfileApiStub} from 'testing/stubs/profile-api-stub';
 import {ProfileStubVariables} from 'testing/stubs/profile-api-stub';
 
+
 describe('ProfilePageComponent', () => {
   function getSubmitButton(wrapper: ReactWrapper): ReactWrapper {
     return wrapper.find('[data-test-id="submit-button"]');

--- a/ui/src/app/pages/signed-in/component.ts
+++ b/ui/src/app/pages/signed-in/component.ts
@@ -95,7 +95,7 @@ export class SignedInComponent implements OnInit, OnDestroy, AfterViewInit {
         this.profile = profile as unknown as FetchProfile;
         setInstitutionCategoryState(this.profile.verifiedInstitutionalAffiliation);
         if (hasRegisteredAccess(this.profile.accessTierShortNames)) {
-          cdrVersionsApi().getCdrVersions().then(resp => {
+          cdrVersionsApi().getCdrVersionsByTier().then(resp => {
             // cdrVersionsInitialized blocks app rendering so that route
             // components don't try to lookup CDR data before it's available.
             // This will need to be a step in the React bootstrapping as well.

--- a/ui/src/app/pages/workspace/workspace-about.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.spec.tsx
@@ -12,7 +12,7 @@ import {currentWorkspaceStore, serverConfigStore, userProfileStore} from 'app/ut
 import {userRolesStub, workspaceStubs} from 'testing/stubs/workspaces';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
-import {CdrVersionsStubVariables, cdrVersionListResponse} from 'testing/stubs/cdr-versions-api-stub';
+import {CdrVersionsStubVariables, cdrVersionTiersResponse} from 'testing/stubs/cdr-versions-api-stub';
 import {SpecificPopulationItems} from './workspace-edit-text';
 import {cdrVersionStore} from "app/utils/stores";
 

--- a/ui/src/app/pages/workspace/workspace-about.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.spec.tsx
@@ -51,7 +51,7 @@ describe('WorkspaceAbout', () => {
       publicApiKeyForErrorReports: 'aaa',
       enableEraCommons: true,
     });
-    cdrVersionStore.set(cdrVersionListResponse);
+    cdrVersionStore.set(cdrVersionTiersResponse);
   });
 
   it('should render', () => {

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -20,7 +20,7 @@ import {getCdrVersion} from 'app/utils/cdr-versions';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 import {
   BillingAccountType,
-  CdrVersionListResponse,
+  CdrVersionTiersResponse,
   Profile,
   UserRole,
   WorkspaceAccessLevel
@@ -28,7 +28,7 @@ import {
 
 interface WorkspaceProps {
   profileState: {profile: Profile, reload: Function, updateCache: Function};
-  cdrVersionListResponse: CdrVersionListResponse;
+  cdrVersionTiersResponse: CdrVersionTiersResponse;
 }
 
 interface WorkspaceState {
@@ -197,7 +197,7 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCd
   }
 
   render() {
-    const {profileState: {profile}, cdrVersionListResponse} = this.props;
+    const {profileState: {profile}, cdrVersionTiersResponse} = this.props;
     const {workspace, workspaceUserRoles, sharing, publishing} = this.state;
     return <div style={styles.mainPage}>
       <FlexColumn style={{margin: '1rem', width: '98%'}}>
@@ -242,7 +242,7 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withUrlParams(), withCd
           <div style={styles.infoBox} data-test-id='cdrVersion'>
             <div style={styles.infoBoxHeader}>Dataset</div>
             <div style={{fontSize: '0.5rem'}}>
-              {workspace ? getCdrVersion(workspace, cdrVersionListResponse).name : 'Loading...'}
+              {workspace ? getCdrVersion(workspace, cdrVersionTiersResponse).name : 'Loading...'}
             </div>
           </div>
           <div style={styles.infoBox} data-test-id='creationDate'>

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -7,7 +7,7 @@ import {currentWorkspaceStore, navigate, serverConfigStore} from 'app/utils/navi
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {DisseminateResearchEnum, ResearchOutcomeEnum, SpecificPopulationEnum,UserApi, WorkspaceAccessLevel, WorkspacesApi} from 'generated/fetch';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
-import {cdrVersionListResponse} from 'testing/stubs/cdr-versions-api-stub';
+import {cdrVersionTiersResponse} from 'testing/stubs/cdr-versions-api-stub';
 import {UserApiStub} from 'testing/stubs/user-api-stub';
 import {workspaceStubs} from 'testing/stubs/workspaces';
 import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -70,7 +70,7 @@ describe('WorkspaceEdit', () => {
     registerApiClient(WorkspacesApi, workspacesApi);
 
     currentWorkspaceStore.next(workspace);
-    cdrVersionStore.set(cdrVersionListResponse);
+    cdrVersionStore.set(cdrVersionTiersResponse);
     serverConfigStore.next({enableBillingUpgrade: true, defaultFreeCreditsDollarLimit: 100.0, gsuiteDomain: ''});
   });
 

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -267,7 +267,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       super(props);
       this.state = {
         billingAccounts: [],
-        cdrVersionItems: this.createInitialCdrVersionsList(DEFAULT_ACCESS_TIER),
+        cdrVersionItems: this.createInitialCdrVersionsList(),
         cloneUserRole: false,
         loading: false,
         populationChecked: props.workspace ? props.workspace.researchPurpose.populationDetails.length > 0 : undefined,
@@ -418,14 +418,14 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       return workspace;
     }
 
-    createInitialCdrVersionsList(accessTierShortName: string): Array<CdrVersion> {
+    createInitialCdrVersionsList(): Array<CdrVersion> {
       if (this.isMode(WorkspaceEditMode.Edit)) {
         // In edit mode, you cannot modify the CDR version, therefore it's fine
         // to show archived CDRs in the drop-down so that it accurately displays
         // the current value.
-        return this.getAllCdrVersionsForTier(accessTierShortName);
+        return this.getAllCdrVersionsForTier(DEFAULT_ACCESS_TIER);
       } else {
-        return this.getLiveCdrVersionsForTier(accessTierShortName);
+        return this.getLiveCdrVersionsForTier(DEFAULT_ACCESS_TIER);
       }
     }
 

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -42,8 +42,14 @@ import {
   withCurrentWorkspace,
   withUserProfile
 } from 'app/utils';
+import {AccessTierShortNames} from 'app/utils/access-tiers';
 import {AnalyticsTracker} from 'app/utils/analytics';
-import {getCdrVersion, hasDefaultCdrVersion} from 'app/utils/cdr-versions';
+import {
+  getCdrVersion,
+  getCdrVersionTier,
+  getDefaultCdrVersionForTier,
+  hasDefaultCdrVersion
+} from 'app/utils/cdr-versions';
 import {reportError} from 'app/utils/errors';
 import {currentWorkspaceStore, navigate, nextWorkspaceWarmupStore, serverConfigStore} from 'app/utils/navigation';
 import {getBillingAccountInfo} from 'app/utils/workbench-gapi-client';
@@ -53,7 +59,7 @@ import {
   ArchivalStatus,
   BillingAccount,
   CdrVersion,
-  CdrVersionListResponse,
+  CdrVersionTiersResponse,
   DisseminateResearchEnum,
   Profile,
   ResearchOutcomeEnum,
@@ -185,6 +191,9 @@ export const styles = reactStyles({
 
 const CREATE_BILLING_ACCOUNT_OPTION_VALUE = 'CREATE_BILLING_ACCOUNT_OPTION';
 
+// default to creating workspaces in the Registered Tier
+const DEFAULT_ACCESS_TIER = AccessTierShortNames.Registered;
+
 // Poll parameters to check Workspace ACLs after creation of a new workspace. See
 // SATURN-104 for details, eventually the root cause should be resolved by fixes
 // to Sam (as part of Postgres migration).
@@ -208,12 +217,12 @@ function getDiseaseNames(keyword) {
 interface UpgradeProps {
   srcWorkspace: Workspace;
   destWorkspace: Workspace;
-  cdrVersionListResponse: CdrVersionListResponse;
+  cdrVersionTiersResponse: CdrVersionTiersResponse;
 }
 const CdrVersionUpgrade = (props: UpgradeProps) => {
-  const {srcWorkspace, destWorkspace, cdrVersionListResponse} = props;
-  const fromCdrVersion = <span style={{fontWeight: 'bold'}}>{getCdrVersion(srcWorkspace, cdrVersionListResponse).name}</span>;
-  const toCdrVersion = <span style={{fontWeight: 'bold'}}>{getCdrVersion(destWorkspace, cdrVersionListResponse).name}</span>;
+  const {srcWorkspace, destWorkspace, cdrVersionTiersResponse} = props;
+  const fromCdrVersion = <span style={{fontWeight: 'bold'}}>{getCdrVersion(srcWorkspace, cdrVersionTiersResponse).name}</span>;
+  const toCdrVersion = <span style={{fontWeight: 'bold'}}>{getCdrVersion(destWorkspace, cdrVersionTiersResponse).name}</span>;
 
   return <div data-test-id='cdr-version-upgrade' style={styles.cdrVersionUpgrade}>
     <div>{`You're duplicating the workspace "${srcWorkspace.name}" to upgrade from`} {fromCdrVersion} to {toCdrVersion}.</div>
@@ -222,7 +231,7 @@ const CdrVersionUpgrade = (props: UpgradeProps) => {
 };
 
 export interface WorkspaceEditProps {
-  cdrVersionListResponse: CdrVersionListResponse;
+  cdrVersionTiersResponse: CdrVersionTiersResponse;
   workspace: WorkspaceData;
   cancel: Function;
   profileState: {
@@ -258,7 +267,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       super(props);
       this.state = {
         billingAccounts: [],
-        cdrVersionItems: this.createInitialCdrVersionsList(),
+        cdrVersionItems: this.createInitialCdrVersionsList(DEFAULT_ACCESS_TIER),
         cloneUserRole: false,
         loading: false,
         populationChecked: props.workspace ? props.workspace.researchPurpose.populationDetails.length > 0 : undefined,
@@ -353,7 +362,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       if (this.isMode(WorkspaceEditMode.Create)) {
         workspace = {
           name: '',
-          accessTierShortName: 'registered',
+          accessTierShortName: DEFAULT_ACCESS_TIER,
           cdrVersionId: '',
           researchPurpose: {
             ancestry: false,
@@ -403,20 +412,20 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       // We preselect the default CDR version when a new workspace is being
       // created (via create or duplicate)
       if (this.isMode(WorkspaceEditMode.Create) || this.isMode(WorkspaceEditMode.Duplicate)) {
-        workspace.cdrVersionId = this.props.cdrVersionListResponse.defaultCdrVersionId;
+        workspace.cdrVersionId = getDefaultCdrVersionForTier(workspace, this.props.cdrVersionTiersResponse).cdrVersionId;
       }
 
       return workspace;
     }
 
-    createInitialCdrVersionsList(): Array<CdrVersion> {
+    createInitialCdrVersionsList(accessTierShortName: string): Array<CdrVersion> {
       if (this.isMode(WorkspaceEditMode.Edit)) {
         // In edit mode, you cannot modify the CDR version, therefore it's fine
         // to show archived CDRs in the drop-down so that it accurately displays
         // the current value.
-        return this.getAllCdrVersions();
+        return this.getAllCdrVersionsForTier(accessTierShortName);
       } else {
-        return this.getLiveCdrVersions();
+        return this.getLiveCdrVersionsForTier(accessTierShortName);
       }
     }
 
@@ -435,9 +444,9 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
         researchPurpose.populationHealth || researchPurpose.socialBehavioral;
     }
 
-    getLiveCdrVersions(): Array<CdrVersion> {
-      const cdrResp = this.props.cdrVersionListResponse;
-      const liveCdrVersions = cdrResp.items.filter(cdr => cdr.archivalStatus === ArchivalStatus.LIVE);
+    getLiveCdrVersionsForTier(accessTierShortName: string): Array<CdrVersion> {
+      const versionsForTier = this.getAllCdrVersionsForTier(accessTierShortName);
+      const liveCdrVersions = versionsForTier.filter(cdr => cdr.archivalStatus === ArchivalStatus.LIVE);
       if (liveCdrVersions.length === 0) {
         throw Error('no live CDR versions were found');
       }
@@ -445,8 +454,8 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       return liveCdrVersions;
     }
 
-    getAllCdrVersions(): Array<CdrVersion> {
-      return [...this.props.cdrVersionListResponse.items];
+    getAllCdrVersionsForTier(accessTierShortName: string): Array<CdrVersion> {
+      return getCdrVersionTier(accessTierShortName, this.props.cdrVersionTiersResponse).versions;
     }
 
     makeDiseaseInput(): React.ReactNode {
@@ -835,7 +844,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       const {workspace: destWorkspace} = this.state;
       return this.isMode(WorkspaceEditMode.Duplicate) &&
           srcWorkspace.cdrVersionId !== destWorkspace.cdrVersionId &&
-          hasDefaultCdrVersion(destWorkspace, this.props.cdrVersionListResponse);
+          hasDefaultCdrVersion(destWorkspace, this.props.cdrVersionTiersResponse);
     }
 
     /**
@@ -999,7 +1008,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
         workspaceCreationErrorMessage,
         workspaceNewAclDelayed
       } = this.state;
-      const {cdrVersionListResponse, profileState: {profile: {freeTierDollarQuota, freeTierUsage}}} = this.props;
+      const {cdrVersionTiersResponse, profileState: {profile: {freeTierDollarQuota, freeTierUsage}}} = this.props;
       const freeTierCreditsBalance = freeTierDollarQuota - freeTierUsage;
       // defined below in the OverlayPanel declaration
       let freeTierBalancePanel: OverlayPanel;
@@ -1008,10 +1017,11 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       return <FadeBox  style={{margin: 'auto', marginTop: '1rem', width: '95.7%'}}>
         <div style={{width: '1120px'}}>
           {loading && <SpinnerOverlay overrideStylesOverlay={styles.spinner}/>}
-          {!hasDefaultCdrVersion(this.state.workspace, cdrVersionListResponse) && showCdrVersionModal &&
+          {!hasDefaultCdrVersion(this.state.workspace, cdrVersionTiersResponse) && showCdrVersionModal &&
             <OldCdrVersionModal
                 onCancel={() => {
-                  this.setState(fp.set(['workspace', 'cdrVersionId'], cdrVersionListResponse.defaultCdrVersionId));
+                  this.setState(fp.set(['workspace', 'cdrVersionId'],
+                    getDefaultCdrVersionForTier(this.state.workspace, cdrVersionTiersResponse)));
                   this.setState({showCdrVersionModal: false});
                 }}
                 onContinue={() => this.setState({showCdrVersionModal: false})}
@@ -1019,7 +1029,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
           {this.isCdrVersionUpgrade() && <CdrVersionUpgrade
               srcWorkspace={this.props.workspace}
               destWorkspace={this.state.workspace}
-              cdrVersionListResponse={cdrVersionListResponse}
+              cdrVersionTiersResponse={cdrVersionTiersResponse}
           />}
           <WorkspaceEditSection header={this.renderHeader()} tooltip={toolTipText.header}
                                 style={{marginTop: '24px'}} largeHeader
@@ -1038,7 +1048,8 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
                   onChange={(v: React.FormEvent<HTMLSelectElement>) => {
                     const selectedVersion = v.currentTarget.value;
                     this.setState(fp.set(['workspace', 'cdrVersionId'], selectedVersion));
-                    this.setState({showCdrVersionModal: selectedVersion !== cdrVersionListResponse.defaultCdrVersionId});
+                    this.setState({showCdrVersionModal: selectedVersion !==
+                          getDefaultCdrVersionForTier(this.state.workspace, cdrVersionTiersResponse).cdrVersionId});
                   }}
                   disabled={this.isMode(WorkspaceEditMode.Edit)}>
                     {cdrVersionItems.map((version, i) => (

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -23,7 +23,7 @@ describe('WorkspaceNavBarComponent', () => {
     urlParamsStore.next({ns: workspaceDataStub.namespace, wsid: workspaceDataStub.id});
     serverConfigStore.next({
       gsuiteDomain: 'fake-research-aou.org', enableResearchReviewPrompt: true});
-    cdrVersionStore.set(cdrVersionListResponse);
+    cdrVersionStore.set(cdrVersionTiersResponse);
   });
 
   it('should render', () => {

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -4,8 +4,7 @@ import * as React from 'react';
 import {WorkspaceNavBarReact} from 'app/pages/workspace/workspace-nav-bar';
 import {currentWorkspaceStore, NavStore, serverConfigStore, urlParamsStore} from 'app/utils/navigation';
 import {workspaceDataStub} from 'testing/stubs/workspaces';
-import {cdrVersionListResponse} from 'testing/stubs/cdr-versions-api-stub';
-import {CdrVersionsStubVariables} from 'testing/stubs/cdr-versions-api-stub';
+import {CdrVersionsStubVariables, cdrVersionTiersResponse} from 'testing/stubs/cdr-versions-api-stub';
 import {cdrVersionStore} from "app/utils/stores";
 
 describe('WorkspaceNavBarComponent', () => {

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -14,10 +14,14 @@ import {
   withCurrentWorkspace,
   withUrlParams
 } from 'app/utils';
-import {getCdrVersion, getDefaultCdrVersion, hasDefaultCdrVersion} from 'app/utils/cdr-versions';
+import {
+  getCdrVersion,
+  getDefaultCdrVersionForTier,
+  hasDefaultCdrVersion
+} from 'app/utils/cdr-versions';
 import {NavStore} from 'app/utils/navigation';
 import {serverConfigStore} from 'app/utils/navigation';
-import {CdrVersionListResponse, Workspace} from 'generated/fetch';
+import {CdrVersionTiersResponse, Workspace} from 'generated/fetch';
 import {CdrVersionUpgradeModal} from './cdr-version-upgrade-modal';
 
 const styles = reactStyles({
@@ -80,8 +84,8 @@ const stylesFunction = {
 
 const USER_DISMISSED_ALERT_VALUE = 'DISMISSED';
 
-const CdrVersion = (props: {workspace: Workspace, cdrVersionListResponse: CdrVersionListResponse}) => {
-  const {workspace, cdrVersionListResponse} = props;
+const CdrVersion = (props: {workspace: Workspace, cdrVersionTiersResponse: CdrVersionTiersResponse}) => {
+  const {workspace, cdrVersionTiersResponse} = props;
   const {namespace, id} = workspace;
 
   const localStorageKey = `${namespace}-${id}-user-dismissed-cdr-version-update-alert`;
@@ -110,10 +114,10 @@ const CdrVersion = (props: {workspace: Workspace, cdrVersionListResponse: CdrVer
   </Clickable>;
 
   return <FlexRow data-test-id='cdr-version' style={{textTransform: 'none'}}>
-    {getCdrVersion(workspace, cdrVersionListResponse).name}
-    {!hasDefaultCdrVersion(workspace, cdrVersionListResponse) && <NewVersionFlag/>}
+    {getCdrVersion(workspace, cdrVersionTiersResponse).name}
+    {!hasDefaultCdrVersion(workspace, cdrVersionTiersResponse) && <NewVersionFlag/>}
     {showModal && <CdrVersionUpgradeModal
-        defaultCdrVersionName={getDefaultCdrVersion(cdrVersionListResponse).name}
+        defaultCdrVersionName={getDefaultCdrVersionForTier(workspace, cdrVersionTiersResponse).name}
         onClose={() => setShowModal(false)}
         upgrade={() => NavStore.navigate(['/workspaces', namespace, id, 'duplicate'])}
     />}
@@ -138,7 +142,7 @@ export const WorkspaceNavBarReact = fp.flow(
   withUrlParams(),
   withCdrVersions(),
 )(props => {
-  const {tabPath, workspace, urlParams: {ns: namespace, wsid: id}, cdrVersionListResponse} = props;
+  const {tabPath, workspace, urlParams: {ns: namespace, wsid: id}, cdrVersionTiersResponse} = props;
   const activeTabIndex = fp.findIndex(['link', tabPath], tabs);
 
   const navTab = (currentTab, disabled) => {
@@ -164,7 +168,7 @@ export const WorkspaceNavBarReact = fp.flow(
     {activeTabIndex > 0 && navSeparator}
     {fp.map(tab => navTab(tab, restrictTab(props.workspace, tab)), tabs)}
     <div style={{flexGrow: 1}}/>
-    {workspace && <CdrVersion workspace={workspace} cdrVersionListResponse={cdrVersionListResponse}/>}
+    {workspace && <CdrVersion workspace={workspace} cdrVersionTiersResponse={cdrVersionTiersResponse}/>}
   </div>;
 });
 

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
@@ -79,7 +79,7 @@ describe('WorkspaceWrapperComponent', () => {
       });
       serverConfigStore.next({gsuiteDomain: 'fake-research-aou.org',
         enableResearchReviewPrompt: true});
-      cdrVersionStore.set(cdrVersionListResponse);
+      cdrVersionStore.set(cdrVersionTiersResponse);
     });
   }));
 

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.spec.ts
@@ -25,7 +25,7 @@ import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
 
 import {cdrVersionStore} from 'app/utils/stores';
 import {findElements} from 'testing/react-testing-utility';
-import {cdrVersionListResponse} from 'testing/stubs/cdr-versions-api-stub';
+import {cdrVersionTiersResponse} from 'testing/stubs/cdr-versions-api-stub';
 import {RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
 import {setupModals, updateAndTick} from 'testing/test-helpers';
 

--- a/ui/src/app/utils/cdr-versions.spec.tsx
+++ b/ui/src/app/utils/cdr-versions.spec.tsx
@@ -50,10 +50,6 @@ describe('cdr-versions', () => {
         expect(getCdrVersion(testWorkspaceMissingVersion, cdrVersionTiersResponse)).toBeUndefined();
     });
 
-    it('should return undefined for a workspace with an invalid access tier', async () => {
-        expect(getCdrVersion(testWorkspaceMissingTier, cdrVersionTiersResponse)).toBeUndefined();
-    });
-
     it('should correctly get the default CDR Version for the registered tier', async () => {
         expect(getDefaultCdrVersionForTier(testWorkspace, cdrVersionTiersResponse)).toBe(defaultCdrVersion);
     });

--- a/ui/src/app/utils/cdr-versions.spec.tsx
+++ b/ui/src/app/utils/cdr-versions.spec.tsx
@@ -2,12 +2,14 @@ import * as React from "react";
 
 import {Workspace} from 'generated/fetch';
 import {WorkspaceStubVariables} from 'testing/stubs/workspaces';
-import {cdrVersionTiersResponse} from 'testing/stubs/cdr-versions-api-stub';
-import {getCdrVersion, hasDefaultCdrVersion, getDefaultCdrVersionForTier} from "./cdr-versions";
-import {AccessTierShortNames} from "./access-tiers";
-
-const registeredCdrVersionTier = cdrVersionTiersResponse.tiers[0];
-const controlledCdrVersionTier = cdrVersionTiersResponse.tiers[1];
+import {
+    altCdrVersion,
+    cdrVersionTiersResponse,
+    controlledCdrVersion,
+    defaultCdrVersion
+} from 'testing/stubs/cdr-versions-api-stub';
+import {getCdrVersion, hasDefaultCdrVersion, getDefaultCdrVersionForTier} from 'app/utils/cdr-versions';
+import {AccessTierShortNames} from 'app/utils/access-tiers';
 
 const stubWorkspace: Workspace = {
     name: WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME,
@@ -15,9 +17,6 @@ const stubWorkspace: Workspace = {
     namespace: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS
 };
 
-const defaultCdrVersion = registeredCdrVersionTier.versions[0];
-const altCdrVersion = registeredCdrVersionTier.versions[1];
-const controlledCdrVersion = controlledCdrVersionTier.versions[0];
 
 const testWorkspace: Workspace = {
     ...stubWorkspace,

--- a/ui/src/app/utils/cdr-versions.tsx
+++ b/ui/src/app/utils/cdr-versions.tsx
@@ -1,19 +1,39 @@
-import {CdrVersion, CdrVersionListResponse, Workspace} from 'generated/fetch';
+import {CdrVersion, CdrVersionTier, CdrVersionTiersResponse, Workspace} from 'generated/fetch';
+import * as fp from 'lodash/fp';
 
-function getCdrVersion(workspace: Workspace, cdrList: CdrVersionListResponse): CdrVersion {
-  return cdrList.items.find(v => v.cdrVersionId === workspace.cdrVersionId);
+function getCdrVersionTier(accessTierShortName: string, cdrTiers: CdrVersionTiersResponse): CdrVersionTier {
+  return cdrTiers.tiers.find(v => v.accessTierShortName === accessTierShortName);
 }
 
-function getDefaultCdrVersion(cdrList: CdrVersionListResponse): CdrVersion {
-  return cdrList.items.find(v => v.cdrVersionId === cdrList.defaultCdrVersionId);
+function getCdrVersion(workspace: Workspace, cdrTiers: CdrVersionTiersResponse): CdrVersion {
+  const tier = getCdrVersionTier(workspace.accessTierShortName, cdrTiers);
+  if (tier) {
+    return tier.versions.find(v => v.cdrVersionId === workspace.cdrVersionId);
+  }
 }
 
-function hasDefaultCdrVersion(workspace: Workspace, cdrList: CdrVersionListResponse): boolean {
-  return workspace.cdrVersionId === cdrList.defaultCdrVersionId;
+function getDefaultCdrVersionForTier(workspace: Workspace, cdrTiers: CdrVersionTiersResponse): CdrVersion {
+  const tier = getCdrVersionTier(workspace.accessTierShortName, cdrTiers);
+  if (tier) {
+    return tier.versions.find(v => v.cdrVersionId === tier.defaultCdrVersionId);
+  }
+}
+
+function hasDefaultCdrVersion(workspace: Workspace, cdrTiers: CdrVersionTiersResponse): boolean {
+  const tier = getCdrVersionTier(workspace.accessTierShortName, cdrTiers);
+  return tier ? workspace.cdrVersionId === tier.defaultCdrVersionId : false;
+}
+
+// does not consider tier; IDs are globally unique, enforced by the API DB
+function findCdrVersion(cdrVersionId: string, cdrTiers: CdrVersionTiersResponse): CdrVersion {
+  const allTiersVersions = fp.flatMap(tier => tier.versions, cdrTiers.tiers);
+  return allTiersVersions.find(v => v.cdrVersionId === cdrVersionId);
 }
 
 export {
+    getCdrVersionTier,
     getCdrVersion,
-    getDefaultCdrVersion,
+    getDefaultCdrVersionForTier,
     hasDefaultCdrVersion,
+    findCdrVersion,
 };

--- a/ui/src/app/utils/cdr-versions.tsx
+++ b/ui/src/app/utils/cdr-versions.tsx
@@ -5,13 +5,6 @@ function getCdrVersionTier(accessTierShortName: string, cdrTiers: CdrVersionTier
   return cdrTiers.tiers.find(v => v.accessTierShortName === accessTierShortName);
 }
 
-function getCdrVersion(workspace: Workspace, cdrTiers: CdrVersionTiersResponse): CdrVersion {
-  const tier = getCdrVersionTier(workspace.accessTierShortName, cdrTiers);
-  if (tier) {
-    return tier.versions.find(v => v.cdrVersionId === workspace.cdrVersionId);
-  }
-}
-
 function getDefaultCdrVersionForTier(workspace: Workspace, cdrTiers: CdrVersionTiersResponse): CdrVersion {
   const tier = getCdrVersionTier(workspace.accessTierShortName, cdrTiers);
   if (tier) {
@@ -30,10 +23,14 @@ function findCdrVersion(cdrVersionId: string, cdrTiers: CdrVersionTiersResponse)
   return allTiersVersions.find(v => v.cdrVersionId === cdrVersionId);
 }
 
+function getCdrVersion(workspace: Workspace, cdrTiers: CdrVersionTiersResponse): CdrVersion {
+  return findCdrVersion(workspace.cdrVersionId, cdrTiers);
+}
+
 export {
     getCdrVersionTier,
-    getCdrVersion,
     getDefaultCdrVersionForTier,
     hasDefaultCdrVersion,
     findCdrVersion,
+    getCdrVersion,
 };

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -373,9 +373,9 @@ export const withRouteConfigData = () => {
   return connectBehaviorSubject(routeConfigDataStore, 'routeConfigData');
 };
 
-// HOC that provides a 'cdrVersionListResponse' prop with the CDR version information.
+// HOC that provides a 'cdrVersionTiersResponse' prop with the CDR version information.
 export const withCdrVersions = () => {
-  return withStore(cdrVersionStore, 'cdrVersionListResponse');
+  return withStore(cdrVersionStore, 'cdrVersionTiersResponse');
 };
 
 // HOC that provides a 'queryParams' prop with current query params

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -1,6 +1,6 @@
 import { BreadcrumbType } from 'app/utils/navigation';
 import {atom, Atom} from 'app/utils/subscribable';
-import {CdrVersion, Profile, Runtime} from 'generated/fetch';
+import {CdrVersionTiersResponse, Profile, Runtime} from 'generated/fetch';
 import * as React from 'react';
 import {StackdriverErrorReporter} from 'stackdriver-errors-js';
 
@@ -25,12 +25,7 @@ interface AuthStore {
 
 export const authStore = atom<AuthStore>({authLoaded: false, isSignedIn: false});
 
-interface CdrVersionStore {
-  items?: Array<CdrVersion>;
-  defaultCdrVersionId: string;
-}
-
-export const cdrVersionStore = atom<CdrVersionStore>({items: [], defaultCdrVersionId: '-1'});
+export const cdrVersionStore = atom<CdrVersionTiersResponse>({tiers: []});
 
 interface ProfileStore {
   profile?: Profile;

--- a/ui/src/testing/stubs/cdr-versions-api-stub.ts
+++ b/ui/src/testing/stubs/cdr-versions-api-stub.ts
@@ -6,7 +6,7 @@ import {
 } from 'generated/fetch';
 import {stubNotImplementedError} from 'testing/stubs/stub-utils';
 
-export class CdrVersionsStubVariables {
+class CdrVersionsStubVariables {
   static DEFAULT_WORKSPACE_CDR_VERSION = 'Fake CDR Version';
   static DEFAULT_WORKSPACE_CDR_VERSION_ID = 'fakeCdrVersion';
   static ALT_WORKSPACE_CDR_VERSION = 'Alternative CDR Version';
@@ -15,7 +15,7 @@ export class CdrVersionsStubVariables {
   static CONTROLLED_TIER_CDR_VERSION_ID = 'ctCdrVersion';
 }
 
-export const cdrVersionTiersResponse: CdrVersionTiersResponse = {
+const cdrVersionTiersResponse: CdrVersionTiersResponse = {
   tiers: [{
     accessTierShortName: AccessTierShortNames.Registered,
     defaultCdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
@@ -59,7 +59,14 @@ export const cdrVersionTiersResponse: CdrVersionTiersResponse = {
   ]
 };
 
-export class CdrVersionsApiStub extends CdrVersionsApi {
+const registeredCdrVersionTier = cdrVersionTiersResponse.tiers[0];
+const defaultCdrVersion = registeredCdrVersionTier.versions[0];
+const altCdrVersion = registeredCdrVersionTier.versions[1];
+
+const controlledCdrVersionTier = cdrVersionTiersResponse.tiers[1];
+const controlledCdrVersion = controlledCdrVersionTier.versions[0];
+
+class CdrVersionsApiStub extends CdrVersionsApi {
   constructor() {
     super(undefined, undefined, (..._: any[]) => { throw stubNotImplementedError; });
   }
@@ -70,3 +77,14 @@ export class CdrVersionsApiStub extends CdrVersionsApi {
     });
   }
 }
+
+export {
+  CdrVersionsApiStub,
+  CdrVersionsStubVariables,
+  cdrVersionTiersResponse,
+  registeredCdrVersionTier,
+  controlledCdrVersionTier,
+  defaultCdrVersion,
+  altCdrVersion,
+  controlledCdrVersion,
+};

--- a/ui/src/testing/stubs/cdr-versions-api-stub.ts
+++ b/ui/src/testing/stubs/cdr-versions-api-stub.ts
@@ -6,7 +6,7 @@ import {
 } from 'generated/fetch';
 import {stubNotImplementedError} from 'testing/stubs/stub-utils';
 
-class CdrVersionsStubVariables {
+export class CdrVersionsStubVariables {
   static DEFAULT_WORKSPACE_CDR_VERSION = 'Fake CDR Version';
   static DEFAULT_WORKSPACE_CDR_VERSION_ID = 'fakeCdrVersion';
   static ALT_WORKSPACE_CDR_VERSION = 'Alternative CDR Version';
@@ -15,7 +15,7 @@ class CdrVersionsStubVariables {
   static CONTROLLED_TIER_CDR_VERSION_ID = 'ctCdrVersion';
 }
 
-const cdrVersionTiersResponse: CdrVersionTiersResponse = {
+export const cdrVersionTiersResponse: CdrVersionTiersResponse = {
   tiers: [{
     accessTierShortName: AccessTierShortNames.Registered,
     defaultCdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
@@ -59,14 +59,14 @@ const cdrVersionTiersResponse: CdrVersionTiersResponse = {
   ]
 };
 
-const registeredCdrVersionTier = cdrVersionTiersResponse.tiers[0];
-const defaultCdrVersion = registeredCdrVersionTier.versions[0];
-const altCdrVersion = registeredCdrVersionTier.versions[1];
+export const registeredCdrVersionTier = cdrVersionTiersResponse.tiers[0];
+export const defaultCdrVersion = registeredCdrVersionTier.versions[0];
+export const altCdrVersion = registeredCdrVersionTier.versions[1];
 
-const controlledCdrVersionTier = cdrVersionTiersResponse.tiers[1];
-const controlledCdrVersion = controlledCdrVersionTier.versions[0];
+export const controlledCdrVersionTier = cdrVersionTiersResponse.tiers[1];
+export const controlledCdrVersion = controlledCdrVersionTier.versions[0];
 
-class CdrVersionsApiStub extends CdrVersionsApi {
+export class CdrVersionsApiStub extends CdrVersionsApi {
   constructor() {
     super(undefined, undefined, (..._: any[]) => { throw stubNotImplementedError; });
   }
@@ -77,14 +77,3 @@ class CdrVersionsApiStub extends CdrVersionsApi {
     });
   }
 }
-
-export {
-  CdrVersionsApiStub,
-  CdrVersionsStubVariables,
-  cdrVersionTiersResponse,
-  registeredCdrVersionTier,
-  controlledCdrVersionTier,
-  defaultCdrVersion,
-  altCdrVersion,
-  controlledCdrVersion,
-};

--- a/ui/src/testing/stubs/cdr-versions-api-stub.ts
+++ b/ui/src/testing/stubs/cdr-versions-api-stub.ts
@@ -1,5 +1,9 @@
 import {AccessTierShortNames} from 'app/utils/access-tiers';
-import {ArchivalStatus, CdrVersion, CdrVersionListResponse, CdrVersionsApi} from 'generated/fetch';
+import {
+  ArchivalStatus,
+  CdrVersionsApi,
+  CdrVersionTiersResponse
+} from 'generated/fetch';
 import {stubNotImplementedError} from 'testing/stubs/stub-utils';
 
 export class CdrVersionsStubVariables {
@@ -7,47 +11,62 @@ export class CdrVersionsStubVariables {
   static DEFAULT_WORKSPACE_CDR_VERSION_ID = 'fakeCdrVersion';
   static ALT_WORKSPACE_CDR_VERSION = 'Alternative CDR Version';
   static ALT_WORKSPACE_CDR_VERSION_ID = 'altCdrVersion';
+  static CONTROLLED_TIER_CDR_VERSION = 'Controlled Tier CDR Version';
+  static CONTROLLED_TIER_CDR_VERSION_ID = 'ctCdrVersion';
 }
 
-export const cdrVersionListResponse: CdrVersionListResponse = {
-  defaultCdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
-  items: [
+export const cdrVersionTiersResponse: CdrVersionTiersResponse = {
+  tiers: [{
+    accessTierShortName: AccessTierShortNames.Registered,
+    defaultCdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
+    versions: [
+      {
+        name: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION,
+        cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
+        accessTierShortName: AccessTierShortNames.Registered,
+        archivalStatus: ArchivalStatus.LIVE,
+        hasMicroarrayData: true,
+        hasFitbitData: true,
+        hasWgsData: true,
+        creationTime: 0
+      },
+      {
+        name: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION,
+        cdrVersionId: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION_ID,
+        accessTierShortName: AccessTierShortNames.Registered,
+        archivalStatus: ArchivalStatus.LIVE,
+        hasMicroarrayData: false,
+        hasFitbitData: true,
+        hasWgsData: false,
+        creationTime: 0
+      },
+    ]},
     {
-      name: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION,
-      cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
-      accessTierShortName: AccessTierShortNames.Registered,
-      archivalStatus: ArchivalStatus.LIVE,
-      hasMicroarrayData: true,
-      hasFitbitData: true,
-      hasWgsData: true,
-      creationTime: 0
-    },
-    {
-      name: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION,
-      cdrVersionId: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION_ID,
-      accessTierShortName: AccessTierShortNames.Registered,
-      archivalStatus: ArchivalStatus.LIVE,
-      hasMicroarrayData: false,
-      hasFitbitData: true,
-      hasWgsData: false,
-      creationTime: 0
-    },
+      accessTierShortName: AccessTierShortNames.Controlled,
+      defaultCdrVersionId: CdrVersionsStubVariables.CONTROLLED_TIER_CDR_VERSION_ID,
+      versions: [
+        {
+          name: CdrVersionsStubVariables.CONTROLLED_TIER_CDR_VERSION,
+          cdrVersionId: CdrVersionsStubVariables.CONTROLLED_TIER_CDR_VERSION_ID,
+          accessTierShortName: AccessTierShortNames.Controlled,
+          archivalStatus: ArchivalStatus.LIVE,
+          hasMicroarrayData: true,
+          hasFitbitData: true,
+          hasWgsData: true,
+          creationTime: 0
+        }
+      ]}
   ]
 };
 
 export class CdrVersionsApiStub extends CdrVersionsApi {
-  public cdrVersions: CdrVersion[];
   constructor() {
     super(undefined, undefined, (..._: any[]) => { throw stubNotImplementedError; });
-    this.cdrVersions = cdrVersionListResponse.items;
   }
 
-  getCdrVersions(options?: any): Promise<CdrVersionListResponse> {
-    return new Promise<CdrVersionListResponse>(resolve => {
-      resolve({
-        ...cdrVersionListResponse,
-        items: this.cdrVersions,
-      });
+  getCdrVersionsByTier(options?: any): Promise<CdrVersionTiersResponse> {
+    return new Promise<CdrVersionTiersResponse>(resolve => {
+      resolve(cdrVersionTiersResponse);
     });
   }
 }


### PR DESCRIPTION
Description:

This does not meet the AC for RW-6300.  It's a necessary step to get there, however.

The original endpoint `getCdrVersions()` returns a `CdrVersionListResponse` with information about the Registered Tier CDR Versions.  A new endpoint `getCdrVersionsByTier()` returns a `CdrVersionTiersResponse` with information about the CDR Versions in all tiers (Registered and Controlled or just Registered, depending on environment).  This PR replaces the use of the former endpoint/entity in favor of the newer versions.  **No visual or behavior changes are expected.  If you find any, that's a bug.**  This PR also does not enable access to any Controlled Tier CDR Version - and one does exist in the Test and Local environments.  **If you are able to access any, that's a bug.**

Local manual testing - anything relating to CDR Versions: create, edit, duplicate workspaces, changing CDR Version where possible (but not tier).  create notebook runtime.  copy resources between workspaces across CDR Versions (but not across tiers).  Observe CDR Version displays in Recent Resources, Workspace About, Workspace Navbar.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
