### PR TITLE
[risk=no] Stop debug logging all outgoing RDR requests

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportConfig.java
@@ -24,7 +24,6 @@ public class RdrExportConfig {
   public RdrApi rdrApi(WorkbenchConfig workbenchConfig) {
     RdrApi api = new RdrApi();
     org.pmiops.workbench.rdr.ApiClient apiClient = new org.pmiops.workbench.rdr.ApiClient();
-    apiClient.setDebugging(true);
     try {
       apiClient.setAccessToken(ServiceAccounts.getScopedServiceAccessToken(SCOPES));
       apiClient.setBasePath("https://" + workbenchConfig.rdrExport.host);

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -139,7 +139,6 @@ public class RdrExportServiceImpl implements RdrExportService {
           userIds.stream()
               .map(userId -> toRdrResearcher(userDao.findUserByUserId(userId)))
               .collect(Collectors.toList());
-      rdrApiProvider.get().getApiClient().setDebugging(true);
       rdrApiProvider.get().exportResearchers(rdrResearchersList);
 
       updateDbRdrExport(RdrEntity.USER, userIds);
@@ -166,7 +165,6 @@ public class RdrExportServiceImpl implements RdrExportService {
               .filter(Objects::nonNull)
               .collect(Collectors.toList());
       if (!rdrWorkspacesList.isEmpty()) {
-        rdrApiProvider.get().getApiClient().setDebugging(true);
         rdrApiProvider.get().exportWorkspaces(rdrWorkspacesList, backfill);
 
         if (backfill != null && backfill != true) {

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -143,8 +143,10 @@ public class RdrExportServiceImpl implements RdrExportService {
 
       updateDbRdrExport(RdrEntity.USER, userIds);
     } catch (ApiException ex) {
-      log.severe("Error while sending researcher data to RDR");
+      log.severe(
+          String.format("Error while sending researcher data to RDR for user IDs: %s", userIds));
     }
+    log.info(String.format("successfully exported researcher data for user IDs: %s", userIds));
   }
 
   /**
@@ -172,8 +174,12 @@ public class RdrExportServiceImpl implements RdrExportService {
         }
       }
     } catch (ApiException ex) {
-      log.severe("Error while sending workspace data to RDR");
+      log.severe(
+          String.format(
+              "Error while sending workspace data to RDR for workspace IDs: %s", workspaceIds));
     }
+    log.info(
+        String.format("successfully exported workspace data for workspace IDs: %s", workspaceIds));
   }
 
   // Convert workbench DBUser to RDR Model

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -91,7 +91,6 @@ public class RdrExportServiceImplTest {
   public void setUp() {
     rdrExportService = spy(rdrExportService);
     when(mockRdrApi.getApiClient()).thenReturn(mockApiClient);
-    when(mockApiClient.setDebugging(true)).thenReturn(null);
 
     dbUserWithEmail = new DbUser();
     dbUserWithEmail.setUserId(1L);


### PR DESCRIPTION
This is spamming the logs and putting potentially sensitive information into our GAE logs.