### PR TITLE
e2e WorkspaceEditPage.fillOutRequiredDuplicationFields()

### DIFF
--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -464,4 +464,12 @@ export default class WorkspaceEditPage extends WorkspaceBase {
     const element = Checkbox.findByName(this.page, FIELD.shareWithCollaboratorsCheckbox.textOption);
     await element.check();
   }
+
+  // Fill out only the fields needed for a successful duplication
+  async fillOutRequiredDuplicationFields(): Promise<string> {
+    await this.getWorkspaceNameTextbox().clear();
+    const workspaceName = await this.fillOutWorkspaceName();
+    await this.requestForReviewRadiobutton(false);
+    return workspaceName;
+  }
 }

--- a/e2e/tests/workspace/old-cdr-version-modal.spec.ts
+++ b/e2e/tests/workspace/old-cdr-version-modal.spec.ts
@@ -15,12 +15,14 @@ describe('OldCdrVersion Modal restrictions', () => {
     const workspacesPage = new WorkspacesPage(page);
     await workspacesPage.load();
 
+    // fill out the fields required for creation and observe that creation is enabled
     const editPage = await workspacesPage.fillOutRequiredCreationFields(makeWorkspaceName());
+    const createButton = editPage.getCreateWorkspaceButton();
+    await createButton.waitUntilEnabled();
 
     // select an old CDR Version
     await editPage.selectCdrVersion(config.altCdrVersionName);
 
-    const createButton = editPage.getCreateWorkspaceButton();
     expect(await createButton.isCursorNotAllowed()).toBe(true);
 
     // fill out the modal checkboxes
@@ -39,15 +41,16 @@ describe('OldCdrVersion Modal restrictions', () => {
     await workspaceCard.asElementHandle().hover();
     await workspaceCard.selectSnowmanMenu(MenuOption.Duplicate, { waitForNav: true });
 
-    // Fill out Workspace Name should be just enough for successful duplication
     const workspaceEditPage = new WorkspaceEditPage(page);
-    await workspaceEditPage.getWorkspaceNameTextbox().clear();
-    await workspaceEditPage.fillOutWorkspaceName();
+
+    // fill out the fields required for duplication and observe that duplication is enabled
+    await workspaceEditPage.fillOutRequiredDuplicationFields();
+    const duplicateButton = workspaceEditPage.getDuplicateWorkspaceButton();
+    await duplicateButton.waitUntilEnabled();
 
     // change CDR Version
     await workspaceEditPage.selectCdrVersion(config.altCdrVersionName);
 
-    const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
-    expect(await finishButton.isCursorNotAllowed()).toBe(true);
+    expect(await duplicateButton.isCursorNotAllowed()).toBe(true);
   });
 });

--- a/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
@@ -20,10 +20,12 @@ describe('Duplicate workspace, changing CDR versions', () => {
     await workspaceCard.asElementHandle().hover();
     await workspaceCard.selectSnowmanMenu(MenuOption.Duplicate, { waitForNav: true });
 
-    // Fill out Workspace Name should be just enough for successful duplication
     const workspaceEditPage = new WorkspaceEditPage(page);
-    await workspaceEditPage.getWorkspaceNameTextbox().clear();
-    const duplicateWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
+
+    // fill out the fields required for duplication and observe that duplication is enabled
+    const duplicateWorkspaceName = await workspaceEditPage.fillOutRequiredDuplicationFields();
+    const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
+    await finishButton.waitUntilEnabled();
 
     // change CDR Version
     await workspaceEditPage.selectCdrVersion(config.altCdrVersionName);
@@ -32,8 +34,6 @@ describe('Duplicate workspace, changing CDR versions', () => {
     const modal = new OldCdrVersionModal(page);
     await modal.consentToOldCdrRestrictions();
 
-    const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
-    await workspaceEditPage.requestForReviewRadiobutton(false);
     await finishButton.waitUntilEnabled();
     await workspaceEditPage.clickCreateFinishButton(finishButton);
 
@@ -63,10 +63,12 @@ describe('Duplicate workspace, changing CDR versions', () => {
     await workspaceCard.asElementHandle().hover();
     await workspaceCard.selectSnowmanMenu(MenuOption.Duplicate, { waitForNav: true });
 
-    // Fill out Workspace Name should be just enough for successful duplication
     const workspaceEditPage = new WorkspaceEditPage(page);
-    await workspaceEditPage.getWorkspaceNameTextbox().clear();
-    const duplicateWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
+
+    // fill out the fields required for duplication and observe that duplication is enabled
+    const duplicateWorkspaceName = await workspaceEditPage.fillOutRequiredDuplicationFields();
+    const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
+    await finishButton.waitUntilEnabled();
 
     // change CDR Version
     await workspaceEditPage.selectCdrVersion(config.defaultCdrVersionName);
@@ -75,8 +77,6 @@ describe('Duplicate workspace, changing CDR versions', () => {
     expect(upgradeMessage).toContain(originalWorkspaceName2);
     expect(upgradeMessage).toContain(`${config.altCdrVersionName} to ${config.defaultCdrVersionName}.`);
 
-    const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
-    await workspaceEditPage.requestForReviewRadiobutton(false);
     await finishButton.waitUntilEnabled();
     await workspaceEditPage.clickCreateFinishButton(finishButton);
 

--- a/e2e/tests/workspace/workspace-duplicate.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate.spec.ts
@@ -25,14 +25,13 @@ describe('Duplicate workspace', () => {
     await workspaceCard.asElementHandle().hover();
     await workspaceCard.selectSnowmanMenu(MenuOption.Duplicate, { waitForNav: true });
 
-    // Fill out Workspace Name should be just enough for successful duplication
     const workspaceEditPage = new WorkspaceEditPage(page);
-    await workspaceEditPage.getWorkspaceNameTextbox().clear();
-    const duplicateWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
 
+    // fill out the fields required for duplication and observe that duplication is enabled
+    const duplicateWorkspaceName = await workspaceEditPage.fillOutRequiredDuplicationFields();
     const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
-    await workspaceEditPage.requestForReviewRadiobutton(false);
     await finishButton.waitUntilEnabled();
+
     await workspaceEditPage.clickCreateFinishButton(finishButton);
 
     // Duplicate workspace Data page is loaded.
@@ -61,15 +60,8 @@ describe('Duplicate workspace', () => {
     const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
     expect(await finishButton.isCursorNotAllowed()).toBe(true);
 
-    // Fill out Workspace Name
-    await workspaceEditPage.getWorkspaceNameTextbox().clear();
-    await workspaceEditPage.fillOutWorkspaceName();
-    // select "Share workspace with same set of collaborators radiobutton
-    await workspaceEditPage.clickShareWithCollaboratorsCheckbox();
-
-    await workspaceEditPage.requestForReviewRadiobutton(false);
+    // fill out the fields required for duplication and observe that duplication is enabled
+    await workspaceEditPage.fillOutRequiredDuplicationFields();
     await finishButton.waitUntilEnabled();
-    expect(await finishButton.isCursorNotAllowed()).toBe(false);
-    // Click Finish button to clone workspace is not needed.
   });
 });


### PR DESCRIPTION
- update duplication tests to use it

Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
