### PR TITLE
[RW-7074][risk=no] e2e Rework open tab function

### DIFF
--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -109,15 +109,15 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
     const tabXpath = buildXPath({ name: subtabName, type: ElementType.Tab });
     const tabLink = new Link(this.page, tabXpath);
     if (!(await tabLink.exists())) {
-      // Try find and click Data tab if the subtab is not found.
+      // Try to find and click Data tab if the subtab is not found.
       const dataTabXpath = buildXPath({ name: TabLabels.Data, type: ElementType.Tab });
       const dataTabLink = new Link(this.page, dataTabXpath);
       if (await dataTabLink.exists()) {
-        // Find Data tab and click it.
+        // Fount the Data tab. Click it.
         await this.openDataPage();
       }
       // else:
-      // Data tab not found. Let openTab func throws error.
+      // Cannot find Data tab or subtab. Let openTab func throws error.
     }
     // openTab func throws error if subtab are not found.
     await this.openTab(subtabName, { waitPageChange: false });

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -97,6 +97,9 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
     const { waitPageChange = true } = opts;
     const selector = buildXPath({ name: pageTabName, type: ElementType.Tab });
     const tabLink = new Link(this.page, selector);
+    if (!(await tabLink.exists())) {
+      throw new Error(`Failed to find and click \"${pageTabName}\" page tab.`);
+    }
     waitPageChange ? await tabLink.clickAndWait() : await tabLink.click();
     await tabLink.dispose();
     return waitWhileLoading(this.page);
@@ -105,19 +108,19 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
   private async openDataSubtab(subtabName: TabLabels): Promise<void> {
     const tabXpath = buildXPath({ name: subtabName, type: ElementType.Tab });
     const tabLink = new Link(this.page, tabXpath);
-    if (await tabLink.exists()) {
-      await this.openTab(subtabName, { waitPageChange: false });
-      return waitWhileLoading(this.page);
-    } else {
-      // Try find and click Data tab if subtab is not found.
+    if (!(await tabLink.exists())) {
+      // Try find and click Data tab if the subtab is not found.
       const dataTabXpath = buildXPath({ name: TabLabels.Data, type: ElementType.Tab });
       const dataTabLink = new Link(this.page, dataTabXpath);
       if (await dataTabLink.exists()) {
-        return this.openDataPage();
+        // Find Data tab and click it.
+        await this.openDataPage();
       }
+      // else:
+      // Data tab not found. Let openTab func throws error.
     }
-    logger.error(`Failed to find and click ${subtabName} tab.`);
-    throw new Error(`Failed to find and click ${subtabName} tab.`);
+    // openTab func throws error if subtab are not found.
+    await this.openTab(subtabName, { waitPageChange: false });
   }
 
   /**

--- a/e2e/app/page/workspace-base.ts
+++ b/e2e/app/page/workspace-base.ts
@@ -113,7 +113,7 @@ export default abstract class WorkspaceBase extends AuthenticatedPage {
       const dataTabXpath = buildXPath({ name: TabLabels.Data, type: ElementType.Tab });
       const dataTabLink = new Link(this.page, dataTabXpath);
       if (await dataTabLink.exists()) {
-        // Fount the Data tab. Click it.
+        // Found Data tab. Click it.
         await this.openDataPage();
       }
       // else:

--- a/e2e/libs/page-manager.ts
+++ b/e2e/libs/page-manager.ts
@@ -48,6 +48,11 @@ export const withBrowser = (launchOpts?: LaunchOptions) => async (
   const browser = await launchBrowser(launchOpts);
   try {
     await testFn(browser);
+  } catch (err) {
+    if (err instanceof Error) {
+      logger.error(err.message);
+      logger.error(err.stack);
+    }
   } finally {
     await browser
       .close()
@@ -73,6 +78,7 @@ export const withPageTest = (launchOpts?: LaunchOptions) => async (
     } catch (err) {
       if (err instanceof Error) {
         logger.error(err.message);
+        logger.error(err.stack);
       }
       // Take screenshot and save html contents immediately after failure.
       await fs.ensureDir(failScreenshotDir);

--- a/e2e/tests/datasets/dataset-snowman-menu-actions.spec.ts
+++ b/e2e/tests/datasets/dataset-snowman-menu-actions.spec.ts
@@ -102,16 +102,13 @@ describe('Datasets card snowman menu actions', () => {
     await renameModal.clickButton(LinkText.RenameDataset, { waitForClose: true });
 
     // Verify existences of old and new Datasets cards.
-    const dataPage = new WorkspaceDataPage(page);
-    await dataPage.openDatasetsSubtab();
-
     const newDatasetExists = await resourceCard.cardExists(newDatasetName, ResourceCard.Dataset);
     expect(newDatasetExists).toBe(true);
 
     const oldDatasetExists = await resourceCard.cardExists(datasetName, ResourceCard.Dataset);
     expect(oldDatasetExists).toBe(false);
-
-    await dataPage.deleteResource(newDatasetName, ResourceCard.Dataset);
+    await new WorkspaceDataPage(page).openDataPage();
+    await resourceCard.delete(newDatasetName, ResourceCard.Dataset);
   });
 
   /**

--- a/e2e/tests/datasets/dataset-snowman-menu-actions.spec.ts
+++ b/e2e/tests/datasets/dataset-snowman-menu-actions.spec.ts
@@ -107,7 +107,7 @@ describe('Datasets card snowman menu actions', () => {
 
     const oldDatasetExists = await resourceCard.cardExists(datasetName, ResourceCard.Dataset);
     expect(oldDatasetExists).toBe(false);
-    await new WorkspaceDataPage(page).openDataPage();
+
     await resourceCard.delete(newDatasetName, ResourceCard.Dataset);
   });
 


### PR DESCRIPTION
Test failure:
`openDatasetsSubtab()` function fails indeterminately in `dataset-snowman-menu.spec`. e.g. [here](https://app.circleci.com/pipelines/github/all-of-us/workbench/11990/workflows/a1ee5e9c-05aa-4ac9-a73c-d6ea3b1fa714/jobs/151491/parallel-runs/3).

UI cause:
`aria-selected` attribute is not a reliable information anymore for determining wether a tab is open or not. Data tab sometimes has `aria-selected=false` when tab is open. It's a minor UI bug recently introduced. I don't know who or what PR has caused it.

<img width="1481" alt="Screen Shot 2021-07-19 at 11 31 09 AM" src="https://user-images.githubusercontent.com/35533885/126220325-f44c377b-9673-4425-bb6d-18709afca791.png">


Proposed fix:
A workaround in test functions to avoid repeated failures: Don't rely on `aria-selected` attribute.

New `openDataSubtab()` function will determine if subtab exists. If found it, click it. If not found, find and click Data tab first then find the subtab.
