### PR TITLE
[RW-6948][risk=no] e2e test goto navigation timeout speculative fix

### DIFF
--- a/e2e/app/page/base-page.ts
+++ b/e2e/app/page/base-page.ts
@@ -26,7 +26,7 @@ export default abstract class BasePage {
    * Load a URL.
    */
   async gotoUrl(url: string): Promise<void> {
-    await this.page.goto(url, { waitUntil: ['networkidle0', 'load'] });
+    await this.page.goto(url, { waitUntil: ['load'] });
   }
 
   /**

--- a/e2e/app/page/base-page.ts
+++ b/e2e/app/page/base-page.ts
@@ -1,4 +1,5 @@
 import { Page, Response } from 'puppeteer';
+import { logger } from 'libs/logger';
 
 /**
  * All Page Object classes will extends the BasePage.
@@ -26,7 +27,10 @@ export default abstract class BasePage {
    * Load a URL.
    */
   async gotoUrl(url: string): Promise<void> {
-    await this.page.goto(url, { waitUntil: ['load'] });
+    const response = await this.page.goto(url, { waitUntil: ['load'] });
+    if (response) {
+      logger.info(`Goto URL: ${url} Response: ${response.status()} ${await response.text()}`);
+    }
   }
 
   /**

--- a/e2e/jest.test-setup.ts
+++ b/e2e/jest.test-setup.ts
@@ -20,7 +20,7 @@ beforeEach(async () => {
   await page.deleteCookie(...(await page.cookies()));
   await page.setUserAgent(userAgent);
   await page.setViewport({ width: 1300, height: 0 });
-  page.setDefaultNavigationTimeout(60000); // Puppeteer default timeout is 30 seconds.
+  page.setDefaultNavigationTimeout(90000); // Puppeteer default timeout is 30 seconds.
   await page.setRequestInterception(true);
 
   /**


### PR DESCRIPTION
Failed CircleCi [job](https://app.circleci.com/pipelines/github/all-of-us/workbench/11257/workflows/d324818d-ec7d-4dc9-a739-c0b629d7b0b6/jobs/146476/tests).

Error was
`TimeoutError: Navigation timeout of 60000 ms exceeded
    at /home/circleci/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/LifecycleWatcher.js:106:111`

I think it is caused by a recent merge [pull/5110](https://github.com/all-of-us/workbench/pull/5110) that enabled navigation timeout.

Fix:
Remove `networkidle0` in goto func; Increase max nav timeout; Log goto response object to help with failure investigation if happen again.