### PR TITLE
[RW-6832][risk=no] updating criteria generation code

### DIFF
--- a/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
+++ b/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
@@ -16,19 +16,21 @@ DS_DATA_DICTIONARY="ds_data_dictionary.csv"
 CB_SURVEY_VERSION="cb_survey_version.csv"
 PREP_CDR_DATE="prep_cdr_date.csv"
 PREP_CRITERIA="prep_criteria.csv"
-PREP_CRITERIA_ANCESTOR="prep_criteria_ancestor.csv"
 PREP_CLINICAL_TERMS="prep_clinical_terms_nc.csv"
 PREP_CONCEPT="prep_concept.csv"
 PREP_CONCEPT_RELATIONSHIP="prep_concept_relationship.csv"
+PREP_SURVEY="prep_survey.csv"
+PREP_PHYSICAL_MEASUREMENT="prep_physical_measurement.csv"
 NON_PREP_FILES=($CRITERIA_MENU
            $DS_DATA_DICTIONARY
            $CB_SURVEY_VERSION)
 PREP_FILES=($PREP_CDR_DATE
            $PREP_CRITERIA
-           $PREP_CRITERIA_ANCESTOR
            $PREP_CLINICAL_TERMS
            $PREP_CONCEPT
-           $PREP_CONCEPT_RELATIONSHIP)
+           $PREP_CONCEPT_RELATIONSHIP
+           $PREP_SURVEY
+           $PREP_PHYSICAL_MEASUREMENT)
 ALL_FILES=("${NON_PREP_FILES[@]}" "${PREP_FILES[@]}")
 DEPENDENT_TABLES=("activity_summary"
             "concept"
@@ -174,10 +176,11 @@ else
       $CB_SURVEY_VERSION | \
       $PREP_CDR_DATE | \
       $PREP_CRITERIA | \
-      $PREP_CRITERIA_ANCESTOR | \
       $PREP_CLINICAL_TERMS | \
       $PREP_CONCEPT | \
-      $PREP_CONCEPT_RELATIONSHIP)
+      $PREP_CONCEPT_RELATIONSHIP | \
+      $PREP_SURVEY | \
+      $PREP_PHYSICAL_MEASUREMENT)
         removeHeaderIfExist file firstColumn
 
         # Check to see if table exists


### PR DESCRIPTION
updating criteria generation code to generate icd9/10 trees via OMOP instead of from prep_criteria. Leaving only CPT4 in prep_criteria and moving physical_measurement and survey criteria out to their own files/table. Creating prep_criteria_ancestor on the fly, not as a seed table. Updating validation script to accomodate new files