### PR TITLE
[RW-6725][risk=low] Real access renewal status in profile response

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -21,10 +21,6 @@ import org.springframework.data.domain.Sort;
 public interface UserService {
   DbUser updateUserWithRetries(Function<DbUser, DbUser> userModifier, DbUser dbUser, Agent agent);
 
-  // Timestamp getExpiration(Timestamp completionTime);
-  // Long getExpirationMsSinceEpoch(Timestamp completionTime);
-  // boolean isCompleteAndNotExpired(Timestamp completionTime);
-  // boolean isDataUseAgreementCompliant(DbUser user);
   List<RenewableAccessModuleStatus> getRenewableAccessModuleStatus(DbUser dbUser);
 
   DbUser createServiceAccountUser(String email);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -15,10 +15,17 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.model.AccessBypassRequest;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.Degree;
+import org.pmiops.workbench.model.RenewableAccessModuleStatus;
 import org.springframework.data.domain.Sort;
 
 public interface UserService {
   DbUser updateUserWithRetries(Function<DbUser, DbUser> userModifier, DbUser dbUser, Agent agent);
+
+  // Timestamp getExpiration(Timestamp completionTime);
+  // Long getExpirationMsSinceEpoch(Timestamp completionTime);
+  // boolean isCompleteAndNotExpired(Timestamp completionTime);
+  // boolean isDataUseAgreementCompliant(DbUser user);
+  List<RenewableAccessModuleStatus> getRenewableAccessModuleStatus(DbUser dbUser);
 
   DbUser createServiceAccountUser(String email);
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -213,56 +213,65 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     tiersForRemoval.forEach(tier -> accessTierService.removeUserFromTier(dbUser, tier));
   }
 
-  public List<RenewableAccessModuleStatus> getRenewableAccessModuleStatus(DbUser dbUser) {
-    return ImmutableList.of(
-      new RenewableAccessModuleStatus()
-          .moduleName(ModuleNameEnum.COMPLIANCETRAINING)
-          .hasExpired(false),
-      new RenewableAccessModuleStatus()
-          .moduleName(ModuleNameEnum.DATAUSEAGREEMENT)
-          .expirationEpochMillis(getExpirationMsSinceEpoch(dbUser.getDataUseAgreementCompletionTime()))
-          .hasExpired(!isDataUseAgreementCompliant(dbUser)),
-      new RenewableAccessModuleStatus()
-          .moduleName(ModuleNameEnum.PROFILECONFIRMATION)
-          .hasExpired(false),
-      new RenewableAccessModuleStatus()
-          .moduleName(ModuleNameEnum.PUBLICATIONCONFIRMATION)
-          .hasExpired(false));
-  }
-
-  private Timestamp getExpiration(Timestamp completionTime) {
-    if (completionTime == null) { return null; }
-    Long expiryDays = configProvider.get().accessRenewal.expiryDays;
-    if (expiryDays == null) { return null; }
-    long expiryDaysInMs = TimeUnit.MILLISECONDS.convert(expiryDays, TimeUnit.DAYS);
-    return new Timestamp(completionTime.getTime() + expiryDaysInMs);
-  }
-
-  private Long getExpirationMsSinceEpoch(Timestamp completionTime) {
-    final Timestamp expiration = getExpiration(completionTime);
-    return expiration == null ? null : expiration.getTime();
-  }
-
-  private boolean isCompleteAndNotExpired(Timestamp completionTime) {
-    if (configProvider.get().access.enableAccessRenewal) {
-      final Timestamp now = new Timestamp(clock.millis());
-      return completionTime != null && getExpiration(completionTime).after(now);
+  private class ModuleTimes {
+    public Optional<Timestamp> completion;
+    public Optional<Timestamp> bypass;
+    public ModuleTimes(Timestamp nullableCompletion, Timestamp nullableBypass) {
+      completion = Optional.ofNullable(nullableCompletion);
+      bypass = Optional.ofNullable(nullableBypass);
     }
-    return completionTime != null;
+    public boolean isBypassed() {
+      return bypass.isPresent();
+    }
+    public boolean isComplete() {
+      return completion.isPresent();
+    }
+    public Optional<Timestamp> getExpiration() {
+      if (isBypassed()) { return Optional.empty(); }
+      if (!completion.isPresent()) { return Optional.empty(); }
+      if (!configProvider.get().access.enableAccessRenewal) { return Optional.empty(); }
+      Long expiryDays = configProvider.get().accessRenewal.expiryDays;
+      if (expiryDays == null) {
+        throw new RuntimeException("config value accessRenewal.expiryDays.expiryDays is null");
+      }
+      long expiryDaysInMs = TimeUnit.MILLISECONDS.convert(expiryDays, TimeUnit.DAYS);
+      return Optional.of(new Timestamp(completion.get().getTime() + expiryDaysInMs));
+    }
+    public boolean hasExpired() {
+      final Timestamp now = new Timestamp(clock.millis());
+      return getExpiration().map(x -> x.before(now)).orElse(false);
+    }
+    public boolean areCompliant() {
+      return isBypassed() || (isComplete() && !hasExpired());
+    }
+  }
+
+  private RenewableAccessModuleStatus mkStatus(ModuleNameEnum name, ModuleTimes times) {
+    return new RenewableAccessModuleStatus().moduleName(name)
+      .expirationEpochMillis(times.getExpiration().map(x -> x.getTime()).orElse(null))
+      .hasExpired(times.hasExpired());
+  }
+
+  public List<RenewableAccessModuleStatus> getRenewableAccessModuleStatus(DbUser user) {
+    return ImmutableList.of(
+      mkStatus(ModuleNameEnum.COMPLIANCETRAINING, new ModuleTimes(
+        user.getComplianceTrainingCompletionTime(), user.getComplianceTrainingBypassTime())),
+      mkStatus(ModuleNameEnum.DATAUSEAGREEMENT, new ModuleTimes(
+        user.getDataUseAgreementCompletionTime(), user.getDataUseAgreementBypassTime())),
+      mkStatus(ModuleNameEnum.PROFILECONFIRMATION, new ModuleTimes(
+        user.getProfileLastConfirmedTime(), null)),
+      mkStatus(ModuleNameEnum.PUBLICATIONCONFIRMATION, new ModuleTimes(
+        user.getPublicationsLastConfirmedTime(), null)));
   }
 
   private boolean isDataUseAgreementCompliant(DbUser user) {
-    if (user.getDataUseAgreementBypassTime() != null
-        || !configProvider.get().access.enableDataUseAgreement) {
-      // Data use agreement version may be ignored, since it's bypassed on the user or env level.
-      return true;
-    } else if (user.getDataUseAgreementSignedVersion() != null
-        && user.getDataUseAgreementSignedVersion() == getCurrentDuccVersion()
-        && isCompleteAndNotExpired(user.getDataUseAgreementCompletionTime())) {
-      // User has signed the most-recent DUCC version.
-      return true;
-    }
-    return false;
+    final ModuleTimes duaTimes = new ModuleTimes(
+      user.getDataUseAgreementCompletionTime(), user.getDataUseAgreementBypassTime());
+    if (!configProvider.get().access.enableDataUseAgreement) { return true; }
+    if (duaTimes.isBypassed()) { return true; }
+    final Integer signedVersion = user.getDataUseAgreementSignedVersion();
+    if (signedVersion == null || signedVersion != getCurrentDuccVersion()) { return false; }
+    return duaTimes.isComplete() && !duaTimes.hasExpired();
   }
 
   // Checking for annual completion time is not a part of this module
@@ -273,9 +282,10 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   private boolean isComplianceTrainingCompliant(DbUser user) {
-    return user.getComplianceTrainingBypassTime() != null
-        || isCompleteAndNotExpired(user.getComplianceTrainingCompletionTime())
-        || !configProvider.get().access.enableComplianceTraining;
+    if (!configProvider.get().access.enableComplianceTraining) { return true; }
+    final ModuleTimes ctTimes = new ModuleTimes(
+      user.getComplianceTrainingCompletionTime(), user.getComplianceTrainingBypassTime());
+    return ctTimes.isBypassed() || (ctTimes.isComplete() && !ctTimes.hasExpired());
   }
 
   private boolean shouldUserBeRegistered(DbUser user) {

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.profile;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.List;
@@ -42,7 +41,6 @@ import org.pmiops.workbench.model.InstitutionalRole;
 import org.pmiops.workbench.model.Profile;
 import org.pmiops.workbench.model.ProfileRenewableAccessModules;
 import org.pmiops.workbench.model.RenewableAccessModuleStatus;
-import org.pmiops.workbench.model.RenewableAccessModuleStatus.ModuleNameEnum;
 import org.pmiops.workbench.model.VerifiedInstitutionalAffiliation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -127,7 +125,7 @@ public class ProfileService {
         accessTierService.getAccessTierShortNamesForUser(user);
 
     final List<RenewableAccessModuleStatus> modulesStatus =
-      userService.getRenewableAccessModuleStatus(userLite);
+        userService.getRenewableAccessModuleStatus(userLite);
 
     final ProfileRenewableAccessModules renewableAccessModules =
         new ProfileRenewableAccessModules()

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -126,23 +126,13 @@ public class ProfileService {
     final List<String> accessTierShortNames =
         accessTierService.getAccessTierShortNamesForUser(user);
 
+    final List<RenewableAccessModuleStatus> modulesStatus =
+      this.userService.getRenewableAccessModuleStatus(userLite);
+
     final ProfileRenewableAccessModules renewableAccessModules =
         new ProfileRenewableAccessModules()
-            .modules(
-                ImmutableList.of(
-                    new RenewableAccessModuleStatus()
-                        .moduleName(ModuleNameEnum.COMPLIANCETRAINING)
-                        .hasExpired(false),
-                    new RenewableAccessModuleStatus()
-                        .moduleName(ModuleNameEnum.DATAUSEAGREEMENT)
-                        .hasExpired(false),
-                    new RenewableAccessModuleStatus()
-                        .moduleName(ModuleNameEnum.PROFILECONFIRMATION)
-                        .hasExpired(false),
-                    new RenewableAccessModuleStatus()
-                        .moduleName(ModuleNameEnum.PUBLICATIONCONFIRMATION)
-                        .hasExpired(false)))
-            .anyModuleHasExpired(false);
+            .modules(modulesStatus)
+            .anyModuleHasExpired(modulesStatus.stream().anyMatch(x -> x.getHasExpired()));
 
     return profileMapper.toModel(
         user,

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -127,7 +127,7 @@ public class ProfileService {
         accessTierService.getAccessTierShortNamesForUser(user);
 
     final List<RenewableAccessModuleStatus> modulesStatus =
-      this.userService.getRenewableAccessModuleStatus(userLite);
+      userService.getRenewableAccessModuleStatus(userLite);
 
     final ProfileRenewableAccessModules renewableAccessModules =
         new ProfileRenewableAccessModules()

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -232,7 +232,7 @@ public class UserServiceAccessTest {
         .isEqualTo(TierAccessStatus.ENABLED);
 
     // Simulate time passing, user is no longer compliant
-    PROVIDED_CLOCK.setInstant(START_INSTANT.plus(1, ChronoUnit.DAYS));
+    PROVIDED_CLOCK.setInstant(START_INSTANT.plus(2, ChronoUnit.DAYS));
     dbUser =
         userService.updateUserWithRetries(
             this::registerUserWithoutDuaBypass, dbUser, Agent.asUser(dbUser));


### PR DESCRIPTION
I tried to make this as concise as possible and would appreciate pointers. Unit tests are a big lift, so added RW-6750 to cover them.

I judge risk to be low because getting the logic wrong could cause someone to stay registered longer than they should be. Avoiding this should be covered by existing tests, but I haven't checked.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
