### PR TITLE
[risk=no][RW-5492] rm obsolete PENDING_DELETION_POST_1PPW_MIGRATION

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -518,7 +518,6 @@ public final class DbStorageEnums {
           ImmutableBiMap.<WorkspaceActiveStatus, Short>builder()
               .put(WorkspaceActiveStatus.ACTIVE, (short) 0)
               .put(WorkspaceActiveStatus.DELETED, (short) 1)
-              .put(WorkspaceActiveStatus.PENDING_DELETION_POST_1PPW_MIGRATION, (short) 2)
               .build();
 
   public static WorkspaceActiveStatus workspaceActiveStatusFromStorage(Short s) {

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4439,7 +4439,6 @@ definitions:
     enum:
     - ACTIVE
     - DELETED
-    - PENDING_DELETION_POST_1PPW_MIGRATION
   ResearchPurpose:
     type: object
     required:

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -231,19 +231,6 @@ public class WorkspaceServiceTest {
   }
 
   @Test
-  public void getWorkspaces_skipPending() {
-    int currentWorkspacesSize = workspaceService.getWorkspaces().size();
-
-    addMockedWorkspace(
-        workspaceIdIncrementer.getAndIncrement(),
-        "inactive",
-        DEFAULT_WORKSPACE_NAMESPACE,
-        WorkspaceAccessLevel.OWNER,
-        WorkspaceActiveStatus.PENDING_DELETION_POST_1PPW_MIGRATION);
-    assertThat(workspaceService.getWorkspaces().size()).isEqualTo(currentWorkspacesSize);
-  }
-
-  @Test
   public void getWorkspaces_skipDeleted() {
     int currentWorkspacesSize = workspaceService.getWorkspaces().size();
 


### PR DESCRIPTION
Description:

This is only part 1 or RW-5492 (the easy part)

Confirmed that no PENDING_DELETION_POST_1PPW_MIGRATION Workspaces exist in any environment: `select * from workspace where active_status = 2;` is empty in all

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
