### PR TITLE
[no ticket][risk=no] Provide e2e env variables types

### DIFF
--- a/e2e/.env.sample
+++ b/e2e/.env.sample
@@ -2,6 +2,6 @@
 USER_NAME=??
 # Workbench login password. Alternatively, set "PASSWORD" environment variable in the yarn command.
 PASSWORD=??
-WRITER_USER=puppetmaster@fake-research-aou.org
-READER_USER=puppettestreader1@fake-research-aou.org
-COLLABORATOR_USER=puppetmaster@fake-research-aou.org
+WRITER_USER=puppetcitester9@fake-research-aou.org
+READER_USER=puppetdevreader1@fake-research-aou.org
+COLLABORATOR_USER=puppetcitester8@fake-research-aou.org

--- a/e2e/.env.sample
+++ b/e2e/.env.sample
@@ -2,6 +2,6 @@
 USER_NAME=??
 # Workbench login password. Alternatively, set "PASSWORD" environment variable in the yarn command.
 PASSWORD=??
-WRITER_USER=??
-READER_USER=??
-COLLABORATOR_USER=??
+WRITER_USER=puppetmaster@fake-research-aou.org
+READER_USER=puppettestreader1@fake-research-aou.org
+COLLABORATOR_USER=puppetmaster@fake-research-aou.org

--- a/e2e/.env.sample
+++ b/e2e/.env.sample
@@ -2,3 +2,6 @@
 USER_NAME=??
 # Workbench login password. Alternatively, set "PASSWORD" environment variable in the yarn command.
 PASSWORD=??
+WRITER_USER=??
+READER_USER=??
+COLLABORATOR_USER=??

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -41,6 +41,7 @@ See [doc](https://docs.google.com/document/d/1rbAlU6CVgfh6R_o2BdD476AXrZR6qB7167
     - `puppeteer-reader-1@staging.fake-research-aou.org`
     - `puppeteer-writer-1@staging.fake-research-aou.org`
 
+## Running Tests on Localhost
 ### Local Test Users
 Developers' Local environments share a Google Suite domain with the Test environment,
 so users with matching emails share the same Terra and Google cloud resources between these
@@ -48,13 +49,16 @@ environments. To avoid contention, it's necessary to create a test user unique t
 environment.  This is the same process as creating any other local user.  Ensure that this 
 user is 2FA-Bypassed and populate the environment property file `.env` with this user's credentials.
 
-## Running tests
-Command line tests are run using the [Yarn](https://classic.yarnpkg.com/en/) build tool. Tests can be run in 
-**headless mode** (with invisible browser execution) or "headful" mode, with the browser
-interactions visible to you.
+Save test user credentials
+  - Copy `.env.sample`, save as `.env`. Update test user emails accordingly.
 
-**To see the list of available Yarn commands**
-- `yarn run`
+Command line tests are run using the [Yarn](https://classic.yarnpkg.com/en/) build tool. 
+  - Run **headless mode** (with invisible browser execution)
+    
+    `yarn test [test_name_here]`
+  - Run **headful mode** (with the browser interactions visible to you)
+    
+    `yarn test:debug [test_name_here]`
 
 ### Examples
 * Run all tests in parallel **in headless Chrome** on deployed AoU "test" environment <div class="text-blue">`yarn test`</div>

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -45,24 +45,28 @@ See [doc](https://docs.google.com/document/d/1rbAlU6CVgfh6R_o2BdD476AXrZR6qB7167
 ### Local Test Users
 Developers' Local environments share a Google Suite domain with the Test environment,
 so users with matching emails share the same Terra and Google cloud resources between these
-environments. To avoid contention, it's necessary to create a test user unique to the local 
-environment.  This is the same process as creating any other local user.  Ensure that this 
-user is 2FA-Bypassed and populate the environment property file `.env` with this user's credentials.
+environments. To avoid contention, it's necessary to create some test users unique to the local 
+environment.  This is the same process as creating other local test users.  Ensure that local test 
+users are 2FA-Bypassed. Fill out the environment property file `.env` with local test users credentials.
 
-Save test user credentials
-  - Copy `.env.sample`, save as `.env`. Update test user emails accordingly.
+e2e tests require 4 test users:
+- USER_NAME: Default test user
+- WRITER_USER: Share workspace to this test user with WRITER role
+- READER_USER: Share workspace to this test user with READER role
+- COLLABORATOR_USER: Share workspace to this test user with OWNER role
 
-Command line tests are run using the [Yarn](https://classic.yarnpkg.com/en/) build tool. 
-  - Run **headless mode** (with invisible browser execution)
+Fill out local test user credentials
+  - Copy `.env.sample`, save as `.env`.
+  - Update `.env` with your local user emails.
     
-    `yarn test [test_name_here]`
-  - Run **headful mode** (with the browser interactions visible to you)
     
-    `yarn test:debug [test_name_here]`
 
-### Examples
-* Run all tests in parallel **in headless Chrome** on deployed AoU "test" environment <div class="text-blue">`yarn test`</div>
-* Run one test on deployed AoU "test" environment <div class="text-blue">`yarn test:debug [TEST_FILE]` </div>
+## Command line tests are run using [Yarn](https://classic.yarnpkg.com/en/)
+**To see the list of available Yarn commands** <div class="text-blue">`yarn run`</div>
+### Examples  
+* Run one test in **headless mode** (with invisible browser execution) <div class="text-blue">`yarn test [TEST_FILE]` </div>
+* Run one test in **headful mode** (with the browser interactions visible to you) <div class="text-blue">`yarn test:debug [TEST_FILE]` </div>
+* Run all tests in parallel in **headless mode** on "test" environment <div class="text-blue">`yarn test`</div>
 * Run one test on your local server <div class="text-blue">`yarn test-local [TEST_FILE]` </div>
 * Run tests against a local UI and API server (RW-6132 will eliminate this distinction):
   * Stop your local API server

--- a/e2e/app/modal/cdr-version-upgrade-modal.ts
+++ b/e2e/app/modal/cdr-version-upgrade-modal.ts
@@ -20,6 +20,6 @@ export default class CdrVersionUpgradeModal extends Modal {
   }
 
   getUpgradeButton(): Button {
-    return Button.findByName(this.page, { normalizeSpace: `Try ${config.defaultCdrVersionName}` }, this);
+    return Button.findByName(this.page, { normalizeSpace: `Try ${config.DEFAULT_CDR_VERSION}` }, this);
   }
 }

--- a/e2e/app/modal/cdr-version-upgrade-modal.ts
+++ b/e2e/app/modal/cdr-version-upgrade-modal.ts
@@ -20,6 +20,6 @@ export default class CdrVersionUpgradeModal extends Modal {
   }
 
   getUpgradeButton(): Button {
-    return Button.findByName(this.page, { normalizeSpace: `Try ${config.DEFAULT_CDR_VERSION}` }, this);
+    return Button.findByName(this.page, { normalizeSpace: `Try ${config.DEFAULT_CDR_VERSION_NAME}` }, this);
   }
 }

--- a/e2e/app/page/authenticated-page.ts
+++ b/e2e/app/page/authenticated-page.ts
@@ -39,7 +39,7 @@ export default abstract class AuthenticatedPage extends BasePage {
   /**
    * Load AoU page URL.
    */
-  async loadPageUrl(url: { value: string }): Promise<void> {
+  async loadPageUrl(url: string): Promise<void> {
     await this.gotoUrl(url);
     await this.waitForLoad();
   }

--- a/e2e/app/page/authenticated-page.ts
+++ b/e2e/app/page/authenticated-page.ts
@@ -39,7 +39,7 @@ export default abstract class AuthenticatedPage extends BasePage {
   /**
    * Load AoU page URL.
    */
-  async loadPageUrl(url: string): Promise<void> {
+  async loadPageUrl(url: { value: string }): Promise<void> {
     await this.gotoUrl(url);
     await this.waitForLoad();
   }

--- a/e2e/app/page/authenticated-page.ts
+++ b/e2e/app/page/authenticated-page.ts
@@ -1,5 +1,4 @@
 import { Page } from 'puppeteer';
-import { PageUrl } from 'app/text-labels';
 import BasePage from 'app/page/base-page';
 import { getPropValue } from 'utils/element-utils';
 import HelpTipsSidebar from 'app/component/help-tips-sidebar';
@@ -40,8 +39,8 @@ export default abstract class AuthenticatedPage extends BasePage {
   /**
    * Load AoU page URL.
    */
-  async loadPageUrl(url: PageUrl): Promise<void> {
-    await this.gotoUrl(url.toString());
+  async loadPageUrl(url: string): Promise<void> {
+    await this.gotoUrl(url);
     await this.waitForLoad();
   }
 

--- a/e2e/app/page/base-page.ts
+++ b/e2e/app/page/base-page.ts
@@ -23,6 +23,7 @@ export default abstract class BasePage {
    * Load a URL.
    */
   async gotoUrl(url: string): Promise<void> {
+    console.log(`goto url: ${url}`);
     const response = await this.page.goto(url, { waitUntil: ['load'] });
     if (response) {
       logger.info(`Goto URL: ${url}. Response status: ${response.status()}\n${await response.text()}`);

--- a/e2e/app/page/base-page.ts
+++ b/e2e/app/page/base-page.ts
@@ -22,12 +22,12 @@ export default abstract class BasePage {
   /**
    * Load a URL.
    */
-  async gotoUrl(url: string): Promise<void> {
-    logger.info(`goto url: ${url}`);
-    const response = await this.page.goto(url, { waitUntil: ['load'] });
+  async gotoUrl(url: { value: string }): Promise<void> {
+    logger.info(`goto url: ${url.value}`);
+    const response = await this.page.goto(url.value, { waitUntil: ['load'] });
     if (response && !response.ok()) {
       // Log response if status is not OK
-        logger.info(`Goto URL: ${url}. Response status: ${response.status()}\n${await response.text()}`);
+      logger.info(`Goto URL: ${url.value}. Response status: ${response.status()}\n${await response.text()}`);
     }
   }
 

--- a/e2e/app/page/base-page.ts
+++ b/e2e/app/page/base-page.ts
@@ -23,10 +23,11 @@ export default abstract class BasePage {
    * Load a URL.
    */
   async gotoUrl(url: string): Promise<void> {
-    console.log(`goto url: ${url}`);
+    logger.info(`goto url: ${url}`);
     const response = await this.page.goto(url, { waitUntil: ['load'] });
-    if (response) {
-      logger.info(`Goto URL: ${url}. Response status: ${response.status()}\n${await response.text()}`);
+    if (response && !response.ok()) {
+      // Log response if status is not OK
+        logger.info(`Goto URL: ${url}. Response status: ${response.status()}\n${await response.text()}`);
     }
   }
 

--- a/e2e/app/page/base-page.ts
+++ b/e2e/app/page/base-page.ts
@@ -22,12 +22,12 @@ export default abstract class BasePage {
   /**
    * Load a URL.
    */
-  async gotoUrl(url: { value: string }): Promise<void> {
-    logger.info(`goto url: ${url.value}`);
-    const response = await this.page.goto(url.value, { waitUntil: ['load'] });
+  async gotoUrl(url: string): Promise<void> {
+    logger.info(`goto url: ${url}`);
+    const response = await this.page.goto(url, { waitUntil: ['load'] });
     if (response && !response.ok()) {
       // Log response if status is not OK
-      logger.info(`Goto URL: ${url.value}. Response status: ${response.status()}\n${await response.text()}`);
+      logger.info(`Goto URL: ${url}. Response status: ${response.status()}\n${await response.text()}`);
     }
   }
 

--- a/e2e/app/page/create-account-page.ts
+++ b/e2e/app/page/create-account-page.ts
@@ -199,7 +199,7 @@ export default class CreateAccountPage extends BasePage {
     await this.selectInstitution(InstitutionSelectValue.Broad);
     await this.getInstitutionValue();
     const emailAddressTextbox = Textbox.findByName(this.page, FieldSelector.InstitutionEmailTextbox.textOption);
-    await emailAddressTextbox.type(config.institutionContactEmail);
+    await emailAddressTextbox.type(config.INSTITUTION_CONTACT_EMAIL);
     await emailAddressTextbox.pressTab(); // tab out to start email validation
     await ClrIconLink.findByName(this.page, {
       containsText: LabelAlias.InstitutionEmail,

--- a/e2e/app/page/google-login.ts
+++ b/e2e/app/page/google-login.ts
@@ -107,7 +107,7 @@ export default class GoogleLoginPage {
    * Open All-of-Us Google login page.
    */
   async load(): Promise<void> {
-    const url = `${config.uiBaseUrl}${config.loginUrlPath}`;
+    const url = `${config.LOGIN_URL}${config.loginUrlPath}`;
     const response = await this.page.goto(url, {
       waitUntil: ['networkidle0', 'domcontentloaded', 'load'],
       timeout: 2 * 60 * 1000
@@ -127,8 +127,8 @@ export default class GoogleLoginPage {
    * @param paswd
    */
   async login(email?: string, paswd?: string): Promise<void> {
-    const user = email || config.userEmail;
-    const pwd = paswd || config.userPassword;
+    const user = email || config.USER_NAME;
+    const pwd = paswd || config.PASSWORD;
 
     if (!user || user.trim().length === 0) {
       console.warn('Login user email: value is empty!!!');

--- a/e2e/app/page/google-login.ts
+++ b/e2e/app/page/google-login.ts
@@ -107,7 +107,7 @@ export default class GoogleLoginPage {
    * Open All-of-Us Google login page.
    */
   async load(): Promise<void> {
-    const url = `${config.LOGIN_URL}${config.LOGIN_URL_PATH}`;
+    const url = `${config.LOGIN_URL_DOMAIN_NAME}${config.LOGIN_URL_PATH}`;
     const response = await this.page.goto(url, {
       waitUntil: ['networkidle0', 'domcontentloaded', 'load'],
       timeout: 2 * 60 * 1000

--- a/e2e/app/page/google-login.ts
+++ b/e2e/app/page/google-login.ts
@@ -107,7 +107,7 @@ export default class GoogleLoginPage {
    * Open All-of-Us Google login page.
    */
   async load(): Promise<void> {
-    const url = `${config.LOGIN_URL}${config.loginUrlPath}`;
+    const url = `${config.LOGIN_URL}${config.LOGIN_URL_PATH}`;
     const response = await this.page.goto(url, {
       waitUntil: ['networkidle0', 'domcontentloaded', 'load'],
       timeout: 2 * 60 * 1000
@@ -166,7 +166,7 @@ export default class GoogleLoginPage {
     const emailInputXpath = '//input[@type="email" and @aria-label="Enter recovery email address"]';
     const [emailInput] = await this.page.$x(emailInputXpath);
     if (emailInput) {
-      await emailInput.type(config.institutionContactEmail);
+      await emailInput.type(config.INSTITUTION_CONTACT_EMAIL);
       await Promise.all([
         this.page.waitForNavigation({ waitUntil: ['networkidle2', 'load'], timeout: 60000 }),
         this.page.keyboard.press(String.fromCharCode(13)) // Press Enter key.

--- a/e2e/app/page/home-page.ts
+++ b/e2e/app/page/home-page.ts
@@ -48,7 +48,7 @@ export default class HomePage extends AuthenticatedPage {
    * Load Home page and ensure page load is completed.
    */
   async load(): Promise<this> {
-    await this.loadPageUrl(PageUrl.Home.value);
+    await this.loadPageUrl(PageUrl.Home);
     return this;
   }
 

--- a/e2e/app/page/home-page.ts
+++ b/e2e/app/page/home-page.ts
@@ -48,7 +48,7 @@ export default class HomePage extends AuthenticatedPage {
    * Load Home page and ensure page load is completed.
    */
   async load(): Promise<this> {
-    await this.loadPageUrl(PageUrl.Home);
+    await this.loadPageUrl(PageUrl.Home.value);
     return this;
   }
 

--- a/e2e/app/page/profile-page.ts
+++ b/e2e/app/page/profile-page.ts
@@ -45,7 +45,7 @@ export default class ProfilePage extends AuthenticatedPage {
    * Load 'Profile' page and ensure page load is completed.
    */
   async load(): Promise<this> {
-    await this.loadPageUrl(PageUrl.Profile.value);
+    await this.loadPageUrl(PageUrl.Profile);
     await waitWhileLoading(this.page);
     return this;
   }

--- a/e2e/app/page/profile-page.ts
+++ b/e2e/app/page/profile-page.ts
@@ -45,7 +45,7 @@ export default class ProfilePage extends AuthenticatedPage {
    * Load 'Profile' page and ensure page load is completed.
    */
   async load(): Promise<this> {
-    await this.loadPageUrl(PageUrl.Profile);
+    await this.loadPageUrl(PageUrl.Profile.value);
     await waitWhileLoading(this.page);
     return this;
   }

--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -68,7 +68,7 @@ export default class WorkspaceAboutPage extends WorkspaceBase {
   }
 
   // if the collaborator is already on this workspace, just remove them before continuing.
-  async removeCollaborator(name = config.collaboratorUsername): Promise<void> {
+  async removeCollaborator(name = config.COLLABORATOR_USER): Promise<void> {
     const modal = await this.openShareModal();
     await modal.removeUser(name);
     await waitWhileLoading(this.page);

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -396,7 +396,7 @@ export default class WorkspaceEditPage extends WorkspaceBase {
    * Select CDR Version by name.
    * @param {string} value
    */
-  async selectCdrVersion(value: string = config.DEFAULT_CDR_VERSION): Promise<string> {
+  async selectCdrVersion(value: string = config.DEFAULT_CDR_VERSION_NAME): Promise<string> {
     const select = this.getCdrVersionSelect();
     return select.selectOption(value);
   }

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -396,7 +396,7 @@ export default class WorkspaceEditPage extends WorkspaceBase {
    * Select CDR Version by name.
    * @param {string} value
    */
-  async selectCdrVersion(value: string = config.defaultCdrVersionName): Promise<string> {
+  async selectCdrVersion(value: string = config.DEFAULT_CDR_VERSION): Promise<string> {
     const select = this.getCdrVersionSelect();
     return select.selectOption(value);
   }

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -53,7 +53,7 @@ export default class WorkspacesPage extends AuthenticatedPage {
    * Load 'Your Workspaces' page and ensure page load is completed.
    */
   async load(): Promise<this> {
-    await this.loadPageUrl(PageUrl.Workspaces.value);
+    await this.loadPageUrl(PageUrl.Workspaces);
     await waitWhileLoading(this.page);
     return this;
   }
@@ -81,7 +81,7 @@ export default class WorkspacesPage extends AuthenticatedPage {
    */
   async createWorkspace(
     workspaceName: string,
-    cdrVersionName: string = config.DEFAULT_CDR_VERSION,
+    cdrVersionName: string = config.DEFAULT_CDR_VERSION_NAME,
     billingAccount: string = UseFreeCredits,
     reviewRequest = false
   ): Promise<string[]> {
@@ -91,7 +91,7 @@ export default class WorkspacesPage extends AuthenticatedPage {
     await editPage.selectCdrVersion(cdrVersionName);
 
     // if the CDR Version is not the default, consent to the necessary restrictions
-    if (cdrVersionName !== config.DEFAULT_CDR_VERSION) {
+    if (cdrVersionName !== config.DEFAULT_CDR_VERSION_NAME) {
       const modal = new OldCdrVersionModal(this.page);
       await modal.waitForLoad();
       await modal.consentToOldCdrRestrictions();

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -53,7 +53,7 @@ export default class WorkspacesPage extends AuthenticatedPage {
    * Load 'Your Workspaces' page and ensure page load is completed.
    */
   async load(): Promise<this> {
-    await this.loadPageUrl(PageUrl.Workspaces);
+    await this.loadPageUrl(PageUrl.Workspaces.value);
     await waitWhileLoading(this.page);
     return this;
   }
@@ -81,7 +81,7 @@ export default class WorkspacesPage extends AuthenticatedPage {
    */
   async createWorkspace(
     workspaceName: string,
-    cdrVersionName: string = config.defaultCdrVersionName,
+    cdrVersionName: string = config.DEFAULT_CDR_VERSION,
     billingAccount: string = UseFreeCredits,
     reviewRequest = false
   ): Promise<string[]> {
@@ -91,7 +91,7 @@ export default class WorkspacesPage extends AuthenticatedPage {
     await editPage.selectCdrVersion(cdrVersionName);
 
     // if the CDR Version is not the default, consent to the necessary restrictions
-    if (cdrVersionName !== config.defaultCdrVersionName) {
+    if (cdrVersionName !== config.DEFAULT_CDR_VERSION) {
       const modal = new OldCdrVersionModal(this.page);
       await modal.waitForLoad();
       await modal.consentToOldCdrRestrictions();

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -1,11 +1,11 @@
 import { config } from 'resources/workbench-config';
-const { LOGIN_URL, WORKSPACES_URL_PATH, ADMIN_URL_PATH, PROFILE_URL_PATH } = config;
+const { LOGIN_URL_DOMAIN_NAME, WORKSPACES_URL_PATH, ADMIN_URL_PATH, PROFILE_URL_PATH } = config;
 
 export const PageUrl = {
-  Home: { value: LOGIN_URL },
-  Workspaces: { value: LOGIN_URL + WORKSPACES_URL_PATH },
-  Admin: { value: LOGIN_URL + ADMIN_URL_PATH },
-  Profile: { value: LOGIN_URL + PROFILE_URL_PATH }
+  Home: { value: LOGIN_URL_DOMAIN_NAME },
+  Workspaces: { value: LOGIN_URL_DOMAIN_NAME + WORKSPACES_URL_PATH },
+  Admin: { value: LOGIN_URL_DOMAIN_NAME + ADMIN_URL_PATH },
+  Profile: { value: LOGIN_URL_DOMAIN_NAME + PROFILE_URL_PATH }
 } as const;
 
 export type PageUrl = keyof typeof PageUrl;

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -1,10 +1,11 @@
 import { config } from 'resources/workbench-config';
+const { LOGIN_URL, WORKSPACES_URL_PATH, ADMIN_URL_PATH, PROFILE_URL_PATH } = config;
 
 export const PageUrl = {
-  Home: { value: config.LOGIN_URL },
-  Workspaces: { value: config.LOGIN_URL + config.workspacesUrlPath },
-  Admin: { value: config.LOGIN_URL + config.adminUrlPath },
-  Profile: { value: config.LOGIN_URL + config.profileUrlPath }
+  Home: { value: LOGIN_URL },
+  Workspaces: { value: LOGIN_URL + WORKSPACES_URL_PATH },
+  Admin: { value: LOGIN_URL + ADMIN_URL_PATH },
+  Profile: { value: LOGIN_URL + PROFILE_URL_PATH }
 } as const;
 
 export type PageUrl = keyof typeof PageUrl;

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -1,14 +1,20 @@
 import { config } from 'resources/workbench-config';
 const { LOGIN_URL_DOMAIN_NAME, WORKSPACES_URL_PATH, ADMIN_URL_PATH, PROFILE_URL_PATH } = config;
 
-export const PageUrl = {
-  Home: { value: LOGIN_URL_DOMAIN_NAME },
-  Workspaces: { value: LOGIN_URL_DOMAIN_NAME + WORKSPACES_URL_PATH },
-  Admin: { value: LOGIN_URL_DOMAIN_NAME + ADMIN_URL_PATH },
-  Profile: { value: LOGIN_URL_DOMAIN_NAME + PROFILE_URL_PATH }
-} as const;
+interface IPageUrl {
+  Home: string,
+  Workspaces: string,
+  Admin: string,
+  Profile: string
+}
 
-export type PageUrl = keyof typeof PageUrl;
+export const PageUrl: IPageUrl = {
+  Home: LOGIN_URL_DOMAIN_NAME,
+  Workspaces: LOGIN_URL_DOMAIN_NAME + WORKSPACES_URL_PATH,
+  Admin: LOGIN_URL_DOMAIN_NAME + ADMIN_URL_PATH,
+  Profile: LOGIN_URL_DOMAIN_NAME + PROFILE_URL_PATH
+};
+
 
 export enum WorkspaceAccessLevel {
   Owner = 'OWNER',

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -1,11 +1,13 @@
 import { config } from 'resources/workbench-config';
 
-export enum PageUrl {
-  Home = config.uiBaseUrl,
-  Workspaces = config.uiBaseUrl + config.workspacesUrlPath,
-  Admin = config.uiBaseUrl + config.adminUrlPath,
-  Profile = config.uiBaseUrl + config.profileUrlPath
-}
+export const PageUrl = {
+  Home: { value: config.LOGIN_URL },
+  Workspaces: { value: config.LOGIN_URL + config.workspacesUrlPath },
+  Admin: { value: config.LOGIN_URL + config.adminUrlPath },
+  Profile: { value: config.LOGIN_URL + config.profileUrlPath }
+} as const;
+
+export type PageUrl = keyof typeof PageUrl;
 
 export enum WorkspaceAccessLevel {
   Owner = 'OWNER',

--- a/e2e/resources/workbench-config.ts
+++ b/e2e/resources/workbench-config.ts
@@ -6,21 +6,21 @@ const env = process.env.WORKBENCH_ENV || 'test';
 const userCredential = {
   USER_NAME: process.env.USER_NAME,
   PASSWORD: process.env.PASSWORD,
-  institutionContactEmail: 'aou-dev-registration@broadinstitute.org',
+  INSTITUTION_CONTACT_EMAIL: 'aou-dev-registration@broadinstitute.org',
   // This is passed via a file to leave open the future option to allow token
   // refresh during a Puppeteer test run, and also limits logging exposure of the token.
-  userAccessTokenFilename: 'signin-tokens/puppeteer-access-token.txt',
-  collaboratorUserAccessTokenFilename: 'signin-tokens/collaborator-puppeteer-access-token.txt',
-  readerUserAccessTokenFilename: 'signin-tokens/reader-puppeteer-access-token.txt',
-  writerUserAccessTokenFilename: 'signin-tokens/writer-puppeteer-access-token.txt'
+  USER_ACCESS_TOKEN_FILE: 'signin-tokens/puppeteer-access-token.txt',
+  COLLABORATOR_ACCESS_TOKEN_FILE: 'signin-tokens/collaborator-puppeteer-access-token.txt',
+  READER_ACCESS_TOKEN_FILE: 'signin-tokens/reader-puppeteer-access-token.txt',
+  WRITER_ACCESS_TOKEN_FILE: 'signin-tokens/writer-puppeteer-access-token.txt'
 };
 
 const urlPath = {
-  loginUrlPath: '/login',
-  workspacesUrlPath: '/workspaces',
-  profileUrlPath: '/profile',
-  libraryUrlPath: '/library',
-  adminUrlPath: '/admin/user'
+  LOGIN_URL_PATH: '/login',
+  WORKSPACES_URL_PATH: '/workspaces',
+  PROFILE_URL_PATH: '/profile',
+  LIBRARY_URL_PATH: '/library',
+  ADMIN_URL_PATH: '/admin/user'
 };
 
 // localhost development server
@@ -31,8 +31,8 @@ const local = {
   COLLABORATOR_USER: process.env.COLLABORATOR_USER || 'puppetmaster@fake-research-aou.org',
   WRITER_USER: process.env.WRITER_USER || 'puppetmaster@fake-research-aou.org',
   READER_USER: process.env.READER_USER || 'puppetcitester1@fake-research-aou.org',
-  DEFAULT_CDR_VERSION: 'Synthetic Dataset v3',
-  ALTERNATIVE_CDR_VERSION: 'Synthetic Dataset v3 with WGS'
+  DEFAULT_CDR_VERSION_NAME: 'Synthetic Dataset v3',
+  ALTERNATIVE_CDR_VERSION_NAME: 'Synthetic Dataset v3 with WGS'
 };
 
 // workbench test environment
@@ -43,8 +43,8 @@ const test = {
   COLLABORATOR_USER: process.env.COLLABORATOR_USER || 'puppetmaster@fake-research-aou.org',
   WRITER_USER: process.env.WRITER_USER || 'puppetmaster@fake-research-aou.org',
   READER_USER: process.env.READER_USER || 'puppetcitestreader1@fake-research-aou.org',
-  DEFAULT_CDR_VERSION: 'Synthetic Dataset v3',
-  ALTERNATIVE_CDR_VERSION: 'Synthetic Dataset v3 with WGS'
+  DEFAULT_CDR_VERSION_NAME: 'Synthetic Dataset v3',
+  ALTERNATIVE_CDR_VERSION_NAME: 'Synthetic Dataset v3 with WGS'
 };
 
 // workbench staging environment
@@ -55,8 +55,8 @@ const staging = {
   COLLABORATOR_USER: process.env.COLLABORATOR_USER || 'puppetcitester4@staging.fake-research-aou.org',
   WRITER_USER: process.env.WRITER_USER || 'puppetmaster@staging.fake-research-aou.org',
   READER_USER: process.env.READER_USER || 'puppetcistagingreader1@staging.fake-research-aou.org',
-  DEFAULT_CDR_VERSION: 'Synthetic Dataset v4',
-  ALTERNATIVE_CDR_VERSION: 'Synthetic Dataset v3'
+  DEFAULT_CDR_VERSION_NAME: 'Synthetic Dataset v4',
+  ALTERNATIVE_CDR_VERSION_NAME: 'Synthetic Dataset v3'
 };
 
 // NOT WORKING: workbench stable environment
@@ -64,8 +64,8 @@ const stable = {
   LOGIN_URL: process.env.STABLE_LOGIN_URL,
   API_URL: process.env.STABLE_API_URL,
   DOMAIN: '@stable.fake-research-aou.org',
-  DEFAULT_CDR_VERSION: 'Synthetic Dataset v4',
-  ALTERNATIVE_CDR_VERSION: 'Synthetic Dataset v3'
+  DEFAULT_CDR_VERSION_NAME: 'Synthetic Dataset v4',
+  ALTERNATIVE_CDR_VERSION_NAME: 'Synthetic Dataset v3'
 };
 
 // workbench perf environment
@@ -76,8 +76,8 @@ const perf = {
   COLLABORATOR_USER: process.env.COLLABORATOR_USER || 'puppetciperfreader@perf.fake-research-aou.org',
   WRITER_USER: process.env.WRITER_USER || 'puppetciperfwriter1@perf.fake-research-aou.org',
   READER_USER: process.env.READER_USER || 'puppetciperfreader@perf.fake-research-aou.org',
-  DEFAULT_CDR_VERSION: 'Synthetic Dataset v4',
-  ALTERNATIVE_CDR_VERSION: 'Synthetic Dataset v3'
+  DEFAULT_CDR_VERSION_NAME: 'Synthetic Dataset v4',
+  ALTERNATIVE_CDR_VERSION_NAME: 'Synthetic Dataset v3'
 };
 
 const environment = {

--- a/e2e/resources/workbench-config.ts
+++ b/e2e/resources/workbench-config.ts
@@ -1,6 +1,5 @@
 import * as fp from 'lodash/fp';
-import { IConfig } from '../types';
-require("dotenv").config();
+import { IConfig } from 'types';
 
 const env = process.env.WORKBENCH_ENV || 'test';
 

--- a/e2e/resources/workbench-config.ts
+++ b/e2e/resources/workbench-config.ts
@@ -1,10 +1,12 @@
 import * as fp from 'lodash/fp';
+import { IConfig } from '../types';
+require("dotenv").config();
 
 const env = process.env.WORKBENCH_ENV || 'test';
 
 const userCredential = {
-  userEmail: process.env.USER_NAME,
-  userPassword: process.env.PASSWORD,
+  USER_NAME: process.env.USER_NAME,
+  PASSWORD: process.env.PASSWORD,
   institutionContactEmail: 'aou-dev-registration@broadinstitute.org',
   // This is passed via a file to leave open the future option to allow token
   // refresh during a Puppeteer test run, and also limits logging exposure of the token.
@@ -24,59 +26,59 @@ const urlPath = {
 
 // localhost development server
 const local = {
-  uiBaseUrl: process.env.DEV_LOGIN_URL || 'http://localhost:4200',
-  apiBaseUrl: process.env.DEV_API_URL || 'http://localhost/v1',
-  userEmailDomain: '@fake-research-aou.org',
-  collaboratorUsername: process.env.COLLABORATOR_USER || 'puppetmaster@fake-research-aou.org',
-  writerUserName: process.env.WRITER_USER || 'puppetmaster@fake-research-aou.org',
-  readerUserName: process.env.READER_USER || 'puppetcitester1@fake-research-aou.org',
-  defaultCdrVersionName: 'Synthetic Dataset v3',
-  altCdrVersionName: 'Synthetic Dataset v3 with WGS'
+  LOGIN_URL: process.env.DEV_LOGIN_URL || 'http://localhost:4200',
+  API_URL: process.env.DEV_API_URL || 'http://localhost/v1',
+  DOMAIN: '@fake-research-aou.org',
+  COLLABORATOR_USER: process.env.COLLABORATOR_USER || 'puppetmaster@fake-research-aou.org',
+  WRITER_USER: process.env.WRITER_USER || 'puppetmaster@fake-research-aou.org',
+  READER_USER: process.env.READER_USER || 'puppetcitester1@fake-research-aou.org',
+  DEFAULT_CDR_VERSION: 'Synthetic Dataset v3',
+  ALTERNATIVE_CDR_VERSION: 'Synthetic Dataset v3 with WGS'
 };
 
 // workbench test environment
 const test = {
-  uiBaseUrl: process.env.TEST_LOGIN_URL || 'https://all-of-us-workbench-test.appspot.com',
-  apiBaseUrl: process.env.TEST_API_URL || 'https://api-dot-all-of-us-workbench-test.appspot.com/v1',
-  userEmailDomain: '@fake-research-aou.org',
-  collaboratorUsername: process.env.COLLABORATOR_USER || 'puppetmaster@fake-research-aou.org',
-  writerUserName: process.env.WRITER_USER || 'puppetmaster@fake-research-aou.org',
-  readerUserName: process.env.READER_USER || 'puppetcitestreader1@fake-research-aou.org',
-  defaultCdrVersionName: 'Synthetic Dataset v3',
-  altCdrVersionName: 'Synthetic Dataset v3 with WGS'
+  LOGIN_URL: process.env.TEST_LOGIN_URL || 'https://all-of-us-workbench-test.appspot.com',
+  API_URL: process.env.TEST_API_URL || 'https://api-dot-all-of-us-workbench-test.appspot.com/v1',
+  DOMAIN: '@fake-research-aou.org',
+  COLLABORATOR_USER: process.env.COLLABORATOR_USER || 'puppetmaster@fake-research-aou.org',
+  WRITER_USER: process.env.WRITER_USER || 'puppetmaster@fake-research-aou.org',
+  READER_USER: process.env.READER_USER || 'puppetcitestreader1@fake-research-aou.org',
+  DEFAULT_CDR_VERSION: 'Synthetic Dataset v3',
+  ALTERNATIVE_CDR_VERSION: 'Synthetic Dataset v3 with WGS'
 };
 
 // workbench staging environment
 const staging = {
-  uiBaseUrl: process.env.STAGING_LOGIN_URL || 'https://all-of-us-rw-staging.appspot.com',
-  apiBaseUrl: process.env.STAGING_API_URL || 'https://api-dot-all-of-us-rw-staging.appspot.com/v1',
-  userEmailDomain: '@staging.fake-research-aou.org',
-  collaboratorUsername: process.env.COLLABORATOR_USER || 'puppetcitester4@staging.fake-research-aou.org',
-  writerUserName: process.env.WRITER_USER || 'puppetmaster@staging.fake-research-aou.org',
-  readerUserName: process.env.READER_USER || 'puppetcistagingreader1@staging.fake-research-aou.org',
-  defaultCdrVersionName: 'Synthetic Dataset v4',
-  altCdrVersionName: 'Synthetic Dataset v3'
+  LOGIN_URL: process.env.STAGING_LOGIN_URL || 'https://all-of-us-rw-staging.appspot.com',
+  API_URL: process.env.STAGING_API_URL || 'https://api-dot-all-of-us-rw-staging.appspot.com/v1',
+  DOMAIN: '@staging.fake-research-aou.org',
+  COLLABORATOR_USER: process.env.COLLABORATOR_USER || 'puppetcitester4@staging.fake-research-aou.org',
+  WRITER_USER: process.env.WRITER_USER || 'puppetmaster@staging.fake-research-aou.org',
+  READER_USER: process.env.READER_USER || 'puppetcistagingreader1@staging.fake-research-aou.org',
+  DEFAULT_CDR_VERSION: 'Synthetic Dataset v4',
+  ALTERNATIVE_CDR_VERSION: 'Synthetic Dataset v3'
 };
 
 // NOT WORKING: workbench stable environment
 const stable = {
-  uiBaseUrl: process.env.STABLE_LOGIN_URL,
-  apiBaseUrl: process.env.STABLE_API_URL,
-  userEmailDomain: '@stable.fake-research-aou.org',
-  defaultCdrVersionName: 'Synthetic Dataset v4',
-  altCdrVersionName: 'Synthetic Dataset v3'
+  LOGIN_URL: process.env.STABLE_LOGIN_URL,
+  API_URL: process.env.STABLE_API_URL,
+  DOMAIN: '@stable.fake-research-aou.org',
+  DEFAULT_CDR_VERSION: 'Synthetic Dataset v4',
+  ALTERNATIVE_CDR_VERSION: 'Synthetic Dataset v3'
 };
 
 // workbench perf environment
 const perf = {
-  uiBaseUrl: process.env.PERF_LOGIN_URL || 'https://all-of-us-rw-perf.appspot.com',
-  apiBaseUrl: process.env.PERF_API_URL || 'https://api-dot-all-of-us-rw-perf.appspot.com/v1',
-  userEmailDomain: '@perf.fake-research-aou.org',
-  collaboratorUsername: process.env.COLLABORATOR_USER || 'puppetciperfreader@perf.fake-research-aou.org',
-  writerUserName: process.env.WRITER_USER || 'puppetciperfwriter1@perf.fake-research-aou.org',
-  readerUserName: process.env.READER_USER || 'puppetciperfreader@perf.fake-research-aou.org',
-  defaultCdrVersionName: 'Synthetic Dataset v4',
-  altCdrVersionName: 'Synthetic Dataset v3'
+  LOGIN_URL: process.env.PERF_LOGIN_URL || 'https://all-of-us-rw-perf.appspot.com',
+  API_URL: process.env.PERF_API_URL || 'https://api-dot-all-of-us-rw-perf.appspot.com/v1',
+  DOMAIN: '@perf.fake-research-aou.org',
+  COLLABORATOR_USER: process.env.COLLABORATOR_USER || 'puppetciperfreader@perf.fake-research-aou.org',
+  WRITER_USER: process.env.WRITER_USER || 'puppetciperfwriter1@perf.fake-research-aou.org',
+  READER_USER: process.env.READER_USER || 'puppetciperfreader@perf.fake-research-aou.org',
+  DEFAULT_CDR_VERSION: 'Synthetic Dataset v4',
+  ALTERNATIVE_CDR_VERSION: 'Synthetic Dataset v3'
 };
 
 const environment = {
@@ -87,4 +89,4 @@ const environment = {
   perf
 };
 
-export const config = fp.mergeAll([environment[env], userCredential, urlPath]);
+export const config: IConfig = fp.mergeAll([environment[env], userCredential, urlPath]);

--- a/e2e/resources/workbench-config.ts
+++ b/e2e/resources/workbench-config.ts
@@ -25,9 +25,9 @@ const urlPath = {
 
 // localhost development server
 const local = {
-  LOGIN_URL: process.env.DEV_LOGIN_URL || 'http://localhost:4200',
+  LOGIN_URL_DOMAIN_NAME: process.env.DEV_LOGIN_URL || 'http://localhost:4200',
   API_URL: process.env.DEV_API_URL || 'http://localhost/v1',
-  DOMAIN: '@fake-research-aou.org',
+  EMAIL_DOMAIN_NAME: '@fake-research-aou.org',
   COLLABORATOR_USER: process.env.COLLABORATOR_USER || 'puppetmaster@fake-research-aou.org',
   WRITER_USER: process.env.WRITER_USER || 'puppetmaster@fake-research-aou.org',
   READER_USER: process.env.READER_USER || 'puppetcitester1@fake-research-aou.org',
@@ -37,9 +37,9 @@ const local = {
 
 // workbench test environment
 const test = {
-  LOGIN_URL: process.env.TEST_LOGIN_URL || 'https://all-of-us-workbench-test.appspot.com',
+  LOGIN_URL_DOMAIN_NAME: process.env.TEST_LOGIN_URL || 'https://all-of-us-workbench-test.appspot.com',
   API_URL: process.env.TEST_API_URL || 'https://api-dot-all-of-us-workbench-test.appspot.com/v1',
-  DOMAIN: '@fake-research-aou.org',
+  EMAIL_DOMAIN_NAME: '@fake-research-aou.org',
   COLLABORATOR_USER: process.env.COLLABORATOR_USER || 'puppetmaster@fake-research-aou.org',
   WRITER_USER: process.env.WRITER_USER || 'puppetmaster@fake-research-aou.org',
   READER_USER: process.env.READER_USER || 'puppetcitestreader1@fake-research-aou.org',
@@ -49,9 +49,9 @@ const test = {
 
 // workbench staging environment
 const staging = {
-  LOGIN_URL: process.env.STAGING_LOGIN_URL || 'https://all-of-us-rw-staging.appspot.com',
+  LOGIN_URL_DOMAIN_NAME: process.env.STAGING_LOGIN_URL || 'https://all-of-us-rw-staging.appspot.com',
   API_URL: process.env.STAGING_API_URL || 'https://api-dot-all-of-us-rw-staging.appspot.com/v1',
-  DOMAIN: '@staging.fake-research-aou.org',
+  EMAIL_DOMAIN_NAME: '@staging.fake-research-aou.org',
   COLLABORATOR_USER: process.env.COLLABORATOR_USER || 'puppetcitester4@staging.fake-research-aou.org',
   WRITER_USER: process.env.WRITER_USER || 'puppetmaster@staging.fake-research-aou.org',
   READER_USER: process.env.READER_USER || 'puppetcistagingreader1@staging.fake-research-aou.org',
@@ -61,18 +61,18 @@ const staging = {
 
 // NOT WORKING: workbench stable environment
 const stable = {
-  LOGIN_URL: process.env.STABLE_LOGIN_URL,
+  LOGIN_URL_DOMAIN_NAME: process.env.STABLE_LOGIN_URL,
   API_URL: process.env.STABLE_API_URL,
-  DOMAIN: '@stable.fake-research-aou.org',
+  EMAIL_DOMAIN_NAME: '@stable.fake-research-aou.org',
   DEFAULT_CDR_VERSION_NAME: 'Synthetic Dataset v4',
   ALTERNATIVE_CDR_VERSION_NAME: 'Synthetic Dataset v3'
 };
 
 // workbench perf environment
 const perf = {
-  LOGIN_URL: process.env.PERF_LOGIN_URL || 'https://all-of-us-rw-perf.appspot.com',
+  LOGIN_URL_DOMAIN_NAME: process.env.PERF_LOGIN_URL || 'https://all-of-us-rw-perf.appspot.com',
   API_URL: process.env.PERF_API_URL || 'https://api-dot-all-of-us-rw-perf.appspot.com/v1',
-  DOMAIN: '@perf.fake-research-aou.org',
+  EMAIL_DOMAIN_NAME: '@perf.fake-research-aou.org',
   COLLABORATOR_USER: process.env.COLLABORATOR_USER || 'puppetciperfreader@perf.fake-research-aou.org',
   WRITER_USER: process.env.WRITER_USER || 'puppetciperfwriter1@perf.fake-research-aou.org',
   READER_USER: process.env.READER_USER || 'puppetciperfreader@perf.fake-research-aou.org',

--- a/e2e/tests/conceptsets/copy-to-workspace.spec.ts
+++ b/e2e/tests/conceptsets/copy-to-workspace.spec.ts
@@ -102,7 +102,7 @@ describe('Copy Concept Set to another workspace', () => {
     const destWorkspace = await createWorkspace(page);
 
     const srcWorkspaceCard = await findOrCreateWorkspaceCard(page, {
-      cdrVersion: config.altCdrVersionName
+      cdrVersion: config.ALTERNATIVE_CDR_VERSION
     });
 
     const { conceptSetName } = await createConceptSet(srcWorkspaceCard);

--- a/e2e/tests/conceptsets/copy-to-workspace.spec.ts
+++ b/e2e/tests/conceptsets/copy-to-workspace.spec.ts
@@ -102,7 +102,7 @@ describe('Copy Concept Set to another workspace', () => {
     const destWorkspace = await createWorkspace(page);
 
     const srcWorkspaceCard = await findOrCreateWorkspaceCard(page, {
-      cdrVersion: config.ALTERNATIVE_CDR_VERSION
+      cdrVersion: config.ALTERNATIVE_CDR_VERSION_NAME
     });
 
     const { conceptSetName } = await createConceptSet(srcWorkspaceCard);

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -138,7 +138,7 @@ describe('Create Dataset', () => {
 
   test('Workspace READER cannot edit dataset', async () => {
     // READER log in in new Incognito page.
-    await signInWithAccessToken(page, config.readerUserAccessTokenFilename);
+    await signInWithAccessToken(page, config.READER_ACCESS_TOKEN_FILE);
 
     // Find workspace created by previous test. If not found, test will fail.
     const workspaceCard = await findWorkspaceCard(page, workspace);

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -130,7 +130,7 @@ describe('Create Dataset', () => {
     await aboutPage.waitForLoad();
 
     const shareWorkspaceModal = await aboutPage.shareWorkspace();
-    await shareWorkspaceModal.shareWithUser(config.readerUserName, WorkspaceAccessLevel.Reader);
+    await shareWorkspaceModal.shareWithUser(config.READER_USER, WorkspaceAccessLevel.Reader);
     await waitWhileLoading(page);
 
     // Don't delete dataset because it's needed in next test.

--- a/e2e/tests/nightly/dataproc-to-gce.spec.ts
+++ b/e2e/tests/nightly/dataproc-to-gce.spec.ts
@@ -16,7 +16,7 @@ describe('Updating runtime compute type', () => {
   });
 
   test('Switch from dataproc to GCE', async () => {
-    await createWorkspace(page, { cdrVersion: config.altCdrVersionName });
+    await createWorkspace(page, { cdrVersion: config.ALTERNATIVE_CDR_VERSION });
 
     // Open the runtime panel
     // Click “customize“ , from the default “create panel”

--- a/e2e/tests/nightly/dataproc-to-gce.spec.ts
+++ b/e2e/tests/nightly/dataproc-to-gce.spec.ts
@@ -16,7 +16,7 @@ describe('Updating runtime compute type', () => {
   });
 
   test('Switch from dataproc to GCE', async () => {
-    await createWorkspace(page, { cdrVersion: config.ALTERNATIVE_CDR_VERSION });
+    await createWorkspace(page, { cdrVersion: config.ALTERNATIVE_CDR_VERSION_NAME });
 
     // Open the runtime panel
     // Click “customize“ , from the default “create panel”

--- a/e2e/tests/nightly/gce-to-dataproc.spec.ts
+++ b/e2e/tests/nightly/gce-to-dataproc.spec.ts
@@ -16,7 +16,7 @@ describe('Updating runtime compute type', () => {
   });
 
   test('Switch from GCE to dataproc', async () => {
-    await createWorkspace(page, { cdrVersion: config.altCdrVersionName });
+    await createWorkspace(page, { cdrVersion: config.ALTERNATIVE_CDR_VERSION });
 
     // Open the runtime panel
     const runtimePanel = new RuntimePanel(page);

--- a/e2e/tests/nightly/gce-to-dataproc.spec.ts
+++ b/e2e/tests/nightly/gce-to-dataproc.spec.ts
@@ -16,7 +16,7 @@ describe('Updating runtime compute type', () => {
   });
 
   test('Switch from GCE to dataproc', async () => {
-    await createWorkspace(page, { cdrVersion: config.ALTERNATIVE_CDR_VERSION });
+    await createWorkspace(page, { cdrVersion: config.ALTERNATIVE_CDR_VERSION_NAME });
 
     // Open the runtime panel
     const runtimePanel = new RuntimePanel(page);

--- a/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
@@ -39,8 +39,8 @@ describe('Workspace owner copy notebook tests', () => {
   test(
     'Copy notebook to another Workspace when CDR versions match',
     async () => {
-      defaultCdrWorkspace = await createCustomCdrVersionWorkspace(config.defaultCdrVersionName);
-      await copyNotebookTest(defaultCdrWorkspace, config.defaultCdrVersionName);
+      defaultCdrWorkspace = await createCustomCdrVersionWorkspace(config.DEFAULT_CDR_VERSION);
+      await copyNotebookTest(defaultCdrWorkspace, config.DEFAULT_CDR_VERSION);
     },
     30 * 60 * 1000
   );
@@ -50,9 +50,9 @@ describe('Workspace owner copy notebook tests', () => {
     async () => {
       // reuse same source workspace for all tests, but always create new destination workspace.
       if (defaultCdrWorkspace === undefined) {
-        defaultCdrWorkspace = await createCustomCdrVersionWorkspace(config.defaultCdrVersionName);
+        defaultCdrWorkspace = await createCustomCdrVersionWorkspace(config.DEFAULT_CDR_VERSION);
       }
-      await copyNotebookTest(defaultCdrWorkspace, config.altCdrVersionName);
+      await copyNotebookTest(defaultCdrWorkspace, config.ALTERNATIVE_CDR_VERSION);
     },
     30 * 60 * 1000
   );

--- a/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
@@ -39,8 +39,8 @@ describe('Workspace owner copy notebook tests', () => {
   test(
     'Copy notebook to another Workspace when CDR versions match',
     async () => {
-      defaultCdrWorkspace = await createCustomCdrVersionWorkspace(config.DEFAULT_CDR_VERSION);
-      await copyNotebookTest(defaultCdrWorkspace, config.DEFAULT_CDR_VERSION);
+      defaultCdrWorkspace = await createCustomCdrVersionWorkspace(config.DEFAULT_CDR_VERSION_NAME);
+      await copyNotebookTest(defaultCdrWorkspace, config.DEFAULT_CDR_VERSION_NAME);
     },
     30 * 60 * 1000
   );
@@ -50,9 +50,9 @@ describe('Workspace owner copy notebook tests', () => {
     async () => {
       // reuse same source workspace for all tests, but always create new destination workspace.
       if (defaultCdrWorkspace === undefined) {
-        defaultCdrWorkspace = await createCustomCdrVersionWorkspace(config.DEFAULT_CDR_VERSION);
+        defaultCdrWorkspace = await createCustomCdrVersionWorkspace(config.DEFAULT_CDR_VERSION_NAME);
       }
-      await copyNotebookTest(defaultCdrWorkspace, config.ALTERNATIVE_CDR_VERSION);
+      await copyNotebookTest(defaultCdrWorkspace, config.ALTERNATIVE_CDR_VERSION_NAME);
     },
     30 * 60 * 1000
   );

--- a/e2e/tests/notebook/notebook-reader-actions.spec.ts
+++ b/e2e/tests/notebook/notebook-reader-actions.spec.ts
@@ -51,7 +51,7 @@ describe('Workspace READER Jupyter notebook action tests', () => {
 
   test('Workspace READER copy notebook to another workspace', async () => {
     // READER log in.
-    await signInWithAccessToken(page, config.readerUserAccessTokenFilename);
+    await signInWithAccessToken(page, config.READER_ACCESS_TOKEN_FILE);
 
     // Create a new Workspace. This is the copy-to workspace.
     const readerWorkspaceName = await createWorkspace(page);
@@ -145,7 +145,7 @@ describe('Workspace READER Jupyter notebook action tests', () => {
 
   test('Workspace READER edit copy of notebook in workspace clone', async () => {
     // READER log in.
-    await signInWithAccessToken(page, config.readerUserAccessTokenFilename);
+    await signInWithAccessToken(page, config.READER_ACCESS_TOKEN_FILE);
 
     // Verify shared Workspace Access Level is READER.
     await new WorkspacesPage(page).load();

--- a/e2e/tests/notebook/notebook-reader-actions.spec.ts
+++ b/e2e/tests/notebook/notebook-reader-actions.spec.ts
@@ -45,7 +45,7 @@ describe('Workspace READER Jupyter notebook action tests', () => {
 
     // Share Workspace to a READER.
     const shareModal = await aboutPage.openShareModal();
-    await shareModal.shareWithUser(config.readerUserName, WorkspaceAccessLevel.Reader);
+    await shareModal.shareWithUser(config.READER_USER, WorkspaceAccessLevel.Reader);
     await waitWhileLoading(page);
   });
 

--- a/e2e/tests/runtime/pause-resume.spec.ts
+++ b/e2e/tests/runtime/pause-resume.spec.ts
@@ -11,7 +11,7 @@ describe('Updating runtime status', () => {
   });
 
   test('Create, pause, resume, delete', async () => {
-    await createWorkspace(page, { cdrVersion: config.altCdrVersionName });
+    await createWorkspace(page, { cdrVersion: config.ALTERNATIVE_CDR_VERSION });
 
     const runtimePanel = new RuntimePanel(page);
 

--- a/e2e/tests/runtime/pause-resume.spec.ts
+++ b/e2e/tests/runtime/pause-resume.spec.ts
@@ -11,7 +11,7 @@ describe('Updating runtime status', () => {
   });
 
   test('Create, pause, resume, delete', async () => {
-    await createWorkspace(page, { cdrVersion: config.ALTERNATIVE_CDR_VERSION });
+    await createWorkspace(page, { cdrVersion: config.ALTERNATIVE_CDR_VERSION_NAME });
 
     const runtimePanel = new RuntimePanel(page);
 

--- a/e2e/tests/user/login.spec.ts
+++ b/e2e/tests/user/login.spec.ts
@@ -18,7 +18,7 @@ describe('Login tests:', () => {
   });
 
   test('Open AoU Workspaces page before login redirects to login page', async () => {
-    const url = `${config.uiBaseUrl}${config.workspacesUrlPath}`;
+    const url = `${config.LOGIN_URL}${config.workspacesUrlPath}`;
     await page.goto(url, { waitUntil: 'networkidle0' });
     const loginPage = new GoogleLoginPage(page);
     expect(await loginPage.loginButton()).toBeTruthy();

--- a/e2e/tests/user/login.spec.ts
+++ b/e2e/tests/user/login.spec.ts
@@ -18,7 +18,7 @@ describe('Login tests:', () => {
   });
 
   test('Open AoU Workspaces page before login redirects to login page', async () => {
-    const url = `${config.LOGIN_URL}${config.WORKSPACES_URL_PATH}`;
+    const url = `${config.LOGIN_URL_DOMAIN_NAME}${config.WORKSPACES_URL_PATH}`;
     await page.goto(url, { waitUntil: 'networkidle0' });
     const loginPage = new GoogleLoginPage(page);
     expect(await loginPage.loginButton()).toBeTruthy();

--- a/e2e/tests/user/login.spec.ts
+++ b/e2e/tests/user/login.spec.ts
@@ -18,7 +18,7 @@ describe('Login tests:', () => {
   });
 
   test('Open AoU Workspaces page before login redirects to login page', async () => {
-    const url = `${config.LOGIN_URL}${config.workspacesUrlPath}`;
+    const url = `${config.LOGIN_URL}${config.WORKSPACES_URL_PATH}`;
     await page.goto(url, { waitUntil: 'networkidle0' });
     const loginPage = new GoogleLoginPage(page);
     expect(await loginPage.loginButton()).toBeTruthy();

--- a/e2e/tests/user/registration-ui.spec.ts
+++ b/e2e/tests/user/registration-ui.spec.ts
@@ -69,7 +69,7 @@ describe('User registration UI tests:', () => {
     expect(await waitForText(page, 'Create your account')).toBeTruthy();
 
     // verify username domain
-    expect(await createAccountPage.getUsernameDomain()).toBe(config.DOMAIN);
+    expect(await createAccountPage.getUsernameDomain()).toBe(config.EMAIL_DOMAIN_NAME);
 
     // verify all input fields are visible and editable on this page
     const allInputs = await page.$$('input');

--- a/e2e/tests/user/registration-ui.spec.ts
+++ b/e2e/tests/user/registration-ui.spec.ts
@@ -69,7 +69,7 @@ describe('User registration UI tests:', () => {
     expect(await waitForText(page, 'Create your account')).toBeTruthy();
 
     // verify username domain
-    expect(await createAccountPage.getUsernameDomain()).toBe(config.userEmailDomain);
+    expect(await createAccountPage.getUsernameDomain()).toBe(config.DOMAIN);
 
     // verify all input fields are visible and editable on this page
     const allInputs = await page.$$('input');

--- a/e2e/tests/workspace/cdr-version-upgrade.spec.ts
+++ b/e2e/tests/workspace/cdr-version-upgrade.spec.ts
@@ -14,11 +14,11 @@ describe('Workspace CDR Version Upgrade modal', () => {
   const workspace = 'e2eUpgradeWorkspaceCDRVersionTest';
 
   test('Clicking Cancel and Upgrade buttons', async () => {
-    await findOrCreateWorkspace(page, { cdrVersion: config.ALTERNATIVE_CDR_VERSION, workspaceName: workspace });
+    await findOrCreateWorkspace(page, { cdrVersion: config.ALTERNATIVE_CDR_VERSION_NAME, workspaceName: workspace });
 
     const workspacePage: WorkspaceBase = new WorkspaceDataPage(page);
     const cdrVersion = await workspacePage.getCdrVersion();
-    expect(cdrVersion).toBe(config.ALTERNATIVE_CDR_VERSION);
+    expect(cdrVersion).toBe(config.ALTERNATIVE_CDR_VERSION_NAME);
 
     let modal = await launchCdrUpgradeModal(page);
 
@@ -37,7 +37,7 @@ describe('Workspace CDR Version Upgrade modal', () => {
     const duplicationPage = new WorkspaceEditPage(page);
     const upgradeMessage = await duplicationPage.getCdrVersionUpgradeMessage();
     expect(upgradeMessage).toContain(workspace);
-    expect(upgradeMessage).toContain(`${config.ALTERNATIVE_CDR_VERSION} to ${config.DEFAULT_CDR_VERSION}.`);
+    expect(upgradeMessage).toContain(`${config.ALTERNATIVE_CDR_VERSION_NAME} to ${config.DEFAULT_CDR_VERSION_NAME}.`);
 
     const editCancelButton = duplicationPage.getCancelButton();
     await editCancelButton.clickAndWait();

--- a/e2e/tests/workspace/cdr-version-upgrade.spec.ts
+++ b/e2e/tests/workspace/cdr-version-upgrade.spec.ts
@@ -14,11 +14,11 @@ describe('Workspace CDR Version Upgrade modal', () => {
   const workspace = 'e2eUpgradeWorkspaceCDRVersionTest';
 
   test('Clicking Cancel and Upgrade buttons', async () => {
-    await findOrCreateWorkspace(page, { cdrVersion: config.altCdrVersionName, workspaceName: workspace });
+    await findOrCreateWorkspace(page, { cdrVersion: config.ALTERNATIVE_CDR_VERSION, workspaceName: workspace });
 
     const workspacePage: WorkspaceBase = new WorkspaceDataPage(page);
     const cdrVersion = await workspacePage.getCdrVersion();
-    expect(cdrVersion).toBe(config.altCdrVersionName);
+    expect(cdrVersion).toBe(config.ALTERNATIVE_CDR_VERSION);
 
     let modal = await launchCdrUpgradeModal(page);
 
@@ -37,7 +37,7 @@ describe('Workspace CDR Version Upgrade modal', () => {
     const duplicationPage = new WorkspaceEditPage(page);
     const upgradeMessage = await duplicationPage.getCdrVersionUpgradeMessage();
     expect(upgradeMessage).toContain(workspace);
-    expect(upgradeMessage).toContain(`${config.altCdrVersionName} to ${config.defaultCdrVersionName}.`);
+    expect(upgradeMessage).toContain(`${config.ALTERNATIVE_CDR_VERSION} to ${config.DEFAULT_CDR_VERSION}.`);
 
     const editCancelButton = duplicationPage.getCancelButton();
     await editCancelButton.clickAndWait();

--- a/e2e/tests/workspace/old-cdr-version-modal.spec.ts
+++ b/e2e/tests/workspace/old-cdr-version-modal.spec.ts
@@ -18,7 +18,7 @@ describe('OldCdrVersion Modal restrictions', () => {
     const editPage = await workspacesPage.fillOutRequiredCreationFields(makeWorkspaceName());
 
     // select an old CDR Version
-    await editPage.selectCdrVersion(config.ALTERNATIVE_CDR_VERSION);
+    await editPage.selectCdrVersion(config.ALTERNATIVE_CDR_VERSION_NAME);
 
     const createButton = editPage.getCreateWorkspaceButton();
     expect(await createButton.isCursorNotAllowed()).toBe(true);
@@ -45,7 +45,7 @@ describe('OldCdrVersion Modal restrictions', () => {
     await workspaceEditPage.fillOutWorkspaceName();
 
     // change CDR Version
-    await workspaceEditPage.selectCdrVersion(config.ALTERNATIVE_CDR_VERSION);
+    await workspaceEditPage.selectCdrVersion(config.ALTERNATIVE_CDR_VERSION_NAME);
 
     const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
     expect(await finishButton.isCursorNotAllowed()).toBe(true);
@@ -64,7 +64,7 @@ describe('OldCdrVersion Modal restrictions', () => {
     await duplicateButton.waitUntilEnabled();
 
     // change CDR Version
-    await workspaceEditPage.selectCdrVersion(config.ALTERNATIVE_CDR_VERSION);
+    await workspaceEditPage.selectCdrVersion(config.ALTERNATIVE_CDR_VERSION_NAME);
     expect(await duplicateButton.isCursorNotAllowed()).toBe(true);
 
     const modal = new OldCdrVersionModal(page);
@@ -73,6 +73,6 @@ describe('OldCdrVersion Modal restrictions', () => {
 
     // the CDR version is forcibly reverted back to the default
     const cdrVersionSelect = workspaceEditPage.getCdrVersionSelect();
-    expect(await cdrVersionSelect.getSelectedValue()).toBe(config.DEFAULT_CDR_VERSION);
+    expect(await cdrVersionSelect.getSelectedValue()).toBe(config.DEFAULT_CDR_VERSION_NAME);
   });
 });

--- a/e2e/tests/workspace/old-cdr-version-modal.spec.ts
+++ b/e2e/tests/workspace/old-cdr-version-modal.spec.ts
@@ -18,7 +18,7 @@ describe('OldCdrVersion Modal restrictions', () => {
     const editPage = await workspacesPage.fillOutRequiredCreationFields(makeWorkspaceName());
 
     // select an old CDR Version
-    await editPage.selectCdrVersion(config.altCdrVersionName);
+    await editPage.selectCdrVersion(config.ALTERNATIVE_CDR_VERSION);
 
     const createButton = editPage.getCreateWorkspaceButton();
     expect(await createButton.isCursorNotAllowed()).toBe(true);
@@ -45,7 +45,7 @@ describe('OldCdrVersion Modal restrictions', () => {
     await workspaceEditPage.fillOutWorkspaceName();
 
     // change CDR Version
-    await workspaceEditPage.selectCdrVersion(config.altCdrVersionName);
+    await workspaceEditPage.selectCdrVersion(config.ALTERNATIVE_CDR_VERSION);
 
     const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
     expect(await finishButton.isCursorNotAllowed()).toBe(true);
@@ -64,7 +64,7 @@ describe('OldCdrVersion Modal restrictions', () => {
     await duplicateButton.waitUntilEnabled();
 
     // change CDR Version
-    await workspaceEditPage.selectCdrVersion(config.altCdrVersionName);
+    await workspaceEditPage.selectCdrVersion(config.ALTERNATIVE_CDR_VERSION);
     expect(await duplicateButton.isCursorNotAllowed()).toBe(true);
 
     const modal = new OldCdrVersionModal(page);
@@ -73,6 +73,6 @@ describe('OldCdrVersion Modal restrictions', () => {
 
     // the CDR version is forcibly reverted back to the default
     const cdrVersionSelect = workspaceEditPage.getCdrVersionSelect();
-    expect(await cdrVersionSelect.getSelectedValue()).toBe(config.defaultCdrVersionName);
+    expect(await cdrVersionSelect.getSelectedValue()).toBe(config.DEFAULT_CDR_VERSION);
   });
 });

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -33,7 +33,7 @@ describe('Creating new workspaces', () => {
     await dataPage.verifyWorkspaceNameOnDataPage(newWorkspaceName);
 
     // Verify the CDR version displays in the workspace navigation bar
-    expect(await dataPage.getCdrVersion()).toBe(config.DEFAULT_CDR_VERSION);
+    expect(await dataPage.getCdrVersion()).toBe(config.DEFAULT_CDR_VERSION_NAME);
 
     // cleanup
     await dataPage.deleteWorkspace();
@@ -95,13 +95,13 @@ describe('Creating new workspaces', () => {
     const createPage = await workspacesPage.fillOutRequiredCreationFields(name);
 
     const cdrVersionSelect = createPage.getCdrVersionSelect();
-    expect(await cdrVersionSelect.getSelectedValue()).toBe(config.DEFAULT_CDR_VERSION);
+    expect(await cdrVersionSelect.getSelectedValue()).toBe(config.DEFAULT_CDR_VERSION_NAME);
 
     await createPage.selectAccessTier(AccessTierDisplayNames.Controlled);
 
     // observe that the CDR Version default has changed
     const selectedCdrVersion = await cdrVersionSelect.getSelectedValue();
-    expect(selectedCdrVersion).not.toBe(config.DEFAULT_CDR_VERSION);
+    expect(selectedCdrVersion).not.toBe(config.DEFAULT_CDR_VERSION_NAME);
 
     // click CREATE WORKSPACE button
     const createButton = createPage.getCreateWorkspaceButton();

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -33,7 +33,7 @@ describe('Creating new workspaces', () => {
     await dataPage.verifyWorkspaceNameOnDataPage(newWorkspaceName);
 
     // Verify the CDR version displays in the workspace navigation bar
-    expect(await dataPage.getCdrVersion()).toBe(config.defaultCdrVersionName);
+    expect(await dataPage.getCdrVersion()).toBe(config.DEFAULT_CDR_VERSION);
 
     // cleanup
     await dataPage.deleteWorkspace();
@@ -95,13 +95,13 @@ describe('Creating new workspaces', () => {
     const createPage = await workspacesPage.fillOutRequiredCreationFields(name);
 
     const cdrVersionSelect = createPage.getCdrVersionSelect();
-    expect(await cdrVersionSelect.getSelectedValue()).toBe(config.defaultCdrVersionName);
+    expect(await cdrVersionSelect.getSelectedValue()).toBe(config.DEFAULT_CDR_VERSION);
 
     await createPage.selectAccessTier(AccessTierDisplayNames.Controlled);
 
     // observe that the CDR Version default has changed
     const selectedCdrVersion = await cdrVersionSelect.getSelectedValue();
-    expect(selectedCdrVersion).not.toBe(config.defaultCdrVersionName);
+    expect(selectedCdrVersion).not.toBe(config.DEFAULT_CDR_VERSION);
 
     // click CREATE WORKSPACE button
     const createButton = createPage.getCreateWorkspaceButton();

--- a/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
@@ -26,7 +26,7 @@ describe('Duplicate workspace, changing CDR versions', () => {
     const duplicateWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
 
     // change CDR Version
-    await workspaceEditPage.selectCdrVersion(config.ALTERNATIVE_CDR_VERSION);
+    await workspaceEditPage.selectCdrVersion(config.ALTERNATIVE_CDR_VERSION_NAME);
 
     // wait for the warning modal and consent to the required restrictions
     const modal = new OldCdrVersionModal(page);
@@ -58,7 +58,7 @@ describe('Duplicate workspace, changing CDR versions', () => {
   test('OWNER can duplicate workspace to a newer CDR Version via Workspace card', async () => {
     const workspaceCard = await findOrCreateWorkspaceCard(page, {
       workspaceName: originalWorkspaceName2,
-      cdrVersion: config.ALTERNATIVE_CDR_VERSION
+      cdrVersion: config.ALTERNATIVE_CDR_VERSION_NAME
     });
     await workspaceCard.asElementHandle().hover();
     await workspaceCard.selectSnowmanMenu(MenuOption.Duplicate, { waitForNav: true });
@@ -69,11 +69,11 @@ describe('Duplicate workspace, changing CDR versions', () => {
     const duplicateWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
 
     // change CDR Version
-    await workspaceEditPage.selectCdrVersion(config.DEFAULT_CDR_VERSION);
+    await workspaceEditPage.selectCdrVersion(config.DEFAULT_CDR_VERSION_NAME);
 
     const upgradeMessage = await workspaceEditPage.getCdrVersionUpgradeMessage();
     expect(upgradeMessage).toContain(originalWorkspaceName2);
-    expect(upgradeMessage).toContain(`${config.ALTERNATIVE_CDR_VERSION} to ${config.DEFAULT_CDR_VERSION}.`);
+    expect(upgradeMessage).toContain(`${config.ALTERNATIVE_CDR_VERSION_NAME} to ${config.DEFAULT_CDR_VERSION_NAME}.`);
 
     const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
     await workspaceEditPage.requestForReviewRadiobutton(false);

--- a/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
+++ b/e2e/tests/workspace/workspace-duplicate-cdr-versions.spec.ts
@@ -26,7 +26,7 @@ describe('Duplicate workspace, changing CDR versions', () => {
     const duplicateWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
 
     // change CDR Version
-    await workspaceEditPage.selectCdrVersion(config.altCdrVersionName);
+    await workspaceEditPage.selectCdrVersion(config.ALTERNATIVE_CDR_VERSION);
 
     // wait for the warning modal and consent to the required restrictions
     const modal = new OldCdrVersionModal(page);
@@ -58,7 +58,7 @@ describe('Duplicate workspace, changing CDR versions', () => {
   test('OWNER can duplicate workspace to a newer CDR Version via Workspace card', async () => {
     const workspaceCard = await findOrCreateWorkspaceCard(page, {
       workspaceName: originalWorkspaceName2,
-      cdrVersion: config.altCdrVersionName
+      cdrVersion: config.ALTERNATIVE_CDR_VERSION
     });
     await workspaceCard.asElementHandle().hover();
     await workspaceCard.selectSnowmanMenu(MenuOption.Duplicate, { waitForNav: true });
@@ -69,11 +69,11 @@ describe('Duplicate workspace, changing CDR versions', () => {
     const duplicateWorkspaceName = await workspaceEditPage.fillOutWorkspaceName();
 
     // change CDR Version
-    await workspaceEditPage.selectCdrVersion(config.defaultCdrVersionName);
+    await workspaceEditPage.selectCdrVersion(config.DEFAULT_CDR_VERSION);
 
     const upgradeMessage = await workspaceEditPage.getCdrVersionUpgradeMessage();
     expect(upgradeMessage).toContain(originalWorkspaceName2);
-    expect(upgradeMessage).toContain(`${config.altCdrVersionName} to ${config.defaultCdrVersionName}.`);
+    expect(upgradeMessage).toContain(`${config.ALTERNATIVE_CDR_VERSION} to ${config.DEFAULT_CDR_VERSION}.`);
 
     const finishButton = workspaceEditPage.getDuplicateWorkspaceButton();
     await workspaceEditPage.requestForReviewRadiobutton(false);

--- a/e2e/tests/workspace/workspace-share-modal.spec.ts
+++ b/e2e/tests/workspace/workspace-share-modal.spec.ts
@@ -10,12 +10,12 @@ describe('Workspace Share Modal', () => {
   const assignAccess = [
     {
       accessRole: WorkspaceAccessLevel.Writer,
-      userEmail: config.writerUserName,
+      userEmail: config.WRITER_USER,
       userAccessTokenFilename: config.writerUserAccessTokenFilename
     },
     {
       accessRole: WorkspaceAccessLevel.Reader,
-      userEmail: config.readerUserName,
+      userEmail: config.READER_USER,
       userAccessTokenFilename: config.readerUserAccessTokenFilename
     }
   ];

--- a/e2e/tests/workspace/workspace-share-modal.spec.ts
+++ b/e2e/tests/workspace/workspace-share-modal.spec.ts
@@ -11,12 +11,12 @@ describe('Workspace Share Modal', () => {
     {
       accessRole: WorkspaceAccessLevel.Writer,
       userEmail: config.WRITER_USER,
-      userAccessTokenFilename: config.writerUserAccessTokenFilename
+      userAccessTokenFilename: config.WRITER_ACCESS_TOKEN_FILE
     },
     {
       accessRole: WorkspaceAccessLevel.Reader,
       userEmail: config.READER_USER,
-      userAccessTokenFilename: config.readerUserAccessTokenFilename
+      userAccessTokenFilename: config.READER_ACCESS_TOKEN_FILE
     }
   ];
 

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -7,16 +7,16 @@ export interface IConfig {
   COLLABORATOR_USER: string;
   WRITER_USER: string;
   READER_USER: string;
-  DEFAULT_CDR_VERSION: string;
-  ALTERNATIVE_CDR_VERSION: string;
-  userAccessTokenFilename: string;
-  collaboratorUserAccessTokenFilename: string;
-  readerUserAccessTokenFilename: string;
-  writerUserAccessTokenFilename: string;
-  loginUrlPath: string;
-  workspacesUrlPath: string;
-  profileUrlPath: string;
-  libraryUrlPath: string;
-  adminUrlPath: string;
-  institutionContactEmail: string;
+  DEFAULT_CDR_VERSION_NAME: string;
+  ALTERNATIVE_CDR_VERSION_NAME: string;
+  USER_ACCESS_TOKEN_FILE: string;
+  COLLABORATOR_ACCESS_TOKEN_FILE: string;
+  READER_ACCESS_TOKEN_FILE: string;
+  WRITER_ACCESS_TOKEN_FILE: string;
+  LOGIN_URL_PATH: string;
+  WORKSPACES_URL_PATH: string;
+  PROFILE_URL_PATH: string;
+  LIBRARY_URL_PATH: string;
+  ADMIN_URL_PATH: string;
+  INSTITUTION_CONTACT_EMAIL: string;
 }

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -1,0 +1,22 @@
+export interface IConfig {
+  USER_NAME: string;
+  PASSWORD: string;
+  LOGIN_URL: string;
+  API_URL: string;
+  DOMAIN: string;
+  COLLABORATOR_USER: string;
+  WRITER_USER: string;
+  READER_USER: string;
+  DEFAULT_CDR_VERSION: string;
+  ALTERNATIVE_CDR_VERSION: string;
+  userAccessTokenFilename: string;
+  collaboratorUserAccessTokenFilename: string;
+  readerUserAccessTokenFilename: string;
+  writerUserAccessTokenFilename: string;
+  loginUrlPath: string;
+  workspacesUrlPath: string;
+  profileUrlPath: string;
+  libraryUrlPath: string;
+  adminUrlPath: string;
+  institutionContactEmail: string;
+}

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -1,9 +1,9 @@
 export interface IConfig {
   USER_NAME: string;
   PASSWORD: string;
-  LOGIN_URL: string;
+  LOGIN_URL_DOMAIN_NAME: string;
   API_URL: string;
-  DOMAIN: string;
+  EMAIL_DOMAIN_NAME: string;
   COLLABORATOR_USER: string;
   WRITER_USER: string;
   READER_USER: string;

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -24,15 +24,15 @@ export async function signOut(page: Page): Promise<void> {
   await page.waitForTimeout(1000);
 }
 
-export async function signInWithAccessToken(page: Page, tokenFilename = config.userAccessTokenFilename): Promise<void> {
+export async function signInWithAccessToken(page: Page, tokenFilename = config.USER_ACCESS_TOKEN_FILE): Promise<void> {
   const token = fs.readFileSync(tokenFilename, 'ascii');
   logger.info('Sign in with access token to Workbench application');
   const homePage = new HomePage(page);
-  await homePage.gotoUrl(PageUrl.Home.value);
+  await homePage.gotoUrl(PageUrl.Home);
 
   // Once ready, initialize the token on the page (this is stored in local storage).
   // See sign-in.service.ts for details.
-  const navigationPromise = page.waitForNavigation({waitUntil: ['load','networkidle0']});
+  const navigationPromise = page.waitForNavigation({ waitUntil: ['load', 'networkidle0'] });
   await page.waitForFunction('!!window["setTestAccessTokenOverride"]');
   await page.evaluate(`window.setTestAccessTokenOverride('${token}')`);
   await navigationPromise;
@@ -43,7 +43,7 @@ export async function signInWithAccessToken(page: Page, tokenFilename = config.u
   // logs; there is some delay between a console.log() execution and capture by
   // Puppeteer. Any console.log() within the above global function, for example,
   // is unlikely to be captured.
-  await homePage.gotoUrl(PageUrl.Home.value);
+  await homePage.gotoUrl(PageUrl.Home);
   await homePage.waitForLoad();
 }
 
@@ -120,7 +120,7 @@ export async function createWorkspace(
   page: Page,
   options: { cdrVersion?: string; workspaceName?: string } = {}
 ): Promise<string> {
-  const { cdrVersion = config.DEFAULT_CDR_VERSION, workspaceName = makeWorkspaceName() } = options;
+  const { cdrVersion = config.DEFAULT_CDR_VERSION_NAME, workspaceName = makeWorkspaceName() } = options;
   const workspacesPage = new WorkspacesPage(page);
   await workspacesPage.load();
   await workspacesPage.createWorkspace(workspaceName, cdrVersion);
@@ -146,7 +146,7 @@ export async function findOrCreateWorkspace(
   page: Page,
   opts: { cdrVersion?: string; workspaceName?: string } = {}
 ): Promise<string> {
-  const { cdrVersion = config.DEFAULT_CDR_VERSION, workspaceName } = opts;
+  const { cdrVersion = config.DEFAULT_CDR_VERSION_NAME, workspaceName } = opts;
   // Returns specified workspaceName Workspace card if exists.
   if (workspaceName !== undefined) {
     const cardFound = await findWorkspaceCard(page, workspaceName);
@@ -197,7 +197,7 @@ export async function findOrCreateWorkspaceCard(
   page: Page,
   options: { cdrVersion?: string; workspaceName?: string } = {}
 ): Promise<WorkspaceCard> {
-  const { cdrVersion = config.DEFAULT_CDR_VERSION, workspaceName = makeWorkspaceName() } = options;
+  const { cdrVersion = config.DEFAULT_CDR_VERSION_NAME, workspaceName = makeWorkspaceName() } = options;
 
   let cardFound = await findWorkspaceCard(page, workspaceName);
   if (cardFound !== null) {

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -28,12 +28,14 @@ export async function signInWithAccessToken(page: Page, tokenFilename = config.u
   const token = fs.readFileSync(tokenFilename, 'ascii');
   logger.info('Sign in with access token to Workbench application');
   const homePage = new HomePage(page);
-  await homePage.gotoUrl(PageUrl.Home.toString());
+  await homePage.gotoUrl(PageUrl.Home.value);
 
   // Once ready, initialize the token on the page (this is stored in local storage).
   // See sign-in.service.ts for details.
+  const navigationPromise = page.waitForNavigation({waitUntil: ['load','networkidle0']});
   await page.waitForFunction('!!window["setTestAccessTokenOverride"]');
   await page.evaluate(`window.setTestAccessTokenOverride('${token}')`);
+  await navigationPromise;
 
   // Force a page reload; auth will be re-initialized with the token now that
   // localstorage has been updated.
@@ -41,7 +43,7 @@ export async function signInWithAccessToken(page: Page, tokenFilename = config.u
   // logs; there is some delay between a console.log() execution and capture by
   // Puppeteer. Any console.log() within the above global function, for example,
   // is unlikely to be captured.
-  await homePage.gotoUrl(PageUrl.Home.toString());
+  await homePage.gotoUrl(PageUrl.Home.value);
   await homePage.waitForLoad();
 }
 

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -118,7 +118,7 @@ export async function createWorkspace(
   page: Page,
   options: { cdrVersion?: string; workspaceName?: string } = {}
 ): Promise<string> {
-  const { cdrVersion = config.defaultCdrVersionName, workspaceName = makeWorkspaceName() } = options;
+  const { cdrVersion = config.DEFAULT_CDR_VERSION, workspaceName = makeWorkspaceName() } = options;
   const workspacesPage = new WorkspacesPage(page);
   await workspacesPage.load();
   await workspacesPage.createWorkspace(workspaceName, cdrVersion);
@@ -144,7 +144,7 @@ export async function findOrCreateWorkspace(
   page: Page,
   opts: { cdrVersion?: string; workspaceName?: string } = {}
 ): Promise<string> {
-  const { cdrVersion = config.defaultCdrVersionName, workspaceName } = opts;
+  const { cdrVersion = config.DEFAULT_CDR_VERSION, workspaceName } = opts;
   // Returns specified workspaceName Workspace card if exists.
   if (workspaceName !== undefined) {
     const cardFound = await findWorkspaceCard(page, workspaceName);
@@ -195,7 +195,7 @@ export async function findOrCreateWorkspaceCard(
   page: Page,
   options: { cdrVersion?: string; workspaceName?: string } = {}
 ): Promise<WorkspaceCard> {
-  const { cdrVersion = config.defaultCdrVersionName, workspaceName = makeWorkspaceName() } = options;
+  const { cdrVersion = config.DEFAULT_CDR_VERSION, workspaceName = makeWorkspaceName() } = options;
 
   let cardFound = await findWorkspaceCard(page, workspaceName);
   if (cardFound !== null) {


### PR DESCRIPTION
Rename workbench env variable names, define env variables types (`types.d.ts`). It fixed some eslint warnings.

Before:
<img width="304" alt="Screen Shot 2021-07-06 at 4 52 49 PM" src="https://user-images.githubusercontent.com/35533885/124665783-27805e80-de7b-11eb-9990-3c4c23c1a7cd.png">

After:
<img width="307" alt="Screen Shot 2021-07-06 at 4 52 28 PM" src="https://user-images.githubusercontent.com/35533885/124665791-2b13e580-de7b-11eb-8070-b7947ba98714.png">

Also updated README.md for running test on localhost.