### PR TITLE
[RW-6820][risk=no] Set EOD June 30 2021 as the earliest access module expiration

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -104,6 +104,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   private final MailService mailService;
 
   private static final Logger log = Logger.getLogger(UserServiceImpl.class.getName());
+  private static final long minExpirationEpochMs = Instant.parse("2021-01-01T00:00:00.00Z").toEpochMilli();    
 
   @Autowired
   public UserServiceImpl(
@@ -236,7 +237,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   private class ModuleTimes {
     public Optional<Timestamp> completion;
     public Optional<Timestamp> bypass;
-    final long minExpirationEpochMs = 1625097600000L; // 2021-07-01T00:00:00.000Z
 
     public ModuleTimes(Timestamp nullableCompletion, Timestamp nullableBypass) {
       completion = Optional.ofNullable(nullableCompletion);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -104,7 +104,8 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   private final MailService mailService;
 
   private static final Logger log = Logger.getLogger(UserServiceImpl.class.getName());
-  private static final long minExpirationEpochMs = Instant.parse("2021-01-01T00:00:00.00Z").toEpochMilli();    
+  private static final long minExpirationEpochMs =
+      Instant.parse("2021-01-01T00:00:00.00Z").toEpochMilli();
 
   @Autowired
   public UserServiceImpl(

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -7,6 +7,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Collection;
@@ -229,6 +230,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   private class ModuleTimes {
     public Optional<Timestamp> completion;
     public Optional<Timestamp> bypass;
+    final long minExpirationEpochMs = 1625097600000L; // 2021-07-01T00:00:00.000Z
 
     public ModuleTimes(Timestamp nullableCompletion, Timestamp nullableBypass) {
       completion = Optional.ofNullable(nullableCompletion);
@@ -251,14 +253,17 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       Preconditions.checkNotNull(
           expiryDays, "expected value for config key accessRenewal.expiryDays.expiryDays");
       long expiryDaysInMs = TimeUnit.MILLISECONDS.convert(expiryDays, TimeUnit.DAYS);
-      return completion.map(c -> new Timestamp(c.getTime() + expiryDaysInMs));
+      return completion.map(
+          c -> new Timestamp(Math.max(c.getTime() + expiryDaysInMs, minExpirationEpochMs)));
     }
 
-    // IMPORTANT: do not use this method as the sole method of determining access compliance!
-    // We must ALSO confirm module completion.
-    // Modules which are not complete are also "not expired"
     public boolean hasExpired() {
+      Preconditions.checkArgument(
+          isComplete(), "Cannot check expiration on module that has not been completed");
       final Timestamp now = new Timestamp(clock.millis());
+      if (now.before(new Timestamp(minExpirationEpochMs))) {
+        return false;
+      }
       return getExpiration().map(x -> x.before(now)).orElse(false);
     }
   }
@@ -267,7 +272,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     return new RenewableAccessModuleStatus()
         .moduleName(name)
         .expirationEpochMillis(times.getExpiration().map(Timestamp::getTime).orElse(null))
-        .hasExpired(times.hasExpired());
+        .hasExpired(times.isComplete() && times.hasExpired());
   }
 
   public List<RenewableAccessModuleStatus> getRenewableAccessModuleStatus(DbUser user) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -7,7 +7,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Collection;

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -55,7 +55,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class UserServiceAccessTest {
   private static final String USERNAME = "abc@fake-research-aou.org";
-  private static final Instant START_INSTANT = Instant.parse("2000-01-01T00:00:00.00Z");
+  private static final Instant START_INSTANT = Instant.parse("2030-01-01T00:00:00.00Z");
   private static final FakeClock PROVIDED_CLOCK = new FakeClock(START_INSTANT);
 
   private static DbUser dbUser;
@@ -66,7 +66,7 @@ public class UserServiceAccessTest {
   private Function<Timestamp, Function<DbUser, DbUser>> registerUserWithTime =
       t -> dbu -> registerUser(t, dbu);
   private Function<DbUser, DbUser> registerUserNow =
-      registerUserWithTime.apply(Timestamp.from(Instant.now()));
+      registerUserWithTime.apply(new Timestamp(PROVIDED_CLOCK.millis()));
 
   @Autowired private AccessTierDao accessTierDao;
   @Autowired private UserAccessTierDao userAccessTierDao;
@@ -209,6 +209,49 @@ public class UserServiceAccessTest {
               user.setDataUseAgreementCompletionTime(new Timestamp(PROVIDED_CLOCK.millis()));
               return user;
             });
+    assertRegisteredTierEnabled(dbUser);
+  }
+
+// This should be removed after June 30 2021
+@Test
+public void testGracePeriod() {
+    providedWorkbenchConfig.access.enableAccessRenewal = true;
+    providedWorkbenchConfig.access.enableDataUseAgreement = true;
+    providedWorkbenchConfig.accessRenewal.expiryDays = (long) 365;
+    Instant mayFirst = Instant.parse("2020-05-01T00:00:00.00Z");
+    Instant julyFirst = Instant.parse("2021-07-01T01:00:00.00Z");
+    PROVIDED_CLOCK.setInstant(mayFirst);
+    // initialize user as registered with generic values including bypassed DUA
+
+    dbUser = updateUserWithRetries(registerUserNow);
+    assertRegisteredTierEnabled(dbUser);
+
+    // add a proper DUA completion which will expire soon, but remove DUA bypass
+
+    dbUser.setDataUseAgreementSignedVersion(userService.getCurrentDuccVersion());
+    dbUser.setDataUseAgreementCompletionTime(new Timestamp(PROVIDED_CLOCK.millis()));
+    dbUser = updateUserWithRetries(this::removeDuaBypass);
+
+    // User is compliant
+    assertRegisteredTierEnabled(dbUser);
+
+    // Simulate time passing, user is granted a grace period
+    advanceClockDays(providedWorkbenchConfig.accessRenewal.expiryDays);
+    dbUser = updateUserWithRetries(Function.identity());
+    assertRegisteredTierEnabled(dbUser);
+
+    // The grace period expires, and the user loses access
+    PROVIDED_CLOCK.setInstant(julyFirst);
+    dbUser = updateUserWithRetries(Function.identity());
+    assertRegisteredTierDisabled(dbUser);
+
+    // The user updates their agreement, the are compliant again
+    dbUser =
+    updateUserWithRetries(
+        user -> {
+          user.setDataUseAgreementCompletionTime(new Timestamp(PROVIDED_CLOCK.millis()));
+          return user;
+    });
     assertRegisteredTierEnabled(dbUser);
   }
 
@@ -555,7 +598,7 @@ public class UserServiceAccessTest {
   }
 
   private void advanceClockDays(long days) {
-    PROVIDED_CLOCK.setInstant(START_INSTANT.plus(days, ChronoUnit.DAYS));
+    PROVIDED_CLOCK.setInstant(Instant.now(PROVIDED_CLOCK).plus(days, ChronoUnit.DAYS));
   }
 
   // checks which power most of these tests - confirm that the unregisteringFunction does that

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -961,7 +961,7 @@ public class UserServiceAccessTest {
   }
 
   private void advanceClockDays(long days) {
-    PROVIDED_CLOCK.setInstant(Instant.now(PROVIDED_CLOCK).plus(days, ChronoUnit.DAYS));
+    PROVIDED_CLOCK.increment(Duration.ofDays(days).toMillis());  
   }
 
   // checks which power most of these tests - confirm that the unregisteringFunction does that

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -227,13 +227,12 @@ public void testGracePeriod() {
     Instant mayFirst = Instant.parse("2020-05-01T00:00:00.00Z");
     Instant julyFirst = Instant.parse("2021-07-01T01:00:00.00Z");
     PROVIDED_CLOCK.setInstant(mayFirst);
+    
     // initialize user as registered with generic values including bypassed DUA
-
     dbUser = updateUserWithRetries(registerUserNow);
     assertRegisteredTierEnabled(dbUser);
 
     // add a proper DUA completion which will expire soon, but remove DUA bypass
-
     dbUser.setDataUseAgreementSignedVersion(userService.getCurrentDuccVersion());
     dbUser.setDataUseAgreementCompletionTime(new Timestamp(PROVIDED_CLOCK.millis()));
     dbUser = updateUserWithRetries(this::removeDuaBypass);
@@ -246,12 +245,12 @@ public void testGracePeriod() {
     dbUser = updateUserWithRetries(Function.identity());
     assertRegisteredTierEnabled(dbUser);
 
-    // The grace period expires, and the user loses access
+    // The grace period is over, and the user loses access
     PROVIDED_CLOCK.setInstant(julyFirst);
     dbUser = updateUserWithRetries(Function.identity());
     assertRegisteredTierDisabled(dbUser);
 
-    // The user updates their agreement, the are compliant again
+    // The user updates their agreement, they are compliant again
     dbUser =
     updateUserWithRetries(
         user -> {

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -961,7 +961,7 @@ public class UserServiceAccessTest {
   }
 
   private void advanceClockDays(long days) {
-    PROVIDED_CLOCK.increment(Duration.ofDays(days).toMillis());  
+    PROVIDED_CLOCK.increment(Duration.ofDays(days).toMillis());
   }
 
   // checks which power most of these tests - confirm that the unregisteringFunction does that

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -218,16 +218,16 @@ public class UserServiceAccessTest {
     assertRegisteredTierEnabled(dbUser);
   }
 
-// This should be removed after June 30 2021
-@Test
-public void testGracePeriod() {
+  // This should be removed after June 30 2021
+  @Test
+  public void testGracePeriod() {
     providedWorkbenchConfig.access.enableAccessRenewal = true;
     providedWorkbenchConfig.access.enableDataUseAgreement = true;
     providedWorkbenchConfig.accessRenewal.expiryDays = (long) 365;
     Instant mayFirst = Instant.parse("2020-05-01T00:00:00.00Z");
     Instant julyFirst = Instant.parse("2021-07-01T01:00:00.00Z");
     PROVIDED_CLOCK.setInstant(mayFirst);
-    
+
     // initialize user as registered with generic values including bypassed DUA
     dbUser = updateUserWithRetries(registerUserNow);
     assertRegisteredTierEnabled(dbUser);
@@ -252,11 +252,11 @@ public void testGracePeriod() {
 
     // The user updates their agreement, they are compliant again
     dbUser =
-    updateUserWithRetries(
-        user -> {
-          user.setDataUseAgreementCompletionTime(new Timestamp(PROVIDED_CLOCK.millis()));
-          return user;
-    });
+        updateUserWithRetries(
+            user -> {
+              user.setDataUseAgreementCompletionTime(new Timestamp(PROVIDED_CLOCK.millis()));
+              return user;
+            });
     assertRegisteredTierEnabled(dbUser);
   }
 


### PR DESCRIPTION
---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
