### PR TITLE
Revert "[RW-7073][noTicket]  Cohort description: Use cohort Id instead of cohort review Id"

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewService.java
@@ -122,6 +122,4 @@ public interface CohortReviewService {
 
   /** Find list of {@link Vocabulary}.* */
   List<Vocabulary> findVocabularies();
-
-  Long participationCount(DbCohort dbCohort);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2989,11 +2989,11 @@ paths:
           description: The Participant Chart data
           schema:
             "$ref": "#/definitions/ParticipantChartDataListResponse"
-  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/charts/{domain}":
+  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/charts/{domain}":
     parameters:
     - "$ref": "#/parameters/workspaceNamespace"
     - "$ref": "#/parameters/workspaceId"
-    - "$ref": "#/parameters/cohortId"
+    - "$ref": "#/parameters/cohortReviewId"
     get:
       tags:
       - cohortReview

--- a/ui/src/app/pages/data/cohort-review/participants-charts.tsx
+++ b/ui/src/app/pages/data/cohort-review/participants-charts.tsx
@@ -125,7 +125,7 @@ export const ParticipantsCharts = withCurrentWorkspace()(
 
     componentDidMount() {
       const {domain, review, workspace: {id, namespace}} = this.props;
-      cohortReviewApi().getCohortChartData(namespace, id, review.cohortId, domain, 10)
+      cohortReviewApi().getCohortChartData(namespace, id, review.cohortReviewId, domain, 10)
         .then(resp => {
           const data = resp.items.map(item => {
             this.nameRefs.push(React.createRef());

--- a/ui/src/app/pages/data/cohort-review/query-report.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/query-report.component.tsx
@@ -281,12 +281,12 @@ export const QueryReport = fp.flow(withCdrVersions(), withCurrentCohortReview(),
       const created = !!cohort ? moment(cohort.creationTime).format('YYYY-MM-DD') : null;
       return <React.Fragment>
         <style>{css}</style>
-        {cohortReview && cohortReview.cohortReviewId && <button
+        <button
           style={styles.backBtn}
           type='button'
           onClick={() => this.goBack()}>
           Back to review set
-        </button>}
+        </button>
         {reviewLoading && <SpinnerOverlay/>}
         {cohortReview && <div style={styles.reportBackground}>
           <div style={styles.container}>


### PR DESCRIPTION
Reverts all-of-us/workbench#5278

This [broke the BigQuery integration tests](https://app.circleci.com/pipelines/github/all-of-us/workbench/12248/workflows/f272777b-8c0a-4c0b-8333-680980a13749/jobs/153125). @freemabd noticed last week these weren't running on Circle, which is why presubmit did not catch these. That issue is now fixed, so rebasing and fixing forward will reveal the issue before merge.