### PR TITLE
[RW-6632][risk=no] Add genomics extract feature flag

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -119,7 +119,8 @@
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": true,
     "enableReportingUploadCron": true,
-    "enableRasLoginGovLinking": false
+    "enableRasLoginGovLinking": false,
+    "enableGenomicExtraction": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-local",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -122,7 +122,8 @@
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
     "enableReportingUploadCron": false,
-    "enableRasLoginGovLinking": false
+    "enableRasLoginGovLinking": false,
+    "enableGenomicExtraction": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-perf",

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -119,7 +119,8 @@
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
     "enableReportingUploadCron": true,
-    "enableRasLoginGovLinking": false
+    "enableRasLoginGovLinking": false,
+    "enableGenomicExtraction": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-preprod",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -118,7 +118,8 @@
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
     "enableReportingUploadCron": true,
-    "enableRasLoginGovLinking": false
+    "enableRasLoginGovLinking": false,
+    "enableGenomicExtraction": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-prod",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -118,7 +118,8 @@
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
     "enableReportingUploadCron": true,
-    "enableRasLoginGovLinking": false
+    "enableRasLoginGovLinking": false,
+    "enableGenomicExtraction": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-stable",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -119,7 +119,8 @@
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
     "enableReportingUploadCron": true,
-    "enableRasLoginGovLinking": false
+    "enableRasLoginGovLinking": false,
+    "enableGenomicExtraction": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-staging",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -119,7 +119,8 @@
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": true,
     "enableReportingUploadCron": true,
-    "enableRasLoginGovLinking": false
+    "enableRasLoginGovLinking": false,
+    "enableGenomicExtraction": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -39,6 +39,7 @@ import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.conceptset.mapper.ConceptSetMapperImpl;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.dataset.DataSetServiceImpl;
 import org.pmiops.workbench.dataset.DatasetConfig;
 import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
@@ -112,6 +113,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
   @Autowired private NotebooksService notebooksService;
   @Autowired private Provider<DbUser> userProvider;
   @Autowired private TestWorkbenchConfig testWorkbenchConfig;
+  @Autowired private Provider<WorkbenchConfig> workbenchConfigProvider;
   @Autowired private WorkspaceDao workspaceDao;
   @Autowired private WorkspaceAuthService workspaceAuthService;
   @Autowired private GenomicExtractionService genomicExtractionService;
@@ -228,7 +230,8 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                 userProvider,
                 prefixProvider,
                 genomicExtractionService,
-                workspaceAuthService));
+                workspaceAuthService,
+                workbenchConfigProvider));
 
     FirecloudWorkspaceResponse fcResponse = new FirecloudWorkspaceResponse();
     fcResponse.setAccessLevel(WorkspaceAccessLevel.OWNER.name());

--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -42,6 +42,7 @@ public class ConfigController implements ConfigApiDelegate {
             .enableEventDateModifier(config.featureFlags.enableEventDateModifier)
             .enableResearchReviewPrompt(config.featureFlags.enableResearchPurposePrompt)
             .enableRasLoginGovLinking(config.featureFlags.enableRasLoginGovLinking)
+            .enableGenomicExtraction(config.featureFlags.enableGenomicExtraction)
             .rasHost(config.ras.host)
             .rasClientId(config.ras.clientId)
             .runtimeImages(

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -471,9 +471,7 @@ public class DataSetController implements DataSetApiDelegate {
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
     DomainValuesResponse response = new DomainValuesResponse();
     if (domainValue.equals(Domain.WHOLE_GENOME_VARIANT.toString())) {
-      if (workbenchConfigProvider.get().featureFlags.enableGenomicExtraction) {
-        response.addItemsItem(new DomainValue().value(WHOLE_GENOME_VALUE));
-      }
+      response.addItemsItem(new DomainValue().value(WHOLE_GENOME_VALUE));
     } else {
       response.setItems(dataSetService.getValueListFromDomain(domainValue));
     }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -277,6 +277,9 @@ public class WorkbenchConfig {
     public boolean enableReportingUploadCron;
     // If true, user account setup requires linking eRA commons via RAS instead of Shibboleth.
     public boolean enableRasLoginGovLinking;
+    // If true, enable genomic extraction functionality for datasets which have genomics data
+    // associated with their CDRs.
+    public boolean enableGenomicExtraction;
   }
 
   public static class ActionAuditConfig {

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4059,6 +4059,10 @@ definitions:
         type: boolean
         default: false
         description: Whether to use enable RAS-AoU linking for login.gov when user setup account.
+      enableGenomicExtraction:
+        type: boolean
+        default: false
+        description: Whether to enable genomic data extraction for eligible datasets.
       rasHost:
         type: string
         description: The RAS base host name.

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -47,6 +47,7 @@ import {
   compoundRuntimeOpStore,
   routeDataStore,
   RuntimeStore,
+  serverConfigStore,
   withStore
 } from 'app/utils/stores';
 import {WorkspaceData} from 'app/utils/workspace-data';
@@ -353,7 +354,8 @@ export const HelpSidebar = fp.flow(
         keys.push('runtime');
       }
 
-      if (getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).hasWgsData) {
+      if (serverConfigStore.get().config.enableGenomicExtraction &&
+          getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).hasWgsData) {
         keys.push('genomicExtractions');
       }
 

--- a/ui/src/app/components/render-resource-card.spec.tsx
+++ b/ui/src/app/components/render-resource-card.spec.tsx
@@ -6,97 +6,102 @@ import {stubDataSet} from 'testing/stubs/data-set-api-stub';
 import {renderResourceCard} from './render-resource-card';
 import {mount} from 'enzyme';
 import {stubResource} from 'testing/stubs/resources-stub';
+import {serverConfigStore} from 'app/utils/stores';
 
 describe('renderResourceCard', () => {
-    it('renders a CohortResourceCard', () => {
-         const testCohort = {
-            ...stubResource,
-            cohort: exampleCohortStubs[0],
-        } as WorkspaceResource;
+  beforeEach(() => {
+    serverConfigStore.set({config: {enableGenomicExtraction: true, gsuiteDomain: ''}});
+  });
 
-        const card = renderResourceCard({
-            resource: testCohort,
-            existingNameList: [],
-            onUpdate: async () => {},
-            menuOnly: false,
-        });
-        const wrapper = mount(card);
-        expect(wrapper.exists()).toBeTruthy();
-        expect(wrapper.text()).toContain('Cohort');
-        expect(wrapper.text()).toContain(testCohort.cohort.name);
-        expect(wrapper.text()).toContain(testCohort.cohort.description);
-        expect(wrapper.text()).toContain('Last Modified');
+  it('renders a CohortResourceCard', () => {
+    const testCohort = {
+      ...stubResource,
+      cohort: exampleCohortStubs[0],
+    } as WorkspaceResource;
+
+    const card = renderResourceCard({
+      resource: testCohort,
+      existingNameList: [],
+      onUpdate: async () => {},
+      menuOnly: false,
     });
+    const wrapper = mount(card);
+    expect(wrapper.exists()).toBeTruthy();
+    expect(wrapper.text()).toContain('Cohort');
+    expect(wrapper.text()).toContain(testCohort.cohort.name);
+    expect(wrapper.text()).toContain(testCohort.cohort.description);
+    expect(wrapper.text()).toContain('Last Modified');
+  });
 
-    it('does not render a card for an invalid resource', () => {
-        const card = renderResourceCard({
-            resource: stubResource,
-            existingNameList: [],
-            onUpdate: async () => {},
-            menuOnly: false,
-        });
-        expect(card).toBeFalsy();
-    })
-
-    it('renders a Cohort menu without other card elements', () => {
-        const testCohort = {
-            ...stubResource,
-            cohort: exampleCohortStubs[0],
-        } as WorkspaceResource;
-
-        const menu = renderResourceCard({
-            resource: testCohort,
-            existingNameList: [],
-            onUpdate: async () => {},
-            menuOnly: true,
-        });
-        const wrapper = mount(menu);
-        expect(wrapper.exists()).toBeTruthy();
-        expect(wrapper.text()).toBe('');
+  it('does not render a card for an invalid resource', () => {
+    const card = renderResourceCard({
+      resource: stubResource,
+      existingNameList: [],
+      onUpdate: async () => {},
+      menuOnly: false,
     });
+    expect(card).toBeFalsy();
+  })
 
-    it('renders a dataset menu', () => {
-      const testDataSet = {
-        ...stubResource,
-        dataSet: {
-          ...stubDataSet(),
-          prePackagedConceptSet: [PrePackagedConceptSetEnum.FITBIT]
-        }
-      } as WorkspaceResource;
+  it('renders a Cohort menu without other card elements', () => {
+    const testCohort = {
+      ...stubResource,
+      cohort: exampleCohortStubs[0],
+    } as WorkspaceResource;
 
-      const menu = renderResourceCard({
-        resource: testDataSet,
-        existingNameList: [],
-        onUpdate: async () => {},
-        menuOnly: true,
-      });
-      const wrapper = mount(menu);
-      wrapper.find({'data-test-id': 'resource-card-menu'}).first().simulate('click');
-      expect(wrapper.text()).toContain('Export to Notebook');
-      expect(wrapper.text()).not.toContain('Extract VCF Files');
+    const menu = renderResourceCard({
+      resource: testCohort,
+      existingNameList: [],
+      onUpdate: async () => {},
+      menuOnly: true,
     });
+    const wrapper = mount(menu);
+    expect(wrapper.exists()).toBeTruthy();
+    expect(wrapper.text()).toBe('');
+  });
 
-    it('renders a dataset menu, with WGS', () => {
-      const testDataSet = {
-        ...stubResource,
-        dataSet: {
-          ...stubDataSet(),
-          prePackagedConceptSet: [
-            PrePackagedConceptSetEnum.PERSON,
-            PrePackagedConceptSetEnum.WHOLEGENOME
-          ]
-        },
-      } as WorkspaceResource;
+  it('renders a dataset menu', () => {
+    const testDataSet = {
+      ...stubResource,
+      dataSet: {
+        ...stubDataSet(),
+        prePackagedConceptSet: [PrePackagedConceptSetEnum.FITBIT]
+      }
+    } as WorkspaceResource;
 
-      const menu = renderResourceCard({
-        resource: testDataSet,
-        existingNameList: [],
-        onUpdate: async () => {},
-        menuOnly: true,
-      });
-      const wrapper = mount(menu);
-      wrapper.find({'data-test-id': 'resource-card-menu'}).first().simulate('click');
-      expect(wrapper.text()).toContain('Export to Notebook');
-      expect(wrapper.text()).toContain('Extract VCF Files');
+    const menu = renderResourceCard({
+      resource: testDataSet,
+      existingNameList: [],
+      onUpdate: async () => {},
+      menuOnly: true,
     });
+    const wrapper = mount(menu);
+    wrapper.find({'data-test-id': 'resource-card-menu'}).first().simulate('click');
+    expect(wrapper.text()).toContain('Export to Notebook');
+    expect(wrapper.text()).not.toContain('Extract VCF Files');
+  });
+
+  it('renders a dataset menu, with WGS', () => {
+    const testDataSet = {
+      ...stubResource,
+      dataSet: {
+        ...stubDataSet(),
+        prePackagedConceptSet: [
+          PrePackagedConceptSetEnum.PERSON,
+          PrePackagedConceptSetEnum.WHOLEGENOME
+        ]
+      },
+    } as WorkspaceResource;
+
+    const menu = renderResourceCard({
+      resource: testDataSet,
+      existingNameList: [],
+      onUpdate: async () => {},
+      menuOnly: true,
+    });
+    const wrapper = mount(menu);
+    wrapper.find({'data-test-id': 'resource-card-menu'}).first().simulate('click');
+    expect(wrapper.text()).toContain('Export to Notebook');
+    expect(wrapper.text()).toContain('Extract VCF Files');
+  });
 })

--- a/ui/src/app/pages/data/data-page.spec.tsx
+++ b/ui/src/app/pages/data/data-page.spec.tsx
@@ -15,8 +15,8 @@ import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
 import {DataSetApiStub} from 'testing/stubs/data-set-api-stub';
 import {workspaceDataStub} from 'testing/stubs/workspaces';
 import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
-
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
+import {serverConfigStore} from 'app/utils/stores';
 
 
 describe('DataPage', () => {
@@ -30,6 +30,7 @@ describe('DataPage', () => {
       ns: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
       wsid: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
     });
+    serverConfigStore.set({config: {enableGenomicExtraction: true, gsuiteDomain: ''}});
     currentWorkspaceStore.next(workspaceDataStub);
   });
 

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -19,7 +19,7 @@ import {CohortsApiStub, exampleCohortStubs} from 'testing/stubs/cohorts-api-stub
 import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
 import {DataSetApiStub} from 'testing/stubs/data-set-api-stub';
 import {workspaceDataStub, workspaceStubs, WorkspaceStubVariables} from 'testing/stubs/workspaces';
-import {cdrVersionStore} from "app/utils/stores";
+import {cdrVersionStore, serverConfigStore} from "app/utils/stores";
 
 describe('DataSetPage', () => {
   beforeEach(() => {
@@ -31,6 +31,7 @@ describe('DataSetPage', () => {
       ns: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
       wsid: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID
     });
+    serverConfigStore.set({config: {enableGenomicExtraction: true, gsuiteDomain: ''}});
     currentWorkspaceStore.next(workspaceDataStub);
     cdrVersionStore.set(cdrVersionTiersResponse);
   });

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -19,7 +19,7 @@ import {CohortsApiStub, exampleCohortStubs} from 'testing/stubs/cohorts-api-stub
 import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
 import {DataSetApiStub} from 'testing/stubs/data-set-api-stub';
 import {workspaceDataStub, workspaceStubs, WorkspaceStubVariables} from 'testing/stubs/workspaces';
-import {cdrVersionStore, serverConfigStore} from "app/utils/stores";
+import {cdrVersionStore, serverConfigStore} from 'app/utils/stores';
 
 describe('DataSetPage', () => {
   beforeEach(() => {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -30,6 +30,7 @@ import {AnalyticsTracker} from 'app/utils/analytics';
 import {getCdrVersion} from 'app/utils/cdr-versions';
 import {currentWorkspaceStore, navigateAndPreventDefaultIfNoKeysPressed} from 'app/utils/navigation';
 import {apiCallWithGatewayTimeoutRetries} from 'app/utils/retry';
+import {serverConfigStore} from 'app/utils/stores';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
@@ -493,7 +494,11 @@ const DataSetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), withUrlPa
           ...PREPACKAGED_WITH_FITBIT_DOMAINS
         };
       }
-      if (getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).hasWgsData) {
+      // Only allow selection of genomics prepackaged concept sets if genomics
+      // data extraction is possible, since extraction is the only action that
+      // can be taken on genomics variant data from the dataset builder.
+      if (serverConfigStore.get().config.enableGenomicExtraction &&
+          getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).hasWgsData) {
         PREPACKAGED_DOMAINS = {
           ...PREPACKAGED_DOMAINS,
           ...PREPACKAGED_WITH_WHOLE_GENOME

--- a/ui/src/app/pages/data/data-set/dataset-resource-card.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-resource-card.tsx
@@ -14,6 +14,7 @@ import {dataSetApi} from 'app/services/swagger-fetch-clients';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {navigate} from 'app/utils/navigation';
 import {getDescription, getDisplayName, getType} from 'app/utils/resources';
+import {serverConfigStore} from 'app/utils/stores';
 import {ACTION_DISABLED_INVALID_BILLING} from 'app/utils/strings';
 import {PrePackagedConceptSetEnum, WorkspaceResource} from 'generated/fetch';
 
@@ -48,7 +49,8 @@ export const DatasetResourceCard = fp.flow(
 
   get actions(): Action[] {
     const {resource, inactiveBilling} = this.props;
-    const hasWgs = (resource.dataSet.prePackagedConceptSet || []).includes(PrePackagedConceptSetEnum.WHOLEGENOME);
+    const enableExtraction = serverConfigStore.get().enableGenomicExtraction && (
+      resource.dataSet.prePackagedConceptSet || []).includes(PrePackagedConceptSetEnum.WHOLEGENOME);
     return [
       {
         icon: 'pencil',
@@ -81,7 +83,7 @@ export const DatasetResourceCard = fp.flow(
         disabled: inactiveBilling || !canWrite(resource),
         hoverText: inactiveBilling && ACTION_DISABLED_INVALID_BILLING
       },
-      ...(hasWgs ? [{
+      ...(enableExtraction ? [{
         faIcon: faDna,
         displayName: 'Extract VCF Files',
         onClick: () => {

--- a/ui/src/app/pages/data/data-set/dataset-resource-card.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-resource-card.tsx
@@ -49,7 +49,7 @@ export const DatasetResourceCard = fp.flow(
 
   get actions(): Action[] {
     const {resource, inactiveBilling} = this.props;
-    const enableExtraction = serverConfigStore.get().enableGenomicExtraction && (
+    const enableExtraction = serverConfigStore.get().config.enableGenomicExtraction && (
       resource.dataSet.prePackagedConceptSet || []).includes(PrePackagedConceptSetEnum.WHOLEGENOME);
     return [
       {


### PR DESCRIPTION
In the product, this has the following implications:
- Whether the prepackaged concept set appears on dataset builder
- Whether the extraction history panel is visible (still only shows on WGS CDRs) 
- Whether you can launch an extraction from the dataset card

Still allowed in WGS CDRs only, with this feature off:
- Selecting dataproc
- Filtering by WGS in cohort builder