### PR TITLE
[risk=no][no ticket] Set the CDR Version ID correctly when clicking cancel on the old-cdr-modal

### DIFF
--- a/e2e/app/modal/old-cdr-version-modal.ts
+++ b/e2e/app/modal/old-cdr-version-modal.ts
@@ -21,6 +21,9 @@ const FIELD = {
   },
   continueButton: {
     textOption: { name: LinkText.Continue }
+  },
+  cancelButton: {
+    textOption: { name: LinkText.Cancel }
   }
 };
 
@@ -47,6 +50,10 @@ export default class OldCdrVersionModal extends Modal {
 
   getContinueButton(): Button {
     return Button.findByName(this.page, FIELD.continueButton.textOption, this);
+  }
+
+  getCancelButton(): Button {
+    return Button.findByName(this.page, FIELD.cancelButton.textOption, this);
   }
 
   /**

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -464,4 +464,12 @@ export default class WorkspaceEditPage extends WorkspaceBase {
     const element = Checkbox.findByName(this.page, FIELD.shareWithCollaboratorsCheckbox.textOption);
     await element.check();
   }
+
+  // Fill out only the fields needed for a successful duplication
+  async fillOutRequiredDuplicationFields(): Promise<string> {
+    await this.getWorkspaceNameTextbox().clear();
+    const workspaceName = await this.fillOutWorkspaceName();
+    await this.requestForReviewRadiobutton(false);
+    return workspaceName;
+  }
 }

--- a/e2e/tests/workspace/old-cdr-version-modal.spec.ts
+++ b/e2e/tests/workspace/old-cdr-version-modal.spec.ts
@@ -50,4 +50,29 @@ describe('OldCdrVersion Modal restrictions', () => {
     const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
     expect(await finishButton.isCursorNotAllowed()).toBe(true);
   });
+
+  test('OWNER cannot bypass older CDR Version restrictions by clicking cancel', async () => {
+    const workspaceCard = await findOrCreateWorkspaceCard(page, { workspaceName: workspace });
+    await workspaceCard.asElementHandle().hover();
+    await workspaceCard.selectSnowmanMenu(MenuOption.Duplicate, { waitForNav: true });
+
+    const workspaceEditPage = new WorkspaceEditPage(page);
+
+    // fill out the fields required for duplication and observe that duplication is enabled
+    await workspaceEditPage.fillOutRequiredDuplicationFields();
+    const duplicateButton = workspaceEditPage.getDuplicateWorkspaceButton();
+    await duplicateButton.waitUntilEnabled();
+
+    // change CDR Version
+    await workspaceEditPage.selectCdrVersion(config.altCdrVersionName);
+    expect(await duplicateButton.isCursorNotAllowed()).toBe(true);
+
+    const modal = new OldCdrVersionModal(page);
+    const cancelButton = await modal.getCancelButton();
+    await cancelButton.click();
+
+    // the CDR version is forcibly reverted back to the default
+    const cdrVersionSelect = await workspaceEditPage.getCdrVersionSelect();
+    expect(await cdrVersionSelect.getSelectedValue()).toBe(config.defaultCdrVersionName);
+  });
 });

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1022,7 +1022,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
             <OldCdrVersionModal
                 onCancel={() => {
                   this.setState(fp.set(['workspace', 'cdrVersionId'],
-                    getDefaultCdrVersionForTier(this.state.workspace, cdrVersionTiersResponse)));
+                    getDefaultCdrVersionForTier(this.state.workspace, cdrVersionTiersResponse).cdrVersionId));
                   this.setState({showCdrVersionModal: false});
                 }}
                 onContinue={() => this.setState({showCdrVersionModal: false})}


### PR DESCRIPTION
Description:

Fixes a bug introduced in #4844

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
