### PR TITLE
[RW-6902][risk=no] Fix breadcrumbs for cohort review routes

### DIFF
--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -348,7 +348,7 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
             path='/workspaces/:ns/:wsid/data/cohorts/:cid/review/participants'
             component={() => <ParticipantsTablePage routeData={{
               title: 'Review Cohort Participants',
-              breadcrumb: BreadcrumbType.Cohort,
+              breadcrumb: BreadcrumbType.CohortReview,
               pageKey: 'reviewParticipants'
             }}/>}
           />
@@ -364,7 +364,7 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
             path='/workspaces/:ns/:wsid/data/cohorts/:cid/review/cohort-description'
             component={() => <QueryReportPage routeData={{
               title: 'Review Cohort Description',
-              breadcrumb: BreadcrumbType.Cohort,
+              breadcrumb: BreadcrumbType.CohortReview,
               pageKey: 'cohortDescription'
             }}/>}
           />
@@ -372,7 +372,7 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
             path='/workspaces/:ns/:wsid/data/cohorts/:cid/review'
             component={() => <CohortReviewPage routeData={{
               title: 'Review Cohort Participants',
-              breadcrumb: BreadcrumbType.Cohort,
+              breadcrumb: BreadcrumbType.CohortReview,
               pageKey: 'reviewParticipants'
             }}/>}
           />

--- a/ui/src/app/components/breadcrumb.spec.tsx
+++ b/ui/src/app/components/breadcrumb.spec.tsx
@@ -4,6 +4,7 @@ import {registerApiClient} from "app/services/swagger-fetch-clients";
 
 import {WorkspacesApi} from "generated/fetch";
 
+import {cohortReviewStubs} from 'testing/stubs/cohort-review-service-stub';
 import {exampleCohortStubs} from "testing/stubs/cohorts-api-stub";
 import {ConceptSetsApiStub} from "testing/stubs/concept-sets-api-stub";
 import {workspaceDataStub, WorkspaceStubVariables} from 'testing/stubs/workspaces';
@@ -23,11 +24,12 @@ describe('getTrail', () => {
     const trail = getTrail(BreadcrumbType.Participant,
       workspaceDataStub,
       exampleCohortStubs[0],
+      cohortReviewStubs[0],
       ConceptSetsApiStub.stubConceptSets()[0],
       {ns: 'testns', wsid: 'testwsid', cid: 88, pid: 77}
     );
     expect(trail.map(item => item.label))
-      .toEqual(['Workspaces', 'defaultWorkspace', 'sample name', 'Participant 77']);
+      .toEqual(['Workspaces', 'defaultWorkspace', 'Cohort Name', 'Participant 77']);
     expect(trail[3].url)
       .toEqual('/workspaces/testns/testwsid/data/cohorts/88/review/participants/77');
   });

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -6,6 +6,7 @@ import {InvalidBillingBanner} from 'app/pages/workspace/invalid-billing-banner';
 import colors from 'app/styles/colors';
 import {
   withCurrentCohort,
+  withCurrentCohortReview,
   withCurrentConceptSet,
   withCurrentWorkspace,
   withRouteConfigData,
@@ -14,7 +15,7 @@ import {
 import {BreadcrumbType, navigateAndPreventDefaultIfNoKeysPressed} from 'app/utils/navigation';
 import {routeDataStore, RouteDataStore, withStore} from 'app/utils/stores';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {BillingStatus, Cohort, ConceptSet} from 'generated/fetch';
+import {BillingStatus, Cohort, CohortReview, ConceptSet} from 'generated/fetch';
 
 const styles = {
   firstLink: {
@@ -44,6 +45,7 @@ export const getTrail = (
   type: BreadcrumbType,
   workspace: WorkspaceData,
   cohort: Cohort,
+  cohortReview: CohortReview,
   conceptSet: ConceptSet,
   urlParams: any
 ): Array<BreadcrumbData> => {
@@ -56,22 +58,22 @@ export const getTrail = (
       ];
     case BreadcrumbType.Workspace:
       return [
-        ...getTrail(BreadcrumbType.Workspaces, workspace, cohort, conceptSet, urlParams),
+        ...getTrail(BreadcrumbType.Workspaces, workspace, cohort, cohortReview, conceptSet, urlParams),
         new BreadcrumbData(workspace ? workspace.name : '...', `${prefix}/data`)
       ];
     case BreadcrumbType.WorkspaceEdit:
       return [
-        ...getTrail(BreadcrumbType.Workspace, workspace, cohort, conceptSet, urlParams),
+        ...getTrail(BreadcrumbType.Workspace, workspace, cohort, cohortReview, conceptSet, urlParams),
         new BreadcrumbData('Edit Workspace', `${prefix}/edit`)
       ];
     case BreadcrumbType.WorkspaceDuplicate:
       return [
-        ...getTrail(BreadcrumbType.Workspace, workspace, cohort, conceptSet, urlParams),
+        ...getTrail(BreadcrumbType.Workspace, workspace, cohort, cohortReview, conceptSet, urlParams),
         new BreadcrumbData('Duplicate Workspace', `${prefix}/duplicate`)
       ];
     case BreadcrumbType.Notebook:
       return [
-        ...getTrail(BreadcrumbType.Workspace, workspace, cohort, conceptSet, urlParams),
+        ...getTrail(BreadcrumbType.Workspace, workspace, cohort, cohortReview, conceptSet, urlParams),
         new BreadcrumbData('Notebooks', `${prefix}/notebooks`),
         new BreadcrumbData(
           nbName && dropNotebookFileSuffix(decodeURIComponent(nbName)),
@@ -80,7 +82,7 @@ export const getTrail = (
       ];
     case BreadcrumbType.ConceptSet:
       return [
-        ...getTrail(BreadcrumbType.Data, workspace, cohort, conceptSet, urlParams),
+        ...getTrail(BreadcrumbType.Data, workspace, cohort, cohortReview, conceptSet, urlParams),
         new BreadcrumbData(
           conceptSet
             ? conceptSet.name
@@ -89,15 +91,23 @@ export const getTrail = (
       ];
     case BreadcrumbType.Cohort:
       return [
-        ...getTrail(BreadcrumbType.Data, workspace, cohort, conceptSet, urlParams),
+        ...getTrail(BreadcrumbType.Data, workspace, cohort, cohortReview, conceptSet, urlParams),
         new BreadcrumbData(
           cohort ? cohort.name : '...',
           `${prefix}/data/cohorts/${cid}/review/participants`
         )
       ];
+    case BreadcrumbType.CohortReview:
+      return [
+        ...getTrail(BreadcrumbType.Data, workspace, cohort, cohortReview, conceptSet, urlParams),
+        new BreadcrumbData(
+          cohortReview ? cohortReview.cohortName : '...',
+          `${prefix}/data/cohorts/${cid}/review/participants`
+        )
+      ];
     case BreadcrumbType.Participant:
       return [
-        ...getTrail(BreadcrumbType.Cohort, workspace, cohort, conceptSet, urlParams),
+        ...getTrail(BreadcrumbType.CohortReview, workspace, cohort, cohortReview, conceptSet, urlParams),
         new BreadcrumbData(
           `Participant ${pid}`,
           `${prefix}/data/cohorts/${cid}/review/participants/${pid}`
@@ -105,22 +115,22 @@ export const getTrail = (
       ];
     case BreadcrumbType.CohortAdd:
       return [
-        ...getTrail(BreadcrumbType.Data, workspace, cohort, conceptSet, urlParams),
+        ...getTrail(BreadcrumbType.Data, workspace, cohort, cohortReview, conceptSet, urlParams),
         new BreadcrumbData('Build Cohort Criteria', `${prefix}/data/cohorts/build`)
       ];
     case BreadcrumbType.SearchConcepts:
       return [
-        ...getTrail(BreadcrumbType.Data, workspace, cohort, conceptSet, urlParams),
+        ...getTrail(BreadcrumbType.Data, workspace, cohort, cohortReview, conceptSet, urlParams),
         new BreadcrumbData('Search Concepts', `${prefix}/data/concepts`)
       ];
     case BreadcrumbType.Dataset:
       return [
-        ...getTrail(BreadcrumbType.Data, workspace, cohort, conceptSet, urlParams),
+        ...getTrail(BreadcrumbType.Data, workspace, cohort, cohortReview, conceptSet, urlParams),
         new BreadcrumbData('Dataset', `${prefix}/data/datasets`)
       ];
     case BreadcrumbType.Data:
       return [
-        ...getTrail(BreadcrumbType.Workspaces, workspace, cohort, conceptSet, urlParams),
+        ...getTrail(BreadcrumbType.Workspaces, workspace, cohort, cohortReview, conceptSet, urlParams),
         new BreadcrumbData(workspace ? workspace.name : '...', `${prefix}/data`)
       ];
     default: return [];
@@ -140,6 +150,7 @@ const BreadcrumbLink = ({href, ...props}) => {
 interface Props {
   workspace: WorkspaceData;
   cohort: Cohort;
+  cohortReview: CohortReview;
   conceptSet: ConceptSet;
   urlParams: any;
   routeConfigData: any;
@@ -153,6 +164,7 @@ interface State {
 export const Breadcrumb = fp.flow(
   withCurrentWorkspace(),
   withCurrentCohort(),
+  withCurrentCohortReview(),
   withCurrentConceptSet(),
   withUrlParams(),
   withRouteConfigData(),
@@ -185,6 +197,7 @@ export const Breadcrumb = fp.flow(
         this.props.routeConfigData.breadcrumb || this.props.reactRouteData.breadcrumb,
         this.props.workspace,
         this.props.cohort,
+        this.props.cohortReview,
         this.props.conceptSet,
         this.props.urlParams
       );

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -2,11 +2,11 @@ import {mount} from 'enzyme';
 import * as React from 'react';
 
 import {act} from 'react-dom/test-utils';
-import {cohortReviewStore} from 'app/services/review-state.service';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {defaultRuntime, RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
 import {
   currentCohortCriteriaStore,
+  currentCohortReviewStore,
   currentWorkspaceStore,
   setSidebarActiveIconStore
 } from 'app/utils/navigation';
@@ -118,7 +118,7 @@ describe('HelpSidebar', () => {
     registerApiClient(RuntimeApi, runtimeStub);
     registerApiClient(WorkspacesApi, new WorkspacesApiStub());
     currentWorkspaceStore.next(workspaceDataStub);
-    cohortReviewStore.next(cohortReviewStubs[0]);
+    currentCohortReviewStore.next(cohortReviewStubs[0]);
     serverConfigStore.set({config: {...defaultServerConfig, enableGenomicExtraction: true}});
     runtimeStore.set({workspaceNamespace: workspaceDataStub.namespace, runtime: runtimeStub.runtime});
     cdrVersionStore.set(cdrVersionTiersResponse);

--- a/ui/src/app/pages/data/cohort-review/cohort-review.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review.tsx
@@ -4,11 +4,11 @@ import {Button} from 'app/components/buttons';
 import {Modal, ModalFooter, ModalTitle} from 'app/components/modals';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {CreateReviewModal} from 'app/pages/data/cohort-review/create-review-modal';
-import {cohortReviewStore, queryResultSizeStore, visitsFilterOptions} from 'app/services/review-state.service';
+import {queryResultSizeStore, visitsFilterOptions} from 'app/services/review-state.service';
 import {cohortBuilderApi, cohortReviewApi, cohortsApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {reactStyles} from 'app/utils';
-import {currentWorkspaceStore, navigate, urlParamsStore} from 'app/utils/navigation';
+import {currentCohortReviewStore, currentWorkspaceStore, navigate, urlParamsStore} from 'app/utils/navigation';
 import {Cohort, CriteriaType, Domain, ReviewStatus, SortOrder, WorkspaceAccessLevel} from 'generated/fetch';
 
 const styles = reactStyles({
@@ -46,7 +46,7 @@ export class CohortReview extends React.Component<{}, State> {
       filters: {items: []}
     }).then(resp => {
       const {cohortReview, queryResultSize} = resp;
-      cohortReviewStore.next(cohortReview);
+      currentCohortReviewStore.next(cohortReview);
       queryResultSizeStore.next(queryResultSize);
       const reviewPresent = cohortReview.reviewStatus !== ReviewStatus.NONE;
       this.setState({reviewPresent});

--- a/ui/src/app/pages/data/cohort-review/detail-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-page.tsx
@@ -5,14 +5,15 @@ import {from} from 'rxjs/observable/from';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {DetailHeader} from 'app/pages/data/cohort-review/detail-header.component';
 import {DetailTabs} from 'app/pages/data/cohort-review/detail-tabs.component';
-import {cohortReviewStore, getVocabOptions, participantStore, vocabOptions} from 'app/services/review-state.service';
+import {getVocabOptions, participantStore, vocabOptions} from 'app/services/review-state.service';
 import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
-import {withCurrentWorkspace} from 'app/utils';
-import {urlParamsStore} from 'app/utils/navigation';
+import {withCurrentCohortReview, withCurrentWorkspace} from 'app/utils';
+import {currentCohortReviewStore, urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {ParticipantCohortStatus, SortOrder} from 'generated/fetch';
+import {CohortReview, ParticipantCohortStatus, SortOrder} from 'generated/fetch';
 
 interface Props {
+  cohortReview: CohortReview;
   workspace: WorkspaceData;
 }
 
@@ -20,7 +21,7 @@ interface State {
   participant: ParticipantCohortStatus;
 }
 
-export const DetailPage = withCurrentWorkspace()(
+export const DetailPage = fp.flow(withCurrentCohortReview(), withCurrentWorkspace())(
   class extends React.Component<Props, State> {
     private subscription;
     constructor(props: any) {
@@ -30,26 +31,29 @@ export const DetailPage = withCurrentWorkspace()(
 
     async componentDidMount() {
       const {workspace: {cdrVersionId, id, namespace}} = this.props;
+      let {cohortReview} = this.props;
       const {ns, wsid, cid} = urlParamsStore.getValue();
-      if (!cohortReviewStore.getValue()) {
+      if (!cohortReview) {
         await cohortReviewApi().getParticipantCohortStatuses(ns, wsid, cid, +cdrVersionId, {
           page: 0,
           pageSize: 25,
           sortOrder: SortOrder.Asc,
           filters: {items: []}
-        }).then(response => cohortReviewStore.next(response.cohortReview));
+        }).then(response => {
+          cohortReview = response.cohortReview;
+          currentCohortReviewStore.next(cohortReview);
+        });
       }
       this.subscription = urlParamsStore.distinctUntilChanged(fp.isEqual)
         .filter(params => !!params.pid)
         .switchMap(({pid}) => {
           return from(cohortReviewApi()
-            .getParticipantCohortStatus(ns, wsid, cohortReviewStore.getValue().cohortReviewId, +pid))
+            .getParticipantCohortStatus(ns, wsid, cohortReview.cohortReviewId, +pid))
             .do(ps => participantStore.next(ps));
         })
         .subscribe();
       if (!vocabOptions.getValue()) {
-        const {cohortReviewId} = cohortReviewStore.getValue();
-        getVocabOptions(namespace, id, cohortReviewId);
+        getVocabOptions(namespace, id, cohortReview.cohortReviewId);
       }
       this.subscription.add(participantStore.subscribe(participant => this.setState({participant})));
     }

--- a/ui/src/app/pages/data/cohort-review/detail-tab-table.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-tab-table.component.tsx
@@ -3,14 +3,14 @@ import {ClrIcon} from 'app/components/icons';
 import {TextInput} from 'app/components/inputs';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {ReviewDomainChartsComponent} from 'app/pages/data/cohort-review/review-domain-charts';
-import {cohortReviewStore, vocabOptions} from 'app/services/review-state.service';
+import {vocabOptions} from 'app/services/review-state.service';
 import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {datatableStyles} from 'app/styles/datatable';
-import {reactStyles, withCurrentWorkspace} from 'app/utils';
+import {reactStyles, withCurrentCohortReview, withCurrentWorkspace} from 'app/utils';
 import {triggerEvent} from 'app/utils/analytics';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {Domain, Operator, PageFilterRequest, SortOrder} from 'generated/fetch';
+import {CohortReview, Domain, Operator, PageFilterRequest, SortOrder} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import * as moment from 'moment';
 import {Column} from 'primereact/column';
@@ -227,6 +227,7 @@ class NameContainer extends React.Component<{data: any, vocab: string}, {showMor
 
 interface Props {
   tabName: string;
+  cohortReview: CohortReview;
   columns: Array<any>;
   domain: Domain;
   participantId: number;
@@ -256,7 +257,7 @@ interface State {
   tabFilterState: any;
 }
 
-export const DetailTabTable = withCurrentWorkspace()(
+export const DetailTabTable = fp.flow(withCurrentCohortReview(), withCurrentWorkspace())(
   class extends React.Component<Props, State> {
     codeInputChange: Function;
     private countAborter = new AbortController();
@@ -438,8 +439,7 @@ export const DetailTabTable = withCurrentWorkspace()(
     }
 
     async callDataApi(request: PageFilterRequest) {
-      const {domain, participantId, workspace: {id, namespace}} = this.props;
-      const {cohortReviewId} = cohortReviewStore.getValue();
+      const {cohortReview: {cohortReviewId}, domain, participantId, workspace: {id, namespace}} = this.props;
       let data = [];
       await cohortReviewApi()
         .getParticipantData(namespace, id, cohortReviewId, participantId, request, {signal: this.dataAborter.signal})
@@ -456,8 +456,7 @@ export const DetailTabTable = withCurrentWorkspace()(
     }
 
     async callCountApi(request: PageFilterRequest) {
-      const {participantId, workspace: {id, namespace}} = this.props;
-      const {cohortReviewId} = cohortReviewStore.getValue();
+      const {cohortReview: {cohortReviewId}, participantId, workspace: {id, namespace}} = this.props;
       let count = null;
       await cohortReviewApi()
         .getParticipantCount(namespace, id, cohortReviewId, participantId, request, {signal: this.countAborter.signal})

--- a/ui/src/app/pages/data/cohort-review/query-report.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/query-report.component.tsx
@@ -2,12 +2,11 @@ import {ComboChart} from 'app/components/combo-chart.component';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {CohortDefinition} from 'app/pages/data/cohort-review/cohort-definition.component';
 import {ParticipantsCharts} from 'app/pages/data/cohort-review/participants-charts';
-import {cohortReviewStore} from 'app/services/review-state.service';
 import {cohortBuilderApi, cohortReviewApi, cohortsApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
-import {reactStyles, withCdrVersions, withCurrentWorkspace} from 'app/utils';
+import {reactStyles, withCdrVersions, withCurrentCohortReview, withCurrentWorkspace} from 'app/utils';
 import {findCdrVersion} from 'app/utils/cdr-versions';
-import {navigate, urlParamsStore} from 'app/utils/navigation';
+import {currentCohortReviewStore, navigate, urlParamsStore} from 'app/utils/navigation';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {
   AgeType,
@@ -186,6 +185,7 @@ const domains = [Domain[Domain.CONDITION],
 
 export interface QueryReportProps {
   cdrVersionTiersResponse: CdrVersionTiersResponse;
+  cohortReview: CohortReview;
   workspace: WorkspaceData;
 }
 export interface QueryReportState {
@@ -194,11 +194,10 @@ export interface QueryReportState {
   data: any;
   groupedData: any;
   chartsLoading: boolean;
-  review: CohortReview;
   reviewLoading: boolean;
 }
 
-export const QueryReport = fp.flow(withCdrVersions(), withCurrentWorkspace())(
+export const QueryReport = fp.flow(withCdrVersions(), withCurrentCohortReview(), withCurrentWorkspace())(
   class extends React.Component<QueryReportProps, QueryReportState> {
     constructor(props: any) {
       super(props);
@@ -208,28 +207,26 @@ export const QueryReport = fp.flow(withCdrVersions(), withCurrentWorkspace())(
         data: null,
         groupedData: null,
         chartsLoading: true,
-        review: cohortReviewStore.getValue(),
         reviewLoading: true
       };
     }
 
     async componentDidMount() {
-      const {cdrVersionTiersResponse, workspace: {cdrVersionId}} = this.props;
-      const {review} = this.state;
+      const {cdrVersionTiersResponse, cohortReview, workspace: {cdrVersionId}} = this.props;
       const {ns, wsid, cid} = urlParamsStore.getValue();
       let request: SearchRequest;
-      if (review) {
+      if (cohortReview) {
         this.setState({reviewLoading: false});
-        request = (JSON.parse(review.cohortDefinition));
+        request = (JSON.parse(cohortReview.cohortDefinition));
       } else {
         await cohortReviewApi().getParticipantCohortStatuses(ns, wsid, cid, +cdrVersionId, {
           page: 0,
           pageSize: 25,
           sortOrder: SortOrder.Asc
-        }).then(({cohortReview}) => {
-          request = (JSON.parse(cohortReview.cohortDefinition));
-          this.setState({review: cohortReview, reviewLoading: false});
-          cohortReviewStore.next(cohortReview);
+        }).then(({cohortReview: review}) => {
+          request = (JSON.parse(review.cohortDefinition));
+          this.setState({reviewLoading: false});
+          currentCohortReviewStore.next(review);
         });
       }
       cohortsApi().getCohort(ns, wsid, cid).then(cohort => this.setState({cohort}));
@@ -276,7 +273,8 @@ export const QueryReport = fp.flow(withCdrVersions(), withCurrentWorkspace())(
     }
 
     render() {
-      const {cdrName, cohort, data, groupedData, chartsLoading, review, reviewLoading} = this.state;
+      const {cohortReview} = this.props;
+      const {cdrName, cohort, data, groupedData, chartsLoading, reviewLoading} = this.state;
       // TODO can we use the creation time from the review instead of the cohort here?
       const created = !!cohort ? moment(cohort.creationTime).format('YYYY-MM-DD') : null;
       return <React.Fragment>
@@ -287,7 +285,8 @@ export const QueryReport = fp.flow(withCdrVersions(), withCurrentWorkspace())(
           onClick={() => this.goBack()}>
           Back to review set
         </button>
-        {reviewLoading ? <SpinnerOverlay/> : <div style={styles.reportBackground}>
+        {reviewLoading && <SpinnerOverlay/>}
+        {cohortReview && <div style={styles.reportBackground}>
           <div style={styles.container}>
             <div style={styles.row}>
               <div style={columns.col6}>
@@ -298,7 +297,7 @@ export const QueryReport = fp.flow(withCdrVersions(), withCurrentWorkspace())(
                         Cohort Name
                       </div>
                       <div style={styles.queryContent}>
-                        {review.cohortName}
+                        {cohortReview.cohortName}
                       </div>
                       <div style={styles.queryTitle}>
                         Created By
@@ -322,7 +321,7 @@ export const QueryReport = fp.flow(withCdrVersions(), withCurrentWorkspace())(
                       </div>
                     </div>
                     <div style={columns.col12}>
-                      <CohortDefinition review={review}/>
+                      <CohortDefinition review={cohortReview}/>
                     </div>
                   </div>
                 </div>
@@ -370,7 +369,7 @@ export const QueryReport = fp.flow(withCdrVersions(), withCurrentWorkspace())(
                           {groupedData[group][row].count.toLocaleString()}
                         </div>
                         <div style={columns.col3}>
-                          {Math.round(groupedData[group][row].count / review.matchedParticipantCount * 100)}%
+                          {Math.round(groupedData[group][row].count / cohortReview.matchedParticipantCount * 100)}%
                         </div>
                       </div>
                     </div>
@@ -405,7 +404,7 @@ export const QueryReport = fp.flow(withCdrVersions(), withCurrentWorkspace())(
                     <div style={{...styles.col, flex: '0 0 83.33333%', maxWidth: '83.33333%'}}>
                       {domains.map((domain, i) => (
                         <div key={i} style={{minHeight: '10rem', position: 'relative'}}>
-                          <ParticipantsCharts domain={domain} review={review}/>
+                          <ParticipantsCharts domain={domain} review={cohortReview}/>
                         </div>
                       ))}
                     </div>

--- a/ui/src/app/pages/data/cohort-review/sidebar-content.component.spec.tsx
+++ b/ui/src/app/pages/data/cohort-review/sidebar-content.component.spec.tsx
@@ -1,9 +1,8 @@
 import {mount} from 'enzyme';
 import * as React from 'react';
 
-import {cohortReviewStore} from 'app/services/review-state.service';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
-import {currentWorkspaceStore} from 'app/utils/navigation';
+import {currentCohortReviewStore, currentWorkspaceStore} from 'app/utils/navigation';
 import {CohortAnnotationDefinitionApi, CohortReviewApi} from 'generated/fetch';
 import {CohortAnnotationDefinitionServiceStub} from 'testing/stubs/cohort-annotation-definition-service-stub';
 import {CohortReviewServiceStub, cohortReviewStubs} from 'testing/stubs/cohort-review-service-stub';
@@ -15,7 +14,7 @@ describe('SidebarContent', () => {
     registerApiClient(CohortReviewApi, new CohortReviewServiceStub());
     registerApiClient(CohortAnnotationDefinitionApi, new CohortAnnotationDefinitionServiceStub());
     currentWorkspaceStore.next(workspaceDataStub);
-    cohortReviewStore.next(cohortReviewStubs[0]);
+    currentCohortReviewStore.next(cohortReviewStubs[0]);
   });
 
   it('should render', () => {

--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -15,7 +15,8 @@ import colors, {addOpacity, colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, withCurrentWorkspace, withUrlParams} from 'app/utils';
 import {
   attributesSelectionStore,
-  currentCohortCriteriaStore, currentCohortStore,
+  currentCohortCriteriaStore,
+  currentCohortStore,
   currentConceptStore,
   setSidebarActiveIconStore
 } from 'app/utils/navigation';

--- a/ui/src/app/services/review-state.service.ts
+++ b/ui/src/app/services/review-state.service.ts
@@ -1,6 +1,7 @@
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
+import {currentCohortReviewStore} from 'app/utils/navigation';
 import {CohortReview, CohortStatus, FilterColumns, ParticipantCohortStatus, SortOrder} from 'generated/fetch';
 
 export const initialFilterState = {
@@ -102,7 +103,6 @@ const initialPaginationState = {
   sortOrder: SortOrder.Asc
 };
 
-export const cohortReviewStore = new BehaviorSubject<CohortReview>(undefined);
 export const visitsFilterOptions = new BehaviorSubject<Array<any>>(null);
 export const filterStateStore = new BehaviorSubject<any>(JSON.parse(JSON.stringify(initialFilterState)));
 export const vocabOptions = new BehaviorSubject<any>(null);
@@ -131,12 +131,12 @@ export function getVocabOptions(workspaceNamespace: string, workspaceId: string,
 }
 
 export function updateParticipant(participant: ParticipantCohortStatus) {
-  const review = cohortReviewStore.getValue();
+  const review = currentCohortReviewStore.getValue();
   if (participant && review) {
     const index = review.participantCohortStatuses.findIndex(p => p.participantId === participant.participantId);
     if (index !== -1) {
       review.participantCohortStatuses[index] = participant;
-      cohortReviewStore.next(review);
+      currentCohortReviewStore.next(review);
     }
   }
 }

--- a/ui/src/app/services/review-state.service.ts
+++ b/ui/src/app/services/review-state.service.ts
@@ -2,7 +2,7 @@ import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 import {cohortReviewApi} from 'app/services/swagger-fetch-clients';
 import {currentCohortReviewStore} from 'app/utils/navigation';
-import {CohortReview, CohortStatus, FilterColumns, ParticipantCohortStatus, SortOrder} from 'generated/fetch';
+import {CohortStatus, FilterColumns, ParticipantCohortStatus, SortOrder} from 'generated/fetch';
 
 export const initialFilterState = {
   global: {

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -2,6 +2,7 @@ import {ElementRef, OnChanges, OnDestroy, OnInit, ViewChild} from '@angular/core
 import {colorWithWhiteness} from 'app/styles/colors';
 import {
   currentCohortCriteriaStore,
+  currentCohortReviewStore,
   currentCohortSearchContextStore,
   currentCohortStore,
   currentConceptSetStore,
@@ -300,6 +301,11 @@ export const withCurrentWorkspace = () => {
 // HOC that provides a 'cohort' prop with current Cohort
 export const withCurrentCohort = () => {
   return connectBehaviorSubject(currentCohortStore, 'cohort');
+};
+
+// HOC that provides a 'cohortReview' prop with current CohortReview
+export const withCurrentCohortReview = () => {
+  return connectBehaviorSubject(currentCohortReviewStore, 'cohortReview');
 };
 
 // HOC that provides a 'criteria' prop with current Cohort

--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -2,7 +2,7 @@ import {ActivatedRouteSnapshot, DetachedRouteHandle, RouteReuseStrategy} from '@
 
 import {Selection} from 'app/cohort-search/selection-list/selection-list.component';
 import {WorkspaceData} from 'app/utils/workspace-data';
-import {Cohort, ConceptSet, Criteria, ErrorResponse} from 'generated/fetch';
+import {Cohort, CohortReview, ConceptSet, Criteria, ErrorResponse} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import {useLocation} from 'react-router';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
@@ -21,6 +21,7 @@ export const nextWorkspaceWarmupStore = new BehaviorSubject<WorkspaceData>(undef
 
 export const currentWorkspaceStore = new BehaviorSubject<WorkspaceData>(undefined);
 export const currentCohortStore = new BehaviorSubject<Cohort>(undefined);
+export const currentCohortReviewStore = new BehaviorSubject<CohortReview>(undefined);
 export const currentConceptSetStore = new BehaviorSubject<ConceptSet>(undefined);
 export const globalErrorStore = new BehaviorSubject<ErrorResponse>(undefined);
 export const urlParamsStore = new BehaviorSubject<any>({});
@@ -118,6 +119,7 @@ export enum BreadcrumbType {
   Notebook = 'Notebook',
   ConceptSet = 'ConceptSet',
   Cohort = 'Cohort',
+  CohortReview = 'CohortReview',
   Participant = 'Participant',
   CohortAdd = 'CohortAdd',
   SearchConcepts = 'SearchConcepts',

--- a/ui/src/test.ts
+++ b/ui/src/test.ts
@@ -12,8 +12,7 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
-import {cohortReviewStore} from 'app/services/review-state.service';
-import {currentWorkspaceStore, currentCohortStore, currentConceptSetStore, urlParamsStore, queryParamsStore, routeConfigDataStore} from 'app/utils/navigation';
+import {currentWorkspaceStore, currentCohortStore, currentCohortReviewStore, currentConceptSetStore, urlParamsStore, queryParamsStore, routeConfigDataStore} from 'app/utils/navigation';
 import {serverConfigStore} from "./app/utils/stores";
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
@@ -29,7 +28,7 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 beforeEach(() => {
-  cohortReviewStore.next(undefined);
+  currentCohortReviewStore.next(undefined);
   currentWorkspaceStore.next(undefined);
   currentCohortStore.next(undefined);
   currentConceptSetStore.next(undefined);

--- a/ui/src/testing/stubs/cohort-review-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-review-service-stub.ts
@@ -40,7 +40,7 @@ export const cohortReviewStubs = [{
   cdrVersionId: 1,
   creationTime: 1,
   cohortDefinition: JSON.stringify(criteriaStub),
-  cohortName: '',
+  cohortName: 'Cohort Name',
   matchedParticipantCount: 1,
   reviewSize: 1,
   reviewedCount: 1,


### PR DESCRIPTION
Fixes issue where the breadcrumb link for the cohort review name only showed `...`.
- Caused by cohort review routes using the `Cohort` breadcrumb type and `currentCohortStore` being empty.
- Fixed by creating a new `CohortReview` breadcrumb type and `currentCohortReviewStore`  to use for cohort review routes.
- Also deleted `cohortReviewStore` and replaced all instances with `currentCohortReviewStore` since we don't need two stores for cohort reviews. (Sorry, this significantly increased the size of the PR but in most cases it's a simple swap out)

Before:
<img width="536" alt="Screen Shot 2021-06-28 at 11 50 20 AM" src="https://user-images.githubusercontent.com/40036095/123674423-36299e80-d807-11eb-80a5-93746f4971f5.png">

After:
<img width="537" alt="Screen Shot 2021-06-28 at 11 51 23 AM" src="https://user-images.githubusercontent.com/40036095/123674458-3d50ac80-d807-11eb-8021-fe0b292b85c4.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
