### PR TITLE
[RW-6866][risk=no] Enforce a 5K sample limit on genomic extraction

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -47,6 +47,8 @@ import org.springframework.stereotype.Service;
 public class GenomicExtractionService {
 
   public static final String EXTRACT_WORKFLOW_NAME = "GvsExtractCohortFromSampleNames";
+  // Theoretical maximum is 20K-30K, keep it lower during the initial alpha period.
+  private static final int MAX_EXTRACTION_SAMPLE_COUNT = 5_000;
 
   private final DataSetService dataSetService;
   private final FireCloudService fireCloudService;
@@ -170,6 +172,13 @@ public class GenomicExtractionService {
     if (personIds.isEmpty()) {
       throw new FailedPreconditionException(
           "provided cohort contains no participants with whole genome data");
+    }
+    if (personIds.size() > MAX_EXTRACTION_SAMPLE_COUNT) {
+      throw new FailedPreconditionException(
+          String.format(
+              "provided dataset contains %d individuals with whole genome data, the current limit "
+                  + "for extraction is %d",
+              personIds.size(), MAX_EXTRACTION_SAMPLE_COUNT));
     }
 
     Blob personIdsFile =

--- a/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -406,6 +408,17 @@ public class GenomicExtractionServiceTest {
   @Test
   public void submitExtractionJob_noWgsData() throws ApiException {
     when(mockDataSetService.getPersonIdsWithWholeGenome(any())).thenReturn(ImmutableList.of());
+
+    assertThrows(
+        FailedPreconditionException.class,
+        () -> genomicExtractionService.submitGenomicExtractionJob(targetWorkspace, dataset));
+  }
+
+  @Test
+  public void submitExtractionJob_tooManySamples() throws ApiException {
+    final List<String> largePersonIdList =
+        LongStream.range(1, 6_000).boxed().map(id -> id.toString()).collect(Collectors.toList());
+    when(mockDataSetService.getPersonIdsWithWholeGenome(any())).thenReturn(largePersonIdList);
 
     assertThrows(
         FailedPreconditionException.class,

--- a/ui/src/app/pages/data/data-set/genomic-extraction-modal.tsx
+++ b/ui/src/app/pages/data/data-set/genomic-extraction-modal.tsx
@@ -85,7 +85,8 @@ export const GenomicExtractionModal = ({
       } else if (runningExtract || succeededExtract || failedExtract) {
         return <WarningMessage iconSize={30} iconPosition={'top'} data-test-id='extract-warning'>
           {runningExtract && <React.Fragment>
-            An extraction is currently running for this dataset; it was started {TimeAgoWithVerboseTooltip(mostRecentExtract.submissionDate)}.
+            An extraction is currently running for this dataset; it was
+            started {TimeAgoWithVerboseTooltip(mostRecentExtract.submissionDate)}.
           </React.Fragment>}
           {succeededExtract && <React.Fragment>
             VCF file(s) already exist for this dataset.
@@ -100,7 +101,7 @@ export const GenomicExtractionModal = ({
       } else {
         return <React.Fragment/>;
       }
-     })()}
+    })()}
     <ModalFooter>
       <Button type='secondary' onClick={() => closeFunction()}>
         { cancelText || 'Cancel' }


### PR DESCRIPTION
* Display the error message returned in JSON from the server, if any - currently these are intended for client consumption, so should be comprehensible by the end user
* Currently we only expect this to happen in two cases:
  * 412: no WGS samples
  * 412: too many WGS samples
* If a client error is encountered, gray out the "extract" button - this is not retryable

Other changes:
* Make error and warning mutually exclusive, showing both looked confusing
* Update language to reference the "genomic job history" panel, rather than the "workspace storage" panel 
* Make styling consistent between warning and error callout

Screenshots:

Error (induced by setting a limit of 1 sample) via dataset card modal:
![image](https://user-images.githubusercontent.com/822298/122612087-63bc5e00-d037-11eb-9995-d6748d265065.png)


Error (induced by setting a limit of 1 sample) via dataset builder:
![image](https://user-images.githubusercontent.com/822298/122612168-851d4a00-d037-11eb-9697-805c307a961a.png)
