### PR TITLE
[RW-6705][risk=medium] API - change all CB API calls to use workspaceNamespace/workspaceId instead of cdrVersionId

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -217,9 +217,6 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     dbWorkspace.setCdrVersion(cdrVersion);
 
     workspaceDao.save(dbWorkspace);
-    when(workspaceAuthService.enforceWorkspaceAccessLevel(
-            WORKSPACE_NAMESPACE, WORKSPACE_ID, WorkspaceAccessLevel.READER))
-        .thenReturn(WorkspaceAccessLevel.READER);
 
     when(workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
             WORKSPACE_NAMESPACE, WORKSPACE_ID, WorkspaceAccessLevel.READER))

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTierForTests;
@@ -17,7 +16,9 @@ import org.joda.time.DateTime;
 import org.joda.time.Period;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.pmiops.workbench.access.AccessTierService;
@@ -125,7 +126,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Autowired private CohortBuilderService cohortBuilderService;
 
-  @Mock private WorkspaceAuthService workspaceAuthService;
+  @Autowired private WorkspaceAuthService workspaceAuthService;
 
   @Autowired private CdrVersionDao cdrVersionDao;
 
@@ -913,58 +914,39 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
         .isTrue();
   }
 
+  @Rule public ExpectedException badRequestThrown = ExpectedException.none();
+
   @Test
   public void validateAttribute() {
     SearchParameter demo = age();
     Attribute attribute = new Attribute().name(AttrName.NUM);
     demo.attributes(ImmutableList.of(attribute));
+    badRequestThrown.expect(BadRequestException.class);
+    badRequestThrown.expectMessage("Bad Request: attribute operator null is not valid.");
+
     SearchRequest searchRequest =
         createSearchRequests(
             Domain.CONDITION.toString(), ImmutableList.of(demo), new ArrayList<>());
-    try {
-      controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
-      fail("Should have thrown BadRequestException!");
-    } catch (BadRequestException bre) {
-      assertThat(bre.getMessage()).isEqualTo("Bad Request: attribute operator null is not valid.");
-    }
+    controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
 
     attribute.operator(Operator.BETWEEN);
-    try {
-      controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
-      fail("Should have thrown BadRequestException!");
-    } catch (BadRequestException bre) {
-      assertThat(bre.getMessage()).isEqualTo("Bad Request: attribute operands are empty.");
-    }
+    badRequestThrown.expectMessage("Bad Request: attribute operator null is not valid.");
+    controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
 
     attribute.operands(ImmutableList.of("20"));
-    try {
-      controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
-      fail("Should have thrown BadRequestException!");
-    } catch (BadRequestException bre) {
-      assertThat(bre.getMessage())
-          .isEqualTo(
-              "Bad Request: attribute NUM can only have 2 operands when using the BETWEEN operator");
-    }
+    badRequestThrown.expectMessage(
+        "Bad Request: attribute NUM can only have 2 operands when using the BETWEEN operator");
+    controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
 
     attribute.operands(ImmutableList.of("s", "20"));
-    try {
-      controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
-      fail("Should have thrown BadRequestException!");
-    } catch (BadRequestException bre) {
-      assertThat(bre.getMessage())
-          .isEqualTo("Bad Request: attribute NUM operands must be numeric.");
-    }
+    badRequestThrown.expectMessage("Bad Request: attribute NUM operands must be numeric.");
+    controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
 
     attribute.operands(ImmutableList.of("10", "20"));
     attribute.operator(Operator.EQUAL);
-    try {
-      controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
-      fail("Should have thrown BadRequestException!");
-    } catch (BadRequestException bre) {
-      assertThat(bre.getMessage())
-          .isEqualTo(
-              "Bad Request: attribute NUM must have one operand when using the EQUAL operator.");
-    }
+    badRequestThrown.expectMessage(
+        "Bad Request: attribute NUM must have one operand when using the EQUAL operator.");
+    controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
   }
 
   @Test
@@ -973,60 +955,33 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     SearchRequest searchRequest =
         createSearchRequests(
             Domain.CONDITION.toString(), ImmutableList.of(icd9()), ImmutableList.of(modifier));
-    try {
-      controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
-      fail("Should have thrown BadRequestException!");
-    } catch (BadRequestException bre) {
-      assertThat(bre.getMessage()).isEqualTo("Bad Request: modifier operator null is not valid.");
-    }
+    badRequestThrown.expect(BadRequestException.class);
+    badRequestThrown.expectMessage("Bad Request: modifier operator null is not valid.");
+    controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
 
     modifier.operator(Operator.BETWEEN);
-    try {
-      controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
-      fail("Should have thrown BadRequestException!");
-    } catch (BadRequestException bre) {
-      assertThat(bre.getMessage()).isEqualTo("Bad Request: modifier operands are empty.");
-    }
+    badRequestThrown.expectMessage("Bad Request: modifier operands are empty.");
+    controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
 
     modifier.operands(ImmutableList.of("20"));
-    try {
-      controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
-      fail("Should have thrown BadRequestException!");
-    } catch (BadRequestException bre) {
-      assertThat(bre.getMessage())
-          .isEqualTo(
-              "Bad Request: modifier AGE_AT_EVENT can only have 2 operands when using the BETWEEN operator");
-    }
+    badRequestThrown.expectMessage(
+        "Bad Request: modifier AGE_AT_EVENT can only have 2 operands when using the BETWEEN operator");
+    controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
 
     modifier.operands(ImmutableList.of("s", "20"));
-    try {
-      controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
-      fail("Should have thrown BadRequestException!");
-    } catch (BadRequestException bre) {
-      assertThat(bre.getMessage())
-          .isEqualTo("Bad Request: modifier AGE_AT_EVENT operands must be numeric.");
-    }
+    badRequestThrown.expectMessage("Bad Request: modifier AGE_AT_EVENT operands must be numeric.");
+    controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
 
     modifier.operands(ImmutableList.of("10", "20"));
     modifier.operator(Operator.EQUAL);
-    try {
-      controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
-      fail("Should have thrown BadRequestException!");
-    } catch (BadRequestException bre) {
-      assertThat(bre.getMessage())
-          .isEqualTo(
-              "Bad Request: modifier AGE_AT_EVENT must have one operand when using the EQUAL operator.");
-    }
+    badRequestThrown.expectMessage(
+        "Bad Request: modifier AGE_AT_EVENT must have one operand when using the EQUAL operator.");
+    controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
 
     modifier.name(ModifierType.EVENT_DATE);
     modifier.operands(ImmutableList.of("10"));
-    try {
-      controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
-      fail("Should have thrown BadRequestException!");
-    } catch (BadRequestException bre) {
-      assertThat(bre.getMessage())
-          .isEqualTo("Bad Request: modifier EVENT_DATE must be a valid date.");
-    }
+    badRequestThrown.expectMessage("Bad Request: modifier EVENT_DATE must be a valid date.");
+    controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
   }
 
   @Test
@@ -1080,29 +1035,21 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void temporalGroupExceptions() {
+    badRequestThrown.expect(BadRequestException.class);
     SearchGroupItem icd9SGI =
         new SearchGroupItem().type(Domain.CONDITION.toString()).addSearchParametersItem(icd9());
 
     SearchGroup temporalGroup = new SearchGroup().items(ImmutableList.of(icd9SGI)).temporal(true);
 
     SearchRequest searchRequest = new SearchRequest().includes(ImmutableList.of(temporalGroup));
-    try {
-      controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
-      fail("Should have thrown BadRequestException!");
-    } catch (BadRequestException bre) {
-      assertThat(bre.getMessage())
-          .isEqualTo("Bad Request: search group item temporal group null is not valid.");
-    }
+    badRequestThrown.expectMessage(
+        "Bad Request: search group item temporal group null is not valid.");
+    controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
 
     icd9SGI.temporalGroup(0);
-    try {
-      controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
-      fail("Should have thrown BadRequestException!");
-    } catch (BadRequestException bre) {
-      assertThat(bre.getMessage())
-          .isEqualTo(
-              "Bad Request: Search Group Items must provided for 2 different temporal groups(0 or 1).");
-    }
+    badRequestThrown.expectMessage(
+        "Bad Request: Search Group Items must provided for 2 different temporal groups(0 or 1).");
+    controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
   }
 
   @Test

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -119,8 +119,6 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private DbCdrVersion cdrVersion;
 
-  private DbWorkspace dbWorkspace;
-
   @Autowired private BigQueryService bigQueryService;
 
   @Autowired private CloudStorageClient cloudStorageClient;
@@ -211,7 +209,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
     cdrVersion = cdrVersionDao.save(cdrVersion);
 
-    dbWorkspace = new DbWorkspace();
+    DbWorkspace dbWorkspace = new DbWorkspace();
     dbWorkspace.setWorkspaceNamespace(WORKSPACE_NAMESPACE);
     dbWorkspace.setName("Saved workspace");
     dbWorkspace.setFirecloudName(WORKSPACE_ID);

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3184,9 +3184,10 @@ paths:
           description: CohortAnnotationDefinition deletion request accepted
           schema:
             "$ref": "#/definitions/EmptyResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/menu/{parentId}":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/menu/{parentId}":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+    - "$ref": "#/parameters/workspaceNamespace"
+    - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3204,23 +3205,25 @@ paths:
           description: A collection of criteria menu options
           schema:
             "$ref": "#/definitions/CriteriaMenuListResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/domaininfo":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/domaininfo":
+    parameters:
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
       description: 'Returns information on the domains of data in the workspace''s
         CDR version along with participant and concept counts'
       operationId: findDomainInfos
-      parameters:
-      - "$ref": "#/parameters/cdrVersionId"
       responses:
         200:
           description: information on the domains
           schema:
             "$ref": "#/definitions/DomainInfoResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/domaininfo/{domain}":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/domaininfo/{domain}":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3242,23 +3245,25 @@ paths:
           description: A count of matching concepts in this domain
           schema:
             "$ref": "#/definitions/DomainCount"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/surveymodule":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/surveymodule":
+    parameters:
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
       description: 'Returns survey information in the workspace''s CDR version along
         with participant and question count'
       operationId: findSurveyModules
-      parameters:
-      - "$ref": "#/parameters/cdrVersionId"
       responses:
         200:
           description: information about the surveys
           schema:
             "$ref": "#/definitions/SurveysResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/surveymodule/{name}":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/surveymodule/{name}":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3280,9 +3285,10 @@ paths:
           description: A count of matching concepts per survey
           schema:
             "$ref": "#/definitions/SurveyCount"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/{domain}/search/term":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/{domain}/search/term":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3314,9 +3320,10 @@ paths:
           description: A collection of criteria
           schema:
             "$ref": "#/definitions/CriteriaListWithCountResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/{domain}/{conceptId}":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/{domain}/{conceptId}":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3339,9 +3346,10 @@ paths:
           description: A collection of criteria
           schema:
             "$ref": "#/definitions/CriteriaListResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/{domain}":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/{domain}":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3400,9 +3408,10 @@ paths:
           description: A collection of criteria
           schema:
             "$ref": "#/definitions/CriteriaListResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/{domain}/search":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/{domain}/search":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3440,9 +3449,10 @@ paths:
           description: A collection of criteria
           schema:
             "$ref": "#/definitions/CriteriaListResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/drug":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/drug":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3464,9 +3474,10 @@ paths:
           description: A collection of criteria
           schema:
             "$ref": "#/definitions/CriteriaListResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/drug/ingredient/{conceptId}":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/drug/ingredient/{conceptId}":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3484,9 +3495,10 @@ paths:
           description: A collection of criteria
           schema:
             "$ref": "#/definitions/CriteriaListResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/attribute/{conceptId}":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/attribute/{conceptId}":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3504,9 +3516,10 @@ paths:
           description: A collection of criteria
           schema:
             "$ref": "#/definitions/CriteriaAttributeListResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/survey/attribute/{surveyConceptId}/{questionConceptId}":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/survey/attribute/{surveyConceptId}/{questionConceptId}":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3530,9 +3543,10 @@ paths:
           description: A collection of SurveyVersion
           schema:
             "$ref": "#/definitions/SurveyVersionListResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/criteria/survey/attribute/{surveyConceptId}/{questionConceptId}/{answerConceptId}":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/survey/attribute/{surveyConceptId}/{questionConceptId}/{answerConceptId}":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3562,9 +3576,10 @@ paths:
           description: A collection of SurveyVersion
           schema:
             "$ref": "#/definitions/SurveyVersionListResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/age/counts":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/age/counts":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3575,9 +3590,10 @@ paths:
           description: A collection age type counts
           schema:
             "$ref": "#/definitions/AgeTypeCountListResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/search":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/search":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     post:
       tags:
       - cohortBuilder
@@ -3599,9 +3615,10 @@ paths:
           schema:
             type: integer
             format: int64
-  "/v1/cohortbuilder/{cdrVersionId}/chartinfo/{genderOrSex}/{age}":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/chartinfo/{genderOrSex}/{age}":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     post:
       tags:
       - cohortBuilder
@@ -3631,9 +3648,10 @@ paths:
           description: A collection of criteria
           schema:
             "$ref": "#/definitions/DemoChartInfoListResponse"
-  "/v1/cohortbuilder/{cdrVersionId}/demographics":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/demographics":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder
@@ -3645,9 +3663,10 @@ paths:
             and ethnicity.
           schema:
             "$ref": "#/definitions/ParticipantDemographics"
-  "/v1/cohortbuilder/{cdrVersionId}/dataFilters":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/dataFilters":
     parameters:
-    - "$ref": "#/parameters/cdrVersionId"
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
     get:
       tags:
       - cohortBuilder

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -69,7 +69,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class CohortBuilderControllerTest extends SpringTest {
 
   private CohortBuilderController controller;
-  private DbWorkspace dbWorkspace;
 
   @Mock private BigQueryService bigQueryService;
   @Mock private CloudStorageClient cloudStorageClient;
@@ -122,7 +121,7 @@ public class CohortBuilderControllerTest extends SpringTest {
     doReturn(mySQLStopWords).when(mySQLStopWordsProvider).get();
     DbCdrVersion cdrVersion = new DbCdrVersion();
     cdrVersion.setCdrVersionId(1l);
-    dbWorkspace = new DbWorkspace();
+    DbWorkspace dbWorkspace = new DbWorkspace();
     dbWorkspace.setWorkspaceNamespace(WORKSPACE_NAMESPACE);
     dbWorkspace.setName("Saved workspace");
     dbWorkspace.setFirecloudName(WORKSPACE_ID);

--- a/ui/src/app/cohort-search/demographics/demographics.component.tsx
+++ b/ui/src/app/cohort-search/demographics/demographics.component.tsx
@@ -167,9 +167,9 @@ export class Demographics extends React.Component<Props, State> {
 
   async loadNodesFromApi() {
     const {criteriaType, selections} = this.props;
-    const {cdrVersionId} = currentWorkspaceStore.getValue();
+    const {id, namespace} = currentWorkspaceStore.getValue();
     this.setState({loading: true});
-    const response = await cohortBuilderApi().findCriteriaBy(+cdrVersionId, Domain.PERSON.toString(), criteriaType.toString());
+    const response = await cohortBuilderApi().findCriteriaBy(namespace, id, Domain.PERSON.toString(), criteriaType.toString());
     const nodes = response.items.filter(item => item.count !== -1)
       .sort(sortByCountThenName)
       .map(node => ({...node, parameterId: `param${node.conceptId || node.code}`}));
@@ -180,13 +180,13 @@ export class Demographics extends React.Component<Props, State> {
   }
 
   async loadAgeNodesFromApi() {
-    const {cdrVersionId} = currentWorkspaceStore.getValue();
+    const {id, namespace} = currentWorkspaceStore.getValue();
     const initialValue = {
       [AttrName.AGE]: [],
       [AttrName.AGEATCONSENT]: [],
       [AttrName.AGEATCDR]: []
     };
-    const response = await cohortBuilderApi().findAgeTypeCounts(+cdrVersionId);
+    const response = await cohortBuilderApi().findAgeTypeCounts(namespace, id);
     const ageTypeNodes = response.items.reduce((acc, item) => {
       acc[item.ageType].push(item);
       return acc;

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -329,16 +329,16 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
       let sourceMatch;
       try {
         this.setState({data: null, apiError: false, inputErrors: [], loading: true, searching: true, standardOnly: false});
-        const {searchContext: {domain, source, selectedSurvey}, workspace: {cdrVersionId}} = this.props;
+        const {searchContext: {domain, source, selectedSurvey}, workspace: {id, namespace}} = this.props;
         const surveyName = selectedSurvey || 'All';
-        const resp = await cohortBuilderApi().findCriteriaByDomainAndSearchTerm(+cdrVersionId, domain, value.trim(), surveyName);
+        const resp = await cohortBuilderApi().findCriteriaByDomainAndSearchTerm(namespace, id, domain, value.trim(), surveyName);
         const data = source !== 'cohort' && this.isSurvey
           ? resp.items.filter(survey => survey.subtype === CriteriaSubType.QUESTION.toString())
           : resp.items;
         if (data.length && this.checkSource) {
           sourceMatch = data.find(item => item.code.toLowerCase() === value.trim().toLowerCase() && !item.isStandard);
           if (sourceMatch) {
-            const stdResp = await cohortBuilderApi().findStandardCriteriaByDomainAndConceptId(+cdrVersionId, domain, sourceMatch.conceptId);
+            const stdResp = await cohortBuilderApi().findStandardCriteriaByDomainAndConceptId(namespace, id, domain, sourceMatch.conceptId);
             this.setState({standardData: stdResp.items});
           }
         }
@@ -395,9 +395,9 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
         try {
           ingredients[row.id] = {open: false, loading: true, error: false, items: []};
           this.setState({ingredients});
-          const {workspace: {cdrVersionId}} = this.props;
+          const {workspace: {id, namespace}} = this.props;
           cohortBuilderApi()
-            .findDrugIngredientByConceptId(+cdrVersionId, row.conceptId)
+            .findDrugIngredientByConceptId(namespace, id, row.conceptId)
             .then(resp => {
               ingredients[row.id] = {open: true, loading: false, error: false, items: resp.items};
               this.setState({ingredients});

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
@@ -214,7 +214,7 @@ export const ModifierPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSea
     }
 
     async componentDidMount() {
-      const {cohortContext: {domain}, workspace: {cdrVersionId}} = this.props;
+      const {cohortContext: {domain}, workspace: {id, namespace}} = this.props;
       const {formState} = this.state;
       if (domain !== Domain.SURVEY) {
         formState.push({
@@ -259,7 +259,7 @@ export const ModifierPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSea
         if (!encountersOptions) {
           // get options for visit modifier from api
           const res = await cohortBuilderApi().findCriteriaBy(
-            +cdrVersionId, Domain[Domain.VISIT], CriteriaType[CriteriaType.VISIT]);
+            namespace, id, Domain[Domain.VISIT], CriteriaType[CriteriaType.VISIT]);
           encountersOptions = res.items;
           encountersStore.next(encountersOptions);
         }
@@ -381,7 +381,7 @@ export const ModifierPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSea
     }
 
     calculate = async() => {
-      const {selections, cohortContext: {domain, role}, workspace: {cdrVersionId}} = this.props;
+      const {selections, cohortContext: {domain, role}, workspace: {id , namespace}} = this.props;
       this.trackEvent('Calculate');
       try {
         this.setState({calculating: true, count: null, calculateError: false});
@@ -397,7 +397,7 @@ export const ModifierPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSea
           }],
           dataFilters: []
         };
-        await cohortBuilderApi().countParticipants(+cdrVersionId, request)
+        await cohortBuilderApi().countParticipants(namespace, id, request)
           .then(response => this.setState({count: response, calculating: false}));
       } catch (error) {
         console.error(error);

--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -264,10 +264,10 @@ export const ListOverview = fp.flow(withCurrentWorkspace(), withCdrVersions()) (
     callApi() {
       const {searchRequest} = this.props;
       const {ageType, genderOrSexType} = this.state;
-      const {cdrVersionId} = currentWorkspaceStore.getValue();
+      const {id, namespace} = currentWorkspaceStore.getValue();
       const request = mapRequest(searchRequest);
       return cohortBuilderApi()
-        .findDemoChartInfo(+cdrVersionId, genderOrSexType.toString(), ageType.toString(), request, {signal: this.aborter.signal});
+        .findDemoChartInfo(namespace, id, genderOrSexType.toString(), ageType.toString(), request, {signal: this.aborter.signal});
     }
 
     get hasActiveItems() {

--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -205,10 +205,10 @@ export class SearchBar extends React.Component<Props, State> {
     const {node: {domainId, isStandard, type}, searchTerms} = this.props;
     triggerEvent(`Cohort Builder Search - ${domainToTitle(domainId)}`, 'Search', searchTerms);
     this.setState({inputErrors: [], loading: true});
-    const {cdrVersionId} = currentWorkspaceStore.getValue();
+    const {id, namespace} = currentWorkspaceStore.getValue();
     const apiCall = domainId === Domain.DRUG.toString()
-      ? cohortBuilderApi().findDrugBrandOrIngredientByValue(+cdrVersionId, searchTerms)
-      : cohortBuilderApi().findCriteriaAutoComplete(+cdrVersionId, domainId, searchTerms, type, isStandard);
+      ? cohortBuilderApi().findDrugBrandOrIngredientByValue(namespace, id, searchTerms)
+      : cohortBuilderApi().findCriteriaAutoComplete(namespace, id, domainId, searchTerms, type, isStandard);
     apiCall.then(resp => {
       const optionNames: Array<string> = [];
       const options = resp.items.filter(option => {
@@ -233,8 +233,8 @@ export class SearchBar extends React.Component<Props, State> {
       setInput(option.name);
       this.setState({highlightedOption: null, options: null, optionSelected: true});
       if (option.type === CriteriaType.BRAND.toString()) {
-        const cdrId = +(currentWorkspaceStore.getValue().cdrVersionId);
-        cohortBuilderApi().findDrugIngredientByConceptId(cdrId, option.conceptId)
+        const {id, namespace} = currentWorkspaceStore.getValue();
+        cohortBuilderApi().findDrugIngredientByConceptId(namespace, id, option.conceptId)
           .then(resp => {
             if (resp.items.length) {
               const ingredients = resp.items.map(it => it.name);

--- a/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
+++ b/ui/src/app/cohort-search/search-group-item/search-group-item.component.tsx
@@ -160,7 +160,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
     }
 
     componentDidMount(): void {
-      const {item: {count, modifiers}, workspace: {cdrVersionId}} = this.props;
+      const {item: {count, modifiers}, workspace: {id, namespace}} = this.props;
       const {encounters} = this.state;
       if (count !== undefined) {
         this.setState({loading: false});
@@ -168,7 +168,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
         this.getItemCount();
       }
       if (!!modifiers && modifiers.some(mod => mod.name === ModifierType.ENCOUNTERS) && !encounters) {
-        cohortBuilderApi().findCriteriaBy(+cdrVersionId, Domain[Domain.VISIT], CriteriaType[CriteriaType.VISIT]).then(res => {
+        cohortBuilderApi().findCriteriaBy(namespace, id, Domain[Domain.VISIT], CriteriaType[CriteriaType.VISIT]).then(res => {
           encountersStore.next(res.items);
           this.setState({encounters: res.items});
         });
@@ -186,7 +186,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
       const {item, role, updateGroup} = this.props;
       try {
         updateGroup();
-        const {cdrVersionId} = currentWorkspaceStore.getValue();
+        const {id, namespace} = currentWorkspaceStore.getValue();
         const mappedItem = mapGroupItem(item, false);
         const request = {
           includes: [],
@@ -194,7 +194,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
           dataFilters: [],
           [role]: [{items: [mappedItem], temporal: false}]
         };
-        await cohortBuilderApi().countParticipants(+cdrVersionId, request).then(count => this.updateSearchRequest('count', count, false));
+        await cohortBuilderApi().countParticipants(namespace, id, request).then(count => this.updateSearchRequest('count', count, false));
       } catch (error) {
         console.error(error);
         this.setState({error: true});

--- a/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
+++ b/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
@@ -180,14 +180,13 @@ const SearchGroupList = fp.flow(withCurrentWorkspace(), withCdrVersions())(
 
     getMenuOptions() {
       this.setState({loadingMenuOptions: true});
-      const {workspace} = this.props;
-      const {cdrVersionId} = workspace;
+      const {workspace: {id, cdrVersionId, namespace}} = this.props;
       const criteriaMenuOptions = criteriaMenuOptionsStore.getValue();
-      cohortBuilderApi().findCriteriaMenu(+cdrVersionId, 0).then(async res => {
+      cohortBuilderApi().findCriteriaMenu(namespace, id, 0).then(async res => {
         const menuOptions = await Promise.all(res.items.map(async item => {
           const option = mapMenuItem(item);
           if (option.group) {
-            const children = await cohortBuilderApi().findCriteriaMenu(+cdrVersionId, option.id);
+            const children = await cohortBuilderApi().findCriteriaMenu(namespace, id, option.id);
             option.children = children.items.map(mapMenuItem);
           }
           return option;

--- a/ui/src/app/cohort-search/search-group/search-group.component.tsx
+++ b/ui/src/app/cohort-search/search-group/search-group.component.tsx
@@ -274,7 +274,7 @@ export const SearchGroup = withCurrentWorkspace()(
     getGroupCount() {
       this.abortPendingCalls();
       this.setState({error: false, loading: true});
-      const {group, role, workspace: {cdrVersionId}} = this.props;
+      const {group, role, workspace: {id, namespace}} = this.props;
       const mappedGroup = mapGroup(group);
       const request = {
         includes: [],
@@ -282,7 +282,7 @@ export const SearchGroup = withCurrentWorkspace()(
         dataFilters: [],
         [role]: [mappedGroup]
       };
-      cohortBuilderApi().countParticipants(+cdrVersionId, request, {signal: this.aborter.signal})
+      cohortBuilderApi().countParticipants(namespace, id , request, {signal: this.aborter.signal})
         .then(count => this.setState({count, initializing: false, loading: false}))
         .catch(error => {
           if (!isAbortError(error)) {

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -164,13 +164,13 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
   loadChildren() {
     const {node: {conceptId, count, domainId, id, isStandard, name, type}} = this.props;
     this.setState({loading: true});
-    const {cdrVersionId} = (currentWorkspaceStore.getValue());
+    const workspace = (currentWorkspaceStore.getValue());
     const criteriaType = domainId === Domain.DRUG.toString() ? CriteriaType.ATC.toString() : type;
-    cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard, id)
+    cohortBuilderApi().findCriteriaBy(workspace.namespace, workspace.id, domainId, criteriaType, isStandard, id)
       .then(resp => {
         if (resp.items.length === 0 && domainId === Domain.DRUG.toString()) {
           cohortBuilderApi()
-            .findCriteriaBy(+cdrVersionId, domainId, CriteriaType[CriteriaType.RXNORM], isStandard, id)
+            .findCriteriaBy(workspace.namespace, workspace.id, domainId, CriteriaType[CriteriaType.RXNORM], isStandard, id)
             .then(rxResp => {
               this.setState({children: rxResp.items, loading: false});
             }, () => this.setState({error: true}));

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -194,17 +194,18 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
     try {
       const {node: {domainId, id, isStandard, type}, selectedSurvey} = this.props;
       this.setState({loading: true});
-      const {cdrVersionId} = currentWorkspaceStore.getValue();
+      const workspace = currentWorkspaceStore.getValue();
+      const cdrVersionId = workspace.cdrVersionId;
       const criteriaType = domainId === Domain.DRUG.toString() ? CriteriaType.ATC.toString() : type;
       const promises = this.sendOnlyCriteriaType(domainId)
-          ? [cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType)]
-          : [cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard, id)];
+          ? [cohortBuilderApi().findCriteriaBy(workspace.namespace, workspace.id, domainId, criteriaType)]
+          : [cohortBuilderApi().findCriteriaBy(workspace.namespace, workspace.id, domainId, criteriaType, isStandard, id)];
       if (this.criteriaLookupNeeded) {
         const criteriaRequest = {
           sourceConceptIds: currentCohortCriteriaStore.getValue().filter(s => !s.isStandard).map(s => s.conceptId),
           standardConceptIds: currentCohortCriteriaStore.getValue().filter(s => s.isStandard).map(s => s.conceptId),
         };
-        promises.push(cohortBuilderApi().findCriteriaForCohortEdit(+cdrVersionId, domainId, criteriaRequest));
+        promises.push(cohortBuilderApi().findCriteriaForCohortEdit(workspace.namespace, workspace.id, domainId, criteriaRequest));
       }
       const [rootNodes, criteriaLookup] = await Promise.all(promises);
       if (criteriaLookup) {
@@ -269,10 +270,10 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
 
   updatePpiSurveys(resp, selectedSurveyChild) {
     const {node: {domainId, isStandard, type}} = this.props;
-    const {cdrVersionId} = (currentWorkspaceStore.getValue());
+    const {cdrVersionId, id, namespace} = (currentWorkspaceStore.getValue());
     const criteriaType = domainId === Domain.DRUG.toString() ? CriteriaType.ATC.toString() : type;
     if (selectedSurveyChild && selectedSurveyChild.length > 0) {
-      cohortBuilderApi().findCriteriaBy(+cdrVersionId, domainId, criteriaType, isStandard, selectedSurveyChild[0].id)
+      cohortBuilderApi().findCriteriaBy(namespace, id, domainId, criteriaType, isStandard, selectedSurveyChild[0].id)
         .then(surveyResponse => this.setState({children: surveyResponse.items}));
     } else {
       this.setState({children: resp.items});

--- a/ui/src/app/pages/data/cohort-review/cohort-review.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review.tsx
@@ -57,7 +57,7 @@ export class CohortReview extends React.Component<{}, State> {
     cohortsApi().getCohort(ns, wsid, cid).then(cohort => this.setState({cohort}));
     if (!visitsFilterOptions.getValue()) {
       cohortBuilderApi().findCriteriaBy(
-        +cdrVersionId, Domain[Domain.VISIT], CriteriaType[CriteriaType.VISIT]
+        ns, wsid, Domain[Domain.VISIT], CriteriaType[CriteriaType.VISIT]
       ).then(response => {
         visitsFilterOptions.next([
           {value: null, label: 'Any'},

--- a/ui/src/app/pages/data/cohort-review/query-report.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/query-report.component.tsx
@@ -211,14 +211,14 @@ export const QueryReport = fp.flow(withCdrVersions(), withCurrentWorkspace())(
     }
 
     componentDidMount() {
-      const {cdrVersionTiersResponse, workspace: {cdrVersionId}} = this.props;
+      const {cdrVersionTiersResponse} = this.props;
       const {review} = this.state;
       const {ns, wsid, cid} = urlParamsStore.getValue();
       cohortsApi().getCohort(ns, wsid, cid).then(cohort => this.setState({cohort}));
       const cdrName = findCdrVersion(review.cdrVersionId.toString(), cdrVersionTiersResponse).name;
       this.setState({cdrName});
       const request = (JSON.parse(review.cohortDefinition)) as SearchRequest;
-      cohortBuilderApi().findDemoChartInfo(+cdrVersionId, GenderOrSexType[GenderOrSexType.GENDER], AgeType[AgeType.AGE], request)
+      cohortBuilderApi().findDemoChartInfo(ns, wsid, GenderOrSexType[GenderOrSexType.GENDER], AgeType[AgeType.AGE], request)
         .then(response => {
           this.groupChartData(response.items);
           this.setState({data: response.items, loading: false});

--- a/ui/src/app/pages/data/cohort-review/table-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/table-page.tsx
@@ -261,7 +261,6 @@ export const ParticipantsTable = withCurrentWorkspace()(
     async componentDidMount() {
       const {filters} = this.state;
       let {demoFilters} = this.state;
-      const {cdrVersionId} = this.props.workspace;
       const promises = [];
       const {ns, wsid} = urlParamsStore.getValue();
       const review = cohortReviewStore.getValue();
@@ -290,7 +289,7 @@ export const ParticipantsTable = withCurrentWorkspace()(
         });
       }
       promises.push(
-        cohortBuilderApi().findParticipantDemographics(+cdrVersionId).then(data => {
+        cohortBuilderApi().findParticipantDemographics(ns, wsid).then(data => {
           const extract = (arr, _type?) => fp.uniq([
             ...arr.map(i => {
               filters[_type].push(i.conceptId.toString());

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -181,14 +181,14 @@ export const ConceptHomepage = fp.flow(withCurrentCohortSearchContext(), withCur
     }
 
     async loadDomainsAndSurveys() {
-      const {cohortContext, workspace: {cdrVersionId}} = this.props;
-      const getDomainInfo = cohortBuilderApi().findDomainInfos(+cdrVersionId)
+      const {cohortContext, workspace: {id, namespace}} = this.props;
+      const getDomainInfo = cohortBuilderApi().findDomainInfos(namespace, id)
         .then(conceptDomainInfo => this.setState({conceptDomainList: conceptDomainInfo.items}))
         .catch((e) => {
           this.setState({domainInfoError: true});
           console.error(e);
         });
-      const getSurveyInfo = cohortBuilderApi().findSurveyModules(+cdrVersionId)
+      const getSurveyInfo = cohortBuilderApi().findSurveyModules(namespace, id)
         .then(surveysInfo => this.setState({conceptSurveysList: surveysInfo.items}))
         .catch((e) => {
           this.setState({surveyInfoError: true});
@@ -202,7 +202,7 @@ export const ConceptHomepage = fp.flow(withCurrentCohortSearchContext(), withCur
     }
 
     async updateCardCounts() {
-      const {cdrVersionId} = this.props.workspace;
+      const {id, namespace} = this.props.workspace;
       const {conceptDomainList, conceptSurveysList, currentInputString} = this.state;
       this.setState({
         domainsLoading: conceptDomainList.map(domain => domain.domain),
@@ -210,7 +210,7 @@ export const ConceptHomepage = fp.flow(withCurrentCohortSearchContext(), withCur
       });
       const promises = [];
       conceptDomainList.forEach(conceptDomain => {
-        promises.push(cohortBuilderApi().findDomainCount(+cdrVersionId, conceptDomain.domain.toString(), currentInputString)
+        promises.push(cohortBuilderApi().findDomainCount(namespace, id, conceptDomain.domain.toString(), currentInputString)
           .then(domainCount => {
             conceptDomain.allConceptCount = domainCount.conceptCount;
             this.setState({domainsLoading: this.state.domainsLoading.filter(domain => domain !== conceptDomain.domain)});
@@ -218,7 +218,7 @@ export const ConceptHomepage = fp.flow(withCurrentCohortSearchContext(), withCur
         );
       });
       conceptSurveysList.forEach(conceptSurvey => {
-        promises.push(cohortBuilderApi().findSurveyCount(+cdrVersionId, conceptSurvey.name, currentInputString)
+        promises.push(cohortBuilderApi().findSurveyCount(namespace, id, conceptSurvey.name, currentInputString)
           .then(surveyCount => {
             conceptSurvey.questionCount = surveyCount.conceptCount;
             this.setState({surveysLoading: this.state.surveysLoading.filter(survey => survey !== conceptSurvey.name)});


### PR DESCRIPTION
Replacing cdrVersionId with workspaceNamespace and workspace Id information.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
