### PR TITLE
[RW-6778][risk=no] Fix tracking of workspace RDR exports

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskRdrExportController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskRdrExportController.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.api;
 
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.logging.Logger;
 import org.pmiops.workbench.model.ArrayOfLong;
 import org.pmiops.workbench.rdr.RdrExportService;
@@ -49,7 +50,7 @@ public class CloudTaskRdrExportController implements CloudTaskRdrExportApiDelega
       log.severe(" call to export Workspace Data had no Ids");
       return ResponseEntity.noContent().build();
     }
-    rdrExportService.exportWorkspaces(workspaceIds, backfill);
+    rdrExportService.exportWorkspaces(workspaceIds, Optional.ofNullable(backfill).orElse(false));
     return ResponseEntity.noContent().build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportService.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportService.java
@@ -10,7 +10,7 @@ public interface RdrExportService {
 
   void exportUsers(List<Long> usersToExport);
 
-  void exportWorkspaces(List<Long> workspacesToExport, Boolean backfill);
+  void exportWorkspaces(List<Long> workspacesToExport, boolean backfill);
 
   void updateDbRdrExport(RdrEntity entity, List<Long> idList);
 

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -169,7 +169,13 @@ public class RdrExportServiceImpl implements RdrExportService {
       if (!rdrWorkspacesList.isEmpty()) {
         rdrApiProvider.get().exportWorkspaces(rdrWorkspacesList, backfill);
 
-        updateDbRdrExport(RdrEntity.WORKSPACE, workspaceIds);
+        // Skip the RDR export table updates on backfills. A normal export may trigger manual review
+        // from the RDR, where-as a backfill does not. Therefore, even if the RDR has the latest
+        // data already from a backfill, we'd still want to resend any normal modifications, if any,
+        // in order to trigger this review process.
+        if (!backfill) {
+          updateDbRdrExport(RdrEntity.WORKSPACE, workspaceIds);
+        }
       }
     } catch (ApiException ex) {
       log.severe(

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -156,7 +156,7 @@ public class RdrExportServiceImpl implements RdrExportService {
    * @param workspaceIds
    */
   @Override
-  public void exportWorkspaces(List<Long> workspaceIds, Boolean backfill) {
+  public void exportWorkspaces(List<Long> workspaceIds, boolean backfill) {
     List<RdrWorkspace> rdrWorkspacesList;
     try {
       rdrWorkspacesList =
@@ -169,9 +169,7 @@ public class RdrExportServiceImpl implements RdrExportService {
       if (!rdrWorkspacesList.isEmpty()) {
         rdrApiProvider.get().exportWorkspaces(rdrWorkspacesList, backfill);
 
-        if (backfill != null && backfill != true) {
-          updateDbRdrExport(RdrEntity.WORKSPACE, workspaceIds);
-        }
+        updateDbRdrExport(RdrEntity.WORKSPACE, workspaceIds);
       }
     } catch (ApiException ex) {
       log.severe(

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -215,7 +215,7 @@ public class RdrExportServiceImplTest {
     verify(mockWorkspaceService)
         .getFirecloudUserRoles(
             mockWorkspace.getWorkspaceNamespace(), mockWorkspace.getFirecloudName());
-    verify(rdrExportDao, times(1)).saveAll(anyList());
+    verify(rdrExportDao, never()).saveAll(anyList());
 
     verify(mockRdrApi).exportWorkspaces(Arrays.asList(rdrWorkspace), true);
   }

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -215,7 +215,7 @@ public class RdrExportServiceImplTest {
     verify(mockWorkspaceService)
         .getFirecloudUserRoles(
             mockWorkspace.getWorkspaceNamespace(), mockWorkspace.getFirecloudName());
-    verify(rdrExportDao, times(1)).save(anyList());
+    verify(rdrExportDao, times(1)).saveAll(anyList());
 
     verify(mockRdrApi).exportWorkspaces(Arrays.asList(rdrWorkspace), true);
   }

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -205,6 +205,21 @@ public class RdrExportServiceImplTest {
     verify(mockRdrApi).exportWorkspaces(Arrays.asList(rdrWorkspace), NO_BACKFILL);
   }
 
+  @Test
+  public void exportWorkspace_backfill() throws ApiException {
+    List<Long> workspaceID = new ArrayList<>();
+    workspaceID.add(1l);
+    RdrWorkspace rdrWorkspace = toDefaultRdrWorkspace(mockWorkspace);
+    when(rdrMapper.toRdrModel(mockWorkspace)).thenReturn(rdrWorkspace);
+    rdrExportService.exportWorkspaces(workspaceID, true);
+    verify(mockWorkspaceService)
+        .getFirecloudUserRoles(
+            mockWorkspace.getWorkspaceNamespace(), mockWorkspace.getFirecloudName());
+    verify(rdrExportDao, times(1)).save(anyList());
+
+    verify(mockRdrApi).exportWorkspaces(Arrays.asList(rdrWorkspace), true);
+  }
+
   /**
    * In case workspace has any specific population FocusOnUnderrepresentedPopulations should be true
    *


### PR DESCRIPTION
Three changes here:

1. Bug fix: When we're **not** backfilling, update the RDR export table.
2. ~~Behavior change: When we are backfilling, update the RDR export table. I don't see why we wouldn't - asked for clarification here: https://github.com/all-of-us/workbench/pull/4674/files#r591814610~~
3. Java style change: Switch to my original preference of using the primitive boolean here. I believe this was a contributing factor to the original bug - use of a nullable boxed boolean type made the predicate in the service less readable and handling this in the controller is a better separation of concerns.
4. Wire change: always send an explicit backfill value to the RDR (true/false), no longer send `null` to imply default / `false`