### PR TITLE
[RW-6538][risk=no] Further limit project audit rate

### DIFF
--- a/api/src/main/webapp/WEB-INF/queue.yaml
+++ b/api/src/main/webapp/WEB-INF/queue.yaml
@@ -10,7 +10,7 @@ queue:
   rate: 4/m
   target: api
   max_concurrent_requests: 1
-  bucket_size: 100
+  bucket_size: 1
   retry_parameters:
     task_retry_limit: 1
     task_age_limit: 5m


### PR DESCRIPTION
Previous change did not succeed in limiting QPS to below the desired rate to the projects API. After re-re-reading the documentation, this appears to be due to the token bucket algorithm: https://cloud.google.com/appengine/docs/standard/python/config/queueref

Whenever we are dispatching a task, we first consider whether we have enough tokens to do so:

- rate: 4/m, the rate at which we replenish tokens
- bucket_size: now 1, the maximum supported tokens, i.e. a burst limiter

max_concurrent_tasks is probably redundant now, but prevents any degenerate cases where we might have a long-running cloud task for any reason, resulting in a build-up of multiple concurrent tasks.

The above explains why I still saw an initial burst of sequential calls to `auditProjectAccess` (up to ~100), before they started rate limiting down to 4/m. This was the initial bucket capacity being exhausted.

As a follow-up: the RDR export queue is likely not properly tuned. It is basically configured to operate in massive spike mode only - then replenishes very slowly.