### PR TITLE
[RW-6783][risk=no] Add endpoint to sync a single user's access tier

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -16,6 +16,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import org.pmiops.workbench.actionaudit.ActionAuditQueryService;
+import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.ProfileAuditor;
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.auth.UserAuthentication;
@@ -365,6 +366,17 @@ public class ProfileController implements ProfileApiDelegate {
     } catch (NotFoundException ex) {
       throw ex;
     } catch (ApiException e) {
+      throw new ServerErrorException(e);
+    }
+    return getProfileResponse(userProvider.get());
+  }
+
+  @Override
+  public ResponseEntity<Profile> syncAccessModuleStatus() {
+    DbUser user = userProvider.get();
+    try {
+      userService.updateUserWithRetries(Function.identity(), user, Agent.asUser(user));
+    } catch (Exception e) {
       throw new ServerErrorException(e);
     }
     return getProfileResponse(userProvider.get());

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -320,6 +320,17 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     return ctTimes.isBypassed() || (ctTimes.isComplete() && !ctTimes.hasExpired());
   }
 
+  private boolean isProfileCompliant(DbUser user) {
+    final ModuleTimes profileTimes = new ModuleTimes(user.getProfileLastConfirmedTime(), null);
+    return !profileTimes.hasExpired();
+  }
+
+  private boolean isPublicationsCompliant(DbUser user) {
+    final ModuleTimes publicationTimes =
+        new ModuleTimes(user.getPublicationsLastConfirmedTime(), null);
+    return !publicationTimes.hasExpired();
+  }
+
   private boolean shouldUserBeRegistered(DbUser user) {
     // beta access bypass and 2FA do not need to be checked for annual renewal
     boolean betaAccessGranted =
@@ -333,6 +344,8 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
         && betaAccessGranted
         && twoFactorAuthComplete
         && isDataUseAgreementCompliant(user)
+        && isPublicationsCompliant(user)
+        && isProfileCompliant(user)
         && EmailVerificationStatus.SUBSCRIBED.equals(user.getEmailVerificationStatusEnum());
   }
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -461,6 +461,24 @@ paths:
           description: The user's profile.
           schema:
             "$ref": "#/definitions/Profile"
+  "/v1/account/sync-access-module-status":
+    post:
+      tags:
+      - profile
+      summary: Sync access module training status
+      description: Sync the status of the user's access modules
+      operationId: syncAccessModuleStatus
+      responses:
+        200:
+          description: The user's profile.
+          schema:
+            "$ref": "#/definitions/Profile"
+        404:
+          description: User not found
+        500:
+          description: Internal Error
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
   "/v1/account/sync-training-status":
     post:
       tags:

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -557,9 +557,10 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertThat(profileController.syncAccessModuleStatus().getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(accessTierService.getAccessTiersForUser(dbUser)).contains(registeredTier);
 
-    // One year passes
+    // // One year passes
     long yearInMillis = TimeUnit.DAYS.toMillis(config.accessRenewal.expiryDays + 1);
     fakeClock.increment(yearInMillis);
+   
 
     // A sync is requested - it should remove access
     assertThat(profileController.syncAccessModuleStatus().getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -581,6 +582,9 @@ public class ProfileControllerTest extends BaseControllerTest {
     dbUser.setProfileLastConfirmedTime(update);
     assertThat(profileController.syncAccessModuleStatus().getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(accessTierService.getAccessTiersForUser(dbUser)).contains(registeredTier);
+
+    // testMe_success is very unhappy with the clock increment... reset it
+    fakeClock.increment(yearInMillis * -1);
   }
 
   @Test


### PR DESCRIPTION
Description:
This change adds a new endpoint that will allow a client to immediately re-sync a user's access tiers once they have completed a training module / gone through an access renewal flow. 

---
**PR checklist**

- [X] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [X] This PR includes appropriate unit tests
- [X] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
