### PR TITLE
[risk=no][RW-6189] Remove the final references to DataAccessLevel

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
@@ -1,31 +1,12 @@
 package org.pmiops.workbench.access;
 
 import java.util.List;
-import javax.annotation.Nullable;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.model.DataAccessLevel;
 
 public interface AccessTierService {
   // TODO remove once we are no longer special-casing the Registered Tier
   String REGISTERED_TIER_SHORT_NAME = "registered";
-
-  /**
-   * Temporary kluge to assist in removing DataAccessLevel: return DataAccessLevel.REGISTERED if the
-   * user has Registered Tier membership
-   *
-   * @param accessTierShortNames a comma-separated list of shortNames associated with Access Tiers.
-   *     e.g. 'registered,controlled'
-   * @return whether a user has Registered Tier membership or not, as a DataAccessLevel
-   */
-  static DataAccessLevel temporaryDataAccessLevelKluge(@Nullable String accessTierShortNames) {
-    if (accessTierShortNames != null
-        && accessTierShortNames.contains(AccessTierService.REGISTERED_TIER_SHORT_NAME)) {
-      return DataAccessLevel.REGISTERED;
-    } else {
-      return DataAccessLevel.UNREGISTERED;
-    }
-  }
 
   /**
    * Return all access tiers in the database, in alphabetical order by shortName

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
@@ -42,7 +42,7 @@ public interface ProfileMapper {
       Double freeTierDollarQuota,
       List<String> accessTierShortNames);
 
-  AdminTableUser adminViewToModel(DbAdminTableUser dbUser);
+  List<AdminTableUser> adminViewToModel(List<DbAdminTableUser> adminTableUsers);
 
   // used by the generated impl of adminViewToModel()
   default List<String> splitAccessTierShortNames(

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
@@ -8,12 +8,11 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.UserDao.DbAdminTableUser;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.model.AdminTableUser;
-import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.Profile;
 import org.pmiops.workbench.model.VerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
@@ -41,10 +40,9 @@ public interface ProfileMapper {
       DbUserTermsOfService latestTermsOfService,
       Double freeTierUsage,
       Double freeTierDollarQuota,
-      List<String> accessTierShortNames,
-      DataAccessLevel dataAccessLevel);
+      List<String> accessTierShortNames);
 
-  AdminTableUser adminViewToModel(UserDao.DbAdminTableUser dbUser, DataAccessLevel dataAccessLevel);
+  AdminTableUser adminViewToModel(DbAdminTableUser dbUser);
 
   // used by the generated impl of adminViewToModel()
   default List<String> splitAccessTierShortNames(

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -37,7 +37,6 @@ import org.pmiops.workbench.model.AccountPropertyUpdate;
 import org.pmiops.workbench.model.Address;
 import org.pmiops.workbench.model.AdminTableUser;
 import org.pmiops.workbench.model.Authority;
-import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.DemographicSurvey;
 import org.pmiops.workbench.model.InstitutionalRole;
 import org.pmiops.workbench.model.Profile;
@@ -124,18 +123,13 @@ public class ProfileService {
     final List<String> accessTierShortNames =
         accessTierService.getAccessTierShortNamesForUser(user);
 
-    // temporary - we will remove Data Access Level from the model in RW-6189
-    final DataAccessLevel dataAccessLevelKluge =
-        AccessTierService.temporaryDataAccessLevelKluge(String.join(",", accessTierShortNames));
-
     return profileMapper.toModel(
         user,
         verifiedInstitutionalAffiliation,
         latestTermsOfService,
         freeTierUsage,
         freeTierDollarQuota,
-        accessTierShortNames,
-        dataAccessLevelKluge);
+        accessTierShortNames);
   }
 
   public void validateAffiliation(Profile profile) {
@@ -472,14 +466,7 @@ public class ProfileService {
 
   public List<AdminTableUser> getAdminTableUsers() {
     return userDao.getAdminTableUsers().stream()
-        .map(
-            dbAdminTableUser -> {
-              // temporary - we will remove Data Access Level from the model in RW-6189
-              DataAccessLevel dataAccessLevelKluge =
-                  AccessTierService.temporaryDataAccessLevelKluge(
-                      dbAdminTableUser.getAccessTierShortNames());
-              return profileMapper.adminViewToModel(dbAdminTableUser, dataAccessLevelKluge);
-            })
+        .map(profileMapper::adminViewToModel)
         .collect(ImmutableList.toImmutableList());
   }
   /**

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.profile;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.List;
@@ -465,10 +464,9 @@ public class ProfileService {
   }
 
   public List<AdminTableUser> getAdminTableUsers() {
-    return userDao.getAdminTableUsers().stream()
-        .map(profileMapper::adminViewToModel)
-        .collect(ImmutableList.toImmutableList());
+    return profileMapper.adminViewToModel(userDao.getAdminTableUsers());
   }
+
   /**
    * Updates the user metadata referenced by the fields of AccountPropertyUpdate.
    *

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3626,13 +3626,6 @@ definitions:
     enum:
     - LIVE
     - ARCHIVED
-  DataAccessLevel:
-    type: string
-    description: DEPRECATED.  Will be replaced by Access Tiers.  Was -> levels of access to data in the curated data repository
-    enum:
-    - unregistered
-    - registered
-    - protected
   RdrEntity:
     type: string
     description: Entities send to RDR
@@ -5246,9 +5239,6 @@ definitions:
         type: array
         items:
           type: string
-      dataAccessLevel:
-        "$ref": "#/definitions/DataAccessLevel"
-        description: DEPRECATED.  Will be replaced by accessTierShortNames.
       givenName:
         type: string
       familyName:
@@ -5351,9 +5341,6 @@ definitions:
         type: array
         items:
           type: string
-      dataAccessLevel:
-        "$ref": "#/definitions/DataAccessLevel"
-        description: DEPRECATED.  Will be replaced by accessTierShortNames.
       degrees:
         type: array
         items:

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -72,7 +72,6 @@ import org.pmiops.workbench.model.AccountPropertyUpdate;
 import org.pmiops.workbench.model.Address;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.CreateAccountRequest;
-import org.pmiops.workbench.model.DataAccessLevel;
 import org.pmiops.workbench.model.DemographicSurvey;
 import org.pmiops.workbench.model.Disability;
 import org.pmiops.workbench.model.DuaType;
@@ -508,8 +507,6 @@ public class ProfileControllerTest extends BaseControllerTest {
                 .getStatusCode())
         .isEqualTo(HttpStatus.OK);
     assertThat(accessTierService.getAccessTiersForUser(dbUser)).contains(registeredTier);
-    Profile profile = profileController.getMe().getBody();
-    assertThat(profile.getDataAccessLevel()).isEqualTo(DataAccessLevel.REGISTERED);
 
     // update and enforce the required version
 
@@ -518,10 +515,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     // a bit of a hack here: use this to sync the registration status
     // see also https://precisionmedicineinitiative.atlassian.net/browse/RW-2352
     profileController.syncTwoFactorAuthStatus();
-
     assertThat(accessTierService.getAccessTiersForUser(dbUser)).doesNotContain(registeredTier);
-    profile = profileController.getMe().getBody();
-    assertThat(profile.getDataAccessLevel()).isEqualTo(DataAccessLevel.UNREGISTERED);
   }
 
   @Test
@@ -1504,7 +1498,6 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertThat(profile.getFamilyName()).isEqualTo(FAMILY_NAME);
     assertThat(profile.getGivenName()).isEqualTo(GIVEN_NAME);
     assertThat(profile.getAccessTierShortNames()).isEmpty();
-    assertThat(profile.getDataAccessLevel()).isEqualTo(DataAccessLevel.UNREGISTERED);
     assertThat(profile.getContactEmailFailure()).isEqualTo(false);
 
     DbUser user = userDao.findUserByUsername(PRIMARY_EMAIL);

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ExportWorkspaceData.java
@@ -306,12 +306,20 @@ public class ExportWorkspaceData {
         Optional.ofNullable(user.getDataUseAgreementCompletionTime())
             .map(dateFormat::format)
             .orElse(""));
+
     // TODO if we revive this tool:
     // update to use Access Tiers instead of Data Access Level
-    row.setCreatorRegistrationState(
-        AccessTierService.temporaryDataAccessLevelKluge(
-                String.join(",", accessTierService.getAccessTierShortNamesForUser(user)))
-            .toString());
+    // we can use this kluge in the meantime
+    // (migrated from AccessTierService.temporaryDataAccessLevelKluge)
+    final String accessTierShortNames =
+        String.join(",", accessTierService.getAccessTierShortNamesForUser(user));
+    if (accessTierShortNames != null
+        && accessTierShortNames.contains(AccessTierService.REGISTERED_TIER_SHORT_NAME)) {
+      row.setCreatorRegistrationState(AccessTierService.REGISTERED_TIER_SHORT_NAME);
+    } else {
+      row.setCreatorRegistrationState("unregistered");
+    }
+
     row.setDegrees(
         Optional.ofNullable(user.getDegreesEnum()).orElse(ImmutableList.of()).stream()
             .map(Degree::toString)


### PR DESCRIPTION
Description:

The final UI reference was removed in #4833 so we should wait until the 19 April release for deployment safety reasons.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
