### PR TITLE
[risk=low][RW-6704][RW-6628] Add access renewal module fields and confirmProfile endpoint

### DIFF
--- a/api/db/changelog/db.changelog-162-add-user-profile-publications-confirmed-times.xml
+++ b/api/db/changelog/db.changelog-162-add-user-profile-publications-confirmed-times.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="thibault" id="changelog-162-add-user-profile-publications-confirmed-times">
+    <addColumn tableName="user">
+      <column name="profile_last_confirmed_time" type="datetime"/>
+    </addColumn>
+    <addColumn tableName="user">
+      <column name="publications_last_confirmed_time" type="datetime"/>
+    </addColumn>
+
+    <!--
+
+    On the initial launch of the access renewal compliance feature, we don't have a record of the
+    most recent time a user confirmed their profile was correct or they confirmed to us the
+    presence or lack of any publications relating to All of Us, because we have never asked for
+    this information before.
+
+    To approximate these confirmation times for existing users, we have chosen to pre-populate
+    these fields with the user's first registration time.  For new users, we will assume the
+    profile to be confirmed on registration and new users to not have any publications, so these
+    values will also be set when new users register for the first time.
+
+    If a user has ever has registered status (membership in the registered tier) then they
+    will have a first_enabled date in the user_access_tier table.  Copy this value (if it exists)
+    to the new fields created here: profile_last_confirmed_time and
+    publications_last_confirmed_time.
+
+    -->
+
+    <sql>
+      -- not all users have access tier memberships.
+      -- update only those who do.
+      UPDATE user u
+      INNER JOIN user_access_tier uat ON u.user_id = uat.user_id
+      INNER JOIN access_tier a ON uat.access_tier_id = a.access_tier_id
+
+      SET
+      u.profile_last_confirmed_time = uat.first_enabled,
+      u.publications_last_confirmed_time = uat.first_enabled
+
+      -- at initial launch, registered tier membership is not distinct from controlled tier
+      -- membership.  So there is no need to check controlled tier.
+      WHERE a.short_name = 'registered'
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-162-add-user-profile-publications-confirmed-times.xml
+++ b/api/db/changelog/db.changelog-162-add-user-profile-publications-confirmed-times.xml
@@ -24,7 +24,7 @@
     profile to be confirmed on registration and new users to not have any publications, so these
     values will also be set when new users register for the first time.
 
-    If a user has ever has registered status (membership in the registered tier) then they
+    If a user has ever had registered status (membership in the registered tier) then they
     will have a first_enabled date in the user_access_tier table.  Copy this value (if it exists)
     to the new fields created here: profile_last_confirmed_time and
     publications_last_confirmed_time.

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -171,6 +171,7 @@
   <include file="changelog/db.changelog-159-delete-data-dictionary-entry-table.xml"/>
   <include file="changelog/db.changelog-160-extraction-job-add-completion-time-and-user-cost.xml"/>
   <include file="changelog/db.changelog-161-extraction-job-add-status.xml"/>
+  <include file="changelog/db.changelog-162-add-user-profile-publications-confirmed-times.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -624,7 +624,7 @@ public class ProfileController implements ProfileApiDelegate {
 
   @Override
   public ResponseEntity<Void> confirmProfile() {
-    profileService.confirmProfile();
+    userService.confirmProfile();
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -621,4 +621,10 @@ public class ProfileController implements ProfileApiDelegate {
         rasLinkService.linkRasLoginGovAccount(body.getAuthCode(), body.getRedirectUrl());
     return ResponseEntity.ok(profileService.getProfile(dbUser));
   }
+
+  @Override
+  public ResponseEntity<Void> confirmProfile() {
+    profileService.confirmProfile();
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -2,7 +2,6 @@ package org.pmiops.workbench.db.dao;
 
 import java.sql.Timestamp;
 import java.util.List;
-import java.util.Set;
 import org.pmiops.workbench.db.model.DbUser;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.Query;
@@ -36,15 +35,6 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
   @Query(
       "SELECT user FROM DbUser user LEFT JOIN FETCH user.authorities LEFT JOIN FETCH user.pageVisits WHERE user.userId = :id")
   DbUser findUserWithAuthoritiesAndPageVisits(@Param("id") long id);
-
-  /** Returns the user with the page visits and authorities loaded. */
-  @Query(
-      "SELECT user"
-          + " FROM DbUser user"
-          + " LEFT JOIN FETCH user.authorities"
-          + " LEFT JOIN FETCH user.pageVisits"
-          + " ORDER BY NULL")
-  Set<DbUser> findAllUsersWithAuthoritiesAndPageVisits();
 
   // Find users matching the requested access tier and a (name or username) search term.
   @Query(

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.db.model.DbAddress;
@@ -154,9 +153,10 @@ public interface UserService {
 
   boolean hasAuthority(long userId, Authority required);
 
-  Set<DbUser> findAllUsersWithAuthoritiesAndPageVisits();
-
   Optional<DbUser> findUserWithAuthoritiesAndPageVisits(long userId);
 
   DbUser updateRasLinkLoginGovStatus(String loginGovUserName);
+
+  /** Confirm that a user's profile is up to date, for annual renewal compliance purposes. */
+  DbUser confirmProfile();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -964,11 +964,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   @Override
-  public Set<DbUser> findAllUsersWithAuthoritiesAndPageVisits() {
-    return userDao.findAllUsersWithAuthoritiesAndPageVisits();
-  }
-
-  @Override
   public DbUser updateRasLinkLoginGovStatus(String loginGovUserName) {
     DbUser dbUser = userProvider.get();
 
@@ -981,5 +976,13 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
         },
         dbUser,
         Agent.asUser(dbUser));
+  }
+
+  /** Confirm that a user's profile is up to date, for annual renewal compliance purposes. */
+  @Override
+  public DbUser confirmProfile() {
+    final DbUser dbUser = userProvider.get();
+    dbUser.setProfileLastConfirmedTime(new Timestamp(clock.instant().toEpochMilli()));
+    return userDao.save(dbUser);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -93,6 +93,8 @@ public class DbUser {
   private Timestamp idVerificationBypassTime;
   private Timestamp twoFactorAuthCompletionTime;
   private Timestamp twoFactorAuthBypassTime;
+  private Timestamp profileLastConfirmedTime;
+  private Timestamp publicationsLastConfirmedTime;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -663,6 +665,24 @@ public class DbUser {
 
   public void setAddress(DbAddress address) {
     this.address = address;
+  }
+
+  @Column(name = "profile_last_confirmed_time")
+  public Timestamp getProfileLastConfirmedTime() {
+    return profileLastConfirmedTime;
+  }
+
+  public void setProfileLastConfirmedTime(Timestamp profileLastConfirmedTime) {
+    this.profileLastConfirmedTime = profileLastConfirmedTime;
+  }
+
+  @Column(name = "publications_last_confirmed_time")
+  public Timestamp getPublicationsLastConfirmedTime() {
+    return publicationsLastConfirmedTime;
+  }
+
+  public void setPublicationsLastConfirmedTime(Timestamp publicationsLastConfirmedTime) {
+    this.publicationsLastConfirmedTime = publicationsLastConfirmedTime;
   }
 
   // null-friendly versions of equals() and hashCode() for DbVerifiedInstitutionalAffiliation

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -2,7 +2,6 @@ package org.pmiops.workbench.db.model;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -243,10 +242,6 @@ public class DbUser {
   @Column(name = "first_registration_completion_time")
   public Timestamp getFirstRegistrationCompletionTime() {
     return firstRegistrationCompletionTime;
-  }
-
-  public void setFirstRegistrationCompletionTime() {
-    setFirstRegistrationCompletionTime(Timestamp.from(Instant.now()));
   }
 
   @VisibleForTesting

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -520,4 +520,11 @@ public class ProfileService {
 
     return getProfile(dbUser);
   }
+
+  /** Confirm that a user's profile is up to date, for annual renewal compliance purposes. */
+  public void confirmProfile() {
+    final DbUser dbUser = userProvider.get();
+    dbUser.setProfileLastConfirmedTime(new Timestamp(clock.instant().toEpochMilli()));
+    userDao.save(dbUser);
+  }
 }

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -135,6 +135,12 @@ public class ProfileService {
                         .hasExpired(false),
                     new RenewableAccessModuleStatus()
                         .moduleName(ModuleNameEnum.DATAUSEAGREEMENT)
+                        .hasExpired(false),
+                    new RenewableAccessModuleStatus()
+                        .moduleName(ModuleNameEnum.PROFILECONFIRMATION)
+                        .hasExpired(false),
+                    new RenewableAccessModuleStatus()
+                        .moduleName(ModuleNameEnum.PUBLICATIONCONFIRMATION)
                         .hasExpired(false)))
             .anyModuleHasExpired(false);
 

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -520,11 +520,4 @@ public class ProfileService {
 
     return getProfile(dbUser);
   }
-
-  /** Confirm that a user's profile is up to date, for annual renewal compliance purposes. */
-  public void confirmProfile() {
-    final DbUser dbUser = userProvider.get();
-    dbUser.setProfileLastConfirmedTime(new Timestamp(clock.instant().toEpochMilli()));
-    userDao.save(dbUser);
-  }
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5555,6 +5555,8 @@ definitions:
         enum:
           - complianceTraining
           - dataUseAgreement
+          - profileConfirmation
+          - publicationConfirmation
       expirationEpochMillis:
         type: integer
         format: int64

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -249,6 +249,16 @@ paths:
       responses:
         204:
           description: Request Received.
+  "/v1/confirmProfile":
+    post:
+      tags:
+        - profile
+      description: Used by users to confirm that their profile is up to date, as part of the
+        annual renewal compliance process.
+      operationId: confirmProfile
+      responses:
+        204:
+          description: Request Received.
   "/v1/is-username-taken":
     get:
       tags:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -258,7 +258,7 @@ paths:
       operationId: confirmProfile
       responses:
         204:
-          description: Request Received.
+          description: Profile Confirmed.
   "/v1/is-username-taken":
     get:
       tags:

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -448,17 +448,15 @@ public class UserServiceTest {
 
     // user confirms profile, so confirmation time is set to START_INSTANT
 
-    userService.confirmProfile();
-
-    DbUser retrievedUser = userDao.findUserByUserId(providedDbUser.getUserId());
+    DbUser retrievedUser = userService.confirmProfile();
     assertThat(retrievedUser.getProfileLastConfirmedTime())
         .isEqualTo(Timestamp.from(START_INSTANT));
 
     // time passes, user confirms again, confirmation time is updated
 
     tick();
-    userService.confirmProfile();
-    retrievedUser = userDao.findUserByUserId(providedDbUser.getUserId());
+
+    retrievedUser = userService.confirmProfile();
     assertThat(retrievedUser.getProfileLastConfirmedTime())
         .isGreaterThan(Timestamp.from(START_INSTANT));
   }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -441,4 +441,25 @@ public class UserServiceTest {
       assertThat(userService.hasAuthority(user.getUserId(), auth)).isTrue();
     }
   }
+
+  @Test
+  public void test_confirmProfile() {
+    assertThat(providedDbUser.getProfileLastConfirmedTime()).isNull();
+
+    // user confirms profile, so confirmation time is set to START_INSTANT
+
+    userService.confirmProfile();
+
+    DbUser retrievedUser = userDao.findUserByUserId(providedDbUser.getUserId());
+    assertThat(retrievedUser.getProfileLastConfirmedTime())
+        .isEqualTo(Timestamp.from(START_INSTANT));
+
+    // time passes, user confirms again, confirmation time is updated
+
+    tick();
+    userService.confirmProfile();
+    retrievedUser = userDao.findUserByUserId(providedDbUser.getUserId());
+    assertThat(retrievedUser.getProfileLastConfirmedTime())
+        .isGreaterThan(Timestamp.from(START_INSTANT));
+  }
 }


### PR DESCRIPTION
Description:

Add the fields `profileLastConfirmedTime` and `publicationsLastConfirmedTime` to DbUser and populate these values from users' first_enabled time in their registered tier memberships.

Add a `POST v1/confirmProfile` endpoint for users to update their `profileLastConfirmedTime` values.

Also remove some unused code.

Testing was by DB and API interaction.

First, confirm that the DB fields are backfilled appropriately for users in the Registered Tier and not set for users who have never had Registered Tier access:
```
mysql> select * from user_access_tier where access_tier_id = 1;
+---------------------+---------+----------------+---------------+---------------------+---------------------+
| user_access_tier_id | user_id | access_tier_id | access_status | first_enabled       | last_updated        |
+---------------------+---------+----------------+---------------+---------------------+---------------------+
|                   1 |       1 |              1 |             1 | 2021-03-30 17:55:52 | 2021-03-30 17:55:52 |
|                   6 |       3 |              1 |             1 | 2021-04-01 14:21:53 | 2021-04-30 15:55:00 |
|                   8 |       2 |              1 |             1 | 2021-04-02 14:08:53 | 2021-04-02 14:08:53 |
+---------------------+---------+----------------+---------------+---------------------+---------------------+
3 rows in set (0.00 sec)

mysql> select user_id, email, profile_last_confirmed_time from user;
+---------+------------------------------------+-----------------------------+
| user_id | email                              | profile_last_confirmed_time |
+---------+------------------------------------+-----------------------------+
|       1 | joel-local@fake-research-aou.org   | 2021-03-30 17:55:52         |
|       2 | puppetjoel2@fake-research-aou.org  | 2021-04-02 14:08:53         |
|       3 | joel-local-2@fake-research-aou.org | 2021-04-01 14:21:53         |
|       4 | joel@fake-research-aou.org         | NULL                        |
+---------+------------------------------------+-----------------------------+
4 rows in set (0.00 sec)

mysql> select user_id, email, publications_last_confirmed_time from user;
+---------+------------------------------------+----------------------------------+
| user_id | email                              | publications_last_confirmed_time |
+---------+------------------------------------+----------------------------------+
|       1 | joel-local@fake-research-aou.org   | 2021-03-30 17:55:52              |
|       2 | puppetjoel2@fake-research-aou.org  | 2021-04-02 14:08:53              |
|       3 | joel-local-2@fake-research-aou.org | 2021-04-01 14:21:53              |
|       4 | joel@fake-research-aou.org         | NULL                             |
+---------+------------------------------------+----------------------------------+
4 rows in set (0.00 sec)
```

Then hit the endpoint as my user `joel-local`
```
curl -H "Authorization: Bearer `gcloud auth print-access-token`" -X POST -d'{}' http://localhost:8081/v1/confirmProfile
```

And observe that `profile_last_confirmed_time` is updated and `publications_last_confirmed_time` is not:
```
mysql> select user_id, email, profile_last_confirmed_time from user;
+---------+------------------------------------+-----------------------------+
| user_id | email                              | profile_last_confirmed_time |
+---------+------------------------------------+-----------------------------+
|       1 | joel-local@fake-research-aou.org   | 2021-05-11 20:48:18         |
|       2 | puppetjoel2@fake-research-aou.org  | 2021-04-02 14:08:53         |
|       3 | joel-local-2@fake-research-aou.org | 2021-04-01 14:21:53         |
|       4 | joel@fake-research-aou.org         | NULL                        |
+---------+------------------------------------+-----------------------------+
4 rows in set (0.00 sec)

mysql> select user_id, email, publications_last_confirmed_time from user;
+---------+------------------------------------+----------------------------------+
| user_id | email                              | publications_last_confirmed_time |
+---------+------------------------------------+----------------------------------+
|       1 | joel-local@fake-research-aou.org   | 2021-03-30 17:55:52              |
|       2 | puppetjoel2@fake-research-aou.org  | 2021-04-02 14:08:53              |
|       3 | joel-local-2@fake-research-aou.org | 2021-04-01 14:21:53              |
|       4 | joel@fake-research-aou.org         | NULL                             |
+---------+------------------------------------+----------------------------------+
4 rows in set (0.00 sec)
```



<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
