### PR TITLE
[RW-6919][risk=moderate] Cache Firecloud group lookups

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
@@ -129,7 +129,7 @@ public class AccessTierServiceImpl implements AccessTierService {
   private void addToAuthDomainIdempotent(DbUser dbUser, DbAccessTier accessTier) {
     final String username = dbUser.getUsername();
     final String authDomainName = accessTier.getAuthDomainName();
-    if (!fireCloudService.isUserMemberOfGroup(username, authDomainName)) {
+    if (!fireCloudService.isUserMemberOfGroupWithCache(username, authDomainName)) {
       fireCloudService.addUserToGroup(username, authDomainName);
       log.info(
           String.format(
@@ -140,7 +140,7 @@ public class AccessTierServiceImpl implements AccessTierService {
   private void removeFromAuthDomainIdempotent(DbUser dbUser, DbAccessTier accessTier) {
     final String username = dbUser.getUsername();
     final String authDomainName = accessTier.getAuthDomainName();
-    if (fireCloudService.isUserMemberOfGroup(username, authDomainName)) {
+    if (fireCloudService.isUserMemberOfGroupWithCache(username, authDomainName)) {
       fireCloudService.removeUserFromGroup(username, authDomainName);
       log.info(
           String.format(

--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -213,8 +213,7 @@ public class UserController implements UserApiDelegate {
       throw new ServerErrorException("Could not retrieve billing accounts list from Google Cloud");
     }
 
-    return Optional.ofNullable(response.getBillingAccounts())
-        .orElse(Collections.emptyList())
+    return Optional.ofNullable(response.getBillingAccounts()).orElse(Collections.emptyList())
         .stream()
         .map(
             googleBillingAccount ->

--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -160,7 +160,7 @@ public class UserController implements UserApiDelegate {
         .anyMatch(
             tier ->
                 tier.getShortName().equals(AccessTierService.REGISTERED_TIER_SHORT_NAME)
-                    && fireCloudService.isUserMemberOfGroup(
+                    && fireCloudService.isUserMemberOfGroupWithCache(
                         userProvider.get().getUsername(), tier.getAuthDomainName()));
   }
 
@@ -213,7 +213,8 @@ public class UserController implements UserApiDelegate {
       throw new ServerErrorException("Could not retrieve billing accounts list from Google Cloud");
     }
 
-    return Optional.ofNullable(response.getBillingAccounts()).orElse(Collections.emptyList())
+    return Optional.ofNullable(response.getBillingAccounts())
+        .orElse(Collections.emptyList())
         .stream()
         .map(
             googleBillingAccount ->

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
@@ -62,7 +62,7 @@ public class CdrVersionService {
     }
 
     String authorizationDomain = version.getAccessTier().getAuthDomainName();
-    if (!fireCloudService.isUserMemberOfGroup(
+    if (!fireCloudService.isUserMemberOfGroupWithCache(
         userProvider.get().getUsername(), authorizationDomain)) {
       throw new ForbiddenException(
           "Requester is not a member of " + authorizationDomain + ", cannot access CDR");

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudCacheConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudCacheConfig.java
@@ -1,0 +1,42 @@
+package org.pmiops.workbench.firecloud;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import java.util.concurrent.TimeUnit;
+import org.pmiops.workbench.firecloud.api.GroupsApi;
+import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupWithMembers;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Configuration
+public class FireCloudCacheConfig {
+  public static final String SERVICE_ACCOUNT_REQUEST_SCOPED_GROUP_CACHE = "firecloudGroupCache";
+
+  /**
+   * @return a request scoped cache of firecloud groups, by group name. Groups are lazily populated
+   *     as requested in the cache, and will expire after a duration. Lazy fetch is authenticated as
+   *     the service, so this should only be used for trusted internal checks (not on arbitrary user
+   *     inputs).
+   */
+  @Bean(name = SERVICE_ACCOUNT_REQUEST_SCOPED_GROUP_CACHE)
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  public LoadingCache<String, FirecloudManagedGroupWithMembers> firecloudGroupCache(
+      final @Qualifier(FireCloudConfig.SERVICE_ACCOUNT_GROUPS_API) GroupsApi groupsApi) {
+    return CacheBuilder.newBuilder()
+        .expireAfterWrite(30, TimeUnit.SECONDS)
+        // Set a small limit, as groups are large, and our system doesn't use many. If we start
+        // using groups more broadly, this limit could be reconsidered.
+        .maximumSize(10)
+        .build(
+            new CacheLoader<String, FirecloudManagedGroupWithMembers>() {
+              @Override
+              public FirecloudManagedGroupWithMembers load(String groupName) throws Exception {
+                return groupsApi.getGroup(groupName);
+              }
+            });
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
@@ -54,7 +54,7 @@ public class FireCloudConfig {
       "serviceAccountStaticNotebooksApi";
   public static final String END_USER_STATIC_NOTEBOOKS_API = "endUserStaticNotebooksApi";
 
-  public static final String SERVICE_ACCOUNT_GROUP_CACHE = "firecloudGroupCache";
+  public static final String SERVICE_ACCOUNT_REQUEST_SCOPED_GROUP_CACHE = "firecloudGroupCache";
 
   public static final List<String> TERRA_SCOPES =
       ImmutableList.of(
@@ -69,9 +69,11 @@ public class FireCloudConfig {
 
   /**
    * @return a request scoped cache of firecloud groups, by group name. Groups are lazily populated
-   *     as requested in the cache, and will expire after a duration
+   *     as requested in the cache, and will expire after a duration. Lazy fetch is authenticated as
+   *     the service, so this should only be used for trusted internal checks (not on arbitrary user
+   *     inputs).
    */
-  @Bean(name = SERVICE_ACCOUNT_GROUP_CACHE)
+  @Bean(name = SERVICE_ACCOUNT_REQUEST_SCOPED_GROUP_CACHE)
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   public LoadingCache<String, FirecloudManagedGroupWithMembers> firecloudGroupCache(
       final @Qualifier(SERVICE_ACCOUNT_GROUPS_API) GroupsApi groupsApi) {

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudConfig.java
@@ -68,8 +68,8 @@ public class FireCloudConfig {
           .build();
 
   /**
-   * @return a request scoped cache of firecloud groups, by group name, consumers should expect this
-   *     map to either be empty, or to have been populated within the span of this request
+   * @return a request scoped cache of firecloud groups, by group name. Groups are lazily populated
+   *     as requested in the cache, and will expire after a duration
    */
   @Bean(name = SERVICE_ACCOUNT_GROUP_CACHE)
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
@@ -77,6 +77,8 @@ public class FireCloudConfig {
       final @Qualifier(SERVICE_ACCOUNT_GROUPS_API) GroupsApi groupsApi) {
     return CacheBuilder.newBuilder()
         .expireAfterWrite(30, TimeUnit.SECONDS)
+        // Set a small limit, as groups are large, and our system doesn't use many. If we start
+        // using groups more broadly, this limit could be reconsidered.
         .maximumSize(10)
         .build(
             new CacheLoader<String, FirecloudManagedGroupWithMembers>() {

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -102,7 +102,7 @@ public interface FireCloudService {
 
   void removeUserFromGroup(String email, String groupName);
 
-  boolean isUserMemberOfGroup(String email, String groupName);
+  boolean isUserMemberOfGroupWithCache(String email, String groupName);
 
   String staticNotebooksConvert(byte[] notebook);
 

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -64,7 +64,8 @@ public class FireCloudServiceImpl implements FireCloudService {
   private final Provider<NihApi> nihApiProvider;
   private final Provider<ProfileApi> profileApiProvider;
   private final Provider<StatusApi> statusApiProvider;
-  private final Provider<LoadingCache<String, FirecloudManagedGroupWithMembers>> groupCacheProvider;
+  private final Provider<LoadingCache<String, FirecloudManagedGroupWithMembers>>
+      requestScopedGroupCacheProvider;
 
   // We call some of the endpoints in these APIs with the user's credentials
   // and others with the app's Service Account credentials
@@ -128,8 +129,9 @@ public class FireCloudServiceImpl implements FireCloudService {
           Provider<StaticNotebooksApi> endUserStaticNotebooksApiProvider,
       @Qualifier(FireCloudConfig.SERVICE_ACCOUNT_STATIC_NOTEBOOKS_API)
           Provider<StaticNotebooksApi> serviceAccountStaticNotebooksApiProvider,
-      @Qualifier(FireCloudConfig.SERVICE_ACCOUNT_GROUP_CACHE)
-          Provider<LoadingCache<String, FirecloudManagedGroupWithMembers>> groupCacheProvider,
+      @Qualifier(FireCloudConfig.SERVICE_ACCOUNT_REQUEST_SCOPED_GROUP_CACHE)
+          Provider<LoadingCache<String, FirecloudManagedGroupWithMembers>>
+              requestScopedGroupCacheProvider,
       FirecloudRetryHandler retryHandler,
       IamCredentialsClient iamCredentialsClient,
       HttpTransport httpTransport) {
@@ -145,7 +147,7 @@ public class FireCloudServiceImpl implements FireCloudService {
     this.retryHandler = retryHandler;
     this.endUserStaticNotebooksApiProvider = endUserStaticNotebooksApiProvider;
     this.serviceAccountStaticNotebooksApiProvider = serviceAccountStaticNotebooksApiProvider;
-    this.groupCacheProvider = groupCacheProvider;
+    this.requestScopedGroupCacheProvider = requestScopedGroupCacheProvider;
     this.iamCredentialsClient = iamCredentialsClient;
     this.httpTransport = httpTransport;
   }
@@ -490,7 +492,7 @@ public class FireCloudServiceImpl implements FireCloudService {
         (context) -> {
           FirecloudManagedGroupWithMembers group = null;
           try {
-            group = groupCacheProvider.get().get(groupName);
+            group = requestScopedGroupCacheProvider.get().get(groupName);
           } catch (ExecutionException e) {
             // This is not expected, but might be possible if we access an entry at the exact time
             // at which is is expiring from the cache. Just retry.

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -6,10 +6,12 @@ import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.inject.Provider;
@@ -45,6 +47,7 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceRequestClone;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.retry.RetryException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -61,6 +64,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   private final Provider<NihApi> nihApiProvider;
   private final Provider<ProfileApi> profileApiProvider;
   private final Provider<StatusApi> statusApiProvider;
+  private final Provider<LoadingCache<String, FirecloudManagedGroupWithMembers>> groupCacheProvider;
 
   // We call some of the endpoints in these APIs with the user's credentials
   // and others with the app's Service Account credentials
@@ -124,6 +128,8 @@ public class FireCloudServiceImpl implements FireCloudService {
           Provider<StaticNotebooksApi> endUserStaticNotebooksApiProvider,
       @Qualifier(FireCloudConfig.SERVICE_ACCOUNT_STATIC_NOTEBOOKS_API)
           Provider<StaticNotebooksApi> serviceAccountStaticNotebooksApiProvider,
+      @Qualifier(FireCloudConfig.SERVICE_ACCOUNT_GROUP_CACHE)
+          Provider<LoadingCache<String, FirecloudManagedGroupWithMembers>> groupCacheProvider,
       FirecloudRetryHandler retryHandler,
       IamCredentialsClient iamCredentialsClient,
       HttpTransport httpTransport) {
@@ -139,6 +145,7 @@ public class FireCloudServiceImpl implements FireCloudService {
     this.retryHandler = retryHandler;
     this.endUserStaticNotebooksApiProvider = endUserStaticNotebooksApiProvider;
     this.serviceAccountStaticNotebooksApiProvider = serviceAccountStaticNotebooksApiProvider;
+    this.groupCacheProvider = groupCacheProvider;
     this.iamCredentialsClient = iamCredentialsClient;
     this.httpTransport = httpTransport;
   }
@@ -478,10 +485,17 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public boolean isUserMemberOfGroup(String email, String groupName) {
+  public boolean isUserMemberOfGroupWithCache(String email, String groupName) {
     return retryHandler.run(
         (context) -> {
-          FirecloudManagedGroupWithMembers group = groupsApiProvider.get().getGroup(groupName);
+          FirecloudManagedGroupWithMembers group = null;
+          try {
+            group = groupCacheProvider.get().get(groupName);
+          } catch (ExecutionException e) {
+            // This is not expected, but might be possible if we access an entry at the exact time
+            // at which is is expiring from the cache. Just retry.
+            throw new RetryException("cache concurrent access failure", e);
+          }
           return group.getMembersEmails().contains(email)
               || group.getAdminsEmails().contains(email);
         });

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -129,7 +129,7 @@ public class FireCloudServiceImpl implements FireCloudService {
           Provider<StaticNotebooksApi> endUserStaticNotebooksApiProvider,
       @Qualifier(FireCloudConfig.SERVICE_ACCOUNT_STATIC_NOTEBOOKS_API)
           Provider<StaticNotebooksApi> serviceAccountStaticNotebooksApiProvider,
-      @Qualifier(FireCloudConfig.SERVICE_ACCOUNT_REQUEST_SCOPED_GROUP_CACHE)
+      @Qualifier(FireCloudCacheConfig.SERVICE_ACCOUNT_REQUEST_SCOPED_GROUP_CACHE)
           Provider<LoadingCache<String, FirecloudManagedGroupWithMembers>>
               requestScopedGroupCacheProvider,
       FirecloudRetryHandler retryHandler,

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -126,7 +126,7 @@ public class UserControllerTest extends SpringTest {
 
   @Test
   public void testUnregistered() {
-    when(fireCloudService.isUserMemberOfGroup(any(), any())).thenReturn(false);
+    when(fireCloudService.isUserMemberOfGroupWithCache(any(), any())).thenReturn(false);
     assertThrows(
         ForbiddenException.class,
         () -> userController.user("Robinson", null, null, null).getBody());
@@ -134,7 +134,7 @@ public class UserControllerTest extends SpringTest {
 
   @Test
   public void testUserSearch() {
-    when(fireCloudService.isUserMemberOfGroup(any(), any())).thenReturn(true);
+    when(fireCloudService.isUserMemberOfGroupWithCache(any(), any())).thenReturn(true);
     DbUser john = userDao.findUserByUsername("john@lis.org");
 
     UserResponse response = userController.user("John", null, null, null).getBody();
@@ -145,7 +145,7 @@ public class UserControllerTest extends SpringTest {
 
   @Test
   public void testUserPartialStringSearch() {
-    when(fireCloudService.isUserMemberOfGroup(any(), any())).thenReturn(true);
+    when(fireCloudService.isUserMemberOfGroupWithCache(any(), any())).thenReturn(true);
     List<DbUser> allUsers = Lists.newArrayList(userDao.findAll());
 
     UserResponse response = userController.user("obin", null, null, null).getBody();
@@ -157,14 +157,14 @@ public class UserControllerTest extends SpringTest {
 
   @Test
   public void testUserEmptyResponse() {
-    when(fireCloudService.isUserMemberOfGroup(any(), any())).thenReturn(true);
+    when(fireCloudService.isUserMemberOfGroupWithCache(any(), any())).thenReturn(true);
     UserResponse response = userController.user("", null, null, null).getBody();
     assertThat(response.getUsers()).hasSize(0);
   }
 
   @Test
   public void testUserNoUsersResponse() {
-    when(fireCloudService.isUserMemberOfGroup(any(), any())).thenReturn(true);
+    when(fireCloudService.isUserMemberOfGroupWithCache(any(), any())).thenReturn(true);
     UserResponse response = userController.user("Smith", null, null, null).getBody();
     assertThat(response.getUsers()).hasSize(0);
   }
@@ -195,7 +195,7 @@ public class UserControllerTest extends SpringTest {
 
   @Test
   public void testUserPageSize() {
-    when(fireCloudService.isUserMemberOfGroup(any(), any())).thenReturn(true);
+    when(fireCloudService.isUserMemberOfGroupWithCache(any(), any())).thenReturn(true);
     int size = 1;
     UserResponse robinsons_0 =
         userController.user("Robinson", PaginationToken.of(0).toBase64(), size, null).getBody();
@@ -222,7 +222,7 @@ public class UserControllerTest extends SpringTest {
 
   @Test
   public void testUserPagedResponses() {
-    when(fireCloudService.isUserMemberOfGroup(any(), any())).thenReturn(true);
+    when(fireCloudService.isUserMemberOfGroupWithCache(any(), any())).thenReturn(true);
     UserResponse robinsons_0_1 =
         userController.user("Robinson", PaginationToken.of(0).toBase64(), 2, null).getBody();
     UserResponse robinsons_2_3 =
@@ -243,7 +243,7 @@ public class UserControllerTest extends SpringTest {
 
   @Test
   public void testUserSort() {
-    when(fireCloudService.isUserMemberOfGroup(any(), any())).thenReturn(true);
+    when(fireCloudService.isUserMemberOfGroupWithCache(any(), any())).thenReturn(true);
     UserResponse robinsonsAsc = userController.user("Robinson", null, null, "asc").getBody();
     UserResponse robinsonsDesc = userController.user("Robinson", null, null, "desc").getBody();
 

--- a/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
@@ -177,7 +177,7 @@ public class CdrVersionServiceTest {
         ForbiddenException.class,
         () -> {
           accessTierService.addUserToTier(user, registeredTier);
-          when(fireCloudService.isUserMemberOfGroup(
+          when(fireCloudService.isUserMemberOfGroupWithCache(
                   user.getUsername(), registeredTier.getAuthDomainName()))
               .thenReturn(false);
           cdrVersionService.setCdrVersion(defaultCdrVersion);
@@ -190,7 +190,7 @@ public class CdrVersionServiceTest {
         ForbiddenException.class,
         () -> {
           accessTierService.addUserToTier(user, registeredTier);
-          when(fireCloudService.isUserMemberOfGroup(
+          when(fireCloudService.isUserMemberOfGroupWithCache(
                   user.getUsername(), registeredTier.getAuthDomainName()))
               .thenReturn(false);
           cdrVersionService.setCdrVersion(defaultCdrVersion.getCdrVersionId());
@@ -238,7 +238,7 @@ public class CdrVersionServiceTest {
         ForbiddenException.class,
         () -> {
           accessTierService.addUserToTier(user, controlledTier);
-          when(fireCloudService.isUserMemberOfGroup(
+          when(fireCloudService.isUserMemberOfGroupWithCache(
                   user.getUsername(), controlledTier.getAuthDomainName()))
               .thenReturn(false);
           cdrVersionService.setCdrVersion(controlledCdrVersion);
@@ -251,7 +251,7 @@ public class CdrVersionServiceTest {
         ForbiddenException.class,
         () -> {
           accessTierService.addUserToTier(user, controlledTier);
-          when(fireCloudService.isUserMemberOfGroup(
+          when(fireCloudService.isUserMemberOfGroupWithCache(
                   user.getUsername(), controlledTier.getAuthDomainName()))
               .thenReturn(false);
           cdrVersionService.setCdrVersion(controlledCdrVersion.getCdrVersionId());
@@ -409,7 +409,8 @@ public class CdrVersionServiceTest {
   private void addMembershipForTest(DbAccessTier tier) {
     accessTierService.addUserToTier(user, tier);
 
-    when(fireCloudService.isUserMemberOfGroup(user.getUsername(), tier.getAuthDomainName()))
+    when(fireCloudService.isUserMemberOfGroupWithCache(
+            user.getUsername(), tier.getAuthDomainName()))
         .thenReturn(true);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
@@ -128,7 +128,7 @@ public class FireCloudServiceImplTest extends SpringTest {
   @Test
   public void testIsUserMemberOfGroup_none() throws Exception {
     when(groupsApi.getGroup("group")).thenReturn(new FirecloudManagedGroupWithMembers());
-    assertThat(service.isUserMemberOfGroup(EMAIL_ADDRESS, "group")).isFalse();
+    assertThat(service.isUserMemberOfGroupWithCache(EMAIL_ADDRESS, "group")).isFalse();
   }
 
   @Test
@@ -136,7 +136,7 @@ public class FireCloudServiceImplTest extends SpringTest {
     FirecloudManagedGroupWithMembers group = new FirecloudManagedGroupWithMembers();
     group.setMembersEmails(Arrays.asList("asdf@fake-research-aou.org"));
     when(groupsApi.getGroup("group")).thenReturn(group);
-    assertThat(service.isUserMemberOfGroup(EMAIL_ADDRESS, "group")).isFalse();
+    assertThat(service.isUserMemberOfGroupWithCache(EMAIL_ADDRESS, "group")).isFalse();
   }
 
   @Test
@@ -145,7 +145,7 @@ public class FireCloudServiceImplTest extends SpringTest {
     group.setAdminsEmails(Arrays.asList(EMAIL_ADDRESS));
 
     when(groupsApi.getGroup("group")).thenReturn(group);
-    assertThat(service.isUserMemberOfGroup(EMAIL_ADDRESS, "group")).isTrue();
+    assertThat(service.isUserMemberOfGroupWithCache(EMAIL_ADDRESS, "group")).isTrue();
   }
 
   @Test
@@ -154,7 +154,7 @@ public class FireCloudServiceImplTest extends SpringTest {
     group.setMembersEmails(Arrays.asList(EMAIL_ADDRESS));
 
     when(groupsApi.getGroup("group")).thenReturn(group);
-    assertThat(service.isUserMemberOfGroup(EMAIL_ADDRESS, "group")).isTrue();
+    assertThat(service.isUserMemberOfGroupWithCache(EMAIL_ADDRESS, "group")).isTrue();
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
@@ -7,8 +7,11 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import org.junit.Rule;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -32,16 +35,24 @@ import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupWithMembers;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.firecloud.model.FirecloudSystemStatus;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.beans.factory.config.CustomScopeConfigurer;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
+import org.springframework.context.support.SimpleThreadScope;
+import org.springframework.web.context.WebApplicationContext;
 
 public class FireCloudServiceImplTest extends SpringTest {
 
   private static final String EMAIL_ADDRESS = "abc@fake-research-aou.org";
+
+  @Autowired
+  @Qualifier(FireCloudCacheConfig.SERVICE_ACCOUNT_REQUEST_SCOPED_GROUP_CACHE)
+  private LoadingCache<String, FirecloudManagedGroupWithMembers> firecloudGroupCache;
 
   @Autowired private FireCloudService service;
 
@@ -49,18 +60,31 @@ public class FireCloudServiceImplTest extends SpringTest {
 
   @MockBean private BillingApi billingApi;
   @MockBean private BillingV2Api billingV2Api;
-  @MockBean private GroupsApi groupsApi;
   @MockBean private HttpTransport httpTransport;
   @MockBean private IamCredentialsClient iamCredentialsClient;
   @MockBean private NihApi nihApi;
   @MockBean private ProfileApi profileApi;
   @MockBean private StatusApi statusApi;
 
+  @MockBean
+  @Qualifier(FireCloudConfig.SERVICE_ACCOUNT_GROUPS_API)
+  private GroupsApi groupsApi;
+
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
 
   @TestConfiguration
-  @Import({FireCloudServiceImpl.class, RetryConfig.class})
+  @Import({FireCloudCacheConfig.class, FireCloudServiceImpl.class, RetryConfig.class})
   static class Configuration {
+    @Bean
+    public CustomScopeConfigurer customScopeConfigurer() {
+      // Configure the request scope so we can reuse the cache config; this is not available by
+      // default in Spring unit tests.
+      CustomScopeConfigurer scopeConfigurer = new CustomScopeConfigurer();
+      scopeConfigurer.setScopes(
+          ImmutableMap.of(WebApplicationContext.SCOPE_REQUEST, new SimpleThreadScope()));
+      return scopeConfigurer;
+    }
+
     @Bean
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     public WorkbenchConfig getWorkbenchConfig() {
@@ -75,6 +99,11 @@ public class FireCloudServiceImplTest extends SpringTest {
     workbenchConfig.firecloud.debugEndpoints = true;
     workbenchConfig.firecloud.timeoutInSeconds = 20;
     workbenchConfig.billing.accountId = "test-billing-account";
+  }
+
+  @AfterEach
+  public void tearDown() {
+    firecloudGroupCache.invalidateAll();
   }
 
   @Test


### PR DESCRIPTION
This should drastically reduce the number of requests to Firecloud during the `synchronizeUserAccess` job, which will hopefully allow it to complete within the 10m time limit (as we work on more scalable approaches).

Verified locally that `synchronizeUserAccess` only makes 2 calls (one per tier), despite having 3 users.