### PR TITLE
[RW-6761][risk=no] Add search bar back to visits tree in CB

### DIFF
--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -191,7 +191,7 @@ export class SearchBar extends React.Component<Props, State> {
   componentDidUpdate(prevProps: Readonly<Props>): void {
     const {node: {domainId}, searchTerms} = this.props;
     if (searchTerms !== prevProps.searchTerms) {
-      if (domainId === Domain.PHYSICALMEASUREMENT.toString()) {
+      if (domainId === Domain.PHYSICALMEASUREMENT.toString() || domainId === Domain.VISIT.toString()) {
         triggerEvent(`Cohort Builder Search - Physical Measurements`, 'Search', searchTerms);
       } else if (this.state.optionSelected) {
         this.setState({optionSelected: false});

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -152,7 +152,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
   }
 
   componentDidUpdate(prevProps: Readonly<TreeNodeProps>): void {
-    const {autocompleteSelection, node: {domainId, group}, searchTerms} = this.props;
+    const {autocompleteSelection, node: {group}, searchTerms} = this.props;
     if (this.inMemorySearch && group && searchTerms !== prevProps.searchTerms) {
       this.searchChildren();
     }
@@ -331,7 +331,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
   }
 
   render() {
-    const {autocompleteSelection, groupSelections, node, node: {code, count, domainId, id, group, hasAttributes, name, selectable},
+    const {autocompleteSelection, groupSelections, node, node: {code, count, id, group, hasAttributes, name, selectable},
       source, scrollToMatch, searchTerms, select, selectedIds, setAttributes} = this.props;
     const {children, error, expanded, hover, loading, searchMatch} = this.state;
     const nodeChildren = this.inMemorySearch ? node.children : children;

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -153,12 +153,17 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
 
   componentDidUpdate(prevProps: Readonly<TreeNodeProps>): void {
     const {autocompleteSelection, node: {domainId, group}, searchTerms} = this.props;
-    if (domainId === Domain.PHYSICALMEASUREMENT.toString() && group && searchTerms !== prevProps.searchTerms) {
+    if (this.inMemorySearch && group && searchTerms !== prevProps.searchTerms) {
       this.searchChildren();
     }
     if (!!autocompleteSelection && autocompleteSelection !== prevProps.autocompleteSelection) {
       this.checkAutocomplete();
     }
+  }
+
+  get inMemorySearch() {
+    const {node: {domainId}} = this.props;
+    return domainId === Domain.PHYSICALMEASUREMENT.toString() || domainId === Domain.VISIT.toString();
   }
 
   loadChildren() {
@@ -226,7 +231,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
           const message = source === 'concept' ? 'Concept Search' : 'Cohort Builder Search';
           triggerEvent(message, 'Click', `${domainToTitle(domainId)} - ${labelName} - Expand`);
         }
-        if (domainId !== Domain.PHYSICALMEASUREMENT.toString() && !children) {
+        if (!this.inMemorySearch && !children) {
           this.loadChildren();
         }
       }
@@ -329,8 +334,8 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
     const {autocompleteSelection, groupSelections, node, node: {code, count, domainId, id, group, hasAttributes, name, selectable},
       source, scrollToMatch, searchTerms, select, selectedIds, setAttributes} = this.props;
     const {children, error, expanded, hover, loading, searchMatch} = this.state;
-    const nodeChildren = domainId === Domain.PHYSICALMEASUREMENT.toString() ? node.children : children;
-    const displayName = domainId === Domain.PHYSICALMEASUREMENT.toString() && !!searchTerms
+    const nodeChildren = this.inMemorySearch ? node.children : children;
+    const displayName = this.inMemorySearch && !!searchTerms
       ? highlightSearchTerm(searchTerms, name, colors.success)
       : name;
     const selectIconStyle = this.selectIconDisabled() ? {...styles.selectIcon, ...styles.disableIcon} : styles.selectIcon;

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -211,11 +211,12 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
       if (criteriaLookup) {
         this.updateCriteriaSelectionStore(criteriaLookup.items);
       }
-      if (domainId === Domain.PHYSICALMEASUREMENT.toString()) {
+      if (domainId === Domain.PHYSICALMEASUREMENT.toString() || domainId === Domain.VISIT.toString()) {
         let children = [];
+        const rootParentId = domainId === Domain.VISIT.toString() ? -1 : 0;
         rootNodes.items.forEach(child => {
           child['children'] = [];
-          if (child.parentId === 0) {
+          if (child.parentId === rootParentId) {
             children.push(child);
           } else {
             children = this.addChildToParent(child, children);
@@ -346,15 +347,13 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
         NOTE: Concept Set can have only 1000 concepts. Please delete some concepts before adding
         more.
       </div>}
-      {node.domainId !== Domain.VISIT.toString() &&
-        <div style={styles.searchBarContainer}>
-          <SearchBar node={node}
-                     searchTerms={searchTerms}
-                     selectOption={selectOption}
-                     setIngredients={(i) => this.setState({ingredients: i})}
-                     setInput={(v) => setSearchTerms(v)}/>
-        </div>
-      }
+      <div style={styles.searchBarContainer}>
+        <SearchBar node={node}
+                   searchTerms={searchTerms}
+                   selectOption={selectOption}
+                   setIngredients={(i) => this.setState({ingredients: i})}
+                   setInput={(v) => setSearchTerms(v)}/>
+      </div>
       {!loading && <div style={{paddingTop: this.showHeader ? '1.5rem' : 0, width: '99%'}}>
         {this.showHeader && <div style={{...styles.treeHeader, border: `1px solid ${colorWithWhiteness(colors.black, 0.8)}`}}>
           {!!ingredients && <div style={styles.ingredients}>


### PR DESCRIPTION
Uses in-memory search, same as physical measurements tree

<img width="1035" alt="Screen Shot 2021-06-04 at 9 39 39 AM" src="https://user-images.githubusercontent.com/40036095/120819158-e6fa9180-c518-11eb-8869-e97ace52a103.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
