### PR TITLE
[ticket=no][risk=no] withErrorModal onDismiss() should be a notification property and not a curried argument

### DIFF
--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -286,13 +286,14 @@ export const HelpSidebar = fp.flow(
     deleteWorkspace = withErrorModal({
       title: 'Error Deleting Workspace',
       message: `Could not delete workspace '${this.props.workspace.name}'.`,
-      showBugReportLink: true
+      showBugReportLink: true,
+      onDismiss: () => {
+        this.setState({currentModal: CurrentModal.None});
+      }
     }, async() => {
       AnalyticsTracker.Workspaces.Delete();
       await workspacesApi().deleteWorkspace(this.props.workspace.namespace, this.props.workspace.id);
       navigate(['/workspaces']);
-    }, () => {
-      this.setState({currentModal: CurrentModal.None});
     });
 
     iconConfig(iconKey): IconConfig {

--- a/ui/src/app/components/modals.tsx
+++ b/ui/src/app/components/modals.tsx
@@ -109,12 +109,11 @@ export const NotificationModal = () => {
   </Modal>;
 };
 
-export const withErrorModal = fp.curry((notificationState: NotificationStore, wrappedFn, onDismiss) => async(...args) => {
+export const withErrorModal = fp.curry((notificationState: NotificationStore, wrappedFn) => async(...args) => {
   try {
     return await wrappedFn(...args);
   } catch (e) {
     notificationStore.set(notificationState);
-    onDismiss();
   }
 });
 


### PR DESCRIPTION
Adding `onDismiss()` as a curried argument broke some usages of the error modal since it would require another argument before invoking the wrapped function.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
