### PR TITLE
[no ticket][risk=no] Fix Puppeteer dataset-create test login issue

### DIFF
--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -13,14 +13,11 @@ import { makeWorkspaceName } from 'utils/str-utils';
 jest.setTimeout(10 * 60 * 1000);
 
 describe('Create Dataset', () => {
-  beforeEach(async () => {
-    await signInWithAccessToken(page);
-  });
-
   const workspace = makeWorkspaceName();
   let datasetName;
 
   test('Cannot create dataset when required inputs are blank', async () => {
+    await signInWithAccessToken(page);
     await findOrCreateWorkspace(page, { workspaceName: workspace });
 
     // Click Add Dataset button.
@@ -91,6 +88,7 @@ describe('Create Dataset', () => {
   });
 
   test('Create dataset with all available inputs', async () => {
+    await signInWithAccessToken(page);
     await findOrCreateWorkspace(page, { workspaceName: workspace });
 
     // Click Add Dataset button.


### PR DESCRIPTION
`beforeEach` block is wrong because last test log in by a different function, `signInAs`. 