### PR TITLE
[risk=low][RW-6688] Prevent notebook copy between tiers in the UI

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -284,6 +284,7 @@ public class UserMetricsController implements UserMetricsApiDelegate {
 
   private void buildFromDbWorkspace(WorkspaceResource resource, DbWorkspace dbWorkspace) {
     resource.setCdrVersionId(commonMappers.cdrVersionToId(dbWorkspace.getCdrVersion()));
+    resource.setAccessTierShortName(dbWorkspace.getCdrVersion().getAccessTier().getShortName());
     resource.setWorkspaceBillingStatus(dbWorkspace.getBillingStatus());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -141,6 +141,7 @@ public interface WorkspaceMapper {
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")
   @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace.billingStatus")
   @Mapping(target = "cdrVersionId", source = "dbWorkspace.cdrVersion")
+  @Mapping(target = "accessTierShortName", source = "dbWorkspace.cdrVersion.accessTier.shortName")
   @Mapping(target = "permission", source = "accessLevel")
   @Mapping(target = "cohort", source = "dbCohort")
   // All workspaceResources have one object and all others are null.
@@ -157,6 +158,7 @@ public interface WorkspaceMapper {
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")
   @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace.billingStatus")
   @Mapping(target = "cdrVersionId", source = "dbWorkspace.cdrVersion")
+  @Mapping(target = "accessTierShortName", source = "dbWorkspace.cdrVersion.accessTier.shortName")
   @Mapping(target = "permission", source = "accessLevel")
   @Mapping(target = "cohortReview", source = "cohortReview")
   // All workspaceResources have one object and all others are null.
@@ -173,6 +175,7 @@ public interface WorkspaceMapper {
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")
   @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace.billingStatus")
   @Mapping(target = "cdrVersionId", source = "dbWorkspace.cdrVersion")
+  @Mapping(target = "accessTierShortName", source = "dbWorkspace.cdrVersion.accessTier.shortName")
   @Mapping(target = "permission", source = "accessLevel")
   @Mapping(target = "conceptSet", source = "conceptSet")
   // All workspaceResources have one object and all others are null.
@@ -189,6 +192,7 @@ public interface WorkspaceMapper {
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")
   @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace.billingStatus")
   @Mapping(target = "cdrVersionId", source = "dbWorkspace.cdrVersion")
+  @Mapping(target = "accessTierShortName", source = "dbWorkspace.cdrVersion.accessTier.shortName")
   @Mapping(target = "permission", source = "accessLevel")
   @Mapping(target = "dataSet", source = "dbDataset", qualifiedByName = "dbModelToClientLight")
   // All workspaceResources have one object and all others are null.

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5920,6 +5920,7 @@ definitions:
       - workspaceFirecloudName
       - workspaceBillingStatus
       - cdrVersionId
+      - accessTiershortName
       - permission
       - modifiedTime
     properties:
@@ -5933,6 +5934,8 @@ definitions:
       workspaceBillingStatus:
         "$ref": "#/definitions/BillingStatus"
       cdrVersionId:
+        type: string
+      accessTierShortName:
         type: string
       permission:
         type: string

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5920,7 +5920,7 @@ definitions:
       - workspaceFirecloudName
       - workspaceBillingStatus
       - cdrVersionId
-      - accessTiershortName
+      - accessTierShortName
       - permission
       - modifiedTime
     properties:

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -22,8 +22,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.pmiops.workbench.cohorts.CohortMapper;
 import org.pmiops.workbench.cohorts.CohortMapperImpl;
+import org.pmiops.workbench.db.dao.AccessTierDao;
+import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbUser;
@@ -39,6 +42,7 @@ import org.pmiops.workbench.model.RecentResourceRequest;
 import org.pmiops.workbench.model.WorkspaceResource;
 import org.pmiops.workbench.model.WorkspaceResourceResponse;
 import org.pmiops.workbench.test.FakeClock;
+import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.FirecloudMapper;
 import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
@@ -66,8 +70,12 @@ public class UserMetricsControllerTest {
   @Autowired private CohortMapper cohortMapper;
   @Autowired private CommonMappers commonMappers;
   @Autowired private FirecloudMapper firecloudMapper;
+  @Autowired private AccessTierDao accessTierDao;
+  @Autowired private CdrVersionDao cdrVersionDao;
 
   private FakeClock fakeClock = new FakeClock(NOW);
+
+  private DbCdrVersion dbCdrVersion;
 
   private DbUser dbUser;
   private DbUserRecentResource dbUserRecentResource1;
@@ -87,6 +95,8 @@ public class UserMetricsControllerTest {
 
   @Before
   public void setUp() {
+    dbCdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+
     dbUser = new DbUser();
     dbUser.setUserId(123L);
 
@@ -110,11 +120,13 @@ public class UserMetricsControllerTest {
     dbWorkspace1.setWorkspaceId(1L);
     dbWorkspace1.setWorkspaceNamespace("workspaceNamespace1");
     dbWorkspace1.setFirecloudName("firecloudname1");
+    dbWorkspace1.setCdrVersion(dbCdrVersion);
 
     dbWorkspace2 = new DbWorkspace();
     dbWorkspace2.setWorkspaceId(2L);
     dbWorkspace2.setWorkspaceNamespace("workspaceNamespace2");
     dbWorkspace2.setFirecloudName("firecloudName2");
+    dbWorkspace2.setCdrVersion(dbCdrVersion);
 
     dbUserRecentResource1 = new DbUserRecentResource();
     dbUserRecentResource1.setNotebookName("gs://bucketFile/notebooks/notebook1.ipynb");

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -73,17 +73,12 @@ public class UserMetricsControllerTest {
   @Autowired private AccessTierDao accessTierDao;
   @Autowired private CdrVersionDao cdrVersionDao;
 
-  private FakeClock fakeClock = new FakeClock(NOW);
-
-  private DbCdrVersion dbCdrVersion;
+  private final FakeClock fakeClock = new FakeClock(NOW);
 
   private DbUser dbUser;
   private DbUserRecentResource dbUserRecentResource1;
   private DbUserRecentResource dbUserRecentResource2;
   private DbUserRecentResource dbUserRecentResource3;
-
-  private FirecloudWorkspace fcWorkspace1;
-  private FirecloudWorkspace fcWorkspace2;
 
   private DbWorkspace dbWorkspace1;
   private DbWorkspace dbWorkspace2;
@@ -95,7 +90,8 @@ public class UserMetricsControllerTest {
 
   @Before
   public void setUp() {
-    dbCdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+    final DbCdrVersion dbCdrVersion =
+        TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
 
     dbUser = new DbUser();
     dbUser.setUserId(123L);
@@ -158,17 +154,17 @@ public class UserMetricsControllerTest {
     when(workspaceDao.findActiveByWorkspaceId(dbUserRecentResource3.getWorkspaceId()))
         .thenReturn(Optional.of(dbWorkspace2));
 
-    fcWorkspace1 = new FirecloudWorkspace();
+    final FirecloudWorkspace fcWorkspace1 = new FirecloudWorkspace();
     fcWorkspace1.setNamespace(dbWorkspace1.getFirecloudName());
 
-    fcWorkspace2 = new FirecloudWorkspace();
+    final FirecloudWorkspace fcWorkspace2 = new FirecloudWorkspace();
     fcWorkspace1.setNamespace(dbWorkspace2.getFirecloudName());
 
-    FirecloudWorkspaceResponse workspaceResponse = new FirecloudWorkspaceResponse();
+    final FirecloudWorkspaceResponse workspaceResponse = new FirecloudWorkspaceResponse();
     workspaceResponse.setAccessLevel("OWNER");
     workspaceResponse.setWorkspace(fcWorkspace1);
 
-    FirecloudWorkspaceResponse workspaceResponse2 = new FirecloudWorkspaceResponse();
+    final FirecloudWorkspaceResponse workspaceResponse2 = new FirecloudWorkspaceResponse();
     workspaceResponse2.setAccessLevel("READER");
     workspaceResponse2.setWorkspace(fcWorkspace2);
 

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -342,8 +342,13 @@ class CopyModalComponent extends React.Component<Props, State> {
         [cdrVersionMismatch && isNotebook, () => this.setNotebookCdrMismatchWarning(destination, fromCdrVersionId)]);
   }
 
-  renderFormBody() {
+  showCdrMismatch(type: ResourceType) {
     const {resourceType} = this.props;
+    const {accessTierMismatch, cdrMismatch} = this.state;
+    return !accessTierMismatch && cdrMismatch && resourceType === type;
+  }
+
+  renderFormBody() {
     const {destination, workspaceOptions, requestState, accessTierMismatch, cdrMismatch, copyErrorMsg, newName} = this.state;
     return (
       <div>
@@ -355,14 +360,14 @@ class CopyModalComponent extends React.Component<Props, State> {
           isOptionDisabled={(option) => this.isDestinationSameWorkspace(option.value)}
         />
         {accessTierMismatch && <AccessTierMismatch text={accessTierMismatch}/>}
-        {!accessTierMismatch && cdrMismatch && resourceType === ResourceType.CONCEPTSET && <ConceptSetCdrMismatch text={cdrMismatch}/>}
+        {this.showCdrMismatch(ResourceType.CONCEPTSET) && <ConceptSetCdrMismatch text={cdrMismatch}/>}
         <div style={headerStyles.formLabel}>Name *</div>
         <TextInput
           autoFocus
           value={newName}
           onChange={v => this.setState({ newName: v })}
         />
-        {!accessTierMismatch && cdrMismatch && resourceType === ResourceType.NOTEBOOK && <NotebookCdrMismatch text={cdrMismatch}/>}
+        {this.showCdrMismatch(ResourceType.NOTEBOOK) && <NotebookCdrMismatch text={cdrMismatch}/>}
         {requestState === RequestState.COPY_ERROR && <ValidationError>{copyErrorMsg}</ValidationError>}
       </div>
     );

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -118,7 +118,7 @@ const NotebookCdrMismatch = (props: {text: string}) =>
     </div>;
 
 const ConceptSetRestrictionText = () => <div style={styles.restriction}>
-  Concept sets can only be copied to workspaces using the same CDR version.
+  Concept sets can only be copied to workspaces using the same access tier and CDR version.
 </div>;
 
 const NotebookRestrictionText = () => <div style={styles.restriction}>

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -329,6 +329,8 @@ class CopyModalComponent extends React.Component<Props, State> {
   validateAndSetDestination(destination: Workspace) {
     const {fromCdrVersionId, fromAccessTierShortName, resourceType} = this.props;
 
+    console.log('fromAccessTierShortName = ' + fromAccessTierShortName);
+
     this.clearCopyError();
 
     const cdrVersionMismatch: boolean = fromCdrVersionId !== destination.cdrVersionId;

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -329,14 +329,14 @@ class CopyModalComponent extends React.Component<Props, State> {
     const {fromCdrVersionId, fromAccessTierShortName, resourceType} = this.props;
 
     this.clearCopyError();
+    this.clearMismatchErrors(destination);
 
     const cdrVersionMismatch: boolean = fromCdrVersionId !== destination.cdrVersionId;
     const accessTierMismatch: boolean = fromAccessTierShortName !== destination.accessTierShortName;
     const isNotebook: boolean = resourceType === ResourceType.NOTEBOOK;
     const isConceptSet: boolean = resourceType === ResourceType.CONCEPTSET;
 
-    cond([!accessTierMismatch && !cdrVersionMismatch, () => this.clearMismatchErrors(destination)],
-        [accessTierMismatch, () => this.setAccessTierMismatchError(destination, fromAccessTierShortName)],
+    cond([accessTierMismatch, () => this.setAccessTierMismatchError(destination, fromAccessTierShortName)],
         [cdrVersionMismatch && isConceptSet, () => this.setConceptSetCdrMismatchError(destination, fromCdrVersionId)],
         // notebooks can be copied to different versions; warn only.
         [cdrVersionMismatch && isNotebook, () => this.setNotebookCdrMismatchWarning(destination, fromCdrVersionId)]);

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -128,7 +128,6 @@ const NotebookRestrictionText = () => <div style={styles.restriction}>
 class CopyModalComponent extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-
     this.state = {
       workspaceOptions: [],
       newName: props.fromResourceName,
@@ -328,8 +327,6 @@ class CopyModalComponent extends React.Component<Props, State> {
 
   validateAndSetDestination(destination: Workspace) {
     const {fromCdrVersionId, fromAccessTierShortName, resourceType} = this.props;
-
-    console.log('fromAccessTierShortName = ' + fromAccessTierShortName);
 
     this.clearCopyError();
 

--- a/ui/src/app/pages/analysis/notebook-resource-card.tsx
+++ b/ui/src/app/pages/analysis/notebook-resource-card.tsx
@@ -162,7 +162,7 @@ export const NotebookResourceCard = fp.flow(
         fromWorkspaceFirecloudName={resource.workspaceFirecloudName}
         fromResourceName={getDisplayName(resource)}
         fromCdrVersionId={resource.cdrVersionId}
-        fromAccessTierShortname={resource.cdrVersionId}
+        fromAccessTierShortName={resource.accessTierShortName}
         resourceType={getType(resource)}
         onClose={() => this.setState({showCopyNotebookModal: false})}
         onCopy={() => this.props.onUpdate()}

--- a/ui/src/app/pages/analysis/notebook-resource-card.tsx
+++ b/ui/src/app/pages/analysis/notebook-resource-card.tsx
@@ -162,6 +162,7 @@ export const NotebookResourceCard = fp.flow(
         fromWorkspaceFirecloudName={resource.workspaceFirecloudName}
         fromResourceName={getDisplayName(resource)}
         fromCdrVersionId={resource.cdrVersionId}
+        fromAccessTierShortname={resource.cdrVersionId}
         resourceType={getType(resource)}
         onClose={() => this.setState({showCopyNotebookModal: false})}
         onCopy={() => this.props.onUpdate()}

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -285,7 +285,7 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
     }
 
     render() {
-      const {cohortContext, workspace: {accessLevel, cdrVersionId, id, namespace}} = this.props;
+      const {cohortContext, workspace: {accessLevel, cdrVersionId, id, namespace, accessTierShortName}} = this.props;
       const {copying, conceptSet, editing, editDescription, editName, error, errorMessage, editSaving, deleting, loading,
         showMoreDescription, showUnsavedModal} = this.state;
       const errors = validate(
@@ -396,6 +396,7 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
                                fromWorkspaceFirecloudName={id}
                                fromResourceName={conceptSet.name}
                                fromCdrVersionId={cdrVersionId}
+                               fromAccessTierShortname={accessTierShortName}
                                resourceType={ResourceType.CONCEPTSET}
                                onClose={() => this.setState({copying: false})}
                                onCopy={() => this.setState({copySaving: false})}

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -396,7 +396,7 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
                                fromWorkspaceFirecloudName={id}
                                fromResourceName={conceptSet.name}
                                fromCdrVersionId={cdrVersionId}
-                               fromAccessTierShortname={accessTierShortName}
+                               fromAccessTierShortName={accessTierShortName}
                                resourceType={ResourceType.CONCEPTSET}
                                onClose={() => this.setState({copying: false})}
                                onCopy={() => this.setState({copySaving: false})}

--- a/ui/src/app/pages/data/concept/concept-set-resource-card.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-resource-card.tsx
@@ -142,7 +142,7 @@ export const ConceptSetResourceCard = fp.flow(
           fromWorkspaceFirecloudName={resource.workspaceFirecloudName}
           fromResourceName={resource.conceptSet.name}
           fromCdrVersionId={resource.cdrVersionId}
-          fromAccessTierShortname={resource.accessTierShortName}
+          fromAccessTierShortName={resource.accessTierShortName}
           resourceType={getType(resource)}
           onClose={() => this.setState({showCopyModal: false})}
           onCopy={() => this.props.onUpdate()}

--- a/ui/src/app/pages/data/concept/concept-set-resource-card.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-resource-card.tsx
@@ -142,6 +142,7 @@ export const ConceptSetResourceCard = fp.flow(
           fromWorkspaceFirecloudName={resource.workspaceFirecloudName}
           fromResourceName={resource.conceptSet.name}
           fromCdrVersionId={resource.cdrVersionId}
+          fromAccessTierShortname={resource.accessTierShortName}
           resourceType={getType(resource)}
           onClose={() => this.setState({showCopyModal: false})}
           onCopy={() => this.props.onUpdate()}

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -93,12 +93,13 @@ function convertToResource(
   inputResource: FileDetail | Cohort | CohortReview | ConceptSet | DataSet,
   resourceType: ResourceType,
   workspace: WorkspaceData): WorkspaceResource {
-  const {namespace, id, accessLevel, cdrVersionId, billingStatus} = workspace;
+  const {namespace, id, accessLevel, accessTierShortName, cdrVersionId, billingStatus} = workspace;
   return {
     workspaceNamespace: namespace,
     workspaceFirecloudName: id,
     permission: WorkspaceAccessLevel[accessLevel],
     modifiedTime: inputResource.lastModifiedTime ? new Date(inputResource.lastModifiedTime).toString() : new Date().toDateString(),
+    accessTierShortName,
     cdrVersionId,
     workspaceBillingStatus: billingStatus,
     cohort: resourceType === ResourceType.COHORT ? inputResource as Cohort : null,

--- a/ui/src/testing/stubs/resources-stub.ts
+++ b/ui/src/testing/stubs/resources-stub.ts
@@ -12,6 +12,7 @@ import {
 } from 'generated/fetch';
 import {CdrVersionsStubVariables} from 'testing/stubs/cdr-versions-api-stub';
 import {WorkspaceStubVariables} from 'testing/stubs/workspaces';
+import {AccessTierShortNames} from 'app/utils/access-tiers';
 
 type InputResource = FileDetail | Cohort | CohortReview | ConceptSet | DataSet;
 export function convertToResources(
@@ -28,5 +29,6 @@ export const stubResource: WorkspaceResource = {
   modifiedTime: '2019-01-28 20:13:58.0',
   permission: 'OWNER',
   cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
+  accessTierShortName: AccessTierShortNames.Registered,
   workspaceBillingStatus: BillingStatus.ACTIVE,
 };


### PR DESCRIPTION
Description:

UI counterpart to #4908 (but not dependent on it)

Update the Copy Modal logic to prevent copies across access tiers.  Keep the existing logic of allowing Notebook copies across CDR Versions within an access tier and preventing Concept Set copies across CDR Versions.

![copy modal tiers](https://user-images.githubusercontent.com/2701406/117338479-9be35500-ae6c-11eb-83d1-aa20922ee2e1.gif)


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
