### PR TITLE
[risk=low][RW-6631] Show AAR completion text when modules are bypassed

### DIFF
--- a/ui/src/app/pages/access/access-renewal-page.spec.tsx
+++ b/ui/src/app/pages/access/access-renewal-page.spec.tsx
@@ -184,30 +184,6 @@ describe('Access Renewal Page', () => {
     expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(1);
   });
 
-  it('should show the correct state when all items are complete or bypassed', async () => {
-    expireAllModules()
-
-    const wrapper = component();
-
-    updateOneModule('profileConfirmation', oneYearFromNow());
-    updateOneModule('publicationConfirmation', oneYearFromNow());
-
-    setBypassTimes(oneYearFromNow);
-
-    setCompletionTimes(oneYearFromNow);
-
-    await waitOneTickAndUpdate(wrapper);
-
-    // Training and DUCC are bypassed
-    expect(findNodesByExactText(wrapper, 'Bypassed').length).toBe(2);
-
-    // Publications and Profile are complete
-    expect(findNodesByExactText(wrapper, 'Confirmed').length).toBe(2);
-    expect(findNodesContainingText(wrapper, `${EXPIRY_DAYS - 1} days`).length).toBe(2);
-
-    expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(1);
-  });
-
   it('should show the correct state when items are bypassed', async () => {
     expireAllModules()
 
@@ -231,5 +207,29 @@ describe('Access Renewal Page', () => {
 
     // State check
     expect(findNodesContainingText(wrapper, 'click the refresh button').length).toBe(0);
+  });
+
+  it('should show the correct state when all items are complete or bypassed', async () => {
+    expireAllModules()
+
+    const wrapper = component();
+
+    updateOneModule('profileConfirmation', oneYearFromNow());
+    updateOneModule('publicationConfirmation', oneYearFromNow());
+
+    setBypassTimes(oneYearFromNow);
+
+    setCompletionTimes(oneYearFromNow);
+
+    await waitOneTickAndUpdate(wrapper);
+
+    // Training and DUCC are bypassed
+    expect(findNodesByExactText(wrapper, 'Bypassed').length).toBe(2);
+
+    // Publications and Profile are complete
+    expect(findNodesByExactText(wrapper, 'Confirmed').length).toBe(2);
+    expect(findNodesContainingText(wrapper, `${EXPIRY_DAYS - 1} days`).length).toBe(2);
+
+    expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(1);
   });
 });

--- a/ui/src/app/pages/access/access-renewal-page.spec.tsx
+++ b/ui/src/app/pages/access/access-renewal-page.spec.tsx
@@ -184,6 +184,30 @@ describe('Access Renewal Page', () => {
     expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(1);
   });
 
+  it('should show the correct state when all items are complete or bypassed', async () => {
+    expireAllModules()
+
+    const wrapper = component();
+
+    updateOneModule('profileConfirmation', oneYearFromNow());
+    updateOneModule('publicationConfirmation', oneYearFromNow());
+
+    setBypassTimes(oneYearFromNow);
+
+    setCompletionTimes(oneYearFromNow);
+
+    await waitOneTickAndUpdate(wrapper);
+
+    // Training and DUCC are bypassed
+    expect(findNodesByExactText(wrapper, 'Bypassed').length).toBe(2);
+
+    // Publications and Profile are complete
+    expect(findNodesByExactText(wrapper, 'Confirmed').length).toBe(2);
+    expect(findNodesContainingText(wrapper, `${EXPIRY_DAYS - 1} days`).length).toBe(2);
+
+    expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(1);
+  });
+
   it('should show the correct state when items are bypassed', async () => {
     expireAllModules()
 

--- a/ui/src/app/pages/access/access-renewal-page.tsx
+++ b/ui/src/app/pages/access/access-renewal-page.tsx
@@ -180,7 +180,7 @@ interface ActionButtonInterface {
 }
 const ActionButton = (
   {isModuleExpiring, wasBypassed, actionButtonText, completedButtonText, onClick, disabled, style}: ActionButtonInterface) => {
-  return !isModuleExpiring || wasBypassed
+  return wasBypassed || !isModuleExpiring
     ? <CompletedButton buttonText={completedButtonText} wasBypassed={wasBypassed} style={style}/>
     : <Button
         onClick={onClick}
@@ -247,8 +247,8 @@ export const AccessRenewalPage = fp.flow(
   const getExpirationTimeFor = moduleName => fp.flow(fp.find({moduleName: moduleName}), fp.get('expirationEpochMillis'))(modules);
 
   const wasBypassed = moduleName => switchCase(moduleName,
-        [ModuleNameEnum.DataUseAgreement, () => !!dataUseAgreementBypassTime],
-        [ModuleNameEnum.ComplianceTraining, () => !!complianceTrainingBypassTime],
+      [ModuleNameEnum.DataUseAgreement, () => !!dataUseAgreementBypassTime],
+      [ModuleNameEnum.ComplianceTraining, () => !!complianceTrainingBypassTime],
       // these cannot be bypassed
       [ModuleNameEnum.ProfileConfirmation, () => false],
       [ModuleNameEnum.PublicationConfirmation, () => false]);


### PR DESCRIPTION
Description:

One of the "polish" steps in RW-6631: ` Completion banner not showing when user has a bypassed module`

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
