### PR TITLE
[RW-3122][risk=no] Move workspace deletion code from workspace-wrapper to help-sidebar

### DIFF
--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -36,6 +36,7 @@ import {
   serverConfigStore
 } from 'app/utils/stores';
 import {CdrVersionsApiStub, cdrVersionTiersResponse} from 'testing/stubs/cdr-versions-api-stub';
+import {ConfirmDeleteModal} from './confirm-delete-modal';
 import {HelpSidebar} from './help-sidebar';
 import {WorkspacesApiStub} from "testing/stubs/workspaces-api-stub";
 import {DataSetApiStub} from "testing/stubs/data-set-api-stub";
@@ -162,13 +163,12 @@ describe('HelpSidebar', () => {
     expect(wrapper.find('[data-test-id="sidebar-content"]').parent().prop('style').width).toBe(0);
   });
 
-  it('should call delete method when clicked', async() => {
-    const deleteSpy = jest.fn();
-    props = {deleteFunction: deleteSpy};
+  it('should show delete workspace modal on clicking delete workspace', async() => {
     const wrapper = await component();
     wrapper.find({'data-test-id': 'workspace-menu-button'}).first().simulate('click');
     wrapper.find({'data-test-id': 'Delete-menu-item'}).first().simulate('click');
-    expect(deleteSpy).toHaveBeenCalled();
+    await waitOneTickAndUpdate(wrapper);
+    expect(wrapper.find(ConfirmDeleteModal).exists()).toBeTruthy();
   });
 
   it('should show workspace share modal on clicking share workspace', async() => {

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -64,11 +64,12 @@ import {getCdrVersion} from 'app/utils/cdr-versions';
 import {
   CdrVersionTiersResponse,
   Criteria, GenomicExtractionJob,
-  ParticipantCohortStatus,
+  ParticipantCohortStatus, ResourceType,
   RuntimeStatus, TerraJobStatus,
   WorkspaceAccessLevel
 } from 'generated/fetch';
 import {Clickable, MenuItem, StyledAnchorTag} from './buttons';
+import {ConfirmDeleteModal} from './confirm-delete-modal';
 import {Spinner} from './spinners';
 
 const LOCAL_STORAGE_KEY_SIDEBAR_STATE = 'WORKSPACE_SIDEBAR_STATE';
@@ -236,6 +237,12 @@ interface Props {
   genomicExtraction: GenomicExtractionStore;
 }
 
+enum CurrentModal {
+  None,
+  Share,
+  Delete
+}
+
 interface State {
   activeIcon: string;
   filteredContent: Array<any>;
@@ -244,6 +251,7 @@ interface State {
   showCriteria: boolean;
   tooltipId: number;
   showShareModal: boolean;
+  currentModal: CurrentModal;
 }
 
 export const HelpSidebar = fp.flow(
@@ -268,7 +276,7 @@ export const HelpSidebar = fp.flow(
         searchTerm: '',
         showCriteria: false,
         tooltipId: undefined,
-        showShareModal: false
+        currentModal: CurrentModal.None
       };
     }
 
@@ -498,7 +506,7 @@ export const HelpSidebar = fp.flow(
               disabled={isNotOwner}
               onClick={() => {
                 AnalyticsTracker.Workspaces.OpenShareModal();
-                this.setState({showShareModal: true});
+                this.setState({currentModal: CurrentModal.Share});
               }}>
               Share
             </MenuItem>
@@ -508,7 +516,7 @@ export const HelpSidebar = fp.flow(
               disabled={isNotOwner}
               onClick={() => {
                 AnalyticsTracker.Workspaces.OpenDeleteModal();
-                deleteFunction();
+                this.setState({currentModal: CurrentModal.Delete});
               }}>
               Delete
             </MenuItem>
@@ -872,7 +880,12 @@ export const HelpSidebar = fp.flow(
           </CSSTransition>
         </TransitionGroup>
 
-        {this.state.showShareModal && <WorkspaceShare onClose={() => this.setState({showShareModal: false})}/>}
+        {this.state.currentModal === CurrentModal.Share && <WorkspaceShare onClose={() => this.setState({currentModal: CurrentModal.None})}/>}
+
+        {this.state.currentModal === CurrentModal.Delete && <ConfirmDeleteModal closeFunction={() => this.setState({currentModal: CurrentModal.None})}
+                                                           resourceType={ResourceType.WORKSPACE}
+                                                           receiveDelete={() => {console.log('hello !')}}
+                                                           resourceName={this.props.workspace.name}/>}
       </div>;
     }
   }

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -285,7 +285,7 @@ export const HelpSidebar = fp.flow(
 
     deleteWorkspace = withErrorModal({
       title: 'Error Deleting Workspace',
-      message: 'Error',
+      message: `Could not delete workspace '${this.props.workspace.name}'.`,
       showBugReportLink: true
     }, async() => {
       AnalyticsTracker.Workspaces.Delete();

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -56,9 +56,12 @@ import {WorkspaceData} from 'app/utils/workspace-data';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
 
+import {Clickable, MenuItem, StyledAnchorTag} from 'app/components/buttons';
+import {ConfirmDeleteModal} from 'app/components/confirm-delete-modal';
 import {GenomicsExtractionTable} from 'app/components/genomics-extraction-table';
 import {HelpTips} from 'app/components/help-tips';
 import {withErrorModal} from 'app/components/modals';
+import {Spinner} from 'app/components/spinners';
 import {WorkspaceShare} from 'app/pages/workspace/workspace-share';
 import {dataSetApi} from 'app/services/swagger-fetch-clients';
 import {workspacesApi} from 'app/services/swagger-fetch-clients';
@@ -67,13 +70,11 @@ import {navigate} from 'app/utils/navigation';
 import {
   CdrVersionTiersResponse,
   Criteria, GenomicExtractionJob,
-  ParticipantCohortStatus, ResourceType,
+  ParticipantCohortStatus,
+  ResourceType,
   RuntimeStatus, TerraJobStatus,
   WorkspaceAccessLevel
 } from 'generated/fetch';
-import {Clickable, MenuItem, StyledAnchorTag} from './buttons';
-import {ConfirmDeleteModal} from './confirm-delete-modal';
-import {Spinner} from './spinners';
 
 const LOCAL_STORAGE_KEY_SIDEBAR_STATE = 'WORKSPACE_SIDEBAR_STATE';
 
@@ -279,23 +280,13 @@ export const HelpSidebar = fp.flow(
       };
     }
 
-    get sidebarStyle() {
-      return {
-        ...styles.sidebar,
-        width: `${this.sidebarWidth}.5rem`,
-      };
-    }
-
-    get sidebarWidth() {
-      return fp.getOr('14', 'bodyWidthRem', this.sidebarContent(this.state.activeIcon));
-    }
     subscription: Subscription;
     private loadLastSavedKey: () => void;
 
     deleteWorkspace = withErrorModal({
       title: 'Error Deleting Workspace',
       message: 'Error',
-      showPromptBugReport: true
+      showBugReportLink: true
     }, async() => {
       AnalyticsTracker.Workspaces.Delete();
       await workspacesApi().deleteWorkspace(this.props.workspace.namespace, this.props.workspace.id);
@@ -707,6 +698,17 @@ export const HelpSidebar = fp.flow(
       </FlexRow>;
     }
 
+    get sidebarStyle() {
+      return {
+        ...styles.sidebar,
+        width: `${this.sidebarWidth}.5rem`,
+      };
+    }
+
+    get sidebarWidth() {
+      return fp.getOr('14', 'bodyWidthRem', this.sidebarContent(this.state.activeIcon));
+    }
+
     sidebarContent(activeIcon): {
       overflow?: string;
       headerPadding?: string;
@@ -913,9 +915,8 @@ export const HelpSidebar = fp.flow(
 })
 export class HelpSidebarComponent extends ReactWrapperBase {
   @Input('pageKey') pageKey: Props['pageKey'];
-  @Input('shareFunction') shareFunction: Props['shareFunction'];
 
   constructor() {
-    super(HelpSidebar, ['pageKey', 'shareFunction']);
+    super(HelpSidebar, ['pageKey' ]);
   }
 }

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -71,6 +71,9 @@ import {
 import {Clickable, MenuItem, StyledAnchorTag} from './buttons';
 import {ConfirmDeleteModal} from './confirm-delete-modal';
 import {Spinner} from './spinners';
+import {workspacesApi} from 'app/services/swagger-fetch-clients';
+import {withErrorModal, withSuccessModal} from 'app/components/modals';
+import {navigate} from 'app/utils/navigation';
 
 const LOCAL_STORAGE_KEY_SIDEBAR_STATE = 'WORKSPACE_SIDEBAR_STATE';
 
@@ -250,7 +253,6 @@ interface State {
   searchTerm: string;
   showCriteria: boolean;
   tooltipId: number;
-  showShareModal: boolean;
   currentModal: CurrentModal;
 }
 
@@ -388,6 +390,14 @@ export const HelpSidebar = fp.flow(
         localStorage.removeItem(LOCAL_STORAGE_KEY_SIDEBAR_STATE);
       }
     }
+
+    deleteWorkspace = withErrorModal({
+      title: 'Error Deleting Workspace',
+      message: 'Error'
+    }, async () => {
+      await workspacesApi().deleteWorkspace(this.props.workspace.namespace, this.props.workspace.id)
+      navigate(['/workspaces']);
+    })
 
     async componentDidMount() {
       const lastSavedKey = localStorage.getItem(LOCAL_STORAGE_KEY_SIDEBAR_STATE);
@@ -884,7 +894,7 @@ export const HelpSidebar = fp.flow(
 
         {this.state.currentModal === CurrentModal.Delete && <ConfirmDeleteModal closeFunction={() => this.setState({currentModal: CurrentModal.None})}
                                                            resourceType={ResourceType.WORKSPACE}
-                                                           receiveDelete={() => {console.log('hello !')}}
+                                                           receiveDelete={() => this.deleteWorkspace()}
                                                            resourceName={this.props.workspace.name}/>}
       </div>;
     }

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -227,7 +227,6 @@ const pageKeyToAnalyticsLabels = {
 };
 
 interface Props {
-  deleteFunction: Function;
   pageKey: string;
   profileState: any;
   shareFunction: Function;
@@ -393,11 +392,15 @@ export const HelpSidebar = fp.flow(
 
     deleteWorkspace = withErrorModal({
       title: 'Error Deleting Workspace',
-      message: 'Error'
+      message: 'Error',
+      showPromptBugReport: true
     }, async () => {
+      AnalyticsTracker.Workspaces.Delete();
       await workspacesApi().deleteWorkspace(this.props.workspace.namespace, this.props.workspace.id)
       navigate(['/workspaces']);
-    })
+    }, () => {
+      this.setState({currentModal: CurrentModal.None});
+    });
 
     async componentDidMount() {
       const lastSavedKey = localStorage.getItem(LOCAL_STORAGE_KEY_SIDEBAR_STATE);
@@ -483,7 +486,7 @@ export const HelpSidebar = fp.flow(
     }
 
     renderWorkspaceMenu() {
-      const {deleteFunction, workspace, workspace: {accessLevel, id, namespace}} = this.props;
+      const {workspace, workspace: {accessLevel, id, namespace}} = this.props;
       const isNotOwner = !workspace || accessLevel !== WorkspaceAccessLevel.OWNER;
       const tooltip = isNotOwner && 'Requires owner permission';
       return <PopupTrigger
@@ -906,11 +909,10 @@ export const HelpSidebar = fp.flow(
   template: '<div #root></div>',
 })
 export class HelpSidebarComponent extends ReactWrapperBase {
-  @Input('deleteFunction') deleteFunction: Props['deleteFunction'];
   @Input('pageKey') pageKey: Props['pageKey'];
   @Input('shareFunction') shareFunction: Props['shareFunction'];
 
   constructor() {
-    super(HelpSidebar, ['deleteFunction', 'pageKey', 'shareFunction']);
+    super(HelpSidebar, ['pageKey', 'shareFunction']);
   }
 }

--- a/ui/src/app/components/modals.tsx
+++ b/ui/src/app/components/modals.tsx
@@ -3,13 +3,13 @@ import * as React from 'react';
 import * as ReactModal from 'react-modal';
 
 import {Button} from 'app/components/buttons';
+import {SpinnerOverlay} from 'app/components/spinners';
 import colors from 'app/styles/colors';
 import {reactStyles, withStyle} from 'app/utils/index';
 import {notificationStore, NotificationStore, profileStore, useStore} from 'app/utils/stores';
+import {openZendeskWidget} from 'app/utils/zendesk';
 import * as fp from 'lodash/fp';
 import {animated, useSpring} from 'react-spring';
-import {SpinnerOverlay} from './spinners';
-import {openZendeskWidget} from "../utils/zendesk";
 
 const { useEffect} = React;
 

--- a/ui/src/app/components/modals.tsx
+++ b/ui/src/app/components/modals.tsx
@@ -10,6 +10,7 @@ import {notificationStore, NotificationStore, profileStore, useStore} from 'app/
 import {openZendeskWidget} from 'app/utils/zendesk';
 import * as fp from 'lodash/fp';
 import {animated, useSpring} from 'react-spring';
+import {TextColumn} from './text-column';
 
 const { useEffect} = React;
 
@@ -91,15 +92,16 @@ export const NotificationModal = () => {
   return notification && <Modal>
     <ModalTitle>{title}</ModalTitle>
     <ModalBody>
-      <div>{message}</div>
-      {showBugReportLink &&
-        <div>
-            Please <a onClick={() => {
-              openZendeskWidget(profile.givenName, profile.familyName, profile.username, profile.contactEmail);
-              notificationStore.set(null);
-            }}> submit a bug report. </a>
-        </div>
-      }
+        <TextColumn>
+          <div>{message}</div>
+          {showBugReportLink &&
+            <div style={{marginTop: '0.5rem'}}>
+                Please <a onClick={() => {
+                  openZendeskWidget(profile.givenName, profile.familyName, profile.username, profile.contactEmail);
+                  notificationStore.set(null);
+                }}> submit a bug report. </a>
+            </div>}
+        </TextColumn>
     </ModalBody>
     <ModalFooter>
       <Button onClick={() => notificationStore.set(null)}>OK</Button>

--- a/ui/src/app/components/modals.tsx
+++ b/ui/src/app/components/modals.tsx
@@ -5,10 +5,11 @@ import * as ReactModal from 'react-modal';
 import {Button} from 'app/components/buttons';
 import colors from 'app/styles/colors';
 import {reactStyles, withStyle} from 'app/utils/index';
-import {notificationStore, NotificationStore, useStore} from 'app/utils/stores';
+import {notificationStore, NotificationStore, profileStore, useStore} from 'app/utils/stores';
 import * as fp from 'lodash/fp';
 import {animated, useSpring} from 'react-spring';
 import {SpinnerOverlay} from './spinners';
+import {openZendeskWidget} from "../utils/zendesk";
 
 const { useEffect} = React;
 
@@ -82,24 +83,34 @@ export const ModalFooter = withStyle(styles.modalFooter)('div');
 // This modal is rendered when there is data present in the notificationStore - rendered at the router level until Angular is gone
 export const NotificationModal = () => {
   const notification = useStore(notificationStore);
-  const {title = '', message = '', onDismiss = fp.noop} = notification || {};
+  const profile = profileStore.get().profile;
+  const {title = '', message = '', showPromptBugReport = false, onDismiss = fp.noop} = notification || {};
 
   useEffect(() => onDismiss);
 
   return notification && <Modal>
     <ModalTitle>{title}</ModalTitle>
-    <ModalBody>{message}</ModalBody>
+    <ModalBody>
+      <div>{message}</div>
+      {showPromptBugReport &&
+        <div>Please <a onClick={() => {
+          openZendeskWidget(profile.givenName, profile.familyName, profile.username, profile.contactEmail);
+          notificationStore.set(null);
+        }}>submit a bug report.</a></div>
+      }
+    </ModalBody>
     <ModalFooter>
       <Button onClick={() => notificationStore.set(null)}>OK</Button>
     </ModalFooter>
   </Modal>;
 };
 
-export const withErrorModal = fp.curry((notificationState: NotificationStore, wrappedFn) => async(...args) => {
+export const withErrorModal = fp.curry((notificationState: NotificationStore, wrappedFn, onDismiss) => async(...args) => {
   try {
     return await wrappedFn(...args);
   } catch (e) {
     notificationStore.set(notificationState);
+    onDismiss();
   }
 });
 

--- a/ui/src/app/components/modals.tsx
+++ b/ui/src/app/components/modals.tsx
@@ -84,7 +84,7 @@ export const ModalFooter = withStyle(styles.modalFooter)('div');
 export const NotificationModal = () => {
   const notification = useStore(notificationStore);
   const profile = profileStore.get().profile;
-  const {title = '', message = '', showPromptBugReport = false, onDismiss = fp.noop} = notification || {};
+  const {title = '', message = '', showBugReportLink: showBugReportLink = false, onDismiss = fp.noop} = notification || {};
 
   useEffect(() => onDismiss);
 
@@ -92,11 +92,13 @@ export const NotificationModal = () => {
     <ModalTitle>{title}</ModalTitle>
     <ModalBody>
       <div>{message}</div>
-      {showPromptBugReport &&
-        <div>Please <a onClick={() => {
-          openZendeskWidget(profile.givenName, profile.familyName, profile.username, profile.contactEmail);
-          notificationStore.set(null);
-        }}>submit a bug report.</a></div>
+      {showBugReportLink &&
+        <div>
+            Please <a onClick={() => {
+              openZendeskWidget(profile.givenName, profile.familyName, profile.username, profile.contactEmail);
+              notificationStore.set(null);
+            }}> submit a bug report. </a>
+        </div>
       }
     </ModalBody>
     <ModalFooter>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.html
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.html
@@ -1,9 +1,8 @@
 <app-workspace-nav-bar *ngIf="displayNavBar" [tabPath]="tabPath"></app-workspace-nav-bar>
-<span *ngIf="menuDataLoading" class="spinner spinner-lg" style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);"></span>
 <ng-container *ngIf="workspace">
   <app-help-sidebar [pageKey]="pageKey"></app-help-sidebar>
   <div [style.margin-right]="pageKey ? '45px' : 0" [style.height]="pageKey && !contentFullHeightOverride ? 'auto': '100%'">
-    <router-outlet *ngIf="workspace"></router-outlet>
+    <router-outlet></router-outlet>
   </div>
 </ng-container>
 <div *ngIf="!workspace" style="position: absolute; top: 50%; left: 50%;" class="spinner"></div>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.html
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.html
@@ -1,24 +1,7 @@
 <app-workspace-nav-bar *ngIf="displayNavBar" [tabPath]="tabPath"></app-workspace-nav-bar>
 <span *ngIf="menuDataLoading" class="spinner spinner-lg" style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);"></span>
 <ng-container *ngIf="workspace">
-  <clr-modal [(clrModalOpen)]="workspaceDeletionError">
-    <h3 class="modal-title">Error:</h3>
-    <div class="modal-body">Could not delete workspace '{{workspace.name}}'. Please <a (click)="submitWorkspaceDeleteBugReport()">submit a bug report.</a></div>
-    <div class="modal-footer">
-      <button type="button" class="btn btn-primary" (click)="workspaceDeletionError = false">Ok</button>
-    </div>
-  </clr-modal>
-
-  <app-confirm-delete-modal *ngIf="confirmDeleting"
-                            [resourceType]="resourceType"
-                            [resourceName]="workspace.name"
-                            [receiveDelete]="receiveDelete"
-                            [closeFunction]="closeConfirmDelete"></app-confirm-delete-modal>
-  <app-bug-report *ngIf="bugReportOpen"
-                  [bugReportDescription]="bugReportDescription"
-                  [onClose]="closeBugReport"></app-bug-report>
-  <app-help-sidebar [deleteFunction]="openConfirmDelete"
-                    [pageKey]="pageKey"></app-help-sidebar>
+  <app-help-sidebar [pageKey]="pageKey"></app-help-sidebar>
   <div [style.margin-right]="pageKey ? '45px' : 0" [style.height]="pageKey && !contentFullHeightOverride ? 'auto': '100%'">
     <router-outlet *ngIf="workspace"></router-outlet>
   </div>

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -5,7 +5,6 @@ import * as fp from 'lodash/fp';
 import {workspacesApi} from 'app/services/swagger-fetch-clients';
 import {
   currentWorkspaceStore,
-  navigate,
   nextWorkspaceWarmupStore,
   routeConfigDataStore,
   setSidebarActiveIconStore,
@@ -14,9 +13,8 @@ import {
 
 import {routeDataStore, runtimeStore} from 'app/utils/stores';
 
-import {AnalyticsTracker} from 'app/utils/analytics';
 import {ExceededActionCountError, LeoRuntimeInitializer} from 'app/utils/leo-runtime-initializer';
-import {ResourceType, Workspace} from 'generated/fetch';
+import {Workspace} from 'generated/fetch';
 
 @Component({
   styleUrls: ['../../../styles/buttons.css',
@@ -25,21 +23,14 @@ import {ResourceType, Workspace} from 'generated/fetch';
 })
 export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   workspace: Workspace;
-  deleting = false;
-  workspaceDeletionError = false;
   tabPath: string;
   displayNavBar = true;
-  menuDataLoading = false;
-  resourceType: ResourceType = ResourceType.WORKSPACE;
   pageKey = 'data';
   pollAborter = new AbortController();
   // The iframe we use to display the Jupyter notebook does something strange
   // to the height calculation of the container, which is normally set to auto.
   // Setting this flag sets the container to 100% so that no content is clipped.
   contentFullHeightOverride = false;
-
-  bugReportOpen: boolean;
-  bugReportDescription = '';
 
   private subscriptions = [];
 

--- a/ui/src/app/pages/workspace/workspace-wrapper/component.ts
+++ b/ui/src/app/pages/workspace/workspace-wrapper/component.ts
@@ -29,7 +29,6 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   workspaceDeletionError = false;
   tabPath: string;
   displayNavBar = true;
-  confirmDeleting = false;
   menuDataLoading = false;
   resourceType: ResourceType = ResourceType.WORKSPACE;
   pageKey = 'data';
@@ -47,12 +46,7 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
   constructor(
     private route: ActivatedRoute,
     private router: Router,
-  ) {
-    this.openConfirmDelete = this.openConfirmDelete.bind(this);
-    this.receiveDelete = this.receiveDelete.bind(this);
-    this.closeConfirmDelete = this.closeConfirmDelete.bind(this);
-    this.closeBugReport = this.closeBugReport.bind(this);
-  }
+  ) {}
 
   ngOnInit(): void {
 
@@ -175,40 +169,6 @@ export class WorkspaceWrapperComponent implements OnInit, OnDestroy {
       return path;
     }
     return path.slice(0, path.indexOf('/'));
-  }
-
-  delete(workspace: Workspace): void {
-    this.deleting = true;
-    workspacesApi().deleteWorkspace(
-      workspace.namespace, workspace.id).then(() => {
-        navigate(['/workspaces']);
-      }).catch(() => {
-        this.workspaceDeletionError = true;
-      });
-  }
-
-  receiveDelete(): void {
-    AnalyticsTracker.Workspaces.Delete();
-    this.delete(this.workspace);
-  }
-
-  openConfirmDelete(): void {
-    this.confirmDeleting = true;
-  }
-
-  closeConfirmDelete(): void {
-    this.confirmDeleting = false;
-  }
-
-  submitWorkspaceDeleteBugReport(): void {
-    this.workspaceDeletionError = false;
-    // this.bugReportComponent.reportBug();
-    this.bugReportDescription = 'Could not delete workspace.';
-    this.bugReportOpen = true;
-  }
-
-  closeBugReport(): void {
-    this.bugReportOpen = false;
   }
 
   // This function does multiple things so we don't have to have two separate'

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -72,11 +72,10 @@ export const profileStore = atom<ProfileStore>({
   })
 });
 
-
 export interface NotificationStore {
   title: string;
   message: string;
-  showPromptBugReport?: boolean;
+  showBugReportLink?: boolean;
   onDismiss?: () => void;
 }
 

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -76,6 +76,7 @@ export const profileStore = atom<ProfileStore>({
 export interface NotificationStore {
   title: string;
   message: string;
+  showPromptBugReport?: boolean;
   onDismiss?: () => void;
 }
 


### PR DESCRIPTION
Trimming down the code in workspace-wrapper by moving it into help sidebar which is where the action is being rendered.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
