### PR TITLE
[RW-6532][risk=no] Correct egress alert window duration parsing to expect seconds

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/opsgenie/EgressEventServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/opsgenie/EgressEventServiceImpl.java
@@ -124,7 +124,7 @@ public class EgressEventServiceImpl implements EgressEventService {
     // For shorter alerting windows, we don't make any claims about staleness. This ensures that we
     // don't misinterpret a delay in when Sumologic runs the query, and when our system receives the
     // event as a stale event.
-    final Duration windowDuration = Duration.ofMillis(egressEvent.getTimeWindowDuration());
+    final Duration windowDuration = Duration.ofSeconds(egressEvent.getTimeWindowDuration());
     if (windowDuration.getSeconds() < MAXIMUM_EXPECTED_EVENT_AGE.getSeconds()) {
       return false;
     }
@@ -145,7 +145,7 @@ public class EgressEventServiceImpl implements EgressEventService {
       messagePrefix =
           String.format(
               "[>%d mins old] ",
-              Duration.ofMillis(egressEvent.getTimeWindowDuration()).toMinutes());
+              Duration.ofSeconds(egressEvent.getTimeWindowDuration()).toMinutes());
     }
 
     return new CreateAlertRequest()

--- a/api/src/test/java/org/pmiops/workbench/opsgenie/EgressEventServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/opsgenie/EgressEventServiceTest.java
@@ -66,7 +66,7 @@ public class EgressEventServiceTest {
           .vmPrefix("all-of-us-111")
           .egressMib(120.7)
           .egressMibThreshold(100.0)
-          .timeWindowStart(NOW.minusMillis(700L).toEpochMilli())
+          .timeWindowStart(NOW.minusSeconds(630).toEpochMilli())
           .timeWindowDuration(600L);
   private static final Clock CLOCK = new FakeClock(NOW);
 
@@ -247,7 +247,7 @@ public class EgressEventServiceTest {
             .egressMibThreshold(100.0)
             // > 2 windows into the past
             .timeWindowStart(NOW.minus(Duration.ofMinutes(125)).toEpochMilli())
-            .timeWindowDuration(Duration.ofMinutes(60).toMillis());
+            .timeWindowDuration(Duration.ofMinutes(60).getSeconds());
 
     egressEventService.handleEvent(oldEgressEvent);
     verify(mockAlertApi).createAlert(alertRequestCaptor.capture());
@@ -271,7 +271,7 @@ public class EgressEventServiceTest {
             .egressMibThreshold(100.0)
             // > 2 windows into the past
             .timeWindowStart(NOW.minus(Duration.ofMinutes(3)).toEpochMilli())
-            .timeWindowDuration(Duration.ofMinutes(1).toMillis());
+            .timeWindowDuration(Duration.ofMinutes(1).getSeconds());
 
     egressEventService.handleEvent(oldEgressEvent);
     verify(mockAlertApi).createAlert(alertRequestCaptor.capture());


### PR DESCRIPTION
Noted during manual testing.