### PR TITLE
[risk=low][RW-6689] Add an endpoint which returns a user expiration date report (as JSON)

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
@@ -70,4 +70,6 @@ public interface AccessTierService {
    * @return the list of tiers which Registered users have access to.
    */
   List<DbAccessTier> getTiersForRegisteredUsers();
+
+  List<DbUser> getAllRegisteredTierUsers();
 }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -5,12 +5,14 @@ import com.google.common.collect.ImmutableMap;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.inject.Provider;
 import javax.mail.MessagingException;
 import javax.mail.internet.AddressException;
@@ -58,6 +60,7 @@ import org.pmiops.workbench.model.Profile;
 import org.pmiops.workbench.model.RasLinkRequestBody;
 import org.pmiops.workbench.model.ResendWelcomeEmailRequest;
 import org.pmiops.workbench.model.UpdateContactEmailRequest;
+import org.pmiops.workbench.model.UserAccessExpirations;
 import org.pmiops.workbench.model.UserAuditLogQueryResponse;
 import org.pmiops.workbench.model.UsernameTakenResponse;
 import org.pmiops.workbench.model.VerifiedInstitutionalAffiliation;
@@ -633,5 +636,19 @@ public class ProfileController implements ProfileApiDelegate {
   public ResponseEntity<Void> confirmPublications() {
     userService.confirmPublications();
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  @Override
+  @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
+  public ResponseEntity<List<UserAccessExpirations>> getRegisteredTierExpirations() {
+    return ResponseEntity.ok(
+        userService.getRegisteredTierExpirations().entrySet().stream()
+            .map(
+                e ->
+                    new UserAccessExpirations()
+                        .userName(e.getKey().getUsername())
+                        .contactEmail(e.getKey().getContactEmail())
+                        .expirationDate(e.getValue().toInstant().toString()))
+            .collect(Collectors.toList()));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -638,7 +638,7 @@ public class ProfileController implements ProfileApiDelegate {
   }
 
   /**
-   * Get a JSON list of users and their registered tier access expiration dates.
+   * Gets a JSON list of users and their registered tier access expiration dates.
    *
    * <p>This endpoint is intended as a temporary manual measure to assist with user communication
    * during the rollout of Annual Access Renewal (AAR).

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import javax.inject.Provider;
 import javax.mail.MessagingException;
 import javax.mail.internet.AddressException;
@@ -638,17 +637,18 @@ public class ProfileController implements ProfileApiDelegate {
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
+  /**
+   * Get a JSON list of users and their registered tier access expiration dates.
+   *
+   * <p>This endpoint is intended as a temporary manual measure to assist with user communication
+   * during the rollout of Annual Access Renewal (AAR).
+   *
+   * <p>Once fully rolled out, we will have an automated expiration email process and this can
+   * likely be removed. See RW-6689 and RW-6703.
+   */
   @Override
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
   public ResponseEntity<List<UserAccessExpirations>> getRegisteredTierAccessExpirations() {
-    return ResponseEntity.ok(
-        userService.getRegisteredTierExpirations().entrySet().stream()
-            .map(
-                e ->
-                    new UserAccessExpirations()
-                        .userName(e.getKey().getUsername())
-                        .contactEmail(e.getKey().getContactEmail())
-                        .expirationDate(e.getValue().toInstant().toString()))
-            .collect(Collectors.toList()));
+    return ResponseEntity.ok(userService.getRegisteredTierExpirations());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -640,7 +640,7 @@ public class ProfileController implements ProfileApiDelegate {
 
   @Override
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
-  public ResponseEntity<List<UserAccessExpirations>> getRegisteredTierExpirations() {
+  public ResponseEntity<List<UserAccessExpirations>> getRegisteredTierAccessExpirations() {
     return ResponseEntity.ok(
         userService.getRegisteredTierExpirations().entrySet().stream()
             .map(

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserAccessTierDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserAccessTierDao.java
@@ -11,4 +11,6 @@ public interface UserAccessTierDao extends CrudRepository<DbUserAccessTier, Long
   Optional<DbUserAccessTier> getByUserAndAccessTier(DbUser user, DbAccessTier accessTier);
 
   List<DbUserAccessTier> getAllByUser(DbUser user);
+
+  List<DbUserAccessTier> getAllByAccessTier(DbAccessTier accessTier);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -171,8 +171,8 @@ public interface UserService {
   void maybeSendAccessExpirationEmail(DbUser user);
 
   /**
-   * Return a mapping of users to their Annual Access Renewal expiration date
-   * for Registered Tier, for users who have them
+   * Return a mapping of users to their Annual Access Renewal expiration date for Registered Tier,
+   * for users who have them
    */
   Map<DbUser, Timestamp> getRegisteredTierExpirations();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -4,7 +4,6 @@ import com.google.api.services.oauth2.model.Userinfoplus;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import org.pmiops.workbench.actionaudit.Agent;
@@ -17,6 +16,7 @@ import org.pmiops.workbench.model.AccessBypassRequest;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.RenewableAccessModuleStatus;
+import org.pmiops.workbench.model.UserAccessExpirations;
 import org.springframework.data.domain.Sort;
 
 public interface UserService {
@@ -174,5 +174,5 @@ public interface UserService {
    * Return a mapping of users to their Annual Access Renewal expiration date for Registered Tier,
    * for users who have them
    */
-  Map<DbUser, Timestamp> getRegisteredTierExpirations();
+  List<UserAccessExpirations> getRegisteredTierExpirations();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -4,6 +4,7 @@ import com.google.api.services.oauth2.model.Userinfoplus;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import org.pmiops.workbench.actionaudit.Agent;
@@ -168,4 +169,10 @@ public interface UserService {
 
   /** Send an Access Renewal Expiration or Warning email to the user, if appropriate */
   void maybeSendAccessExpirationEmail(DbUser user);
+
+  /**
+   * Return a mapping of users to their Annual Access Renewal expiration date
+   * for Registered Tier, for users who have them
+   */
+  Map<DbUser, Timestamp> getRegisteredTierExpirations();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -1143,6 +1143,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
                     .contactEmail(e.getKey().getContactEmail())
                     .givenName(e.getKey().getGivenName())
                     .familyName(e.getKey().getFamilyName())
+                    // converts to UTC
                     .expirationDate(e.getValue().get().toInstant().toString()))
         .collect(Collectors.toList());
   }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -1125,14 +1125,13 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   /**
-   * Return a mapping of users to their Annual Access Renewal expiration date
-   * for Registered Tier, for users who have them
+   * Return a mapping of users to their Annual Access Renewal expiration date for Registered Tier,
+   * for users who have them
    */
   @Override
   public Map<DbUser, Timestamp> getRegisteredTierExpirations() {
-    final List<DbUser> rtUsers = accessTierService.getAllRegisteredTierUsers();
-
-    return rtUsers.stream()
+    // restrict to current RT users
+    return accessTierService.getAllRegisteredTierUsers().stream()
         .map(u -> ImmutablePair.of(u, getRegisteredTierExpirationForEmails(u)))
         // don't return users who don't have expiration dates.
         // see getRegisteredTierExpirationForEmails() for details on how this might happen

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -1141,6 +1141,8 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
                 new UserAccessExpirations()
                     .userName(e.getKey().getUsername())
                     .contactEmail(e.getKey().getContactEmail())
+                    .givenName(e.getKey().getGivenName())
+                    .familyName(e.getKey().getFamilyName())
                     .expirationDate(e.getValue().get().toInstant().toString()))
         .collect(Collectors.toList());
   }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5711,6 +5711,12 @@ definitions:
       contactEmail:
         type: string
         description: the institutional contact email of the user
+      givenName:
+        type: string
+        description: the user's given name (first name)
+      familyName:
+        type: string
+        description: the user's family name (last name)
       expirationDate:
         type: string
         description: the time a user's access will expire, in ISO-8601 format

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1282,14 +1282,12 @@ paths:
           description: User associated with request could not be found
           schema:
             "$ref": "#/definitions/ErrorResponse"
-  "/v1/admin/users/expirations":
-    post:
+  "/v1/admin/accessExpirations":
+    get:
       tags:
         - profile
-      consumes:
-        - application/json
       description: 'Retrieves a mapping of users to access expiration times.  Requires ACCESS_CONTROL_ADMIN authority.'
-      operationId: getRegisteredTierExpirations
+      operationId: getRegisteredTierAccessExpirations
       responses:
         200:
           description: 'An array of users and their access expirations'

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1282,6 +1282,25 @@ paths:
           description: User associated with request could not be found
           schema:
             "$ref": "#/definitions/ErrorResponse"
+  "/v1/admin/users/expirations":
+    post:
+      tags:
+        - profile
+      consumes:
+        - application/json
+      description: 'Retrieves a mapping of users to access expiration times.  Requires ACCESS_CONTROL_ADMIN authority.'
+      operationId: getRegisteredTierExpirations
+      responses:
+        200:
+          description: 'An array of users and their access expirations'
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/UserAccessExpirations"
+        403:
+          description: User doesn't have the ACCESS_CONTROL_ADMIN authority
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
   "/v1/admin/users/{userId}":
     get:
       tags:
@@ -5684,6 +5703,19 @@ definitions:
       hasExpired:
         type: boolean
         description: Whether this module has expired according to the server's clock.
+
+  UserAccessExpirations:
+    type: object
+    properties:
+      userName:
+        type: string
+        description: a full All of Us email userName
+      contactEmail:
+        type: string
+        description: the institutional contact email of the user
+      expirationDate:
+        type: string
+        description: the time a user's access will expire, in ISO-8601 format
 
   DemographicSurvey:
     type: object

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -1019,7 +1019,7 @@ public class UserServiceAccessTest {
     // the 2 unbypassable modules would expire in a year (5/1/2021)
     // but this is before the initial enforcement date, so we use that value instead
     // (equal to UserServiceImpl.MIN_ACCESS_EXPIRATION_EPOCH_MS)
-    final String initialEnforcementDate = "2021-07-01T00:00:00.00Z";
+    final String initialEnforcementDate = "2021-07-01T00:00:00Z";
 
     final List<UserAccessExpirations> expirations = userService.getRegisteredTierExpirations();
     assertThat(expirations.size()).isEqualTo(1);

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -1001,6 +1001,7 @@ public class UserServiceAccessTest {
     assertThat(expirations.get(0).getContactEmail()).isEqualTo(dbUser.getContactEmail());
     assertThat(expirations.get(0).getGivenName()).isEqualTo(dbUser.getGivenName());
     assertThat(expirations.get(0).getFamilyName()).isEqualTo(dbUser.getFamilyName());
+
     assertThat(expirations.get(0).getExpirationDate()).isEqualTo(aYearFromNow);
   }
 
@@ -1028,7 +1029,6 @@ public class UserServiceAccessTest {
     assertThat(expirations.get(0).getGivenName()).isEqualTo(dbUser.getGivenName());
     assertThat(expirations.get(0).getFamilyName()).isEqualTo(dbUser.getFamilyName());
 
-    // ... but 5/1/2021 is before the initial enforcement date
     assertThat(expirations.get(0).getExpirationDate()).isEqualTo(initialEnforcementDate);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -999,6 +999,8 @@ public class UserServiceAccessTest {
     assertThat(expirations.size()).isEqualTo(1);
     assertThat(expirations.get(0).getUserName()).isEqualTo(dbUser.getUsername());
     assertThat(expirations.get(0).getContactEmail()).isEqualTo(dbUser.getContactEmail());
+    assertThat(expirations.get(0).getGivenName()).isEqualTo(dbUser.getGivenName());
+    assertThat(expirations.get(0).getFamilyName()).isEqualTo(dbUser.getFamilyName());
     assertThat(expirations.get(0).getExpirationDate()).isEqualTo(aYearFromNow);
   }
 
@@ -1023,6 +1025,8 @@ public class UserServiceAccessTest {
     assertThat(expirations.size()).isEqualTo(1);
     assertThat(expirations.get(0).getUserName()).isEqualTo(dbUser.getUsername());
     assertThat(expirations.get(0).getContactEmail()).isEqualTo(dbUser.getContactEmail());
+    assertThat(expirations.get(0).getGivenName()).isEqualTo(dbUser.getGivenName());
+    assertThat(expirations.get(0).getFamilyName()).isEqualTo(dbUser.getFamilyName());
 
     // ... but 5/1/2021 is before the initial enforcement date
     assertThat(expirations.get(0).getExpirationDate()).isEqualTo(initialEnforcementDate);


### PR DESCRIPTION
Description:

Users with ACCESS_CONTROL_ADMIN Authority can call a new endpoint `/v1/admin/accessExpirations` which produces a list of users and their AAR expiration times.  Output looks like (prettyprinted)
```
[
  {
    "userName": "joel-local@fake-research-aou.org",
    "contactEmail": "thibault@broadinstitute.org",
    "givenName": "Joel",
    "familyName": "Local",
    "expirationDate": "2021-07-01T00:00:00Z"
  },
  {
    "userName": "puppetjoel2@fake-research-aou.org",
    "contactEmail": "thibault@broadinstitute.org",
    "givenName": "Puppet Joel",
    "familyName": "2",
    "expirationDate": "2021-07-01T00:00:00Z"
  }
]
```

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
