### PR TITLE
[RW-6692][risk=low] Eliminate spurious changes to user.lastModifiedTime

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
@@ -4,8 +4,6 @@ import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.common.collect.Sets;
 import com.google.common.math.DoubleMath;
-import java.sql.Timestamp;
-import java.time.Clock;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -42,7 +40,6 @@ import org.springframework.stereotype.Service;
 public class FreeTierBillingService {
 
   private final BigQueryService bigQueryService;
-  private final Clock clock;
   private final MailService mailService;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final UserDao userDao;
@@ -59,7 +56,6 @@ public class FreeTierBillingService {
   @Autowired
   public FreeTierBillingService(
       BigQueryService bigQueryService,
-      Clock clock,
       MailService mailService,
       Provider<WorkbenchConfig> workbenchConfigProvider,
       UserDao userDao,
@@ -67,7 +63,6 @@ public class FreeTierBillingService {
       WorkspaceDao workspaceDao,
       WorkspaceFreeTierUsageDao workspaceFreeTierUsageDao) {
     this.bigQueryService = bigQueryService;
-    this.clock = clock;
     this.mailService = mailService;
     this.userDao = userDao;
     this.workbenchConfigProvider = workbenchConfigProvider;
@@ -329,7 +324,6 @@ public class FreeTierBillingService {
 
       // TODO: prevent setting this limit directly except in this method?
       user.setFreeTierCreditsLimitDollarsOverride(newDollarLimit);
-      user.setLastModifiedTime(new Timestamp(clock.instant().toEpochMilli()));
       user = userDao.save(user);
 
       if (userHasRemainingFreeTierCredits(user)) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -149,8 +149,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     while (true) {
       dbUser = userModifier.apply(dbUser);
       updateUserAccessTiers(dbUser, agent);
-      Timestamp now = new Timestamp(clock.instant().toEpochMilli());
-      dbUser.setLastModifiedTime(now);
       try {
         return userDao.save(dbUser);
       } catch (ObjectOptimisticLockingFailureException e) {
@@ -366,9 +364,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       dbUser.setDegreesEnum(degrees);
     }
     dbUser.setDemographicSurvey(dbDemographicSurvey);
-    Timestamp now = new Timestamp(clock.instant().toEpochMilli());
-    dbUser.setCreationTime(now);
-    dbUser.setLastModifiedTime(now);
 
     // For existing user that do not have address
     if (dbAddress != null) {

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -24,6 +24,8 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.Version;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.EmailVerificationStatus;
@@ -626,19 +628,23 @@ public class DbUser {
   }
 
   @Column(name = "last_modified_time")
+  @UpdateTimestamp
   public Timestamp getLastModifiedTime() {
     return lastModifiedTime;
   }
 
+  @VisibleForTesting
   public void setLastModifiedTime(Timestamp lastModifiedTime) {
     this.lastModifiedTime = lastModifiedTime;
   }
 
   @Column(name = "creation_time")
+  @CreationTimestamp
   public Timestamp getCreationTime() {
     return creationTime;
   }
 
+  @VisibleForTesting
   public void setCreationTime(Timestamp creationTime) {
     this.creationTime = creationTime;
   }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -627,8 +627,8 @@ public class DbUser {
     this.demographicSurvey = demographicSurvey;
   }
 
-  @Column(name = "last_modified_time")
   @UpdateTimestamp
+  @Column(name = "last_modified_time")
   public Timestamp getLastModifiedTime() {
     return lastModifiedTime;
   }
@@ -638,8 +638,8 @@ public class DbUser {
     this.lastModifiedTime = lastModifiedTime;
   }
 
-  @Column(name = "creation_time")
   @CreationTimestamp
+  @Column(name = "creation_time")
   public Timestamp getCreationTime() {
     return creationTime;
   }

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -241,9 +241,6 @@ public class ProfileService {
       dbDemographicSurvey.setUser(user);
     }
     user.setDemographicSurvey(dbDemographicSurvey);
-
-    user.setLastModifiedTime(now);
-
     userService.updateUserWithConflictHandling(user);
 
     // FIXME: why not do a getOrCreateAffiliation() here and then update that object & save?

--- a/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.mail.MessagingException;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,6 +63,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 @DataJpaTest
 public class FreeTierBillingServiceTest {
 
+  private static final Instant START_INSTANT = Instant.parse("2000-01-01T00:00:00.00Z");
+  private static final FakeClock CLOCK = new FakeClock(START_INSTANT);
+
   private static final double DEFAULT_PERCENTAGE_TOLERANCE = 0.000001;
 
   @MockBean private UserServiceAuditor mockUserServiceAuditor;
@@ -81,16 +83,11 @@ public class FreeTierBillingServiceTest {
   private static final String SINGLE_WORKSPACE_TEST_USER = "test@test.com";
   private static final String SINGLE_WORKSPACE_TEST_PROJECT = "aou-test-123";
 
-  // An arbitrary timestamp to use as the anchor time for tests.
-  private static final Instant START_INSTANT = Instant.parse("2000-01-01T00:00:00.00Z");
-  private static final FakeClock CLOCK = new FakeClock(START_INSTANT);
-
   @TestConfiguration
   @Import({FreeTierBillingService.class})
   @MockBean({BigQueryService.class, MailService.class})
   static class Configuration {
     @Bean
-    @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     public Clock clock() {
       return CLOCK;
     }
@@ -111,11 +108,6 @@ public class FreeTierBillingServiceTest {
 
     // by default we have 0 spend
     doReturn(mockBQTableSingleResult(0.0)).when(bigQueryService).executeQuery(any());
-  }
-
-  @After
-  public void resetClock() {
-    CLOCK.setInstant(START_INSTANT);
   }
 
   @Test
@@ -338,29 +330,16 @@ public class FreeTierBillingServiceTest {
   public void maybeSetDollarLimitOverride_true() {
     workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
-    assertThat(user.getLastModifiedTime()).isNull();
-
-    // we update the user and should see this last modified time
-    final Instant time2 = START_INSTANT.plusSeconds(1000);
-    CLOCK.setInstant(time2);
 
     assertThat(freeTierBillingService.maybeSetDollarLimitOverride(user, 200.0)).isTrue();
     verify(mockUserServiceAuditor)
         .fireSetFreeTierDollarLimitOverride(user.getUserId(), null, 200.0);
     assertWithinBillingTolerance(freeTierBillingService.getUserFreeTierDollarLimit(user), 200.0);
-    assertThat(userDao.findUserByUserId(user.getUserId()).getLastModifiedTime())
-        .isEqualTo(new Timestamp(time2.toEpochMilli()));
-
-    // we update the user again and should see this new last modified time
-    final Instant time3 = START_INSTANT.plusSeconds(2000);
-    CLOCK.setInstant(time3);
 
     assertThat(freeTierBillingService.maybeSetDollarLimitOverride(user, 100.0)).isTrue();
     verify(mockUserServiceAuditor)
         .fireSetFreeTierDollarLimitOverride(user.getUserId(), 200.0, 100.0);
     assertWithinBillingTolerance(freeTierBillingService.getUserFreeTierDollarLimit(user), 100.0);
-    assertThat(userDao.findUserByUserId(user.getUserId()).getLastModifiedTime())
-        .isEqualTo(new Timestamp(time3.toEpochMilli()));
   }
 
   @Test
@@ -371,7 +350,6 @@ public class FreeTierBillingServiceTest {
     assertThat(freeTierBillingService.maybeSetDollarLimitOverride(user, 100.0)).isFalse();
     verify(mockUserServiceAuditor, never())
         .fireSetFreeTierDollarLimitOverride(anyLong(), anyDouble(), anyDouble());
-    assertThat(user.getLastModifiedTime()).isNull();
     assertWithinBillingTolerance(freeTierBillingService.getUserFreeTierDollarLimit(user), 100.0);
 
     workbenchConfig.billing.defaultFreeCreditsDollarLimit = 200.0;
@@ -380,7 +358,6 @@ public class FreeTierBillingServiceTest {
     assertThat(freeTierBillingService.maybeSetDollarLimitOverride(user, 200.0)).isFalse();
     verify(mockUserServiceAuditor, never())
         .fireSetFreeTierDollarLimitOverride(anyLong(), anyDouble(), anyDouble());
-    assertThat(user.getLastModifiedTime()).isNull();
     assertWithinBillingTolerance(freeTierBillingService.getUserFreeTierDollarLimit(user), 200.0);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -14,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
@@ -280,6 +282,34 @@ public class UserServiceTest {
 
     DbUser retrievedUser = userDao.findUserByUsername(USERNAME);
     assertThat(retrievedUser.getEraCommonsCompletionTime()).isNull();
+  }
+
+  @Test
+  public void testSyncEraCommonsStatus_lastModified() {
+    // User starts without eRA commons.
+    Supplier<Timestamp> getLastModified =
+        () -> userDao.findUserByUsername(USERNAME).getLastModifiedTime();
+    Timestamp modifiedTime0 = getLastModified.get();
+
+    when(mockFireCloudService.getNihStatus())
+        .thenReturn(
+            new FirecloudNihStatus()
+                .linkedNihUsername("nih-user")
+                // FireCloud stores the NIH status in seconds, not msecs.
+                .linkExpireTime(START_INSTANT.toEpochMilli() / 1000));
+    userService.syncEraCommonsStatus();
+    Timestamp modifiedTime1 = getLastModified.get();
+    assertWithMessage(
+            "modified time should change when eRA commons status changes, want %s < %s",
+            modifiedTime0, modifiedTime1)
+        .that(modifiedTime0.before(modifiedTime1))
+        .isTrue();
+
+    userService.syncEraCommonsStatus();
+    assertWithMessage(
+            "modified time should not change on sync, if eRA commons status doesn't change")
+        .that(modifiedTime1)
+        .isEqualTo(getLastModified.get());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
@@ -121,7 +121,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
     assertTimeApprox(
         user.getComplianceTrainingExpirationTime(), USER__COMPLIANCE_TRAINING_EXPIRATION_TIME);
     assertThat(user.getContactEmail()).isEqualTo(USER__CONTACT_EMAIL);
-    assertTimeApprox(user.getCreationTime(), USER__CREATION_TIME);
     assertThat(user.getCurrentPosition()).isEqualTo(USER__CURRENT_POSITION);
     assertThat(user.getAccessTierShortNames()).isEqualTo(USER__ACCESS_TIER_SHORT_NAMES);
     assertTimeApprox(user.getDataUseAgreementBypassTime(), USER__DATA_USE_AGREEMENT_BYPASS_TIME);
@@ -141,7 +140,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
     assertThat(user.getFreeTierCreditsLimitDollarsOverride())
         .isEqualTo(USER__FREE_TIER_CREDITS_LIMIT_DOLLARS_OVERRIDE);
     assertThat(user.getGivenName()).isEqualTo(USER__GIVEN_NAME);
-    assertTimeApprox(user.getLastModifiedTime(), USER__LAST_MODIFIED_TIME);
     assertThat(user.getProfessionalUrl()).isEqualTo(USER__PROFESSIONAL_URL);
     assertTimeApprox(user.getTwoFactorAuthBypassTime(), USER__TWO_FACTOR_AUTH_BYPASS_TIME);
     assertTimeApprox(user.getTwoFactorAuthCompletionTime(), USER__TWO_FACTOR_AUTH_COMPLETION_TIME);
@@ -159,6 +157,12 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
     assertThat(user.getGenderIdentities()).isEqualTo(USER__GENDER_IDENTITY.toString());
     assertThat(user.getIdentifiesAsLgbtq()).isEqualTo(USER__IDENTIFIES_AS_LGBTQ);
     assertThat(user.getLgbtqIdentity()).isEqualTo(USER__LGBTQ_IDENTITY);
+
+    // Simple null check only. These are autopopulated by Hibernate, so if the entity is saved to
+    // the database, these values will not match what was specified in this text fixture. We
+    // populate values when creating the DTO to support tests that may not persist to the DB layer.
+    assertThat(user.getCreationTime()).isNotNull();
+    assertThat(user.getLastModifiedTime()).isNotNull();
   }
 
   @Override


### PR DESCRIPTION
- Leverage `@UpdateTimestamp` for automatic timestamp updates via Hibernate, which resolves an issue with excessive updates to `lastModifiedTime` (i.e. on every cron run).
- Switch to `@CreationTimestamp` for consistency, this way these columns have an identical value on initial insertion

## Why this works
These annotations only have an effect if you make a change which would modify the database row. A no-op `save()` does not change the lastModified time, which is exactly the desired behavior for offline cronjobs etc. This should reduce RDR export user selection to expected levels, since it looks at `lastModifiedTime` to determine whether to send data.

Tested by locally triggering crons, profile updates, user create and observing the expected `last_modified_time` in the database.

Filed https://precisionmedicineinitiative.atlassian.net/browse/RW-6743 to explore this for the rest of the models.

One downside: this approach is less testable than the clock approach. Hibernate does not make it easy to stub out this value for testing purposes: https://github.com/hibernate/hibernate-orm/blob/main/hibernate-core/src/main/java/org/hibernate/tuple/TimestampGenerators.java