### PR TITLE
[RW-5256][risk=no] Move main Cohort Builder 'build' route to React router

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -1,9 +1,9 @@
 import {NgModule} from '@angular/core';
 import {NavigationEnd, Router, RouterModule, Routes} from '@angular/router';
 
+import {NavigationGuard} from 'app/guards/navigation-guard';
 import {AppRouting} from './app-routing';
 import {CanDeactivateGuard} from './guards/can-deactivate-guard.service';
-import {NavigationGuard} from './guards/navigation-guard';
 import {RegistrationGuard} from './guards/registration-guard.service';
 import {SignInGuard} from './guards/sign-in-guard.service';
 

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -3,10 +3,10 @@ import {NavigationEnd, Router, RouterModule, Routes} from '@angular/router';
 
 import {AppRouting} from './app-routing';
 import {CanDeactivateGuard} from './guards/can-deactivate-guard.service';
+import {NavigationGuard} from './guards/navigation-guard';
 import {RegistrationGuard} from './guards/registration-guard.service';
 import {SignInGuard} from './guards/sign-in-guard.service';
 
-import {CohortPageComponent} from './cohort-search/cohort-page/cohort-page.component';
 import {ConceptSearchComponent} from './pages/data/concept/concept-search';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceWrapperComponent} from './pages/workspace/workspace-wrapper/component';
@@ -49,6 +49,7 @@ const routes: Routes = [
     component: SignedInComponent,
     canActivate: [SignInGuard],
     canActivateChild: [SignInGuard, DisabledGuard],
+    canDeactivate: [NavigationGuard],
     runGuardsAndResolvers: 'always',
     children: [
       // legacy / duplicated routes go HERE
@@ -187,13 +188,8 @@ const routes: Routes = [
                             children: [
                               {
                                 path: '',
-                                component: CohortPageComponent,
-                                canDeactivate: [CanDeactivateGuard],
-                                data: {
-                                  title: 'Build Cohort Criteria',
-                                  breadcrumb: BreadcrumbType.CohortAdd,
-                                  pageKey: 'cohortBuilder'
-                                }
+                                component: AppRouting,
+                                data: {}
                               },
                             ]
                           },

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -1,4 +1,5 @@
 import {Component as AComponent} from '@angular/core';
+import {CohortPage} from 'app/cohort-search/cohort-page/cohort-page.component';
 import {AppRoute, AppRouter, Guard, Navigate, ProtectedRoutes, withFullHeight, withRouteData} from 'app/components/app-router';
 import {AccessRenewalPage} from 'app/pages/access/access-renewal-page';
 import {WorkspaceAudit} from 'app/pages/admin/admin-workspace-audit';
@@ -15,7 +16,6 @@ import {serverConfigStore} from 'app/utils/stores';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 import {Redirect} from 'react-router';
-import {CohortPage} from './cohort-search/cohort-page/cohort-page.component';
 import {NOTEBOOK_PAGE_KEY} from './components/help-sidebar';
 import {NotificationModal} from './components/modals';
 import {AdminBanner} from './pages/admin/admin-banner';

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -15,6 +15,7 @@ import {serverConfigStore} from 'app/utils/stores';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 import {Redirect} from 'react-router';
+import {CohortPage} from './cohort-search/cohort-page/cohort-page.component';
 import {NOTEBOOK_PAGE_KEY} from './components/help-sidebar';
 import {NotificationModal} from './components/modals';
 import {AdminBanner} from './pages/admin/admin-banner';
@@ -68,6 +69,7 @@ const expiredGuard: Guard = {
 const AdminBannerPage = withRouteData(AdminBanner);
 const AdminNotebookViewPage = withRouteData(AdminNotebookView);
 const AdminReviewWorkspacePage = withRouteData(AdminReviewWorkspace);
+const CohortPagePage = withRouteData(CohortPage);
 const CohortActionsPage = withRouteData(CohortActions);
 const CohortReviewPage = withRouteData(CohortReview);
 const ConceptHomepagePage = withRouteData(ConceptHomepage);
@@ -323,6 +325,14 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
               breadcrumb: BreadcrumbType.Dataset,
               pageKey: 'datasetBuilder'
             }}/>}
+          />
+          <AppRoute
+              path='/workspaces/:ns/:wsid/data/cohorts/build'
+              component={() => <CohortPagePage routeData={{
+                title: 'Build Cohort Criteria',
+                breadcrumb: BreadcrumbType.CohortAdd,
+                pageKey: 'cohortBuilder'
+              }}/>}
           />
           <AppRoute
             path='/workspaces/:ns/:wsid/data/cohorts/:cid/actions'

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -9,12 +9,13 @@ import {WorkspaceWrapperComponent} from 'app/pages/workspace/workspace-wrapper/c
 import * as StackTrace from 'stacktrace-js';
 
 import {CanDeactivateGuard} from './guards/can-deactivate-guard.service';
+import {NavigationGuard} from './guards/navigation-guard';
 import {SignInService} from './services/sign-in.service';
 import {WINDOW_REF} from './utils';
 import {WorkbenchRouteReuseStrategy} from './utils/navigation';
 
 import {AppRouting} from './app-routing';
-import {CohortPageComponent} from './cohort-search/cohort-page/cohort-page.component';
+// import {CohortPageComponent} from './cohort-search/cohort-page/cohort-page.component';
 import {BugReportComponent} from './components/bug-report';
 import {ConfirmDeleteModalComponent} from './components/confirm-delete-modal';
 import {HelpSidebarComponent} from './components/help-sidebar';
@@ -55,7 +56,7 @@ import {FooterComponent} from './components/footer';
     AppComponent,
     AppRouting,
     BugReportComponent,
-    CohortPageComponent,
+//    CohortPageComponent,
     ConceptSearchComponent,
     ConfirmDeleteModalComponent,
     FooterComponent,
@@ -76,7 +77,8 @@ import {FooterComponent} from './components/footer';
     },
     WorkbenchRouteReuseStrategy,
     {provide: RouteReuseStrategy, useExisting: WorkbenchRouteReuseStrategy},
-    CanDeactivateGuard
+    CanDeactivateGuard,
+    NavigationGuard
   ],
   // This specifies the top-level components, to load first.
   bootstrap: [AppComponent, InitialErrorComponent]

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -8,14 +8,13 @@ import {ClarityModule} from '@clr/angular';
 import {WorkspaceWrapperComponent} from 'app/pages/workspace/workspace-wrapper/component';
 import * as StackTrace from 'stacktrace-js';
 
+import {NavigationGuard} from 'app/guards/navigation-guard';
 import {CanDeactivateGuard} from './guards/can-deactivate-guard.service';
-import {NavigationGuard} from './guards/navigation-guard';
 import {SignInService} from './services/sign-in.service';
 import {WINDOW_REF} from './utils';
 import {WorkbenchRouteReuseStrategy} from './utils/navigation';
 
 import {AppRouting} from './app-routing';
-// import {CohortPageComponent} from './cohort-search/cohort-page/cohort-page.component';
 import {BugReportComponent} from './components/bug-report';
 import {ConfirmDeleteModalComponent} from './components/confirm-delete-modal';
 import {HelpSidebarComponent} from './components/help-sidebar';
@@ -56,7 +55,6 @@ import {FooterComponent} from './components/footer';
     AppComponent,
     AppRouting,
     BugReportComponent,
-//    CohortPageComponent,
     ConceptSearchComponent,
     ConfirmDeleteModalComponent,
     FooterComponent,

--- a/ui/src/app/cohort-search/cohort-page/cohort-page.component.tsx
+++ b/ui/src/app/cohort-search/cohort-page/cohort-page.component.tsx
@@ -246,15 +246,11 @@ export const CohortPage = fp.flow(withCurrentWorkspace(), withCurrentCohortSearc
                       cohortChanged={cohortChanged}
                       searchRequest={criteria}
                       updateCount={updateCount}
-                      updating={() => {
-                        this.setState({updatingCohort: true});
-                      }}/>}
+                      updating={() => this.setState({updatingCohort: true})}/>}
                 </div>
                 {loading && <SpinnerOverlay/>}
               </FlexRowWrap>
-              {this.showCohortSearch && <CohortSearch setUnsavedChanges={(unsaved) => {
-                this.setState({unsavedSelections: unsaved});
-              }}/>}
+              {this.showCohortSearch && <CohortSearch setUnsavedChanges={(unsaved) => this.setState({unsavedSelections: unsaved})}/>}
             </React.Fragment>
           }
         </div>

--- a/ui/src/app/guards/navigation-guard.tsx
+++ b/ui/src/app/guards/navigation-guard.tsx
@@ -1,0 +1,16 @@
+import {Injectable} from '@angular/core';
+import {CanDeactivate} from '@angular/router';
+import {navigationGuardStore} from 'app/utils/stores';
+
+@Injectable()
+export class NavigationGuard implements CanDeactivate<any> {
+  canDeactivate(): Promise<boolean> | boolean {
+    const navigationGuardedComponent = navigationGuardStore.get() && navigationGuardStore.get().component;
+
+    if (navigationGuardedComponent) {
+      return navigationGuardedComponent.canDeactivate();
+    }
+
+    return true;
+  }
+}

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -1,3 +1,4 @@
+import {CanComponentDeactivate} from 'app/guards/can-deactivate-guard.service';
 import {profileApi} from 'app/services/swagger-fetch-clients';
 import { BreadcrumbType } from 'app/utils/navigation';
 import {atom, Atom} from 'app/utils/subscribable';
@@ -136,6 +137,11 @@ export interface ServerConfigStore {
 
 export const serverConfigStore = atom<ServerConfigStore>({});
 
+export interface NavigationGuardStore {
+  component?: CanComponentDeactivate;
+}
+
+export const navigationGuardStore = atom<NavigationGuardStore>({});
 
 /**
  * @name useStore


### PR DESCRIPTION
### Approach 

React components can register themselves with the `NavigationGuardStore` to let the application know that it could have state that should be saved before navigating away. Components should also unregister themselves on unmount.

A high level Angular guard will read from the `NavigationGuardStore` and run the `canDeactivate` check to see if the underlying page should show a warning modal or not.

The solution does use some angular code but it's only used at the root route so all the child components that were blocked on a working `CanDeactivateGuard` should be able to be converted now.



---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
