### PR TITLE
[risk=low][RW-7002] Don't show disabled access modules in AAR screen

### DIFF
--- a/ui/src/app/pages/access/access-renewal-page.spec.tsx
+++ b/ui/src/app/pages/access/access-renewal-page.spec.tsx
@@ -44,10 +44,10 @@ describe('Access Renewal Page', () => {
     profileStore.set({profile: newProfile, load, reload, updateCache});
   }
 
-  function removeOneModule(updateModuleName) {
+  function removeOneModule(toBeRemoved) {
     const oldProfile = profileStore.get().profile;
     const newModules = fp.map(({moduleName, expirationEpochMillis}) =>
-        (moduleName === updateModuleName ? {} : {
+        (moduleName === toBeRemoved ? {} : {
           moduleName,
           expirationEpochMillis}),
         oldProfile.renewableAccessModules.modules);

--- a/ui/src/app/pages/access/access-renewal-page.spec.tsx
+++ b/ui/src/app/pages/access/access-renewal-page.spec.tsx
@@ -18,6 +18,9 @@ const oneYearFromNow = () => Date.now() + 1000 * 60 * 60 * 24 * EXPIRY_DAYS
 const oneHourAgo = () => Date.now() - 1000 * 60 * 60;
 
 describe('Access Renewal Page', () => {
+  const load = jest.fn();
+  const reload = jest.fn();
+  const updateCache = jest.fn();
 
   function expireAllModules() {
     const expiredTime = oneHourAgo();
@@ -37,6 +40,17 @@ describe('Access Renewal Page', () => {
       moduleName,
       expirationEpochMillis: moduleName === updateModuleName ? time : expirationEpochMillis
     }), oldProfile.renewableAccessModules.modules);
+    const newProfile = fp.set(['renewableAccessModules', 'modules'], newModules, oldProfile)
+    profileStore.set({profile: newProfile, load, reload, updateCache});
+  }
+
+  function removeOneModule(updateModuleName) {
+    const oldProfile = profileStore.get().profile;
+    const newModules = fp.map(({moduleName, expirationEpochMillis}) =>
+        (moduleName === updateModuleName ? {} : {
+          moduleName,
+          expirationEpochMillis}),
+        oldProfile.renewableAccessModules.modules);
     const newProfile = fp.set(['renewableAccessModules', 'modules'], newModules, oldProfile)
     profileStore.set({profile: newProfile, load, reload, updateCache});
   }
@@ -68,10 +82,6 @@ describe('Access Renewal Page', () => {
   const component = () => {
     return mount(<AccessRenewalPage/>);
   };
-
-  const load = jest.fn();
-  const reload = jest.fn();
-  const updateCache = jest.fn();
 
   beforeEach(() => {
     const profileApi = new ProfileApiStub();
@@ -228,33 +238,37 @@ describe('Access Renewal Page', () => {
   });
 
   it('should show the correct state when modules are disabled', async () => {
-    expireAllModules()
-
     serverConfigStore.set({config: {
       ...defaultServerConfig,
         enableDataUseAgreement: false,
         enableComplianceTraining: false
       }});
-    expireAllModules()
 
     const wrapper = component();
+
+    setCompletionTimes(() => Date.now());
 
     updateOneModule('profileConfirmation', oneYearFromNow());
     updateOneModule('publicationConfirmation', oneYearFromNow());
 
-    setCompletionTimes(() => Date.now());
+    // these modules will not be returned in RenewableAccessModules because they are disabled
+
+    removeOneModule('complianceTraining');
+    removeOneModule('dataUseAgreement');
 
     await waitOneTickAndUpdate(wrapper);
 
     // profileConfirmation and publicationConfirmation are complete
     expect(findNodesByExactText(wrapper, 'Confirmed').length).toBe(2);
     expect(findNodesContainingText(wrapper, `${EXPIRY_DAYS - 1} days`).length).toBe(2);
-    expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(1);
 
     // complianceTraining and dataUseAgreement are not shown because these modules are disabled
     expect(findNodesByExactText(wrapper, 'Completed').length).toBe(0);
     expect(findNodesByExactText(wrapper, 'View & Sign').length).toBe(0)
     expect(findNodesByExactText(wrapper, 'Complete Training').length).toBe(0);
+
+    // all of the necessary steps = 2 rather than the usual 4
+    expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(1);
   });
 
 });

--- a/ui/src/app/pages/access/access-renewal-page.tsx
+++ b/ui/src/app/pages/access/access-renewal-page.tsx
@@ -24,7 +24,7 @@ import {
 } from 'app/utils';
 import {maybeDaysRemaining, redirectToTraining} from 'app/utils/access-utils';
 import {navigateByUrl} from 'app/utils/navigation';
-import {profileStore, useStore} from 'app/utils/stores';
+import {profileStore, serverConfigStore, useStore} from 'app/utils/stores';
 import {RenewableAccessModuleStatus} from 'generated/fetch';
 import ModuleNameEnum = RenewableAccessModuleStatus.ModuleNameEnum;
 
@@ -224,6 +224,10 @@ export const AccessRenewalPage = fp.flow(
     renewableAccessModules: {modules}},
     profile
   } = useStore(profileStore);
+  const {config: {
+    enableComplianceTraining,
+    enableDataUseAgreement,
+  }} = useStore(serverConfigStore);
   const [publications, setPublications] = useState<boolean>(null);
   const noReportId = useId();
   const reportId = useId();
@@ -335,7 +339,7 @@ export const AccessRenewalPage = fp.flow(
         </div>
       </RenewalCard>
       {/* Compliance Training */}
-      <RenewalCard step={3}
+      {enableComplianceTraining && <RenewalCard step={3}
         TitleComponent={() => <div><AoU/> Responsible Conduct of Research Training</div>}
         lastCompletionTime={complianceTrainingCompletionTime}
         nextReviewTime={getExpirationTimeFor(ModuleNameEnum.ComplianceTraining)}
@@ -365,9 +369,9 @@ export const AccessRenewalPage = fp.flow(
             }}
             style={{height: '1.6rem', marginLeft: '0.75rem', width: 'max-content'}}>Refresh</Button>}
         </FlexRow>
-      </RenewalCard>
+      </RenewalCard>}
       {/* DUCC */}
-      <RenewalCard step={4}
+      {enableDataUseAgreement && <RenewalCard step={enableComplianceTraining ? 4 : 3}
         TitleComponent={() => 'Sign Data User Code of Conduct'}
         lastCompletionTime={dataUseAgreementCompletionTime}
         nextReviewTime={getExpirationTimeFor(ModuleNameEnum.DataUseAgreement)}
@@ -378,7 +382,7 @@ export const AccessRenewalPage = fp.flow(
           completedButtonText='Completed'
           onClick={() => navigateByUrl('data-code-of-conduct?renewal=1')}
           wasBypassed={wasBypassed(ModuleNameEnum.DataUseAgreement)}/>
-      </RenewalCard>
+      </RenewalCard>}
     </div>
     {loading && <SpinnerOverlay dark={true} opacity={0.6}/>}
   </FadeBox>;


### PR DESCRIPTION
Don't return disabled modules in Profile.renewableAccessModules and don't display them in the AAR screen.  Example where complianceTraining is disabled:

<img width="1182" alt="aar-screen-fix" src="https://user-images.githubusercontent.com/2701406/124823071-c3bf6980-df3e-11eb-91a3-1d7c48be36ed.png">

Also tested locally removing both FF-disable-able modules and it looked fine with only 2 cards.
 
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
