### PR TITLE
[RW-6144][risk=no]  Ellipsis menu on concept-set page vs concept-set card

### DIFF
--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -72,17 +72,17 @@ const ConceptSetMenu: React.FunctionComponent<ConceptSetMenuProps> = ({canDelete
     closeOnClick
     content={<React.Fragment>
       <TooltipTrigger>
+        <TooltipTrigger content={<div>Requires Write Permission</div>}
+                        disabled={canEdit}>
+          <MenuItem icon='pencil'
+                    onClick={onEdit}
+                    disabled={!canEdit}>
+            Rename
+          </MenuItem>
+        </TooltipTrigger>
         <MenuItem icon='copy'
                   onClick={onCopy}>
           Copy to another Workspace
-        </MenuItem>
-      </TooltipTrigger>
-      <TooltipTrigger content={<div>Requires Write Permission</div>}
-                      disabled={canEdit}>
-        <MenuItem icon='pencil'
-                  onClick={onEdit}
-                  disabled={!canEdit}>
-          Edit
         </MenuItem>
       </TooltipTrigger>
       <TooltipTrigger content={<div>Requires Owner Permission</div>}


### PR DESCRIPTION
Before:
Concept List page: 
<img width="369" alt="Screen Shot 2021-05-19 at 1 56 36 PM" src="https://user-images.githubusercontent.com/34481816/118861445-82013380-b8aa-11eb-834b-1fcad2b1abd4.png">

Concept Home page:
<img width="607" alt="Screen Shot 2021-05-19 at 1 59 24 PM" src="https://user-images.githubusercontent.com/34481816/118861378-6d24a000-b8aa-11eb-8572-77a8e3a18420.png">

After:
I felt Rename is a better name for option than Edit option for Concept Homepage, so the new page options:
<img width="1568" alt="Screen Shot 2021-05-19 at 1 56 26 PM" src="https://user-images.githubusercontent.com/34481816/118861602-af4de180-b8aa-11eb-8ec4-f9a8571ee0bb.png">

This still does the same thing, let user change Concept Set name and description



---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
