### PR TITLE
[RW-6759][risk=no] Fix resource name in dataset reference warning modal

### DIFF
--- a/ui/src/app/components/data-set-reference-modal.tsx
+++ b/ui/src/app/components/data-set-reference-modal.tsx
@@ -59,7 +59,7 @@ class DataSetReferenceModal extends React.Component<Props, {}> {
                 <div style={{paddingBottom: '1rem'}}>
                     The {resourceWithTypeElem} is referenced by the following datasets: {dataSetsElem}.
                     Deleting the {resourceWithTypeElem} will make these datasets unavailable for use.
-                    Are you sure you want to delete {resourceElem} ?
+                    Are you sure you want to delete {resourceElem}?
                 </div>
                 <div style={{float: 'right'}}>
                     <Button type='secondary' style={{marginRight: '2rem'}} onClick={onCancel}>Cancel</Button>

--- a/ui/src/app/components/data-set-reference-modal.tsx
+++ b/ui/src/app/components/data-set-reference-modal.tsx
@@ -1,4 +1,3 @@
-import * as fp from 'lodash/fp';
 import * as React from 'react';
 
 import {dataSetApi} from 'app/services/swagger-fetch-clients';

--- a/ui/src/app/components/data-set-reference-modal.tsx
+++ b/ui/src/app/components/data-set-reference-modal.tsx
@@ -48,7 +48,7 @@ class DataSetReferenceModal extends React.Component<Props, {}> {
   render() {
     const {referencedResource, dataSets, onCancel} = this.props;
 
-    const resourceName = fp.startCase(getDisplayName(referencedResource));
+    const resourceName = getDisplayName(referencedResource);
     const resourceElem = <span style={styles.resource}>{resourceName}</span>;
     const resourceWithTypeElem = <span>{getTypeString(referencedResource)} {resourceElem}</span>;
     const dataSetsElem = <span style={styles.dataSets}>{dataSets}</span>;


### PR DESCRIPTION
Fix the display of the resource name so it appears as the user entered it.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
