### PR TITLE
[RW-6553][risk=no] Update query report page to support Controlled Tier

### DIFF
--- a/ui/src/app/pages/data/cohort-review/query-report.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/query-report.component.tsx
@@ -3,9 +3,10 @@ import {SpinnerOverlay} from 'app/components/spinners';
 import {CohortDefinition} from 'app/pages/data/cohort-review/cohort-definition.component';
 import {ParticipantsCharts} from 'app/pages/data/cohort-review/participants-charts';
 import {cohortReviewStore} from 'app/services/review-state.service';
-import {cdrVersionsApi, cohortBuilderApi, cohortsApi} from 'app/services/swagger-fetch-clients';
+import {cohortBuilderApi, cohortsApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, withCdrVersions, withCurrentWorkspace} from 'app/utils';
+import {findCdrVersion} from 'app/utils/cdr-versions';
 import {navigate, urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {
@@ -210,13 +211,11 @@ export const QueryReport = fp.flow(withCdrVersions(), withCurrentWorkspace())(
     }
 
     componentDidMount() {
-      const {cdrVersionTiersResponse, workspace: {accessTierShortName, cdrVersionId}} = this.props;
+      const {cdrVersionTiersResponse, workspace: {cdrVersionId}} = this.props;
       const {review} = this.state;
       const {ns, wsid, cid} = urlParamsStore.getValue();
       cohortsApi().getCohort(ns, wsid, cid).then(cohort => this.setState({cohort}));
-      const cdrName = cdrVersionTiersResponse.tiers
-        .find(tier => tier.accessTierShortName === accessTierShortName).versions
-        .find(version => version.cdrVersionId === review.cdrVersionId.toString()).name;
+      const cdrName = findCdrVersion(review.cdrVersionId.toString(), cdrVersionTiersResponse).name;
       this.setState({cdrName});
       const request = (JSON.parse(review.cohortDefinition)) as SearchRequest;
       cohortBuilderApi().findDemoChartInfo(+cdrVersionId, GenderOrSexType[GenderOrSexType.GENDER], AgeType[AgeType.AGE], request)


### PR DESCRIPTION
- Update how we get the CDR name for the Query Report page to support Controlled Tier CDRs
- Use `cdrVersionStore` instead of calling the api since it has the same data
---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
