### PR TITLE
[RW-6538][risk=no] Reduce audit queue throughput

### DIFF
--- a/api/src/main/webapp/WEB-INF/queue.yaml
+++ b/api/src/main/webapp/WEB-INF/queue.yaml
@@ -9,6 +9,7 @@ queue:
 - name: auditProjectQueue
   rate: 4/m
   target: api
+  max_concurrent_requests: 1
   bucket_size: 100
   retry_parameters:
     task_retry_limit: 1


### PR DESCRIPTION
The overall throughput seems correct. From what we observe in prod, there is an initial burst of requests which overtakes our project quota. After this, the 4/m stabilizes, and requests succeed. Try to manage the initial burst with this setting.