### PR TITLE
[RW-6762][risk=no] Show only selected subtype in Measurements hierarchy in CB

### DIFF
--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -202,7 +202,7 @@ export class SearchBar extends React.Component<Props, State> {
   }
 
   handleInput() {
-    const {node: {domainId, isStandard, type}, searchTerms} = this.props;
+    const {node: {domainId, isStandard, subtype, type}, searchTerms} = this.props;
     triggerEvent(`Cohort Builder Search - ${domainToTitle(domainId)}`, 'Search', searchTerms);
     this.setState({inputErrors: [], loading: true});
     const {id, namespace} = currentWorkspaceStore.getValue();
@@ -212,7 +212,7 @@ export class SearchBar extends React.Component<Props, State> {
     apiCall.then(resp => {
       const optionNames: Array<string> = [];
       const options = resp.items.filter(option => {
-        if (!optionNames.includes(option.name)) {
+        if (!optionNames.includes(option.name) && (domainId !== Domain.MEASUREMENT.toString() || option.subtype === subtype)) {
           optionNames.push(option.name);
           return true;
         }

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -192,20 +192,19 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
 
   async loadRootNodes() {
     try {
-      const {node: {domainId, id, isStandard, subtype, type}, selectedSurvey} = this.props;
+      const {node: {domainId, id, isStandard, parentId, subtype, type}, selectedSurvey} = this.props;
       this.setState({loading: true});
-      const workspace = currentWorkspaceStore.getValue();
-      const cdrVersionId = workspace.cdrVersionId;
+      const {cdrVersionId, id: workspaceId, namespace} = currentWorkspaceStore.getValue();
       const criteriaType = domainId === Domain.DRUG.toString() ? CriteriaType.ATC.toString() : type;
       const promises = this.sendOnlyCriteriaType(domainId)
-          ? [cohortBuilderApi().findCriteriaBy(workspace.namespace, workspace.id, domainId, criteriaType)]
-          : [cohortBuilderApi().findCriteriaBy(workspace.namespace, workspace.id, domainId, criteriaType, isStandard, id)];
+          ? [cohortBuilderApi().findCriteriaBy(namespace, workspaceId, domainId, criteriaType)]
+          : [cohortBuilderApi().findCriteriaBy(namespace, workspaceId, domainId, criteriaType, isStandard, id)];
       if (this.criteriaLookupNeeded) {
         const criteriaRequest = {
           sourceConceptIds: currentCohortCriteriaStore.getValue().filter(s => !s.isStandard).map(s => s.conceptId),
           standardConceptIds: currentCohortCriteriaStore.getValue().filter(s => s.isStandard).map(s => s.conceptId),
         };
-        promises.push(cohortBuilderApi().findCriteriaForCohortEdit(workspace.namespace, workspace.id, domainId, criteriaRequest));
+        promises.push(cohortBuilderApi().findCriteriaForCohortEdit(namespace, workspaceId, domainId, criteriaRequest));
       }
       const [rootNodes, criteriaLookup] = await Promise.all(promises);
       if (criteriaLookup) {
@@ -227,8 +226,7 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
         // Temp: This should be handle in API
         this.updatePpiSurveys(rootNodes, rootNodes.items.filter(child => child.name === selectedSurvey));
       } else if (domainId === Domain.SURVEY.toString() && this.props.source === 'conceptSetDetails') {
-        const selectedSurveyChild = rootNodes.items.filter(child => child.id === this.props.node.parentId);
-        this.updatePpiSurveys(rootNodes, selectedSurveyChild);
+        this.updatePpiSurveys(rootNodes, rootNodes.items.filter(child => child.id === parentId));
       } else {
         this.setState({
           children: domainId === Domain.MEASUREMENT.toString() ?

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -192,7 +192,7 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
 
   async loadRootNodes() {
     try {
-      const {node: {domainId, id, isStandard, type}, selectedSurvey} = this.props;
+      const {node: {domainId, id, isStandard, subtype, type}, selectedSurvey} = this.props;
       this.setState({loading: true});
       const workspace = currentWorkspaceStore.getValue();
       const cdrVersionId = workspace.cdrVersionId;
@@ -230,7 +230,12 @@ export const CriteriaTree = fp.flow(withCurrentWorkspace(), withCurrentConcept()
         const selectedSurveyChild = rootNodes.items.filter(child => child.id === this.props.node.parentId);
         this.updatePpiSurveys(rootNodes, selectedSurveyChild);
       } else {
-        this.setState({children: rootNodes.items});
+        this.setState({
+          children: domainId === Domain.MEASUREMENT.toString() ?
+            // For Measurements, only show the subtype of the node selected in list search and don't display the code
+            rootNodes.items.filter(node => node.subtype === subtype).map(node => ({...node, code: null})) :
+            rootNodes.items
+        });
         if (domainId === Domain.SURVEY.toString()) {
           const rootSurveys = ppiSurveys.getValue();
           if (!rootSurveys[cdrVersionId]) {


### PR DESCRIPTION
- Only show 'Clinical' or 'Lab' node depending in which subtype was selected from the list search
- When searching in the hierarchy view, show results only from the selected subtype
- Hide the code for the top-level 'Clinical' and 'Lab' nodes

Show only top Clinical node when criteria of subtype CLIN are selected:

https://user-images.githubusercontent.com/40036095/121389653-43dbba80-c912-11eb-8a14-6533fca92b7f.mov

Show only top Lab node when criteria of subtype LAB are selected:

https://user-images.githubusercontent.com/40036095/121389764-58b84e00-c912-11eb-8ac4-855fb3319d43.mov

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
