### PR TITLE
[no ticket][risk=no] Puppeteer disable a test due to RW-6885

### DIFF
--- a/e2e/tests/datasets/export-to-notebook.spec.ts
+++ b/e2e/tests/datasets/export-to-notebook.spec.ts
@@ -17,7 +17,9 @@ import ExportToNotebookModal from 'app/modal/export-to-notebook-modal';
 jest.setTimeout(30 * 60 * 1000);
 
 describe('Export to notebook tests', () => {
-  const KernelLanguages = [{ LANGUAGE: Language.R }, { LANGUAGE: Language.Python }];
+
+  // TODO Add back R kernel notebook test after bug fix. https://precisionmedicineinitiative.atlassian.net/browse/RW-6885
+  const KernelLanguages = [{ LANGUAGE: Language.Python }];
 
   beforeEach(async () => {
     await signInWithAccessToken(page);

--- a/e2e/tests/datasets/export-to-notebook.spec.ts
+++ b/e2e/tests/datasets/export-to-notebook.spec.ts
@@ -16,7 +16,7 @@ import ExportToNotebookModal from 'app/modal/export-to-notebook-modal';
 // 30 minutes. Test involves starting of notebook that could take a long time to create.
 jest.setTimeout(30 * 60 * 1000);
 
-describe('Export to notebook tests', () => {
+describe('Export dataset to notebook tests', () => {
 
   // TODO Add back R kernel notebook test after bug fix. https://precisionmedicineinitiative.atlassian.net/browse/RW-6885
   const KernelLanguages = [{ LANGUAGE: Language.Python }];


### PR DESCRIPTION
Temporarily disable failing test until bug is fixed to avoid master branch builds failures.