### PR TITLE
[risk=low][RW-6240] Add a tier label safety check to publish-cdr

### DIFF
--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -61,7 +61,7 @@ def bq_ingest(tier, tier_name, source_project, dataset_name, table_match_filter=
 
   # validate the CDR's tier label against the user-supplied tier, as a safety check
 
-  cdr_metadata = JSON.parse(`bq show --format=json "#{source_fq_dataset}"`)
+  cdr_metadata = JSON.parse(common.capture_stdout %{bq show --format=json #{source_fq_dataset}})
   dataset_tier = cdr_metadata.dig('labels', 'data_tier')
 
   if dataset_tier

--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -64,7 +64,7 @@ def bq_ingest(tier, tier_name, source_project, dataset_name, table_match_filter=
   cdr_metadata = JSON.parse(`bq show --format=json "#{source_fq_dataset}"`)
   dataset_tier = cdr_metadata['labels']['data_tier']
   unless dataset_tier == tier_name
-    raise ArgumentError.new("The source dataset's access tier #{dataset_tier} differs from #{tier_name}")
+    raise ArgumentError.new("The dataset's access tier '#{dataset_tier}' differs from the requested '#{tier_name}'. Aborting.")
   end
 
   # Copy through an intermediate project and delete after (include TTL in case later steps fail).

--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -62,9 +62,14 @@ def bq_ingest(tier, tier_name, source_project, dataset_name, table_match_filter=
   # validate the CDR's tier label against the user-supplied tier, as a safety check
 
   cdr_metadata = JSON.parse(`bq show --format=json "#{source_fq_dataset}"`)
-  dataset_tier = cdr_metadata['labels']['data_tier']
-  unless dataset_tier == tier_name
-    raise ArgumentError.new("The dataset's access tier '#{dataset_tier}' differs from the requested '#{tier_name}'. Aborting.")
+  dataset_tier = cdr_metadata.dig('labels', 'data_tier')
+
+  if dataset_tier
+    unless dataset_tier == tier_name
+      raise ArgumentError.new("The dataset's access tier '#{dataset_tier}' differs from the requested '#{tier_name}'. Aborting.")
+    end
+  else
+    puts "WARNING: no data_tier label found for #{source_fq_dataset}"
   end
 
   # Copy through an intermediate project and delete after (include TTL in case later steps fail).

--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -69,7 +69,7 @@ def bq_ingest(tier, tier_name, source_project, dataset_name, table_match_filter=
       raise ArgumentError.new("The dataset's access tier '#{dataset_tier}' differs from the requested '#{tier_name}'. Aborting.")
     end
   else
-    puts "WARNING: no data_tier label found for #{source_fq_dataset}"
+    common.warning "no data_tier label found for #{source_fq_dataset}"
   end
 
   # Copy through an intermediate project and delete after (include TTL in case later steps fail).


### PR DESCRIPTION
Description:

Published CDRs now have labels indicating which access tier they belong to.  If the publisher attempts to publish a dataset to the wrong tier, an exception is raised.

```
Traceback (most recent call last):
        9: from /w/api/db-cdr/generate-cdr/project.rb:6:in `<main>'
        8: from /w/aou-utils/workbench.rb:61:in `handle_argv_or_die'
        7: from /w/aou-utils/utils/common.rb:86:in `handle_or_die'
        6: from /w/api/db-cdr/generate-cdr/libproject/devstart.rb:200:in `block in <top (required)>'
        5: from /w/api/db-cdr/generate-cdr/libproject/devstart.rb:169:in `publish_cdr'
        4: from /w/api/db-cdr/generate-cdr/libproject/devstart.rb:40:in `service_account_context_for_bq'
        3: from /w/aou-utils/serviceaccounts.rb:60:in `run'
        2: from /w/api/db-cdr/generate-cdr/libproject/devstart.rb:45:in `block in service_account_context_for_bq'
        1: from /w/api/db-cdr/generate-cdr/libproject/devstart.rb:170:in `block in publish_cdr'
/w/api/db-cdr/generate-cdr/libproject/devstart.rb:67:in `bq_ingest': The dataset's access tier 'registered' differs from the requested 'controlled'. Aborting. (ArgumentError)
```

Tested by [commenting out the actual publishing step](https://github.com/all-of-us/workbench/commit/2538395aa7e6545084902f2c2856989baa804249), on all of the current Prod and Preprod CDRs.  Note that choosing `controlled` tier for Prod fails at an earlier step, since there is no Prod Controlled Tier in `environments` 

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
