### PR TITLE
[risk=low][RW-6918] Fix AAR email logic when modules are disabled

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -1158,7 +1158,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     // Here we do need to know if any are EMPTY, for the next step.
     final Set<Optional<Timestamp>> expirations =
         getRenewableAccessModules(user).entrySet().stream()
-            .filter(entry -> moduleIsEnabledInEnvironment(entry.getKey()))
+            .filter(entry -> isModuleEnabledInEnvironment(entry.getKey()))
             .filter(entry -> !entry.getValue().isBypassed())
             .map(entry -> entry.getValue().getExpiration())
             .collect(Collectors.toSet());
@@ -1179,7 +1179,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     }
   }
 
-  private boolean moduleIsEnabledInEnvironment(ModuleNameEnum moduleName) {
+  private boolean isModuleEnabledInEnvironment(ModuleNameEnum moduleName) {
     final AccessConfig accessConfig = configProvider.get().access;
 
     switch (moduleName) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -35,6 +35,7 @@ import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.actionaudit.targetproperties.BypassTimeTargetProperty;
 import org.pmiops.workbench.compliance.ComplianceService;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.config.WorkbenchConfig.AccessConfig;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbAdminActionHistory;
@@ -1140,11 +1141,14 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
    * Return the user's registered tier access expiration time, for the purpose of sending an access
    * renewal reminder or expiration email.
    *
-   * <p>First: ignore any bypassed modules. These are in compliance and do not need to be renewed.
+   * <p>First: ignore any modules which have been disabled in this environment.
    *
-   * <p>Next: do all un-bypassed modules have expiration times? If yes, return the min (earliest).
-   * If no, either the feature flag is not set or the user does not have access for reasons other
-   * than access renewal compliance. In either negative case, we should not send an email.
+   * <p>Next: ignore any bypassed modules. These are in compliance and do not need to be renewed.
+   *
+   * <p>Finally: do all enabled un-bypassed modules have expiration times? If yes, return the min
+   * (earliest). If no, either the AAR feature flag is not set or the user does not have access for
+   * reasons other than access renewal compliance. In either negative case, we should not send an
+   * email.
    *
    * <p>Note that this method may return EMPTY for both valid and invalid users, so this method
    * SHOULD NOT BE USED FOR ACCESS DECISIONS.
@@ -1153,9 +1157,10 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     // Collection<Optional<T>> is usually a code smell.
     // Here we do need to know if any are EMPTY, for the next step.
     final Set<Optional<Timestamp>> expirations =
-        getRenewableAccessModules(user).values().stream()
-            .filter(times -> !times.isBypassed())
-            .map(ModuleTimes::getExpiration)
+        getRenewableAccessModules(user).entrySet().stream()
+            .filter(entry -> moduleIsEnabledInEnvironment(entry.getKey()))
+            .filter(entry -> !entry.getValue().isBypassed())
+            .map(entry -> entry.getValue().getExpiration())
             .collect(Collectors.toSet());
 
     // if any un-bypassed modules are incomplete, we know:
@@ -1171,6 +1176,19 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
           // note: min() returns EMPTY if the stream is empty at this point,
           // which is also an indicator that we should not send an email
           .min(Timestamp::compareTo);
+    }
+  }
+
+  private boolean moduleIsEnabledInEnvironment(ModuleNameEnum moduleName) {
+    final AccessConfig accessConfig = configProvider.get().access;
+
+    switch (moduleName) {
+      case COMPLIANCETRAINING:
+        return accessConfig.enableComplianceTraining;
+      case DATAUSEAGREEMENT:
+        return accessConfig.enableDataUseAgreement;
+      default:
+        return true;
     }
   }
 

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -126,6 +126,10 @@ public class UserServiceAccessTest {
   @BeforeEach
   public void setUp() {
     providedWorkbenchConfig = WorkbenchConfig.createEmptyConfig();
+    providedWorkbenchConfig.access.enableAccessRenewal = true;
+    providedWorkbenchConfig.access.enableComplianceTraining = true;
+    providedWorkbenchConfig.access.enableDataUseAgreement = true;
+    providedWorkbenchConfig.access.enableEraCommons = true;
     providedWorkbenchConfig.accessRenewal.expiryDays = EXPIRATION_DAYS;
     providedWorkbenchConfig.accessRenewal.expiryDaysWarningThresholds =
         ImmutableList.of(1L, 3L, 7L, 15L, 30L);
@@ -197,9 +201,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void testSimulateUserFlowThroughRenewal() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-    providedWorkbenchConfig.access.enableDataUseAgreement = true;
-
     // initialize user as registered with generic values including bypassed DUA
 
     dbUser = updateUserWithRetries(registerUserNow);
@@ -232,9 +233,6 @@ public class UserServiceAccessTest {
   // This should be removed after June 30 2021
   @Test
   public void testGracePeriod() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-    providedWorkbenchConfig.access.enableDataUseAgreement = true;
-    providedWorkbenchConfig.accessRenewal.expiryDays = (long) 365;
     Instant mayFirst = Instant.parse("2020-05-01T00:00:00.00Z");
     Instant julyFirst = Instant.parse("2021-07-01T01:00:00.00Z");
     PROVIDED_CLOCK.setInstant(mayFirst);
@@ -278,7 +276,6 @@ public class UserServiceAccessTest {
   @Test
   public void testRenewalFlag() {
     providedWorkbenchConfig.access.enableAccessRenewal = false;
-    providedWorkbenchConfig.access.enableDataUseAgreement = true;
 
     final Timestamp willExpire = Timestamp.from(START_INSTANT);
 
@@ -352,8 +349,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_era_unbypassed_noncompliant() {
-    providedWorkbenchConfig.access.enableEraCommons = true;
-
     testUnregistration(
         user -> {
           user.setEraCommonsBypassTime(null);
@@ -376,7 +371,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_training_unbypassed_no_aar_noncompliant() {
-    providedWorkbenchConfig.access.enableComplianceTraining = true;
     providedWorkbenchConfig.access.enableAccessRenewal = false;
 
     testUnregistration(
@@ -388,9 +382,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_training_unbypassed_aar_noncompliant() {
-    providedWorkbenchConfig.access.enableComplianceTraining = true;
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     testUnregistration(
         user -> {
           user.setComplianceTrainingBypassTime(null);
@@ -400,9 +391,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_training_unbypassed_aar_expired_noncompliant() {
-    providedWorkbenchConfig.access.enableComplianceTraining = true;
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     testUnregistration(
         user -> {
           user.setComplianceTrainingBypassTime(null);
@@ -420,7 +408,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_dua_unbypassed_no_aar_noncompliant() {
-    providedWorkbenchConfig.access.enableDataUseAgreement = true;
     providedWorkbenchConfig.access.enableAccessRenewal = false;
 
     testUnregistration(
@@ -432,7 +419,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_dua_unbypassed_no_aar_missing_version_noncompliant() {
-    providedWorkbenchConfig.access.enableDataUseAgreement = true;
     providedWorkbenchConfig.access.enableAccessRenewal = false;
 
     testUnregistration(
@@ -445,7 +431,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_dua_unbypassed_no_aar_wrong_version_noncompliant() {
-    providedWorkbenchConfig.access.enableDataUseAgreement = true;
     providedWorkbenchConfig.access.enableAccessRenewal = false;
 
     testUnregistration(
@@ -459,9 +444,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_dua_unbypassed_aar_noncompliant() {
-    providedWorkbenchConfig.access.enableDataUseAgreement = true;
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     testUnregistration(
         user -> {
           user.setDataUseAgreementBypassTime(null);
@@ -471,9 +453,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_dua_unbypassed_aar_missing_version_noncompliant() {
-    providedWorkbenchConfig.access.enableDataUseAgreement = true;
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     testUnregistration(
         user -> {
           user.setDataUseAgreementBypassTime(null);
@@ -484,9 +463,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_dua_unbypassed_aar_wrong_version_noncompliant() {
-    providedWorkbenchConfig.access.enableDataUseAgreement = true;
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     testUnregistration(
         user -> {
           user.setDataUseAgreementBypassTime(null);
@@ -498,9 +474,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_dua_unbypassed_aar_expired_noncompliant() {
-    providedWorkbenchConfig.access.enableDataUseAgreement = true;
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     testUnregistration(
         user -> {
           user.setDataUseAgreementBypassTime(null);
@@ -518,8 +491,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_publications_not_confirmed() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     testUnregistration(
         user -> {
           user.setPublicationsLastConfirmedTime(null);
@@ -529,8 +500,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_publications_expired() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     testUnregistration(
         user -> {
           final Timestamp willExpire = Timestamp.from(START_INSTANT);
@@ -546,8 +515,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_profile_not_confirmed() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     testUnregistration(
         user -> {
           user.setProfileLastConfirmedTime(null);
@@ -557,8 +524,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_profile_expired() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     testUnregistration(
         user -> {
           final Timestamp willExpire = Timestamp.from(START_INSTANT);
@@ -572,8 +537,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_maybeSendAccessExpirationEmail_up_to_date() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     dbUser.setProfileLastConfirmedTime(now);
     dbUser.setPublicationsLastConfirmedTime(now);
@@ -591,8 +554,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_maybeSendAccessExpirationEmail_bypassed_is_up_to_date() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
 
     dbUser.setDataUseAgreementBypassTime(now);
@@ -610,8 +571,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_maybeSendAccessExpirationEmail_expiring_1() throws MessagingException {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     dbUser.setProfileLastConfirmedTime(now);
@@ -633,6 +592,7 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_maybeSendAccessExpirationEmail_expiring_1_FF_false() {
+    providedWorkbenchConfig.access.enableAccessRenewal = false;
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     dbUser.setProfileLastConfirmedTime(now);
@@ -684,8 +644,6 @@ public class UserServiceAccessTest {
   @Test
   public void test_maybeSendAccessExpirationEmail_expiring_1_with_bypass()
       throws MessagingException {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     dbUser.setProfileLastConfirmedTime(now);
@@ -710,8 +668,6 @@ public class UserServiceAccessTest {
   @Test
   public void test_maybeSendAccessExpirationEmail_expiring_1_with_older_bypass()
       throws MessagingException {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     dbUser.setProfileLastConfirmedTime(now);
@@ -736,8 +692,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_maybeSendAccessExpirationEmail_expiring_today() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     dbUser.setProfileLastConfirmedTime(now);
@@ -758,8 +712,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_maybeSendAccessExpirationEmail_expiring_30() throws MessagingException {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     dbUser.setProfileLastConfirmedTime(now);
@@ -781,8 +733,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_maybeSendAccessExpirationEmail_expiring_31() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     dbUser.setProfileLastConfirmedTime(now);
@@ -803,8 +753,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_maybeSendAccessExpirationEmail_expiring_15_and_30() throws MessagingException {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     dbUser.setProfileLastConfirmedTime(now);
@@ -835,8 +783,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_maybeSendAccessExpirationEmail_expiring_14_and_15() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     dbUser.setProfileLastConfirmedTime(now);
@@ -858,8 +804,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_maybeSendAccessExpirationEmail_expired() throws MessagingException {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     dbUser.setProfileLastConfirmedTime(now);
@@ -883,8 +827,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_maybeSendAccessExpirationEmail_expired_grace_period() throws MessagingException {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     // set "today" to be June 1
     PROVIDED_CLOCK.setInstant(Instant.parse("2021-06-01T00:00:00Z"));
 
@@ -911,8 +853,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_maybeSendAccessExpirationEmail_expired_FF_false() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     dbUser.setProfileLastConfirmedTime(now);
@@ -937,8 +877,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_maybeSendAccessExpirationEmail_extra_expired() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     dbUser.setProfileLastConfirmedTime(now);
@@ -962,14 +900,11 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_getRegisteredTierExpirations_empty() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
     assertThat(userService.getRegisteredTierExpirations()).isEmpty();
   }
 
   @Test
   public void test_getRegisteredTierExpirations_one_year() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
-
     // register user by setting 2 bypassable modules' bypass to now
     // and the 2 unbypassable modules' completions to now
 
@@ -995,7 +930,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_getRegisteredTierExpirations_one_year_compliance_disabled() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
     providedWorkbenchConfig.access.enableComplianceTraining = false;
 
     // register user by setting the DUCC bypass to now
@@ -1044,7 +978,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_getRegisteredTierExpirations_one_year_ducc_disabled() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
     providedWorkbenchConfig.access.enableDataUseAgreement = false;
 
     // register user by setting the Compliance bypass to now
@@ -1089,7 +1022,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_getRegisteredTierExpirations_initial_enforcement_date() {
-    providedWorkbenchConfig.access.enableAccessRenewal = true;
     Instant mayFirst = Instant.parse("2020-05-01T00:00:00.00Z");
     PROVIDED_CLOCK.setInstant(mayFirst);
 

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -233,6 +233,7 @@ public class UserServiceAccessTest {
   // This should be removed after June 30 2021
   @Test
   public void testGracePeriod() {
+    providedWorkbenchConfig.accessRenewal.expiryDays = (long) 365;
     Instant mayFirst = Instant.parse("2020-05-01T00:00:00.00Z");
     Instant julyFirst = Instant.parse("2021-07-01T01:00:00.00Z");
     PROVIDED_CLOCK.setInstant(mayFirst);


### PR DESCRIPTION
Description:

This does not complete RW-6918.  This allows us to run the AAR expiration report in Preprod which we need to figure out the correct timing for RW-6918.  This also fixes automatic AAR expiration emails in Preprod, and this all applies to Staging as well.

The logic for sending AAR expiration emails and producing the expiration report (`getRenewableAccessModules()`) had a bug: if any of the AAR modules is disabled in an environment, in the worst case no emails would ever be sent and no users would appear in the report.  This is currently the situation on Preprod, so this fix is a requirement for enabling a reasonable expiration period on Preprod.

Correct this logic to filter out disabled modules.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
