### PR TITLE
[RW-7098][risk=low] Treat cost restriction as a warning for workspaces with increased credits

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -17,7 +17,6 @@ import {
   withCurrentWorkspace,
   withUserProfile
 } from 'app/utils';
-import {serverConfigStore} from 'app/utils/stores';
 import {
   ComputeType,
   findMachineByName,
@@ -40,6 +39,7 @@ import {
   useCustomRuntime,
   useRuntimeStatus
 } from 'app/utils/runtime-utils';
+import {serverConfigStore} from 'app/utils/stores';
 import {WorkspaceData} from 'app/utils/workspace-data';
 
 import {AoU} from 'app/components/text-wrappers';

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -17,6 +17,7 @@ import {
   withCurrentWorkspace,
   withUserProfile
 } from 'app/utils';
+import {serverConfigStore} from 'app/utils/stores';
 import {
   ComputeType,
   findMachineByName,
@@ -943,13 +944,22 @@ export const RuntimePanel = fp.flow(
     };
   };
 
+  const costErrorsAsWarnings = (
+    workspace.billingAccountType === BillingAccountType.USERPROVIDED ||
+    // We've increased the workspace creator's free credits. This means they may be expecting to run
+    // a more expensive analysis, and the program has extended some further trust for free credit
+    // use. Allow them to provision a larger runtime (still warn them). Block them if they get below
+    // the default amount of free credits because (1) this can result in overspend and (2) we have
+    // easy access to remaining credits, and not the creator's quota.
+    creatorFreeCreditsRemaining > serverConfigStore.get().config.defaultFreeCreditsDollarLimit);
+
   const runningCostValidatorWithMessage = () => {
     const maxRunningCost = workspace.billingAccountType === BillingAccountType.FREETIER
       ? 25
       : 150;
-    const message = workspace.billingAccountType === BillingAccountType.FREETIER
-      ? '^Your runtime is too expensive. To proceed using free credits, reduce your running costs below $25/hr.'
-      : '^Your runtime is very expensive. Are you sure you wish to proceed?';
+    const message = costErrorsAsWarnings
+      ? '^Your runtime is expensive. Are you sure you wish to proceed?'
+      : `^Your runtime is too expensive. To proceed using free credits, reduce your running costs below $${maxRunningCost}/hr.`;
     return {
       numericality: {
         lessThan: maxRunningCost,
@@ -996,7 +1006,7 @@ export const RuntimePanel = fp.flow(
     if (dataprocErrors) {
       errorDivs.push(summarizeErrors(dataprocErrors));
     }
-    if (workspace.billingAccountType === BillingAccountType.FREETIER && runningCostErrors) {
+    if (!costErrorsAsWarnings && runningCostErrors) {
       errorDivs.push(summarizeErrors(runningCostErrors));
     }
     return errorDivs;
@@ -1004,7 +1014,7 @@ export const RuntimePanel = fp.flow(
 
   const getWarningMessageContent = () => {
     const warningDivs = [];
-    if (workspace.billingAccountType === BillingAccountType.USERPROVIDED && runningCostErrors) {
+    if (costErrorsAsWarnings && runningCostErrors) {
       warningDivs.push(summarizeErrors(runningCostErrors));
     }
     return warningDivs;


### PR DESCRIPTION
This is more complicated than I'd like, but it threads the needle for requested use case per ticket.

Updated conditions where the cost error is warning, rather than a blocking error:
- user provides their own billing account (once supported)
- or, workspace creator has >$300 remaining free credits

This is because:
- The ability to potentially overspend should be tied to the free credits account you are using, if anything
- You cannot currently fetch the free credits limit for the creator, just the remaining credits (correctly); otherwise we could compare to see if they have an override instead
- Also puts some protections in place against overspend, if free credits are too low

Alternative considered:

Make this a warning for operational users. Felt like this would make it more challenging to reproduce certain behaviors, and would provide an inconsistent experience for different users within the same workspace.