### PR TITLE
[risk=no][RW-6904] Publication and profile confirmed times cannot be null

### DIFF
--- a/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
+++ b/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
@@ -8,26 +8,36 @@
 
     <!-- Update and backfill profile confirmation time -->
 
-    <addDefaultValue tableName="user" columnName="profile_last_confirmed_time" defaultValueDate="current_timestamp"/>
-
+    <sql>
+      alter table user modify profile_last_confirmed_time datetime default current_timestamp
+    </sql>
     <sql>
       update user
       set profile_last_confirmed_time = coalesce(first_sign_in_time, current_timestamp)
       where profile_last_confirmed_time is null
     </sql>
-
-    <addNotNullConstraint columnName="profile_last_confirmed_time" columnDataType="datetime" tableName="user"/>
+    <sql>
+      alter table user modify profile_last_confirmed_time datetime default current_timestamp not null
+    </sql>
 
     <!-- Update and backfill publication confirmation time -->
 
-    <addDefaultValue tableName="user" columnName="publications_last_confirmed_time" defaultValueDate="current_timestamp"/>
-
+    <sql>
+      alter table user modify publications_last_confirmed_time datetime default current_timestamp
+    </sql>
     <sql>
       update user
       set publications_last_confirmed_time = coalesce(first_sign_in_time, current_timestamp)
       where publications_last_confirmed_time is null
     </sql>
+    <sql>
+      alter table user modify publications_last_confirmed_time datetime default current_timestamp not null
+    </sql>
 
-    <addNotNullConstraint columnName="publications_last_confirmed_time" columnDataType="datetime" tableName="user"/>
+    <rollback>
+      alter table user modify publications_last_confirmed_time datetime;
+      alter table user modify profile_last_confirmed_time datetime;
+    </rollback>
+
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
+++ b/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
@@ -8,14 +8,14 @@
     <addDefaultValue tableName="user" columnName="publications_last_confirmed_time" defaultValue="CURRENT_TIMESTAMP"/>
 
     <sql>
-      -- migration copied from 162
+      -- migration copied and modified from 162
       UPDATE user u
       INNER JOIN user_access_tier uat ON u.user_id = uat.user_id
       INNER JOIN access_tier a ON uat.access_tier_id = a.access_tier_id
 
       SET
       u.publications_last_confirmed_time = uat.first_enabled
-      WHERE u.publications_last_confirmed_time is null
+      WHERE a.short_name = 'registered' and u.publications_last_confirmed_time is null
     </sql>
 
     <addNotNullConstraint

--- a/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
+++ b/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
@@ -6,32 +6,26 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
   <changeSet author="psantos-dmohs-jmthibault" id="changelog-165-set-default-publications-confirmed-time">
 
-    <!-- Update and backfill profile confirmation time -->
+    <sql>
+      -- Update and backfill profile confirmation time
 
-    <sql>
-      alter table user modify profile_last_confirmed_time datetime default current_timestamp
-    </sql>
-    <sql>
+      alter table user modify profile_last_confirmed_time datetime default current_timestamp;
+
       update user
       set profile_last_confirmed_time = coalesce(first_sign_in_time, current_timestamp)
-      where profile_last_confirmed_time is null
-    </sql>
-    <sql>
-      alter table user modify profile_last_confirmed_time datetime default current_timestamp not null
-    </sql>
+      where profile_last_confirmed_time is null;
 
-    <!-- Update and backfill publication confirmation time -->
+      alter table user modify profile_last_confirmed_time datetime default current_timestamp not null;
 
-    <sql>
-      alter table user modify publications_last_confirmed_time datetime default current_timestamp
-    </sql>
-    <sql>
+      -- Update and backfill publication confirmation time
+
+      alter table user modify publications_last_confirmed_time datetime default current_timestamp;
+
       update user
       set publications_last_confirmed_time = coalesce(first_sign_in_time, current_timestamp)
-      where publications_last_confirmed_time is null
-    </sql>
-    <sql>
-      alter table user modify publications_last_confirmed_time datetime default current_timestamp not null
+      where publications_last_confirmed_time is null;
+
+      alter table user modify publications_last_confirmed_time datetime default current_timestamp not null;
     </sql>
 
     <rollback>

--- a/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
+++ b/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="psantos-dmohs" id="changelog-165-set-default-publications-confirmed-time">
+    <addDefaultValue tableName="user" columnName="profile_last_confirmed_time" defaultValue="CURRENT_TIMESTAMP"/>
+
+    <!--
+
+    On the initial launch of the access renewal compliance feature, we don't have a record of the
+    most recent time a user confirmed their profile was correct or they confirmed to us the
+    presence or lack of any publications relating to All of Us, because we have never asked for
+    this information before.
+
+    To approximate these confirmation times for existing users, we have chosen to pre-populate
+    these fields with the user's first registration time.  For new users, we will assume the
+    profile to be confirmed on registration and new users to not have any publications, so these
+    values will also be set when new users register for the first time.
+
+    If a user has ever had registered status (membership in the registered tier) then they
+    will have a first_enabled date in the user_access_tier table.  Copy this value (if it exists)
+    to the new fields created here: profile_last_confirmed_time and
+    publications_last_confirmed_time.
+
+    -->
+
+    <sql>
+      -- not all users have access tier memberships.
+      -- update only those who do.
+      UPDATE user u
+      INNER JOIN user_access_tier uat ON u.user_id = uat.user_id
+      INNER JOIN access_tier a ON uat.access_tier_id = a.access_tier_id
+
+      SET
+      u.profile_last_confirmed_time = uat.first_enabled,
+      u.publications_last_confirmed_time = uat.first_enabled
+
+      -- at initial launch, registered tier membership is not distinct from controlled tier
+      -- membership.  So there is no need to check controlled tier.
+      WHERE a.short_name = 'registered' and 
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
+++ b/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
@@ -4,22 +4,15 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-  <changeSet author="psantos-dmohs" id="changelog-165-set-default-publications-confirmed-time">
-    <addDefaultValue tableName="user" columnName="publications_last_confirmed_time" defaultValue="CURRENT_TIMESTAMP"/>
+  <changeSet author="psantos-dmohs-jmthibault" id="changelog-165-set-default-publications-confirmed-time">
+    <addDefaultValue tableName="user" columnName="publications_last_confirmed_time" defaultValue="current_timestamp"/>
 
     <sql>
-      -- migration copied and modified from 162
-      UPDATE user u
-      INNER JOIN user_access_tier uat ON u.user_id = uat.user_id
-      INNER JOIN access_tier a ON uat.access_tier_id = a.access_tier_id
-
-      SET
-      u.publications_last_confirmed_time = uat.first_enabled
-      WHERE a.short_name = 'registered' and u.publications_last_confirmed_time is null
+      update user
+      set publications_last_confirmed_time = coalesce(first_sign_in_time, current_timestamp)
+      where publications_last_confirmed_time is null
     </sql>
 
-    <addNotNullConstraint
-            columnName="publications_last_confirmed_time"
-            tableName="user"/>
+    <addNotNullConstraint columnName="publications_last_confirmed_time" columnDataType="datetime" tableName="user"/>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
+++ b/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
@@ -5,7 +5,22 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
   <changeSet author="psantos-dmohs-jmthibault" id="changelog-165-set-default-publications-confirmed-time">
-    <addDefaultValue tableName="user" columnName="publications_last_confirmed_time" defaultValue="current_timestamp"/>
+
+    <!-- Update and backfill profile confirmation time -->
+
+    <addDefaultValue tableName="user" columnName="profile_last_confirmed_time" defaultValueDate="current_timestamp"/>
+
+    <sql>
+      update user
+      set profile_last_confirmed_time = coalesce(first_sign_in_time, current_timestamp)
+      where profile_last_confirmed_time is null
+    </sql>
+
+    <addNotNullConstraint columnName="profile_last_confirmed_time" columnDataType="datetime" tableName="user"/>
+
+    <!-- Update and backfill publication confirmation time -->
+
+    <addDefaultValue tableName="user" columnName="publications_last_confirmed_time" defaultValueDate="current_timestamp"/>
 
     <sql>
       update user

--- a/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
+++ b/api/db/changelog/db.changelog-165-set-default-publications-confirmed-time.xml
@@ -5,41 +5,21 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
   <changeSet author="psantos-dmohs" id="changelog-165-set-default-publications-confirmed-time">
-    <addDefaultValue tableName="user" columnName="profile_last_confirmed_time" defaultValue="CURRENT_TIMESTAMP"/>
-
-    <!--
-
-    On the initial launch of the access renewal compliance feature, we don't have a record of the
-    most recent time a user confirmed their profile was correct or they confirmed to us the
-    presence or lack of any publications relating to All of Us, because we have never asked for
-    this information before.
-
-    To approximate these confirmation times for existing users, we have chosen to pre-populate
-    these fields with the user's first registration time.  For new users, we will assume the
-    profile to be confirmed on registration and new users to not have any publications, so these
-    values will also be set when new users register for the first time.
-
-    If a user has ever had registered status (membership in the registered tier) then they
-    will have a first_enabled date in the user_access_tier table.  Copy this value (if it exists)
-    to the new fields created here: profile_last_confirmed_time and
-    publications_last_confirmed_time.
-
-    -->
+    <addDefaultValue tableName="user" columnName="publications_last_confirmed_time" defaultValue="CURRENT_TIMESTAMP"/>
 
     <sql>
-      -- not all users have access tier memberships.
-      -- update only those who do.
+      -- migration copied from 162
       UPDATE user u
       INNER JOIN user_access_tier uat ON u.user_id = uat.user_id
       INNER JOIN access_tier a ON uat.access_tier_id = a.access_tier_id
 
       SET
-      u.profile_last_confirmed_time = uat.first_enabled,
       u.publications_last_confirmed_time = uat.first_enabled
-
-      -- at initial launch, registered tier membership is not distinct from controlled tier
-      -- membership.  So there is no need to check controlled tier.
-      WHERE a.short_name = 'registered' and 
+      WHERE u.publications_last_confirmed_time is null
     </sql>
+
+    <addNotNullConstraint
+            columnName="publications_last_confirmed_time"
+            tableName="user"/>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -174,6 +174,7 @@
   <include file="changelog/db.changelog-162-add-user-profile-publications-confirmed-times.xml"/>
   <include file="changelog/db.changelog-163-delete-institutional-affiliation.xml"/>
   <include file="changelog/db.changelog-164-genomic-extraction-store-output-dir.xml"/>
+  <include file="changelog/db.changelog-165-set-default-publications-confirmed-time.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -463,6 +463,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       DbDemographicSurvey dbDemographicSurvey,
       DbVerifiedInstitutionalAffiliation dbVerifiedAffiliation) {
     DbUser dbUser = new DbUser();
+    Timestamp now = new Timestamp(clock.instant().toEpochMilli());
     dbUser.setCreationNonce(Math.abs(random.nextLong()));
     dbUser.setUsername(username);
     dbUser.setContactEmail(contactEmail);
@@ -476,6 +477,8 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     dbUser.setAboutYou(null);
     dbUser.setEmailVerificationStatusEnum(EmailVerificationStatus.UNVERIFIED);
     dbUser.setAddress(dbAddress);
+    dbUser.setProfileLastConfirmedTime(now);
+    dbUser.setPublicationsLastConfirmedTime(now);
     if (degrees != null) {
       dbUser.setDegreesEnum(degrees);
     }


### PR DESCRIPTION
This will set a default value on the `publications_last_confirmed_time` column and the `profile_last_confirmed_time` column. It backfills making a best effort, then enforces a not null constraint.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
