### PR TITLE
[ticket=no][risk=no] Prevent the scroll bar from spazzing out on loading workspace list

### DIFF
--- a/ui/src/app/pages/workspace/workspace-list.tsx
+++ b/ui/src/app/pages/workspace/workspace-list.tsx
@@ -110,7 +110,7 @@ export const WorkspaceList = withUserProfile()
           </AlertDanger>}
           <div style={styles.cardArea}>
             {workspacesLoading ?
-              (<Spinner style={{width: '100%', marginTop: '1.5rem'}}/>) :
+              (<Spinner style={{margin: '1.5rem auto'}}/>) :
               (<div style={{display: 'flex', marginTop: '1.5rem', flexWrap: 'wrap'}}>
                 <NewWorkspaceButton />
                 {workspaceList.map(wp => {


### PR DESCRIPTION
Previous
![spazzing_scroll](https://user-images.githubusercontent.com/2770197/123449771-fade6400-d5a9-11eb-80da-17ce61198745.gif)

New
![normal_scroll](https://user-images.githubusercontent.com/2770197/123449779-fd40be00-d5a9-11eb-833b-cae30ef7ef89.gif)


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
