### PR TITLE
Chavanr/admin feature user

### DIFF
--- a/e2e/app/component/admin-table.ts
+++ b/e2e/app/component/admin-table.ts
@@ -3,6 +3,7 @@ import Container from 'app/container';
 //import { getPropValue } from 'utils/element-utils';
 import Table from './table';
 
+
 const defaultXpath = '//*[contains(concat(normalize-space(@class), " "), "p-datatable ")]';
 
 export default class adminTable extends Table {

--- a/e2e/app/component/admin-table.ts
+++ b/e2e/app/component/admin-table.ts
@@ -1,0 +1,57 @@
+import { Page } from 'puppeteer';
+import Container from 'app/container';
+//import { getPropValue } from 'utils/element-utils';
+import Table from './table';
+
+const defaultXpath = '//*[contains(concat(normalize-space(@class), " "), "p-datatable ")]/div[1]';
+
+export default class adminTable extends Table {
+  constructor(page: Page, xpath: string = defaultXpath, container?: Container) {
+    super(page, xpath, container);
+  }
+
+  getFrozenHeader(): Table {
+    return new Table(this.page, `${this.getXpath()}/div[1]//table[@class="p-datatable-scrollable-header-table"]`);
+  }
+
+  getFrozenBody(): Table {
+    return new Table(this.page, `${this.getXpath()}/div[1]//table[@class="p-datatable-scrollable-body-table"]`);
+  }
+
+  getHeaderTable(): Table {
+    return new Table(this.page, `${this.getXpath()}/div[2]//table[@class="p-datatable-scrollable-header-table"]`);
+  }
+
+  getBodyTable(): Table {
+    return new Table(this.page, `${this.getXpath()}/div[2]//table[@class="p-datatable-scrollable-body-table"]`);
+  }
+
+  getFooterTable(): Table {
+    return new Table(this.page, `${this.getXpath()}/div[2]//table[@class="p-datatable-scrollable-footer-table"]`);
+  }
+
+  // gets the column index
+  async getColumnIndex(header: string): Promise<number> {
+    const headerTable = this.getHeaderTable();
+    const columnNames = await headerTable.getColumnNames();
+    const colIndexNum = columnNames.indexOf(header);
+    return colIndexNum + 1;
+  }
+
+  /**
+   * Finds table column names. Returns in array of string.
+   * @returns {Array<string>}
+   */
+  async getColumnNames(): Promise<string[]> {
+    const headerTable = this.getHeaderTable();
+    return headerTable.getColumnNames();
+  }
+
+  async getNameColindex(): Promise<number> {
+    const dataTable = this.getFrozenHeader();
+    const columnName = await dataTable.getColumnNames();
+    const colIndexNum = columnName.indexOf('Name');
+    console.log(columnName);
+    return colIndexNum + 1;
+  }
+}

--- a/e2e/app/component/admin-table.ts
+++ b/e2e/app/component/admin-table.ts
@@ -3,7 +3,7 @@ import Container from 'app/container';
 //import { getPropValue } from 'utils/element-utils';
 import Table from './table';
 
-const defaultXpath = '//*[contains(concat(normalize-space(@class), " "), "p-datatable ")]/div[1]';
+const defaultXpath = '//*[contains(concat(normalize-space(@class), " "), "p-datatable ")]';
 
 export default class adminTable extends Table {
   constructor(page: Page, xpath: string = defaultXpath, container?: Container) {
@@ -11,23 +11,23 @@ export default class adminTable extends Table {
   }
 
   getFrozenHeader(): Table {
-    return new Table(this.page, `${this.getXpath()}/div[1]//table[@class="p-datatable-scrollable-header-table"]`);
+    return new Table(this.page, `${this.getXpath()}//div[@class="p-datatable-scrollable-view p-datatable-frozen-view"]//table[@class="p-datatable-scrollable-header-table"]`);
   }
 
   getFrozenBody(): Table {
-    return new Table(this.page, `${this.getXpath()}/div[1]//table[@class="p-datatable-scrollable-body-table"]`);
+    return new Table(this.page, `${this.getXpath()}//div[@class="p-datatable-scrollable-view p-datatable-frozen-view"]//table[@class="p-datatable-scrollable-body-table"]`);
   }
 
   getHeaderTable(): Table {
-    return new Table(this.page, `${this.getXpath()}/div[2]//table[@class="p-datatable-scrollable-header-table"]`);
+    return new Table(this.page, `${this.getXpath()}//div[@class="p-datatable-scrollable-view p-datatable-unfrozen-view"]//table[@class="p-datatable-scrollable-header-table"]`);
   }
 
   getBodyTable(): Table {
-    return new Table(this.page, `${this.getXpath()}/div[2]//table[@class="p-datatable-scrollable-body-table"]`);
+    return new Table(this.page, `${this.getXpath()}//div[@class="p-datatable-scrollable-view p-datatable-unfrozen-view"]//table[@class="p-datatable-scrollable-body-table"]`);
   }
 
   getFooterTable(): Table {
-    return new Table(this.page, `${this.getXpath()}/div[2]//table[@class="p-datatable-scrollable-footer-table"]`);
+    return new Table(this.page, `${this.getXpath()}//div[@class="p-datatable-scrollable-view p-datatable-unfrozen-view"]//table[@class="p-datatable-scrollable-footer-table"]`);
   }
 
   // gets the column index

--- a/e2e/app/component/bypass-modules.ts
+++ b/e2e/app/component/bypass-modules.ts
@@ -1,0 +1,82 @@
+import { Page } from 'puppeteer';
+import BaseMenu from './base-menu';
+import Checkbox from 'app/element/checkbox';
+
+const defaultXpath = '//*[@id="popup-root"]';
+
+export default class BypassLink extends BaseMenu {
+  constructor(page: Page, xpath: string = defaultXpath) {
+    super(page, xpath);
+  }
+
+  /**
+   *  Get texts of all visible options.
+   */
+  async getAllToggleTexts(): Promise<string[]> {
+    const selector = `${this.getXpath()}//label/span/text()`;
+    return this.getMenuItemTexts(selector);
+  }
+
+  getMenuItemXpath(toggleAccessText: string): string {
+    return `//*[@role="switch" and normalize-space()="${toggleAccessText}"]`;
+  }
+
+  async bypassAllModules(): Promise<Page> {
+    await this.getTrainingToggle();
+    await this.getEraCommToggle();
+    await this.getTwoFAToggle();
+    await this.getDUCCToggle();
+    await this.clickCheckmarkBypass();
+    await this.waitUntilGone(page);
+    return page;
+  }
+
+  /**
+   * Toggle checkbox state.
+   * @param {boolean} checked
+   */
+  async getTrainingToggle(): Promise<void> {
+    const xpath = `${this.getXpath()}//label/span[text()='Compliance Training']`;
+    const checkbox = new Checkbox(this.page, xpath);
+    await checkbox.check();
+  }
+
+  async getEraCommToggle(): Promise<boolean> {
+    const xpath = `${this.getXpath()}//label/span[text()='eRA Commons Linking']`;
+    const checkbox = new Checkbox(this.page, xpath);
+    await checkbox.toggle(true);
+    return true;
+  }
+
+  async getTwoFAToggle(): Promise<boolean> {
+    const xpath = `${this.getXpath()}//label/span[text()='Two Factor Auth']`;
+    const checkbox = new Checkbox(this.page, xpath);
+    await checkbox.toggle(true);
+    return true;
+  }
+
+  async getDUCCToggle(): Promise<boolean> {
+    const xpath = `${this.getXpath()}//label/span[text()='Data Use Agreement']`;
+    const checkbox = new Checkbox(this.page, xpath);
+    await checkbox.toggle(true);
+    return true;
+  }
+
+  // click the checkmark on the bypass module to save the bypass access
+  async clickCheckmarkBypass(): Promise<void> {
+    const xpath = `${this.getXpath()}//*[local-name()='svg' and @data-icon='check']`;
+    const button = new Checkbox(this.page, xpath);
+    await button.click();
+  }
+
+  // click the cancel icon to close the bypass module
+  async clickCancelBypass(): Promise<void> {
+    const xpath = `${this.getXpath()}//*[local-name()='svg' and @data-icon='times']`;
+    const button = new Checkbox(this.page, xpath);
+    await button.click();
+  }
+
+  async waitUntilGone(page: Page, timeout = 60000): Promise<void> {
+    await page.waitForXPath(this.xpath, { hidden: true, timeout });
+  }
+}

--- a/e2e/app/page/admin-user-audit-page.ts
+++ b/e2e/app/page/admin-user-audit-page.ts
@@ -1,0 +1,16 @@
+import { Page } from 'puppeteer';
+import AuthenticatedPage from 'app/page/authenticated-page';
+import { waitForDocumentTitle, waitWhileLoading } from 'utils/waits-utils';
+
+const PageTitle = 'User Audit';
+
+export default class UserAuditPage extends AuthenticatedPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async isLoaded(): Promise<boolean> {
+    await Promise.all([waitForDocumentTitle(this.page, PageTitle), waitWhileLoading(this.page)]);
+    return true;
+  }
+}

--- a/e2e/app/page/admin-user-list-page.ts
+++ b/e2e/app/page/admin-user-list-page.ts
@@ -1,0 +1,110 @@
+import { Page } from 'puppeteer';
+import AuthenticatedPage from 'app/page/authenticated-page';
+import { waitForDocumentTitle, waitWhileLoading } from 'utils/waits-utils';
+import { getPropValue } from 'utils/element-utils';
+import Table from 'app/component/table';
+import AdminTable from 'app/component/admin-table';
+import Textbox from 'app/element/textbox';
+import BypassLink from 'app/component/bypass-modules';
+import UserAuditPage from './admin-user-audit-page';
+import UserProfileInfo from './admin-user-profile-info';
+
+export const PageTitle = 'User Admin Table';
+
+export default class UserAdminPage extends AuthenticatedPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async isLoaded(): Promise<boolean> {
+    await Promise.all([waitForDocumentTitle(this.page, PageTitle), waitWhileLoading(this.page)]);
+    await this.getUserAdminTable().exists();
+    return true;
+  }
+
+  getUserAdminTable(): AdminTable {
+    return new AdminTable(this.page);
+  }
+
+  waitForSearchBox(): Textbox {
+    return Textbox.findByName(this.page, { name: 'Search' });
+  }
+
+  async searchUser(username: string): Promise<Table> {
+    const userAdminTable = this.getUserAdminTable();
+    const searchBox = this.waitForSearchBox();
+    await searchBox.type(username);
+    await waitWhileLoading(this.page);
+    return userAdminTable;
+  }
+
+  /**
+   * username rowindex & bypasslink colindex.
+   * @param {string} username username.
+   * @param {number} colIndex column index
+   * @param {number} rowIndex row index
+   */
+
+  async clickBypassLink(rowIndex = 1, colIndex = 1): Promise<BypassLink> {
+    const dataTable = this.getUserAdminTable();
+    const bodyTable = dataTable.getBodyTable();
+    const cell = await bodyTable.getCell(rowIndex, colIndex);
+    await getPropValue<string>(cell, 'textContent');
+    await cell.click();
+    const bypassModal = new BypassLink(this.page);
+    return bypassModal;
+  }
+
+  // click on the name link in the frozen column to navigate to the user info page
+  async clickNameLink(rowIndex = 1, colIndex = 1): Promise<Page> {
+    const dataTable = this.getUserAdminTable();
+    const bodyTable = dataTable.getFrozenBody();
+    const cell = await bodyTable.getCell(rowIndex, colIndex);
+    await getPropValue<string>(cell, 'textContent');
+    await cell.click();
+    browser.on('targetcreated', function (target) {
+      console.log(target.type + ' was created');
+    });
+    const userProfileInfo = new UserProfileInfo(page);
+    await userProfileInfo.isLoaded(); 
+    return page;
+  }
+
+  // to disable/enable an user click in the "user lockout" column
+  async clickUserLockout(rowIndex = 1, colIndex = 1): Promise<Page> {
+    const dataTable = this.getUserAdminTable();
+    const bodyTable = dataTable.getBodyTable();
+    const cell = await bodyTable.getCell(rowIndex, colIndex);
+    await getPropValue<string>(cell, 'textContent');
+    await cell.click();
+    return page;
+  }
+
+  // extract only the status text to verify the user status
+  async getStatusText(rowIndex = 1, colIndex = 1): Promise<string> {
+    const dataTable = this.getUserAdminTable();
+    const bodyTable = dataTable.getBodyTable();
+    const cell = await bodyTable.getCell(rowIndex, colIndex);
+    const textContent = await getPropValue<string>(cell, 'textContent');
+    return textContent;
+  }
+
+  async clickAuditLink(rowIndex = 1, colIndex = 1): Promise<Page> {
+    const dataTable = this.getUserAdminTable();
+    const bodyTable = dataTable.getBodyTable();
+    const cell = await bodyTable.getCell(rowIndex, colIndex);
+    await getPropValue<string>(cell, 'textContent');
+    const userAuditPage = new UserAuditPage(page);
+    await cell.click();
+    browser.on('targetcreated', function (target) {
+      console.log(target.type + ' was created');
+    });
+    
+    
+    await userAuditPage.isLoaded(); 
+    //await browser.newPage();
+    
+    return page;
+  }
+}
+

--- a/e2e/app/page/admin-user-profile-info.ts
+++ b/e2e/app/page/admin-user-profile-info.ts
@@ -1,0 +1,31 @@
+import { Page } from 'puppeteer';
+import AuthenticatedPage from 'app/page/authenticated-page';
+import { waitForDocumentTitle, waitWhileLoading } from 'utils/waits-utils';
+import Button from 'app/element/button';
+
+const LabelAlias = {
+  Save: 'Save'
+};
+export const PageTitle = 'User Profile Information Page';
+
+export default class UserProfileInfo extends AuthenticatedPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async isLoaded(): Promise<boolean> {
+    await Promise.all([waitForDocumentTitle(this.page, PageTitle), waitWhileLoading(this.page)]);
+    return true;
+  }
+
+  async waitForSaveButton(isActive: boolean): Promise<Button> {
+    const button = this.getSaveUserProfileButton();
+    const isCursorEnabled = !(await button.isCursorNotAllowed());
+    expect(isCursorEnabled).toBe<boolean>(isActive);
+    return button;
+  }
+
+  getSaveUserProfileButton(): Button {
+    return Button.findByName(this.page, { name: LabelAlias.Save });
+  }
+}

--- a/e2e/tests/admin/user-admin.spec.ts
+++ b/e2e/tests/admin/user-admin.spec.ts
@@ -1,0 +1,113 @@
+import UserAdminPage from 'app/page/admin-user-list-page';
+import {signInWithAccessToken} from 'utils/test-utils';
+import navigation, { NavLink } from 'app/component/navigation';
+import AdminTable from 'app/component/admin-table';
+
+
+let username = "admin_test@fake-research-aou.org";
+
+describe('Admin', () => {
+
+    beforeEach(async () => {
+      await signInWithAccessToken(page);
+      //await navigation.navMenu(page, NavLink.ADMIN);
+      await navigation.navMenu(page, NavLink.USER_ADMIN);
+      
+    });
+
+    test('admin able to update bypass access', async () => { 
+      let userAdminPage = new UserAdminPage(page);
+      await userAdminPage.waitForLoad();
+      //look up for the user
+      await userAdminPage.searchUser(username);
+      await userAdminPage.waitForLoad();
+
+      //Verify table column names match.
+       const columns = [
+          'Status',
+          'Institution',
+          'Registration date',
+          'User name',
+          'Contact Email',
+          'User Lockout',
+          'First Sign-in',
+          '2FA',
+          'Training',
+          'eRA Commons',
+          'DUCC',
+          'Bypass',
+          'Audit'
+        ]
+        let adminTable = new AdminTable(page);
+        const columnNames = await adminTable.getColumnNames();
+        console.log(columnNames);
+        expect(columnNames).toHaveLength(columns.length);
+        expect(columnNames.sort()).toEqual(columns.sort());
+       
+      // const usernameIndex = await adminTable.getUsernameIndex(username);
+      //   const columnIndex = await adminTable.bypassLinkColindex()
+      //   console.log(columnIndex);
+
+      // //   //click on the bypass link
+      //   let bypassLinkModal  = await userAdminPage.clickBypassLink(1, columnIndex);
+      //  let toggleText = await bypassLinkModal.getAllToggleTexts();
+      //  console.log(toggleText);
+    
+
+      // // change toggle to green for all the modules
+      //  await bypassLinkModal.bypassAllModules();
+
+      //get the index of the user lockout column
+      const userLockoutColIndex = await adminTable.getColumnIndex("User Lockout");
+      console.log(`userLockoutColIndex: ${userLockoutColIndex}`);
+      //click to disable the user
+       await userAdminPage.clickUserLockout(1, userLockoutColIndex);
+       await userAdminPage.waitForLoad();
+
+       const statusColIndex = await adminTable.getColumnIndex("Status");
+       //verify that the status col has status as active and user lockout displays ENABLE
+      const userStatus = await userAdminPage.getStatusText(1, statusColIndex);
+      console.log(`userStatus: ${userStatus}`);
+
+      const auditColIndex = await adminTable.getColumnIndex("Audit");
+      console.log(`auditColIndex: ${auditColIndex}`);
+       //verify that the status col has status as active and user lockout displays ENABLE
+     await userAdminPage.clickAuditLink(1, auditColIndex);
+
+      const nameColIndex = await adminTable.getNameColindex();
+
+       //click on the name link to navigate to the user profile page
+       console.log(nameColIndex);
+       await userAdminPage.clickNameLink(1, nameColIndex); 
+       
+       // declare new tab, now you can work with it
+      
+        // verify that all the modules display a checkmark in the respective columns
+
+        // click on the user name to navigate to the user profile info page
+
+         // Verify "Save Profile" button is disabled first time page is opened.
+        //await userProfileInfo.waitForSaveButton(false);
+
+        // verify that all the modules are displaying the green toggle
+
+    });
+
+    test.skip('admin able to update the free credits', async () => { 
+
+    //verify that the default free credit is displaying
+
+    //verify that the admin is able to update the free credits
+    });
+
+    test.skip('admin able to disable and enable the user', async () => { 
+
+        //verify that the User Lockout column is displaying DISABLE (default state)
+
+        //verify that the status column is displaying Active (default status)
+    
+        //verify that the admin is able to update the free credits
+        });
+
+
+});

--- a/e2e/tests/admin/user-admin.spec.ts
+++ b/e2e/tests/admin/user-admin.spec.ts
@@ -40,21 +40,19 @@ describe('Admin', () => {
         ]
         let adminTable = new AdminTable(page);
         const columnNames = await adminTable.getColumnNames();
-        console.log(columnNames);
         expect(columnNames).toHaveLength(columns.length);
         expect(columnNames.sort()).toEqual(columns.sort());
        
-      // const usernameIndex = await adminTable.getUsernameIndex(username);
-      //   const columnIndex = await adminTable.bypassLinkColindex()
-      //   console.log(columnIndex);
+      // get the index of the user name column
+      const usernameColIndex = await adminTable.getColumnIndex("User name");
 
-      // //   //click on the bypass link
-      //   let bypassLinkModal  = await userAdminPage.clickBypassLink(1, columnIndex);
-      //  let toggleText = await bypassLinkModal.getAllToggleTexts();
-      //  console.log(toggleText);
+      //click on the bypass link
+      let bypassLinkModal  = await userAdminPage.clickBypassLink(1, usernameColIndex);
+       let toggleText = await bypassLinkModal.getAllToggleTexts();
+       console.log(toggleText);
     
 
-      // // change toggle to green for all the modules
+      // change toggle to green for all the modules
       //  await bypassLinkModal.bypassAllModules();
 
       //get the index of the user lockout column

--- a/e2e/tests/admin/user-admin.spec.ts
+++ b/e2e/tests/admin/user-admin.spec.ts
@@ -40,18 +40,18 @@ describe('Admin', () => {
         ]
         let adminTable = new AdminTable(page);
         const columnNames = await adminTable.getColumnNames();
+        console.log(columnNames);
         expect(columnNames).toHaveLength(columns.length);
         expect(columnNames.sort()).toEqual(columns.sort());
        
-      // get the index of the user name column
-      const usernameColIndex = await adminTable.getColumnIndex("User name");
+      // get the index of the Bypass column
+      const bypassColIndex = await adminTable.getColumnIndex("Bypass");
 
       //click on the bypass link
-      let bypassLinkModal  = await userAdminPage.clickBypassLink(1, usernameColIndex);
-       let toggleText = await bypassLinkModal.getAllToggleTexts();
+      let bypassLinkModal  = await userAdminPage.clickBypassLink(1, bypassColIndex);
+      let toggleText = await bypassLinkModal.getAllToggleTexts();
        console.log(toggleText);
     
-
       // change toggle to green for all the modules
       //  await bypassLinkModal.bypassAllModules();
 
@@ -70,7 +70,8 @@ describe('Admin', () => {
       const auditColIndex = await adminTable.getColumnIndex("Audit");
       console.log(`auditColIndex: ${auditColIndex}`);
        //verify that the status col has status as active and user lockout displays ENABLE
-     await userAdminPage.clickAuditLink(1, auditColIndex);
+      await userAdminPage.clickAuditLink(1, auditColIndex);
+
 
       const nameColIndex = await adminTable.getNameColindex();
 


### PR DESCRIPTION
Created a test case for the Workbench admin feature.
This PR contains the initial test case of the user Admin.

1. navigate to the user admin menu
2. search the username. >> this one will eventually be the username that is created in the create account test case.
3. verify the column names
4. find the index of the column : user name,
5. find the index of the column : user lockout >> disable/enable the user
6. find the index of the column : status >> check the user’s status
7. find the index of the column : audit >> click on the audit link in the column >> navigate to the audit page (new tab)
8. find the index of the column : name >> click on the name link >>navigate to the user profile page (new tab)

NOTE: This test will fail because the code on (line 75 user-admin.spec.ts) is suppose to open the new tab.

**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
