### PR TITLE
[no ticket][risk=no] Puppeteer flaky tests fix

### DIFF
--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -372,6 +372,13 @@ export default class BaseElement {
   }
 
   async exists(): Promise<boolean> {
-    return (await this.page.$x(this.xpath)).length !== 0;
+    return this.page
+      .waitForXPath(this.xpath, { visible: true, timeout: 2000 })
+      .then(() => {
+        return true;
+      })
+      .catch(() => {
+        return false;
+      });
   }
 }

--- a/e2e/app/modal/share-modal.ts
+++ b/e2e/app/modal/share-modal.ts
@@ -21,30 +21,57 @@ export default class ShareModal extends Modal {
   }
 
   async shareWithUser(userName: string, level: WorkspaceAccessLevel): Promise<void> {
-    const dropDownXpath = `${this.getXpath()}//*[@data-test-id="drop-down"]`;
+    const dropDownXpath = this.getXpath() + '//*[@data-test-id="drop-down"][.//clr-icon[@shape="plus-circle"]]';
     const waitForDropDown = async () => {
       await waitWhileLoading(this.page);
       await this.page.waitForXPath(dropDownXpath, { visible: true });
     };
+
     const waitForClose = async () => {
       await waitWhileLoading(this.page);
       await this.page.waitForXPath(dropDownXpath, { hidden: true });
     };
 
-    const searchBox = this.waitForSearchBox();
-    await searchBox.type(`${userName}`, { delay: 20 });
+    const findCollaboratorAddIcon = () => {
+      return ClrIconLink.findByName(
+        this.page,
+        { type: ElementType.Icon, iconShape: 'plus-circle', containsText: userName, ancestorLevel: 2 },
+        this
+      );
+    };
 
-    await waitForDropDown(); // Needed for the dropdown
-    const addCollab = this.waitForAddCollaboratorIcon(userName);
-    await addCollab.click();
-    await waitForClose();
+    const pickUserRole = async () => {
+      const roleInput = await this.waitForRoleSelectorForUser(userName);
+      await roleInput.click();
 
-    const roleInput = await this.waitForRoleSelectorForUser(userName);
-    await roleInput.click();
+      const ownerOpt = await this.waitForRoleOption(level);
+      await ownerOpt.click();
+    };
 
-    const ownerOpt = await this.waitForRoleOption(level);
-    await ownerOpt.click();
+    let maxAttempts = 2;
+    // Try 2 times: enter email and find add icon.
+    const typeAndAddUser = async () => {
+      await this.waitForSearchBox().type(userName, { delay: 50 });
+      await waitForDropDown();
+      try {
+        const addIcon = findCollaboratorAddIcon();
+        await addIcon.click();
+        await waitForClose();
+        return;
+      } catch (err) {
+        // Click failed.
+      }
+      if (maxAttempts <= 0) {
+        return;
+      }
+      maxAttempts--;
+      await this.page.waitForTimeout(1000).then(() => {
+        return typeAndAddUser();
+      });
+    };
 
+    await typeAndAddUser();
+    await pickUserRole();
     await this.clickButton(LinkText.Save, { waitForClose: true });
     logger.info(`Shared workspace to ${userName} with role ${level}`);
   }
@@ -79,14 +106,6 @@ export default class ShareModal extends Modal {
     return Textbox.findByName(this.page, { name: 'Find Collaborators' }, this);
   }
 
-  waitForAddCollaboratorIcon(email: string): ClrIconLink {
-    return ClrIconLink.findByName(
-      this.page,
-      { type: ElementType.Icon, iconShape: 'plus-circle', containsText: email, ancestorLevel: 2 },
-      this
-    );
-  }
-
   async waitForRoleSelectorForUser(username: string): Promise<Textbox> {
     const box = new Textbox(this.page, `${this.collabRowXPath(username)}//input[@type="text"]`);
     await box.waitForXPath({ visible: true });
@@ -97,5 +116,20 @@ export default class ShareModal extends Modal {
     // The label in the select menu uses title case.
     const levelText = level[0].toUpperCase() + level.substring(1).toLowerCase();
     return this.page.waitForXPath(`//*[starts-with(@id,"react-select") and text()="${levelText}"]`, { visible: true });
+  }
+
+  async notFindUser(email: string): Promise<boolean> {
+    const notFoundXpath =
+      this.getXpath() + '//*[@data-test-id="drop-down"][not(.//*[text()="No results based on your search"])]';
+    await this.waitForSearchBox().type(email, { delay: 20 });
+    await waitWhileLoading(this.page);
+    return await this.page
+      .waitForXPath(notFoundXpath, { visible: true })
+      .then(() => {
+        return true;
+      })
+      .catch(() => {
+        return false;
+      });
   }
 }

--- a/e2e/app/modal/share-modal.ts
+++ b/e2e/app/modal/share-modal.ts
@@ -118,7 +118,7 @@ export default class ShareModal extends Modal {
     await this.waitForSearchBox().type(email, { delay: 20 });
     await waitWhileLoading(this.page);
     return await this.page
-      .waitForXPath(notFoundXpath, { visible: true })
+      .waitForXPath(notFoundXpath, { visible: true, timeout: 5000 })
       .then(() => {
         return true;
       })

--- a/e2e/app/modal/share-modal.ts
+++ b/e2e/app/modal/share-modal.ts
@@ -32,8 +32,7 @@ export default class ShareModal extends Modal {
     };
 
     const searchBox = this.waitForSearchBox();
-    // Type in user email and append it with two whitespaces. Otherwise the select dropdown is not showing.
-    await searchBox.type(`${userName}  `, { delay: 20 });
+    await searchBox.type(`${userName}`, { delay: 20 });
 
     await waitForDropDown(); // Needed for the dropdown
     const addCollab = this.waitForAddCollaboratorIcon(userName);

--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -45,7 +45,7 @@ export default class WorkspaceAboutPage extends WorkspaceBase {
     const share = Button.findByName(this.page, { containsText: 'Share' });
     await share.click();
     const modal = new ShareModal(this.page);
-    await modal.waitUntilVisible();
+    await modal.waitForLoad();
     return modal;
   }
 

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -9,8 +9,8 @@ import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import { config } from 'resources/workbench-config';
 import { makeWorkspaceName } from 'utils/str-utils';
 
-// 30 minutes. Test involves notebook that could take a long time to create.
-jest.setTimeout(30 * 60 * 1000);
+// 10 minutes.
+jest.setTimeout(10 * 60 * 1000);
 
 describe('Create Dataset', () => {
   beforeEach(async () => {

--- a/e2e/tests/datasets/dataset-snowman-menu-actions.spec.ts
+++ b/e2e/tests/datasets/dataset-snowman-menu-actions.spec.ts
@@ -10,6 +10,9 @@ import { waitForText, waitWhileLoading } from 'utils/waits-utils';
 import DatasetBuildPage from 'app/page/dataset-build-page';
 import DatasetEditPage from 'app/page/dataset-edit-page';
 
+// 10 minutes.
+jest.setTimeout(10 * 60 * 1000);
+
 describe('Datasets card snowman menu actions', () => {
   const KernelLanguages = [{ LANGUAGE: Language.R }, { LANGUAGE: Language.Python }];
 

--- a/e2e/tests/datasets/export-to-notebook.spec.ts
+++ b/e2e/tests/datasets/export-to-notebook.spec.ts
@@ -1,13 +1,13 @@
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
-import {makeRandomName, makeWorkspaceName} from 'utils/str-utils';
-import {findOrCreateWorkspace, signInWithAccessToken} from 'utils/test-utils';
+import { makeRandomName, makeWorkspaceName } from 'utils/str-utils';
+import { findOrCreateWorkspace, signInWithAccessToken } from 'utils/test-utils';
 import CohortActionsPage from 'app/page/cohort-actions-page';
-import {Ethnicity, Sex} from 'app/page/cohort-participants-group';
-import {Language, LinkText, MenuOption, ResourceCard} from 'app/text-labels';
+import { Ethnicity, Sex } from 'app/page/cohort-participants-group';
+import { Language, LinkText, MenuOption, ResourceCard } from 'app/text-labels';
 import DataResourceCard from 'app/component/data-resource-card';
-import {getPropValue} from 'utils/element-utils';
+import { getPropValue } from 'utils/element-utils';
 import CohortBuildPage from 'app/page/cohort-build-page';
 import DeleteConfirmationModal from 'app/modal/delete-confirmation-modal';
 import WarningDiscardChangesModal from 'app/modal/warning-discard-changes-modal';
@@ -60,7 +60,7 @@ describe('Export to notebook tests', () => {
     const notebookPreviewPage = new NotebookPreviewPage(page);
     await notebookPreviewPage.waitForLoad();
 
-    const analysisPage = await notebookPreviewPage.goAnalysisPage()
+    const analysisPage = await notebookPreviewPage.goAnalysisPage();
 
     await analysisPage.deleteResource(notebookName, ResourceCard.Notebook);
 

--- a/e2e/tests/workspace/workspace-share-modal.spec.ts
+++ b/e2e/tests/workspace/workspace-share-modal.spec.ts
@@ -4,7 +4,7 @@ import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import { config } from 'resources/workbench-config';
 import WorkspacesPage from 'app/page/workspaces-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-//import { makeWorkspaceName } from 'utils/str-utils';
+import { makeWorkspaceName } from 'utils/str-utils';
 
 describe('Workspace Share Modal', () => {
   const assignAccess = [
@@ -13,7 +13,7 @@ describe('Workspace Share Modal', () => {
   ];
 
   // Create new workspace with default CDR version
-  const workspace = 'aoutest-407581621629013'; //makeWorkspaceName();
+  const workspace = makeWorkspaceName();
 
   test.each(assignAccess)('Share workspace %s', async (assign) => {
     await signInWithAccessToken(page);

--- a/e2e/tests/workspace/workspace-share-modal.spec.ts
+++ b/e2e/tests/workspace/workspace-share-modal.spec.ts
@@ -4,7 +4,7 @@ import WorkspaceAboutPage from 'app/page/workspace-about-page';
 import { config } from 'resources/workbench-config';
 import WorkspacesPage from 'app/page/workspaces-page';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import { makeWorkspaceName } from 'utils/str-utils';
+//import { makeWorkspaceName } from 'utils/str-utils';
 
 describe('Workspace Share Modal', () => {
   const assignAccess = [
@@ -13,7 +13,7 @@ describe('Workspace Share Modal', () => {
   ];
 
   // Create new workspace with default CDR version
-  const workspace = makeWorkspaceName();
+  const workspace = 'aoutest-407581621629013'; //makeWorkspaceName();
 
   test.each(assignAccess)('Share workspace %s', async (assign) => {
     await signInWithAccessToken(page);


### PR DESCRIPTION
`workspace-share-modal.spec` has failed [here](https://app.circleci.com/pipelines/github/all-of-us/workbench/10494/workflows/7edb403d-69aa-4393-b504-006c715a576f/jobs/141162).
`dataset-snowman-menu-actions.spec.ts` has failed [here](https://app.circleci.com/pipelines/github/all-of-us/workbench/10498/workflows/866a4093-cf0b-4cf9-afff-a29489080fcf/jobs/141189).

Adding two whitespaces at the end of the user name has caused share-modal test to fail on master branch. The fix drops the whitespace and search for dropdown as puppeteer is typing char by char instead of type all char then search for dropdown.