### PR TITLE
[RW-3122][risk=no] Remove workspace share from workspace wrapper

### DIFF
--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -58,6 +58,7 @@ import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
 
 import {GenomicsExtractionTable} from 'app/components/genomics-extraction-table';
 import {HelpTips} from 'app/components/help-tips';
+import {WorkspaceShare} from 'app/pages/workspace/workspace-share';
 import {dataSetApi} from 'app/services/swagger-fetch-clients';
 import {getCdrVersion} from 'app/utils/cdr-versions';
 import {
@@ -242,6 +243,7 @@ interface State {
   searchTerm: string;
   showCriteria: boolean;
   tooltipId: number;
+  showShareModal: boolean;
 }
 
 export const HelpSidebar = fp.flow(
@@ -265,7 +267,8 @@ export const HelpSidebar = fp.flow(
         participant: undefined,
         searchTerm: '',
         showCriteria: false,
-        tooltipId: undefined
+        tooltipId: undefined,
+        showShareModal: false
       };
     }
 
@@ -462,7 +465,7 @@ export const HelpSidebar = fp.flow(
     }
 
     renderWorkspaceMenu() {
-      const {deleteFunction, shareFunction, workspace, workspace: {accessLevel, id, namespace}} = this.props;
+      const {deleteFunction, workspace, workspace: {accessLevel, id, namespace}} = this.props;
       const isNotOwner = !workspace || accessLevel !== WorkspaceAccessLevel.OWNER;
       const tooltip = isNotOwner && 'Requires owner permission';
       return <PopupTrigger
@@ -495,7 +498,7 @@ export const HelpSidebar = fp.flow(
               disabled={isNotOwner}
               onClick={() => {
                 AnalyticsTracker.Workspaces.OpenShareModal();
-                shareFunction();
+                this.setState({showShareModal: true});
               }}>
               Share
             </MenuItem>
@@ -868,6 +871,8 @@ export const HelpSidebar = fp.flow(
             </div>
           </CSSTransition>
         </TransitionGroup>
+
+        {this.state.showShareModal && <WorkspaceShare onClose={() => this.setState({showShareModal: false})}/>}
       </div>;
     }
   }

--- a/ui/src/app/pages/workspace/workspace-share.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.spec.tsx
@@ -51,12 +51,10 @@ describe('WorkspaceShareComponent', () => {
 
   beforeEach(() => {
     registerApiClient(UserApi, new UserApiStub([harryRole, hermioneRole, ronRole, lunaRole]));
-    registerApiClient(WorkspacesApi,
-      new WorkspacesApiStub([tomRiddleDiary], tomRiddleDiaryUserRoles));
+    registerApiClient(WorkspacesApi, new WorkspacesApiStub([tomRiddleDiary], tomRiddleDiaryUserRoles));
+
     props = {
-      onClose: () => {},
-      accessLevel: WorkspaceAccessLevel.OWNER,
-      userRoles: tomRiddleDiaryUserRoles
+      onClose: () => {}
     };
 
     profileStore.set({
@@ -71,8 +69,10 @@ describe('WorkspaceShareComponent', () => {
     currentWorkspaceStore.next(tomRiddleDiary);
   });
 
-  it('display correct users', () => {
+  it('display correct users', async() => {
     const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
     expect(wrapper).toBeTruthy();
     expect(wrapper.find('[data-test-id="collab-user-name"]').length).toBe(3);
     expect(wrapper.find('[data-test-id="collab-user-email"]').length).toBe(3);
@@ -83,16 +83,20 @@ describe('WorkspaceShareComponent', () => {
       .toEqual(expectedUsers.map(u => u.email));
   });
 
-  it('displays correct role info', () => {
+  it('displays correct role info', async() => {
     const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
     expect(wrapper.find(getSelectString(harryRole)).first().text()).toEqual(fp.capitalize(WorkspaceAccessLevel[harryRole.role]));
     expect(wrapper.find(getSelectString(hermioneRole)).first().text()).toEqual(fp.capitalize(WorkspaceAccessLevel[hermioneRole.role]));
     expect(wrapper.find(getSelectString(ronRole)).first().text()).toEqual(fp.capitalize(WorkspaceAccessLevel[ronRole.role]));
     expect(wrapper.find(getSelectString(lunaRole)).length).toBe(0);
   });
 
-  it('removes user correctly', () => {
+  it('removes user correctly', async() => {
     const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
     wrapper.find('[data-test-id="remove-collab-ron.weasley@hogwarts.edu"]').first().simulate('click');
     const expectedNames = fp.sortBy('familyName', [harry, hermione])
       .map(u => u.givenName + ' ' + u.familyName);
@@ -119,8 +123,10 @@ describe('WorkspaceShareComponent', () => {
     expect(wrapper.find(dataString).length).toBe(0);
   });
 
-  it('does not allow self role change', () => {
+  it('does not allow self role change', async() => {
     const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
     expect(wrapper.find('[data-test-id="harry.potter@hogwarts.edu-user-role"]').first()
       .props()['isDisabled']).toBe(true);
   });

--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -184,7 +184,6 @@ export const WorkspaceShare = fp.flow(withCurrentWorkspace(), withUserProfile())
       workspaceUpdateConflictError: false,
       loadingUserRoles: true,
       userRoles: [],
-//      userRoles: fp.sortBy('familyName', this.props.userRoles),
       searchTerm: '',
       dropDown: false,
     };
@@ -206,9 +205,7 @@ export const WorkspaceShare = fp.flow(withCurrentWorkspace(), withUserProfile())
     try {
       const resp = await workspacesApi()
         .getFirecloudWorkspaceUserRoles(this.props.workspace.namespace, this.props.workspace.id);
-      this.setState({
-        userRoles: fp.sortBy('familyName', resp.items)
-      });
+      this.setState({userRoles: fp.sortBy('familyName', resp.items)});
     } catch (error) {
       if (error.status === 404) {
         this.setState({workspaceFound: false});

--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -1,4 +1,3 @@
-import {Component, Input, OnInit} from '@angular/core';
 
 import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {userApi, workspacesApi} from 'app/services/swagger-fetch-clients';
@@ -6,7 +5,6 @@ import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {
   isBlank,
   reactStyles,
-  ReactWrapperBase,
   withCurrentWorkspace,
   withUserProfile
 } from 'app/utils';
@@ -22,7 +20,6 @@ import {
   Profile,
   User,
   UserRole,
-  Workspace,
   WorkspaceAccessLevel,
   WorkspaceUserRolesResponse,
 } from 'generated/fetch/api';
@@ -31,7 +28,7 @@ import {Button} from 'app/components/buttons';
 import {FlexRow} from 'app/components/flex';
 import {ClrIcon, InfoIcon} from 'app/components/icons';
 import {TooltipTrigger} from 'app/components/popups';
-import {SpinnerOverlay} from 'app/components/spinners';
+import {Spinner, SpinnerOverlay} from 'app/components/spinners';
 import {AnalyticsTracker} from 'app/utils/analytics';
 
 const styles = reactStyles( {
@@ -156,21 +153,18 @@ export interface State {
   saving: boolean;
   workspaceFound: boolean;
   workspaceUpdateConflictError: boolean;
+  loadingUserRoles: boolean;
   userRoles: UserRole[];
   searchTerm: string;
   dropDown: boolean;
 }
 
 export interface Props {
-  accessLevel: WorkspaceAccessLevel;
   onClose: Function;
-  // The userRoles to pre-populate the share dialog. Must be filled with all
-  // pre-existing roles on the workspace for this dialog to work correctly.
-  userRoles: UserRole[];
 }
 
 interface HocProps extends Props {
-  workspace: Workspace;
+  workspace: WorkspaceData;
   profileState: {profile: Profile, reload: Function, updateCache: Function};
 }
 
@@ -188,7 +182,9 @@ export const WorkspaceShare = fp.flow(withCurrentWorkspace(), withUserProfile())
       saving: false,
       workspaceFound: (this.props.workspace !== null),
       workspaceUpdateConflictError: false,
-      userRoles: fp.sortBy('familyName', this.props.userRoles),
+      loadingUserRoles: true,
+      userRoles: [],
+//      userRoles: fp.sortBy('familyName', this.props.userRoles),
       searchTerm: '',
       dropDown: false,
     };
@@ -197,6 +193,8 @@ export const WorkspaceShare = fp.flow(withCurrentWorkspace(), withUserProfile())
 
   componentDidMount(): void {
     document.addEventListener('mousedown', this.handleClickOutsideSearch, false);
+
+    this.loadUserRoles();
   }
 
   componentWillUnmount(): void {
@@ -204,14 +202,19 @@ export const WorkspaceShare = fp.flow(withCurrentWorkspace(), withUserProfile())
   }
 
   async loadUserRoles() {
+    this.setState({loadingUserRoles: true});
     try {
       const resp = await workspacesApi()
         .getFirecloudWorkspaceUserRoles(this.props.workspace.namespace, this.props.workspace.id);
-      this.setState({userRoles: fp.sortBy('familyName', resp.items)});
+      this.setState({
+        userRoles: fp.sortBy('familyName', resp.items)
+      });
     } catch (error) {
       if (error.status === 404) {
         this.setState({workspaceFound: false});
       }
+    } finally {
+      this.setState({loadingUserRoles: false});
     }
   }
 
@@ -323,7 +326,7 @@ export const WorkspaceShare = fp.flow(withCurrentWorkspace(), withUserProfile())
   }
 
   get hasPermission(): boolean {
-    return this.props.accessLevel === WorkspaceAccessLevel.OWNER;
+    return this.props.workspace.accessLevel === WorkspaceAccessLevel.OWNER;
   }
 
   get showSearchResults(): boolean {
@@ -409,43 +412,46 @@ export const WorkspaceShare = fp.flow(withCurrentWorkspace(), withUserProfile())
           {this.state.workspaceShareError && <div style={{color: 'red'}}>
             Failed to share workspace. Please try again.
           </div>}
-            <h3>Current Collaborators</h3>
-          <div style={{overflowY: this.state.dropDown ? 'hidden' : 'auto'}}>
-            {this.state.userRoles.map((user, i) => {
-              return <div key={user.email}>
-                <div data-test-id='collab-user-row' style={styles.wrapper}>
-                  <div style={styles.box}>
-                    <h5 data-test-id='collab-user-name'
-                        style={{...styles.userName, ...styles.collabUser}}>
-                      {user.givenName} {user.familyName}
-                    </h5>
-                    <div data-test-id='collab-user-email'
-                         style={styles.userName}>{user.email}</div>
-                    {/* Minimally, the z-index must be higher than that of the
+          <h3>Current Collaborators</h3>
+          {this.state.loadingUserRoles
+            ? <Spinner size={36} style={{margin: 'auto', marginTop: '1rem'}}/>
+            : <div style={{overflowY: this.state.dropDown ? 'hidden' : 'auto'}}>
+              {this.state.userRoles.map((user, i) => {
+                return <div key={user.email}>
+                  <div data-test-id='collab-user-row' style={styles.wrapper}>
+                    <div style={styles.box}>
+                      <h5 data-test-id='collab-user-name'
+                          style={{...styles.userName, ...styles.collabUser}}>
+                        {user.givenName} {user.familyName}
+                      </h5>
+                      <div data-test-id='collab-user-email'
+                           style={styles.userName}>{user.email}</div>
+                      {/* Minimally, the z-index must be higher than that of the
                         modal. See https://react-select.com/advanced#portaling */}
-                    <Select value={user.role}
-                            styles={{menuPortal: base => ({ ...base, zIndex: 110 })}}
-                            menuPortalTarget={document.getElementById('popup-root')}
-                            isDisabled={user.email === this.props.profileState.profile.username}
-                            classNamePrefix={this.cleanClassNameForSelect(user.email)}
-                            data-test-id={user.email + '-user-role'}
-                            onChange={e => this.setRole(e, user)}
-                            options={UserRoleOptions}/>
+                      <Select value={user.role}
+                              styles={{menuPortal: base => ({ ...base, zIndex: 110 })}}
+                              menuPortalTarget={document.getElementById('popup-root')}
+                              isDisabled={user.email === this.props.profileState.profile.username}
+                              classNamePrefix={this.cleanClassNameForSelect(user.email)}
+                              data-test-id={user.email + '-user-role'}
+                              onChange={e => this.setRole(e, user)}
+                              options={UserRoleOptions}/>
+                    </div>
+                    <div style={styles.box}>
+                      <div style={styles.collaboratorIcon}>
+                        {(this.hasPermission && (user.email !== this.props.profileState.profile.username)) &&
+                        <ClrIcon data-test-id={'remove-collab-' + user.email} shape='minus-circle'
+                                 style={{height: '21px', width: '21px'}}
+                                 onClick={() => this.removeCollaborator(user)}/>}
+                      </div>
+                    </div>
                   </div>
-                <div style={styles.box}>
-                  <div style={styles.collaboratorIcon}>
-                    {(this.hasPermission && (user.email !== this.props.profileState.profile.username)) &&
-                    <ClrIcon data-test-id={'remove-collab-' + user.email} shape='minus-circle'
-                             style={{height: '21px', width: '21px'}}
-                             onClick={() => this.removeCollaborator(user)}/>}
-                  </div>
-                </div>
-                </div>
                   {(this.state.userRoles.length !== i + 1) &&
                   <div style={{borderTop: '1px solid grey', width: '100%', marginTop: '.5rem'}}/>}
-              </div>;
-            })}
-          </div>
+                </div>;
+              })}
+            </div>
+          }
         </ModalBody>
         <ModalFooter style={{alignItems: 'center'}}>
             <Button type='link' style={{marginRight: '.8rem', border: 'none'}}
@@ -473,19 +479,3 @@ export const WorkspaceShare = fp.flow(withCurrentWorkspace(), withUserProfile())
     </React.Fragment>;
   }
 });
-
-@Component({
-  selector: 'app-workspace-share',
-  template: '<div #root></div>'
-})
-export class WorkspaceShareComponent extends ReactWrapperBase implements OnInit {
-  @Input('workspace') workspace: Workspace;
-  @Input('accessLevel') accessLevel: WorkspaceAccessLevel;
-  @Input('onClose') onClose: Props['onClose'];
-  @Input('userRoles') userRoles: Props['userRoles'];
-
-  constructor() {
-    super(WorkspaceShare, ['workspace', 'accessLevel', 'onClose', 'userRoles']);
-  }
-
-}

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.html
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.html
@@ -9,10 +9,6 @@
     </div>
   </clr-modal>
 
-  <app-workspace-share *ngIf="sharing" [onClose]="closeShare"
-                       [workspace]="workspace"
-                       [accessLevel]="accessLevel"
-                       [userRoles]="userRoles"></app-workspace-share>
   <app-confirm-delete-modal *ngIf="confirmDeleting"
                             [resourceType]="resourceType"
                             [resourceName]="workspace.name"
@@ -22,8 +18,7 @@
                   [bugReportDescription]="bugReportDescription"
                   [onClose]="closeBugReport"></app-bug-report>
   <app-help-sidebar [deleteFunction]="openConfirmDelete"
-                    [pageKey]="pageKey"
-                    [shareFunction]="handleShareAction"></app-help-sidebar>
+                    [pageKey]="pageKey"></app-help-sidebar>
   <div [style.margin-right]="pageKey ? '45px' : 0" [style.height]="pageKey && !contentFullHeightOverride ? 'auto': '100%'">
     <router-outlet *ngIf="workspace"></router-outlet>
   </div>


### PR DESCRIPTION
Moving workspace-share into help sidebar and removing all references and class variables related to it in workspace-wrapper.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
