### PR TITLE
[no ticket][risk=no] Puppeteer workspace-duplicate flaky test fix

### DIFF
--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -211,10 +211,4 @@ export default class WorkspaceCard extends CardBase {
     }
   }
 
-  async waitUntilGone(workspaceName: string, timeout: 60000): Promise<void> {
-    const selector =
-      `${WorkspaceCardSelector.cardRootXpath}//*[${WorkspaceCardSelector.cardNameXpath}` +
-      ` and normalize-space(text())="${workspaceName}"]`;
-    await this.page.waitForXPath(selector, { hidden: true, timeout });
-  }
 }

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -31,7 +31,9 @@ export default class WorkspaceCard extends CardBase {
     const card = await WorkspaceCard.findCard(page, workspaceName);
     await card.selectSnowmanMenu(MenuOption.Delete, { waitForNav: false });
     // Handle Delete Confirmation modal
-    return new WorkspaceEditPage(page).dismissDeleteWorkspaceModal();
+    const modalText = new WorkspaceEditPage(page).dismissDeleteWorkspaceModal();
+    await WorkspaceCard.waitUntilGone(page, workspaceName);
+    return modalText;
   }
 
   /**
@@ -85,6 +87,13 @@ export default class WorkspaceCard extends CardBase {
     }
     logger.info(`"${workspaceName}" workspace card not found`);
     return null; // not found
+  }
+
+  static async waitUntilGone(page: Page, workspaceName: string, timeout = 60000): Promise<void> {
+    const selector =
+      `${WorkspaceCardSelector.cardRootXpath}//*[${WorkspaceCardSelector.cardNameXpath}` +
+      ` and normalize-space(text())="${workspaceName}"]`;
+    await page.waitForXPath(selector, { hidden: true, timeout });
   }
 
   constructor(page: Page) {
@@ -200,5 +209,12 @@ export default class WorkspaceCard extends CardBase {
       expect(await snowmanMenu.isOptionDisabled(MenuOption.Delete)).toBe(false);
       expect(await snowmanMenu.isOptionDisabled(MenuOption.Duplicate)).toBe(false);
     }
+  }
+
+  async waitUntilGone(workspaceName: string, timeout: 60000): Promise<void> {
+    const selector =
+      `${WorkspaceCardSelector.cardRootXpath}//*[${WorkspaceCardSelector.cardNameXpath}` +
+      ` and normalize-space(text())="${workspaceName}"]`;
+    await this.page.waitForXPath(selector, { hidden: true, timeout });
   }
 }

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -258,11 +258,12 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
    */
   async dismissDeleteWorkspaceModal(clickButtonText: LinkText = LinkText.DeleteWorkspace): Promise<string[]> {
     const modal = new Modal(this.page);
+    const modalText = await modal.getTextContent();
     const textBox = modal.waitForTextbox('type DELETE to confirm');
     await textBox.type('delete');
     await modal.clickButton(clickButtonText, { waitForClose: true });
     await waitWhileLoading(this.page);
-    return undefined;
+    return modalText;
   }
 
   /**

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -271,10 +271,7 @@ export default class WorkspaceEditPage extends WorkspaceBase {
     // Wait for Workspace name text-field, Billing Account Select.
     await Promise.all([this.getWorkspaceNameTextbox().waitForXPath(), select.waitForXPath()]);
     // Build Workspace page is used for Duplicate and Create. Wait for Create or Duplicate button.
-    await Promise.race([
-      this.getCreateWorkspaceButton().waitForXPath({}),
-      this.getDuplicateWorkspaceButton().waitForXPath({})
-    ]);
+    await this.getCancelButton().waitForXPath();
     return true;
   }
 

--- a/e2e/tests/workspace/workspace-duplicate.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate.spec.ts
@@ -46,6 +46,7 @@ describe('Duplicate workspace', () => {
     await workspacesPage.waitForLoad();
 
     await WorkspaceCard.deleteWorkspace(page, duplicateWorkspaceName);
+    await workspacesPage.waitForLoad();
     expect(await WorkspaceCard.findCard(page, duplicateWorkspaceName)).toBeFalsy();
   });
 
@@ -66,10 +67,14 @@ describe('Duplicate workspace', () => {
     await workspaceEditPage.fillOutWorkspaceName();
     // select "Share workspace with same set of collaborators radiobutton
     await workspaceEditPage.clickShareWithCollaboratorsCheckbox();
-
     await workspaceEditPage.requestForReviewRadiobutton(false);
     await finishButton.waitUntilEnabled();
     expect(await finishButton.isCursorNotAllowed()).toBe(false);
-    // Click Finish button to clone workspace is not needed.
+
+    // Click CANCEL button.
+    const cancelButton = workspaceEditPage.getCancelButton();
+    await cancelButton.clickAndWait();
+
+    await dataPage.waitForLoad();
   });
 });

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -378,7 +378,6 @@ export async function waitWhileLoading(
   opts: { waitForRuntime?: boolean } = {}
 ): Promise<void> {
   const { waitForRuntime = false } = opts;
-
   const notBlankPageSelector = '[data-test-id="sign-in-container"], title:not(empty), div.spinner, svg[viewBox]';
   const spinElementsSelector = `[style*="running spin"], .spinner:empty, [style*="running rotation"]${
     waitForRuntime ? '' : ':not([aria-hidden="true"]):not([data-test-id="runtime-status-icon"])'
@@ -388,20 +387,21 @@ export async function waitWhileLoading(
   await Promise.race([page.waitForSelector(notBlankPageSelector), page.waitForSelector(spinElementsSelector)]);
 
   // Wait for spinners stop and gone.
-  await page
-    .waitForFunction(
+  await Promise.all([
+    page.waitForFunction(
       (css) => {
-        const elements = document.querySelectorAll(css);
-        return elements && elements.length === 0;
+        return !document.querySelectorAll(css).length;
       },
       { polling: 'mutation', timeout },
       spinElementsSelector
-    )
-    .catch((err) => {
-      logger.error(`waitWhileLoading() failed: spinner xpath="${spinElementsSelector}"`);
-      logger.error(err);
-      throw new Error(err);
-    });
+    ),
+    page.waitForSelector(spinElementsSelector, { hidden: true, timeout })
+  ]).catch((err) => {
+    logger.error(`waitWhileLoading() failed: spinner xpath="${spinElementsSelector}"`);
+    logger.error(err);
+    logger.error(err.stack);
+    throw new Error(err);
+  });
 
   await page.waitForTimeout(500);
 }


### PR DESCRIPTION
When deleting a Workspace in "Your Workspaces" page, test can fail because the Workspace card can take a while to be removed in UI.