### PR TITLE
[RW-6929][risk=low]: Dual write and backfill completion time for all modules

### DIFF
--- a/api/db/changelog/db.changelog-172-backfill-user-access-module.xml
+++ b/api/db/changelog/db.changelog-172-backfill-user-access-module.xml
@@ -4,28 +4,76 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
-  <changeSet author="yonghao" id="changelog-171-user-access-module-user-drop-null-constraint-and-add-bypassable">
-    <addColumn tableName="access_module">
-      <column name="bypassable" type="boolean">
-        <constraints nullable="false"/>
-      </column>
-    </addColumn>
+  <changeSet author="yonghao" id="changelog-172-backfill-user-access-module">
+    <!--Back fill ERA_COMMONS module-->
     <sql>
-      UPDATE access_module SET bypassable = true WHERE name = 'TWO_FACTOR_AUTH';
-      UPDATE access_module SET bypassable = true WHERE name = 'ERA_COMMONS';
-      UPDATE access_module SET bypassable = true WHERE name = 'RAS_LOGIN_GOV';
-      UPDATE access_module SET bypassable = true WHERE name = 'RT_COMPLIANCE_TRAINING';
-      UPDATE access_module SET bypassable = true WHERE name = 'DATA_USER_CODE_OF_CONDUCT';
-      UPDATE access_module SET bypassable = false WHERE name = 'PROFILE_CONFIRMATION';
-      UPDATE access_module SET bypassable = false WHERE name = 'PUBLICATION_CONFIRMATION';
+      INSERT INTO user_access_module
+      (user_id, access_module_id, completion_time, bypass_time)
+      SELECT
+      u.user_id,
+      a.access_module_id,
+      u.era_commons_completion_time AS completion_time,
+      u.era_commons_bypass_time AS bypass_time
+      FROM user u, access_module a
+      WHERE a.name = 'ERA_COMMONS'
     </sql>
-    <dropNotNullConstraint
-      columnDataType="datetime"
-      columnName="bypass_time"
-      tableName="user_access_module"/>
-    <dropNotNullConstraint
-      columnDataType="datetime"
-      columnName="completion_time"
-      tableName="user_access_module"/>
+    <!--Back fill TWO_FACTOR_AUTH module-->
+    <sql>
+      INSERT INTO user_access_module
+      (user_id, access_module_id, completion_time, bypass_time)
+      SELECT
+      u.user_id,
+      a.access_module_id,
+      u.two_factor_auth_completion_time AS completion_time,
+      u.two_factor_auth_bypass_time AS bypass_time
+      FROM user u, access_module a
+      WHERE a.name = 'TWO_FACTOR_AUTH'
+    </sql>
+    <!--Back fill RT_COMPLIANCE_TRAINING module-->
+    <sql>
+      INSERT INTO user_access_module
+      (user_id, access_module_id, completion_time, bypass_time)
+      SELECT
+      u.user_id,
+      a.access_module_id,
+      u.compliance_training_completion_time AS completion_time,
+      u.compliance_training_bypass_time AS bypass_time
+      FROM user u, access_module a
+      WHERE a.name = 'RT_COMPLIANCE_TRAINING'
+    </sql>
+    <!--Back fill DATA_USER_CODE_OF_CONDUCT module-->
+    <sql>
+      INSERT INTO user_access_module
+      (user_id, access_module_id, completion_time, bypass_time)
+      SELECT
+      u.user_id,
+      a.access_module_id,
+      u.data_use_agreement_completion_time AS completion_time,
+      u.data_use_agreement_bypass_time AS bypass_time
+      FROM user u, access_module a
+      WHERE a.name = 'DATA_USER_CODE_OF_CONDUCT'
+    </sql>
+    <!--Back fill PROFILE_CONFIRMATION module-->
+    <sql>
+      INSERT INTO user_access_module
+      (user_id, access_module_id, completion_time)
+      SELECT
+      u.user_id,
+      a.access_module_id,
+      u.profile_last_confirmed_time AS completion_time
+      FROM user u, access_module a
+      WHERE a.name = 'PROFILE_CONFIRMATION'
+    </sql>
+    <!--Back fill PUBLICATION_CONFIRMATION module-->
+    <sql>
+      INSERT INTO user_access_module
+      (user_id, access_module_id, completion_time)
+      SELECT
+      u.user_id,
+      a.access_module_id,
+      u.publications_last_confirmed_time AS completion_time
+      FROM user u, access_module a
+      WHERE a.name = 'PUBLICATION_CONFIRMATION'
+    </sql>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-172-backfill-user-access-module.xml
+++ b/api/db/changelog/db.changelog-172-backfill-user-access-module.xml
@@ -5,6 +5,13 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
   <changeSet author="yonghao" id="changelog-172-backfill-user-access-module">
+    <addUniqueConstraint tableName="user_access_module"
+      columnNames="user_id, access_module_id"
+      constraintName="user_access_module_unique_name_per_user_per_module"/>
+    <!--Remove everything before backfill-->
+    <sql>
+      DELETE from user_access_module WHERE true
+    </sql>
     <!--Back fill ERA_COMMONS module-->
     <sql>
       INSERT INTO user_access_module

--- a/api/db/changelog/db.changelog-172-backfill-user-access-module.xml
+++ b/api/db/changelog/db.changelog-172-backfill-user-access-module.xml
@@ -5,13 +5,13 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
   <changeSet author="yonghao" id="changelog-172-backfill-user-access-module">
-    <addUniqueConstraint tableName="user_access_module"
-      columnNames="user_id, access_module_id"
-      constraintName="user_access_module_unique_name_per_user_per_module"/>
     <!--Remove everything before backfill-->
     <sql>
       DELETE from user_access_module WHERE true
     </sql>
+    <addUniqueConstraint tableName="user_access_module"
+      columnNames="user_id, access_module_id"
+      constraintName="user_access_module_unique_name_per_user_per_module"/>
     <!--Back fill ERA_COMMONS module-->
     <sql>
       INSERT INTO user_access_module

--- a/api/db/changelog/db.changelog-172-backfill-user-access-module.xml
+++ b/api/db/changelog/db.changelog-172-backfill-user-access-module.xml
@@ -29,17 +29,6 @@
       FROM user u, access_module a
       WHERE a.name = 'RAS_LOGIN_GOV'
     </sql>
-    <sql>
-      INSERT INTO user_access_module
-      (user_id, access_module_id, completion_time, bypass_time)
-      SELECT
-      u.user_id,
-      a.access_module_id,
-      u.era_commons_completion_time AS completion_time,
-      u.era_commons_bypass_time AS bypass_time
-      FROM user u, access_module a
-      WHERE a.name = 'ERA_COMMONS'
-    </sql>
     <!--Back fill RT_COMPLIANCE_TRAINING module-->
     <sql>
       INSERT INTO user_access_module

--- a/api/db/changelog/db.changelog-172-backfill-user-access-module.xml
+++ b/api/db/changelog/db.changelog-172-backfill-user-access-module.xml
@@ -17,17 +17,28 @@
       FROM user u, access_module a
       WHERE a.name = 'ERA_COMMONS'
     </sql>
-    <!--Back fill TWO_FACTOR_AUTH module-->
+    <!--Back fill RAS_LOGIN_GOV module-->
     <sql>
       INSERT INTO user_access_module
       (user_id, access_module_id, completion_time, bypass_time)
       SELECT
       u.user_id,
       a.access_module_id,
-      u.two_factor_auth_completion_time AS completion_time,
-      u.two_factor_auth_bypass_time AS bypass_time
+      u.ras_link_login_gov_completion_time AS completion_time,
+      u.ras_link_login_gov_bypass_time AS bypass_time
       FROM user u, access_module a
-      WHERE a.name = 'TWO_FACTOR_AUTH'
+      WHERE a.name = 'RAS_LOGIN_GOV'
+    </sql>
+    <sql>
+      INSERT INTO user_access_module
+      (user_id, access_module_id, completion_time, bypass_time)
+      SELECT
+      u.user_id,
+      a.access_module_id,
+      u.era_commons_completion_time AS completion_time,
+      u.era_commons_bypass_time AS bypass_time
+      FROM user u, access_module a
+      WHERE a.name = 'ERA_COMMONS'
     </sql>
     <!--Back fill RT_COMPLIANCE_TRAINING module-->
     <sql>

--- a/api/db/changelog/db.changelog-172-backfill-user-access-module.xml
+++ b/api/db/changelog/db.changelog-172-backfill-user-access-module.xml
@@ -17,6 +17,18 @@
       FROM user u, access_module a
       WHERE a.name = 'ERA_COMMONS'
     </sql>
+    <!--Back fill TWO_FACTOR_AUTH module-->
+    <sql>
+      INSERT INTO user_access_module
+      (user_id, access_module_id, completion_time, bypass_time)
+      SELECT
+      u.user_id,
+      a.access_module_id,
+      u.two_factor_auth_completion_time AS completion_time,
+      u.two_factor_auth_bypass_time AS bypass_time
+      FROM user u, access_module a
+      WHERE a.name = 'TWO_FACTOR_AUTH'
+    </sql>
     <!--Back fill RAS_LOGIN_GOV module-->
     <sql>
       INSERT INTO user_access_module

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -181,6 +181,7 @@
   <include file="changelog/db.changelog-169-add-institution-tier-requirement-tables.xml"/>
   <include file="changelog/db.changelog-170-add-access-tier-id-into-institution-tables.xml"/>
   <include file="changelog/db.changelog-171-user-access-module-user-drop-null-constraint-and-add-bypassable.xml"/>
+  <include file="changelog/db.changelog-changelog-172-backfill-user-access-module.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -181,7 +181,7 @@
   <include file="changelog/db.changelog-169-add-institution-tier-requirement-tables.xml"/>
   <include file="changelog/db.changelog-170-add-access-tier-id-into-institution-tables.xml"/>
   <include file="changelog/db.changelog-171-user-access-module-user-drop-null-constraint-and-add-bypassable.xml"/>
-  <include file="changelog/db.changelog-changelog-172-backfill-user-access-module.xml"/>
+  <include file="changelog/db.changelog-172-backfill-user-access-module.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
@@ -1,8 +1,12 @@
 package org.pmiops.workbench.access;
 
+import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.AccessModule;
 
 public interface AccessModuleService {
   /** Updates bypass time for a module. */
   void updateBypassTime(long userId, AccessModule accessModuleName, boolean isBypassed);
+
+  /** Update module status to complete for a user. */
+  void completeModule(DbUser dbUser, AccessModule accessModuleName);
 }

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.access;
 
+import java.sql.Timestamp;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.AccessModule;
 
@@ -8,5 +9,5 @@ public interface AccessModuleService {
   void updateBypassTime(long userId, AccessModule accessModuleName, boolean isBypassed);
 
   /** Update module status to complete for a user. */
-  void completeModule(DbUser dbUser, AccessModule accessModuleName);
+  void updateCompletionTime(DbUser dbUser, AccessModule accessModuleName, Timestamp timestamp);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -473,6 +473,9 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     dbUser.setAddress(dbAddress);
     dbUser.setProfileLastConfirmedTime(now);
     dbUser.setPublicationsLastConfirmedTime(now);
+    accessModuleService.updateCompletionTime(
+        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
     if (degrees != null) {
       dbUser.setDegreesEnum(degrees);
     }
@@ -837,7 +840,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
 
       return updateUserWithRetries(
           u -> {
-            // user.setEraCommonsCompletionTime() will be replaced by
+            // user.setComplianceTrainingCompletionTime() will be replaced by
             // accessModuleService.updateCompletionTime()
             u.setComplianceTrainingCompletionTime(newComplianceTrainingCompletionTime);
             accessModuleService.updateCompletionTime(
@@ -1095,7 +1098,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
 
     return updateUserWithRetries(
         user -> {
-          // user.setProfileLastConfirmedTime() will be replaced by
+          // user.setRasLinkLoginGovUsername() will be replaced by
           // accessModuleService.updateCompletionTime()
           Timestamp timestamp = new Timestamp(clock.instant().toEpochMilli());
           user.setRasLinkLoginGovUsername(loginGovUserName);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -1095,8 +1095,12 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
 
     return updateUserWithRetries(
         user -> {
+          // user.setProfileLastConfirmedTime() will be replaced by
+          // accessModuleService.updateCompletionTime()
+          Timestamp timestamp = new Timestamp(clock.instant().toEpochMilli());
           user.setRasLinkLoginGovUsername(loginGovUserName);
-          user.setRasLinkLoginGovCompletionTime(new Timestamp(clock.instant().toEpochMilli()));
+          user.setRasLinkLoginGovCompletionTime(timestamp);
+          accessModuleService.updateCompletionTime(user, AccessModuleName.RAS_LOGIN_GOV, timestamp);
           // TODO(RW-6480): Determine if need to set link expiration time.
           return user;
         },

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -987,7 +987,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
         user -> {
           if (isEnrolledIn2FA) {
             if (user.getTwoFactorAuthCompletionTime() == null) {
-              // user.setEraCommonsCompletionTime() will be replaced by
+              // user.setTwoFactorAuthCompletionTime() will be replaced by
               // accessModuleService.updateCompletionTime()
               Timestamp timestamp = new Timestamp(clock.instant().toEpochMilli());
               user.setTwoFactorAuthCompletionTime(timestamp);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -473,9 +473,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     dbUser.setAddress(dbAddress);
     dbUser.setProfileLastConfirmedTime(now);
     dbUser.setPublicationsLastConfirmedTime(now);
-    accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
     if (degrees != null) {
       dbUser.setDegreesEnum(degrees);
     }
@@ -493,6 +490,9 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       dbUser = userDao.save(dbUser);
       dbVerifiedAffiliation.setUser(dbUser);
       verifiedInstitutionalAffiliationDao.save(dbVerifiedAffiliation);
+      accessModuleService.updateCompletionTime(
+          dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
+      accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
     } catch (DataIntegrityViolationException e) {
       dbUser = userDao.findUserByUsername(username);
       if (dbUser == null) {

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -39,6 +39,7 @@ import org.pmiops.workbench.model.UserAccessExpiration;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
 import org.pmiops.workbench.utils.TestMockFactory;
+import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -84,6 +85,9 @@ public class UserServiceAccessTest {
   @Import({
     UserServiceTestConfiguration.class,
     AccessTierServiceImpl.class,
+    AccessModuleServiceImpl.class,
+    UserAccessModuleMapperImpl.class,
+    CommonMappers.class,
   })
   @MockBean({
     ComplianceService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.SpringTest;
+import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.cdr.CdrVersionContext;
 import org.pmiops.workbench.cdr.CdrVersionService;
@@ -211,6 +212,7 @@ public class CohortReviewControllerTest extends SpringTest {
     WorkspaceService.class,
     WorkspaceAuthService.class,
     AccessTierService.class,
+    AccessModuleService.class,
     CdrVersionService.class,
   })
   static class Configuration {

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -22,6 +22,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.SpringTest;
+import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
@@ -218,6 +219,7 @@ public class CohortsControllerTest extends SpringTest {
     AccessTierServiceImpl.class,
   })
   @MockBean({
+    AccessModuleService.class,
     BigQueryService.class,
     BillingProjectAuditor.class,
     BillingProjectBufferService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.SpringTest;
+import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
@@ -207,6 +208,7 @@ public class ConceptSetsControllerTest extends SpringTest {
     AccessTierServiceImpl.class,
   })
   @MockBean({
+    AccessModuleService.class,
     BigQueryService.class,
     BillingProjectAuditor.class,
     BillingProjectBufferService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -50,6 +50,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.invocation.InvocationOnMock;
 import org.pmiops.workbench.SpringTest;
+import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
@@ -241,6 +242,7 @@ public class DataSetControllerTest extends SpringTest {
     AccessTierServiceImpl.class,
   })
   @MockBean({
+    AccessModuleService.class,
     BigQueryService.class,
     BillingProjectAuditor.class,
     CloudBillingClient.class,

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.pmiops.workbench.SpringTest;
+import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.actionaudit.auditors.LeonardoRuntimeAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
@@ -167,6 +168,7 @@ public class RuntimeControllerTest extends SpringTest {
     AccessTierServiceImpl.class,
   })
   @MockBean({
+    AccessModuleService.class,
     ConceptSetService.class,
     CohortService.class,
     MailService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -19,7 +19,9 @@ import org.apache.commons.collections4.ListUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.SpringTest;
+import org.pmiops.workbench.access.AccessModuleServiceImpl;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
+import org.pmiops.workbench.access.UserAccessModuleMapperImpl;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.compliance.ComplianceService;
@@ -45,6 +47,7 @@ import org.pmiops.workbench.test.FakeLongRandom;
 import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
 import org.pmiops.workbench.utils.PaginationToken;
 import org.pmiops.workbench.utils.TestMockFactory;
+import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -70,6 +73,9 @@ public class UserControllerTest extends SpringTest {
     UserController.class,
     UserServiceTestConfiguration.class,
     AccessTierServiceImpl.class,
+    AccessModuleServiceImpl.class,
+    UserAccessModuleMapperImpl.class,
+    CommonMappers.class,
   })
   @MockBean({
     AdminActionHistoryDao.class,

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -372,13 +372,6 @@ public class UserServiceTest extends SpringTest {
     // twoFactorAuthCompletionTime should now be set
     DbUser user = userDao.findUserByUsername(USERNAME);
     assertThat(user.getTwoFactorAuthCompletionTime()).isNotNull();
-    assertThat(
-            userAccessModuleDao
-                .getByUserAndAccessModule(
-                    user, accessModuleDao.findOneByName(AccessModuleName.TWO_FACTOR_AUTH).get())
-                .get()
-                .getCompletionTime())
-        .isNotNull();
     assertThat(getModuleCompletionTime(AccessModuleName.TWO_FACTOR_AUTH, user)).isNotNull();
     // twoFactorAuthCompletionTime should not change when already set
     tick();


### PR DESCRIPTION
Description:
Note: 

1. This PR just replace the setModuleCompletionTime, getModuleCompletionTime still read from DbUser. I will have separate PR to make all get calls use DbUserAccessModule's completion time (after dual write, and verify it works)
2. I also considered to move the entire logic to AccessModule service instead of just use to set the completion time. But that is too complicated, and I feel that is not necessary(we end up create another giant `userServiceImpl` style class). So I choose the easy and safe and clear path 

Verified data: 
```
mysql>       INSERT INTO user_access_module
    ->       (user_id, access_module_id, completion_time, bypass_time)
    ->       SELECT
    ->       u.user_id,
    ->       a.access_module_id,
    ->       u.era_commons_completion_time AS completion_time,
    ->       u.era_commons_bypass_time AS bypass_time
    ->       FROM user u, access_module a
    ->       WHERE a.name = 'ERA_COMMONS';
Query OK, 2631 rows affected (0.14 sec)
Records: 2631  Duplicates: 0  Warnings: 0
 
mysql> select * from user_access_module limit 100;
+-----------------------+------------------+---------+---------------------+---------------------+
| user_access_module_id | access_module_id | user_id | completion_time     | bypass_time         |
+-----------------------+------------------+---------+---------------------+---------------------+
|                     1 |                5 |    3806 | NULL                | NULL                |
|                     2 |                1 |     137 | 2019-05-15 17:07:05 | NULL                |
|                     3 |                1 |     138 | NULL                | NULL                |
|                     4 |                1 |     139 | 2019-05-15 17:07:07 | NULL                |
|                     5 |                1 |     140 | NULL                | NULL                |
|                     6 |                1 |     141 | 2020-04-14 13:28:59 | 2020-04-28 18:36:12 |
|                     7 |                1 |     142 | NULL                | NULL                |
|                     8 |                1 |     143 | NULL                | 2019-05-20 20:12:44 |
|                     9 |                1 |     144 | NULL                | 2019-09-24 18:18:05 |
|                    10 |                1 |     145 | NULL                | NULL                |
|                    11 |                1 |     146 | NULL                | NULL                |
|                    12 |                1 |     147 | NULL                | NULL                |
|                    13 |                1 |     148 | NULL                | NULL                |
|                    14 |                1 |     149 | 2019-10-30 01:54:46 | 2019-07-19 17:43:32 |
|                    15 |                1 |     150 | NULL                | 2019-07-26 18:17:21 |
|                    16 |                1 |     151 | NULL                | NULL                |
|                    17 |                1 |     152 | NULL                | NULL                |
|                    18 |                1 |     153 | NULL                | 2020-04-23 19:43:22 |
|                    19 |                1 |     154 | NULL                | 2019-09-09 18:04:10 |
|                    20 |                1 |     155 | NULL                | NULL                |
|                    21 |                1 |     156 | NULL                | NULL                |
|                    22 |                1 |     157 | NULL                | NULL                |
|                    23 |                1 |     158 | NULL                | 2019-03-21 19:08:04 |
```

A random user:
```
mysql> mysql> select * from user_access_module where user_id = 146;
+-----------------------+------------------+---------+---------------------+-------------+
| user_access_module_id | access_module_id | user_id | completion_time     | bypass_time |
+-----------------------+------------------+---------+---------------------+-------------+
|                    11 |                1 |     146 | NULL                | NULL        |
|                  4106 |                1 |     146 | NULL                | NULL        |
|                  8201 |                2 |     146 | 2019-11-05 13:43:51 | NULL        |
|                 12296 |                4 |     146 | NULL                | NULL        |
|                 16391 |                5 |     146 | NULL                | NULL        |
|                 20486 |                6 |     146 | 2019-11-06 15:42:42 | NULL        |
|                 24581 |                7 |     146 | 2021-07-01 00:00:00 | NULL        |
|                 53246 |                3 |     146 | NULL | NULL        |

+-----------------------+------------------+---------+---------------------+-------------+

```

DbUser:
```
mysql> select user_id, era_commons_completion_time, era_commons_bypass_time, compliance_training_completion_time , compliance_training_bypass_time, profile_last_confirmed_time, publications_last_confirmed_time , two_factor_auth_completion_time , two_factor_auth_bypass_time , data_use_agreement_completion_time , data_use_agreement_bypass_time from user where user_id=146;
+---------+-----------------------------+-------------------------+-------------------------------------+---------------------------------+-----------------------------+----------------------------------+---------------------------------+-----------------------------+------------------------------------+--------------------------------+
| user_id | era_commons_completion_time | era_commons_bypass_time | compliance_training_completion_time | compliance_training_bypass_time | profile_last_confirmed_time | publications_last_confirmed_time | two_factor_auth_completion_time | two_factor_auth_bypass_time | data_use_agreement_completion_time | data_use_agreement_bypass_time |
+---------+-----------------------------+-------------------------+-------------------------------------+---------------------------------+-----------------------------+----------------------------------+---------------------------------+-----------------------------+------------------------------------+--------------------------------+
|     146 | NULL                        | NULL                    | NULL                                | NULL                            | 2019-11-06 15:42:42         | 2021-07-01 00:00:00              | 2019-11-05 13:43:51             | NULL                        | NULL                               | NULL                           |
+---------+-----------------------------+-------------------------+-------------------------------------+---------------------------------+-----------------------------+----------------------------------+---------------------------------+-----------------------------+------------------------------------+--------------------------------+

```
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
