### PR TITLE
[no ticket][risk=no] stop long warning from cropping up in console all the time

### DIFF
--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -245,7 +245,6 @@ export const MenuItem = ({icon = null, faIcon = null, tooltip = '', disabled = f
 };
 
 export const IconButton = ({icon: Icon, style = {}, hover = {}, tooltip = '', disabled = false, ...props}) => {
-  const childProps = props.propagateDataTestId ? fp.omit(['propagateDataTestId'], props) : fp.omit(['propagateDataTestId', 'data-test-id'], props);
   return <TooltipTrigger side='left' content={tooltip}>
     <LocalInteractive tagName='div'
                  style={{
@@ -255,7 +254,7 @@ export const IconButton = ({icon: Icon, style = {}, hover = {}, tooltip = '', di
                  }}
                  hover={{color: !disabled && colorWithWhiteness(colors.accent, 0.2), ...hover}}
                  disabled={disabled}
-                 {...childProps}>
+                 {...props}>
         <Icon disabled={disabled} style={style}/>
     </LocalInteractive>
   </TooltipTrigger>;

--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -198,7 +198,7 @@ const computeStyle = ({style = {}, hover = {}, disabledStyle = {}}, {disabled}) 
 
 export const Clickable = ({as = 'div', disabled = false, onClick = null, propagateDataTestId = false, ...props}) => {
   // `fp.omit` used to prevent propagation of test IDs to the rendered child component.
-  const childProps = propagateDataTestId ? props : fp.omit(['data-test-id'], props);
+  const childProps = propagateDataTestId ? fp.omit(['propagateDataTestId'], props) : fp.omit(['propagateDataTestId', 'data-test-id'], props);
   return <Interactive
     as={as} {...childProps}
     onClick={(...args) => onClick && !disabled && onClick(...args)}
@@ -245,6 +245,7 @@ export const MenuItem = ({icon = null, faIcon = null, tooltip = '', disabled = f
 };
 
 export const IconButton = ({icon: Icon, style = {}, hover = {}, tooltip = '', disabled = false, ...props}) => {
+  const childProps = props.propagateDataTestId ? fp.omit(['propagateDataTestId'], props) : fp.omit(['propagateDataTestId', 'data-test-id'], props);
   return <TooltipTrigger side='left' content={tooltip}>
     <LocalInteractive tagName='div'
                  style={{
@@ -254,7 +255,7 @@ export const IconButton = ({icon: Icon, style = {}, hover = {}, tooltip = '', di
                  }}
                  hover={{color: !disabled && colorWithWhiteness(colors.accent, 0.2), ...hover}}
                  disabled={disabled}
-                 {...props}>
+                 {...childProps}>
         <Icon disabled={disabled} style={style}/>
     </LocalInteractive>
   </TooltipTrigger>;


### PR DESCRIPTION
<img width="1679" alt="Screen Shot 2021-06-22 at 11 56 58 AM" src="https://user-images.githubusercontent.com/1847690/122958907-f5d2a800-d350-11eb-95d3-3f504b01a8c7.png">

behold the console without the thousand pixel warning about `propagateDataTestId`

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
