### PR TITLE
[RW-7074][risk=no] Fix bug where clicking on the active workspace nav bar tab will unhighlight it

### DIFF
--- a/ui/src/app/pages/app/component.ts
+++ b/ui/src/app/pages/app/component.ts
@@ -100,7 +100,6 @@ export class AppComponent implements OnInit, OnDestroy {
         const {snapshot: {params, queryParams, routeConfig}} = this.getLeafRoute();
         urlParamsStore.next(params);
         queryParamsStore.next(queryParams);
-        routeConfigDataStore.next(routeConfig.data);
       }
     }));
 


### PR DESCRIPTION
The bug was caused by two things
- The routeConfigData store being unset by a subscription in the Angular router even though the Angular router no longer receives actual route config data. This causes even more rerenders of our application because the routeConfigData prop is updated more times than it needs to be during a route change.
- The `WorkspaceRoutes` didn't render on nav change because of `React.memo`. Normally, this would render and trigger the `withRouteData` HOC's which sets the route config data.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
