### PR TITLE
[risk=low][no ticket] ProfileController.updateProfile() confirms the profile

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -479,6 +479,8 @@ public class ProfileController implements ProfileApiDelegate {
 
   @Override
   public ResponseEntity<Void> updateProfile(Profile updatedProfile) {
+    confirmProfile();
+
     DbUser user = userProvider.get();
 
     // Save current profile for audit trail. Continue to use the userProvider (instead

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -985,6 +985,20 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertProfile(updatedProfile);
   }
 
+  @Test
+  public void testUpdateProfile_confirmsProfile() {
+    createAccountAndDbUserWithAffiliation();
+    Profile profile = profileController.getMe().getBody();
+    assertThat(profile.getProfileLastConfirmedTime()).isNull();
+
+    // make an arbitrary change
+    profile.setAboutYou("I'm a changed person.");
+    profileController.updateProfile(profile);
+
+    Profile updatedProfile = profileController.getMe().getBody();
+    assertThat(updatedProfile.getProfileLastConfirmedTime()).isEqualTo(fakeClock.millis());
+  }
+
   @Test(expected = NotFoundException.class)
   public void test_updateAccountProperties_null_user() {
     profileService.updateAccountProperties(new AccountPropertyUpdate());


### PR DESCRIPTION
Description:

When a user updates their profile, we want this to count as a "profile confirmation" for the purposes of annual renewal.  This adds a confirmProfile() call to **ProfileController**.updateProfile(), which is the endpoint called by the UI for user-directed profile updates.

Note that **ProfileService**.updateProfile() is used more generally, for both admin- and user-directed updates, so is not appropriate for this task. 

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
