### PR TITLE
[RW-6873][risk=low] Implement local cloud tasks queue stub for development

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -140,5 +140,8 @@
   "accessRenewal": {
     "expiryDays": 365,
     "expiryDaysWarningThresholds": [ 1, 3, 7, 15, 30 ]
+  },
+  "offlineBatch": {
+    "unsafeCloudTasksForwardingHost": "http:\/\/localhost:8081"
   }
 }

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -140,5 +140,7 @@
   "accessRenewal": {
     "expiryDays": 365,
     "expiryDaysWarningThresholds": [ 1, 3, 7, 15, 30 ]
+  },
+  "offlineBatch": {
   }
 }

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -135,5 +135,7 @@
   "accessRenewal": {
     "expiryDays": 365,
     "expiryDaysWarningThresholds": [ 1, 3, 7, 15, 30 ]
+  },
+  "offlineBatch": {
   }
 }

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -139,5 +139,7 @@
   "accessRenewal": {
     "expiryDays": 365,
     "expiryDaysWarningThresholds": [ 1, 3, 7, 15, 30 ]
+  },
+  "offlineBatch": {
   }
 }

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -139,5 +139,7 @@
   "accessRenewal": {
     "expiryDays": 365,
     "expiryDaysWarningThresholds": [ 1, 3, 7, 15, 30 ]
+  },
+  "offlineBatch": {
   }
 }

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -140,5 +140,7 @@
   "accessRenewal": {
     "expiryDays": 365,
     "expiryDaysWarningThresholds": [ 1, 3, 7, 15, 30 ]
+  },
+  "offlineBatch": {
   }
 }

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -140,5 +140,7 @@
   "accessRenewal": {
     "expiryDays": 3650,
     "expiryDaysWarningThresholds": [ 1, 3, 7, 15, 30 ]
+  },
+  "offlineBatch": {
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/CloudTasksConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/CloudTasksConfig.java
@@ -1,0 +1,34 @@
+package org.pmiops.workbench.cloudtasks;
+
+import com.google.cloud.tasks.v2.CloudTasksClient;
+import java.io.IOException;
+import java.util.logging.Logger;
+import org.apache.logging.log4j.util.Strings;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Configuration
+public class CloudTasksConfig {
+
+  private static Logger log = Logger.getLogger(CloudTasksConfig.class.getName());
+
+  @Bean(destroyMethod = "close")
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  CloudTasksClient cloudTasksClient(WorkbenchConfig workbenchConfig) throws IOException {
+    if (Strings.isNotEmpty(workbenchConfig.offlineBatch.unsafeCloudTasksForwardingHost)) {
+      log.warning(
+          String.format(
+              "Cloud Tasks will be forwarded synchronously to '%s'. This should only happen during "
+                  + "local development. If you are seeing this in a cloud environment, please "
+                  + "investigate immediately.",
+              workbenchConfig.offlineBatch.unsafeCloudTasksForwardingHost));
+      return CloudTasksClient.create(
+          new ForwardingCloudTasksStub(
+              workbenchConfig.offlineBatch.unsafeCloudTasksForwardingHost));
+    }
+    return CloudTasksClient.create();
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/CloudTasksConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/CloudTasksConfig.java
@@ -1,9 +1,9 @@
 package org.pmiops.workbench.cloudtasks;
 
 import com.google.cloud.tasks.v2.CloudTasksClient;
+import com.google.common.base.Strings;
 import java.io.IOException;
 import java.util.logging.Logger;
-import org.apache.logging.log4j.util.Strings;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,7 +18,7 @@ public class CloudTasksConfig {
   @Bean(destroyMethod = "close")
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   CloudTasksClient cloudTasksClient(WorkbenchConfig workbenchConfig) throws IOException {
-    if (Strings.isNotEmpty(workbenchConfig.offlineBatch.unsafeCloudTasksForwardingHost)) {
+    if (!Strings.isNullOrEmpty(workbenchConfig.offlineBatch.unsafeCloudTasksForwardingHost)) {
       log.warning(
           String.format(
               "Cloud Tasks will be forwarded synchronously to '%s'. This should only happen during "

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/ForwardingCloudTasksStub.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/ForwardingCloudTasksStub.java
@@ -26,9 +26,12 @@ import java.util.logging.Logger;
  * testing purposes only.
  *
  * <p>Limitations:
- * <li>Only Google App Engine cloud tasks are supported
- * <li>Only task creation is supported
- * <li>Queue configuration (queue name, project name) are not validated
+ *
+ * <ul>
+ *   <li>Only Google App Engine cloud tasks are supported
+ *   <li>Only task creation is supported
+ *   <li>Queue configuration (queue name, project name) are not validated
+ * </ul>
  */
 public class ForwardingCloudTasksStub extends CloudTasksStub {
   private static final Logger log = Logger.getLogger(ForwardingCloudTasksStub.class.getName());

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/ForwardingCloudTasksStub.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/ForwardingCloudTasksStub.java
@@ -1,0 +1,103 @@
+package org.pmiops.workbench.cloudtasks;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.tasks.v2.AppEngineHttpRequest;
+import com.google.cloud.tasks.v2.CreateTaskRequest;
+import com.google.cloud.tasks.v2.QueueName;
+import com.google.cloud.tasks.v2.Task;
+import com.google.cloud.tasks.v2.stub.CloudTasksStub;
+import com.squareup.okhttp.Callback;
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.Response;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Stateless Cloud Tasks stub which immediately forwards all incoming tasks for execution. Tasks are
+ * dispatched asynchronously, and are not throttled or queued. This stub is intended to be used for
+ * testing purposes only.
+ *
+ * <p>Limitations:
+ * <li>Only Google App Engine cloud tasks are supported
+ * <li>Only task creation is supported
+ * <li>Queue configuration (queue name, project name) are not validated
+ */
+public class ForwardingCloudTasksStub extends CloudTasksStub {
+  private static final Logger log = Logger.getLogger(ForwardingCloudTasksStub.class.getName());
+
+  private final String baseUrl;
+
+  public ForwardingCloudTasksStub(String baseUrl) {
+    this.baseUrl = baseUrl;
+  }
+
+  @Override
+  public UnaryCallable<CreateTaskRequest, Task> createTaskCallable() {
+    return new UnaryCallable<CreateTaskRequest, Task>() {
+      @Override
+      public ApiFuture<Task> futureCall(CreateTaskRequest request, ApiCallContext context) {
+        final QueueName queueName = QueueName.parse(request.getParent());
+        final AppEngineHttpRequest gaeReq = request.getTask().getAppEngineHttpRequest();
+        final Request apiReq =
+            new Request.Builder()
+                .url(baseUrl + gaeReq.getRelativeUri())
+                .addHeader("X-AppEngine-QueueName", queueName.getQueue())
+                .post(
+                    RequestBody.create(
+                        MediaType.parse("application/json; charset=utf-8"),
+                        gaeReq.getBody().toStringUtf8()))
+                .build();
+
+        log.info(
+            String.format(
+                "asynchronously forwarding task request for queue '%s', to handler '%s'",
+                queueName.getQueue(), apiReq.url()));
+        new OkHttpClient()
+            .newCall(apiReq)
+            .enqueue(
+                new Callback() {
+                  @Override
+                  public void onFailure(Request request, IOException e) {
+                    log.log(Level.SEVERE, "task execution failed", e);
+                  }
+
+                  @Override
+                  public void onResponse(Response response) {}
+                });
+        return ApiFutures.immediateFuture(request.getTask());
+      }
+    };
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public void shutdown() {}
+
+  @Override
+  public boolean isShutdown() {
+    return true;
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return true;
+  }
+
+  @Override
+  public void shutdownNow() {}
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) {
+    return true;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -32,6 +32,7 @@ public class WorkbenchConfig {
   public ReportingConfig reporting;
   public RasConfig ras;
   public AccessRenewalConfig accessRenewal;
+  public OfflineBatchConfig offlineBatch;
 
   /** Creates a config with non-null-but-empty member variables, for use in testing. */
   public static WorkbenchConfig createEmptyConfig() {
@@ -58,6 +59,7 @@ public class WorkbenchConfig {
     config.reporting = new ReportingConfig();
     config.ras = new RasConfig();
     config.accessRenewal = new AccessRenewalConfig();
+    config.offlineBatch = new OfflineBatchConfig();
     return config;
   }
 
@@ -328,5 +330,9 @@ public class WorkbenchConfig {
     public Long expiryDays;
     // Thresholds for email alerting based on approaching module expiration, in days
     public List<Long> expiryDaysWarningThresholds;
+  }
+
+  public static class OfflineBatchConfig {
+    public String unsafeCloudTasksForwardingHost;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
@@ -2,11 +2,9 @@ package org.pmiops.workbench.interceptors;
 
 import com.google.api.client.http.HttpMethods;
 import io.swagger.annotations.ApiOperation;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.web.method.HandlerMethod;
@@ -22,9 +20,6 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 public class CloudTaskInterceptor extends HandlerInterceptorAdapter {
   public static final String QUEUE_NAME_REQUEST_HEADER = "X-AppEngine-QueueName";
   private static final String CLOUD_TASK_TAG = "cloudTask";
-  // Keep queue name consistent with the name as in OfflineRdrExportController
-  public static final Set<String> VALID_QUEUE_NAME_SET =
-      new HashSet<>(Arrays.asList("rdrExportQueue"));
 
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
@@ -47,8 +42,7 @@ public class CloudTaskInterceptor extends HandlerInterceptorAdapter {
       }
     }
 
-    boolean hasQueueNameHeader =
-        VALID_QUEUE_NAME_SET.contains(request.getHeader(QUEUE_NAME_REQUEST_HEADER));
+    boolean hasQueueNameHeader = Strings.isNotEmpty(request.getHeader(QUEUE_NAME_REQUEST_HEADER));
     if (requireCloudTaskHeader && !hasQueueNameHeader) {
       response.sendError(
           HttpServletResponse.SC_FORBIDDEN,

--- a/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
@@ -1,10 +1,10 @@
 package org.pmiops.workbench.interceptors;
 
 import com.google.api.client.http.HttpMethods;
+import com.google.common.base.Strings;
 import io.swagger.annotations.ApiOperation;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.logging.log4j.util.Strings;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.web.method.HandlerMethod;
@@ -42,7 +42,8 @@ public class CloudTaskInterceptor extends HandlerInterceptorAdapter {
       }
     }
 
-    boolean hasQueueNameHeader = Strings.isNotEmpty(request.getHeader(QUEUE_NAME_REQUEST_HEADER));
+    boolean hasQueueNameHeader =
+        !Strings.isNullOrEmpty(request.getHeader(QUEUE_NAME_REQUEST_HEADER));
     if (requireCloudTaskHeader && !hasQueueNameHeader) {
       response.sendError(
           HttpServletResponse.SC_FORBIDDEN,

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrTaskQueue.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrTaskQueue.java
@@ -12,7 +12,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -21,7 +20,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class RdrTaskQueue {
-  private static final Logger log = Logger.getLogger(RdrTaskQueue.class.getName());
   private static final String BASE_PATH = "/v1/cloudTask";
   public static final String EXPORT_RESEARCHER_PATH = BASE_PATH + "/exportResearcherData";
   public static final String EXPORT_USER_PATH = BASE_PATH + "/exportWorkspaceData";

--- a/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest.java
@@ -50,16 +50,6 @@ public class CloudTaskInterceptorTest extends SpringTest {
   }
 
   @Test
-  public void prehandleForCloudTaskWithBadHeader() throws Exception {
-    when(request.getMethod()).thenReturn(HttpMethods.POST);
-    when(handler.getMethod())
-        .thenReturn(
-            CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, ArrayOfLong.class));
-    when(request.getHeader(CloudTaskInterceptor.QUEUE_NAME_REQUEST_HEADER)).thenReturn("asdf");
-    assertThat(interceptor.preHandle(request, response, handler)).isFalse();
-  }
-
-  @Test
   public void prehandleForCloudTaskWithHeader() throws Exception {
     when(request.getMethod()).thenReturn(HttpMethods.POST);
     when(handler.getMethod())

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillWorkspacesToRdr.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillWorkspacesToRdr.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.tools;
 
+import com.google.cloud.tasks.v2.CloudTasksClient;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.logging.Logger;
@@ -62,8 +63,9 @@ public class BackfillWorkspacesToRdr {
   @Bean
   private RdrTaskQueue rdrTaskQueue(
       WorkbenchLocationConfigService locationConfigService,
+      Provider<CloudTasksClient> cloudTasksClientProvider,
       Provider<WorkbenchConfig> configProvider) {
-    return new RdrTaskQueue(locationConfigService, configProvider);
+    return new RdrTaskQueue(locationConfigService, cloudTasksClientProvider, configProvider);
   }
 
   @Bean


### PR DESCRIPTION
## Approach

- For local testing, swap out implementations for the `CloudTasksClient`. This constructor accepts alternate stubs, which by default will throw an `UnsupportedException` on any other method invocation.
- Provide a simple implementation of this stub which only implements the subset of the Cloud Tasks API we currently care about
- When creating a task, this stub immediately fires off an HTTP request to the API server (itself) to invoke the task handler
- The stub immediately returns without blocking on the response

## Alternatives considered

### Local controller emulating Cloud Tasks API

This approach would swap out the `endpoint` in the CloudTasksClient, and dispatch a normal, well-formed Cloud Tasks API request to a handler we own. Unfortunately, I discovered this client appears to only support gRPC, meaning we'd need to provide a controller which spoke gRPC. Since we don't currently serve gRPC endpoints elsewhere, this felt like too complex of a dependency to pull in for this purpose.

Secondly, I failed to figure out how to make an insecure gRPC connection (http, not https), which would be desired for a local connection (though an in-process channel perhaps could also be used).

### 3p emulator

Here we would wire up https://github.com/aertje/cloud-tasks-emulator via docker-compose, then point the cloud tasks endpoint to a local port. This felt like a somewhat complex dependency to pull in, and would probably need a fair amount of testing to validate that it does what we want.

Again, to make this work I would need to figure out how to create an insecure gRPC connection in Java. (this is likely possible, but not obvious from docs)

## Other learnings

- Getting the active port in our Spring Boot server is surprisingly difficult. I believe it has something to do with the GAE DevAppServer integration. I failed to find a way to grab the port 8081 dynamically (though in the end, my approach did not require it)
- A "destroy" method can be specified for a bean, this is nice for closeable resources (i.e. CloudTasksClient in this PR)