### PR TITLE
[no ticket][risk=no] Switch React router to use bare Routes

### DIFF
--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -1,7 +1,7 @@
 import {Component as AComponent} from '@angular/core';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-import {Redirect, Route} from 'react-router';
+import {Redirect} from 'react-router';
 
 import {
   AppRoute,
@@ -10,6 +10,7 @@ import {
 } from 'app/components/app-router';
 import {NotificationModal} from 'app/components/modals';
 import {withRoutingSpinner} from 'app/components/with-routing-spinner';
+import {signInGuard} from 'app/guards/react-guards';
 import {CookiePolicy} from 'app/pages/cookie-policy';
 import {SignIn} from 'app/pages/login/sign-in';
 import {SessionExpired} from 'app/pages/session-expired';
@@ -21,7 +22,6 @@ import {ReactWrapperBase} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {authStore, useStore} from 'app/utils/stores';
 import {Subscription} from 'rxjs/Subscription';
-import {signInGuard} from "app/guards/react-guards";
 
 const CookiePolicyPage = fp.flow(withRouteData, withRoutingSpinner)(CookiePolicy);
 const SessionExpiredPage = fp.flow(withRouteData, withRoutingSpinner)(SessionExpired);

--- a/ui/src/app/app-routing.tsx
+++ b/ui/src/app/app-routing.tsx
@@ -1,9 +1,13 @@
 import {Component as AComponent} from '@angular/core';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-import {Redirect} from 'react-router';
+import {Redirect, Route} from 'react-router';
 
-import {AppRoute, AppRouter, Guard, ProtectedRoutes, withRouteData} from 'app/components/app-router';
+import {
+  AppRoute,
+  AppRouter,
+  withRouteData
+} from 'app/components/app-router';
 import {NotificationModal} from 'app/components/modals';
 import {withRoutingSpinner} from 'app/components/with-routing-spinner';
 import {CookiePolicy} from 'app/pages/cookie-policy';
@@ -17,11 +21,7 @@ import {ReactWrapperBase} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {authStore, useStore} from 'app/utils/stores';
 import {Subscription} from 'rxjs/Subscription';
-
-const signInGuard: Guard = {
-  allowed: (): boolean => authStore.get().isSignedIn,
-  redirectPath: '/login'
-};
+import {signInGuard} from "app/guards/react-guards";
 
 const CookiePolicyPage = fp.flow(withRouteData, withRoutingSpinner)(CookiePolicy);
 const SessionExpiredPage = fp.flow(withRouteData, withRoutingSpinner)(SessionExpired);
@@ -46,36 +46,35 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> = ({onSi
     <AppRouter>
       <AppRoute
           path='/cookie-policy'
-          component={() => <CookiePolicyPage routeData={{title: 'Cookie Policy'}}/>}
+          render={() => <CookiePolicyPage routeData={{title: 'Cookie Policy'}}/>}
       />
       <AppRoute
           path='/login'
-          component={() => <SignInPage routeData={{title: 'Sign In'}} onSignIn={onSignIn} signIn={signIn}/>}
+          render={() => <SignInPage routeData={{title: 'Sign In'}} onSignIn={onSignIn} signIn={signIn}/>}
       />
       <AppRoute
           path='/session-expired'
-          component={() => <SessionExpiredPage routeData={{title: 'You have been signed out'}} signIn={signIn}/>}
+          render={() => <SessionExpiredPage routeData={{title: 'You have been signed out'}} signIn={signIn}/>}
       />
       <AppRoute
           path='/sign-in-again'
-          component={() => <SignInAgainPage routeData={{title: 'You have been signed out'}} signIn={signIn}/>}
+          render={() => <SignInAgainPage routeData={{title: 'You have been signed out'}} signIn={signIn}/>}
       />
       <AppRoute
           path='/user-disabled'
-          component={() => <UserDisabledPage routeData={{title: 'Disabled'}}/>}
+          render={() => <UserDisabledPage routeData={{title: 'Disabled'}}/>}
       />
-      <ProtectedRoutes guards={[signInGuard]}>
-        <AppRoute
-            path=''
-            exact={false}
-            component={() => <SignedInPage
-                intermediaryRoute={true}
-                routeData={{}}
-                subscribeToInactivitySignOut={subscribeToInactivitySignOut}
-                signOut={signOut}
-            />}
-        />
-      </ProtectedRoutes>
+      <AppRoute
+          path=''
+          exact={false}
+          guards={[signInGuard]}
+          render={() => <SignedInPage
+              intermediaryRoute={true}
+              routeData={{}}
+              subscribeToInactivitySignOut={subscribeToInactivitySignOut}
+              signOut={signOut}
+          />}
+      />
     </AppRouter>
   </React.Fragment>;
 };

--- a/ui/src/app/components/app-router.spec.tsx
+++ b/ui/src/app/components/app-router.spec.tsx
@@ -1,8 +1,13 @@
 import * as React from "react";
-import {AppRoute, AppRouter, Guard, NavRedirect, ProtectedRoutes} from "app/components/app-router";
+import {
+  AppRoute,
+  AppRouter,
+  NavRedirect,
+} from "app/components/app-router";
 import {MemoryRouter} from "react-router";
 import {mount} from "enzyme";
 import {NavStore} from "app/utils/navigation";
+import {Guard} from "app/guards/react-guards";
 
 jest.mock('react-router-dom', () => {
   const originalModule = jest.requireActual('react-router-dom');
@@ -77,19 +82,11 @@ const makeAppRouter = () => {
   return <AppRouter>
     <AppRoute path='/unprotected-route' component={() => <TestComponent text={'Unprotected Route'}/>}/>
     <AppRoute path='/punting' component={() => <TestComponent text={'Punting'}/>}/>
-    <ProtectedRoutes guards={[alwaysFalseGuard]}>
-      <AppRoute path='/unreachable-path' component={() => <TestComponent text={'Unreachable Path'}/>}/>
-    </ProtectedRoutes>
-    <ProtectedRoutes guards={[alwaysTrueGuard]}>
-      <AppRoute path='/protected-route' component={() => <TestComponent text={'Protected Route'}/>}/>
-      <AppRoute path='/other-protected-route' component={() => <TestComponent text={'Other Protected Route'}/>}/>
-      <ProtectedRoutes guards={[otherAlwaysTrueGuard]}>
-        <AppRoute path='/nested-protected-route' component={() => <TestComponent text={'Nested Protected Route'}/>}/>
-      </ProtectedRoutes>
-      <ProtectedRoutes guards={[alwaysFalseGuard]}>
-        <AppRoute path='/nested-unreachable-path' component={() => <TestComponent text={'Unreachable Path'}/>}/>
-      </ProtectedRoutes>
-    </ProtectedRoutes>
+    <AppRoute path='/unreachable-path' guards={[alwaysFalseGuard]} component={() => <TestComponent text={'Unreachable Path'}/>}/>
+    <AppRoute path='/protected-route' guards={[alwaysTrueGuard]} component={() => <TestComponent text={'Protected Route'}/>}/>
+    <AppRoute path='/other-protected-route' guards={[alwaysTrueGuard]} component={() => <TestComponent text={'Other Protected Route'}/>}/>
+    <AppRoute path='/nested-protected-route' guards={[alwaysTrueGuard, otherAlwaysTrueGuard]} component={() => <TestComponent text={'Nested Protected Route'}/>}/>
+    <AppRoute path='/nested-unreachable-path' guards={[alwaysTrueGuard, alwaysFalseGuard]}component={() => <TestComponent text={'Unreachable Path'}/>}/>
   </AppRouter>
 }
 

--- a/ui/src/app/components/app-router.tsx
+++ b/ui/src/app/components/app-router.tsx
@@ -61,7 +61,6 @@ export const NavRedirect = ({path}) => {
 };
 
 interface AppRouteProps extends RouteProps {
-  exact?: boolean;
   guards?: Array<Guard>;
 }
 

--- a/ui/src/app/components/app-router.tsx
+++ b/ui/src/app/components/app-router.tsx
@@ -43,7 +43,7 @@ export const withFullHeight = WrappedComponent => ({...props}) => {
 };
 
 export const SubRoute = ({children}): React.ReactElement => <Switch>{children}</Switch>;
-export const AppRouter = ({children}): React.ReactElement => <BrowserRouter>{children}</BrowserRouter>;
+export const AppRouter = ({children}): React.ReactElement => <BrowserRouter><Switch>{children}</Switch></BrowserRouter>;
 
 export const RouteLink = ({path, style = {}, children}): React.ReactElement => <Link style={{...style}} to={path}>{children}</Link>;
 

--- a/ui/src/app/components/app-router.tsx
+++ b/ui/src/app/components/app-router.tsx
@@ -1,3 +1,4 @@
+import {Guard} from 'app/guards/react-guards';
 import {navigate, routeConfigDataStore, urlParamsStore} from 'app/utils/navigation';
 import {routeDataStore} from 'app/utils/stores';
 import * as fp from 'lodash/fp';
@@ -10,14 +11,10 @@ import {
   Route,
   RouteProps,
   Switch,
-  useHistory,
   useLocation,
   useParams,
   useRouteMatch
 } from 'react-router-dom';
-import {Guard} from "app/guards/react-guards";
-
-const {Fragment} = React;
 
 export const usePath = () => {
   const {path} = useRouteMatch();
@@ -64,11 +61,11 @@ export const NavRedirect = ({path}) => {
 };
 
 interface AppRouteProps extends RouteProps {
-  guards?: Array<Guard>
+  guards?: Array<Guard>;
 }
 
 export class AppRoute extends Route<AppRouteProps> {
-  static defaultProps = {exact: true}
+  static defaultProps = {exact: true};
 
   constructor(props) {
     super(props);

--- a/ui/src/app/components/app-router.tsx
+++ b/ui/src/app/components/app-router.tsx
@@ -64,7 +64,6 @@ export const NavRedirect = ({path}) => {
 };
 
 interface AppRouteProps extends RouteProps {
-  data?: object
   guards?: Array<Guard>
 }
 

--- a/ui/src/app/components/app-router.tsx
+++ b/ui/src/app/components/app-router.tsx
@@ -61,6 +61,7 @@ export const NavRedirect = ({path}) => {
 };
 
 interface AppRouteProps extends RouteProps {
+  exact?: boolean;
   guards?: Array<Guard>;
 }
 

--- a/ui/src/app/guards/react-guards.ts
+++ b/ui/src/app/guards/react-guards.ts
@@ -1,0 +1,22 @@
+import {hasRegisteredAccess} from "app/utils/access-tiers";
+import {authStore, profileStore} from "app/utils/stores";
+
+export interface Guard {
+  allowed: () => boolean;
+  redirectPath: string;
+}
+
+export const expiredGuard: Guard = {
+  allowed: (): boolean => !profileStore.get().profile.renewableAccessModules.anyModuleHasExpired,
+  redirectPath: '/access-renewal'
+};
+
+export const registrationGuard: Guard = {
+  allowed: (): boolean => hasRegisteredAccess(profileStore.get().profile.accessTierShortNames),
+  redirectPath: '/'
+};
+
+export const signInGuard: Guard = {
+  allowed: (): boolean => authStore.get().isSignedIn,
+  redirectPath: '/login'
+};

--- a/ui/src/app/guards/react-guards.ts
+++ b/ui/src/app/guards/react-guards.ts
@@ -1,5 +1,5 @@
-import {hasRegisteredAccess} from "app/utils/access-tiers";
-import {authStore, profileStore} from "app/utils/stores";
+import {hasRegisteredAccess} from 'app/utils/access-tiers';
+import {authStore, profileStore} from 'app/utils/stores';
 
 export interface Guard {
   allowed: () => boolean;

--- a/ui/src/app/signed-in-app-routing.tsx
+++ b/ui/src/app/signed-in-app-routing.tsx
@@ -2,8 +2,6 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 import {
   AppRoute,
-  Guard,
-  ProtectedRoutes,
   withFullHeight,
   withRouteData
 } from './components/app-router';
@@ -27,19 +25,8 @@ import {WorkspaceEdit, WorkspaceEditMode} from './pages/workspace/workspace-edit
 import {WorkspaceLibrary} from './pages/workspace/workspace-library';
 import {WorkspaceList} from './pages/workspace/workspace-list';
 import {WorkspaceWrapper} from './pages/workspace/workspace-wrapper';
-import {hasRegisteredAccess} from './utils/access-tiers';
 import {BreadcrumbType} from './utils/navigation';
-import {profileStore} from './utils/stores';
-
-const registrationGuard: Guard = {
-  allowed: (): boolean => hasRegisteredAccess(profileStore.get().profile.accessTierShortNames),
-  redirectPath: '/'
-};
-
-const expiredGuard: Guard = {
-  allowed: (): boolean => !profileStore.get().profile.renewableAccessModules.anyModuleHasExpired,
-  redirectPath: '/access-renewal'
-};
+import {expiredGuard, registrationGuard} from "./guards/react-guards";
 
 const AccessRenewalPage = fp.flow(withRouteData, withRoutingSpinner)(AccessRenewal);
 const AdminBannerPage = fp.flow(withRouteData, withRoutingSpinner)(AdminBanner);
@@ -68,67 +55,66 @@ const WorkspaceSearchAdminPage = fp.flow(withRouteData, withRoutingSpinner)(Admi
  */
 export const SignedInRoutes = React.memo(() => {
   return <React.Fragment>
-    <ProtectedRoutes guards={[expiredGuard]}>
-      <AppRoute
-          path='/'
-          component={() => <HomepagePage routeData={{title: 'Homepage'}}/>}
-      />
-    </ProtectedRoutes>
+    <AppRoute
+        path='/'
+        guards={[expiredGuard]}
+        render={() => <HomepagePage routeData={{title: 'Homepage'}}/>}
+    />
     <AppRoute
         path='/access-renewal'
-        component={() => <AccessRenewalPage routeData={{title: 'Access Renewal'}}/>}
+        render={() => <AccessRenewalPage routeData={{title: 'Access Renewal'}}/>}
     />
     <AppRoute
         path='/admin/banner'
-        component={() => <AdminBannerPage routeData={{title: 'Create Banner'}}/>}
+        render={() => <AdminBannerPage routeData={{title: 'Create Banner'}}/>}
     />
     <AppRoute
         path='/admin/institution'
-        component={() => <InstitutionAdminPage routeData={{title: 'Institution Admin'}}/>}
+        render={() => <InstitutionAdminPage routeData={{title: 'Institution Admin'}}/>}
     />
     <AppRoute
         path='/admin/institution/add'
-        component={() => <InstitutionEditAdminPage routeData={{title: 'Institution Admin'}}/>}
+        render={() => <InstitutionEditAdminPage routeData={{title: 'Institution Admin'}}/>}
     />
     <AppRoute
         path='/admin/institution/edit/:institutionId'
-        component={() => <InstitutionEditAdminPage routeData={{title: 'Institution Admin'}}/>}
+        render={() => <InstitutionEditAdminPage routeData={{title: 'Institution Admin'}}/>}
     />
     <AppRoute
         path='/admin/user' // included for backwards compatibility
-        component={() => <UsersAdminPage routeData={{title: 'User Admin Table'}}/>}
+        render={() => <UsersAdminPage routeData={{title: 'User Admin Table'}}/>}
     />
     <AppRoute
         path='/admin/review-workspace'
-        component={() => <AdminReviewWorkspacePage routeData={{title: 'Review Workspaces'}}/>}
+        render={() => <AdminReviewWorkspacePage routeData={{title: 'Review Workspaces'}}/>}
     />
     <AppRoute
         path='/admin/users'
-        component={() => <UsersAdminPage routeData={{title: 'User Admin Table'}}/>}
+        render={() => <UsersAdminPage routeData={{title: 'User Admin Table'}}/>}
     />
     <AppRoute
         path='/admin/users/:usernameWithoutGsuiteDomain'
-        component={() => <UserAdminPage routeData={{title: 'User Admin'}}/>}
+        render={() => <UserAdminPage routeData={{title: 'User Admin'}}/>}
     />
     <AppRoute
         path='/admin/user-audit'
-        component={() => <UserAuditPage routeData={{title: 'User Audit'}}/>}
+        render={() => <UserAuditPage routeData={{title: 'User Audit'}}/>}
     />
     <AppRoute
         path='/admin/user-audit/:username'
-        component={() => <UserAuditPage routeData={{title: 'User Audit'}}/>}
+        render={() => <UserAuditPage routeData={{title: 'User Audit'}}/>}
     />
     <AppRoute
         path='/admin/workspaces'
-        component={() => <WorkspaceSearchAdminPage routeData={{title: 'Workspace Admin'}}/>}
+        render={() => <WorkspaceSearchAdminPage routeData={{title: 'Workspace Admin'}}/>}
     />
     <AppRoute
         path='/admin/workspaces/:workspaceNamespace'
-        component={() => <WorkspaceAdminPage routeData={{title: 'Workspace Admin'}}/>}
+        render={() => <WorkspaceAdminPage routeData={{title: 'Workspace Admin'}}/>}
     />
     <AppRoute
         path='/admin/workspace-audit'
-        component={() => <WorkspaceAuditPage routeData={{title: 'Workspace Audit'}}/>}
+        render={() => <WorkspaceAuditPage routeData={{title: 'Workspace Audit'}}/>}
     />
     <AppRoute
         path='/admin/workspace-audit/:workspaceNamespace'
@@ -136,48 +122,49 @@ export const SignedInRoutes = React.memo(() => {
     />
     <AppRoute
         path='/admin/workspaces/:workspaceNamespace/:nbName'
-        component={() => <AdminNotebookViewPage routeData={{
+        render={() => <AdminNotebookViewPage routeData={{
           pathElementForTitle: 'nbName',
           minimizeChrome: true
         }}/>}
     />
     <AppRoute
         path='/data-code-of-conduct'
-        component={() => <DataUserCodeOfConductPage routeData={{
+        render={() => <DataUserCodeOfConductPage routeData={{
           title: 'Data User Code of Conduct',
           minimizeChrome: true
         }} />}
     />
-    <AppRoute path='/profile' component={() => <ProfilePage routeData={{title: 'Profile'}}/>}/>
-    <AppRoute path='/nih-callback' component={() => <HomepagePage routeData={{title: 'Homepage'}}/>} />
-    <AppRoute path='/ras-callback' component={() => <HomepagePage routeData={{title: 'Homepage'}}/>} />
-
-    <ProtectedRoutes guards={[expiredGuard, registrationGuard]}>
-      <AppRoute
-          path='/library'
-          component={() => <WorkspaceLibraryPage routeData={{title: 'Workspace Library', minimizeChrome: false}}/>}
-      />
-      <AppRoute
-          path='/workspaces'
-          component={() => <WorkspaceListPage
-              routeData={{
-                title: 'View Workspaces',
-                breadcrumb: BreadcrumbType.Workspaces
-              }}
-          />}
-      />
-      <AppRoute
-          path='/workspaces/build'
-          component={() => <WorkspaceEditPage
-              routeData={{title: 'Create Workspace'}}
-              workspaceEditMode={WorkspaceEditMode.Create}
-          />}
-      />
-      <AppRoute
-          path='/workspaces/:ns/:wsid'
-          exact={false}
-          component={() => <WorkspaceWrapperPage intermediaryRoute={true} routeData={{}}/>}
-      />
-    </ProtectedRoutes>
+    <AppRoute path='/profile' render={() => <ProfilePage routeData={{title: 'Profile'}}/>}/>
+    <AppRoute path='/nih-callback' render={() => <HomepagePage routeData={{title: 'Homepage'}}/>} />
+    <AppRoute path='/ras-callback' render={() => <HomepagePage routeData={{title: 'Homepage'}}/>} />
+    <AppRoute
+        path='/library'
+        guards={[expiredGuard, registrationGuard]}
+        render={() => <WorkspaceLibraryPage routeData={{title: 'Workspace Library', minimizeChrome: false}}/>}
+    />
+    <AppRoute
+        path='/workspaces'
+        guards={[expiredGuard, registrationGuard]}
+        render={() => <WorkspaceListPage
+            routeData={{
+              title: 'View Workspaces',
+              breadcrumb: BreadcrumbType.Workspaces
+            }}
+        />}
+    />
+    <AppRoute
+        path='/workspaces/build'
+        guards={[expiredGuard, registrationGuard]}
+        component={() => <WorkspaceEditPage
+            routeData={{title: 'Create Workspace'}}
+            workspaceEditMode={WorkspaceEditMode.Create}
+        />}
+    />
+    <AppRoute
+        path='/workspaces/:ns/:wsid'
+        guards={[expiredGuard, registrationGuard]}
+        exact={false}
+        render={() => <WorkspaceWrapperPage intermediaryRoute={true} routeData={{}}/>}
+    />
   </React.Fragment>;
 });

--- a/ui/src/app/signed-in-app-routing.tsx
+++ b/ui/src/app/signed-in-app-routing.tsx
@@ -6,6 +6,7 @@ import {
   withRouteData
 } from './components/app-router';
 import {withRoutingSpinner} from './components/with-routing-spinner';
+import {expiredGuard, registrationGuard} from './guards/react-guards';
 import {AccessRenewal} from './pages/access/access-renewal';
 import {AdminBanner} from './pages/admin/admin-banner';
 import {AdminInstitution} from './pages/admin/admin-institution';
@@ -26,7 +27,6 @@ import {WorkspaceLibrary} from './pages/workspace/workspace-library';
 import {WorkspaceList} from './pages/workspace/workspace-list';
 import {WorkspaceWrapper} from './pages/workspace/workspace-wrapper';
 import {BreadcrumbType} from './utils/navigation';
-import {expiredGuard, registrationGuard} from "./guards/react-guards";
 
 const AccessRenewalPage = fp.flow(withRouteData, withRoutingSpinner)(AccessRenewal);
 const AdminBannerPage = fp.flow(withRouteData, withRoutingSpinner)(AdminBanner);

--- a/ui/src/app/workspace-app-routing.tsx
+++ b/ui/src/app/workspace-app-routing.tsx
@@ -4,6 +4,7 @@ import {withRoutingSpinner} from 'app/components/with-routing-spinner';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 import {NOTEBOOK_PAGE_KEY} from './components/help-sidebar';
+import {expiredGuard, registrationGuard} from './guards/react-guards';
 import {InteractiveNotebook} from './pages/analysis/interactive-notebook';
 import {NotebookList} from './pages/analysis/notebook-list';
 import {NotebookRedirect} from './pages/analysis/notebook-redirect';
@@ -20,7 +21,6 @@ import {DatasetPage} from './pages/data/data-set/dataset-page';
 import {WorkspaceAbout} from './pages/workspace/workspace-about';
 import {WorkspaceEdit, WorkspaceEditMode} from './pages/workspace/workspace-edit';
 import {BreadcrumbType} from './utils/navigation';
-import {expiredGuard, registrationGuard} from "./guards/react-guards";
 
 const CohortPagePage = fp.flow(withRouteData, withRoutingSpinner)(CohortPage);
 const CohortActionsPage = fp.flow(withRouteData, withRoutingSpinner)(CohortActions);

--- a/ui/src/app/workspace-app-routing.tsx
+++ b/ui/src/app/workspace-app-routing.tsx
@@ -20,6 +20,7 @@ import {DatasetPage} from './pages/data/data-set/dataset-page';
 import {WorkspaceAbout} from './pages/workspace/workspace-about';
 import {WorkspaceEdit, WorkspaceEditMode} from './pages/workspace/workspace-edit';
 import {BreadcrumbType} from './utils/navigation';
+import {expiredGuard, registrationGuard} from "./guards/react-guards";
 
 const CohortPagePage = fp.flow(withRouteData, withRoutingSpinner)(CohortPage);
 const CohortActionsPage = fp.flow(withRouteData, withRoutingSpinner)(CohortActions);
@@ -45,7 +46,8 @@ export const WorkspaceRoutes = React.memo(() => {
   return <React.Fragment>
     <AppRoute
       path='/workspaces/:ns/:wsid/about'
-      component={() => <WorkspaceAboutPage
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <WorkspaceAboutPage
         routeData={{
           title: 'View Workspace Details',
           breadcrumb: BreadcrumbType.Workspace,
@@ -56,7 +58,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/duplicate'
-      component={() => <WorkspaceEditPage
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <WorkspaceEditPage
         routeData={{
           title: 'Duplicate Workspace',
           breadcrumb: BreadcrumbType.WorkspaceDuplicate,
@@ -67,7 +70,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/edit'
-      component={() => <WorkspaceEditPage
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <WorkspaceEditPage
         routeData={{
           title: 'Edit Workspace',
           breadcrumb: BreadcrumbType.WorkspaceEdit,
@@ -78,7 +82,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/notebooks'
-      component={() => <NotebookListPage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <NotebookListPage routeData={{
         title: 'View Notebooks',
         pageKey: 'notebooks',
         workspaceNavBarTab: 'notebooks',
@@ -87,7 +92,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/notebooks/preview/:nbName'
-      component={() => <InteractiveNotebookPage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <InteractiveNotebookPage routeData={{
         pathElementForTitle: 'nbName',
         breadcrumb: BreadcrumbType.Notebook,
         pageKey: NOTEBOOK_PAGE_KEY,
@@ -97,7 +103,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/notebooks/:nbName'
-      component={() => <NotebookRedirectPage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <NotebookRedirectPage routeData={{
         pathElementForTitle: 'nbName', // use the (urldecoded) captured value nbName
         breadcrumb: BreadcrumbType.Notebook,
         // The iframe we use to display the Jupyter notebook does something strange
@@ -111,7 +118,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/data'
-      component={() => <DataComponentPage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <DataComponentPage routeData={{
         title: 'Data Page',
         breadcrumb: BreadcrumbType.Workspace,
         workspaceNavBarTab: 'data',
@@ -120,7 +128,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/data/data-sets'
-      component={() => <DataSetComponentPage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <DataSetComponentPage routeData={{
         title: 'Dataset Page',
         breadcrumb: BreadcrumbType.Dataset,
         workspaceNavBarTab: 'data',
@@ -129,7 +138,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/data/data-sets/:dataSetId'
-      component={() => <DataSetComponentPage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <DataSetComponentPage routeData={{
         title: 'Edit Dataset',
         breadcrumb: BreadcrumbType.Dataset,
         workspaceNavBarTab: 'data',
@@ -138,7 +148,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/data/cohorts/build'
-      component={() => <CohortPagePage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <CohortPagePage routeData={{
         title: 'Build Cohort Criteria',
         breadcrumb: BreadcrumbType.CohortAdd,
         workspaceNavBarTab: 'data',
@@ -147,7 +158,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/data/cohorts/:cid/actions'
-      component={() => <CohortActionsPage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <CohortActionsPage routeData={{
         title: 'Cohort Actions',
         breadcrumb: BreadcrumbType.Cohort,
         workspaceNavBarTab: 'data',
@@ -156,7 +168,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/data/cohorts/:cid/review/participants'
-      component={() => <ParticipantsTablePage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <ParticipantsTablePage routeData={{
         title: 'Review Cohort Participants',
         breadcrumb: BreadcrumbType.Cohort,
         workspaceNavBarTab: 'data',
@@ -165,7 +178,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/data/cohorts/:cid/review/participants/:pid'
-      component={() => <DetailPagePage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <DetailPagePage routeData={{
         title: 'Participant Detail',
         breadcrumb: BreadcrumbType.Participant,
         workspaceNavBarTab: 'data',
@@ -174,7 +188,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/data/cohorts/:cid/review/cohort-description'
-      component={() => <QueryReportPage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <QueryReportPage routeData={{
         title: 'Review Cohort Description',
         breadcrumb: BreadcrumbType.Cohort,
         workspaceNavBarTab: 'data',
@@ -183,7 +198,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/data/cohorts/:cid/review'
-      component={() => <CohortReviewPage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <CohortReviewPage routeData={{
         title: 'Review Cohort Participants',
         breadcrumb: BreadcrumbType.Cohort,
         workspaceNavBarTab: 'data',
@@ -192,7 +208,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/data/concepts'
-      component={() => <ConceptHomepagePage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <ConceptHomepagePage routeData={{
         title: 'Search Concepts',
         breadcrumb: BreadcrumbType.SearchConcepts,
         workspaceNavBarTab: 'data',
@@ -201,7 +218,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/data/concepts/sets/:csid'
-      component={() => <ConceptSearchPage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <ConceptSearchPage routeData={{
         title: 'Concept Set',
         breadcrumb: BreadcrumbType.ConceptSet,
         workspaceNavBarTab: 'data',
@@ -210,7 +228,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/data/concepts/:domain'
-      component={() => <ConceptSearchPage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <ConceptSearchPage routeData={{
         title: 'Search Concepts',
         breadcrumb: BreadcrumbType.SearchConcepts,
         workspaceNavBarTab: 'data',
@@ -219,7 +238,8 @@ export const WorkspaceRoutes = React.memo(() => {
     />
     <AppRoute
       path='/workspaces/:ns/:wsid/data/concepts/sets/:csid/actions'
-      component={() => <ConceptSetActionsPage routeData={{
+      guards={[expiredGuard, registrationGuard]}
+      render={() => <ConceptSetActionsPage routeData={{
         title: 'Concept Set Actions',
         breadcrumb: BreadcrumbType.ConceptSet,
         workspaceNavBarTab: 'data',


### PR DESCRIPTION
- put a `Switch` at the base level of the `AppRouter`
- change `AppRoute` to being a class that extends `Route` so that all children of the `Switch` are a `Route` instead of a function that returns a `Route`
  - default `exact={true}` using `defaultProps`: https://reactjs.org/docs/react-component.html#defaultprops
  - like the old `AppRoute`, return a `NavRedirect` if we fail any guards
  - otherwise, do the superclass render (which calls the `render` passed in as a prop)
- tear out `ProtectedRoutes` and explicitly set guards on each route

---

**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
