### PR TITLE
[RW-6667][risk=no] API changes to support access module expiration and renewal

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
@@ -14,6 +14,7 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.model.AdminTableUser;
 import org.pmiops.workbench.model.Profile;
+import org.pmiops.workbench.model.ProfileRenewableAccessModules;
 import org.pmiops.workbench.model.VerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
@@ -40,7 +41,8 @@ public interface ProfileMapper {
       DbUserTermsOfService latestTermsOfService,
       Double freeTierUsage,
       Double freeTierDollarQuota,
-      List<String> accessTierShortNames);
+      List<String> accessTierShortNames,
+      ProfileRenewableAccessModules renewableAccessModules);
 
   List<AdminTableUser> adminViewToModel(List<DbAdminTableUser> adminTableUsers);
 

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.profile;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.List;
@@ -39,6 +40,9 @@ import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.DemographicSurvey;
 import org.pmiops.workbench.model.InstitutionalRole;
 import org.pmiops.workbench.model.Profile;
+import org.pmiops.workbench.model.ProfileRenewableAccessModules;
+import org.pmiops.workbench.model.RenewableAccessModuleStatus;
+import org.pmiops.workbench.model.RenewableAccessModuleStatus.ModuleNameEnum;
 import org.pmiops.workbench.model.VerifiedInstitutionalAffiliation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -122,13 +126,22 @@ public class ProfileService {
     final List<String> accessTierShortNames =
         accessTierService.getAccessTierShortNamesForUser(user);
 
+    final ProfileRenewableAccessModules renewableAccessModules = new ProfileRenewableAccessModules()
+      .modules(ImmutableList.of(
+        new RenewableAccessModuleStatus().moduleName(ModuleNameEnum.COMPLIANCETRAINING)
+          .hasExpired(false),
+        new RenewableAccessModuleStatus().moduleName(ModuleNameEnum.DATAUSEAGREEMENT)
+          .hasExpired(false)))
+      .anyModuleHasExpired(false);
+
     return profileMapper.toModel(
         user,
         verifiedInstitutionalAffiliation,
         latestTermsOfService,
         freeTierUsage,
         freeTierDollarQuota,
-        accessTierShortNames);
+        accessTierShortNames,
+        renewableAccessModules);
   }
 
   public void validateAffiliation(Profile profile) {

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -126,13 +126,17 @@ public class ProfileService {
     final List<String> accessTierShortNames =
         accessTierService.getAccessTierShortNamesForUser(user);
 
-    final ProfileRenewableAccessModules renewableAccessModules = new ProfileRenewableAccessModules()
-      .modules(ImmutableList.of(
-        new RenewableAccessModuleStatus().moduleName(ModuleNameEnum.COMPLIANCETRAINING)
-          .hasExpired(false),
-        new RenewableAccessModuleStatus().moduleName(ModuleNameEnum.DATAUSEAGREEMENT)
-          .hasExpired(false)))
-      .anyModuleHasExpired(false);
+    final ProfileRenewableAccessModules renewableAccessModules =
+        new ProfileRenewableAccessModules()
+            .modules(
+                ImmutableList.of(
+                    new RenewableAccessModuleStatus()
+                        .moduleName(ModuleNameEnum.COMPLIANCETRAINING)
+                        .hasExpired(false),
+                    new RenewableAccessModuleStatus()
+                        .moduleName(ModuleNameEnum.DATAUSEAGREEMENT)
+                        .hasExpired(false)))
+            .anyModuleHasExpired(false);
 
     return profileMapper.toModel(
         user,

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5552,7 +5552,7 @@ definitions:
       moduleName:
         type: string
         enum:
-          - compolianceTraining
+          - complianceTraining
           - dataUseAgreement
       expirationEpochMillis:
         type: integer

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5534,6 +5534,33 @@ definitions:
         format: int64
         description: Timestamp when the user was bypassed for completing login.gov linking
           linking.
+      renewableAccessModules:
+        modules:
+          type: array
+          items:
+            "$ref": "#/definitions/RenewableAccessModuleStatus"
+        compliance:
+          anyModuleHasExpired:
+            type: boolean
+            description: >
+              Whether any modules have expired. Each expired module will have
+              the corresponding hasExpired flag set in the modules array.
+
+  RenewableAccessModuleStatus:
+    type: object
+    properties:
+      moduleName:
+        type: string
+        enum:
+          - training
+          - dataUseAgreement
+      expirationEpochMillis:
+        type: integer
+        format: int64
+        description: When this module expired or will expire.
+      hasExpired:
+        type: boolean
+        description: Whether this module has expired according to the server's clock.
 
   DemographicSurvey:
     type: object

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5535,11 +5535,12 @@ definitions:
         description: Timestamp when the user was bypassed for completing login.gov linking
           linking.
       renewableAccessModules:
-        modules:
-          type: array
-          items:
-            "$ref": "#/definitions/RenewableAccessModuleStatus"
-        compliance:
+        type: object
+        properties:
+          modules:
+            type: array
+            items:
+              "$ref": "#/definitions/RenewableAccessModuleStatus"
           anyModuleHasExpired:
             type: boolean
             description: >

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5552,7 +5552,7 @@ definitions:
       moduleName:
         type: string
         enum:
-          - training
+          - compolianceTraining
           - dataUseAgreement
       expirationEpochMillis:
         type: integer


### PR DESCRIPTION
Description:
This adds expiration information for compliance training and the data use agreement.

Response to /v1/profile is hardcoded as "All modules will never expire and are not currently expired":
```
{
  ...
  renewableAccessModules: {
    modules: [
      {
        moduleName: 'complianceTraining',
        expirationEpochMillis: null,
        hasExpired: false
      },
      {
        moduleName: 'dataUseAgreement',
        expirationEpochMillis: null,
        hasExpired: false
      }
    ],
    anyModuleHasExpired: false
  }
}
```

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
