### PR TITLE
[noTicket][risk=no] Revert dataset cohort link to cohort review

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -252,24 +252,6 @@ const ImmutableListItem: React.FunctionComponent <{
     </div>;
   };
 
-const ImmutableWorkspaceCohortListItem: React.FunctionComponent<{
-  name: string, onChange: Function, checked: boolean, cohortId: number, namespace: string, wid: string}>
-    = ({name, onChange, checked, cohortId, namespace, wid}) => {
-      return <div style={styles.listItem}>
-        <input type='checkbox' value={name} onChange={() => onChange()}
-               style={styles.listItemCheckbox} checked={checked}/>
-        <FlexRow style={{lineHeight: '1.5rem', color: colors.primary, width: '100%'}}>
-          <div>{name}</div>
-          <div style={{marginLeft: 'auto', paddingRight: '1rem'}}>
-            <a href={'/workspaces/' + namespace + '/' + wid + '/data/cohorts/' + cohortId + '/review/cohort-description'}
-            target='_blank'>
-              <ClrIcon size='20' shape='bar-chart'/>
-            </a>
-          </div>
-    </FlexRow>
-  </div>;
-    };
-
 const Subheader = (props) => {
   return <div style={{...styles.subheader, ...props.style}}>{props.children}</div>;
 };
@@ -1181,15 +1163,11 @@ export const DatasetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), wi
                                        () => this.selectPrePackagedCohort()}/>
                   <Subheader>Workspace Cohorts</Subheader>
                   {!loadingResources && this.state.cohortList.map(cohort =>
-                    <ImmutableWorkspaceCohortListItem key={cohort.id} name={cohort.name}
-                                      data-test-id='cohort-list-item'
-                                      checked={selectedCohortIds.includes(cohort.id)}
-                                      cohortId={cohort.id}
-                                      namespace={namespace}
-                                      wid={id}
-                                      onChange={
-                                        () => this.selectCohort(cohort)}/>
-                    )
+                      <ImmutableListItem key={cohort.id} name={cohort.name}
+                                       data-test-id='cohort-list-item'
+                                       checked={selectedCohortIds.includes(cohort.id)}
+                                       onChange={
+                                         () => this.selectCohort(cohort)}/>)
                   }
                   {loadingResources && <Spinner style={{position: 'relative', top: '0.5rem',
                     left: '7rem'}}/>}


### PR DESCRIPTION

Reverting the link on dataset workbench cohort to cohort review since we need to add some more logic to check if review has been created or not while loading dataSet

<img width="487" alt="Screen Shot 2021-07-16 at 2 52 15 PM" src="https://user-images.githubusercontent.com/34481816/125995413-febf6938-a63c-4999-80e0-777bf86a054d.png">

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
