### PR TITLE
[RW-6939][risk=low] Avoid duplication of foreign entities on profile update

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -496,8 +496,8 @@ public class ProfileController implements ProfileApiDelegate {
       throw new BadRequestException("Cannot update Verified Institutional Affiliation");
     }
 
-    profileService.updateProfile(user, updatedProfile, previousProfile);
-    confirmProfile();
+    DbUser updatedUser = profileService.updateProfile(user, updatedProfile, previousProfile);
+    userService.confirmProfile(updatedUser);
 
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
@@ -627,7 +627,7 @@ public class ProfileController implements ProfileApiDelegate {
 
   @Override
   public ResponseEntity<Void> confirmProfile() {
-    userService.confirmProfile();
+    userService.confirmProfile(userProvider.get());
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -162,7 +162,7 @@ public interface UserService {
   DbUser updateRasLinkLoginGovStatus(String loginGovUserName);
 
   /** Confirm that a user's profile is up to date, for annual renewal compliance purposes. */
-  DbUser confirmProfile();
+  DbUser confirmProfile(DbUser u);
 
   /** Confirm that a user has either reported any AoU-related publications, or has none. */
   DbUser confirmPublications();

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -1093,8 +1093,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
 
   /** Confirm that a user's profile is up to date, for annual renewal compliance purposes. */
   @Override
-  public DbUser confirmProfile() {
-    final DbUser dbUser = userProvider.get();
+  public DbUser confirmProfile(DbUser dbUser) {
     return updateUserWithRetries(
         user -> {
           user.setProfileLastConfirmedTime(new Timestamp(clock.instant().toEpochMilli()));

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -201,7 +201,7 @@ public class ProfileService {
    * @param updatedProfile
    * @param previousProfile
    */
-  public void updateProfile(DbUser user, Profile updatedProfile, Profile previousProfile) {
+  public DbUser updateProfile(DbUser user, Profile updatedProfile, Profile previousProfile) {
     // Apply cleaning methods to both the previous and updated profile, to avoid false positive
     // field diffs due to null-to-empty-object changes.
     cleanProfile(updatedProfile);
@@ -236,7 +236,8 @@ public class ProfileService {
       dbDemographicSurvey.setUser(user);
     }
     user.setDemographicSurvey(dbDemographicSurvey);
-    userService.updateUserWithConflictHandling(user);
+
+    DbUser updatedUser = userService.updateUserWithConflictHandling(user);
 
     // FIXME: why not do a getOrCreateAffiliation() here and then update that object & save?
 
@@ -260,6 +261,7 @@ public class ProfileService {
 
     final Profile appliedUpdatedProfile = getProfile(user);
     profileAuditor.fireUpdateAction(previousProfile, appliedUpdatedProfile);
+    return updatedUser;
   }
 
   public void cleanProfile(Profile profile) {

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -481,7 +481,7 @@ public class UserServiceTest extends SpringTest {
 
     // user confirms profile, so confirmation time is set to START_INSTANT
 
-    userService.confirmProfile();
+    userService.confirmProfile(providedDbUser);
     assertThat(providedDbUser.getProfileLastConfirmedTime())
         .isEqualTo(Timestamp.from(START_INSTANT));
 
@@ -489,7 +489,7 @@ public class UserServiceTest extends SpringTest {
 
     tick();
 
-    userService.confirmProfile();
+    userService.confirmProfile(providedDbUser);
     assertThat(providedDbUser.getProfileLastConfirmedTime())
         .isGreaterThan(Timestamp.from(START_INSTANT));
   }


### PR DESCRIPTION
## The bug

`updateProfile()` and `confirmProfile()` both grabbed the current user value from the `@RequestContext` provider. The behavior is undefined as to what happens if you do this multiple times within a request which mutates the user object within that request. There are no guarantees made that the value of this provider will be up-to-date for changes made within that same request. While it can be mutated during the request (arguably, this is not desirable), it should be generally considered to track the original value of the user object when the request originally came in.

In this case (I'll just talk about address here, this is also a bug for demographics survey):
-  `updateProfile()` method calls `setAddress()` with a new Address object (with no ID assigned) before saving
- after the `save()`, the `Address` object is not dynamically updated, but is available in the resulting return-value of `save()` (previously discarded)
- when `confirmProfile()` grabs `userProvider.get()`, it still has an ID-less `Address` returned by `getAddress()`. This is because `updateProfile` mutated the original copy of `DbUser` from the provider, but never saved the ID.
- when `confirmProfile()` calls `save()`, this creates a new `Address` row, because there is no ID on the `Address` object

## The fix

Use the up-to-date `DbUser` value when invoking `confirmProfile()` from `updateProfile()`.

Other fixes which probably would have also worked, but I think are less preferred:
- In confirmProfile(), directly read the latest value of `DbUser`, e.g. `userDao.findById(dbUser.getId());`
- (hacky) In updateProfile(), call `setAddress()` on the original request-scoped `dbUser` model; would need to be grabbed manually for any foreign relationships

## Testing

Deleted my address/demographic_survey rows repeatedly locally.

## Other potential issues

- This could have been caught earlier with a foreign key constraint, and would have avoided writing bad data (update would have failed, instead of putting the DB into an undefined state)
- Noticing that we recreate a new row in the address table every time we do an update. This seems to work, but also seems that it may be unintended.
- Noticing that the Address and demographics survey models define `@ManyToOne`, although they actually claim to be `@OneToOne`, probably a bug but seems to have no discernable effect on the current method, so leaving that out