### PR TITLE
[risk=low][RW-6922] rm API uses of the enableAccessRenewal Feature Flag

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
@@ -128,12 +128,10 @@ public class AccessModuleServiceImpl implements AccessModuleService {
    *   <li>The module is expirable.
    *   <li>The module was completed(CompletionTime is not null).
    *   <li>The module is not bypassed(BypassTime is null).
-   *   <li>Access annual renewal is enabled(enableAccessRenewal is true).
    * </ul>
    */
   private Optional<Timestamp> getExpirationTime(DbUserAccessModule dbUserAccessModule) {
-    if (!configProvider.get().access.enableAccessRenewal
-        || !dbUserAccessModule.getAccessModule().getExpirable()
+    if (!dbUserAccessModule.getAccessModule().getExpirable()
         || dbUserAccessModule.getCompletionTime() == null
         || dbUserAccessModule.getBypassTime() != null) {
       return Optional.empty();

--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -39,7 +39,6 @@ public class ConfigController implements ConfigApiDelegate {
             .enableEventDateModifier(config.featureFlags.enableEventDateModifier)
             .enableResearchReviewPrompt(config.featureFlags.enableResearchPurposePrompt)
             .enableRasLoginGovLinking(config.access.enableRasLoginGovLinking)
-            .enableAccessRenewal(config.access.enableAccessRenewal)
             .enableGenomicExtraction(config.featureFlags.enableGenomicExtraction)
             .enableAccessModuleRewrite(config.featureFlags.enableAccessModuleRewrite)
             .enableStandardSourceDomains(config.featureFlags.enableStandardSourceDomains)

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -262,7 +262,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     }
 
     public Optional<Timestamp> getExpiration() {
-      if (isBypassed() || !configProvider.get().access.enableAccessRenewal) {
+      if (isBypassed()) {
         return Optional.empty();
       }
       return completion.map(
@@ -348,22 +348,12 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     return ctTimes.isBypassed() || (ctTimes.isComplete() && !ctTimes.hasExpired());
   }
 
-  // these 2 modules will not be checked at all until we flip the feature flag
-
   private boolean isProfileConfirmationCompliant(DbUser user) {
-    if (!configProvider.get().access.enableAccessRenewal) {
-      return true;
-    }
-
     final ModuleTimes profileTimes = new ModuleTimes(user.getProfileLastConfirmedTime(), null);
     return profileTimes.isComplete() && !profileTimes.hasExpired();
   }
 
   private boolean isPublicationConfirmationCompliant(DbUser user) {
-    if (!configProvider.get().access.enableAccessRenewal) {
-      return true;
-    }
-
     final ModuleTimes publicationTimes =
         new ModuleTimes(user.getPublicationsLastConfirmedTime(), null);
     return publicationTimes.isComplete() && !publicationTimes.hasExpired();

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4217,10 +4217,6 @@ definitions:
         type: boolean
         default: false
         description: Whether to use enable RAS-AoU linking for login.gov when user setup account.
-      enableAccessRenewal:
-        type: boolean
-        default: false
-        description: Whether to enable the access renewal, allowing users to expire.
       enableGenomicExtraction:
         type: boolean
         default: false

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.access;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.pmiops.workbench.access.AccessModuleServiceImpl.deriveExpirationTimestamp;
@@ -80,7 +79,6 @@ public class AccessModuleServiceTest extends SpringTest {
     user = userDao.save(user);
     config = WorkbenchConfig.createEmptyConfig();
     config.featureFlags.enableAccessModuleRewrite = true;
-    config.access.enableAccessRenewal = true;
     TestMockFactory.createAccessModules(accessModuleDao);
     accessModules = accessModuleDao.findAll();
   }
@@ -286,30 +284,6 @@ public class AccessModuleServiceTest extends SpringTest {
             expectedProfileModuleStatus,
             expectedPublicationModuleStatus,
             expectedRtTrainingModuleStatus);
-  }
-
-  @Test
-  public void testGetClientAccessModuleStatus_aarNotEnabled() {
-    config.access.enableAccessRenewal = false;
-    config.accessRenewal.expiryDays = 10L;
-
-    // RT Training module: Completion time is not null, bypass is null. But AAR is not enabeld,
-    // no expiration time.
-    Timestamp rtTrainingCompletionTime = Timestamp.from(Instant.now());
-    DbUserAccessModule rtTrainingAccessModule =
-        new DbUserAccessModule()
-            .setAccessModule(
-                accessModuleDao.findOneByName(AccessModuleName.RT_COMPLIANCE_TRAINING).get())
-            .setUser(user)
-            .setCompletionTime(rtTrainingCompletionTime);
-    AccessModuleStatus expectedRtTrainingModuleStatus =
-        new AccessModuleStatus()
-            .moduleName(AccessModule.COMPLIANCE_TRAINING)
-            .completionEpochMillis(rtTrainingCompletionTime.getTime());
-    userAccessModuleDao.save(rtTrainingAccessModule);
-
-    assertThat(accessModuleService.getClientAccessModuleStatus(user))
-        .containsExactly(expectedRtTrainingModuleStatus);
   }
 
   private static Optional<Instant> nullableTimestampToOptionalInstant(


### PR DESCRIPTION
Description:

Wait until #5258 is deployed to Prod before merging.  (done)

After this is merged and deployed to Prod, we can remove the FF itself.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
