### PR TITLE
[risk=no] Fix scrollbar display in cohort review table

### DIFF
--- a/ui/src/app/styles/datatable.ts
+++ b/ui/src/app/styles/datatable.ts
@@ -28,6 +28,9 @@ export const datatableStyles = `
     border: 1px solid #c8c8c8;
     border-radius: 3px;
   }
+  .p-datatable-scrollable-body {
+    -webkit-transform: translate3d(0, 0, 0);
+  }
   .p-datatable .p-paginator.p-paginator-bottom {
     border: 0;
     margin-top: 20px;


### PR DESCRIPTION
Fixes issue where the scrollbar from the participant detail table is visible from behind the annotations sidebar.

Before:

https://user-images.githubusercontent.com/40036095/118070875-58a54c80-b36c-11eb-9873-a25b0e877490.mov

After:

https://user-images.githubusercontent.com/40036095/118070904-61961e00-b36c-11eb-9661-068f47aa3b9d.mov

