### PR TITLE
[no ticket][risk=no] e2e nightly test "owner-copy-to-workspace.spec.ts" is not working

### DIFF
--- a/e2e/app/container.ts
+++ b/e2e/app/container.ts
@@ -63,18 +63,18 @@ export default class Container {
       fp.flow(
         fp.filter<{ shouldWait: boolean; waitFn: () => Promise<void> }>('shouldWait'),
         fp.map((item) => item.waitFn()),
-        fp.concat([button.click({ delay: 10 }), waitWhileLoading(this.page)])
+        fp.concat([button.click({ delay: 10 })])
       )([
         {
           shouldWait: waitForNav,
-          waitFn: async () => {
-            await this.page.waitForNavigation({ waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout });
+          waitFn: () => {
+            this.page.waitForNavigation({ waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout });
           }
         },
         {
           shouldWait: waitForClose,
-          waitFn: async () => {
-            await this.waitUntilClose(timeout);
+          waitFn: () => {
+            this.waitUntilClose(timeout);
           }
         }
       ])

--- a/e2e/app/modal/base-modal.ts
+++ b/e2e/app/modal/base-modal.ts
@@ -63,10 +63,6 @@ export default abstract class BaseModal extends Container {
     return Checkbox.findByName(this.page, { name: checkboxName }, this);
   }
 
-  async waitUntilClose(timeout = 90000): Promise<void> {
-    await this.page.waitForXPath(this.xpath, { hidden: true, timeout });
-  }
-
   /**
    * Returns true if Dialog exists on page.
    */

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -486,7 +486,7 @@ export default class WorkspaceEditPage extends WorkspaceBase {
     const modal = new NewWorkspaceModal(this.page);
     await modal.waitForLoad();
     const modalTextContent = await modal.getTextContent();
-    await modal.clickButton(LinkText.Confirm, { waitForClose: true, waitForNav: true });
+    await modal.clickButton(LinkText.Confirm, { waitForClose: true, waitForNav: true, timeout: 120000 });
     await waitWhileLoading(this.page);
     return modalTextContent;
   }

--- a/e2e/tests/datasets/export-to-notebook.spec.ts
+++ b/e2e/tests/datasets/export-to-notebook.spec.ts
@@ -71,7 +71,7 @@ describe('Export dataset to notebook tests', () => {
     // Delete the cohort.
     await deleteCohort(cohortName, datasetName);
 
-    // Associated dataset is not gone after delete cohort.
+    // Associated dataset is gone after delete cohort.
     await dataPage.openTab(TabLabels.Datasets, { waitPageChange: false });
     expect(await new DataResourceCard(page).cardExists(datasetName, ResourceCard.Dataset)).toBe(false);
   });

--- a/e2e/tests/datasets/export-to-notebook.spec.ts
+++ b/e2e/tests/datasets/export-to-notebook.spec.ts
@@ -12,6 +12,7 @@ import CohortBuildPage from 'app/page/cohort-build-page';
 import DeleteConfirmationModal from 'app/modal/delete-confirmation-modal';
 import WarningDiscardChangesModal from 'app/modal/warning-discard-changes-modal';
 import ExportToNotebookModal from 'app/modal/export-to-notebook-modal';
+import {TabLabels} from "app/page/workspace-base";
 
 // 30 minutes. Test involves starting of notebook that could take a long time to create.
 jest.setTimeout(30 * 60 * 1000);
@@ -70,8 +71,8 @@ describe('Export dataset to notebook tests', () => {
     // Delete the cohort.
     await deleteCohort(cohortName, datasetName);
 
-    // Dataset automatically is no longer exists after delete cohort.
-    await dataPage.openDatasetsSubtab();
+    // Associated dataset is not gone after delete cohort.
+    await dataPage.openTab(TabLabels.Datasets, { waitPageChange: false });
     expect(await new DataResourceCard(page).cardExists(datasetName, ResourceCard.Dataset)).toBe(false);
   });
 

--- a/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
@@ -79,7 +79,6 @@ async function copyNotebookTest(sourceWorkspaceName: string, destCdrVersionName:
   const modal = new Modal(page);
   await modal.waitForLoad();
   const modalText = await modal.getTextContent();
-  console.log(`modal text: ${modalText}`);
   expect(
     modalText.some((text) => {
       return text.includes('Notebooks can only be copied to workspaces in the same access tier.');

--- a/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
@@ -6,9 +6,6 @@ import { createWorkspace, findWorkspaceCard, signInWithAccessToken } from 'utils
 import { config } from 'resources/workbench-config';
 import Modal from 'app/modal/modal';
 
-// re-run one more time if test has failed
-jest.retryTimes(1);
-
 // Reuse same source workspace for all tests in this file, in order to reduce test playback time.
 // Workspace to be created in first test. If create failed in first test, next test will try create it.
 let defaultCdrWorkspace: string;
@@ -81,10 +78,23 @@ async function copyNotebookTest(sourceWorkspaceName: string, destCdrVersionName:
   // Verify Copy Success modal.
   const modal = new Modal(page);
   await modal.waitForLoad();
-  const textContent = await modal.getTextContent();
-  const successMsg =
-    `Successfully copied ${sourceNotebookName}  to ${destWorkspace} . ` + 'Do you want to view the copied Notebook?';
-  expect(textContent).toContain(successMsg);
+  const modalText = await modal.getTextContent();
+  expect(
+    modalText.some((text) => {
+      return text === 'Notebooks can only be copied to workspaces in the same access tier.';
+    })
+  ).toBeTruthy();
+  expect(
+    modalText.some((text) => {
+      return text === `Successfully copied ${sourceNotebookName} to ${destWorkspace}`;
+    })
+  ).toBeTruthy();
+  expect(
+    modalText.some((text) => {
+      return text === 'Do you want to view the copied Notebook?';
+    })
+  ).toBeTruthy();
+
   // Dismiss modal.
   await modal.clickButton(LinkText.StayHere, { waitForClose: true });
 

--- a/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
@@ -79,19 +79,20 @@ async function copyNotebookTest(sourceWorkspaceName: string, destCdrVersionName:
   const modal = new Modal(page);
   await modal.waitForLoad();
   const modalText = await modal.getTextContent();
+  console.log(`modal text: ${modalText}`);
   expect(
     modalText.some((text) => {
-      return text === 'Notebooks can only be copied to workspaces in the same access tier.';
+      return text.includes('Notebooks can only be copied to workspaces in the same access tier.');
     })
   ).toBeTruthy();
   expect(
     modalText.some((text) => {
-      return text === `Successfully copied ${sourceNotebookName} to ${destWorkspace}`;
+      return text.includes(`Successfully copied ${sourceNotebookName} to ${destWorkspace}`);
     })
   ).toBeTruthy();
   expect(
     modalText.some((text) => {
-      return text === 'Do you want to view the copied Notebook?';
+      return text.includes('Do you want to view the copied Notebook?');
     })
   ).toBeTruthy();
 


### PR DESCRIPTION
Test failure was caused by code issue: `clickButton() fp.flow`.
I noticed test failure message today in CircleCI nightly [job](https://app.circleci.com/pipelines/github/all-of-us/workbench/11702/workflows/ccbe078d-2dba-4fc9-904b-e64b200f1575/jobs/149645/artifacts) test log. Test failed silently, so the CircleCI job did not fail.

```
BUILD SUCCESSFUL in 13s
20 actionable tasks: 1 executed, 19 up-to-date
Running owner-copy-to-workspace.spec at 7/9/2021, 00:16:19
Running gce-to-dataproc.spec at 7/9/2021, 00:16:19
Saved screenshot: logs/screenshot/Copy-notebook-to-another-Workspace-when-CDR-versions-match.png
Saved html file: logs/html/Copy-notebook-to-another-Workspace-when-CDR-versions-match.html
```