### PR TITLE
[RW-6538][risk=no] Improve retry handling of Google auth token errors

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.exceptions;
 
+import com.google.api.client.auth.oauth2.TokenResponseException;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -32,6 +33,8 @@ public class ExceptionUtils {
       throw new ServerUnavailableException(e);
     } else if (isGoogleConflictException(e)) {
       throw new ConflictException(e);
+    } else if (e instanceof TokenResponseException) {
+      throw codeToException(((TokenResponseException) e).getStatusCode());
     }
     throw new ServerErrorException(e);
   }
@@ -80,7 +83,7 @@ public class ExceptionUtils {
     return code == HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
   }
 
-  private static RuntimeException codeToException(int code) {
+  public static RuntimeException codeToException(int code) {
 
     if (code == HttpStatus.NOT_FOUND.value()) {
       return new NotFoundException();

--- a/api/src/main/java/org/pmiops/workbench/google/GoogleRetryHandler.java
+++ b/api/src/main/java/org/pmiops/workbench/google/GoogleRetryHandler.java
@@ -34,8 +34,7 @@ public class GoogleRetryHandler extends RetryHandler<IOException> {
         return HttpServletResponse.SC_GATEWAY_TIMEOUT;
       }
       if (lastException instanceof TokenResponseException) {
-        throw ExceptionUtils.codeToException(
-            ((TokenResponseException) lastException).getStatusCode());
+        return ((TokenResponseException) lastException).getStatusCode();
       }
       return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
     }

--- a/api/src/main/java/org/pmiops/workbench/google/GoogleRetryHandler.java
+++ b/api/src/main/java/org/pmiops/workbench/google/GoogleRetryHandler.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.google;
 
+import com.google.api.client.auth.oauth2.TokenResponseException;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -31,6 +32,10 @@ public class GoogleRetryHandler extends RetryHandler<IOException> {
       }
       if (lastException instanceof SocketTimeoutException) {
         return HttpServletResponse.SC_GATEWAY_TIMEOUT;
+      }
+      if (lastException instanceof TokenResponseException) {
+        throw ExceptionUtils.codeToException(
+            ((TokenResponseException) lastException).getStatusCode());
       }
       return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
     }


### PR DESCRIPTION
This is mostly relevant in test, where we often get errors like:

```
ResponseCodeRetryPolicy.java:49org.pmiops.workbench.utils.ResponseCodeRetryPolicy logRetry: Google API unavailable, retrying after 1 attempts
com.google.api.client.auth.oauth2.TokenResponseException: 400
POST https://oauth2.googleapis.com/token
{
  "error" : "invalid_grant",
  "error_description" : "Invalid email or User ID"
}
```

due to non-existent users. We are currently retrying these, and we shouldn't be.