### PR TITLE
[risk=no] Turn off billing upgrade in lower environments

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -108,7 +108,7 @@
   "featureFlags": {
     "unsafeAllowDeleteUser": true,
     "unsafeAllowAccessToAllTiersForRegisteredUsers": true,
-    "enableBillingUpgrade": true,
+    "enableBillingUpgrade": false,
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": true,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -108,7 +108,7 @@
   "featureFlags": {
     "unsafeAllowDeleteUser": true,
     "unsafeAllowAccessToAllTiersForRegisteredUsers": true,
-    "enableBillingUpgrade": true,
+    "enableBillingUpgrade": false,
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -108,7 +108,7 @@
   "featureFlags": {
     "unsafeAllowDeleteUser": false,
     "unsafeAllowAccessToAllTiersForRegisteredUsers": true,
-    "enableBillingUpgrade": true,
+    "enableBillingUpgrade": false,
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -108,7 +108,7 @@
   "featureFlags": {
     "unsafeAllowDeleteUser": true,
     "unsafeAllowAccessToAllTiersForRegisteredUsers": true,
-    "enableBillingUpgrade": true,
+    "enableBillingUpgrade": false,
     "enableV3DataUserCodeOfConduct": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": true,


### PR DESCRIPTION
This was left on presumably unintentionally since we first attempted to launch. Just realized today it was still enabled... Will be more accurate to develop and test with this off.