### PR TITLE
[RW-6582][risk=no] Fix save criteria button when updating modifiers

### DIFF
--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.tsx
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.tsx
@@ -176,6 +176,8 @@ export const CohortSearch = withCurrentCohortSearchContext()(class extends React
         }, () => this.setUnsavedChanges());
       }
     });
+    // Check for changes when the search context changes, mainly to detect modifier changes
+    this.subscription.add(currentCohortSearchContextStore.subscribe(() => this.setUnsavedChanges()));
   }
 
   componentWillUnmount() {
@@ -204,7 +206,8 @@ export const CohortSearch = withCurrentCohortSearchContext()(class extends React
           // If a lookup has been done, we delete the ids before comparing search parameters and selections
           selectionsClone.forEach(selection => delete selection.id);
         }
-        unsavedChanges = sortAndStringify(requestItem.searchParameters) !== sortAndStringify(selectionsClone);
+        unsavedChanges = sortAndStringify(requestItem.searchParameters) !== sortAndStringify(selectionsClone) ||
+          JSON.stringify(item.modifiers) !== JSON.stringify(requestItem.modifiers);
       }
     }
     this.setState({unsavedChanges});

--- a/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
+++ b/ui/src/app/cohort-search/modifier-page/modifier-page.component.tsx
@@ -16,7 +16,7 @@ import {triggerEvent} from 'app/utils/analytics';
 import {currentCohortSearchContextStore} from 'app/utils/navigation';
 import {serverConfigStore} from 'app/utils/stores';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {Criteria, CriteriaType, Domain, ModifierType, Operator} from 'generated/fetch';
+import {Criteria, CriteriaType, Domain, Modifier, ModifierType, Operator} from 'generated/fetch';
 
 
 const styles = reactStyles({
@@ -160,7 +160,7 @@ interface Selection extends Criteria {
 
 interface Props {
   selections: Array<Selection>;
-  closeModifiers: Function;
+  closeModifiers: (modifiers?: Array<Modifier>) => void;
   workspace: WorkspaceData;
   cohortContext: any;
 }
@@ -372,7 +372,7 @@ export const ModifierPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSea
       const {cohortContext} = this.props;
       cohortContext.item.modifiers = this.getModifiersFromForm();
       currentCohortSearchContextStore.next(cohortContext);
-      this.props.closeModifiers();
+      this.props.closeModifiers(cohortContext.item.modifiers);
     }
 
     get addEncounters() {

--- a/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
+++ b/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
@@ -298,6 +298,13 @@ export const SelectionList = fp.flow(withCurrentCohortCriteria(), withCurrentCoh
       currentCohortCriteriaStore.next(updateList);
     }
 
+    closeModifiers(modifiers) {
+      if (modifiers) {
+        this.setState({modifiers}, () => this.checkCriteriaChanges());
+      }
+      this.setState({showModifiersSlide: false});
+    }
+
     closeSidebar() {
       attributesSelectionStore.next(undefined);
       setSidebarActiveIconStore.next(null);
@@ -396,10 +403,7 @@ export const SelectionList = fp.flow(withCurrentCohortCriteria(), withCurrentCoh
             </FlexRowWrap>
           </React.Fragment>}
           {showModifiersSlide && !attributesSelection && <ModifierPage selections={criteria}
-                                               closeModifiers={() => {
-                                                 this.setState({showModifiersSlide: false});
-                                                 this.checkCriteriaChanges();
-                                               }}/>}
+                                                                       closeModifiers={(modifiers) => this.closeModifiers(modifiers)}/>}
           {!!attributesSelection && <AttributesPage back={() => this.closeSidebar()}
                                                     close={() => attributesSelectionStore.next(undefined)}
                                                     node={attributesSelection}/>}

--- a/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
+++ b/ui/src/app/cohort-search/selection-list/selection-list.component.tsx
@@ -273,7 +273,7 @@ export const SelectionList = fp.flow(withCurrentCohortCriteria(), withCurrentCoh
     checkCriteriaChanges() {
       const {cohortContext: {groupId, item, role}, criteria} = this.props;
       if (criteria.length === 0) {
-        this.setState({disableSave: true});
+        this.setState({disableSave: true, modifiers: []});
       } else {
         const requestItem = getItemFromSearchRequest(groupId, item.id, role);
         if (requestItem) {


### PR DESCRIPTION
Fixes issue where Save Criteria button was still disabled after changing the modifiers of a search item

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
