### PR TITLE
[draft] Attempt at converting main CB route with navigation blocking

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -6,7 +6,6 @@ import {CanDeactivateGuard} from './guards/can-deactivate-guard.service';
 import {RegistrationGuard} from './guards/registration-guard.service';
 import {SignInGuard} from './guards/sign-in-guard.service';
 
-import {CohortPageComponent} from './cohort-search/cohort-page/cohort-page.component';
 import {ConceptSearchComponent} from './pages/data/concept/concept-search';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceWrapperComponent} from './pages/workspace/workspace-wrapper/component';

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -187,13 +187,8 @@ const routes: Routes = [
                             children: [
                               {
                                 path: '',
-                                component: CohortPageComponent,
-                                canDeactivate: [CanDeactivateGuard],
-                                data: {
-                                  title: 'Build Cohort Criteria',
-                                  breadcrumb: BreadcrumbType.CohortAdd,
-                                  pageKey: 'cohortBuilder'
-                                }
+                                component: AppRouting,
+                                data: {}
                               },
                             ]
                           },

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -1,6 +1,5 @@
 import {Component as AComponent} from '@angular/core';
 import {CohortPage} from 'app/cohort-search/cohort-page/cohort-page.component';
-import {AppRoute, AppRouter, Guard, ProtectedRoutes, withFullHeight, withRouteData, withRouterPrompt} from 'app/components/app-router';
 import {AppRoute, AppRouter, Guard, Navigate, ProtectedRoutes, withFullHeight, withRouteData} from 'app/components/app-router';
 import {AccessRenewalPage} from 'app/pages/access/access-renewal-page';
 import {WorkspaceAudit} from 'app/pages/admin/admin-workspace-audit';
@@ -385,7 +384,7 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
           />
           <AppRoute
               path='/workspaces/:ns/:wsid/data/cohorts/build'
-              component={({routeHistory}) => <CohortPagePage routeData={{
+              component={() => <CohortPagePage routeData={{
                 title: 'Build Cohort Criteria',
                 breadcrumb: BreadcrumbType.CohortAdd,
                 pageKey: 'cohortBuilder'

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -1,4 +1,6 @@
 import {Component as AComponent} from '@angular/core';
+import {CohortPage} from 'app/cohort-search/cohort-page/cohort-page.component';
+import {AppRoute, AppRouter, Guard, ProtectedRoutes, withFullHeight, withRouteData, withRouterPrompt} from 'app/components/app-router';
 import {AppRoute, AppRouter, Guard, Navigate, ProtectedRoutes, withFullHeight, withRouteData} from 'app/components/app-router';
 import {AccessRenewalPage} from 'app/pages/access/access-renewal-page';
 import {WorkspaceAudit} from 'app/pages/admin/admin-workspace-audit';
@@ -69,6 +71,7 @@ const AdminBannerPage = withRouteData(AdminBanner);
 const AdminNotebookViewPage = withRouteData(AdminNotebookView);
 const AdminReviewWorkspacePage = withRouteData(AdminReviewWorkspace);
 const CohortActionsPage = withRouteData(CohortActions);
+const CohortPagePage = fp.flow(withRouteData, withRouterPrompt)(CohortPage);
 const CohortReviewPage = withRouteData(CohortReview);
 const ConceptHomepagePage = withRouteData(ConceptHomepage);
 const ConceptSetActionsPage = withRouteData(ConceptSetActions);
@@ -379,6 +382,15 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
               breadcrumb: BreadcrumbType.ConceptSet,
               pageKey: 'conceptSetActions'
             }}/>}
+          />
+          <AppRoute
+              path='/workspaces/:ns/:wsid/data/cohorts/build'
+              component={({routeHistory}) => <CohortPagePage routeData={{
+                title: 'Build Cohort Criteria',
+                breadcrumb: BreadcrumbType.CohortAdd,
+                pageKey: 'cohortBuilder'
+              }}
+              routeHistory={routeHistory}/>}
           />
         </ProtectedRoutes>
       </ProtectedRoutes>

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -71,7 +71,7 @@ const AdminBannerPage = withRouteData(AdminBanner);
 const AdminNotebookViewPage = withRouteData(AdminNotebookView);
 const AdminReviewWorkspacePage = withRouteData(AdminReviewWorkspace);
 const CohortActionsPage = withRouteData(CohortActions);
-const CohortPagePage = fp.flow(withRouteData, withRouterPrompt)(CohortPage);
+const CohortPagePage = withRouteData(CohortPage);
 const CohortReviewPage = withRouteData(CohortReview);
 const ConceptHomepagePage = withRouteData(ConceptHomepage);
 const ConceptSetActionsPage = withRouteData(ConceptSetActions);
@@ -389,8 +389,7 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
                 title: 'Build Cohort Criteria',
                 breadcrumb: BreadcrumbType.CohortAdd,
                 pageKey: 'cohortBuilder'
-              }}
-              routeHistory={routeHistory}/>}
+              }}/>}
           />
         </ProtectedRoutes>
       </ProtectedRoutes>

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -14,7 +14,6 @@ import {WINDOW_REF} from './utils';
 import {WorkbenchRouteReuseStrategy} from './utils/navigation';
 
 import {AppRouting} from './app-routing';
-import {CohortPageComponent} from './cohort-search/cohort-page/cohort-page.component';
 import {BugReportComponent} from './components/bug-report';
 import {ConfirmDeleteModalComponent} from './components/confirm-delete-modal';
 import {HelpSidebarComponent} from './components/help-sidebar';
@@ -56,7 +55,6 @@ import {FooterComponent} from './components/footer';
     AppComponent,
     AppRouting,
     BugReportComponent,
-    CohortPageComponent,
     ConceptSearchComponent,
     ConfirmDeleteModalComponent,
     FooterComponent,

--- a/ui/src/app/components/app-router.tsx
+++ b/ui/src/app/components/app-router.tsx
@@ -2,7 +2,7 @@ import {navigate} from 'app/utils/navigation';
 import {routeDataStore} from 'app/utils/stores';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-import { BrowserRouter, Link, Redirect, Route, Switch, useHistory, useLocation, useParams, useRouteMatch} from 'react-router-dom';
+import { BrowserRouter, Link, Prompt, Redirect, Route, Switch, useHistory, useLocation, useParams, useRouteMatch} from 'react-router-dom';
 
 const {Fragment} = React;
 
@@ -23,6 +23,14 @@ export const withRouteData = WrappedComponent => ({routeData, ...props}) => {
 
 export const withFullHeight = WrappedComponent => ({...props}) => {
   return <div style={{height: '100%'}}><WrappedComponent {...props} /></div>;
+};
+
+export const withRouterPrompt = WrappedComponent => ({...props}) => {
+  let showPrompt = false;
+  return <Fragment>
+    <WrappedComponent setPrompt={(s) => showPrompt = s} {...props} />
+    <Prompt message={'You have unsaved changes'} when={showPrompt}/>
+  </Fragment>;
 };
 
 export const SubRoute = ({children}): React.ReactElement => <Switch>{children}</Switch>;
@@ -46,6 +54,7 @@ export const AppRoute = ({path, data = {}, guards = [], component: Component}): 
   return <Route exact={true} path={path} render={
     () => {
       const { redirectPath = null } = fp.find(({allowed}) => !allowed(), guards) || {};
+      console.log(routeHistory);
       return redirectPath
         ? <NavRedirect path={redirectPath}/>
         : <Component urlParams={routeParams} routeHistory={routeHistory} routeConfig={data}/>;

--- a/ui/src/app/components/app-router.tsx
+++ b/ui/src/app/components/app-router.tsx
@@ -2,7 +2,7 @@ import {navigate} from 'app/utils/navigation';
 import {routeDataStore} from 'app/utils/stores';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-import { BrowserRouter, Link, Prompt, Redirect, Route, Switch, useHistory, useLocation, useParams, useRouteMatch} from 'react-router-dom';
+import { BrowserRouter, Link, Redirect, Route, Switch, useHistory, useLocation, useParams, useRouteMatch} from 'react-router-dom';
 
 const {Fragment} = React;
 
@@ -23,14 +23,6 @@ export const withRouteData = WrappedComponent => ({routeData, ...props}) => {
 
 export const withFullHeight = WrappedComponent => ({...props}) => {
   return <div style={{height: '100%'}}><WrappedComponent {...props} /></div>;
-};
-
-export const withRouterPrompt = WrappedComponent => ({...props}) => {
-  let showPrompt = false;
-  return <Fragment>
-    <WrappedComponent setPrompt={(s) => showPrompt = s} {...props} />
-    <Prompt message={'You have unsaved changes'} when={showPrompt}/>
-  </Fragment>;
 };
 
 export const SubRoute = ({children}): React.ReactElement => <Switch>{children}</Switch>;
@@ -54,7 +46,6 @@ export const AppRoute = ({path, data = {}, guards = [], component: Component}): 
   return <Route exact={true} path={path} render={
     () => {
       const { redirectPath = null } = fp.find(({allowed}) => !allowed(), guards) || {};
-      console.log(routeHistory);
       return redirectPath
         ? <NavRedirect path={redirectPath}/>
         : <Component urlParams={routeParams} routeHistory={routeHistory} routeConfig={data}/>;


### PR DESCRIPTION
Trying to block navigation away from cohort builder if there are unsaved changes using React Router's `history.block()`.
We were achieving this using the `canDeactivate` guard in the Angular wrapper.

Sorry for the delay, please take a look and let me know if you have any questions. Thanks!
@als364 @petesantos 