### PR TITLE
[RW-6224][risk=no] Eliminate some React warnings

### DIFF
--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -260,7 +260,7 @@ export const IconButton = ({icon: Icon, style = {}, hover = {}, tooltip = '', di
   </TooltipTrigger>;
 };
 
-export const SnowmanButton = ({...props}) => <IconButton icon={SnowmanIcon} {...props} propagateDataTestId={true}/>;
+export const SnowmanButton = ({...props}) => <IconButton icon={SnowmanIcon} {...props} />;
 
 const cardButtonBase = {
   style: {

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -324,6 +324,7 @@ export const useCustomRuntime = (currentWorkspaceNamespace):
   useRuntime(currentWorkspaceNamespace);
 
   useEffect(() => {
+    let mounted = true;
     const aborter = new AbortController();
     const runAction = async() => {
       // Only delete if the runtime already exists.
@@ -369,7 +370,9 @@ export const useCustomRuntime = (currentWorkspaceNamespace):
         }
       } finally {
         markCompoundRuntimeOperationCompleted(currentWorkspaceNamespace);
-        setRequestedRuntime(undefined);
+        if (mounted) {
+          setRequestedRuntime(undefined);
+        }
       }
     };
 
@@ -380,6 +383,11 @@ export const useCustomRuntime = (currentWorkspaceNamespace):
       });
       runAction();
     }
+
+    // After dismount, we still want the above store modifications to occur.
+    // However, we should not continue to mutate the now unmounted hook state -
+    // this will result in React warnings.
+    return () => { mounted = false; };
   }, [requestedRuntime]);
 
   return [{currentRuntime: runtime, pendingRuntime}, setRequestedRuntime];


### PR DESCRIPTION
* Runtime store was attempting to make a state update after dismount. This custom hook is a bit messy overall, but this seems like the correct incremental fix to avoid the warning.
* Newer `Interactive` component does not have the `propagateTestId` prop. I think the option does not make sense based on my understanding of forwardRef, so I removed the caller that was supplying it.