### PR TITLE
[risk=low][no ticket] Don't NPE for this config mismatch.  Also, buffer some Perf CT projects.

### DIFF
--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -27,7 +27,8 @@
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
     "retryCount": 4,
     "bufferCapacityPerTier": {
-      "registered": 300
+      "registered": 300,
+      "controlled": 20
     },
     "bufferRefillProjectsPerTask": 5,
     "bufferStatusChecksPerTask": 10,

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -327,10 +327,11 @@ public class BillingProjectBufferService implements GaugeDataCollector {
         workbenchConfigProvider.get().billing.bufferCapacityPerTier;
 
     if (!capacityPerTier.containsKey(accessTierShortName)) {
-      log.log(
-          Level.SEVERE,
-          "Workbench Config Error: no 'billing.bufferCapacityPerTier' entry for '%s' tier",
-          accessTierShortName);
+      final String message =
+          String.format(
+              "Workbench Config Error: no 'billing.bufferCapacityPerTier' entry for '%s' tier",
+              accessTierShortName);
+      log.severe(message);
       return 0;
     }
 

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -322,6 +322,11 @@ public class BillingProjectBufferService implements GaugeDataCollector {
   }
 
   private int getBufferMaxCapacity(String accessTierShortName) {
+    if (!workbenchConfigProvider.get().billing.bufferCapacityPerTier.containsKey(accessTierShortName)) {
+      log.log(Level.SEVERE, "Workbench Config Error: no 'billing.bufferCapacityPerTier' entry for '%s' tier", accessTierShortName);
+      return 0;
+    }
+
     return workbenchConfigProvider.get().billing.bufferCapacityPerTier.get(accessTierShortName);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -322,12 +323,18 @@ public class BillingProjectBufferService implements GaugeDataCollector {
   }
 
   private int getBufferMaxCapacity(String accessTierShortName) {
-    if (!workbenchConfigProvider.get().billing.bufferCapacityPerTier.containsKey(accessTierShortName)) {
-      log.log(Level.SEVERE, "Workbench Config Error: no 'billing.bufferCapacityPerTier' entry for '%s' tier", accessTierShortName);
+    Map<String, Integer> capacityPerTier =
+        workbenchConfigProvider.get().billing.bufferCapacityPerTier;
+
+    if (!capacityPerTier.containsKey(accessTierShortName)) {
+      log.log(
+          Level.SEVERE,
+          "Workbench Config Error: no 'billing.bufferCapacityPerTier' entry for '%s' tier",
+          accessTierShortName);
       return 0;
     }
 
-    return workbenchConfigProvider.get().billing.bufferCapacityPerTier.get(accessTierShortName);
+    return capacityPerTier.get(accessTierShortName);
   }
 
   public BillingProjectBufferStatus getStatus() {


### PR DESCRIPTION
Description:

If an Access Tier is added to an environment's cdr_config.json without a corresponding config_json change to add the tier to the billing buffer capacity map, we hit an NPE preventing *all* billing project creation.

This change ensures that we don't NPE if we have a config mismatch.  I tested that a config mismatch in the other direction causes no problems.

TODO is there a better way to ensure config consistency here?  Maybe buffer capacity can live in the cdr_config?  Or maybe this is moot after Terra-PPW - we may not need a buffer then, depending on Terra performance.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
