### PR TITLE
[no ticket][risk=no] Puppeteer fix faker eslint warnings

### DIFF
--- a/e2e/app/modal/conceptset-save-modal.ts
+++ b/e2e/app/modal/conceptset-save-modal.ts
@@ -8,8 +8,7 @@ import { LinkText } from 'app/text-labels';
 import { getPropValue } from 'utils/element-utils';
 import { waitWhileLoading } from 'utils/waits-utils';
 import Modal from './modal';
-
-const faker = require('faker/locale/en_US');
+import faker from 'faker';
 
 export enum SaveOption {
   CreateNewSet = 'Create new set',

--- a/e2e/app/page/cohort-build-page.ts
+++ b/e2e/app/page/cohort-build-page.ts
@@ -14,8 +14,8 @@ import CohortSaveAsModal from 'app/modal/cohort-save-as-modal';
 import { getPropValue } from 'utils/element-utils';
 import WarningDiscardChangesModal from 'app/modal/warning-discard-changes-modal';
 import WorkspaceDataPage from './workspace-data-page';
+import faker from 'faker';
 
-const faker = require('faker/locale/en_US');
 const PageTitle = 'Build Cohort Criteria';
 
 export enum FieldSelector {

--- a/e2e/resources/data/user-registration-data.ts
+++ b/e2e/resources/data/user-registration-data.ts
@@ -1,4 +1,4 @@
-const faker = require('faker/locale/en_US');
+import faker from 'faker';
 
 const newUserName = `aoutestuser${Math.floor(Math.random() * 1000)}${Math.floor(Date.now() / 1000)}`;
 

--- a/e2e/utils/faker-utils.ts
+++ b/e2e/utils/faker-utils.ts
@@ -1,4 +1,4 @@
-const faker = require('faker/locale/en_US');
+import faker from 'faker';
 
 /**
  * Get a fake user information.

--- a/e2e/utils/str-utils.ts
+++ b/e2e/utils/str-utils.ts
@@ -1,7 +1,7 @@
 import * as fp from 'lodash/fp';
 import { Page } from 'puppeteer';
 
-const faker = require('faker/locale/en_US');
+import faker from 'faker';
 
 export function makeString(charLimit?: number): string {
   let loremStr: string = faker.lorem.paragraphs();


### PR DESCRIPTION
Fix eslint warnings caused by faker.

Before change (382 warnings):
<img width="290" alt="Screen Shot 2021-05-25 at 1 40 42 PM" src="https://user-images.githubusercontent.com/35533885/119543863-1feb7700-bd5f-11eb-9b85-f46688af1474.png">

After change (325 warnings):
<img width="290" alt="Screen Shot 2021-05-25 at 1 39 23 PM" src="https://user-images.githubusercontent.com/35533885/119543871-237efe00-bd5f-11eb-9e71-4aa0d8f66daf.png">
