### PR TITLE
[RW-6989][risk=no] UI: Fix texts string in Delete Workspace Error modal 

### DIFF
--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -8,7 +8,7 @@ import {WorkspaceCardBase} from 'app/components/card';
 import {ConfirmDeleteModal} from 'app/components/confirm-delete-modal';
 import {FlexColumn, FlexRow} from 'app/components/flex';
 import {ClrIcon, ControlledTierBadge} from 'app/components/icons';
-import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
+import {Modal, ModalBody, ModalFooter, ModalTitle, withErrorModal} from 'app/components/modals';
 import {PopupTrigger, TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
 import {AouTitle} from 'app/components/text-wrappers';
@@ -162,19 +162,18 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
     };
   }
 
-  async deleteWorkspace() {
-    const {workspace} = this.props;
-    this.setState({
-      confirmDeleting: false,
-      loadingData: true});
-    try {
-      await workspacesApi().deleteWorkspace(workspace.namespace, workspace.id);
-      this.setState({loadingData: false});
-      await this.props.reload();
-    } catch (e) {
-      this.setState({bugReportOpen: true, bugReportError: 'Could not delete workspace', loadingData: false});
+  deleteWorkspace = withErrorModal({
+    title: 'Error Deleting Workspace',
+    message: `Could not delete workspace '${this.props.workspace.id}'.`,
+    showBugReportLink: true,
+    onDismiss: () => {
+      this.setState({confirmDeleting: false, loadingData: true});
     }
-  }
+  }, async() => {
+    AnalyticsTracker.Workspaces.Delete();
+    await workspacesApi().deleteWorkspace(this.props.workspace.namespace, this.props.workspace.id);
+    await this.props.reload();
+  });
 
   async handleShareDialogClose() {
     // Share workspace publishes to current workspace,

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -167,7 +167,7 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
     message: `Could not delete workspace '${this.props.workspace.id}'.`,
     showBugReportLink: true,
     onDismiss: () => {
-      this.setState({confirmDeleting: false, loadingData: true});
+      this.setState({confirmDeleting: false, loadingData: false});
     }
   }, async() => {
     AnalyticsTracker.Workspaces.Delete();

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -130,8 +130,6 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
 };
 
 interface WorkspaceCardState {
-  bugReportError: string;
-  bugReportOpen: boolean;
   confirmDeleting: boolean;
   // Whether this card is busy loading data specific to the workspace.
   loadingData: boolean;
@@ -153,8 +151,6 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
   constructor(props) {
     super(props);
     this.state = {
-      bugReportError: '',
-      bugReportOpen: false,
       confirmDeleting: false,
       loadingData: false,
       showShareModal: false,
@@ -210,7 +206,7 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
 
   render() {
     const {workspace, workspace: {accessTierShortName}, accessLevel} = this.props;
-    const {bugReportError, bugReportOpen, confirmDeleting, loadingData,
+    const {confirmDeleting, loadingData,
       showShareModal, showResearchPurposeReviewModal} = this.state;
 
     return <React.Fragment>
@@ -294,8 +290,6 @@ export class WorkspaceCard extends React.Component<WorkspaceCardProps, Workspace
       {showShareModal && <WorkspaceShare data-test-id='workspace-share-modal'
                                   workspace={{...workspace, accessLevel}}
                                   onClose={() => this.handleShareDialogClose()} />}
-      {bugReportOpen && <BugReportModal bugReportDescription={bugReportError}
-                                        onClose={() => this.setState({bugReportOpen: false})}/>}
       {showResearchPurposeReviewModal && <Modal data-test-id='workspace-review-modal'>
         <ModalTitle>Please review Research Purpose for Workspace '{workspace.name}'</ModalTitle>
         <ModalBody style={{display: 'flex', flexDirection: 'column'}}>

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import {ResourceType, Workspace, WorkspaceAccessLevel} from 'generated/fetch';
 
-import {BugReportModal} from 'app/components/bug-report';
 import {Button, Clickable, MenuItem, SnowmanButton} from 'app/components/buttons';
 import {WorkspaceCardBase} from 'app/components/card';
 import {ConfirmDeleteModal} from 'app/components/confirm-delete-modal';


### PR DESCRIPTION
Error message screenshot:

<img width="678" alt="Screen Shot 2021-07-01 at 5 06 56 PM" src="https://user-images.githubusercontent.com/35533885/124189870-608d8d00-da8f-11eb-8cd4-36e635f07430.png">

Steps I used to force error modal to display:
* Start local UI server.
* Connect to local UI server on 2 different incognito pages.
* Delete a workspace in page 1, then quickly delete the same workspace again in page 2.
* Because two delete calls were made, delete in page 2 failed when delete in page 1 succeeded.

New look after change:

<img width="631" alt="Screen Shot 2021-07-01 at 5 03 23 PM" src="https://user-images.githubusercontent.com/35533885/124189918-7602b700-da8f-11eb-93f4-ffc513fa9509.png">

After close modal, page is not auto reloaded:

<img width="1163" alt="Screen Shot 2021-07-01 at 5 03 34 PM" src="https://user-images.githubusercontent.com/35533885/124189960-831fa600-da8f-11eb-9768-6d3766c702d3.png">

User reload the page. workspace is gone.

<img width="1111" alt="Screen Shot 2021-07-01 at 5 03 50 PM" src="https://user-images.githubusercontent.com/35533885/124190035-9cc0ed80-da8f-11eb-891a-4a62fa7dfa2b.png">
