### PR TITLE
[RW-6373][risk = low]: Remove eRA Commons account linking. 

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -100,58 +100,6 @@ public class OfflineUserController implements OfflineUserApiDelegate {
   }
 
   /**
-   * Updates eRA Commons information for all users in the database.
-   *
-   * <p>This API method is called by a cron job and is not part of our normal user-facing surface.
-   */
-  @Override
-  public ResponseEntity<Void> bulkSyncEraCommonsStatus() {
-    int errorCount = 0;
-    int userCount = 0;
-    int completionChangeCount = 0;
-    int accessLevelChangeCount = 0;
-
-    for (DbUser user : userService.getAllUsersExcludingDisabled()) {
-      userCount++;
-      try {
-        // User accounts are registered with Terra on first sign-in. Users who have never signed in
-        // are therefore unusable for impersonated calls to Terra to check on their eRA commons
-        // status.
-        if (user.getFirstSignInTime() == null) {
-          continue;
-        }
-
-        Timestamp oldTime = user.getEraCommonsCompletionTime();
-        List<String> oldTiers = accessTierService.getAccessTierShortNamesForUser(user);
-
-        DbUser updatedUser =
-            userService.syncEraCommonsStatusUsingImpersonation(user, Agent.asSystem());
-
-        Timestamp newTime = updatedUser.getEraCommonsCompletionTime();
-        List<String> newTiers = accessTierService.getAccessTierShortNamesForUser(user);
-
-        completionChangeCount +=
-            logCompletionChange(user, oldTime, newTime, AccessModule.ERA_COMMONS);
-        accessLevelChangeCount += logAccessTierChange(user, oldTiers, newTiers);
-      } catch (org.pmiops.workbench.firecloud.ApiException e) {
-        errorCount++;
-        logSyncError(user, e, AccessModule.ERA_COMMONS);
-      } catch (IOException e) {
-        errorCount++;
-        log.severe(
-            String.format(
-                "Error fetching impersonated creds for user %s: %s",
-                user.getUsername(), e.getMessage()));
-      }
-    }
-
-    logChangeTotals(userCount, completionChangeCount, accessLevelChangeCount);
-    throwIfErrors(errorCount, AccessModule.ERA_COMMONS);
-
-    return ResponseEntity.noContent().build();
-  }
-
-  /**
    * Updates 2FA information for all users in the database.
    *
    * <p>This API method is called by a cron job and is not part of our normal user-facing surface.

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.api;
 
 import com.google.common.collect.ImmutableMap;
-import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.db.dao;
 
 import com.google.api.services.oauth2.model.Userinfoplus;
-import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -100,9 +100,6 @@ public interface UserService {
 
   DbUser syncEraCommonsStatus();
 
-  DbUser syncEraCommonsStatusUsingImpersonation(DbUser user, Agent agent)
-      throws IOException, org.pmiops.workbench.firecloud.ApiException;
-
   /**
    * Synchronize the 2FA enablement status of the currently signed-in user between the Workbench
    * database and the gsuite directory API. This may affect the user's enabled access tiers. This

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -901,39 +901,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     return setEraCommonsStatus(user, nihStatus, Agent.asUser(user));
   }
 
-  /**
-   * Syncs the eraCommons access module status for an arbitrary user.
-   *
-   * <p>This uses impersonated credentials and should only be called in the context of a cron job or
-   * a request from a user with elevated privileges.
-   *
-   * <p>Returns the updated User object.
-   */
-  @Override
-  public DbUser syncEraCommonsStatusUsingImpersonation(DbUser user, Agent agent)
-      throws IOException, org.pmiops.workbench.firecloud.ApiException {
-    if (isServiceAccount(user)) {
-      // Skip sync for service account user rows.
-      return user;
-    }
-
-    ApiClient apiClient = fireCloudService.getApiClientWithImpersonation(user.getUsername());
-    NihApi api = new NihApi(apiClient);
-    try {
-      FirecloudNihStatus nihStatus = api.nihStatus();
-      return setEraCommonsStatus(user, nihStatus, agent);
-    } catch (org.pmiops.workbench.firecloud.ApiException e) {
-      if (e.getCode() == HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
-        // We'll catch the NOT_FOUND ApiException here, since we expect many users to have an empty
-        // eRA Commons linkage.
-        log.info(String.format("NIH Status not found for user %s", user.getUsername()));
-        return user;
-      } else {
-        throw e;
-      }
-    }
-  }
-
   @Override
   public void syncTwoFactorAuthStatus() {
     DbUser user = userProvider.get();

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -2,13 +2,11 @@ package org.pmiops.workbench.db.dao;
 
 import static org.pmiops.workbench.access.AccessModuleServiceImpl.deriveExpirationTimestamp;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.services.oauth2.model.Userinfoplus;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
@@ -52,9 +50,7 @@ import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
-import org.pmiops.workbench.firecloud.ApiClient;
 import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.firecloud.api.NihApi;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.mail.MailService;

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1494,21 +1494,6 @@ paths:
           description: Internal Error
           schema:
             "$ref": "#/definitions/ErrorResponse"
-  "/v1/cron/bulkSyncEraCommonsStatus":
-    get:
-      security: []
-      tags:
-      - offlineUser
-      - cron
-      description: sync eRA Commons linkage status for all users.
-      operationId: bulkSyncEraCommonsStatus
-      responses:
-        204:
-          description: All users' eRA Commons statuses were updated.
-        500:
-          description: Internal Error
-          schema:
-            "$ref": "#/definitions/ErrorResponse"
   "/v1/cron/bulkSyncTwoFactorAuthStatus":
     get:
       security: []

--- a/api/src/main/webapp/WEB-INF/cron_base.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_base.yaml
@@ -13,13 +13,6 @@ cron:
   timezone: UTC
   target: api
 - description: >
-    Daily sync of eRA Commons linkage status (via FireCloud API). Records changes in the log,
-    but currently does not drive any downstream processes.
-  url: /v1/cron/bulkSyncEraCommonsStatus
-  schedule: every 24 hours
-  timezone: UTC
-  target: api
-- description: >
     Update our database cache of users' two-factor authentication settings on their GSuite accounts
     via Google Directory Service.
   url: /v1/cron/bulkSyncTwoFactorAuthStatus

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Functions;
-import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Arrays;

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
@@ -160,34 +160,4 @@ public class OfflineUserControllerTest extends SpringTest {
     }
     verify(mockUserService, times(2)).syncTwoFactorAuthStatus(any(), any(), eq(false));
   }
-
-  @Test
-  public void testBulkSyncEraCommonsStatus()
-      throws IOException, org.pmiops.workbench.firecloud.ApiException {
-    doAnswer(i -> i.getArgument(0))
-        .when(mockUserService)
-        .syncEraCommonsStatusUsingImpersonation(any(), any());
-    offlineUserController.bulkSyncEraCommonsStatus();
-    verify(mockUserService, times(3)).syncEraCommonsStatusUsingImpersonation(any(), any());
-  }
-
-  @Test
-  public void testBulkSyncEraCommonsStatusWithSingleUserError()
-      throws ApiException, NotFoundException, IOException,
-          org.pmiops.workbench.firecloud.ApiException {
-    assertThrows(
-        ServerErrorException.class,
-        () -> {
-          doAnswer(i -> i.getArgument(0))
-              .when(mockUserService)
-              .syncEraCommonsStatusUsingImpersonation(any(), any());
-          doThrow(new org.pmiops.workbench.firecloud.ApiException("Unknown error"))
-              .when(mockUserService)
-              .syncEraCommonsStatusUsingImpersonation(
-                  argThat(user -> user.getUsername().equals("a@fake-research-aou.org")), any());
-          offlineUserController.bulkSyncEraCommonsStatus();
-          // Even when a single call throws an exception, we call the service for all users.
-          verify(mockUserService, times(3)).syncEraCommonsStatusUsingImpersonation(any(), any());
-        });
-  }
 }


### PR DESCRIPTION
Description:
We will drop account syncing as that is a registration requirement. The RAS login only happens once, no future sync is needed. Because:

The existing cron job actually does not work for us. Terra has a daily job to sync with dpGap whitelist, and update Terra’s userinfo. Our cron job talks to Terra and updates user status in AoU. We only use expiration time, which is immutable in Terra. Terra’ cron job just update dbGap data permission, but not other field. 

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
