### PR TITLE
[RW-6905][risk=low] Add DbRetry utils and use that to retry get recent resource operation

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/DbRetryUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/db/DbRetryUtils.java
@@ -1,0 +1,71 @@
+package org.pmiops.workbench.db;
+
+import com.google.common.base.Preconditions;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.dao.TransientDataAccessException;
+
+/** Utilities to execute database operations with retry support. */
+public final class DbRetryUtils {
+  private static final Logger logger = Logger.getLogger(DbRetryUtils.class.getName());
+
+  private DbRetryUtils() {}
+
+  /**
+   * Executes a database operation and retries if retryable
+   *
+   * @param execute database operation to execute
+   * @param retrySleep fixed retry sleep interval
+   * @param maxNumAttempts maximum times this operation will be run
+   * @param <T> database operation class
+   * @return database operation class
+   * @throws InterruptedException on thread interruption
+   * @throws DataAccessException throws the last DB operation error if maxNumAttempts is exceeded.
+   */
+  public static <T> T executeAndRetry(
+      DatabaseOperation<T> execute, Duration retrySleep, int maxNumAttempts)
+      throws InterruptedException {
+    Preconditions.checkArgument(maxNumAttempts > 0, "maxNumAttempts must be at least 1");
+    int numAttempts = 1;
+    while (numAttempts <= maxNumAttempts) {
+      try {
+        return execute.execute();
+      } catch (DataAccessException e) {
+        if (!shouldRetryQuery(e) || (numAttempts == maxNumAttempts)) {
+          throw e;
+        }
+        logger.log(
+            Level.WARNING,
+            String.format(
+                "Caught exception, retrying DB operation. Attempts so far: %d", numAttempts),
+            e);
+      }
+      ++numAttempts;
+      TimeUnit.MILLISECONDS.sleep(retrySleep.toMillis());
+    }
+    throw new IllegalStateException(
+        "Exceeded maximum number of retries without throwing an exception. This should never happen.");
+  }
+
+  /**
+   * Tests an exception to see if it is retryable.
+   *
+   * @param dataAccessException execption to test
+   * @return {@code true} if that is retryable {@link DataAccessException}.
+   */
+  public static boolean shouldRetryQuery(DataAccessException dataAccessException) {
+    return ExceptionUtils.hasCause(dataAccessException, RecoverableDataAccessException.class)
+        || ExceptionUtils.hasCause(dataAccessException, TransientDataAccessException.class);
+  }
+
+  /** How to execute this database operation. */
+  @FunctionalInterface
+  public interface DatabaseOperation<T> {
+    T execute();
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/db/DbRetryUtilsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/DbRetryUtilsTest.java
@@ -1,0 +1,68 @@
+package org.pmiops.workbench.db;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.DataAccessException;
+
+public class DbRetryUtilsTest {
+  private static final CannotSerializeTransactionException RETRY_EXCEPTION =
+      new CannotSerializeTransactionException("test");
+
+  @SuppressWarnings("unchecked")
+  @Mock
+  DbRetryUtils.DatabaseOperation<Boolean> mockDatabaseOperation =
+      mock(DbRetryUtils.DatabaseOperation.class);
+
+  @Test
+  public void succeedAfterRetry() throws Exception {
+    // Throw retryable exception 3 times then succeed.
+    when(mockDatabaseOperation.execute())
+        .thenThrow(RETRY_EXCEPTION)
+        .thenThrow(RETRY_EXCEPTION)
+        .thenThrow(RETRY_EXCEPTION)
+        .thenReturn(true);
+    assertThat(DbRetryUtils.executeAndRetry(mockDatabaseOperation, Duration.ofMillis(1), 10))
+        .isTrue();
+    verify(mockDatabaseOperation, times(4)).execute();
+  }
+
+  @Test
+  public void exceedMaxRetry() throws Exception {
+    when(mockDatabaseOperation.execute()).thenThrow(RETRY_EXCEPTION);
+    DataAccessException finalException =
+        assertThrows(
+            DataAccessException.class,
+            () -> DbRetryUtils.executeAndRetry(mockDatabaseOperation, Duration.ofMillis(1), 3));
+    verify(mockDatabaseOperation, times(3)).execute();
+    assertThat(finalException).isEqualTo(RETRY_EXCEPTION);
+  }
+
+  @Test
+  public void nonRetryableExecute() throws Exception {
+    when(mockDatabaseOperation.execute()).thenThrow(new RuntimeException("non-retryable"));
+    RuntimeException finalException =
+        assertThrows(
+            RuntimeException.class,
+            () -> DbRetryUtils.executeAndRetry(mockDatabaseOperation, Duration.ofMillis(1), 3));
+
+    verify(mockDatabaseOperation, times(1)).execute();
+    assertThat(finalException.getMessage()).isEqualTo("non-retryable");
+  }
+
+  @Test
+  public void zeroMaxAttemptsInvalid() throws Exception {
+    when(mockDatabaseOperation.execute()).thenReturn(true);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DbRetryUtils.executeAndRetry(mockDatabaseOperation, Duration.ofMillis(1), 0));
+  }
+}


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
