### PR TITLE
[RW-6687][risk=no]  [P2] Dataset name (CDR Version) overflows its box in the Workspace About sidebar

### DIFF
--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -54,7 +54,8 @@ const styles = reactStyles({
     paddingBottom: '0.5rem'
   },
   infoBox: {
-    backgroundColor: colorWithWhiteness(colors.primary, 0.75), height: '2rem', width: '6rem',
+    backgroundColor: colorWithWhiteness(colors.primary, 0.75),
+    width: '6rem',
     borderRadius: '5px', padding: '0.4rem', marginRight: '0.5rem', marginBottom: '0.5rem',
     color: colors.primary, lineHeight: '14px'
   },


### PR DESCRIPTION
The height was restricting the background color in case the cdr version was too long. Removing that solved the problem 

Before
![image](https://user-images.githubusercontent.com/34481816/117705525-25ab5f00-b19a-11eb-82be-649b61c35c66.png)

After
<img width="263" alt="Screen Shot 2021-05-10 at 2 11 08 PM" src="https://user-images.githubusercontent.com/34481816/117705415-03b1dc80-b19a-11eb-9168-1826064ebdd7.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
