### PR TITLE
[RW-4600][risk=no] UI: link each code from concept ID column

### DIFF
--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -449,9 +449,8 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
     }
 
     getConceptLink(conceptId) {
-      const link = environment.publicUiUrl + '/ehr/' +
+      return environment.publicUiUrl + '/ehr/' +
         domainToTitle(this.props.searchContext.domain).toLowerCase() + '?search=' + conceptId;
-      return link;
     }
 
     renderRow(row: any, child: boolean, elementId: string) {

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -495,7 +495,6 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
             {row.conceptId}
           </StyledAnchorTag>
         </td>
-        {/*<td style={{...columnBodyStyle, width: '10%', paddingRight: '0.5rem'}}>{row.conceptId}</td>*/}
         <td style={{...columnBodyStyle, width: '10%', paddingRight: '0.5rem'}}>{row.isStandard ? 'Standard' : 'Source'}</td>
         <td style={{...columnBodyStyle}}>{!brand && row.type}</td>
         <td style={{...columnBodyStyle, paddingLeft: '0.2rem', paddingRight: '0.5rem'}}>

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -5,7 +5,7 @@ import {Key} from 'ts-key-enum';
 
 import {domainToTitle} from 'app/cohort-search/utils';
 import {AlertDanger} from 'app/components/alert';
-import {Clickable} from 'app/components/buttons';
+import {Clickable, StyledAnchorTag} from 'app/components/buttons';
 import {FlexRow} from 'app/components/flex';
 import {ClrIcon} from 'app/components/icons';
 import {TextInput} from 'app/components/inputs';
@@ -22,6 +22,7 @@ import {
   setSidebarActiveIconStore
 } from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
+import {environment} from 'environments/environment';
 import {
   CdrVersion,
   CdrVersionTiersResponse,
@@ -447,6 +448,12 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
       return this.props.searchContext.domain === Domain.SURVEY;
     }
 
+    getConceptLink(conceptId) {
+      const link = environment.publicUiUrl + '/ehr/' +
+        domainToTitle(this.props.searchContext.domain).toLowerCase() + '?search=' + conceptId;
+      return link;
+    }
+
     renderRow(row: any, child: boolean, elementId: string) {
       const {hoverId, ingredients} = this.state;
       const attributes = this.props.searchContext.source === 'cohort' && row.hasAttributes;
@@ -484,7 +491,12 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
             </div>
           </TooltipTrigger>
         </td>
-        <td style={{...columnBodyStyle, width: '10%', paddingRight: '0.5rem'}}>{row.conceptId}</td>
+        <td style={{...columnBodyStyle, width: '10%', paddingRight: '0.5rem'}}>
+          <StyledAnchorTag href={this.getConceptLink(row.conceptId)} target='_blank'>
+            {row.conceptId}
+          </StyledAnchorTag>
+        </td>
+        {/*<td style={{...columnBodyStyle, width: '10%', paddingRight: '0.5rem'}}>{row.conceptId}</td>*/}
         <td style={{...columnBodyStyle, width: '10%', paddingRight: '0.5rem'}}>{row.isStandard ? 'Standard' : 'Source'}</td>
         <td style={{...columnBodyStyle}}>{!brand && row.type}</td>
         <td style={{...columnBodyStyle, paddingLeft: '0.2rem', paddingRight: '0.5rem'}}>


### PR DESCRIPTION
Concept Id in cohort/concept table is now a link pointing to databrowser. There is going to be a story in data browser to update the link workbench is using <databrowser>/ehr/{domain}?search={conceptId} to something that uses just the concept Id and not domain

<img width="1576" alt="Screen Shot 2021-06-09 at 2 33 56 PM" src="https://user-images.githubusercontent.com/34481816/121410478-9f1ca580-c930-11eb-8068-eea1e7bb2bd1.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
