### PR TITLE
[RW-6800][risk=no] Improve runtime warnings / language

### DIFF
--- a/ui/src/app/pages/analysis/notebook-redirect.tsx
+++ b/ui/src/app/pages/analysis/notebook-redirect.tsx
@@ -51,6 +51,14 @@ export const progressStrings: Map<Progress, string> = new Map([
   [Progress.Redirecting, 'Redirecting to the notebook server'],
 ]);
 
+// Statuses during which the user can interact with the Runtime UIs, e.g. via
+// an iframe. When the runtime is in other states, requests to the runtime host
+// are likely to fail.
+const interactiveRuntimeStatuses = new Set<RuntimeStatus>([
+  RuntimeStatus.Running,
+  RuntimeStatus.Updating
+]);
+
 const styles = reactStyles({
   main: {
     display: 'flex', flexDirection: 'column', marginLeft: '3rem', paddingTop: '1rem', width: '780px'
@@ -310,12 +318,12 @@ export const NotebookRedirect = fp.flow(
       }
 
       // If we're already loaded (viewing the notebooks iframe), and the
-      // runtime transitions out of the "running" state, navigate back to
+      // runtime transitions out of an interactive state, navigate back to
       // the preview page as the iframe will start erroring.
+      const isLoaded = runtime !== undefined && this.state.progress === Progress.Loaded;
       const {status: prevStatus = null} = prevProps.runtimeStore.runtime || {};
-      const isLoaded = this.state.progress === Progress.Loaded;
-      if (isLoaded && prevStatus === RuntimeStatus.Running &&
-          runtime !== undefined && (runtime === null || runtime.status !== RuntimeStatus.Running)) {
+      const {status: curStatus = null} = runtime || {};
+      if (isLoaded && interactiveRuntimeStatuses.has(prevStatus) && !interactiveRuntimeStatuses.has(curStatus)) {
         navigate([
           'workspaces', workspace.namespace, workspace.id,
           // navigate will encode the notebook name automatically

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -570,7 +570,7 @@ describe('RuntimePanel', () => {
     expect(wrapper.find(WarningMessage).text().includes('reboot')).toBeTruthy();
   });
 
-  it('should warn user about reboot if there are updates that require one - number of workers',
+  it('should not warn user for updates where not needed - number of workers',
     async() => {
       const runtime = {
         ...runtimeApiStub.runtime,
@@ -585,10 +585,10 @@ describe('RuntimePanel', () => {
       await pickNumWorkers(wrapper, getNumWorkers(wrapper) + 2);
       await mustClickButton(wrapper, 'Next');
 
-      expect(wrapper.find(WarningMessage).text().includes('reboot')).toBeTruthy();
+      expect(wrapper.find(WarningMessage).exists()).toBeFalsy();
     });
 
-  it('should warn user about reboot if there are updates that require one - number of preemptible workers', async() => {
+  it('should not warn user for updates where not needed - number of preemptibles', async() => {
     const runtime = {...runtimeApiStub.runtime, gceConfig: null, dataprocConfig: defaultDataprocConfig()};
     runtimeStore.set({runtime: runtime, workspaceNamespace: workspaceStubs[0].namespace});
 
@@ -597,7 +597,7 @@ describe('RuntimePanel', () => {
     await pickNumPreemptibleWorkers(wrapper, getNumPreemptibleWorkers(wrapper) + 2);
     await mustClickButton(wrapper, 'Next');
 
-    expect(wrapper.find(WarningMessage).text().includes('reboot')).toBeTruthy();
+    expect(wrapper.find(WarningMessage).exists()).toBeFalsy();
   });
 
   it('should warn user about reboot if there are updates that require one - CPU', async() => {

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -32,9 +32,9 @@ import {
 import {formatUsd} from 'app/utils/numbers';
 import {applyPresetOverride, runtimePresets} from 'app/utils/runtime-presets';
 import {
+  diffsToUpdateMessaging,
   getRuntimeConfigDiffs,
   RuntimeConfig,
-  RuntimeDiffState,
   RuntimeStatusRequest,
   useCustomRuntime,
   useRuntimeStatus
@@ -725,7 +725,7 @@ const CreatePanel = ({creatorFreeCreditsRemaining, profile, setPanelContent, wor
 
 const ConfirmUpdatePanel = ({initialRuntimeConfig, newRuntimeConfig, onCancel, updateButton}) => {
   const runtimeDiffs = getRuntimeConfigDiffs(initialRuntimeConfig, newRuntimeConfig);
-  const needsDelete = runtimeDiffs.map(diff => diff.differenceType).includes(RuntimeDiffState.NEEDS_DELETE);
+  const updateMessaging = diffsToUpdateMessaging(runtimeDiffs);
 
   return <React.Fragment>
     <div style={styles.controlSection}>
@@ -759,28 +759,15 @@ const ConfirmUpdatePanel = ({initialRuntimeConfig, newRuntimeConfig, onCancel, u
       </FlexRow>
     </div>
 
-    <WarningMessage iconSize={30} iconPosition={'center'}>
-      <TextColumn>
-        {needsDelete ? <React.Fragment>
-          <div>
-            You've made changes that can only take effect upon deletion and re-creation of
-            your cloud environment.
-          </div>
-          <div style={{marginTop: '0.5rem'}}>
-            Any in-memory state and local file modifications will be erased. Data stored in
-            workspace buckets is never affected by changes to your cloud environment.
-          </div>
-        </React.Fragment> : <React.Fragment>
-          <div>
-            These changes require a reboot of your environment to take effect.
-          </div>
-          <div style={{marginTop: '0.5rem'}}>
-            Any in-memory state will be erased, but local file modifications will be preserved.
-            Data stored in workspace buckets is never affected by changes to your cloud environment.
-          </div>
-        </React.Fragment>}
-      </TextColumn>
-    </WarningMessage>
+    {updateMessaging.warn &&
+     <WarningMessage iconSize={30} iconPosition={'center'}>
+       <TextColumn>
+         <React.Fragment>
+           <div>{updateMessaging.warn}</div>
+           <div style={{marginTop: '0.5rem'}}>{updateMessaging.warnMore}</div>
+         </React.Fragment>
+       </TextColumn>
+     </WarningMessage>}
 
     <FlexRow style={{justifyContent: 'flex-end', marginTop: '.75rem'}}>
       <Button
@@ -876,7 +863,7 @@ export const RuntimePanel = fp.flow(
 
   const runtimeDiffs = getRuntimeConfigDiffs(initialRuntimeConfig, newRuntimeConfig);
   const runtimeChanged = runtimeExists && runtimeDiffs.length > 0;
-  const needsDelete = runtimeDiffs.map(diff => diff.differenceType).includes(RuntimeDiffState.NEEDS_DELETE);
+  const updateMessaging = diffsToUpdateMessaging(runtimeDiffs);
 
   const [creatorFreeCreditsRemaining, setCreatorFreeCreditsRemaining] = useState(null);
   useEffect(() => {
@@ -1035,7 +1022,7 @@ export const RuntimePanel = fp.flow(
         setRequestedRuntime(createRuntimeRequest(newRuntimeConfig));
         onClose();
       }}>
-      {needsDelete ? 'APPLY & RECREATE' : 'APPLY & REBOOT'}
+      {updateMessaging.applyAction}
     </Button>;
   };
 
@@ -1141,10 +1128,10 @@ export const RuntimePanel = fp.flow(
                }
              </FlexColumn>
            </div>
-           {runtimeExists && runtimeChanged &&
-             <WarningMessage iconSize={30} iconPosition={'center'}>
-                <div>You've made changes that require recreating your environment to take effect.</div>
-             </WarningMessage>
+           {runtimeExists && updateMessaging.warn &&
+            <WarningMessage iconSize={30} iconPosition={'center'}>
+              <div>{updateMessaging.warn}</div>
+            </WarningMessage>
            }
            {getErrorMessageContent().length > 0 &&
              <ErrorMessage iconSize={16} iconPosition={'top'} data-test-id={'runtime-error-messages'}>


### PR DESCRIPTION
Changes:
- Add a 3rd scenario on update: `CAN_UPDATE_IN_PLACE`; no warning is shown for this. Previous `CAN_UPDATE` becomes `CAN_UPDATE_WITH_REBOOT`
- Don't navigate from the Jupyter iframe during `UPDATING`, jupyter is still active during in-place updates
- Show alternate warning text on the customize page, depending on the update type
- Generalize the warning code
- Update some of the warning messages for consistency

![capture (1)](https://user-images.githubusercontent.com/822298/127080309-18647ba8-2c08-4ebb-9d02-76c69ef24fa3.gif)
