### PR TITLE
[RW-6546][risk=no] Handle FAILED workflow status for cromwell submission

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionMapper.java
@@ -1,9 +1,5 @@
 package org.pmiops.workbench.genomics;
 
-import com.google.common.collect.ImmutableBiMap;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.mapstruct.CollectionMappingStrategy;
@@ -17,7 +13,6 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkflow;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkflowStatus;
 import org.pmiops.workbench.model.GenomicExtractionJob;
 import org.pmiops.workbench.model.TerraJobStatus;
-import org.pmiops.workbench.model.TerraWorkflowStatus;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
@@ -39,8 +34,10 @@ public interface GenomicExtractionMapper {
   default TerraJobStatus convertJobStatus(FirecloudSubmission submission) {
     // FirecloudSubmission.status doesn't capture the distinction between 'succeeded' and 'failed'
     // in 'done' so we have to check the workflows themselves.
-    Set<FirecloudWorkflowStatus> workflowStatuses = submission.getWorkflows().stream()
-        .map(FirecloudWorkflow::getStatus).collect(Collectors.toSet());
+    Set<FirecloudWorkflowStatus> workflowStatuses =
+        submission.getWorkflows().stream()
+            .map(FirecloudWorkflow::getStatus)
+            .collect(Collectors.toSet());
 
     if (submission.getStatus() == FirecloudSubmissionStatus.DONE) {
       if (workflowStatuses.contains(FirecloudWorkflowStatus.FAILED)) {

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionMapper.java
@@ -1,13 +1,23 @@
 package org.pmiops.workbench.genomics;
 
+import com.google.common.collect.ImmutableBiMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbWgsExtractCromwellSubmission;
+import org.pmiops.workbench.firecloud.model.FirecloudSubmission;
 import org.pmiops.workbench.firecloud.model.FirecloudSubmissionStatus;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkflow;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkflowStatus;
 import org.pmiops.workbench.model.GenomicExtractionJob;
 import org.pmiops.workbench.model.TerraJobStatus;
+import org.pmiops.workbench.model.TerraWorkflowStatus;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
@@ -26,13 +36,22 @@ public interface GenomicExtractionMapper {
   @Mapping(target = "submissionDate", source = "dbSubmission.terraSubmissionDate")
   GenomicExtractionJob toApi(DbWgsExtractCromwellSubmission dbSubmission);
 
-  default TerraJobStatus convertJobStatus(FirecloudSubmissionStatus status) {
-    if (status == FirecloudSubmissionStatus.DONE) {
+  default TerraJobStatus convertJobStatus(FirecloudSubmission submission) {
+    // FirecloudSubmission.status doesn't capture the distinction between 'succeeded' and 'failed'
+    // in 'done' so we have to check the workflows themselves.
+    Set<FirecloudWorkflowStatus> workflowStatuses = submission.getWorkflows().stream()
+        .map(FirecloudWorkflow::getStatus).collect(Collectors.toSet());
+
+    if (submission.getStatus() == FirecloudSubmissionStatus.DONE) {
+      if (workflowStatuses.contains(FirecloudWorkflowStatus.FAILED)) {
+        return TerraJobStatus.FAILED;
+      }
       return TerraJobStatus.SUCCEEDED;
-    } else if (status == FirecloudSubmissionStatus.ABORTED
-        || status == FirecloudSubmissionStatus.ABORTING) {
+    } else if (submission.getStatus() == FirecloudSubmissionStatus.ABORTED
+        || submission.getStatus() == FirecloudSubmissionStatus.ABORTING) {
       return TerraJobStatus.FAILED;
     } else {
+      // Accepted, Evaluating, Submitting, Submitted
       return TerraJobStatus.RUNNING;
     }
   }

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -129,7 +129,7 @@ public class GenomicExtractionService {
                               dbSubmission.getSubmissionId());
 
                   TerraJobStatus status =
-                      genomicExtractionMapper.convertJobStatus(firecloudSubmission.getStatus());
+                      genomicExtractionMapper.convertJobStatus(firecloudSubmission);
                   dbSubmission.setTerraStatusEnum(status);
                   if (status != TerraJobStatus.RUNNING) {
                     dbSubmission.setCompletionTime(

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -116,8 +116,8 @@ public class GenomicExtractionService {
             dbSubmission -> {
               try {
                 // Don't bother checking if we already know the job is in a terminal status.
-                if (dbSubmission.getTerraStatusEnum() == TerraJobStatus.RUNNING
-                    || dbSubmission.getTerraStatusEnum() == null) {
+                if (dbSubmission.getTerraStatusEnum() == null
+                    || dbSubmission.getTerraStatusEnum() == TerraJobStatus.RUNNING) {
                   WgsCohortExtractionConfig cohortExtractionConfig =
                       workbenchConfigProvider.get().wgsCohortExtraction;
                   FirecloudSubmission firecloudSubmission =
@@ -129,7 +129,9 @@ public class GenomicExtractionService {
                               dbSubmission.getSubmissionId());
 
                   TerraJobStatus status =
-                      genomicExtractionMapper.convertJobStatus(firecloudSubmission);
+                      genomicExtractionMapper.convertWorkflowStatus(
+                          // Extraction submissions should only have one workflow.
+                          firecloudSubmission.getWorkflows().get(0).getStatus());
                   dbSubmission.setTerraStatusEnum(status);
                   if (status != TerraJobStatus.RUNNING) {
                     dbSubmission.setCompletionTime(

--- a/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
@@ -225,7 +225,10 @@ public class GenomicExtractionServiceTest {
         new FirecloudSubmission()
             .submissionId(dbWgsExtractCromwellSubmission.getSubmissionId())
             .status(FirecloudSubmissionStatus.DONE)
-            .addWorkflowsItem(new FirecloudWorkflow().statusLastChangedDate(completionTimestamp))
+            .addWorkflowsItem(
+                new FirecloudWorkflow()
+                    .statusLastChangedDate(completionTimestamp)
+                    .status(FirecloudWorkflowStatus.SUCCEEDED))
             .submissionDate(submissionDate));
 
     GenomicExtractionJob wgsCohortExtractionJob =

--- a/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
@@ -281,35 +281,43 @@ public class GenomicExtractionServiceTest {
     Map<Long, TerraJobStatus> expectedStatuses = new HashMap<>();
 
     expectedStatuses.put(
-        createSubmissionAndMockMonitorCall(FirecloudSubmissionStatus.DONE, FirecloudWorkflowStatus.SUCCEEDED)
+        createSubmissionAndMockMonitorCall(
+                FirecloudSubmissionStatus.DONE, FirecloudWorkflowStatus.SUCCEEDED)
             .getWgsExtractCromwellSubmissionId(),
         TerraJobStatus.SUCCEEDED);
     expectedStatuses.put(
-        createSubmissionAndMockMonitorCall(FirecloudSubmissionStatus.DONE, FirecloudWorkflowStatus.FAILED)
+        createSubmissionAndMockMonitorCall(
+                FirecloudSubmissionStatus.DONE, FirecloudWorkflowStatus.FAILED)
             .getWgsExtractCromwellSubmissionId(),
         TerraJobStatus.FAILED);
     expectedStatuses.put(
-        createSubmissionAndMockMonitorCall(FirecloudSubmissionStatus.ABORTED, FirecloudWorkflowStatus.ABORTED)
+        createSubmissionAndMockMonitorCall(
+                FirecloudSubmissionStatus.ABORTED, FirecloudWorkflowStatus.ABORTED)
             .getWgsExtractCromwellSubmissionId(),
         TerraJobStatus.FAILED);
     expectedStatuses.put(
-        createSubmissionAndMockMonitorCall(FirecloudSubmissionStatus.ABORTING, FirecloudWorkflowStatus.ABORTING)
+        createSubmissionAndMockMonitorCall(
+                FirecloudSubmissionStatus.ABORTING, FirecloudWorkflowStatus.ABORTING)
             .getWgsExtractCromwellSubmissionId(),
         TerraJobStatus.FAILED);
     expectedStatuses.put(
-        createSubmissionAndMockMonitorCall(FirecloudSubmissionStatus.ACCEPTED, FirecloudWorkflowStatus.QUEUED)
+        createSubmissionAndMockMonitorCall(
+                FirecloudSubmissionStatus.ACCEPTED, FirecloudWorkflowStatus.QUEUED)
             .getWgsExtractCromwellSubmissionId(),
         TerraJobStatus.RUNNING);
     expectedStatuses.put(
-        createSubmissionAndMockMonitorCall(FirecloudSubmissionStatus.EVALUATING, FirecloudWorkflowStatus.RUNNING)
+        createSubmissionAndMockMonitorCall(
+                FirecloudSubmissionStatus.EVALUATING, FirecloudWorkflowStatus.RUNNING)
             .getWgsExtractCromwellSubmissionId(),
         TerraJobStatus.RUNNING);
     expectedStatuses.put(
-        createSubmissionAndMockMonitorCall(FirecloudSubmissionStatus.SUBMITTED, FirecloudWorkflowStatus.SUBMITTED)
+        createSubmissionAndMockMonitorCall(
+                FirecloudSubmissionStatus.SUBMITTED, FirecloudWorkflowStatus.SUBMITTED)
             .getWgsExtractCromwellSubmissionId(),
         TerraJobStatus.RUNNING);
     expectedStatuses.put(
-        createSubmissionAndMockMonitorCall(FirecloudSubmissionStatus.SUBMITTING, FirecloudWorkflowStatus.LAUNCHING)
+        createSubmissionAndMockMonitorCall(
+                FirecloudSubmissionStatus.SUBMITTING, FirecloudWorkflowStatus.LAUNCHING)
             .getWgsExtractCromwellSubmissionId(),
         TerraJobStatus.RUNNING);
 
@@ -336,8 +344,8 @@ public class GenomicExtractionServiceTest {
   }
 
   private DbWgsExtractCromwellSubmission createSubmissionAndMockMonitorCall(
-      FirecloudSubmissionStatus submissionStatus,
-      FirecloudWorkflowStatus workflowStatus) throws ApiException {
+      FirecloudSubmissionStatus submissionStatus, FirecloudWorkflowStatus workflowStatus)
+      throws ApiException {
     DbWgsExtractCromwellSubmission dbWgsExtractCromwellSubmission =
         createDbWgsExtractCromwellSubmission();
     doReturn(


### PR DESCRIPTION
Now failed workflows should count as failed on our end too even though there's no 'failed' submission status.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
