### PR TITLE
[risk=low][RW-6689] improvements to getRegisteredTierAccessExpirations

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -59,7 +59,7 @@ import org.pmiops.workbench.model.Profile;
 import org.pmiops.workbench.model.RasLinkRequestBody;
 import org.pmiops.workbench.model.ResendWelcomeEmailRequest;
 import org.pmiops.workbench.model.UpdateContactEmailRequest;
-import org.pmiops.workbench.model.UserAccessExpirations;
+import org.pmiops.workbench.model.UserAccessExpiration;
 import org.pmiops.workbench.model.UserAuditLogQueryResponse;
 import org.pmiops.workbench.model.UsernameTakenResponse;
 import org.pmiops.workbench.model.VerifiedInstitutionalAffiliation;
@@ -648,7 +648,7 @@ public class ProfileController implements ProfileApiDelegate {
    */
   @Override
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
-  public ResponseEntity<List<UserAccessExpirations>> getRegisteredTierAccessExpirations() {
+  public ResponseEntity<List<UserAccessExpiration>> getRegisteredTierAccessExpirations() {
     return ResponseEntity.ok(userService.getRegisteredTierExpirations());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -16,7 +16,7 @@ import org.pmiops.workbench.model.AccessBypassRequest;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.RenewableAccessModuleStatus;
-import org.pmiops.workbench.model.UserAccessExpirations;
+import org.pmiops.workbench.model.UserAccessExpiration;
 import org.springframework.data.domain.Sort;
 
 public interface UserService {
@@ -174,5 +174,5 @@ public interface UserService {
    * Return a mapping of users to their Annual Access Renewal expiration date for Registered Tier,
    * for users who have them
    */
-  List<UserAccessExpirations> getRegisteredTierExpirations();
+  List<UserAccessExpiration> getRegisteredTierExpirations();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -57,7 +57,7 @@ import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.EmailVerificationStatus;
 import org.pmiops.workbench.model.RenewableAccessModuleStatus;
 import org.pmiops.workbench.model.RenewableAccessModuleStatus.ModuleNameEnum;
-import org.pmiops.workbench.model.UserAccessExpirations;
+import org.pmiops.workbench.model.UserAccessExpiration;
 import org.pmiops.workbench.monitoring.GaugeDataCollector;
 import org.pmiops.workbench.monitoring.MeasurementBundle;
 import org.pmiops.workbench.monitoring.labels.MetricLabel;
@@ -1129,20 +1129,20 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
    * for users who have them
    */
   @Override
-  public List<UserAccessExpirations> getRegisteredTierExpirations() {
+  public List<UserAccessExpiration> getRegisteredTierExpirations() {
     // restrict to current RT users
     return accessTierService.getAllRegisteredTierUsers().stream()
-        .flatMap(this::maybeAccessExpirations)
+        .flatMap(this::maybeAccessExpiration)
         .collect(Collectors.toList());
   }
 
-  // streams a UserAccessExpirations object, if the user has an expiration
-  private Stream<UserAccessExpirations> maybeAccessExpirations(DbUser user) {
+  // streams a UserAccessExpiration object, if the user has an expiration
+  private Stream<UserAccessExpiration> maybeAccessExpiration(DbUser user) {
     return getRegisteredTierExpirationForEmails(user)
         .map(
             exp ->
                 Stream.of(
-                    new UserAccessExpirations()
+                    new UserAccessExpiration()
                         .userName(user.getUsername())
                         .contactEmail(user.getContactEmail())
                         .givenName(user.getGivenName())

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1294,7 +1294,7 @@ paths:
           schema:
             type: array
             items:
-              "$ref": "#/definitions/UserAccessExpirations"
+              "$ref": "#/definitions/UserAccessExpiration"
         403:
           description: User doesn't have the ACCESS_CONTROL_ADMIN authority
           schema:
@@ -5702,7 +5702,7 @@ definitions:
         type: boolean
         description: Whether this module has expired according to the server's clock.
 
-  UserAccessExpirations:
+  UserAccessExpiration:
     type: object
     properties:
       userName:

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -35,7 +35,7 @@ import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.EmailVerificationStatus;
 import org.pmiops.workbench.model.TierAccessStatus;
-import org.pmiops.workbench.model.UserAccessExpirations;
+import org.pmiops.workbench.model.UserAccessExpiration;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
 import org.pmiops.workbench.utils.TestMockFactory;
@@ -995,7 +995,7 @@ public class UserServiceAccessTest {
     final String aYearFromNow =
         PROVIDED_CLOCK.instant().plus(EXPIRATION_DAYS, ChronoUnit.DAYS).toString();
 
-    final List<UserAccessExpirations> expirations = userService.getRegisteredTierExpirations();
+    final List<UserAccessExpiration> expirations = userService.getRegisteredTierExpirations();
     assertThat(expirations.size()).isEqualTo(1);
     assertThat(expirations.get(0).getUserName()).isEqualTo(dbUser.getUsername());
     assertThat(expirations.get(0).getContactEmail()).isEqualTo(dbUser.getContactEmail());
@@ -1022,7 +1022,7 @@ public class UserServiceAccessTest {
     // (equal to UserServiceImpl.MIN_ACCESS_EXPIRATION_EPOCH_MS)
     final String initialEnforcementDate = "2021-07-01T00:00:00Z";
 
-    final List<UserAccessExpirations> expirations = userService.getRegisteredTierExpirations();
+    final List<UserAccessExpiration> expirations = userService.getRegisteredTierExpirations();
     assertThat(expirations.size()).isEqualTo(1);
     assertThat(expirations.get(0).getUserName()).isEqualTo(dbUser.getUsername());
     assertThat(expirations.get(0).getContactEmail()).isEqualTo(dbUser.getContactEmail());


### PR DESCRIPTION
Description:

I thought of a few improvements right after merging #5102 
* rename UserAccessExpirations to singular
* better Optional streaming via flatMap

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
