### PR TITLE
[RW-6910][risk=no] Fix highlighting issue for CB search in-memory trees

### DIFF
--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -449,26 +449,30 @@ export function highlightSearchTerm(searchTerm: string, stringToHighlight: strin
   if (searchTerm.length < 3) {
     return stringToHighlight;
   }
-  const words: string[] = [];
-  const matchString = new RegExp(searchTerm.replace(/([^a-zA-z0-9]+)/g, () => '').trim(), 'i');
-  const matches = stringToHighlight.match(new RegExp(matchString, 'gi'));
-  const splits = stringToHighlight.split(new RegExp(matchString, 'gi'));
-  if (matches) {
-    for (let i = 0; i < matches.length; i++) {
-      words.push(splits[i], matches[i]);
+  try {
+    const words: string[] = [];
+    const matchString = new RegExp(searchTerm.replace(/([^a-zA-z0-9 \-<>=\/]+)/g, () => '').trim(), 'i');
+    const matches = stringToHighlight.match(new RegExp(matchString, 'gi'));
+    const splits = stringToHighlight.split(new RegExp(matchString, 'gi'));
+    if (matches) {
+      for (let i = 0; i < matches.length; i++) {
+        words.push(splits[i], matches[i]);
+      }
+      words.push(splits[splits.length - 1]);
+    } else {
+      words.push(splits[0]);
     }
-    words.push(splits[splits.length - 1]);
-  } else {
-    words.push(splits[0]);
-  }
-  return words.map((word, w) => <span key={w}
-    style={matchString.test(word.toLowerCase()) ? {
-      color: colorWithWhiteness(highlightColor, -0.4),
-      backgroundColor: colorWithWhiteness(highlightColor, 0.7),
-      display: 'inline-block'
-    } : {}}>
+    return words.map((word, w) => <span key={w}
+                                        style={matchString.test(word.toLowerCase()) ? {
+                                          color: colorWithWhiteness(highlightColor, -0.4),
+                                          backgroundColor: colorWithWhiteness(highlightColor, 0.7),
+                                          display: 'inline-block'
+                                        } : {}}>
       {word}
     </span>);
+  } catch (e) {
+    return stringToHighlight;
+  }
 }
 
 // render a float value as US currency, rounded to cents: 255.372793 -> $255.37


### PR DESCRIPTION
- Fixes issue where highlighted terms in the tree go away when multiple search terms are typed
- Also fixed highlighting for special characters that commonly appear in criteria names ( - < > = / )

Before:
<img width="571" alt="Screen Shot 2021-07-13 at 10 29 31 AM" src="https://user-images.githubusercontent.com/40036095/125481534-950eef0b-9392-4567-a087-cee32d9346be.png">

After:
<img width="526" alt="Screen Shot 2021-07-13 at 10 29 52 AM" src="https://user-images.githubusercontent.com/40036095/125481567-13b91161-467e-42b9-ab0a-0823a55806b6.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
