### PR TITLE
[no ticket][risk=no] Puppeteer log: null response handling

### DIFF
--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -227,12 +227,13 @@ const getResponseText = async (request: Request): Promise<string> => {
 
 const logError = async (request: Request): Promise<void> => {
   const response = request.response();
+  const status = response ? response.status() : '';
   const failureText = request.failure() !== null ? stringifyData(request.failure().errorText) : '';
   const responseText = stringifyData(await getResponseText(request));
   logger.log(
     'error',
     'Request failed: %s %s %s\n%s %s',
-    response.status(),
+    status,
     request.method(),
     request.url(),
     responseText,


### PR DESCRIPTION
Could fail test if failed request did not have any response body.

```
test name: Loading registration workflow
status: failed
failure: [
  "TypeError: Cannot read property 'status' of null\n" +
    '    at logError (/home/circleci/workbench/e2e/jest.test-setup.ts:235:14)\n' +
    '    at /home/circleci/workbench/e2e/jest.test-setup.ts:48:7'
]
```

After fix:
(test no longer fails when response is null caused by aborted request)
```
console.log
      ERROR: [4/30/2021, 19:02:20] - Request failed:  POST https://api-dot-all-of-us-workbench-test.appspot.com/v1/institutions/Broad/checkEmail
       net::ERR_ABORTED

      at Console.log (node_modules/winston/lib/winston/transports/console.js:79:23)
```