### PR TITLE
[no ticket][risk=no] Puppeteer remove disk size check in gce-to-dataproc.spec

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -23,6 +23,7 @@
     "test:ci": "yarn _test --ci --maxWorkers=2 --forceExit",
     "test:ci:debug": "yarn _test --ci --debug --maxWorkers=1 --bail 1",
     "test-nightly": "cross-env WORKBENCH_ENV=test TEST_MODE=nightly-integration yarn _test --maxWorkers=2",
+    "test-nightly:debug": "cross-env PUPPETEER_HEADLESS=false WORKBENCH_ENV=test TEST_MODE=nightly-integration yarn _test --detectOpenHandles",
     "test-nightly-local-devup": "cross-env WORKBENCH_ENV=local TEST_MODE=nightly-integration yarn jest --maxWorkers=1",
     "test-nightly-local-devup:debug": "cross-env WORKBENCH_ENV=local TEST_MODE=nightly-integration PUPPETEER_HEADLESS=false DEBUG=true yarn jest --maxWorkers=1",
     "build": "tsc -p tsconfig.json",

--- a/e2e/tests/nightly/dataproc-to-gce.spec.ts
+++ b/e2e/tests/nightly/dataproc-to-gce.spec.ts
@@ -59,15 +59,12 @@ describe('Updating runtime compute type', () => {
     // Run notebook to validate runtime settings (cpu, disk, memory)
     const cpusOutputText = await notebook.runCodeCell(2, { codeFile: 'resources/python-code/count-cpus.py' });
     expect(parseInt(cpusOutputText, 10)).toBe(8);
+
     // This gets the amount of memory available to Python in bytes
     const memoryOutputText = await notebook.runCodeCell(3, { codeFile: 'resources/python-code/count-memory.py' });
-    expect(parseInt(memoryOutputText, 10)).toBeGreaterThanOrEqual(28 * 1000 * 1000 * 1000);
-    expect(parseInt(memoryOutputText, 10)).toBeLessThanOrEqual(32 * 1000 * 1000 * 1000);
-    // This gets the disk space in bytes
-    const diskOutputText = await notebook.runCodeCell(4, { codeFile: 'resources/python-code/count-disk-space.py' });
-    // for whatever reason this always comes out at around 52 billion bytes despite definitely asking for 60
-    expect(parseInt(diskOutputText, 10)).toBeGreaterThanOrEqual(50 * 1000 * 1000 * 1000);
-    expect(parseInt(diskOutputText, 10)).toBeLessThanOrEqual(70 * 1000 * 1000 * 1000);
+    expect(parseInt(memoryOutputText, 10)).toBeGreaterThanOrEqual(28);
+    expect(parseInt(memoryOutputText, 10)).toBeLessThanOrEqual(32);
+
     await notebook.save();
 
     // Delete runtime

--- a/e2e/tests/nightly/dataproc-to-gce.spec.ts
+++ b/e2e/tests/nightly/dataproc-to-gce.spec.ts
@@ -8,7 +8,7 @@ import { createWorkspace, signInWithAccessToken } from 'utils/test-utils';
 // This one is going to take a long time
 jest.setTimeout(60 * 30 * 1000);
 // Retry one more when fails
-jest.retryTimes(1);
+jest.retryTimes(0);
 
 describe('Updating runtime compute type', () => {
   beforeEach(async () => {

--- a/e2e/tests/nightly/dataproc-to-gce.spec.ts
+++ b/e2e/tests/nightly/dataproc-to-gce.spec.ts
@@ -5,7 +5,7 @@ import { config } from 'resources/workbench-config';
 import { makeRandomName } from 'utils/str-utils';
 import { createWorkspace, signInWithAccessToken } from 'utils/test-utils';
 
-// This one is going to take a long time
+// This test could take a long time to run
 jest.setTimeout(60 * 30 * 1000);
 // Retry one more when fails
 jest.retryTimes(0);
@@ -60,7 +60,7 @@ describe('Updating runtime compute type', () => {
     const cpusOutputText = await notebook.runCodeCell(2, { codeFile: 'resources/python-code/count-cpus.py' });
     expect(parseInt(cpusOutputText, 10)).toBe(8);
 
-    // This gets the amount of memory available to Python in bytes
+    // This gets the amount of memory available to Python in GiB
     const memoryOutputText = await notebook.runCodeCell(3, { codeFile: 'resources/python-code/count-memory.py' });
     expect(parseInt(memoryOutputText, 10)).toBeGreaterThanOrEqual(28);
     expect(parseInt(memoryOutputText, 10)).toBeLessThanOrEqual(32);

--- a/e2e/tests/nightly/gce-to-dataproc.spec.ts
+++ b/e2e/tests/nightly/gce-to-dataproc.spec.ts
@@ -40,7 +40,7 @@ describe('Updating runtime compute type', () => {
     // Default memory is 15 gibibytes, we'll check that it is between 14GiB and 16GiB
     expect(parseFloat(memoryOutputText)).toBeGreaterThanOrEqual(14);
     expect(parseFloat(memoryOutputText)).toBeLessThanOrEqual(16);
-    
+
     await notebook.save();
 
     // Open runtime panel

--- a/e2e/tests/nightly/gce-to-dataproc.spec.ts
+++ b/e2e/tests/nightly/gce-to-dataproc.spec.ts
@@ -5,7 +5,7 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import { makeRandomName } from 'utils/str-utils';
 import { ResourceCard } from 'app/text-labels';
 
-// This one is going to take a long time
+// This test could take a long time to run
 jest.setTimeout(60 * 30 * 1000);
 // Retry one more when fails
 jest.retryTimes(0);
@@ -67,7 +67,7 @@ describe('Updating runtime compute type', () => {
     await notebookPreviewPage.openEditMode(notebookName);
 
     // Run notebook to validate runtime settings
-    const workersOutputText = await notebook.runCodeCell(4, { codeFile: 'resources/python-code/count-workers.py' });
+    const workersOutputText = await notebook.runCodeCell(3, { codeFile: 'resources/python-code/count-workers.py' });
     // Spark config always seems to start at this and then scale if you need additional threads.
     expect(workersOutputText).toBe("'2'");
     await notebook.save();

--- a/e2e/tests/nightly/gce-to-dataproc.spec.ts
+++ b/e2e/tests/nightly/gce-to-dataproc.spec.ts
@@ -8,7 +8,7 @@ import { ResourceCard } from 'app/text-labels';
 // This one is going to take a long time
 jest.setTimeout(60 * 30 * 1000);
 // Retry one more when fails
-jest.retryTimes(1);
+jest.retryTimes(0);
 
 describe('Updating runtime compute type', () => {
   beforeEach(async () => {

--- a/e2e/tests/nightly/gce-to-dataproc.spec.ts
+++ b/e2e/tests/nightly/gce-to-dataproc.spec.ts
@@ -40,11 +40,7 @@ describe('Updating runtime compute type', () => {
     // Default memory is 15 gibibytes, we'll check that it is between 14GiB and 16GiB
     expect(parseFloat(memoryOutputText)).toBeGreaterThanOrEqual(14);
     expect(parseFloat(memoryOutputText)).toBeLessThanOrEqual(16);
-    // This gets the disk space in bytes
-    const diskOutputText = await notebook.runCodeCell(3, { codeFile: 'resources/python-code/count-disk-space.py' });
-    // Default disk is 100 gibibytes, we'll check that it is between 95GiB and 105GiB
-    expect(parseFloat(diskOutputText)).toBeGreaterThanOrEqual(95);
-    expect(parseFloat(diskOutputText)).toBeLessThanOrEqual(105);
+    
     await notebook.save();
 
     // Open runtime panel


### PR DESCRIPTION
Removing disk size check because it's problematic.

nightly tests verified and passed on localhost:

![Screen Shot 2021-05-04 at 3 28 56 PM](https://user-images.githubusercontent.com/35533885/117059700-133eaa80-acee-11eb-9b0e-abf7617c9e54.png)
