### PR TITLE
[risk=no] Update nightly disk size tests

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -2,5 +2,7 @@ engines:
   tslint:
     enabled: true
     base_sub_dir: ui
-exclude_paths:	
+exclude_paths:
   - ui/karma.conf.js
+  - e2e/resources/python-code/**
+  - e2e/resources/r-code/**

--- a/e2e/resources/python-code/count-disk-space.py
+++ b/e2e/resources/python-code/count-disk-space.py
@@ -1,2 +1,7 @@
 import psutil
-psutil.disk_usage('/').total
+import os
+
+# Convert to GiB. Note that '/' does not exactly correspond to the disk size
+# that we specify in our runtime configuration, but the notebooks dir is a
+# docker volume mounted from our requested disk.
+psutil.disk_usage(os.getenv('NOTEBOOKS_DIR')).total / (1<<30)

--- a/e2e/resources/python-code/count-memory.py
+++ b/e2e/resources/python-code/count-memory.py
@@ -1,2 +1,4 @@
 import psutil
-psutil.virtual_memory().total
+
+# Convert to GiB.
+psutil.virtual_memory().total / (1<<30)

--- a/e2e/tests/nightly/gce-to-dataproc.spec.ts
+++ b/e2e/tests/nightly/gce-to-dataproc.spec.ts
@@ -37,14 +37,14 @@ describe('Updating runtime compute type', () => {
     expect(parseInt(cpusOutputText, 10)).toBe(4);
     // This gets the amount of memory available to Python in bytes
     const memoryOutputText = await notebook.runCodeCell(2, { codeFile: 'resources/python-code/count-memory.py' });
-    // Default memory is 15 gibibytes, we'll check that it is between 14 billion and 16 billion bytes
-    expect(parseInt(memoryOutputText, 10)).toBeGreaterThanOrEqual(14 * 1000 * 1000 * 1000);
-    expect(parseInt(memoryOutputText, 10)).toBeLessThanOrEqual(16 * 1000 * 1000 * 1000);
+    // Default memory is 15 gibibytes, we'll check that it is between 14GiB and 16GiB
+    expect(parseFloat(memoryOutputText)).toBeGreaterThanOrEqual(14);
+    expect(parseFloat(memoryOutputText)).toBeLessThanOrEqual(16);
     // This gets the disk space in bytes
     const diskOutputText = await notebook.runCodeCell(3, { codeFile: 'resources/python-code/count-disk-space.py' });
-    // Default disk is 50 gibibytes, we'll check that it is between 45 and 55 billion bytes
-    expect(parseInt(diskOutputText, 10)).toBeGreaterThanOrEqual(45 * 1000 * 1000 * 1000);
-    expect(parseInt(diskOutputText, 10)).toBeLessThanOrEqual(55 * 1000 * 1000 * 1000);
+    // Default disk is 100 gibibytes, we'll check that it is between 95GiB and 105GiB
+    expect(parseFloat(diskOutputText)).toBeGreaterThanOrEqual(95);
+    expect(parseFloat(diskOutputText)).toBeLessThanOrEqual(105);
     await notebook.save();
 
     // Open runtime panel


### PR DESCRIPTION
Default disk size has changed. Checking the volume more directly maps to the disk size we're configuring in the runtime panel. Previous error was:

```
Updating runtime compute type Switch from GCE to dataproc - tests/nightly/gce-to-dataproc.spec.ts
Error: expect(received).toBeLessThanOrEqual(expected)
Expected: <= 55000000000
Received:    63344238592
```

Previous code checked the overlay size, which I think more directly maps to a default boot disk size that Leo controls - while the notebooks volume corresponds to our requested disk size.

```

 -h
!df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay          59G   16G   41G  28% /
tmpfs            64M     0   64M   0% /dev
tmpfs           7.4G     0  7.4G   0% /sys/fs/cgroup
/dev/sda1        59G   16G   41G  28% /etc/hosts
shm              64M     0   64M   0% /dev/shm
/dev/sdb         98G   61M   98G   1% /home/jupyter-user/notebooks
tmpfs           7.4G     0  7.4G   0% /proc/acpi
tmpfs           7.4G     0  7.4G   0% /sys/firmware
```