### PR TITLE
[no ticket][risk=no] Fix CircleCI broken job: wait_until_previous_workflow_done

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -625,8 +625,7 @@ workflows:
     jobs:
       # Running two or more build-test-deploy workflows concurrently may result in failures to
       #  puppeteer-test, api-deploy-to-test or/and ui-deploy-to-test jobs.
-      - wait_until_previous_workflow_done:
-          <<: *filter-master-branch
+      - wait_until_previous_workflow_done
       # Always run basic test/lint/compilation (open PRs, master branch merge)
       # Note: by default tags are not picked up.
       - api-local-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,6 +333,7 @@ jobs:
   wait_until_previous_workflow_done:
     executor: workbench-executor
     steps:
+      - checkout-code
       - run:
           command: bash .circleci/workflow-queue-v1.sh
           name: "Wait until all previously submitted builds to complete."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,7 +626,8 @@ workflows:
     jobs:
       # Running two or more build-test-deploy workflows concurrently may result in failures to
       #  puppeteer-test, api-deploy-to-test or/and ui-deploy-to-test jobs.
-      - wait_until_previous_workflow_done
+      - wait_until_previous_workflow_done:
+          <<: *filter-master-branch
       # Always run basic test/lint/compilation (open PRs, master branch merge)
       # Note: by default tags are not picked up.
       - api-local-test


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
