### PR TITLE
[risk=moderate][RW-6300] Access Tier dropdown for Create Workspace

### DIFF
--- a/api/config/cdr_config_local.json
+++ b/api/config/cdr_config_local.json
@@ -11,7 +11,7 @@
     {
       "accessTierId": 2,
       "shortName": "controlled",
-      "displayName": "Fake Controlled Tier For Test/Local",
+      "displayName": "Controlled Tier",
       "servicePerimeter": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test_2",
       "authDomainName": "all-of-us-test-prototype-3",
       "authDomainGroupEmail": "all-of-us-test-prototype-3@dev.test.firecloud.org"

--- a/api/config/cdr_config_local.json
+++ b/api/config/cdr_config_local.json
@@ -22,6 +22,7 @@
       "cdrVersionId": 1,
       "name": "[Removed] Synthetic Dataset v1",
       "archivalStatus": 1,
+      "accessTier": "registered",
       "bigqueryProject": "",
       "bigqueryDataset": "",
       "creationTime": "2018-06-06 00:00:00Z",
@@ -30,13 +31,13 @@
       "cdrDbName": "cdr",
       "elasticIndexBaseName": "cdr",
       "hasFitbitData": false,
-      "hasCopeSurveyData": false,
-      "accessTier": "registered"
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 2,
       "name": "[Removed] Synthetic Dataset v2",
       "archivalStatus": 1,
+      "accessTier": "registered",
       "bigqueryProject": "",
       "bigqueryDataset": "",
       "creationTime": "2018-06-06 00:00:00Z",
@@ -45,12 +46,12 @@
       "cdrDbName": "cdr",
       "elasticIndexBaseName": "cdr",
       "hasFitbitData": false,
-      "hasCopeSurveyData": false,
-      "accessTier": "registered"
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 3,
       "isDefault": true,
+      "accessTier": "registered",
       "name": "Synthetic Dataset v3",
       "bigqueryProject": "fc-aou-cdr-synth-test",
       "bigqueryDataset": "test_R2019q4r3",
@@ -60,14 +61,14 @@
       "cdrDbName": "cdr",
       "elasticIndexBaseName": "cdr",
       "hasFitbitData": true,
-      "hasCopeSurveyData": true,
-      "accessTier": "registered"
+      "hasCopeSurveyData": true
     },
     {
       "cdrVersionId": 4,
       "isDefault": false,
       "archivalStatus": 1,
       "name": "[Removed] Synthetic Dataset v3 with Microarray",
+      "accessTier": "registered",
       "bigqueryProject": "",
       "bigqueryDataset": "",
       "creationTime": "2020-08-26 00:09:51Z",
@@ -76,12 +77,12 @@
       "cdrDbName": "cdr",
       "elasticIndexBaseName": "cdr",
       "hasFitbitData": true,
-      "hasCopeSurveyData": true,
-      "accessTier": "registered"
+      "hasCopeSurveyData": true
     },
     {
       "cdrVersionId": 5,
       "isDefault": true,
+      "accessTier": "controlled",
       "name": "Synthetic Dataset in the Controlled Tier",
       "bigqueryProject": "fc-aou-cdr-synth-test-2",
       "bigqueryDataset": "test_R2019q4r3",
@@ -91,12 +92,12 @@
       "cdrDbName": "cdr",
       "elasticIndexBaseName": "cdr",
       "hasFitbitData": true,
-      "hasCopeSurveyData": true,
-      "accessTier": "controlled"
+      "hasCopeSurveyData": true
     },
     {
       "cdrVersionId": 6,
       "isDefault": false,
+      "accessTier": "registered",
       "name": "Synthetic Dataset v3 with WGS",
       "bigqueryProject": "fc-aou-cdr-synth-test",
       "bigqueryDataset": "test_R2019q4r3",
@@ -107,8 +108,22 @@
       "cdrDbName": "cdr",
       "elasticIndexBaseName": "cdr",
       "hasFitbitData": true,
-      "hasCopeSurveyData": true,
-      "accessTier": "registered"
+      "hasCopeSurveyData": true
+    },
+    {
+      "cdrVersionId": 7,
+      "isDefault": false,
+      "accessTier": "controlled",
+      "name": "Outdated CT CDR",
+      "bigqueryProject": "fc-aou-cdr-synth-test-2",
+      "bigqueryDataset": "test_R2019q4r3",
+      "creationTime": "2020-08-26 00:09:51Z",
+      "releaseNumber": 3,
+      "numParticipants": 234525,
+      "cdrDbName": "cdr",
+      "elasticIndexBaseName": "cdr",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     }
   ]
 }

--- a/api/config/cdr_config_perf.json
+++ b/api/config/cdr_config_perf.json
@@ -11,7 +11,7 @@
     {
       "accessTierId": 2,
       "shortName": "controlled",
-      "displayName": "Fake Controlled Tier For Perf",
+      "displayName": "Controlled Tier",
       "servicePerimeter": "accessPolicies/228353087260/servicePerimeters/terra_perf_aou_perf_2",
       "authDomainName": "all-of-us-controlled-perf",
       "authDomainGroupEmail": "all-of-us-controlled-perf@perf.test.firecloud.org"

--- a/api/config/cdr_config_staging.json
+++ b/api/config/cdr_config_staging.json
@@ -11,7 +11,7 @@
     {
       "accessTierId": 2,
       "shortName": "controlled",
-      "displayName": "Fake Controlled Tier For Staging",
+      "displayName": "Controlled Tier",
       "servicePerimeter": "accessPolicies/357236995176/servicePerimeters/terra_prod_aou_staging",
       "authDomainName": "all-of-us-controlled-staging",
       "authDomainGroupEmail": "all-of-us-controlled-staging@firecloud.org"

--- a/api/config/cdr_config_test.json
+++ b/api/config/cdr_config_test.json
@@ -11,7 +11,7 @@
     {
       "accessTierId": 2,
       "shortName": "controlled",
-      "displayName": "Fake Controlled Tier For Test/Local",
+      "displayName": "Controlled Tier",
       "servicePerimeter": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test_2",
       "authDomainName": "all-of-us-test-prototype-3",
       "authDomainGroupEmail": "all-of-us-test-prototype-3@dev.test.firecloud.org"

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
@@ -160,6 +160,7 @@ public class CdrVersionService {
                 .map(cdrVersionMapper::dbModelToClient)
                 .collect(Collectors.toList()))
         .defaultCdrVersionId(String.valueOf(defaultVersions.get(0)))
-        .accessTierShortName(accessTier.getShortName());
+        .accessTierShortName(accessTier.getShortName())
+        .accessTierDisplayName(accessTier.getDisplayName());
   }
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3807,10 +3807,13 @@ definitions:
     type: object
     required:
       - accessTierShortName
+      - accessTierDisplayName
       - defaultCdrVersionId
       - versions
     properties:
       accessTierShortName:
+        type: string
+      accessTierDisplayName:
         type: string
       defaultCdrVersionId:
         type: string

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -756,18 +756,19 @@ public class WorkspacesControllerTest extends SpringTest {
     assertThat(requestedWorkspace.getAccessTierShortName()).isNull();
     requestedWorkspace.setAccessTierShortName("some nonsense value!");
 
-    final Workspace createdWorkspace = workspacesController.createWorkspace(requestedWorkspace).getBody();
+    final Workspace createdWorkspace =
+        workspacesController.createWorkspace(requestedWorkspace).getBody();
     assertThat(createdWorkspace.getAccessTierShortName()).isEqualTo(accessTier.getShortName());
-}
+  }
 
   @Test
   public void testCreateWorkspace_accessTierIgnored_controlled() {
     final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
 
-    DbCdrVersion controlledTierCdr = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao, 2);
+    DbCdrVersion controlledTierCdr =
+        TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao, 2);
     controlledTierCdr.setAccessTier(controlledTier);
     controlledTierCdr = cdrVersionDao.save(controlledTierCdr);
-
 
     final Workspace requestedWorkspace = createWorkspace();
     assertThat(requestedWorkspace.getAccessTierShortName()).isNull();
@@ -776,7 +777,8 @@ public class WorkspacesControllerTest extends SpringTest {
     // even if we pretend it's registered - the CDR Version will override this
     requestedWorkspace.setAccessTierShortName(AccessTierService.REGISTERED_TIER_SHORT_NAME);
 
-    final Workspace createdWorkspace = workspacesController.createWorkspace(requestedWorkspace).getBody();
+    final Workspace createdWorkspace =
+        workspacesController.createWorkspace(requestedWorkspace).getBody();
     assertThat(createdWorkspace.getAccessTierShortName()).isEqualTo(controlledTier.getShortName());
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -613,6 +613,7 @@ public class WorkspacesControllerTest extends SpringTest {
     assertThat(workspace2.getCreationTime()).isEqualTo(NOW_TIME);
     assertThat(workspace2.getLastModifiedTime()).isEqualTo(NOW_TIME);
     assertThat(workspace2.getCdrVersionId()).isEqualTo(cdrVersionId);
+    assertThat(workspace2.getAccessTierShortName()).isEqualTo(accessTier.getShortName());
     assertThat(workspace2.getCreator()).isEqualTo(LOGGED_IN_USER_EMAIL);
     assertThat(workspace2.getId()).isEqualTo("name");
     assertThat(workspace2.getName()).isEqualTo("name");
@@ -744,6 +745,39 @@ public class WorkspacesControllerTest extends SpringTest {
     Workspace workspace = createWorkspace();
     workspace.setCdrVersionId(archivedCdrVersionId);
     workspacesController.createWorkspace(workspace).getBody();
+  }
+
+  // we do not actually use the accessTierShortName of the Workspace passed to
+  // createWorkspace() - instead we derive it from the cdrVersionId
+
+  @Test
+  public void testCreateWorkspace_accessTierIgnored() {
+    final Workspace requestedWorkspace = createWorkspace();
+    assertThat(requestedWorkspace.getAccessTierShortName()).isNull();
+    requestedWorkspace.setAccessTierShortName("some nonsense value!");
+
+    final Workspace createdWorkspace = workspacesController.createWorkspace(requestedWorkspace).getBody();
+    assertThat(createdWorkspace.getAccessTierShortName()).isEqualTo(accessTier.getShortName());
+}
+
+  @Test
+  public void testCreateWorkspace_accessTierIgnored_controlled() {
+    final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+
+    DbCdrVersion controlledTierCdr = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao, 2);
+    controlledTierCdr.setAccessTier(controlledTier);
+    controlledTierCdr = cdrVersionDao.save(controlledTierCdr);
+
+
+    final Workspace requestedWorkspace = createWorkspace();
+    assertThat(requestedWorkspace.getAccessTierShortName()).isNull();
+
+    requestedWorkspace.setCdrVersionId(String.valueOf(controlledTierCdr.getCdrVersionId()));
+    // even if we pretend it's registered - the CDR Version will override this
+    requestedWorkspace.setAccessTierShortName(AccessTierService.REGISTERED_TIER_SHORT_NAME);
+
+    final Workspace createdWorkspace = workspacesController.createWorkspace(requestedWorkspace).getBody();
+    assertThat(createdWorkspace.getAccessTierShortName()).isEqualTo(controlledTier.getShortName());
   }
 
   @Test

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -210,5 +210,4 @@ export default class WorkspaceCard extends CardBase {
       expect(await snowmanMenu.isOptionDisabled(MenuOption.Duplicate)).toBe(false);
     }
   }
-
 }

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -265,6 +265,17 @@ export const FIELD = {
   }
 };
 
+// matches ui/src/app/utils/access-tiers.tsx
+export enum AccessTierShortNames {
+  Registered = 'registered',
+  Controlled = 'controlled',
+}
+
+export enum AccessTierDisplayNames {
+  Registered = 'Registered Tier',
+  Controlled = 'Controlled Tier',
+}
+
 export default class WorkspaceEditPage extends WorkspaceBase {
   constructor(page: Page) {
     super(page);
@@ -279,6 +290,10 @@ export default class WorkspaceEditPage extends WorkspaceBase {
     // Build Workspace page is used for Duplicate and Create. Wait for Create or Duplicate button.
     await this.getCancelButton().waitForXPath();
     return true;
+  }
+
+  getDataAccessTierSelect(): Select {
+    return Select.findByName(this.page, FIELD.accessTierSelect.textOption);
   }
 
   /**
@@ -362,6 +377,15 @@ export default class WorkspaceEditPage extends WorkspaceBase {
   // Question 4. one of many checkboxes
   increaseWellnessResilience(): WebComponent {
     return new WebComponent(this.page, FIELD.DESCRIBE_ANTICIPATED_OUTCOMES.seeksIncreaseWellnessCheckbox.textOption);
+  }
+
+  /**
+   * Select Data Access Tier by name.
+   * @param {string} value
+   */
+  async selectAccessTier(value: string = AccessTierShortNames.Registered): Promise<string> {
+    const select = this.getDataAccessTierSelect();
+    return select.selectOption(value);
   }
 
   /**

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -20,7 +20,6 @@ export const PageTitle = 'Create|Duplicate Workspace';
 
 export const LabelAlias = {
   SELECT_BILLING: 'Select account', // select billing account
-  WORKSPACE_NAME: 'Workspace Name', // Workspace name input textbox
   RESEARCH_PURPOSE: 'Research purpose',
   EDUCATION_PURPOSE: 'Educational Purpose',
   FOR_PROFIT_PURPOSE: 'For-Profit Purpose',
@@ -67,6 +66,12 @@ export const LabelAlias = {
   SHARE_WITH_COLLABORATORS: 'Share workspace with the same set of collaborators' // visible when clone workspace
 };
 
+export const DataTestAlias = {
+  WORKSPACE_NAME: 'workspace-name',
+  ACCESS_TIER_SELECT: 'select-access-tier',
+  CDR_VERSION_SELECT: 'select-cdr-version',
+}
+
 export const FIELD = {
   createWorkspaceButton: {
     textOption: { name: LinkText.CreateWorkspace }
@@ -78,12 +83,13 @@ export const FIELD = {
     textOption: { name: LinkText.Cancel }
   },
   workspaceNameTextbox: {
-    textOption: { name: LabelAlias.WORKSPACE_NAME, ancestorLevel: 2, type: ElementType.Textbox }
+    textOption: { dataTestId: DataTestAlias.WORKSPACE_NAME, type: ElementType.Textbox }
+  },
+  accessTierSelect: {
+    textOption: { dataTestId: DataTestAlias.ACCESS_TIER_SELECT, type: ElementType.Select }
   },
   cdrVersionSelect: {
-    // Note: The CDR Version dropdown does not have a label of its own.
-    // Use the nearby Workspace Name instead.
-    textOption: { name: LabelAlias.WORKSPACE_NAME, type: ElementType.Select }
+     textOption: { dataTestId: DataTestAlias.CDR_VERSION_SELECT, type: ElementType.Select }
   },
   billingAccountSelect: {
     textOption: { name: LabelAlias.SELECT_BILLING, type: ElementType.Select }

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -69,8 +69,8 @@ export const LabelAlias = {
 export const DataTestAlias = {
   WORKSPACE_NAME: 'workspace-name',
   ACCESS_TIER_SELECT: 'select-access-tier',
-  CDR_VERSION_SELECT: 'select-cdr-version',
-}
+  CDR_VERSION_SELECT: 'select-cdr-version'
+};
 
 export const FIELD = {
   createWorkspaceButton: {
@@ -89,7 +89,7 @@ export const FIELD = {
     textOption: { dataTestId: DataTestAlias.ACCESS_TIER_SELECT, type: ElementType.Select }
   },
   cdrVersionSelect: {
-     textOption: { dataTestId: DataTestAlias.CDR_VERSION_SELECT, type: ElementType.Select }
+    textOption: { dataTestId: DataTestAlias.CDR_VERSION_SELECT, type: ElementType.Select }
   },
   billingAccountSelect: {
     textOption: { name: LabelAlias.SELECT_BILLING, type: ElementType.Select }
@@ -268,12 +268,12 @@ export const FIELD = {
 // matches ui/src/app/utils/access-tiers.tsx
 export enum AccessTierShortNames {
   Registered = 'registered',
-  Controlled = 'controlled',
+  Controlled = 'controlled'
 }
 
 export enum AccessTierDisplayNames {
   Registered = 'Registered Tier',
-  Controlled = 'Controlled Tier',
+  Controlled = 'Controlled Tier'
 }
 
 export default class WorkspaceEditPage extends WorkspaceBase {

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -383,7 +383,7 @@ export default class WorkspaceEditPage extends WorkspaceBase {
    * Select Data Access Tier by name.
    * @param {string} value
    */
-  async selectAccessTier(value: string = AccessTierShortNames.Registered): Promise<string> {
+  async selectAccessTier(value: string = AccessTierDisplayNames.Registered): Promise<string> {
     const select = this.getDataAccessTierSelect();
     return select.selectOption(value);
   }

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -5,7 +5,7 @@ import Button from 'app/element/button';
 import * as testData from 'resources/data/workspace-data';
 import { makeWorkspaceName } from 'utils/str-utils';
 import { UseFreeCredits } from 'app/page/workspace-base';
-import WorkspaceEditPage, {AccessTierDisplayNames} from 'app/page/workspace-edit-page';
+import WorkspaceEditPage, { AccessTierDisplayNames } from 'app/page/workspace-edit-page';
 import { config } from 'resources/workbench-config';
 
 describe('Creating new workspaces', () => {

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -5,7 +5,7 @@ import Button from 'app/element/button';
 import * as testData from 'resources/data/workspace-data';
 import { makeWorkspaceName } from 'utils/str-utils';
 import { UseFreeCredits } from 'app/page/workspace-base';
-import WorkspaceEditPage, {AccessTierShortNames} from 'app/page/workspace-edit-page';
+import WorkspaceEditPage, {AccessTierDisplayNames} from 'app/page/workspace-edit-page';
 import { config } from 'resources/workbench-config';
 
 describe('Creating new workspaces', () => {
@@ -97,7 +97,7 @@ describe('Creating new workspaces', () => {
     const cdrVersionSelect = await createPage.getCdrVersionSelect();
     expect(await cdrVersionSelect.getSelectedValue()).toBe(config.defaultCdrVersionName);
 
-    await createPage.selectAccessTier(AccessTierShortNames.Controlled);
+    await createPage.selectAccessTier(AccessTierDisplayNames.Controlled);
 
     // observe that the CDR Version default has changed
     const selectedCdrVersion = await cdrVersionSelect.getSelectedValue();

--- a/e2e/tests/workspace/workspace-duplicate.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate.spec.ts
@@ -30,9 +30,9 @@ describe('Duplicate workspace', () => {
     await workspaceEditPage.getWorkspaceNameTextbox().clear();
     const duplicateWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
 
-    // observe that we cannot change Data Access Tier.
+    // observe that we cannot change the Data Access Tier.
     const accessTierSelect = workspaceEditPage.getDataAccessTierSelect();
-    expect(await accessTierSelect.isCursorNotAllowed()).toEqual(true);
+    expect(await accessTierSelect.isDisabled()).toEqual(true);
 
     const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
     await workspaceEditPage.requestForReviewRadiobutton(false);

--- a/e2e/tests/workspace/workspace-duplicate.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate.spec.ts
@@ -30,6 +30,10 @@ describe('Duplicate workspace', () => {
     await workspaceEditPage.getWorkspaceNameTextbox().clear();
     const duplicateWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
 
+    // observe that we cannot change Data Access Tier.
+    const accessTierSelect = workspaceEditPage.getDataAccessTierSelect();
+    expect(await accessTierSelect.isCursorNotAllowed()).toEqual(true);
+
     const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
     await workspaceEditPage.requestForReviewRadiobutton(false);
     await finishButton.waitUntilEnabled();

--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -25,8 +25,13 @@ describe('Editing workspace via workspace card snowman menu', () => {
 
     const workspaceEditPage = new WorkspaceEditPage(page);
 
+    // Data Access Tier is readonly.
+    const accessTierSelect = workspaceEditPage.getDataAccessTierSelect();
+    expect(await accessTierSelect.isDisabled()).toEqual(true);
+
     // CDR Version Select is readonly. Get selected value.
     const cdrVersionSelect = workspaceEditPage.getCdrVersionSelect();
+    expect(await cdrVersionSelect.isDisabled()).toEqual(true);
     const selectedValue = await cdrVersionSelect.getSelectedValue();
 
     // Change question #2 answer

--- a/ui/src/app/pages/profile/data-access-panel.tsx
+++ b/ui/src/app/pages/profile/data-access-panel.tsx
@@ -3,6 +3,7 @@ import {CheckCircle, ControlledTierBadge} from 'app/components/icons';
 import {styles} from 'app/pages/profile/profile-styles';
 import colors from 'app/styles/colors';
 import * as Utils from 'app/utils';
+import {AccessTierDisplayNames} from 'app/utils/access-tiers';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 
@@ -17,7 +18,7 @@ const RegisteredTierSection = ({isInRegisteredTier = false}) => {
     gridTemplateAreas: `"regPrimary regAvailable"
                           "regSecondary regSecondary"`
   }}>
-    <div style={{...styles.inputLabel, gridArea: 'regPrimary', marginRight: '0.5rem'}}>Registered tier</div>
+    <div style={{...styles.inputLabel, gridArea: 'regPrimary', marginRight: '0.5rem'}}>{AccessTierDisplayNames.Registered}</div>
     {isInRegisteredTier
       ? <CheckCircle style={{gridArea: 'regAvailable'}} color={colors.success} size={23}/>
       : <div style={{ ...styles.dataAccessText, gridArea: 'regSecondary'}}>
@@ -39,7 +40,7 @@ const ControlledTierSection = ({ hasInstitutionalAgreement = false, isInControll
                           ". ctSecondary ctSecondary"`
   }}>
     <ControlledTierBadge style={{gridArea: 'ctBadge'}}/>
-    <div style={{...styles.inputLabel, gridArea: 'ctLabel'}}>Controlled tier</div>
+    <div style={{...styles.inputLabel, gridArea: 'ctLabel'}}>{AccessTierDisplayNames.Controlled}</div>
     {Utils.cond<React.ReactElement>(
       // TODO: Remove update href and remove _blank target from Anchor tags
       [hasInstitutionalAgreement && userRevoked, () => <React.Fragment>

--- a/ui/src/app/pages/workspace/workspace-edit-text.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit-text.tsx
@@ -1,3 +1,4 @@
+import {FlexColumn} from 'app/components/flex';
 import {TooltipTrigger} from 'app/components/popups';
 import {AoU, AouTitle} from 'app/components/text-wrappers';
 import colors from 'app/styles/colors';
@@ -8,7 +9,6 @@ import {
 } from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-
 
 export const toolTipTextDemographic = 'For example, by stratifying results based on race/ethnicity, age, ' +
     'sex, gender identity, sexual orientation, geography, disability status, access to care, ' +
@@ -140,6 +140,12 @@ export const toolTipText = {
   cdrSelect: <div>The Curated Data Repository (CDR) is where research data from the <AouTitle/> is
     stored. The CDR is periodically updated as new data becomes available for
     use. You can select which version of the CDR you wish to query in this workspace.</div>,
+  tierSelect: <FlexColumn>
+    <div style={{fontWeight: 'bold'}}>Registered Tier dataset</div>
+    <div>This dataset includes surveys, electronic health records, biosamples, and physical measurements.</div>
+    <div style={{fontWeight: 'bold'}}>Controlled Tier dataset</div>
+    <div>This dataset contains expanded participant data, including genomics. Before you can access controlled tier data,
+    your institution will need to sign an amended agreement with the All of Us Data and Research Center.</div></FlexColumn>,
   researchPurpose: <div>You are required to describe your research purpose, or the reason why you
     are conducting this study. This information, along with your name, will be posted on the
     publicly available <i>All of Us</i> website (https://www.researchallofus.org/) to inform our

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -5,7 +5,15 @@ import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore, navigate} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {DisseminateResearchEnum, ResearchOutcomeEnum, SpecificPopulationEnum,UserApi, WorkspaceAccessLevel, WorkspacesApi} from 'generated/fetch';
+import {
+  CdrVersionTier,
+  DisseminateResearchEnum,
+  ResearchOutcomeEnum,
+  SpecificPopulationEnum,
+  UserApi,
+  WorkspaceAccessLevel,
+  WorkspacesApi
+} from 'generated/fetch';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {cdrVersionTiersResponse} from 'testing/stubs/cdr-versions-api-stub';
 import {UserApiStub} from 'testing/stubs/user-api-stub';
@@ -14,7 +22,8 @@ import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
 import {WorkspaceEdit, WorkspaceEditMode} from 'app/pages/workspace/workspace-edit';
 import {WorkspaceEditSection} from 'app/pages/workspace/workspace-edit-section';
 import {CdrVersionsStubVariables} from 'testing/stubs/cdr-versions-api-stub';
-import {cdrVersionStore, serverConfigStore} from "app/utils/stores";
+import {cdrVersionStore, serverConfigStore} from 'app/utils/stores';
+import {AccessTierShortNames} from 'app/utils/access-tiers';
 
 jest.mock('app/utils/navigation', () => ({
   ...(jest.requireActual('app/utils/navigation')),
@@ -260,6 +269,29 @@ describe('WorkspaceEdit', () => {
 
     // old CDR Version warning does not appear
     expect(wrapper.find('[data-test-id="old-cdr-version-warning"]').exists()).toBeFalsy();
+  });
+
+  it('enables access tier selection on creation when multiple tiers are available', async() => {
+    workspaceEditMode = WorkspaceEditMode.Create;
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    const accessTierSelection = wrapper.find('[data-test-id="select-access-tier"]');
+    expect(accessTierSelection.exists()).toBeTruthy();
+
+    // defaults to registered
+    expect(accessTierSelection.find('select').props().value).toBe(AccessTierShortNames.Registered);
+  });
+
+  it('does not enable access tier selection on creation when multiple tiers are not available', async() => {
+    cdrVersionStore.set( {tiers: [cdrVersionTiersResponse.tiers[0]]});
+    workspaceEditMode = WorkspaceEditMode.Create;
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(wrapper.find('[data-test-id="select-access-tier"]').exists()).toBeFalsy();
   });
 
   // regression test for RW-5132

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -17,6 +17,7 @@ import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {
   altCdrVersion,
   cdrVersionTiersResponse,
+  controlledCdrVersion,
   defaultCdrVersion,
 } from 'testing/stubs/cdr-versions-api-stub';
 import {UserApiStub} from 'testing/stubs/user-api-stub';
@@ -289,30 +290,31 @@ describe('WorkspaceEdit', () => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
 
-    const accessTierSelection = wrapper.find('[data-test-id="select-access-tier"]');
+    const accessTierSelection = wrapper.find('[data-test-id="select-access-tier"]').find('select');
     expect(accessTierSelection.exists()).toBeTruthy();
 
     // defaults to registered
-    const selectionProps = accessTierSelection.find('select').props();
+    const selectionProps = accessTierSelection.props();
     expect(selectionProps.disabled).toBeFalsy();
     expect(selectionProps.value).toBe(AccessTierShortNames.Registered);
 
     // when Registered is selected, the CDR Version dropdown lists the registered tier CDR Versions
     // defaultCdrVersion and altCdrVersion, with defaultCdrVersion selected
 
-    const cdrVersionsSelect = wrapper.find('[data-test-id="select-cdr-version"]').find('select');
-    expect(cdrVersionsSelect.props().value).toBe(defaultCdrVersion.cdrVersionId);
+    const cdrVersionsSelect = () => wrapper.find('[data-test-id="select-cdr-version"]').find('select');
+    expect(cdrVersionsSelect().props().value).toBe(defaultCdrVersion.cdrVersionId);
 
-    const cdrVersionSelectOptions: Array<string> = cdrVersionsSelect.children().map(o => o.props().value);
-    expect(cdrVersionSelectOptions).toEqual([defaultCdrVersion.cdrVersionId, altCdrVersion.cdrVersionId]);
+    const cdrVersionSelectOptions = (): Array<string> => cdrVersionsSelect().children().map(o => o.props().value);
+    expect(cdrVersionSelectOptions()).toEqual([defaultCdrVersion.cdrVersionId, altCdrVersion.cdrVersionId]);
 
     // when Controlled is selected, the CDR Version dropdown lists the (one) controlled tier CDR Version
 
-    // TODO make this test work somehow - I have manually tested the functionality here
-    // accessTierSelection.simulate('change', {target: {value: AccessTierShortNames.Controlled}});
-    // await waitOneTickAndUpdate(accessTierSelection);
-    // expect(cdrVersionsSelect.props().value).toBe(controlledCdrVersion.cdrVersionId);
-    // expect(cdrVersionSelectOptions).toEqual([controlledCdrVersion.cdrVersionId]);
+    const domNode = accessTierSelection.getDOMNode() as HTMLSelectElement;
+    domNode.value = AccessTierShortNames.Controlled;
+    accessTierSelection.simulate('change', {target: domNode});
+    await waitOneTickAndUpdate(accessTierSelection);
+    expect(cdrVersionsSelect().props().value).toBe(controlledCdrVersion.cdrVersionId);
+    expect(cdrVersionSelectOptions()).toEqual([controlledCdrVersion.cdrVersionId]);
   });
 
   it('retains the tier on edit and does not permit changes - Registered', async() => {

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -13,7 +13,7 @@ import {
   WorkspaceAccessLevel,
   WorkspacesApi
 } from 'generated/fetch';
-import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
+import {simulateSelection, waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {
   altCdrVersion,
   cdrVersionTiersResponse,
@@ -309,10 +309,8 @@ describe('WorkspaceEdit', () => {
 
     // when Controlled is selected, the CDR Version dropdown lists the (one) controlled tier CDR Version
 
-    const domNode = accessTierSelection.getDOMNode() as HTMLSelectElement;
-    domNode.value = AccessTierShortNames.Controlled;
-    accessTierSelection.simulate('change', {target: domNode});
-    await waitOneTickAndUpdate(accessTierSelection);
+    await simulateSelection(accessTierSelection, AccessTierShortNames.Controlled);
+
     expect(cdrVersionsSelect().props().value).toBe(controlledCdrVersion.cdrVersionId);
     expect(cdrVersionSelectOptions()).toEqual([controlledCdrVersion.cdrVersionId]);
   });

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -998,10 +998,8 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
 
     // show the Access Tiers selection dropdown only when there are multiple tiers to choose from
     enableAccessTierSelection(): boolean {
-      const {cdrVersionTiersResponse} = this.props;
-      console.log(cdrVersionTiersResponse.tiers.length);
-      console.log(JSON.stringify(cdrVersionTiersResponse.tiers));
-      return !!cdrVersionTiersResponse && !!cdrVersionTiersResponse.tiers && cdrVersionTiersResponse.tiers.length > 1;
+      const {tiers} = this.props.cdrVersionTiersResponse || {tiers: []};
+      return tiers.length > 1;
     }
 
     render() {

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -292,7 +292,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
         showResearchPurpose: this.updateSelectedResearch(),
         showStigmatizationDetails: false,
         showUnderservedPopulationDetails: false,
-        workspace: this.createInitialWorkspaceState(),
+        workspace: this.initializeWorkspaceState(),
         workspaceCreationConflictError: false,
         workspaceCreationError: false,
         workspaceCreationErrorMessage: '',
@@ -362,6 +362,36 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       await this.fetchBillingAccounts();
     }
 
+    createWorkspace(): Workspace {
+      return {
+        name: '',
+        accessTierShortName: DEFAULT_ACCESS_TIER,
+        cdrVersionId: '',
+        researchPurpose: {
+          ancestry: false,
+          anticipatedFindings: '',
+          commercialPurpose: false,
+          controlSet: false,
+          diseaseFocusedResearch: false,
+          diseaseOfFocus: '',
+          drugDevelopment: false,
+          educational: false,
+          intendedStudy: '',
+          scientificApproach: '',
+          methodsDevelopment: false,
+          otherPopulationDetails: '',
+          otherPurpose: false,
+          otherPurposeDetails: '',
+          ethics: false,
+          populationDetails: [],
+          populationHealth: false,
+          reviewRequested: undefined,
+          socialBehavioral: false,
+          reasonForAllOfUs: '',
+        }
+      };
+    }
+
     /**
      * Creates the initial workspace state object. For a CREATE mode dialog,
      * this is effectively an empty Workspace object. For EDIT or DUPLICATE
@@ -370,38 +400,9 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
      * This is where logic lives to auto-set the CDR version and
      * "reviewRequested" flag, which depend on the workspace state & edit mode.
      */
-    createInitialWorkspaceState(): Workspace {
-      // copy the props into a new object so our modifications here don't affect them
-      let workspace: Workspace = {...this.props.workspace};
-      if (this.isMode(WorkspaceEditMode.Create)) {
-        workspace = {
-          name: '',
-          accessTierShortName: DEFAULT_ACCESS_TIER,
-          cdrVersionId: '',
-          researchPurpose: {
-            ancestry: false,
-            anticipatedFindings: '',
-            commercialPurpose: false,
-            controlSet: false,
-            diseaseFocusedResearch: false,
-            diseaseOfFocus: '',
-            drugDevelopment: false,
-            educational: false,
-            intendedStudy: '',
-            scientificApproach: '',
-            methodsDevelopment: false,
-            otherPopulationDetails: '',
-            otherPurpose: false,
-            otherPurposeDetails: '',
-            ethics: false,
-            populationDetails: [],
-            populationHealth: false,
-            reviewRequested: undefined,
-            socialBehavioral: false,
-            reasonForAllOfUs: '',
-          }
-        };
-      }
+    initializeWorkspaceState(): Workspace {
+      // create a new Workspace from scratch or copy the props into a new object so our modifications here don't affect them
+      const workspace: Workspace = this.isMode(WorkspaceEditMode.Create) ? this.createWorkspace() : {...this.props.workspace};
 
       if (!fp.includes(DisseminateResearchEnum.OTHER, workspace.researchPurpose.disseminateResearchFindingList)) {
         workspace.researchPurpose.otherDisseminateResearchFindings = '';

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -75,13 +75,19 @@ import {OldCdrVersionModal} from './old-cdr-version-modal';
 
 export const styles = reactStyles({
   categoryRow: {
-    display: 'flex', flexDirection: 'row', padding: '0.6rem 0', width: '95%'
+    display: 'flex',
+    flexDirection: 'row',
+    padding: '0.6rem 0',
+    width: '95%'
   },
   checkboxRow: {
-    display: 'inline-block', padding: '0.2rem 0', marginRight: '1rem'
+    display: 'inline-block',
+    padding: '0.2rem 0',
+    marginRight: '1rem'
   },
   checkboxStyle: {
-    marginRight: '.31667rem', zoom: '1.5'
+    marginRight: '.31667rem',
+    zoom: '1.5'
   },
   header: {
     fontWeight: 600,
@@ -139,7 +145,6 @@ export const styles = reactStyles({
     verticalAlign: 'middle',
     position: 'relative',
     overflow: 'visible',
-    width: '11.3rem',
     marginRight: '20px'
   },
   shortDescription: {
@@ -175,7 +180,6 @@ export const styles = reactStyles({
     borderColor: 'rgb(151, 151, 151)',
     borderRadius: '6px',
     height: '1.5rem',
-    width: '12rem',
   },
   researchPurposeDescription: {
     marginLeft: '-0.9rem',
@@ -201,6 +205,12 @@ export const styles = reactStyles({
     backgroundColor: colorWithWhiteness(colors.accent, 0.85),
     maxWidth: 'fit-content',
   },
+  accessTierSpacing: {
+    width: '11em',
+  },
+  cdrVersionSpacing: {
+    width: '30em',
+  }
 });
 
 const CREATE_BILLING_ACCOUNT_OPTION_VALUE = 'CREATE_BILLING_ACCOUNT_OPTION';
@@ -1071,7 +1081,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
                          onChange={v => this.setState(fp.set(['workspace', 'name'], v))}/>
             </FlexColumn>
             {this.enableAccessTierSelection() &&
-              <FlexColumn style={{marginRight: '20px'}}>
+              <FlexColumn>
                 <div style={styles.fieldHeader}>
                   Data access tier
                   <TooltipTrigger content={toolTipText.tierSelect}>
@@ -1081,8 +1091,8 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
                 <TooltipTrigger
                   content='To use a different access tier, create a new workspace.'
                   disabled={this.isMode(WorkspaceEditMode.Create)}>
-                  <div data-test-id='select-access-tier' style={styles.select}>
-                    <select style={styles.selectInput}
+                  <div data-test-id='select-access-tier' style={{...styles.select, ...styles.accessTierSpacing}}>
+                    <select style={{...styles.selectInput, ...styles.accessTierSpacing}}
                             value={accessTierShortName}
                             onChange={(v: React.FormEvent<HTMLSelectElement>) => {
                               const selectedTier = v.currentTarget.value;
@@ -1113,8 +1123,8 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
               <TooltipTrigger
                 content='To use a different dataset version, duplicate or create a new workspace.'
                 disabled={!(this.isMode(WorkspaceEditMode.Edit))}>
-              <div data-test-id='select-cdr-version' style={styles.select}>
-                <select style={styles.selectInput}
+              <div data-test-id='select-cdr-version' style={{...styles.select, ...styles.cdrVersionSpacing}}>
+                <select style={{...styles.selectInput, ...styles.cdrVersionSpacing}}
                   value={cdrVersionId}
                   onChange={(v: React.FormEvent<HTMLSelectElement>) => {
                     const selectedVersion = v.currentTarget.value;

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -996,6 +996,14 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       return validate(values, constraints, {fullMessages: false});
     }
 
+    // show the Access Tiers selection dropdown only when there are multiple tiers to choose from
+    enableAccessTierSelection(): boolean {
+      const {cdrVersionTiersResponse} = this.props;
+      console.log(cdrVersionTiersResponse.tiers.length);
+      console.log(JSON.stringify(cdrVersionTiersResponse.tiers));
+      return !!cdrVersionTiersResponse && !!cdrVersionTiersResponse.tiers && cdrVersionTiersResponse.tiers.length > 1;
+    }
+
     render() {
       const {enableBillingUpgrade} = serverConfigStore.get().config;
       const {
@@ -1064,38 +1072,39 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
                          value = {name}
                          onChange={v => this.setState(fp.set(['workspace', 'name'], v))}/>
             </FlexColumn>
-            <FlexColumn style={{marginRight: '20px'}}>
-              <div style={styles.fieldHeader}>
-                Data access tier
-                <TooltipTrigger content={toolTipText.tierSelect}>
-                  <InfoIcon style={styles.infoIcon}/>
-                </TooltipTrigger>
-              </div>
-              <TooltipTrigger
-                content='To use a different access tier, create a new workspace.'
-                disabled={this.isMode(WorkspaceEditMode.Create)}>
-                <div data-test-id='select-access-tier' style={styles.select}>
-                  <select style={styles.selectInput}
-                          value={accessTierShortName}
-                          onChange={(v: React.FormEvent<HTMLSelectElement>) => {
-                            const selectedTier = v.currentTarget.value;
-                            this.setState(fp.set(['workspace', 'accessTierShortName'], selectedTier));
-
-                            // Populate CDR Versions dropdown and set default version
-                            this.setState({cdrVersions: this.getCdrVersions(selectedTier)});
-                            this.setState(fp.set(['workspace', 'cdrVersionId'],
-                              getDefaultCdrVersionForTier(selectedTier, cdrVersionTiersResponse).cdrVersionId));
-                          }}
-                          disabled={!this.isMode(WorkspaceEditMode.Create)}>
-                    {cdrVersionTiersResponse.tiers.map((tier, i) => (
-                        <option key={tier.accessTierShortName} value={tier.accessTierShortName}>
-                          {tier.accessTierDisplayName}
-                        </option>
-                    ))}
-                  </select>
+            {this.enableAccessTierSelection() &&
+              <FlexColumn style={{marginRight: '20px'}}>
+                <div style={styles.fieldHeader}>
+                  Data access tier
+                  <TooltipTrigger content={toolTipText.tierSelect}>
+                    <InfoIcon style={styles.infoIcon}/>
+                  </TooltipTrigger>
                 </div>
-              </TooltipTrigger>
-            </FlexColumn>
+                <TooltipTrigger
+                  content='To use a different access tier, create a new workspace.'
+                  disabled={this.isMode(WorkspaceEditMode.Create)}>
+                  <div data-test-id='select-access-tier' style={styles.select}>
+                    <select style={styles.selectInput}
+                            value={accessTierShortName}
+                            onChange={(v: React.FormEvent<HTMLSelectElement>) => {
+                              const selectedTier = v.currentTarget.value;
+                              this.setState(fp.set(['workspace', 'accessTierShortName'], selectedTier));
+
+                              // Populate CDR Versions dropdown and set default version
+                              this.setState({cdrVersions: this.getCdrVersions(selectedTier)});
+                              this.setState(fp.set(['workspace', 'cdrVersionId'],
+                                getDefaultCdrVersionForTier(selectedTier, cdrVersionTiersResponse).cdrVersionId));
+                            }}
+                            disabled={!this.isMode(WorkspaceEditMode.Create)}>
+                      {cdrVersionTiersResponse.tiers.map((tier, i) => (
+                          <option key={tier.accessTierShortName} value={tier.accessTierShortName}>
+                            {tier.accessTierDisplayName}
+                          </option>
+                      ))}
+                    </select>
+                  </div>
+                </TooltipTrigger>
+              </FlexColumn>}
             <FlexColumn>
               <div style={styles.fieldHeader}>
                 Dataset version

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1099,7 +1099,8 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
                               this.setState(fp.flow(
                                 fp.set(['workspace', 'accessTierShortName'], selectedTier),
                                 fp.set(['cdrVersions'], this.getCdrVersions(selectedTier)),
-                                fp.set(['workspace', 'cdrVersionId'], getDefaultCdrVersionForTier(selectedTier, cdrVersionTiersResponse).cdrVersionId)));
+                                fp.set(['workspace', 'cdrVersionId'],
+                                  getDefaultCdrVersionForTier(selectedTier, cdrVersionTiersResponse).cdrVersionId)));
                             }}
                             disabled={!this.isMode(WorkspaceEditMode.Create)}>
                       {cdrVersionTiersResponse.tiers.map((tier, i) => (

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1096,12 +1096,10 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
                             value={accessTierShortName}
                             onChange={(v: React.FormEvent<HTMLSelectElement>) => {
                               const selectedTier = v.currentTarget.value;
-                              this.setState(fp.set(['workspace', 'accessTierShortName'], selectedTier));
-
-                              // Populate CDR Versions dropdown and set default version
-                              this.setState({cdrVersions: this.getCdrVersions(selectedTier)});
-                              this.setState(fp.set(['workspace', 'cdrVersionId'],
-                                getDefaultCdrVersionForTier(selectedTier, cdrVersionTiersResponse).cdrVersionId));
+                              this.setState(fp.flow(
+                                fp.set(['workspace', 'accessTierShortName'], selectedTier),
+                                fp.set(['cdrVersions'], this.getCdrVersions(selectedTier)),
+                                fp.set(['workspace', 'cdrVersionId'], getDefaultCdrVersionForTier(selectedTier, cdrVersionTiersResponse).cdrVersionId)));
                             }}
                             disabled={!this.isMode(WorkspaceEditMode.Create)}>
                       {cdrVersionTiersResponse.tiers.map((tier, i) => (

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1056,7 +1056,11 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
               <div style={styles.fieldHeader}>
                 Workspace name
               </div>
-              <TextInput type='text' style={styles.textInput} autoFocus placeholder='Workspace Name'
+              <TextInput data-test-id='workspace-name'
+                         type='text'
+                         style={styles.textInput}
+                         autoFocus
+                         placeholder='Workspace Name'
                          value = {name}
                          onChange={v => this.setState(fp.set(['workspace', 'name'], v))}/>
             </FlexColumn>
@@ -1070,28 +1074,28 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
               <TooltipTrigger
                 content='To use a different access tier, create a new workspace.'
                 disabled={this.isMode(WorkspaceEditMode.Create)}>
-              <div data-test-id='select-access-tier' style={styles.select}>
-                <select style={styles.selectInput}
-                        value={accessTierShortName}
-                        onChange={(v: React.FormEvent<HTMLSelectElement>) => {
-                          const selectedTier = v.currentTarget.value;
-                          this.setState(fp.set(['workspace', 'accessTierShortName'], selectedTier));
+                <div data-test-id='select-access-tier' style={styles.select}>
+                  <select style={styles.selectInput}
+                          value={accessTierShortName}
+                          onChange={(v: React.FormEvent<HTMLSelectElement>) => {
+                            const selectedTier = v.currentTarget.value;
+                            this.setState(fp.set(['workspace', 'accessTierShortName'], selectedTier));
 
-                          // Populate CDR Versions dropdown and set default version
-                          this.setState({cdrVersions: this.getCdrVersions(selectedTier)});
-                          this.setState(fp.set(['workspace', 'cdrVersionId'],
-                            getDefaultCdrVersionForTier(selectedTier, cdrVersionTiersResponse).cdrVersionId));
-                        }}
-                        disabled={!this.isMode(WorkspaceEditMode.Create)}>
-                  {cdrVersionTiersResponse.tiers.map((tier, i) => (
-                      <option key={tier.accessTierShortName} value={tier.accessTierShortName}>
-                        {tier.accessTierDisplayName}
-                      </option>
-                  ))}
-                </select>
-              </div>
-            </TooltipTrigger>
-             </FlexColumn>
+                            // Populate CDR Versions dropdown and set default version
+                            this.setState({cdrVersions: this.getCdrVersions(selectedTier)});
+                            this.setState(fp.set(['workspace', 'cdrVersionId'],
+                              getDefaultCdrVersionForTier(selectedTier, cdrVersionTiersResponse).cdrVersionId));
+                          }}
+                          disabled={!this.isMode(WorkspaceEditMode.Create)}>
+                    {cdrVersionTiersResponse.tiers.map((tier, i) => (
+                        <option key={tier.accessTierShortName} value={tier.accessTierShortName}>
+                          {tier.accessTierDisplayName}
+                        </option>
+                    ))}
+                  </select>
+                </div>
+              </TooltipTrigger>
+            </FlexColumn>
             <FlexColumn>
               <div style={styles.fieldHeader}>
                 Dataset version

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -117,7 +117,7 @@ const CdrVersion = (props: {workspace: Workspace, cdrVersionTiersResponse: CdrVe
     {getCdrVersion(workspace, cdrVersionTiersResponse).name}
     {!hasDefaultCdrVersion(workspace, cdrVersionTiersResponse) && <NewVersionFlag/>}
     {showModal && <CdrVersionUpgradeModal
-        defaultCdrVersionName={getDefaultCdrVersionForTier(workspace, cdrVersionTiersResponse).name}
+        defaultCdrVersionName={getDefaultCdrVersionForTier(workspace.accessTierShortName, cdrVersionTiersResponse).name}
         onClose={() => setShowModal(false)}
         upgrade={() => NavStore.navigate(['/workspaces', namespace, id, 'duplicate'])}
     />}

--- a/ui/src/app/utils/access-tiers.tsx
+++ b/ui/src/app/utils/access-tiers.tsx
@@ -5,6 +5,11 @@ export enum AccessTierShortNames {
     Controlled = 'controlled',
 }
 
+export enum AccessTierDisplayNames {
+    Registered = 'Registered Tier',
+    Controlled = 'Controlled Tier',
+}
+
 /**
  * Determine whether the given access level is Registered. This is required to do most things in the Workbench app
  * (outside of local/test development).

--- a/ui/src/app/utils/cdr-versions.spec.tsx
+++ b/ui/src/app/utils/cdr-versions.spec.tsx
@@ -51,15 +51,15 @@ describe('cdr-versions', () => {
     });
 
     it('should correctly get the default CDR Version for the registered tier', async () => {
-        expect(getDefaultCdrVersionForTier(testWorkspace, cdrVersionTiersResponse)).toBe(defaultCdrVersion);
+        expect(getDefaultCdrVersionForTier(AccessTierShortNames.Registered, cdrVersionTiersResponse)).toBe(defaultCdrVersion);
     });
 
     it('should correctly get the default CDR Version for the controlled tier', async () => {
-        expect(getDefaultCdrVersionForTier(ctWorkspace, cdrVersionTiersResponse)).toBe(controlledCdrVersion);
+        expect(getDefaultCdrVersionForTier(AccessTierShortNames.Controlled, cdrVersionTiersResponse)).toBe(controlledCdrVersion);
     });
 
     it('should return undefined when the tier is invalid', async () => {
-        expect(getDefaultCdrVersionForTier(testWorkspaceMissingTier, cdrVersionTiersResponse)).toBeUndefined();
+        expect(getDefaultCdrVersionForTier('invalid', cdrVersionTiersResponse)).toBeUndefined();
     });
 
     it('should detect when a Workspace has the default CDR Version for its tier', async () => {

--- a/ui/src/app/utils/cdr-versions.tsx
+++ b/ui/src/app/utils/cdr-versions.tsx
@@ -5,8 +5,8 @@ function getCdrVersionTier(accessTierShortName: string, cdrTiers: CdrVersionTier
   return cdrTiers.tiers.find(v => v.accessTierShortName === accessTierShortName);
 }
 
-function getDefaultCdrVersionForTier(workspace: Workspace, cdrTiers: CdrVersionTiersResponse): CdrVersion {
-  const tier = getCdrVersionTier(workspace.accessTierShortName, cdrTiers);
+function getDefaultCdrVersionForTier(accessTierShortName: string, cdrTiers: CdrVersionTiersResponse): CdrVersion {
+  const tier = getCdrVersionTier(accessTierShortName, cdrTiers);
   if (tier) {
     return tier.versions.find(v => v.cdrVersionId === tier.defaultCdrVersionId);
   }

--- a/ui/src/testing/react-test-helpers.ts
+++ b/ui/src/testing/react-test-helpers.ts
@@ -21,6 +21,13 @@ export async function waitForFakeTimersAndUpdate(wrapper: ReactWrapper) {
   await waitOneTickAndUpdate(wrapper);
 }
 
+export async function simulateSelection(selectElement: ReactWrapper, selection: string) {
+  const domNode = selectElement.getDOMNode() as HTMLSelectElement;
+  domNode.value = selection;
+  selectElement.simulate('change', {target: domNode});
+  await waitOneTickAndUpdate(selectElement);
+}
+
 // We only want to check against the actual text node
 // Capturing other nodes in this search will return the parent nodes as well as the text,
 // The "nodes" that exclusively have text do not have a node name and return null

--- a/ui/src/testing/stubs/cdr-versions-api-stub.ts
+++ b/ui/src/testing/stubs/cdr-versions-api-stub.ts
@@ -1,4 +1,4 @@
-import {AccessTierShortNames} from 'app/utils/access-tiers';
+import {AccessTierDisplayNames, AccessTierShortNames} from 'app/utils/access-tiers';
 import {
   ArchivalStatus,
   CdrVersionsApi,
@@ -18,6 +18,7 @@ export class CdrVersionsStubVariables {
 export const cdrVersionTiersResponse: CdrVersionTiersResponse = {
   tiers: [{
     accessTierShortName: AccessTierShortNames.Registered,
+    accessTierDisplayName: AccessTierDisplayNames.Registered,
     defaultCdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     versions: [
       {
@@ -41,6 +42,7 @@ export const cdrVersionTiersResponse: CdrVersionTiersResponse = {
     ]},
     {
       accessTierShortName: AccessTierShortNames.Controlled,
+      accessTierDisplayName: AccessTierDisplayNames.Controlled,
       defaultCdrVersionId: CdrVersionsStubVariables.CONTROLLED_TIER_CDR_VERSION_ID,
       versions: [
         {


### PR DESCRIPTION
Description:

Add an Access Tier dropdown to the Workspace Create page for environments with multiple tiers.
![Create_and_old-cdr-modal](https://user-images.githubusercontent.com/2701406/116435234-24cd1180-a819-11eb-8238-c159f4dee61f.gif)

Workspace Edit and Duplicate: show dropdown but disable - tier changes are not possible.
![Edit_Duplicate](https://user-images.githubusercontent.com/2701406/116434562-82ad2980-a818-11eb-8c17-93afcbe17796.gif)

Duplication of a CT Workspace - note that tier changing is not possible, and the "Old CDR Version" modal and the CDR Version upgrade text appear appropriately.
![CT_Duplicate](https://user-images.githubusercontent.com/2701406/116434783-b6884f00-a818-11eb-9917-ce6c99c2bacb.gif)

Prod will not have multiple tiers at this time, so the CdrVersionTiersResponse will not contain multiple tiers.  Therefore the tier choice dropdown will not appear (tested locally by hacking the local CdrVersionTiersResponse):
<img width="799" alt="Prod view - no dropdown" src="https://user-images.githubusercontent.com/2701406/116435057-f818fa00-a818-11eb-9598-97d349d55595.png">

Update tooltip location to match mocks
Before
<img width="330" alt="Before CDRV tooltip" src="https://user-images.githubusercontent.com/2701406/116434219-3a8e0700-a818-11eb-8d93-b237791dcc4b.png">
After
<img width="300" alt="after CDRV tooltip" src="https://user-images.githubusercontent.com/2701406/116434239-4083e800-a818-11eb-9c3a-6fdef4fae6cd.png">



<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
