### PR TITLE
[risk=low][no ticket] Force submodule updates due to a recent incompatible change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ commands:
     steps:
       - checkout
       - run:
-          command: git submodule update --init --recursive
+          command: git submodule update -f --init --recursive
 
   deploy-to-staging-perf:
     description: "Deploy API and UI to staging or perf App Engine"

--- a/api/docs/developer-system-initialization.md
+++ b/api/docs/developer-system-initialization.md
@@ -26,7 +26,7 @@ cd workbench
 # though this mechanism is being phased out. In the meantime, we need
 # to run this on every clone (or on certain changes to the upstream
 # repositories). 
-git submodule update --init --recursive
+git submodule update -f --init --recursive
 ```
 
 ## .npmrc

--- a/api/genomics/wdl/RandomizeVcf/Dockerfile
+++ b/api/genomics/wdl/RandomizeVcf/Dockerfile
@@ -21,5 +21,5 @@ RUN wget "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin
 ENV PATH="/opt/gradle/gradle-${GRADLE_VERSION}/bin:${PATH}"
 # Force a lower concurrent-ruby version, as we only have Ruby 2.3.
 RUN gem install jira-ruby
-RUN git clone https://github.com/all-of-us/workbench && cd workbench && git submodule update --init --recursive
+RUN git clone https://github.com/all-of-us/workbench && cd workbench && git submodule update -f --init --recursive
 RUN cd workbench/api && ./gradlew -p genomics build

--- a/deploy/bootstrap-docker.sh
+++ b/deploy/bootstrap-docker.sh
@@ -30,7 +30,7 @@ git fetch --tags
 git clean -fdx
 
 git checkout "${WORKBENCH_VERSION}"
-git submodule update --init --recursive
+git submodule update -f --init --recursive
 git status
 
 exec "$@"


### PR DESCRIPTION
Description:

Deploy failed with this error:
```
+ docker-compose build deploy
deploy uses an image, skipping
+ docker-compose run --rm -e WORKBENCH_VERSION=v6-20-rc1 -v /tmp/deploy@all-of-us-rw-stable.iam.gserviceaccount.com-key20210504-29182-1w64xf4.json:/creds/sa-key.json deploy deploy/project.rb deploy --account deploy@all-of-us-rw-stable.iam.gserviceaccount.com --project all-of-us-rw-stable --promote --app-version v6-20-rc1 --git-version v6-20-rc1 --key-file /creds/sa-key.json
Creating deploy_deploy_run ... done
M       aou-utils
HEAD is now at 4194affdc syncing CDR verisons (#4925)
error: The following untracked working tree files would be overwritten by checkout:
        utils/.sample-project.rb
        utils/.sample-project.yaml
        utils/LICENSE
        utils/README.md
        utils/common.rb
        utils/completion.bash
        utils/dockerhelper.rb
        utils/syncfiles.rb
Please move or remove them before you switch branches.
Aborting
Unable to checkout '5a7ff708451a2fc82b239a3f402588f6da451e98' in submodule path 'aou-utils'
ERROR: 1
```

As discussed [here](https://pmi-engteam.slack.com/archives/CHRN2R51N/p1619716923476000), the fix is to force the submodule update.

This PR adds `-f` everywhere we reference submodules.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
