### PR TITLE
[risk=low][RW-4838] Rename a few "DUA" to "DUCC"

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/AccessUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessUtils.java
@@ -19,7 +19,7 @@ public class AccessUtils {
           .put(AccessModule.ERA_COMMONS, AccessModuleName.ERA_COMMONS)
           .put(AccessModule.COMPLIANCE_TRAINING, AccessModuleName.RT_COMPLIANCE_TRAINING)
           .put(AccessModule.RAS_LINK_LOGIN_GOV, AccessModuleName.RAS_LOGIN_GOV)
-          .put(AccessModule.DATA_USE_AGREEMENT, AccessModuleName.DATA_USER_CODE_OF_CONDUCT)
+          .put(AccessModule.DATA_USER_CODE_OF_CONDUCT, AccessModuleName.DATA_USER_CODE_OF_CONDUCT)
           .put(AccessModule.PUBLICATION_CONFIRMATION, AccessModuleName.PUBLICATION_CONFIRMATION)
           .put(AccessModule.PROFILE_CONFIRMATION, AccessModuleName.PROFILE_CONFIRMATION)
           .build();

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -1025,7 +1025,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       newBypassTime = null;
     }
     switch (accessBypassRequest.getModuleName()) {
-      case DATA_USE_AGREEMENT:
+      case DATA_USER_CODE_OF_CONDUCT:
         previousBypassTime = user.getDataUseAgreementBypassTime();
         setDataUseAgreementBypassTime(userDatabaseId, previousBypassTime, newBypassTime);
         break;

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4750,7 +4750,7 @@ definitions:
   AccessModule:
     type: string
     enum:
-    - DATA_USE_AGREEMENT
+    - DATA_USER_CODE_OF_CONDUCT
     - COMPLIANCE_TRAINING
     - ERA_COMMONS
     - TWO_FACTOR_AUTH

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
@@ -270,7 +270,7 @@ public class AccessModuleServiceTest extends SpringTest {
     DbUserAccessModule duccAccessModule =
         new DbUserAccessModule().setAccessModule(ducc).setUser(user);
     AccessModuleStatus expectedDuccModuleStatus =
-        new AccessModuleStatus().moduleName(AccessModule.DATA_USE_AGREEMENT);
+        new AccessModuleStatus().moduleName(AccessModule.DATA_USER_CODE_OF_CONDUCT);
 
     userAccessModuleDao.saveAll(
         ImmutableList.of(

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -1415,7 +1415,9 @@ public class ProfileControllerTest extends BaseControllerTest {
 
     final List<AccessBypassRequest> bypasses1 =
         ImmutableList.of(
-            new AccessBypassRequest().moduleName(AccessModule.DATA_USE_AGREEMENT).isBypassed(true),
+            new AccessBypassRequest()
+                .moduleName(AccessModule.DATA_USER_CODE_OF_CONDUCT)
+                .isBypassed(true),
             // would un-bypass if a bypass had existed
             new AccessBypassRequest()
                 .moduleName(AccessModule.COMPLIANCE_TRAINING)
@@ -1436,7 +1438,9 @@ public class ProfileControllerTest extends BaseControllerTest {
     final List<AccessBypassRequest> bypasses2 =
         ImmutableList.of(
             // un-bypass the previously bypassed
-            new AccessBypassRequest().moduleName(AccessModule.DATA_USE_AGREEMENT).isBypassed(false),
+            new AccessBypassRequest()
+                .moduleName(AccessModule.DATA_USER_CODE_OF_CONDUCT)
+                .isBypassed(false),
             // bypass
             new AccessBypassRequest().moduleName(AccessModule.COMPLIANCE_TRAINING).isBypassed(true),
             new AccessBypassRequest().moduleName(AccessModule.ERA_COMMONS).isBypassed(true),

--- a/ui/src/app/pages/admin/admin-user-bypass.tsx
+++ b/ui/src/app/pages/admin/admin-user-bypass.tsx
@@ -140,7 +140,7 @@ export class AdminUserBypass extends React.Component<Props, State> {
           />
           <Toggle name='Data User Code of Conduct'
                   checked={selectedModules.includes(AccessModule.DATAUSERCODEOFCONDUCT)}
-                  data-test-id='data-use-agreement-toggle'
+                  data-test-id='ducc-toggle'
                   onToggle={() => {this.setState({selectedModules:
                     fp.xor(selectedModules, [AccessModule.DATAUSERCODEOFCONDUCT])}); }}
           />

--- a/ui/src/app/pages/admin/admin-user-bypass.tsx
+++ b/ui/src/app/pages/admin/admin-user-bypass.tsx
@@ -34,7 +34,7 @@ interface State {
 const getBypassedModules = (user: AdminTableUser): Array<AccessModule> => {
   return [
     ...(user.complianceTrainingBypassTime ? [AccessModule.COMPLIANCETRAINING] : []),
-    ...(user.dataUseAgreementBypassTime ? [AccessModule.DATAUSEAGREEMENT] : []),
+    ...(user.dataUseAgreementBypassTime ? [AccessModule.DATAUSERCODEOFCONDUCT] : []),
     ...(user.eraCommonsBypassTime ? [AccessModule.ERACOMMONS] : []),
     ...(user.twoFactorAuthBypassTime ? [AccessModule.TWOFACTORAUTH] : []),
     ...(user.rasLinkLoginGovBypassTime ? [AccessModule.RASLINKLOGINGOV] : []),
@@ -138,11 +138,11 @@ export class AdminUserBypass extends React.Component<Props, State> {
                   onToggle={() => {this.setState({selectedModules:
                     fp.xor(selectedModules, [AccessModule.TWOFACTORAUTH])}); }}
           />
-          <Toggle name='Data Use Agreement'
-                  checked={selectedModules.includes(AccessModule.DATAUSEAGREEMENT)}
+          <Toggle name='Data User Code of Conduct'
+                  checked={selectedModules.includes(AccessModule.DATAUSERCODEOFCONDUCT)}
                   data-test-id='data-use-agreement-toggle'
                   onToggle={() => {this.setState({selectedModules:
-                    fp.xor(selectedModules, [AccessModule.DATAUSEAGREEMENT])}); }}
+                    fp.xor(selectedModules, [AccessModule.DATAUSERCODEOFCONDUCT])}); }}
           />
           {enableRasLoginGovLinking && <Toggle name='RAS Login.gov Link'
                                        checked={selectedModules.includes(AccessModule.RASLINKLOGINGOV)}

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -304,7 +304,7 @@ export class RegistrationDashboard extends React.Component<RegistrationDashboard
       AccessModule.COMPLIANCETRAINING,
       AccessModule.ERACOMMONS,
       AccessModule.TWOFACTORAUTH,
-      AccessModule.DATAUSEAGREEMENT,
+      AccessModule.DATAUSERCODEOFCONDUCT,
       AccessModule.RASLINKLOGINGOV,
     ];
 

--- a/ui/src/app/pages/homepage/registration-dashboard.tsx
+++ b/ui/src/app/pages/homepage/registration-dashboard.tsx
@@ -193,10 +193,10 @@ export const getRegistrationTasks = () => serverConfigStore.get().config ? ([
       if (profile.dataUseAgreementBypassTime) {
         return profile.dataUseAgreementBypassTime;
       }
-      // The DUA completion time field tracks the most recent DUA completion
-      // timestamp, but doesn't specify whether that DUA is currently active.
-      const requiredDuaVersion = getLiveDUCCVersion();
-      if (profile.dataUseAgreementSignedVersion === requiredDuaVersion) {
+      // The DUCC completion time field tracks the most recent DUCC completion
+      // timestamp, but doesn't specify whether that DUCC is currently active.
+      const requiredDuccVersion = getLiveDUCCVersion();
+      if (profile.dataUseAgreementSignedVersion === requiredDuccVersion) {
         return profile.dataUseAgreementCompletionTime;
       }
       return null;

--- a/ui/src/app/pages/profile/profile-component.tsx
+++ b/ui/src/app/pages/profile/profile-component.tsx
@@ -303,7 +303,7 @@ export const ProfileComponent = fp.flow(
       }
     }
 
-    private getDataUseAgreementText(profile) {
+    private getDUCCText(profile) {
       const universalText = <a onClick={getRegistrationTasksMap()['dataUserCodeOfConduct'].onClick}>
       View code of conduct
     </a>;
@@ -631,7 +631,7 @@ export const ProfileComponent = fp.flow(
                   isComplete={!!(getRegistrationTasksMap()['dataUserCodeOfConduct'].completionTimestamp(profile))}
                   completeStep={getRegistrationTasksMap()['dataUserCodeOfConduct'].onClick}
                   childrenStyle={{marginLeft: 0}}
-                  content={this.getDataUseAgreementText(profile)}
+                  content={this.getDUCCText(profile)}
                 >
               </ProfileRegistrationStepStatus>
             </div>

--- a/ui/src/app/pages/workspace/workspace-edit-text.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit-text.tsx
@@ -14,10 +14,10 @@ export const toolTipTextDemographic = 'For example, by stratifying results based
     'sex, gender identity, sexual orientation, geography, disability status, access to care, ' +
     'education level, or income\n';
 
-export const toolTipTextDataUseAgreement = <div>These steps include, but are not limited to:
+export const toolTipTextDucc = <div>These steps include, but are not limited to:
   <ul>
     <li>Giving careful consideration to the sensibilities of the different groups of people you are studying.</li>
-    <li> Ensuring that you understand, and suitably wield, your analytical tools.</li>
+    <li>Ensuring that you understand, and suitably wield, your analytical tools.</li>
     <li>Being conscientiously expansive in your inclusion of participant populations and your analytical controls. </li>
     <li>Using precise language to describe your findings including both what your results mean and do not mean.</li>
   </ul>
@@ -221,8 +221,8 @@ export const researchPurposeQuestions: Array<ResearchPurposeQuestion> = [
       misused by others to foster stigma. While it may not be possible to completely prevent misuse
       of research for stigmatizing purposes, data users can take important steps to minimize the
         risk of this happening–</div>
-      <TooltipTrigger content={toolTipTextDataUseAgreement}>
-        <div>taking this step is a condition of your Data Use Agreement.</div>
+      <TooltipTrigger content={toolTipTextDucc}>
+        <div>taking this step is a condition of your Data User Code of Conduct agreement.</div>
       </TooltipTrigger>
       <div>If you are concerned that your research could inadvertently stigmatize participants
       or communities, or if you are unsure, let us know. We encourage you to request a review of

--- a/ui/src/app/pages/workspace/workspace-edit-text.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit-text.tsx
@@ -220,9 +220,9 @@ export const researchPurposeQuestions: Array<ResearchPurposeQuestion> = [
       <div>in analyses can result, often unintentionally, in findings that may be misinterpreted or
       misused by others to foster stigma. While it may not be possible to completely prevent misuse
       of research for stigmatizing purposes, data users can take important steps to minimize the
-        risk of this happening–</div>
+      risk of this happening–taking this step is a condition of your</div>
       <TooltipTrigger content={toolTipTextDucc}>
-        <div>taking this step is a condition of your Data User Code of Conduct agreement.</div>
+        <div> Data User Code of Conduct agreement. </div>
       </TooltipTrigger>
       <div>If you are concerned that your research could inadvertently stigmatize participants
       or communities, or if you are unsure, let us know. We encourage you to request a review of

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -28,8 +28,8 @@ import {
   SpecificPopulationItem,
   SpecificPopulationItems,
   toolTipText,
-  toolTipTextDataUseAgreement,
   toolTipTextDemographic,
+  toolTipTextDucc,
   toolTipTextStigmatization
 } from 'app/pages/workspace/workspace-edit-text';
 import {WorkspaceResearchSummary} from 'app/pages/workspace/workspace-research-summary';
@@ -1372,7 +1372,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
             in findings that may be misinterpreted or misused by others to foster stigma. While it
             may not be possible to completely prevent misuse of research for stigmatizing purposes,
             data users can take important steps to minimize the risk of this happening–
-            <TooltipTrigger content={toolTipTextDataUseAgreement}>
+            <TooltipTrigger content={toolTipTextDucc}>
               <Link style={{display: 'inline-block'}}>taking this step is a condition of your
                 Data Use Agreement.</Link>
             </TooltipTrigger>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1371,9 +1371,10 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
             &nbsp;in analyses can result, often unintentionally,
             in findings that may be misinterpreted or misused by others to foster stigma. While it
             may not be possible to completely prevent misuse of research for stigmatizing purposes,
-            data users can take important steps to minimize the risk of this happening–
+            data users can take important steps to minimize the risk of this happening–taking this
+            step is a condition of your
             <TooltipTrigger content={toolTipTextDucc}>
-              <Link style={{display: 'inline-block'}}>taking this step is a condition of your Data User Code of Conduct agreement.</Link>
+              <Link style={{display: 'inline-block'}}>Data User Code of Conduct agreement.</Link>
             </TooltipTrigger>
             &nbsp;If you are concerned that your research could inadvertently stigmatize
             participants or communities, or if you are unsure, let us know. We encourage you to

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1373,8 +1373,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
             may not be possible to completely prevent misuse of research for stigmatizing purposes,
             data users can take important steps to minimize the risk of this happening–
             <TooltipTrigger content={toolTipTextDucc}>
-              <Link style={{display: 'inline-block'}}>taking this step is a condition of your
-                Data Use Agreement.</Link>
+              <Link style={{display: 'inline-block'}}>taking this step is a condition of your Data User Code of Conduct agreement.</Link>
             </TooltipTrigger>
             &nbsp;If you are concerned that your research could inadvertently stigmatize
             participants or communities, or if you are unsure, let us know. We encourage you to


### PR DESCRIPTION
Description:

This is only a small portion of RW-4838.  Most of the renaming will occur as as part of the migration to the new Access Modules system.

This includes a small change to Workspace Edit:
<img width="837" alt="Screen Shot 2021-07-14 at 2 41 49 PM" src="https://user-images.githubusercontent.com/2701406/125675801-3509ce0e-bc11-43d3-aee6-7836c8e704c0.png">


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
