### PR TITLE
[RW-6782][risk=no] Revert extraction flag in preprod

### DIFF
--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -114,7 +114,7 @@
     "enableResearchPurposePrompt": false,
     "enableReportingUploadCron": true,
     "enableRasLoginGovLinking": false,
-    "enableGenomicExtraction": true,
+    "enableGenomicExtraction": false,
     "enableFireCloudV2Billing" : false
   },
   "actionAudit": {


### PR DESCRIPTION
For now, we just want to turn this on for limited testing periods, so demo project users don't accidentally misuse it before the feature is complete.