### PR TITLE
[RW-6321][risk=no] Move ConceptSearchComponent routes into React Router

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -3,18 +3,16 @@ import {NavigationEnd, Router, RouterModule, Routes} from '@angular/router';
 
 import {NavigationGuard} from 'app/guards/navigation-guard';
 import {AppRouting} from './app-routing';
-import {CanDeactivateGuard} from './guards/can-deactivate-guard.service';
 import {RegistrationGuard} from './guards/registration-guard.service';
 import {SignInGuard} from './guards/sign-in-guard.service';
 
-import {ConceptSearchComponent} from './pages/data/concept/concept-search';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceWrapperComponent} from './pages/workspace/workspace-wrapper/component';
 
 import {environment} from 'environments/environment';
 import {DisabledGuard} from './guards/disabled-guard.service';
 import {WorkspaceGuard} from './guards/workspace-guard.service';
-import {BreadcrumbType, NavStore} from './utils/navigation';
+import {NavStore} from './utils/navigation';
 
 
 declare let gtag: Function;
@@ -158,6 +156,7 @@ const routes: Routes = [
                   },
                   {
                     path: 'data',
+                    component: AppRouting,
                     children: [
                       {
                         path: '',
@@ -225,31 +224,24 @@ const routes: Routes = [
                           data: {}
                         }, {
                           path: ':domain',
-                          component: ConceptSearchComponent,
-                          canDeactivate: [CanDeactivateGuard],
-                          data: {
-                            title: 'Search Concepts',
-                            breadcrumb: BreadcrumbType.SearchConcepts,
-                            pageKey: 'conceptSets'
-                          }
+                          component: AppRouting,
+                          data: {}
                         }]
                       },
                       {
                         path: 'concepts/sets',
-                        children: [{
-                          path: ':csid',
-                          component: ConceptSearchComponent,
-                          canDeactivate: [CanDeactivateGuard],
-                          data: {
-                            title: 'Concept Set',
-                            breadcrumb: BreadcrumbType.ConceptSet,
-                            pageKey: 'conceptSets'
+                        children: [
+                          {
+                            path: ':csid',
+                            component: AppRouting,
+                            data: {}
                           },
-                        }, {
-                          path: ':csid/actions',
-                          component: AppRouting,
-                          data: {},
-                        }, ]
+                          {
+                            path: ':csid/actions',
+                            component: AppRouting,
+                            data: {},
+                          },
+                        ]
                       }
                     ]
                   }]

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -156,7 +156,6 @@ const routes: Routes = [
                   },
                   {
                     path: 'data',
-                    component: AppRouting,
                     children: [
                       {
                         path: '',

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -36,6 +36,7 @@ import {QueryReport} from './pages/data/cohort-review/query-report.component';
 import {ParticipantsTable} from './pages/data/cohort-review/table-page';
 import {CohortActions} from './pages/data/cohort/cohort-actions';
 import {ConceptHomepage} from './pages/data/concept/concept-homepage';
+import {ConceptSearch} from './pages/data/concept/concept-search';
 import {ConceptSetActions} from './pages/data/concept/concept-set-actions';
 import {DataComponent} from './pages/data/data-component';
 import {DatasetPage} from './pages/data/data-set/dataset-page';
@@ -73,6 +74,7 @@ const CohortPagePage = withRouteData(CohortPage);
 const CohortActionsPage = withRouteData(CohortActions);
 const CohortReviewPage = withRouteData(CohortReview);
 const ConceptHomepagePage = withRouteData(ConceptHomepage);
+const ConceptSearchPage = withRouteData(ConceptSearch);
 const ConceptSetActionsPage = withRouteData(ConceptSetActions);
 const CookiePolicyPage = withRouteData(CookiePolicy);
 const DataComponentPage = withRouteData(DataComponent);
@@ -381,6 +383,22 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
               breadcrumb: BreadcrumbType.SearchConcepts,
               pageKey: 'searchConceptSets'
             }}/>}
+          />
+          <AppRoute
+              path='/workspaces/:ns/:wsid/data/concepts/sets/:csid'
+              component={() => <ConceptSearchPage routeData={{
+                title: 'Concept Set',
+                breadcrumb: BreadcrumbType.ConceptSet,
+                pageKey: 'conceptSets'
+              }}/>}
+          />
+          <AppRoute
+              path='/workspaces/:ns/:wsid/data/concepts/:domain'
+              component={() => <ConceptSearchPage routeData={{
+                title: 'Search Concepts',
+                breadcrumb: BreadcrumbType.SearchConcepts,
+                pageKey: 'conceptSets'
+              }}/>}
           />
           <AppRoute
             path='/workspaces/:ns/:wsid/data/concepts/sets/:csid/actions'

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -20,7 +20,6 @@ import {ConfirmDeleteModalComponent} from './components/confirm-delete-modal';
 import {HelpSidebarComponent} from './components/help-sidebar';
 import {RoutingSpinnerComponent} from './components/routing-spinner/component';
 import {AppComponent} from './pages/app/component';
-import {ConceptSearchComponent} from './pages/data/concept/concept-search';
 import {InitialErrorComponent} from './pages/initial-error/component';
 import {SignedInComponent} from './pages/signed-in/component';
 import {WorkspaceNavBarComponent} from './pages/workspace/workspace-nav-bar';
@@ -55,7 +54,6 @@ import {FooterComponent} from './components/footer';
     AppComponent,
     AppRouting,
     BugReportComponent,
-    ConceptSearchComponent,
     ConfirmDeleteModalComponent,
     FooterComponent,
     HelpSidebarComponent,

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -1,4 +1,3 @@
-import {Component} from '@angular/core';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 import {Subscription} from 'rxjs/Subscription';
@@ -19,7 +18,6 @@ import {conceptSetsApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
   reactStyles,
-  ReactWrapperBase,
   withCurrentCohortSearchContext,
   withCurrentConcept,
   withCurrentWorkspace,
@@ -33,6 +31,7 @@ import {
   queryParamsStore,
   setSidebarActiveIconStore
 } from 'app/utils/navigation';
+import {navigationGuardStore} from 'app/utils/stores';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 import {ConceptSet, CopyRequest, Criteria, Domain, ResourceType, WorkspaceAccessLevel} from 'generated/fetch';
@@ -102,9 +101,6 @@ function sortAndStringify(concepts) {
 interface Props {
   cohortContext: any;
   concept: Array<Criteria>;
-  setConceptSetUpdating: (conceptSetUpdating: boolean) => void;
-  setShowUnsavedModal: (showUnsavedModal: () => Promise<boolean>) => void;
-  setUnsavedConceptChanges: (unsavedConceptChanges: boolean) => void;
   workspace: WorkspaceData;
   urlParams: any;
 }
@@ -125,6 +121,7 @@ interface State {
   // Show if trying to navigate away with unsaved changes
   showUnsavedModal: boolean;
   unsavedChanges: boolean;
+  conceptSetUpdating: boolean;
 }
 
 export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurrentConcept(), withCurrentWorkspace(), withUrlParams())
@@ -147,9 +144,9 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
         loading: this.isDetailPage,
         showMoreDescription: false,
         showUnsavedModal: false,
-        unsavedChanges: false
+        unsavedChanges: false,
+        conceptSetUpdating: false
       };
-      this.showUnsavedModal = this.showUnsavedModal.bind(this);
     }
 
     componentDidMount() {
@@ -163,8 +160,8 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
           this.checkUnsavedConceptChanges(currentConcepts);
         }
       });
-      this.subscription.add(conceptSetUpdating.subscribe(updating => this.props.setConceptSetUpdating(updating)));
-      this.props.setShowUnsavedModal(this.showUnsavedModal);
+      this.subscription.add(conceptSetUpdating.subscribe(updating => this.setState({conceptSetUpdating: updating})));
+      navigationGuardStore.set({component: this});
     }
 
     componentWillUnmount() {
@@ -172,6 +169,7 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
       currentConceptStore.next(undefined);
       currentConceptSetStore.next(undefined);
       this.subscription.unsubscribe();
+      navigationGuardStore.set(null);
     }
 
     checkUnsavedConceptChanges(currentConcepts) {
@@ -183,7 +181,6 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
       const unsavedChanges = (!currentConceptSet && currentConcepts.length > 0) ||
         (!!currentConceptSet && sortAndStringify(currentConceptSet.criteriums) !== sortAndStringify(currentConceptsMap));
       this.setState({unsavedChanges});
-      this.props.setUnsavedConceptChanges(unsavedChanges);
     }
 
     async getConceptSet() {
@@ -249,6 +246,10 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
     async showUnsavedModal() {
       this.setState({showUnsavedModal: true});
       return await new Promise<boolean>((resolve => this.resolveUnsavedModal = resolve));
+    }
+
+    canDeactivate(): Promise<boolean> | boolean {
+      return !this.state.unsavedChanges || this.state.conceptSetUpdating || this.showUnsavedModal();
     }
 
     getModalResponse(res: boolean) {
@@ -416,35 +417,3 @@ export const ConceptSearch = fp.flow(withCurrentCohortSearchContext(), withCurre
       </React.Fragment>;
     }
   });
-
-@Component({
-  template: '<div #root></div>'
-})
-
-export class ConceptSearchComponent extends ReactWrapperBase {
-  conceptSetUpdating: boolean;
-  showUnsavedModal: () => Promise<boolean>;
-  unsavedConceptChanges: boolean;
-  constructor() {
-    super(ConceptSearch, ['setConceptSetUpdating', 'setShowUnsavedModal', 'setUnsavedConceptChanges']);
-    this.setConceptSetUpdating = this.setConceptSetUpdating.bind(this);
-    this.setShowUnsavedModal = this.setShowUnsavedModal.bind(this);
-    this.setUnsavedConceptChanges = this.setUnsavedConceptChanges.bind(this);
-  }
-
-  setShowUnsavedModal(showUnsavedModal: () => Promise<boolean>): void {
-    this.showUnsavedModal = showUnsavedModal;
-  }
-
-  setConceptSetUpdating(csUpdating: boolean): void {
-    this.conceptSetUpdating = csUpdating;
-  }
-
-  setUnsavedConceptChanges(unsavedConceptChanges: boolean): void {
-    this.unsavedConceptChanges = unsavedConceptChanges;
-  }
-
-  canDeactivate(): Promise<boolean> | boolean {
-    return !this.unsavedConceptChanges || this.conceptSetUpdating || this.showUnsavedModal();
-  }
-}


### PR DESCRIPTION
Same approach as in https://github.com/all-of-us/workbench/pull/5159

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
