### PR TITLE
[RW-6397][risk=no] CB UI - change request for visits

### DIFF
--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -186,6 +186,10 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
     }
   }
 
+  sendOnlyCriteriaType(domainId) {
+    return domainId === Domain.VISIT.toString() || domainId === Domain.PHYSICALMEASUREMENT.toString();
+  }
+
   async loadRootNodes() {
     try {
       const {node: {domainId, id, isStandard, type}, selectedSurvey} = this.props;
@@ -194,8 +198,8 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
       const criteriaType = domainId === Domain.DRUG.toString() ? CriteriaType.ATC.toString() : type;
       const parentId = domainId === Domain.PHYSICALMEASUREMENT.toString() ? null : id;
 
-      const promises = (domainId === Domain.VISIT.toString())
-          ? [cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard)]
+      const promises = this.sendOnlyCriteriaType(domainId)
+          ? [cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType)]
           : [cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard, parentId)];
       if (this.criteriaLookupNeeded) {
         const criteriaRequest = {

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -193,7 +193,10 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
       const {cdrVersionId} = currentWorkspaceStore.getValue();
       const criteriaType = domainId === Domain.DRUG.toString() ? CriteriaType.ATC.toString() : type;
       const parentId = domainId === Domain.PHYSICALMEASUREMENT.toString() ? null : id;
-      const promises = [cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard, parentId)];
+
+      const promises = (domainId === Domain.VISIT.toString())
+          ? [cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard)]
+          : [cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard, parentId)];
       if (this.criteriaLookupNeeded) {
         const criteriaRequest = {
           sourceConceptIds: currentCohortCriteriaStore.getValue().filter(s => !s.isStandard).map(s => s.conceptId),

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -196,11 +196,9 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
       this.setState({loading: true});
       const {cdrVersionId} = currentWorkspaceStore.getValue();
       const criteriaType = domainId === Domain.DRUG.toString() ? CriteriaType.ATC.toString() : type;
-      const parentId = domainId === Domain.PHYSICALMEASUREMENT.toString() ? null : id;
-
       const promises = this.sendOnlyCriteriaType(domainId)
           ? [cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType)]
-          : [cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard, parentId)];
+          : [cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard, id)];
       if (this.criteriaLookupNeeded) {
         const criteriaRequest = {
           sourceConceptIds: currentCohortCriteriaStore.getValue().filter(s => !s.isStandard).map(s => s.conceptId),


### PR DESCRIPTION
Description from ticket:
_When you select "visits" from add criteria and you are sending request to the API to get the list of visits, only send the domain and type which both = "VISIT". Remove parent_id = 0 as a query parameter_


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
