### PR TITLE
[no ticket][risk=no] Improve e2e JS console

### DIFF
--- a/e2e/libs/logger.js
+++ b/e2e/libs/logger.js
@@ -16,7 +16,7 @@ const logger = createLogger({
     format.splat(),
     format.timestamp({ format: timeNow }),
     format.printf((info) => {
-      return `${info.level.toUpperCase()}: [${info.timestamp}] - ${info.message}`;
+      return `[${info.timestamp}] - ${info.message}`;
     })
   ),
   transports: [new winston.transports.Console({ handleExceptions: true })],


### PR DESCRIPTION
Better JS Console messsage grouping to make test log less cluttered and easier to read.

Before:

```
console.log
      INFO: [6/10/2021, 13:35:26] - Page Console: "[Local->Test] R-7556797943 | All of Us Researcher Workbench"
      actions

      at Console.log (node_modules/winston/lib/winston/transports/console.js:79:23)

    console.log
      INFO: [6/10/2021, 13:35:26] - Page Console: "[Local->Test] R-7556797943 | All of Us Researcher Workbench"
      jupyter-notebook:find-and-replace

      at Console.log (node_modules/winston/lib/winston/transports/console.js:79:23)

    console.log
      INFO: [6/10/2021, 13:35:26] - Page Console: "[Local->Test] R-7556797943 | All of Us Researcher Workbench"
      does not exist, still binding it in case it will be defined later...

      at Console.log (node_modules/winston/lib/winston/transports/console.js:79:23)

    console.log
      INFO: [6/10/2021, 13:35:26] - Page Console: "[Local->Test] R-7556797943 | All of Us Researcher Workbench"
      Loaded moment locale

      at Console.log (node_modules/winston/lib/winston/transports/console.js:79:23)

    console.log
      INFO: [6/10/2021, 13:35:26] - Page Console: "[Local->Test] R-7556797943 | All of Us Researcher Workbench"
      en

      at Console.log (node_modules/winston/lib/winston/transports/console.js:79:23)
```

After:

```
console.log
      INFO: [6/10/2021, 14:39:54] - Page Console: [Test] R-3517018 | All of Us Researcher Workbench
      actions
      jupyter-notebook:find-and-replace
      does not exist, still binding it in case it will be defined later...

      at Console.log (node_modules/winston/lib/winston/transports/console.js:79:23)

    console.log
      INFO: [6/10/2021, 14:39:54] - Page Console: [Test] R-3517018 | All of Us Researcher Workbench
      Loaded moment locale
      en

      at Console.log (node_modules/winston/lib/winston/transports/console.js:79:23)
 ```