### PR TITLE
[no ticket][risk=no] e2e notebook code cleanup and refactor

### DIFF
--- a/e2e/app/page/base-page.ts
+++ b/e2e/app/page/base-page.ts
@@ -25,7 +25,7 @@ export default abstract class BasePage {
   async gotoUrl(url: string): Promise<void> {
     const response = await this.page.goto(url, { waitUntil: ['load'] });
     if (response) {
-      logger.info(`Goto URL: ${url} Response: ${response.status()} ${await response.text()}`);
+      logger.info(`Goto URL: ${url}. Response status: ${response.status()}\n${await response.text()}`);
     }
   }
 

--- a/e2e/app/page/base-page.ts
+++ b/e2e/app/page/base-page.ts
@@ -6,11 +6,7 @@ import { logger } from 'libs/logger';
  * Contains common functions/actions that help with tests creation.
  */
 export default abstract class BasePage {
-  page: Page;
-
-  protected constructor(page: Page) {
-    this.page = page;
-  }
+  protected constructor(protected readonly page: Page) {}
 
   async getPageTitle(): Promise<string> {
     return this.page.title();

--- a/e2e/app/page/notebook-cell.ts
+++ b/e2e/app/page/notebook-cell.ts
@@ -1,5 +1,6 @@
 import { ElementHandle, Frame, Page } from 'puppeteer';
 import { getPropValue } from 'utils/element-utils';
+import NotebookFrame from './notebook-frame';
 
 export enum CellType {
   // To append to css selector
@@ -11,8 +12,10 @@ export enum CellType {
 /**
  * Notebook Cell represents the root element that contains both the code input and output cells.
  */
-export default class NotebookCell {
-  private iframe: Frame; // Jupyter notebook iframe
+export default class NotebookCell extends NotebookFrame {
+  isLoaded(): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
 
   /**
    *
@@ -20,11 +23,9 @@ export default class NotebookCell {
    * @param {CellType} cellType: Code or Markdown cell. Default value is Code cell.
    * @param {number} cellIndex Cell index. (first index is 1)
    */
-  constructor(
-    private readonly page: Page,
-    private readonly cellType: CellType = CellType.Code,
-    private cellIndex: number = 1
-  ) {}
+  constructor(page: Page, private readonly cellType: CellType = CellType.Code, private cellIndex: number = 1) {
+    super(page);
+  }
 
   async getLastCell(): Promise<NotebookCell | null> {
     const elements = await this.findAllCells();
@@ -125,14 +126,6 @@ export default class NotebookCell {
     const selector = `${this.outputSelector(this.getCellIndex())}.output_error`;
     const iframe = await this.getIFrame();
     return iframe.waitForSelector(selector, { visible: true, timeout: timeOut });
-  }
-
-  private async getIFrame(): Promise<Frame> {
-    if (this.iframe === undefined) {
-      const frame = await this.page.waitForSelector('iframe[src*="notebooks"]');
-      this.iframe = await frame.contentFrame();
-    }
-    return this.iframe;
   }
 
   private async findAllCells(): Promise<ElementHandle[]> {

--- a/e2e/app/page/notebook-frame.ts
+++ b/e2e/app/page/notebook-frame.ts
@@ -1,0 +1,13 @@
+import AuthenticatedPage from './authenticated-page';
+import { Frame, Page } from 'puppeteer';
+
+export default abstract class NotebookFrame extends AuthenticatedPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async getIFrame(): Promise<Frame> {
+    const frame = await this.page.waitForSelector('iframe[src*="notebooks"]');
+    return frame.contentFrame();
+  }
+}

--- a/e2e/tests/datasets/export-to-notebook.spec.ts
+++ b/e2e/tests/datasets/export-to-notebook.spec.ts
@@ -17,7 +17,6 @@ import ExportToNotebookModal from 'app/modal/export-to-notebook-modal';
 jest.setTimeout(30 * 60 * 1000);
 
 describe('Export dataset to notebook tests', () => {
-
   const KernelLanguages = [{ LANGUAGE: Language.Python }, { LANGUAGE: Language.R }];
 
   beforeEach(async () => {


### PR DESCRIPTION
`getIFrame()` function were repeated in several notebook page classes. Created new abstract `notebookframe.ts` class to avoid code duplication.