### PR TITLE
[risk=low][no ticket] AAR: init profile and publications confirmation times for new users

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -489,6 +489,12 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       dbDemographicSurvey.setUser(dbUser);
     }
 
+    // we require users to re-confirm their profile and publications as part of the
+    // Annual Access Renewal process.  Here we start the clock for new users.
+
+    dbUser.setProfileLastConfirmedTime(new Timestamp(clock.millis()));
+    dbUser.setPublicationsLastConfirmedTime(new Timestamp(clock.millis()));
+
     try {
       dbUser = userDao.save(dbUser);
       dbVerifiedAffiliation.setUser(dbUser);


### PR DESCRIPTION
Description:

New users currently begin their lives in a state where the last profile and publications confirmation times are NULL.  When we switch on AAR, they would be non-compliant because of this.  Instead, initialize these values to now, so they will expire in 1 year.

Some existing users are OK - those per environment who had RT membership at the time of merging of Liquibase changeset 162.

TODO: this does not address the following cases:
* existing users who did not have RT at Liquibase 162
* new users created between Liquibase 162 and the merging of this change

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
