### PR TITLE
[no ticket][risk=no] Puppeteer fix deleteWorkspace func failure

### DIFF
--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -33,7 +33,7 @@ export default class WorkspaceCard extends CardBase {
     await card.selectSnowmanMenu(MenuOption.Delete, { waitForNav: false });
     // Handle Delete Confirmation modal
     const modalText = new WorkspaceEditPage(page).dismissDeleteWorkspaceModal();
-    await WorkspaceCard.waitUntilGone(page, workspaceName);
+    await WorkspaceCard.waitUntilGone(page, workspaceName, 120000);
     return modalText;
   }
 

--- a/e2e/app/container.ts
+++ b/e2e/app/container.ts
@@ -63,7 +63,7 @@ export default class Container {
       fp.flow(
         fp.filter<{ shouldWait: boolean; waitFn: () => Promise<void> }>('shouldWait'),
         fp.map((item) => item.waitFn()),
-        fp.concat([button.click({ delay: 10 })])
+        fp.concat([button.click({ delay: 10 }), waitWhileLoading(this.page)])
       )([
         {
           shouldWait: waitForNav,

--- a/e2e/tests/workspace/workspace-share-modal.spec.ts
+++ b/e2e/tests/workspace/workspace-share-modal.spec.ts
@@ -8,8 +8,16 @@ import { makeWorkspaceName } from 'utils/str-utils';
 
 describe('Workspace Share Modal', () => {
   const assignAccess = [
-    { accessRole: WorkspaceAccessLevel.Writer, userEmail: config.writerUserName, userAccessTokenFilename: config.writerUserAccessTokenFilename},
-    { accessRole: WorkspaceAccessLevel.Reader, userEmail: config.readerUserName, userAccessTokenFilename: config.readerUserAccessTokenFilename }
+    {
+      accessRole: WorkspaceAccessLevel.Writer,
+      userEmail: config.writerUserName,
+      userAccessTokenFilename: config.writerUserAccessTokenFilename
+    },
+    {
+      accessRole: WorkspaceAccessLevel.Reader,
+      userEmail: config.readerUserName,
+      userAccessTokenFilename: config.readerUserAccessTokenFilename
+    }
   ];
 
   // Create new workspace with default CDR version

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -396,11 +396,16 @@ export async function waitWhileLoading(
       spinElementsSelector
     ),
     page.waitForSelector(spinElementsSelector, { hidden: true, timeout })
-  ]).catch((err) => {
-    logger.error(`waitWhileLoading() failed: spinner xpath="${spinElementsSelector}"`);
-    logger.error(err);
-    logger.error(err.stack);
-    throw new Error(err);
+  ]).catch((err: Error) => {
+    logger.error(`Failed wait for spinner stop: xpath="${spinElementsSelector}"`);
+    if (err.message.includes('Target closed')) {
+      // Leave blank. Ignore error and continue test.
+      // Puppeteer can throw following exception when polling for mutation status if object has disappeared in DOM.
+      //   Error: Protocol error (Runtime.callFunctionOn): Target closed.
+    } else {
+      logger.error(err.stack);
+      throw err;
+    }
   });
 
   await page.waitForTimeout(500);

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -400,8 +400,9 @@ export async function waitWhileLoading(
     logger.error(`Failed wait for spinner stop: xpath="${spinElementsSelector}"`);
     if (err.message.includes('Target closed')) {
       // Leave blank. Ignore error and continue test.
-      // Puppeteer can throw following exception when polling for mutation status if object has disappeared in DOM.
-      //   Error: Protocol error (Runtime.callFunctionOn): Target closed.
+      // Puppeteer can throw following exception when polling for mutation status if this object disappeared in DOM
+      //   or page navigation happened.
+      // Error: Protocol error (Runtime.callFunctionOn): Target closed.
     } else {
       logger.error(err.stack);
       throw err;


### PR DESCRIPTION
`WorkspaceCard.deleteWorkspace()` function could fail if delete took longer than 60 seconds. Failed in `workspace-duplicate-cdr-versions.spec.ts` test [here](https://app.circleci.com/pipelines/github/all-of-us/workbench/11495/workflows/d80070df-4913-4f55-886b-846a4f22b1b1/jobs/148187/tests) in CircleCI.

Test failure stacktrace

```
test name: OWNER can duplicate workspace to a newer CDR Version via Workspace card
status: failed
failure: [
  'TimeoutError: waiting for XPath `.//*[child::*[@data-test-id="workspace-card"]]//*[@data-test-id="workspace-card-name" and normalize-space(text())="aoutest-404061625158614"]` to be hidden failed: timeout 60000ms exceeded\n' +
    '    at new WaitTask (/home/circleci/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:505:34)\n' +
    '    at DOMWorld.waitForXPath (/home/circleci/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:441:26)\n' +
    '    at Frame.waitForXPath (/home/circleci/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/FrameManager.js:866:51)\n' +
    '    at Page.waitForXPath (/home/circleci/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:1288:33)\n' +
    '    at Function.waitUntilGone (/home/circleci/workbench/e2e/app/component/workspace-card.ts:97:16)\n' +
    '    at Function.deleteWorkspace (/home/circleci/workbench/e2e/app/component/workspace-card.ts:36:25)\n' +
    '    at Object.<anonymous> (/home/circleci/workbench/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts:93:5)',
  'Error: Error: Protocol error (Runtime.callFunctionOn): Target closed.\n' +
    '    at /home/circleci/workbench/e2e/utils/waits-utils.ts:403:11\n' +
    '    at runMicrotasks (<anonymous>)\n' +
    '    at runNextTicks (internal/process/task_queues.js:62:5)\n' +
    '    at listOnTimeout (internal/timers.js:523:9)\n' +
    '    at processTimers (internal/timers.js:497:7)\n' +
    '    at Object.waitWhileLoading (/home/circleci/workbench/e2e/utils/waits-utils.ts:390:3)\n' +
    '    at WorkspaceEditPage.dismissDeleteWorkspaceModal (/home/circleci/workbench/e2e/app/page/workspace-base.ts:262:5)'
]
```