### PR TITLE
[RW-6738][risk=no] Allow users to navigate to profile when signed in

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -72,6 +72,11 @@ const routes: Routes = [
         component: AppRouting,
         data: {}
       },
+      {
+        path: 'profile',
+        component: AppRouting,
+        data: {}
+      },
       // non-migrated routes go HERE
       {
         path: '',
@@ -81,11 +86,6 @@ const routes: Routes = [
           // legacy / duplicated routes go HERE
           {
             path: 'library',
-            component: AppRouting,
-            data: {}
-          },
-          {
-            path: 'profile',
             component: AppRouting,
             data: {}
           },

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -76,7 +76,6 @@ const InteractiveNotebookPage = withRouteData(InteractiveNotebook);
 const NotebookListPage = withRouteData(NotebookList);
 const NotebookRedirectPage = withRouteData(NotebookRedirect);
 const ParticipantsTablePage = withRouteData(ParticipantsTable);
-const ProfilePagePage = withRouteData(ProfilePage); // again bad sorry
 const QueryReportPage = withRouteData(QueryReport);
 const SessionExpiredPage = withRouteData(SessionExpired);
 const SignInAgainPage = withRouteData(SignInAgain);
@@ -197,6 +196,7 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
             minimizeChrome: true
           }} />}
       />
+      <AppRoute path='/profile' component={() => <ProfilePage routeData={{title: 'Profile'}}/>}/>
       <AppRoute path='/nih-callback' component={() => <HomepagePage routeData={{title: 'Homepage'}}/>} />
       <AppRoute path='/ras-callback' component={() => <HomepagePage routeData={{title: 'Homepage'}}/>} />
 
@@ -204,10 +204,6 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
         <AppRoute
           path='/library'
           component={() => <WorkspaceLibraryPage routeData={{title: 'Workspace Library', minimizeChrome: false}}/>}
-        />
-        <AppRoute
-          path='/profile'
-          component={() => <ProfilePagePage routeData={{title: 'Profile'}}/>}
         />
         <AppRoute
           path='/workspaces'

--- a/ui/src/app/components/side-nav.spec.tsx
+++ b/ui/src/app/components/side-nav.spec.tsx
@@ -28,7 +28,7 @@ describe('SideNav', () => {
     const wrapper = mount(<SideNav {...props} profile={{...ProfileStubVariables.PROFILE_STUB, accessTierShortNames: []}}/>);
     wrapper.setState({showUserOptions: true});
     // These are our expected items to be disabled when you are not registered
-    let disabledItemText = ['Profile', 'Your Workspaces', 'Featured Workspaces', 'User Support Hub'];
+    let disabledItemText = ['Your Workspaces', 'Featured Workspaces', 'User Support Hub'];
     const sideNavItems = wrapper.find(SideNavItem);
     let disabledItems = sideNavItems.filterWhere(sideNavItem => sideNavItem.props().disabled);
     sideNavItems.forEach(sideNavItem => {

--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -7,7 +7,6 @@ import {AuthorityGuardedAction, hasAuthorityForAction} from 'app/utils/authoriti
 import {navigate, navigateSignOut, signInStore} from 'app/utils/navigation';
 import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
 import {Profile} from 'generated/fetch';
-import {authStore, AuthStore, withStore} from'app/utils/stores';
 import * as React from 'react';
 
 const styles = reactStyles({
@@ -211,7 +210,6 @@ export interface SideNavProps {
   userAuditActive: boolean;
   workspaceAuditActive: boolean;
   workspacesActive: boolean;
-  authStore: AuthStore;
 }
 
 export interface SideNavState {
@@ -221,7 +219,7 @@ export interface SideNavState {
   userRef: React.RefObject<SideNavItem>;
 }
 
-export const SideNav = withStore(authStore, 'authStore')(class extends React.Component<SideNavProps, SideNavState> {
+export class SideNav extends React.Component<SideNavProps, SideNavState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -259,7 +257,7 @@ export const SideNav = withStore(authStore, 'authStore')(class extends React.Com
   }
 
   render() {
-    const {profile, authStore: {isSignedIn}} = this.props;
+    const {profile} = this.props;
     return <div style={styles.sideNav}>
       <SideNavItem
         hasProfileImage={true}
@@ -275,7 +273,6 @@ export const SideNav = withStore(authStore, 'authStore')(class extends React.Com
           onToggleSideNav={() => this.props.onToggleSideNav()}
           href='/profile'
           active={this.props.profileActive}
-          disabled={!isSignedIn}
         />
       }
       {
@@ -380,4 +377,4 @@ export const SideNav = withStore(authStore, 'authStore')(class extends React.Com
       }
     </div>;
   }
-})
+}

--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -7,6 +7,7 @@ import {AuthorityGuardedAction, hasAuthorityForAction} from 'app/utils/authoriti
 import {navigate, navigateSignOut, signInStore} from 'app/utils/navigation';
 import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
 import {Profile} from 'generated/fetch';
+import {authStore, AuthStore, withStore} from'app/utils/stores';
 import * as React from 'react';
 
 const styles = reactStyles({
@@ -210,6 +211,7 @@ export interface SideNavProps {
   userAuditActive: boolean;
   workspaceAuditActive: boolean;
   workspacesActive: boolean;
+  authStore: AuthStore;
 }
 
 export interface SideNavState {
@@ -219,7 +221,7 @@ export interface SideNavState {
   userRef: React.RefObject<SideNavItem>;
 }
 
-export class SideNav extends React.Component<SideNavProps, SideNavState> {
+export const SideNav = withStore(authStore, 'authStore')(class extends React.Component<SideNavProps, SideNavState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -257,7 +259,7 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
   }
 
   render() {
-    const {profile} = this.props;
+    const {profile, authStore: {isSignedIn}} = this.props;
     return <div style={styles.sideNav}>
       <SideNavItem
         hasProfileImage={true}
@@ -273,7 +275,7 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
           onToggleSideNav={() => this.props.onToggleSideNav()}
           href='/profile'
           active={this.props.profileActive}
-          disabled={!hasRegisteredAccess(profile.accessTierShortNames)}
+          disabled={!isSignedIn}
         />
       }
       {
@@ -378,4 +380,4 @@ export class SideNav extends React.Component<SideNavProps, SideNavState> {
       }
     </div>;
   }
-}
+})

--- a/ui/src/app/pages/profile/profile-page.tsx
+++ b/ui/src/app/pages/profile/profile-page.tsx
@@ -2,6 +2,7 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 import * as validate from 'validate.js';
 
+import {withRouteData} from 'app/components/app-router';
 import {Button} from 'app/components/buttons';
 import {FadeBox} from 'app/components/containers';
 import {FlexColumn, FlexRow} from 'app/components/flex';
@@ -34,7 +35,6 @@ import {environment} from 'environments/environment';
 import {InstitutionalRole, Profile} from 'generated/fetch';
 import {PublicInstitutionDetails} from 'generated/fetch';
 import {Dropdown} from 'primereact/dropdown';
-import {withRouteData} from 'app/components/app-router';
 
 
 // validators for validate.js

--- a/ui/src/app/pages/profile/profile-page.tsx
+++ b/ui/src/app/pages/profile/profile-page.tsx
@@ -34,6 +34,7 @@ import {environment} from 'environments/environment';
 import {InstitutionalRole, Profile} from 'generated/fetch';
 import {PublicInstitutionDetails} from 'generated/fetch';
 import {Dropdown} from 'primereact/dropdown';
+import {withRouteData} from 'app/components/app-router';
 
 
 // validators for validate.js
@@ -126,6 +127,7 @@ const getControlledTierContent = fp.flow(
 );
 
 export const ProfilePage = fp.flow(
+  withRouteData,
   withUserProfile(),
   withProfileErrorModal
   )(class extends React.Component<

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -18,7 +18,7 @@ export interface RouteDataStore {
 
 export const routeDataStore = atom<RouteDataStore>({});
 
-export interface AuthStore {
+interface AuthStore {
   authLoaded: boolean;
   isSignedIn: boolean;
 }

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -18,7 +18,7 @@ export interface RouteDataStore {
 
 export const routeDataStore = atom<RouteDataStore>({});
 
-interface AuthStore {
+export interface AuthStore {
   authLoaded: boolean;
   isSignedIn: boolean;
 }


### PR DESCRIPTION
Description:
This change will allow signed in users to access their profile regardless of whether they are in an access tier.
This is critical to allowing users to regain access if their account expires

Profile access before change
![profile-access-before](https://user-images.githubusercontent.com/50371603/118556076-6fafba00-b731-11eb-8cdd-14f1540c326e.gif)

Profile access after change
![profile-access-after](https://user-images.githubusercontent.com/50371603/118556110-7807f500-b731-11eb-805f-054f906300c7.gif)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
