### PR TITLE
[risk=no] Include progress bar type in pandas GBQ codegen

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -1089,7 +1089,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                     queryJobConfiguration.getNamedParameters())
                 + "\"\"\"";
         dataFrameSection =
-            namespace + "df = pandas.read_gbq(" + namespace + "sql, dialect=\"standard\")";
+            namespace + "df = pandas.read_gbq(" + namespace + "sql, dialect=\"standard\", progress_bar_type=\"tqdm_notebook\")";
         displayHeadSection = namespace + "df.head(5)";
         break;
       case R:

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -1089,7 +1089,10 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                     queryJobConfiguration.getNamedParameters())
                 + "\"\"\"";
         dataFrameSection =
-            namespace + "df = pandas.read_gbq(" + namespace + "sql, dialect=\"standard\", progress_bar_type=\"tqdm_notebook\")";
+            namespace
+                + "df = pandas.read_gbq("
+                + namespace
+                + "sql, dialect=\"standard\", progress_bar_type=\"tqdm_notebook\")";
         displayHeadSection = namespace + "df.head(5)";
         break;
       case R:


### PR DESCRIPTION
Looks like this was lost when we last [upgraded pandas](https://github.com/pandas-dev/pandas/blob/v1.2.4/pandas/io/gbq.py#L134-L155), the default value is no longer contextually inferred.

![image](https://user-images.githubusercontent.com/822298/117048659-1626a480-acc8-11eb-8d28-063563941f24.png)
