### PR TITLE
[no ticket][risk=no] Puppeteer failed test log name fix

### DIFF
--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -6,7 +6,8 @@ const { CIRCLE_BUILD_NUM } = process.env;
 
 const userAgent =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko)' +
-  ' Chrome/80.0.3987.149 Safari/537.36' + (CIRCLE_BUILD_NUM ? ` (circle-build-number/${CIRCLE_BUILD_NUM})` : '');
+  ' Chrome/80.0.3987.149 Safari/537.36' +
+  (CIRCLE_BUILD_NUM ? ` (circle-build-number/${CIRCLE_BUILD_NUM})` : '');
 
 /**
  * Set up page common properties:

--- a/e2e/libs/jest-reporter.js
+++ b/e2e/libs/jest-reporter.js
@@ -18,8 +18,6 @@ module.exports = class JestReporter {
   // Called at the beginning of every test file
   onTestStart(test) {
     console.info(`Running ${path.parse(test.path).name} at ${this.timeNow()}`);
-    this.testName = path.parse(test.path).name;
-    this.testLogName = `${this.logDir}/${this.testName}.log`;
   }
 
   // Called with the result of every test file
@@ -29,6 +27,7 @@ module.exports = class JestReporter {
     });
     if (hasFailure) {
       // Save logs of failed test
+      this.testName = path.parse(testResult.path).name;
       this.testLogName = `${this.logDir}/${this.testName}-FAILED.log`;
       this.logger = this.createLogger(this.testLogName);
 

--- a/e2e/libs/jest-reporter.js
+++ b/e2e/libs/jest-reporter.js
@@ -3,10 +3,6 @@ const path = require('path');
 const winston = require('winston');
 
 module.exports = class JestReporter {
-  testName;
-  testLogName;
-  logger;
-
   constructor(globalConfig, options) {
     if (globalConfig.verbose === true) {
       throw Error("Verbose must be false or Console messages won't be available.");
@@ -27,32 +23,32 @@ module.exports = class JestReporter {
     });
     if (hasFailure) {
       // Save logs of failed test
-      this.testName = path.parse(testResult.testFilePath).name;
-      this.testLogName = `${this.logDir}/${this.testName}-FAILED.log`;
-      this.logger = this.createLogger(this.testLogName);
+      const testName = path.parse(testResult.testFilePath).name;
+      const testLogName = `${this.logDir}/${testName}-FAILED.log`;
+      const logger = this.createLogger(testLogName);
 
       // Read jest console messages and save to a log file.
       // Get all console logs.
       if (testResult.console) {
         testResult.console.forEach((log) => {
-          this.logger.info(log.message);
+          logger.info(log.message);
         });
       }
 
       // Get failure messages.
-      this.logger.info('\n\nTests Summary');
+      logger.info('\n\nTests Summary');
       testResult.testResults.forEach((result) => {
-        this.logger.info('----------------------------------------------');
-        this.logger.log('info', 'test name: %s', result.title);
-        this.logger.log('info', 'status: %s', result.status);
+        logger.info('----------------------------------------------');
+        logger.log('info', 'test name: %s', result.title);
+        logger.log('info', 'status: %s', result.status);
         // Get failure message.
         if (result.failureMessages) {
           const failure = result.failureMessages;
-          this.logger.log('info', 'failure: %s', failure);
+          logger.log('info', 'failure: %s', failure);
         }
-        this.logger.info('');
+        logger.info('');
       });
-      console.log(`Saved log of failed test: ${this.testLogName}`);
+      console.log(`Saved log of failed test: ${testLogName}`);
     }
   }
 
@@ -76,7 +72,7 @@ module.exports = class JestReporter {
   }
 
   createLogger(fileName) {
-    const logger = winston.createLogger({
+    const loggerInstance = winston.createLogger({
       level: process.env.LOG_LEVEL || 'info',
       format: winston.format.combine(
         winston.format.splat(),
@@ -93,6 +89,6 @@ module.exports = class JestReporter {
       ],
       exitOnError: false
     });
-    return logger;
+    return loggerInstance;
   }
 };

--- a/e2e/libs/jest-reporter.js
+++ b/e2e/libs/jest-reporter.js
@@ -27,7 +27,7 @@ module.exports = class JestReporter {
     });
     if (hasFailure) {
       // Save logs of failed test
-      this.testName = path.parse(testResult.path).name;
+      this.testName = path.parse(testResult.testFilePath).name;
       this.testLogName = `${this.logDir}/${this.testName}-FAILED.log`;
       this.logger = this.createLogger(this.testLogName);
 


### PR DESCRIPTION
Because two tests running in parallel caused log name mix-up. 

Ex: Failed test log should be for `conceptset-edit-rename.spec`.

`sidenav.spec` started at 16:36:50. It passed.
`conceptset-edit-rename.spec` started at 16:35:25. It failed.

![Screen Shot 2021-05-03 at 5 02 54 PM](https://user-images.githubusercontent.com/35533885/116933767-02c8fa00-ac32-11eb-90b0-bb979b80e0b6.png)

Issue fixed:

![Screen Shot 2021-05-03 at 5 45 18 PM](https://user-images.githubusercontent.com/35533885/116937529-5ee24d00-ac37-11eb-906d-23de281b0138.png)
