### PR TITLE
[risk=low][RW-6688] Prevent notebook copy between tiers in the API

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -16,7 +16,10 @@ import org.owasp.html.PolicyFactory;
 import org.owasp.html.Sanitizers;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.FailedPreconditionException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudStorageClient;
@@ -127,22 +130,36 @@ public class NotebooksServiceImpl implements NotebooksService {
   @Override
   public FileDetail copyNotebook(
       String fromWorkspaceNamespace,
-      String fromWorkspaceName,
+      String fromWorkspaceFirecloudName,
       String fromNotebookName,
       String toWorkspaceNamespace,
-      String toWorkspaceName,
+      String toWorkspaceFirecloudName,
       String newNotebookName) {
     workspaceAuthService.enforceWorkspaceAccessLevel(
-        fromWorkspaceNamespace, fromWorkspaceName, WorkspaceAccessLevel.READER);
+        fromWorkspaceNamespace, fromWorkspaceFirecloudName, WorkspaceAccessLevel.READER);
     workspaceAuthService.enforceWorkspaceAccessLevel(
-        toWorkspaceNamespace, toWorkspaceName, WorkspaceAccessLevel.WRITER);
-    workspaceAuthService.validateActiveBilling(toWorkspaceNamespace, toWorkspaceName);
+        toWorkspaceNamespace, toWorkspaceFirecloudName, WorkspaceAccessLevel.WRITER);
+    workspaceAuthService.validateActiveBilling(toWorkspaceNamespace, toWorkspaceFirecloudName);
     newNotebookName = NotebooksService.withNotebookExtension(newNotebookName);
 
+    final DbWorkspace fromWorkspace =
+        workspaceDao.getRequired(fromWorkspaceNamespace, fromWorkspaceFirecloudName);
+    final DbAccessTier fromTier = fromWorkspace.getCdrVersion().getAccessTier();
+    final DbWorkspace toWorkspace =
+        workspaceDao.getRequired(toWorkspaceNamespace, toWorkspaceFirecloudName);
+    final DbAccessTier toTier = toWorkspace.getCdrVersion().getAccessTier();
+
+    if (!fromTier.equals(toTier)) {
+      final String msg =
+          String.format(
+              "Cannot copy from %s to %s", fromTier.getDisplayName(), fromTier.getDisplayName());
+      throw new BadRequestException(msg);
+    }
+
     GoogleCloudLocators fromNotebookLocators =
-        getNotebookLocators(fromWorkspaceNamespace, fromWorkspaceName, fromNotebookName);
+        getNotebookLocators(fromWorkspaceNamespace, fromWorkspaceFirecloudName, fromNotebookName);
     GoogleCloudLocators newNotebookLocators =
-        getNotebookLocators(toWorkspaceNamespace, toWorkspaceName, newNotebookName);
+        getNotebookLocators(toWorkspaceNamespace, toWorkspaceFirecloudName, newNotebookName);
 
     if (!cloudStorageClient
         .getExistingBlobIdsIn(Collections.singletonList(newNotebookLocators.blobId))
@@ -157,9 +174,7 @@ public class NotebooksServiceImpl implements NotebooksService {
     Timestamp now = new Timestamp(clock.instant().toEpochMilli());
     fileDetail.setLastModifiedTime(now.getTime());
     userRecentResourceService.updateNotebookEntry(
-        workspaceDao.getRequired(toWorkspaceNamespace, toWorkspaceName).getWorkspaceId(),
-        userProvider.get().getUserId(),
-        newNotebookLocators.fullPath);
+        toWorkspace.getWorkspaceId(), userProvider.get().getUserId(), newNotebookLocators.fullPath);
 
     return fileDetail;
   }
@@ -271,10 +286,10 @@ public class NotebooksServiceImpl implements NotebooksService {
   }
 
   private GoogleCloudLocators getNotebookLocators(
-      String workspaceNamespace, String workspaceName, String notebookName) {
+      String workspaceNamespace, String firecloudName, String notebookName) {
     String bucket =
         fireCloudService
-            .getWorkspace(workspaceNamespace, workspaceName)
+            .getWorkspace(workspaceNamespace, firecloudName)
             .getWorkspace()
             .getBucketName();
     String blobPath = NOTEBOOKS_WORKSPACE_DIRECTORY + "/" + notebookName;

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -152,7 +152,8 @@ public class NotebooksServiceImpl implements NotebooksService {
     if (!fromTier.equals(toTier)) {
       final String msg =
           String.format(
-              "Cannot copy from %s to %s", fromTier.getDisplayName(), toTier.getDisplayName());
+              "Cannot copy between access tiers (attempted copy from %s to %s)",
+              fromTier.getDisplayName(), toTier.getDisplayName());
       throw new BadRequestException(msg);
     }
 

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -152,7 +152,7 @@ public class NotebooksServiceImpl implements NotebooksService {
     if (!fromTier.equals(toTier)) {
       final String msg =
           String.format(
-              "Cannot copy from %s to %s", fromTier.getDisplayName(), fromTier.getDisplayName());
+              "Cannot copy from %s to %s", fromTier.getDisplayName(), toTier.getDisplayName());
       throw new BadRequestException(msg);
     }
 

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -57,7 +57,7 @@ public class NotebooksServiceTest {
   private static final String PREVIOUS_NOTEBOOK = "previous notebook";
 
   private static DbUser dbUser;
-  private static DbWorkspace dbWorkspace = new DbWorkspace();
+  private static DbWorkspace dbWorkspace;
 
   @MockBean private LogsBasedMetricService mockLogsBasedMetricsService;
 
@@ -96,6 +96,7 @@ public class NotebooksServiceTest {
     dbUser = userDao.save(dbUser);
 
     // workspaceDao is a mock, so we don't need to save the workspace
+    dbWorkspace = new DbWorkspace();
     dbWorkspace.setCdrVersion(
         TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao));
   }

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -16,6 +16,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.pmiops.workbench.db.dao.AccessTierDao;
+import org.pmiops.workbench.db.dao.CdrVersionDao;
+import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbUser;
@@ -28,9 +31,11 @@ import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.monitoring.LogsBasedMetricService;
 import org.pmiops.workbench.monitoring.views.EventMetric;
 import org.pmiops.workbench.test.FakeClock;
+import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.workspaces.WorkspaceAuthService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
@@ -39,6 +44,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
+@DataJpaTest
 public class NotebooksServiceTest {
   private static final JSONObject NOTEBOOK_CONTENTS =
       new JSONObject().put("who", "I'm a notebook!");
@@ -48,16 +54,20 @@ public class NotebooksServiceTest {
   private static final String NOTEBOOK_NAME = "my first notebook";
   private static final String NAMESPACE_NAME = "namespace_name";
   private static final String WORKSPACE_NAME = "workspace_name";
-  private static final DbWorkspace WORKSPACE = new DbWorkspace();
   private static final String PREVIOUS_NOTEBOOK = "previous notebook";
 
-  private static DbUser DB_USER;
+  private static DbUser dbUser;
+  private static DbWorkspace dbWorkspace = new DbWorkspace();
 
   @MockBean private LogsBasedMetricService mockLogsBasedMetricsService;
 
   @MockBean private FireCloudService mockFirecloudService;
   @MockBean private CloudStorageClient mockCloudStorageClient;
   @MockBean private WorkspaceDao workspaceDao;
+
+  @Autowired private AccessTierDao accessTierDao;
+  @Autowired private CdrVersionDao cdrVersionDao;
+  @Autowired private UserDao userDao;
 
   @Autowired private NotebooksService notebooksService;
 
@@ -74,15 +84,20 @@ public class NotebooksServiceTest {
     @Bean
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     DbUser getDbUser() {
-      return DB_USER;
+      return dbUser;
     }
   }
 
   @Before
   public void setup() {
-    DB_USER = new DbUser();
-    DB_USER.setUserId(101L);
-    DB_USER.setUsername("panic@thedis.co");
+    dbUser = new DbUser();
+    dbUser.setUserId(101L);
+    dbUser.setUsername("panic@thedis.co");
+    dbUser = userDao.save(dbUser);
+
+    // workspaceDao is a mock, so we don't need to save the workspace
+    dbWorkspace.setCdrVersion(
+        TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao));
   }
 
   @Mock private Blob mockBlob;
@@ -170,7 +185,7 @@ public class NotebooksServiceTest {
   @Test
   public void testDeleteNotebook_firesMetric() {
     doReturn(WORKSPACE_RESPONSE).when(mockFirecloudService).getWorkspace(anyString(), anyString());
-    doReturn(WORKSPACE).when(workspaceDao).getRequired(anyString(), anyString());
+    doReturn(dbWorkspace).when(workspaceDao).getRequired(anyString(), anyString());
 
     notebooksService.deleteNotebook(NAMESPACE_NAME, WORKSPACE_NAME, NOTEBOOK_NAME);
     verify(mockLogsBasedMetricsService).recordEvent(EventMetric.NOTEBOOK_DELETE);
@@ -179,7 +194,7 @@ public class NotebooksServiceTest {
   @Test
   public void testCloneNotebook_firesMetric() {
     doReturn(WORKSPACE_RESPONSE).when(mockFirecloudService).getWorkspace(anyString(), anyString());
-    doReturn(WORKSPACE).when(workspaceDao).getRequired(anyString(), anyString());
+    doReturn(dbWorkspace).when(workspaceDao).getRequired(anyString(), anyString());
 
     notebooksService.cloneNotebook(NAMESPACE_NAME, WORKSPACE_NAME, PREVIOUS_NOTEBOOK);
     verify(mockLogsBasedMetricsService).recordEvent(EventMetric.NOTEBOOK_CLONE);

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -45,6 +45,9 @@ public class TestMockFactory {
       "gonewiththewind"; // should match workspace name w/o spaces
   public static final String DEFAULT_GOOGLE_PROJECT = "aou-rw-test-123";
 
+  // TODO there's something off about how "workspaceName" here works.  Investigate.
+  // For best results, use a lowercase-only workspaceName.
+  // To me, this hints at a firecloudName/aouName discrepancy somewhere in here.
   public Workspace createWorkspace(String workspaceNameSpace, String workspaceName) {
     List<DisseminateResearchEnum> disseminateResearchEnumsList = new ArrayList<>();
     disseminateResearchEnumsList.add(DisseminateResearchEnum.PRESENATATION_SCIENTIFIC_CONFERENCES);


### PR DESCRIPTION
Description:

API only - we should continue to work on a UI solution for RW-6688.

Tested locally - no visible effect on the UI but the API error message is better.  Copying notebooks between CDR Versions still works as long as they're in the same tier.
 
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
