### PR TITLE
[risk=low][no ticket] Change isDefault to object Boolean

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
@@ -123,7 +123,7 @@ public class CdrDbConfig {
                 .getAccessTier()
                 .getShortName()
                 .equals(AccessTierService.REGISTERED_TIER_SHORT_NAME)
-            && cdrVersion.getIsDefault()) {
+            && cdrVersion.getIsDefaultNotNull()) {
           if (defaultId != null) {
             throw new ServerErrorException(
                 String.format(

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
@@ -151,7 +151,7 @@ public class CdrVersionService {
 
     List<Long> defaultVersions =
         cdrVersions.stream()
-            .filter(DbCdrVersion::getIsDefault)
+            .filter(DbCdrVersion::getIsDefaultNotNull)
             .map(DbCdrVersion::getCdrVersionId)
             .collect(Collectors.toList());
     if (defaultVersions.isEmpty()) {

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.db.model;
 
 import java.sql.Timestamp;
 import java.util.Objects;
+import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -9,13 +10,14 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import javax.validation.constraints.NotNull;
 import org.pmiops.workbench.model.ArchivalStatus;
 
 @Entity
 @Table(name = "cdr_version")
 public class DbCdrVersion {
   private long cdrVersionId;
-  private boolean isDefault;
+  private Boolean isDefault;
   private String name;
   private DbAccessTier accessTier;
   private short releaseNumber;
@@ -42,13 +44,22 @@ public class DbCdrVersion {
     this.cdrVersionId = cdrVersionId;
   }
 
+  // I changed the type to object Boolean because Hibernate started complaining about assigning
+  // nulls to primitive boolean.  TODO why now / what changed?
+
   @Column(name = "is_default")
-  public boolean getIsDefault() {
+  public Boolean getIsDefault() {
     return isDefault;
   }
 
-  public void setIsDefault(boolean isDefault) {
+  public void setIsDefault(Boolean isDefault) {
     this.isDefault = isDefault;
+  }
+
+  @Transient
+  @NotNull
+  public boolean getIsDefaultNotNull() {
+    return Optional.ofNullable(isDefault).orElse(false);
   }
 
   @Column(name = "name")

--- a/api/src/main/java/org/pmiops/workbench/tools/cdrconfig/CdrVersionVO.java
+++ b/api/src/main/java/org/pmiops/workbench/tools/cdrconfig/CdrVersionVO.java
@@ -9,7 +9,7 @@ import java.sql.Timestamp;
 // adapted from DbCdrVersion
 public class CdrVersionVO {
   public long cdrVersionId;
-  public boolean isDefault;
+  public Boolean isDefault;
   public String name;
   public String accessTier; // modified from DbAccessTier type in DbCdrVersion
   public short releaseNumber;

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
@@ -144,7 +144,7 @@ public class UpdateCdrConfig {
                 id, accessTier));
       }
 
-      if (v.isDefault) {
+      if (v.isDefault != null && v.isDefault) {
         if (v.archivalStatus != DbStorageEnums.archivalStatusToStorage(ArchivalStatus.LIVE)) {
           throw new IllegalArgumentException(
               String.format("Archived CDR Version %d cannot be the default", id));


### PR DESCRIPTION
Description:

Despite no apparent changes, Hibernate is now complaining that it can't assign DB nulls to primitive boolean.  This makes sense - but why now?

This completely blocks local development for me (so it could be something local?) so I'm converting this field to object Boolean while I consider longer term fixes.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
