### PR TITLE
[risk=no] Suppress Hibernate logspam in unit tests

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/testconfig/TestJpaConfig.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/TestJpaConfig.java
@@ -63,7 +63,6 @@ public class TestJpaConfig {
     hibernateProperties.setProperty("hibernate.hbm2ddl.auto", "create-drop");
     hibernateProperties.setProperty(
         "hibernate.dialect", "org.pmiops.workbench.cdr.CommonTestDialect");
-    hibernateProperties.setProperty("hibernate.show_sql", "true");
 
     return hibernateProperties;
   }

--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -11,12 +11,13 @@ spring.main.allow-bean-definition-overriding=true
 # Avoid log spam in tests
 spring.main.log-startup-info=OFF
 spring.main.banner-mode=off
-logging.level.org.springframework=ERROR
+logging.level.org.springframework=WARN
+
+# Change to true for verbose Hibernate SQL
 spring.jpa.properties.hibernate.show_sql=false
-spring.jpa.show-sql=false
 
 # Uncomment the following to turn on full SQL debugging
-#spring.jpa.properties.hibernate.show_sql=true
+#spring.jpa.show-sql=false
 #spring.jpa.properties.hibernate.format_sql=true
 #spring.jpa.properties.hibernate.type=trace
 # Show Hibernate statements in addition to SQL

--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -17,7 +17,7 @@ logging.level.org.springframework=WARN
 spring.jpa.properties.hibernate.show_sql=false
 
 # Uncomment the following to turn on full SQL debugging
-#spring.jpa.show-sql=false
+#spring.jpa.show-sql=true
 #spring.jpa.properties.hibernate.format_sql=true
 #spring.jpa.properties.hibernate.type=trace
 # Show Hibernate statements in addition to SQL

--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -7,6 +7,14 @@ spring.jpa.properties.hibernate.dialect=org.pmiops.workbench.cdr.CommonTestDiale
 spring.liquibase.enabled=false
 # To allow each tests override and customize their the beans.
 spring.main.allow-bean-definition-overriding=true
+
+# Avoid log spam in tests
+spring.main.log-startup-info=OFF
+spring.main.banner-mode=off
+logging.level.org.springframework=ERROR
+spring.jpa.properties.hibernate.show_sql=false
+spring.jpa.show-sql=false
+
 # Uncomment the following to turn on full SQL debugging
 #spring.jpa.properties.hibernate.show_sql=true
 #spring.jpa.properties.hibernate.format_sql=true

--- a/api/src/test/resources/logback-test.xml
+++ b/api/src/test/resources/logback-test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml" />
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+</configuration>


### PR DESCRIPTION
When running Java unit tests, eliminate the pages of Spring logspam. This can be re-enabled locally if desired, per comments in application.properties.

`logback-test.xml` was necessary for the initial bootstrapping logs by spring framework. Apparently these logs happen before `application.properties` gets parsed.