### PR TITLE
[RW-6840][risk=no]: Move enableRasLoginGovLinking to access

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -102,7 +102,8 @@
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": true,
     "unsafeAllowUserCreationFromGSuiteData": true,
-    "enableAccessRenewal": true
+    "enableAccessRenewal": true,
+    "enableRasLoginGovLinking": false
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,
@@ -111,7 +112,6 @@
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": true,
-    "enableRasLoginGovLinking": false,
     "enableGenomicExtraction": true,
     "enableFireCloudV2Billing" : false
   },

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -102,7 +102,8 @@
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": true,
     "unsafeAllowUserCreationFromGSuiteData": false,
-    "enableAccessRenewal": false
+    "enableAccessRenewal": false,
+    "enableRasLoginGovLinking": false
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,
@@ -111,7 +112,6 @@
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
-    "enableRasLoginGovLinking": false,
     "enableGenomicExtraction": false,
     "enableFireCloudV2Billing" : false
   },

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -102,7 +102,8 @@
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
-    "enableAccessRenewal": false
+    "enableAccessRenewal": false,
+    "enableRasLoginGovLinking": false
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,
@@ -111,7 +112,6 @@
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
-    "enableRasLoginGovLinking": false,
     "enableGenomicExtraction": true,
     "enableFireCloudV2Billing" : false
   },

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -101,7 +101,8 @@
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
-    "enableAccessRenewal": false
+    "enableAccessRenewal": false,
+    "enableRasLoginGovLinking": false
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,
@@ -110,7 +111,6 @@
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
-    "enableRasLoginGovLinking": false,
     "enableGenomicExtraction": false,
     "enableFireCloudV2Billing" : false
   },

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -101,7 +101,8 @@
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
-    "enableAccessRenewal": true
+    "enableAccessRenewal": true,
+    "enableRasLoginGovLinking": false
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,
@@ -110,7 +111,6 @@
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
-    "enableRasLoginGovLinking": false,
     "enableGenomicExtraction": false,
     "enableFireCloudV2Billing" : false
   },

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -102,7 +102,8 @@
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
-    "enableAccessRenewal": true
+    "enableAccessRenewal": true,
+    "enableRasLoginGovLinking": false
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,
@@ -111,7 +112,6 @@
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
-    "enableRasLoginGovLinking": false,
     "enableGenomicExtraction": false,
     "enableFireCloudV2Billing" : false
   },

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -102,7 +102,8 @@
     "enableBetaAccess": false,
     "unsafeAllowSelfBypass": true,
     "unsafeAllowUserCreationFromGSuiteData": true,
-    "enableAccessRenewal": true
+    "enableAccessRenewal": true,
+    "enableRasLoginGovLinking": false
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,
@@ -111,9 +112,8 @@
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": true,
-    "enableRasLoginGovLinking": false,
     "enableGenomicExtraction": true,
-    "enableFireCloudV2Billing" : false
+    "enableFireCloudV2Billing" : false,
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -113,7 +113,7 @@
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": true,
     "enableGenomicExtraction": true,
-    "enableFireCloudV2Billing" : false,
+    "enableFireCloudV2Billing" : false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -41,7 +41,7 @@ public class ConfigController implements ConfigApiDelegate {
             .enableV3DataUserCodeOfConduct(config.featureFlags.enableV3DataUserCodeOfConduct)
             .enableEventDateModifier(config.featureFlags.enableEventDateModifier)
             .enableResearchReviewPrompt(config.featureFlags.enableResearchPurposePrompt)
-            .enableRasLoginGovLinking(config.featureFlags.enableRasLoginGovLinking)
+            .enableRasLoginGovLinking(config.access.enableRasLoginGovLinking)
             .enableAccessRenewal(config.access.enableAccessRenewal)
             .enableGenomicExtraction(config.featureFlags.enableGenomicExtraction)
             .rasHost(config.ras.host)

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -244,6 +244,8 @@ public class WorkbenchConfig {
     public boolean enableBetaAccess;
     // If true, users can be expired on the system, losing access
     public boolean enableAccessRenewal;
+    // If true, user account setup requires linking eRA commons via RAS instead of Shibboleth.
+    public boolean enableRasLoginGovLinking;
   }
 
   public static class FeatureFlagsConfig {
@@ -265,8 +267,6 @@ public class WorkbenchConfig {
     // Flag to indicate whether to show Update research purpose prompt after an year of workspace
     // creation
     public boolean enableResearchPurposePrompt;
-    // If true, user account setup requires linking eRA commons via RAS instead of Shibboleth.
-    public boolean enableRasLoginGovLinking;
     // If true, enable genomic extraction functionality for datasets which have genomics data
     // associated with their CDRs.
     public boolean enableGenomicExtraction;


### PR DESCRIPTION
Description:
enableRasLoginGovLinking is part of access and should live in access not feature flag. 

This is a safe change because that is not turned on in any env yet. 
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
