### PR TITLE
[risk=low][RW-6882] remove obsolete fields from AdminUser and DbUser

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -102,8 +102,6 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
 
     void setInstitutionName(String institutionName);
 
-    Timestamp getFirstRegistrationCompletionTime();
-
     Timestamp getFirstSignInTime();
 
     Timestamp getCreationTime();
@@ -116,19 +114,9 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
 
     Timestamp getComplianceTrainingCompletionTime();
 
-    Timestamp getBetaAccessBypassTime();
-
-    Timestamp getEmailVerificationBypassTime();
-
-    Timestamp getEmailVerificationCompletionTime();
-
     Timestamp getEraCommonsBypassTime();
 
     Timestamp getEraCommonsCompletionTime();
-
-    Timestamp getIdVerificationBypassTime();
-
-    Timestamp getIdVerificationCompletionTime();
 
     Timestamp getTwoFactorAuthBypassTime();
 
@@ -157,20 +145,14 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + "u.family_name AS familyName, "
               + "u.contact_email AS contactEmail, "
               + "i.display_name AS institutionName, "
-              + "u.first_registration_completion_time AS firstRegistrationCompletionTime, "
               + "u.creation_time AS creationTime, "
               + "u.first_sign_in_time AS firstSignInTime, "
               + "u.data_use_agreement_bypass_time AS dataUseAgreementBypassTime, "
               + "u.data_use_agreement_completion_time AS dataUseAgreementCompletionTime, "
               + "u.compliance_training_bypass_time AS complianceTrainingBypassTime, "
               + "u.compliance_training_completion_time AS complianceTrainingCompletionTime, "
-              + "u.beta_access_bypass_time AS betaAccessBypassTime, "
-              + "u.email_verification_bypass_time AS emailVerificationBypassTime, "
-              + "u.email_verification_completion_time AS emailVerificationCompletionTime, "
               + "u.era_commons_bypass_time AS eraCommonsBypassTime, "
               + "u.era_commons_completion_time AS eraCommonsCompletionTime, "
-              + "u.id_verification_bypass_time AS idVerificationBypassTime, "
-              + "u.id_verification_completion_time AS idVerificationCompletionTime, "
               + "u.two_factor_auth_bypass_time AS twoFactorAuthBypassTime, "
               + "u.two_factor_auth_completion_time AS twoFactorAuthCompletionTime, "
               + "u.ras_link_login_gov_bypass_time AS rasLinkLoginGovBypassTime, "

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -103,16 +103,6 @@ public class DbUser {
   private Timestamp publicationsLastConfirmedTime;
 
   // potentially obsolete access module fields.  These are likely to be deleted in the near future.
-
-  @Deprecated private Timestamp betaAccessRequestTime;
-  @Deprecated private Timestamp betaAccessBypassTime;
-
-  @Deprecated private Timestamp idVerificationCompletionTime;
-  @Deprecated private Timestamp idVerificationBypassTime;
-
-  @Deprecated private Timestamp emailVerificationCompletionTime;
-  @Deprecated private Timestamp emailVerificationBypassTime;
-
   // Moodle badges are indexed by username, not this value.  See ComplianceService.
   @Deprecated private Integer moodleId;
 
@@ -371,17 +361,6 @@ public class DbUser {
   }
 
   @Deprecated
-  @Column(name = "beta_access_request_time")
-  public Timestamp getBetaAccessRequestTime() {
-    return betaAccessRequestTime;
-  }
-
-  @Deprecated
-  public void setBetaAccessRequestTime(Timestamp betaAccessRequestTime) {
-    this.betaAccessRequestTime = betaAccessRequestTime;
-  }
-
-  @Deprecated
   @Column(name = "moodle_id")
   public Integer getMoodleId() {
     return moodleId;
@@ -508,39 +487,6 @@ public class DbUser {
     this.complianceTrainingExpirationTime = null;
   }
 
-  @Deprecated
-  @Column(name = "beta_access_bypass_time")
-  public Timestamp getBetaAccessBypassTime() {
-    return betaAccessBypassTime;
-  }
-
-  @Deprecated
-  public void setBetaAccessBypassTime(Timestamp betaAccessBypassTime) {
-    this.betaAccessBypassTime = betaAccessBypassTime;
-  }
-
-  @Deprecated
-  @Column(name = "email_verification_completion_time")
-  public Timestamp getEmailVerificationCompletionTime() {
-    return emailVerificationCompletionTime;
-  }
-
-  @Deprecated
-  public void setEmailVerificationCompletionTime(Timestamp emailVerificationCompletionTime) {
-    this.emailVerificationCompletionTime = emailVerificationCompletionTime;
-  }
-
-  @Deprecated
-  @Column(name = "email_verification_bypass_time")
-  public Timestamp getEmailVerificationBypassTime() {
-    return emailVerificationBypassTime;
-  }
-
-  @Deprecated
-  public void setEmailVerificationBypassTime(Timestamp emailVerificationBypassTime) {
-    this.emailVerificationBypassTime = emailVerificationBypassTime;
-  }
-
   @Column(name = "era_commons_bypass_time")
   public Timestamp getEraCommonsBypassTime() {
     return eraCommonsBypassTime;
@@ -548,32 +494,6 @@ public class DbUser {
 
   public void setEraCommonsBypassTime(Timestamp eraCommonsBypassTime) {
     this.eraCommonsBypassTime = eraCommonsBypassTime;
-  }
-
-  /*
-   * This column and attribute appear to be disused. We should drop the column and the code here
-   * together.
-   */
-  @Deprecated
-  @Column(name = "id_verification_completion_time")
-  public Timestamp getIdVerificationCompletionTime() {
-    return idVerificationCompletionTime;
-  }
-
-  @Deprecated
-  public void setIdVerificationCompletionTime(Timestamp idVerificationCompletionTime) {
-    this.idVerificationCompletionTime = idVerificationCompletionTime;
-  }
-
-  @Column(name = "id_verification_bypass_time")
-  @Deprecated
-  public Timestamp getIdVerificationBypassTime() {
-    return idVerificationBypassTime;
-  }
-
-  @Deprecated
-  public void setIdVerificationBypassTime(Timestamp idVerificationBypassTime) {
-    this.idVerificationBypassTime = idVerificationBypassTime;
   }
 
   @Column(name = "two_factor_auth_completion_time")

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5458,19 +5458,10 @@ definitions:
       institutionName:
         description: Verified institution name
         type: string
-      firstRegistrationCompletionTime:
-        type: integer
-        format: int64
       firstSignInTime:
         type: integer
         format: int64
       creationTime:
-        type: integer
-        format: int64
-      idVerificationBypassTime:
-        type: integer
-        format: int64
-      idVerificationCompletionTime:
         type: integer
         format: int64
       twoFactorAuthBypassTime:
@@ -5495,15 +5486,6 @@ definitions:
         type: integer
         format: int64
       complianceTrainingCompletionTime:
-        type: integer
-        format: int64
-      betaAccessBypassTime:
-        type: integer
-        format: int64
-      emailVerificationBypassTime:
-        type: integer
-        format: int64
-      emailVerificationCompletionTime:
         type: integer
         format: int64
       dataUseAgreementBypassTime:

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
@@ -159,7 +159,6 @@ public class UserDaoTest extends SpringTest {
     user.setContactEmail(contactEmail);
     user.setGivenName("givenName");
     user.setFamilyName("familyName");
-    user.setFirstRegistrationCompletionTime(nowTime);
     user.setDataUseAgreementCompletionTime(nowTime);
     user.setDataUseAgreementBypassTime(nowTime);
     user.setEraCommonsBypassTime(nowTime);
@@ -171,12 +170,6 @@ public class UserDaoTest extends SpringTest {
     user.setDataUseAgreementBypassTime(nowTime);
     user.setTwoFactorAuthBypassTime(nowTime);
     user.setTwoFactorAuthCompletionTime(nowTime);
-    user.setBetaAccessBypassTime(nowTime);
-    user.setBetaAccessRequestTime(nowTime);
-    user.setEmailVerificationCompletionTime(nowTime);
-    user.setEmailVerificationBypassTime(nowTime);
-    user.setIdVerificationBypassTime(nowTime);
-    user.setIdVerificationCompletionTime(nowTime);
     user.setCreationTime(nowTime);
     user.setFirstSignInTime(nowTime);
 

--- a/ui/src/app/pages/admin/admin-user.tsx
+++ b/ui/src/app/pages/admin/admin-user.tsx
@@ -12,7 +12,6 @@ import {SpinnerOverlay} from 'app/components/spinners';
 import {institutionApi, profileApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {
-  displayDateWithoutHours,
   formatFreeCreditsUSD,
   isBlank,
   reactStyles,
@@ -522,18 +521,6 @@ export const AdminUser = withUrlParams()(class extends React.Component<Props, St
                   (updatedProfile.accessTierShortNames)
                 }
                 inputId={'accessTiers'}
-                disabled={true}
-                inputStyle={{...styles.textInput, ...styles.backgroundColorDark}}
-                containerStyle={styles.textInputContainer}
-            />
-            <TextInputWithLabel
-                labelText={'Registration date'}
-                placeholder={
-                  updatedProfile.firstRegistrationCompletionTime
-                      ? displayDateWithoutHours(updatedProfile.firstRegistrationCompletionTime)
-                      : ''
-                }
-                inputId={'firstRegistrationCompletionTime'}
                 disabled={true}
                 inputStyle={{...styles.textInput, ...styles.backgroundColorDark}}
                 containerStyle={styles.textInputContainer}

--- a/ui/src/app/pages/admin/admin-users.tsx
+++ b/ui/src/app/pages/admin/admin-users.tsx
@@ -165,8 +165,6 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
       dataUseAgreement: this.accessModuleCellContents(user, 'dataUseAgreement'),
       eraCommons: this.accessModuleCellContents(user, 'eraCommons'),
       rasLinkLoginGov: this.accessModuleCellContents(user, 'rasLinkLoginGov'),
-      firstRegistrationCompletionTime: this.formattedTimestampOrEmptyString(user.firstRegistrationCompletionTime),
-      firstRegistrationCompletionTimestamp: user.firstRegistrationCompletionTime,
       firstSignInTime: this.formattedTimestampOrEmptyString(user.firstSignInTime),
       firstSignInTimestamp: user.firstSignInTime,
       institutionName: user.institutionName,
@@ -208,7 +206,7 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
                    paginator={true}
                    rows={50}
                    scrollable
-                   sortField={'firstRegistrationCompletionTimestamp'}
+                   sortField={'firstSignInTimestamp'}
                    style={styles.tableStyle}>
           <Column field='name'
                   bodyStyle={{...styles.colStyle}}
@@ -231,14 +229,6 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
                   header='Institution'
                   headerStyle={{...styles.colStyle, width: '180px'}}
                   sortable={true}
-          />
-          <Column field='firstRegistrationCompletionTime'
-                  bodyStyle={{...styles.colStyle}}
-                  excludeGlobalFilter={true}
-                  header='Registration date'
-                  headerStyle={{...styles.colStyle, width: '180px'}}
-                  sortable={true}
-                  sortField={'firstRegistrationCompletionTimestamp'}
           />
           <Column field='username'
                   bodyStyle={{...styles.colStyle}}

--- a/ui/src/app/pages/admin/admin-users.tsx
+++ b/ui/src/app/pages/admin/admin-users.tsx
@@ -232,7 +232,7 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
           />
           <Column field='username'
                   bodyStyle={{...styles.colStyle}}
-                  header='User name'
+                  header='User Name'
                   headerStyle={{...styles.colStyle, width: '200px'}}
                   sortable={true}
           />


### PR DESCRIPTION
Description:

Remove the no-longer-populated field **first_registration_completion_time / "Registration Date"** from the User Admin page:

before
<img width="1448" alt="before" src="https://user-images.githubusercontent.com/2701406/123829964-e0b9c400-d8d0-11eb-89bf-430697327631.png">

after
<img width="1267" alt="after" src="https://user-images.githubusercontent.com/2701406/123829984-e4e5e180-d8d0-11eb-8aff-d81b81e3cee1.png">


Remove these fields from DbUser and AdminUser
```
first_registration_completion_time
beta_access_bypass_time
email_verification_completion_time
email_verification_bypass_time
id_verification_completion_time
id_verification_bypass_time
```

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
