### PR TITLE
[risk=no][no ticket] Move access determination tests to a separate test class

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -1,0 +1,238 @@
+package org.pmiops.workbench.access;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pmiops.workbench.actionaudit.Agent;
+import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
+import org.pmiops.workbench.compliance.ComplianceService;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.AccessTierDao;
+import org.pmiops.workbench.db.dao.UserAccessTierDao;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.UserService;
+import org.pmiops.workbench.db.dao.UserServiceImpl;
+import org.pmiops.workbench.db.model.DbAccessTier;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserAccessTier;
+import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.model.EmailVerificationStatus;
+import org.pmiops.workbench.model.TierAccessStatus;
+import org.pmiops.workbench.test.FakeClock;
+import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
+import org.pmiops.workbench.utils.TestMockFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * Tests to cover access change determinations by executing {@link
+ * UserService#updateUserWithRetries(java.util.function.Function,
+ * org.pmiops.workbench.db.model.DbUser, org.pmiops.workbench.actionaudit.Agent)} with different
+ * configurations, which ultimately executes the private method {@link
+ * UserServiceImpl#shouldUserBeRegistered(org.pmiops.workbench.db.model.DbUser)} to make this
+ * determination:
+ *
+ * <pre>{@code
+ * return !user.getDisabled()
+ *   && complianceTrainingCompliant
+ *   && eraCommonsCompliant
+ *   && betaAccessGranted
+ *   && twoFactorAuthComplete
+ *   && dataUseAgreementCompliant
+ *   && EmailVerificationStatus.SUBSCRIBED.equals(
+ *     user.getEmailVerificationStatusEnum());
+ * }</pre>
+ */
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class UserServiceAccessTest {
+  private static final String USERNAME = "abc@fake-research-aou.org";
+  private static final Instant START_INSTANT = Instant.parse("2000-01-01T00:00:00.00Z");
+  private static final FakeClock PROVIDED_CLOCK = new FakeClock(START_INSTANT);
+
+  private static DbUser providedDbUser;
+  private static WorkbenchConfig providedWorkbenchConfig;
+
+  private static DbAccessTier registeredTier;
+
+  @Autowired private AccessTierDao accessTierDao;
+  @Autowired private UserAccessTierDao userAccessTierDao;
+  @Autowired private UserDao userDao;
+  @Autowired private UserService userService;
+
+  @Import({
+    UserServiceTestConfiguration.class,
+    AccessTierServiceImpl.class,
+  })
+  @MockBean({
+    ComplianceService.class,
+    DirectoryService.class,
+    FireCloudService.class,
+    UserServiceAuditor.class,
+  })
+  @TestConfiguration
+  static class Configuration {
+    @Bean
+    Clock clock() {
+      return PROVIDED_CLOCK;
+    }
+
+    @Bean
+    Random getRandom() {
+      return new Random();
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    WorkbenchConfig getWorkbenchConfig() {
+      return providedWorkbenchConfig;
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    DbUser getDbUser() {
+      return providedDbUser;
+    }
+  }
+
+  @Before
+  public void setUp() {
+    providedWorkbenchConfig = WorkbenchConfig.createEmptyConfig();
+
+    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+
+    DbUser user = new DbUser();
+    user.setUsername(USERNAME);
+    user = userDao.save(user);
+    providedDbUser = user;
+  }
+
+  @Test
+  public void test_updateUserWithRetries_register() {
+    DbUser dbUser = userDao.save(new DbUser());
+    assertThat(userAccessTierDao.findAll()).isEmpty();
+
+    dbUser = userService.updateUserWithRetries(this::registerUser, dbUser, Agent.asUser(dbUser));
+
+    assertThat(userAccessTierDao.findAll()).hasSize(1);
+    Optional<DbUserAccessTier> userAccessMaybe =
+        userAccessTierDao.getByUserAndAccessTier(dbUser, registeredTier);
+    assertThat(userAccessMaybe).isPresent();
+    assertThat(userAccessMaybe.get().getTierAccessStatusEnum()).isEqualTo(TierAccessStatus.ENABLED);
+  }
+
+  @Test
+  public void test_updateUserWithRetries_register_includes_others() {
+    providedWorkbenchConfig.featureFlags.unsafeAllowAccessToAllTiersForRegisteredUsers = true;
+
+    DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    DbAccessTier aThirdTierWhyNot =
+        accessTierDao.save(
+            new DbAccessTier()
+                .setAccessTierId(3)
+                .setShortName("three")
+                .setDisplayName("Third Tier")
+                .setAuthDomainName("Third Tier Auth Domain")
+                .setAuthDomainGroupEmail("t3-users@fake-research-aou.org")
+                .setServicePerimeter("tier/3/perimeter"));
+
+    DbUser dbUser = userDao.save(new DbUser());
+    assertThat(userAccessTierDao.findAll()).isEmpty();
+
+    dbUser = userService.updateUserWithRetries(this::registerUser, dbUser, Agent.asUser(dbUser));
+
+    List<DbAccessTier> expectedTiers =
+        ImmutableList.of(registeredTier, controlledTier, aThirdTierWhyNot);
+
+    assertThat(userAccessTierDao.findAll()).hasSize(expectedTiers.size());
+    for (DbAccessTier tier : expectedTiers) {
+      Optional<DbUserAccessTier> userAccessMaybe =
+          userAccessTierDao.getByUserAndAccessTier(dbUser, tier);
+      assertThat(userAccessMaybe).isPresent();
+      assertThat(userAccessMaybe.get().getTierAccessStatusEnum())
+          .isEqualTo(TierAccessStatus.ENABLED);
+    }
+  }
+
+  @Test
+  public void test_updateUserWithRetries_unregister() {
+    DbUser dbUser = new DbUser();
+    assertThat(userAccessTierDao.findAll()).isEmpty();
+
+    dbUser = userService.updateUserWithRetries(this::unregisterUser, dbUser, Agent.asUser(dbUser));
+
+    // the user has never been registered so they have no DbUserAccessTier entry
+
+    assertThat(userAccessTierDao.findAll()).hasSize(0);
+    Optional<DbUserAccessTier> userAccessMaybe =
+        userAccessTierDao.getByUserAndAccessTier(dbUser, registeredTier);
+    assertThat(userAccessMaybe).isEmpty();
+  }
+
+  @Test
+  public void test_updateUserWithRetries_register_then_unregister() {
+    DbUser dbUser = new DbUser();
+    assertThat(userAccessTierDao.findAll()).isEmpty();
+
+    dbUser = userService.updateUserWithRetries(this::registerUser, dbUser, Agent.asUser(dbUser));
+    dbUser = userService.updateUserWithRetries(this::unregisterUser, dbUser, Agent.asUser(dbUser));
+
+    // The user received a DbUserAccessTier when they were registered.
+    // They still have it after unregistering but now it is DISABLED.
+
+    assertThat(userAccessTierDao.findAll()).hasSize(1);
+    Optional<DbUserAccessTier> userAccessMaybe =
+        userAccessTierDao.getByUserAndAccessTier(dbUser, registeredTier);
+    assertThat(userAccessMaybe).isPresent();
+    assertThat(userAccessMaybe.get().getTierAccessStatusEnum())
+        .isEqualTo(TierAccessStatus.DISABLED);
+  }
+
+  private DbUser registerUser(DbUser user) {
+    // shouldUserBeRegistered logic:
+    //    return !user.getDisabled()
+    //        && complianceTrainingCompliant
+    //        && eraCommonsCompliant
+    //        && betaAccessGranted
+    //        && twoFactorAuthComplete
+    //        && dataUseAgreementCompliant
+    //        && EmailVerificationStatus.SUBSCRIBED.equals(user.getEmailVerificationStatusEnum());
+
+    Timestamp now = Timestamp.from(Instant.now());
+
+    user.setDisabled(false);
+    user.setEmailVerificationStatusEnum(EmailVerificationStatus.SUBSCRIBED);
+    user.setComplianceTrainingBypassTime(now);
+    user.setEraCommonsBypassTime(now);
+    user.setBetaAccessBypassTime(now);
+    user.setTwoFactorAuthBypassTime(now);
+    user.setDataUseAgreementBypassTime(now);
+
+    return userDao.save(user);
+  }
+
+  private DbUser unregisterUser(DbUser user) {
+    user.setDisabled(true);
+    return userDao.save(user);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -49,18 +49,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * org.pmiops.workbench.db.model.DbUser, org.pmiops.workbench.actionaudit.Agent)} with different
  * configurations, which ultimately executes the private method {@link
  * UserServiceImpl#shouldUserBeRegistered(org.pmiops.workbench.db.model.DbUser)} to make this
- * determination:
- *
- * <pre>{@code
- * return !user.getDisabled()
- *   && complianceTrainingCompliant
- *   && eraCommonsCompliant
- *   && betaAccessGranted
- *   && twoFactorAuthComplete
- *   && dataUseAgreementCompliant
- *   && EmailVerificationStatus.SUBSCRIBED.equals(
- *     user.getEmailVerificationStatusEnum());
- * }</pre>
+ * determination.
  */
 @RunWith(SpringRunner.class)
 @DataJpaTest

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -1,19 +1,16 @@
 package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableList;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
@@ -22,22 +19,18 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
-import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.actionaudit.targetproperties.BypassTimeTargetProperty;
 import org.pmiops.workbench.compliance.ComplianceService;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.db.model.DbUserAccessTier;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.model.Authority;
-import org.pmiops.workbench.model.EmailVerificationStatus;
-import org.pmiops.workbench.model.TierAccessStatus;
 import org.pmiops.workbench.moodle.ApiException;
 import org.pmiops.workbench.moodle.model.BadgeDetailsV2;
 import org.pmiops.workbench.test.FakeClock;
@@ -80,7 +73,6 @@ public class UserServiceTest {
   @Autowired private UserService userService;
   @Autowired private UserDao userDao;
   @Autowired private AccessTierDao accessTierDao;
-  @Autowired private UserAccessTierDao userAccessTierDao;
 
   @Import({
     UserServiceTestConfiguration.class,
@@ -447,114 +439,5 @@ public class UserServiceTest {
     for (Authority auth : Authority.values()) {
       assertThat(userService.hasAuthority(user.getUserId(), auth)).isTrue();
     }
-  }
-
-  @Test
-  public void test_updateUserWithRetries_register() {
-    DbUser dbUser = userDao.save(new DbUser());
-    assertThat(userAccessTierDao.findAll()).isEmpty();
-
-    dbUser = userService.updateUserWithRetries(this::registerUser, dbUser, Agent.asUser(dbUser));
-
-    assertThat(userAccessTierDao.findAll()).hasSize(1);
-    Optional<DbUserAccessTier> userAccessMaybe =
-        userAccessTierDao.getByUserAndAccessTier(dbUser, registeredTier);
-    assertThat(userAccessMaybe).isPresent();
-    assertThat(userAccessMaybe.get().getTierAccessStatusEnum()).isEqualTo(TierAccessStatus.ENABLED);
-  }
-
-  @Test
-  public void test_updateUserWithRetries_register_includes_others() {
-    providedWorkbenchConfig.featureFlags.unsafeAllowAccessToAllTiersForRegisteredUsers = true;
-
-    DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
-    DbAccessTier aThirdTierWhyNot =
-        accessTierDao.save(
-            new DbAccessTier()
-                .setAccessTierId(3)
-                .setShortName("three")
-                .setDisplayName("Third Tier")
-                .setAuthDomainName("Third Tier Auth Domain")
-                .setAuthDomainGroupEmail("t3-users@fake-research-aou.org")
-                .setServicePerimeter("tier/3/perimeter"));
-
-    DbUser dbUser = userDao.save(new DbUser());
-    assertThat(userAccessTierDao.findAll()).isEmpty();
-
-    dbUser = userService.updateUserWithRetries(this::registerUser, dbUser, Agent.asUser(dbUser));
-
-    List<DbAccessTier> expectedTiers =
-        ImmutableList.of(registeredTier, controlledTier, aThirdTierWhyNot);
-
-    assertThat(userAccessTierDao.findAll()).hasSize(expectedTiers.size());
-    for (DbAccessTier tier : expectedTiers) {
-      Optional<DbUserAccessTier> userAccessMaybe =
-          userAccessTierDao.getByUserAndAccessTier(dbUser, tier);
-      assertThat(userAccessMaybe).isPresent();
-      assertThat(userAccessMaybe.get().getTierAccessStatusEnum())
-          .isEqualTo(TierAccessStatus.ENABLED);
-    }
-  }
-
-  @Test
-  public void test_updateUserWithRetries_unregister() {
-    DbUser dbUser = new DbUser();
-    assertThat(userAccessTierDao.findAll()).isEmpty();
-
-    dbUser = userService.updateUserWithRetries(this::unregisterUser, dbUser, Agent.asUser(dbUser));
-
-    // the user has never been registered so they have no DbUserAccessTier entry
-
-    assertThat(userAccessTierDao.findAll()).hasSize(0);
-    Optional<DbUserAccessTier> userAccessMaybe =
-        userAccessTierDao.getByUserAndAccessTier(dbUser, registeredTier);
-    assertThat(userAccessMaybe).isEmpty();
-  }
-
-  @Test
-  public void test_updateUserWithRetries_register_then_unregister() {
-    DbUser dbUser = new DbUser();
-    assertThat(userAccessTierDao.findAll()).isEmpty();
-
-    dbUser = userService.updateUserWithRetries(this::registerUser, dbUser, Agent.asUser(dbUser));
-    dbUser = userService.updateUserWithRetries(this::unregisterUser, dbUser, Agent.asUser(dbUser));
-
-    // The user received a DbUserAccessTier when they were registered.
-    // They still have it after unregistering but now it is DISABLED.
-
-    assertThat(userAccessTierDao.findAll()).hasSize(1);
-    Optional<DbUserAccessTier> userAccessMaybe =
-        userAccessTierDao.getByUserAndAccessTier(dbUser, registeredTier);
-    assertThat(userAccessMaybe).isPresent();
-    assertThat(userAccessMaybe.get().getTierAccessStatusEnum())
-        .isEqualTo(TierAccessStatus.DISABLED);
-  }
-
-  private DbUser registerUser(DbUser user) {
-    // shouldUserBeRegistered logic:
-    //    return !user.getDisabled()
-    //        && complianceTrainingCompliant
-    //        && eraCommonsCompliant
-    //        && betaAccessGranted
-    //        && twoFactorAuthComplete
-    //        && dataUseAgreementCompliant
-    //        && EmailVerificationStatus.SUBSCRIBED.equals(user.getEmailVerificationStatusEnum());
-
-    Timestamp now = Timestamp.from(Instant.now());
-
-    user.setDisabled(false);
-    user.setEmailVerificationStatusEnum(EmailVerificationStatus.SUBSCRIBED);
-    user.setComplianceTrainingBypassTime(now);
-    user.setEraCommonsBypassTime(now);
-    user.setBetaAccessBypassTime(now);
-    user.setTwoFactorAuthBypassTime(now);
-    user.setDataUseAgreementBypassTime(now);
-
-    return userDao.save(user);
-  }
-
-  private DbUser unregisterUser(DbUser user) {
-    user.setDisabled(true);
-    return userDao.save(user);
   }
 }


### PR DESCRIPTION
Description:

Since our access determination needs will become more complex in the near future (due to Annual Renewal and Controlled Tier Beta) I'd like to add some test cases.  As a first step, this PR moves existing tests into a new file.  There's no additional test code here.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
