### PR TITLE
[risk=no][RW-6889] Fix bug in test tools

### DIFF
--- a/ui/src/app/components/modals.spec.tsx
+++ b/ui/src/app/components/modals.spec.tsx
@@ -37,10 +37,6 @@ describe('NotificationModal', () => {
     // Click button to dismiss - modal should not render
     wrapper.find('[role="button"]').first().simulate('click');
 
-    // enzyme needs some encouragement
-    await waitOneTickAndUpdate(wrapper);
-    expect(notificationStore.get()).toEqual(null);
-
     // Modal should be gone
     await waitOneTickAndUpdate(wrapper);
     expect(findNodesByExactText(wrapper, meta.title).length).toBe(0);

--- a/ui/src/app/components/modals.spec.tsx
+++ b/ui/src/app/components/modals.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import {NotificationModal} from 'app/components/modals';
 import {notificationStore} from 'app/utils/stores';
-import {findNodesByExactText, waitOneTickAndUpdate} from 'testing/react-test-helpers';
+import {findNodesByExactText, waitOnTimersAndUpdate} from 'testing/react-test-helpers';
 
 
 describe('NotificationModal', () => {
@@ -26,11 +26,11 @@ describe('NotificationModal', () => {
     notificationStore.set(meta);
 
     // enzyme needs some encouragement
-    await waitOneTickAndUpdate(wrapper);
+    await waitOnTimersAndUpdate(wrapper);
     expect(notificationStore.get()).toEqual(meta);
 
     // When the store has data it should render
-    await waitOneTickAndUpdate(wrapper);
+    await waitOnTimersAndUpdate(wrapper);
     expect(findNodesByExactText(wrapper, meta.title).length).toBe(1);
     expect(findNodesByExactText(wrapper, meta.message).length).toBe(1);
 
@@ -38,7 +38,7 @@ describe('NotificationModal', () => {
     wrapper.find('[role="button"]').first().simulate('click');
 
     // Modal should be gone
-    await waitOneTickAndUpdate(wrapper);
+    await waitOnTimersAndUpdate(wrapper);
     expect(findNodesByExactText(wrapper, meta.title).length).toBe(0);
   });
 });

--- a/ui/src/testing/react-test-helpers.ts
+++ b/ui/src/testing/react-test-helpers.ts
@@ -9,12 +9,14 @@ import * as fp from 'lodash/fp';
 // And fails with:
 //   ReferenceError: Zone is not defined
 export async function waitOneTickAndUpdate(wrapper: ReactWrapper) {
-  // Make sure to use setTimeout. Combining setTimeout (used in UI) and setImmediate can result in a non-deterministic order of events
   const waitImmediate = () => new Promise<void>(resolve => setImmediate(resolve))
   await act(waitImmediate);
   wrapper.update();
 }
 
+// Combining a setTimeout with a delay of 0 (used in UI) and setImmediate can result in a non-deterministic order of events
+// If you are testing code that uses setTimeout this may be a safer choice.
+// If you are using fakeAsync waitOneTickAndUpdate is preferred
 export async function waitOnTimersAndUpdate(wrapper: ReactWrapper){
   const waitForTimeout = () => new Promise<void>(resolve => setTimeout(resolve, 0));
   await act(waitForTimeout);

--- a/ui/src/testing/react-test-helpers.ts
+++ b/ui/src/testing/react-test-helpers.ts
@@ -10,8 +10,14 @@ import * as fp from 'lodash/fp';
 //   ReferenceError: Zone is not defined
 export async function waitOneTickAndUpdate(wrapper: ReactWrapper) {
   // Make sure to use setTimeout. Combining setTimeout (used in UI) and setImmediate can result in a non-deterministic order of events
-  const waitImmediate = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+  const waitImmediate = () => new Promise<void>(resolve => setImmediate(resolve))
   await act(waitImmediate);
+  wrapper.update();
+}
+
+export async function waitOnTimersAndUpdate(wrapper: ReactWrapper){
+  const waitForTimeout = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+  await act(waitForTimeout);
   wrapper.update();
 }
 

--- a/ui/src/testing/react-test-helpers.ts
+++ b/ui/src/testing/react-test-helpers.ts
@@ -9,7 +9,8 @@ import * as fp from 'lodash/fp';
 // And fails with:
 //   ReferenceError: Zone is not defined
 export async function waitOneTickAndUpdate(wrapper: ReactWrapper) {
-  const waitImmediate = () => new Promise<void>(resolve => setImmediate(resolve));
+  // Make sure to use setTimeout. Combining setTimeout (used in UI) and setImmediate can result in a non-deterministic order of events
+  const waitImmediate = () => new Promise<void>(resolve => setTimeout(resolve, 0));
   await act(waitImmediate);
   wrapper.update();
 }


### PR DESCRIPTION
Description:
https://precisionmedicineinitiative.atlassian.net/browse/RW-6889
Fixes an issue in the test tools where using a `setImmediate` call can cause test flakiness when testing UI code that uses a
`setTimeout(fn, 0)`.

According to the[ node documentation](https://nodejs.dev/learn/understanding-setimmediate), it is not clear whether a `setTimeout` of 0 or `setImmediate` will execute first in the next iteration of the event loop.

Running the test in succession demonstrated non-deterministic behavior. After switching to `setTimeout` I no longer saw the issue.


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
