### PR TITLE
[risk=no][ticket=no] Enable HTML report of puppeteer results

### DIFF
--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -16,8 +16,9 @@ module.exports = {
       {
         resultDir: 'logs',
         resultJson: 'test-results.json',
+        resultHtml: 'puppeteer-test-results.html',
         reportTitle: 'AoU integration tests',
-        report: false
+        report: true
       }
     ],
     [


### PR DESCRIPTION
The terminal/JSON output of puppeteer is hard to look at when running locally. The HTML report is friendlier way to view the failures and stack traces.

![image](https://user-images.githubusercontent.com/2770197/119854070-c14d0700-bede-11eb-9f9c-9739b8a3a076.png)
