### PR TITLE
[no ticket][risk=no] Puppeteer handling error: Execution context was destroyed

### DIFF
--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -157,7 +157,7 @@ const getPageTitle = async () => {
       return title.textContent;
     })
     .catch(() => {
-      return 'getPageTitle() func failed';
+      return '';
     });
 };
 

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -113,11 +113,16 @@ beforeEach(async () => {
       );
     } catch (ex) {
       // arg.jsonValue() sometimes throws exception. Try another way when encountering error.
-      logger.error(`Exception thrown when reading page console: ${ex}`);
-      const args = await Promise.all(message.args().map((jsHandle) => describeJsHandle(jsHandle)));
-      const concatenatedText = args.filter((arg) => !!arg).join('\n');
-      const msgType = message.type() === 'warning' ? 'warn' : message.type();
-      logger.info(`Page Console ${msgType.toUpperCase()}: "${title}"\n${concatenatedText}`);
+      logger.error(`Exception thrown when reading page console (approach 1): ${ex}`);
+      await Promise.all(message.args().map((jsHandle) => describeJsHandle(jsHandle)))
+        .then((args) => {
+          const concatenatedText = args.filter((arg) => !!arg).join('\n');
+          const msgType = message.type() === 'warning' ? 'warn' : message.type();
+          logger.info(`Page Console ${msgType.toUpperCase()}: "${title}"\n${concatenatedText}`);
+        })
+        .catch((ex1) => {
+          logger.error(`Exception thrown when reading page console (approach 2): ${ex1}`);
+        });
     }
   });
 


### PR DESCRIPTION
Handling error thrown on rare occasion during getting JS Console messages. Test fails without handing. [CircleCI job](https://app.circleci.com/pipelines/github/all-of-us/workbench/10872/workflows/e11f53ed-f504-451d-b0d7-52519f82326d/jobs/143776/parallel-runs/0?filterBy=FAILED).

```
'Error: Execution context was destroyed, most likely because of a navigation.\n' +
    '    at rewriteError (/home/circleci/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:261:23)\n' +
    '    at runMicrotasks (<anonymous>)\n' +
    '    at runNextTicks (internal/process/task_queues.js:62:5)\n' +
    '    at listOnTimeout (internal/timers.js:523:9)\n' +
    '    at processTimers (internal/timers.js:497:7)\n' +
    '    at ExecutionContext._evaluateInternal (/home/circleci/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:215:61)\n' +
    '    at ExecutionContext.evaluate (/home/circleci/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:106:16)\n' +
    '    at async Promise.all (index 0)\n' +
    '    at /home/circleci/workbench/e2e/jest.test-setup.ts:117:20'
```