### PR TITLE
[RW-7044][RW-7095][risk=moderate] Upgrade to latest Leo runtime image

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -10,7 +10,7 @@
     "leoBaseUrl": "https:\/\/leonardo.dsde-dev.broadinstitute.org",
     "xAppIdValue": "local-AoU-RW",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.1.5",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:2.0.1",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev",
     "runtimeImages": {

--- a/api/src/main/webapp/static/initialize_notebook_runtime.sh
+++ b/api/src/main/webapp/static/initialize_notebook_runtime.sh
@@ -8,16 +8,34 @@ set -x
 # API server and its path is passed in as jupyterUserScriptUri during notebook
 # runtime creation.
 
-# As of initial Workbench launch, we will not be offering or have a need for
-# Spark on notebooks runtimes. Disable the kernels to avoid presenting spurious
-# kernel options to researchers. See https://github.com/DataBiosphere/leonardo/issues/321.
-jupyter kernelspec uninstall -f pyspark2
-jupyter kernelspec uninstall -f pyspark3
-
 # Enable any built-in extensions. Snippets menu is used for AoU-specific code
 # snippet insertion, see README.md for more details.
-jupyter nbextension enable snippets_menu/main
+# Note: keep the command line invocation here in-sync with how Leo installs its
+# own default extensions: https://github.com/DataBiosphere/terra-docker/blob/master/terra-jupyter-base/scripts/extension/install_jupyter_contrib_nbextensions.sh
+sudo -E -u jupyter /opt/conda/bin/jupyter nbextension enable snippets_menu/main
 
 # Section represents the jupyter page to which the extension will be applied to
-jupyter nbextension enable aou-upload-policy-extension/main --section=tree
+sudo -E -u jupyter /opt/conda/bin/jupyter nbextension enable aou-upload-policy-extension/main --section=tree
 
+# Setup gitignore to avoid accidental checkin of data on AoU. Ideally this would be
+# configured on the image, per https://github.com/DataBiosphere/terra-docker/pull/234
+# but that's no longer possible as the home directory is mounted at runtime.
+ignore_file=/home/jupyter/gitignore_global
+cat <<EOF > ${ignore_file}
+# By default, all files should be ignored by git.
+# We want to be sure to exclude files containing data such as CSVs and images such as PNGs.
+*.*
+# Now, allow the file types that we do want to track via source control.
+!*.ipynb
+!*.py
+!*.r
+!*.R
+!*.wdl
+!*.sh
+# Allow documentation files.
+!*.md
+!*.rst
+!LICENSE*
+EOF
+chown jupyter:users ${ignore_file}
+git config --global core.excludesfile ${ignore_file}

--- a/e2e/resources/python-code/git-ignore-check.py
+++ b/e2e/resources/python-code/git-ignore-check.py
@@ -17,6 +17,8 @@
 
 actual = !cd /tmp/workbench-snippets/; git status
 
+print(actual)
+
 assert(any('should_be_visible' in s for s in actual))
 assert(not any('should_be_ignored' in s for s in actual))
 

--- a/e2e/resources/python-code/git-ignore-check.py
+++ b/e2e/resources/python-code/git-ignore-check.py
@@ -17,9 +17,9 @@
 ! touch /tmp/workbench-snippets/should_be_visible.rst
 ! touch /tmp/workbench-snippets/LICENSE.should_be_visible
 ! mkdir -p /tmp/workbench-snippets/some_directory/
-! cd /tmp/workbench-snippets/; git add some_directory
 ! touch /tmp/workbench-snippets/some_directory/should_be_ignored.CSV
 ! touch /tmp/workbench-snippets/some_directory/should_be_visible.sh
+! cd /tmp/workbench-snippets/; git add some_directory
 
 actual = !cd /tmp/workbench-snippets/; git status --porcelain
 

--- a/e2e/resources/python-code/git-ignore-check.py
+++ b/e2e/resources/python-code/git-ignore-check.py
@@ -1,3 +1,5 @@
+# Any git repo will do here, workbench-snippets is small and relevant to AoU's
+# notebook images.
 ! git clone https://github.com/all-of-us/workbench-snippets.git /tmp/workbench-snippets
 
 ! touch /tmp/workbench-snippets/should_be_ignored.png
@@ -11,15 +13,20 @@
 ! touch /tmp/workbench-snippets/should_be_visible.wdl
 ! touch /tmp/workbench-snippets/should_be_visible.sh
 ! touch /tmp/workbench-snippets/should_be_visible.md
-! mkdir -p /tmp/workbench-snippets/some_diretory/
-! touch /tmp/workbench-snippets/some_diretory/should_be_ignored.CSV
-! touch /tmp/workbench-snippets/some_diretory/should_be_visible.sh
+! touch /tmp/workbench-snippets/should_be_visible.ipynb
+! touch /tmp/workbench-snippets/should_be_visible.rst
+! touch /tmp/workbench-snippets/LICENSE.should_be_visible
+! mkdir -p /tmp/workbench-snippets/some_directory/
+! cd /tmp/workbench-snippets/; git add some_directory
+! touch /tmp/workbench-snippets/some_directory/should_be_ignored.CSV
+! touch /tmp/workbench-snippets/some_directory/should_be_visible.sh
 
-actual = !cd /tmp/workbench-snippets/; git status
+actual = !cd /tmp/workbench-snippets/; git status --porcelain
 
-print(actual)
+visible = list(filter(lambda s : 'should_be_visible' in s, actual))
+assert len(visible) == 10, f"wrong number of visible files ({len(visible)}): {visible}"
 
-assert(any('should_be_visible' in s for s in actual))
-assert(not any('should_be_ignored' in s for s in actual))
+ignored = list(filter(lambda s : 'should_be_ignored' in s, actual))
+assert len(ignored) == 0, f"found {len(ignored)} files which should have been ignored: {ignored}"
 
 print("success")

--- a/e2e/resources/python-code/git-ignore-check.py
+++ b/e2e/resources/python-code/git-ignore-check.py
@@ -1,0 +1,23 @@
+! git clone https://github.com/all-of-us/workbench-snippets.git /tmp/workbench-snippets
+
+! touch /tmp/workbench-snippets/should_be_ignored.png
+! touch /tmp/workbench-snippets/should_be_ignored.csv
+! touch /tmp/workbench-snippets/should_be_ignored.tsv
+! touch /tmp/workbench-snippets/should_be_ignored.CSV
+! touch /tmp/workbench-snippets/should_be_ignored.TSV
+! touch /tmp/workbench-snippets/should_be_visible.r
+! touch /tmp/workbench-snippets/should_be_visible.R
+! touch /tmp/workbench-snippets/should_be_visible.py
+! touch /tmp/workbench-snippets/should_be_visible.wdl
+! touch /tmp/workbench-snippets/should_be_visible.sh
+! touch /tmp/workbench-snippets/should_be_visible.md
+! mkdir -p /tmp/workbench-snippets/some_diretory/
+! touch /tmp/workbench-snippets/some_diretory/should_be_ignored.CSV
+! touch /tmp/workbench-snippets/some_diretory/should_be_visible.sh
+
+actual = !cd /tmp/workbench-snippets/; git status
+
+assert(any('should_be_visible' in s for s in actual))
+assert(not any('should_be_ignored' in s for s in actual))
+
+print("success")

--- a/e2e/tests/notebook/notebook-create-python.spec.ts
+++ b/e2e/tests/notebook/notebook-create-python.spec.ts
@@ -62,17 +62,20 @@ describe('Create python kernel notebook', () => {
     // toContain() is not a strong enough check: error text also includes "success" because it's in the code
     expect(cell2OutputText.endsWith('success')).toBeTruthy();
 
-    await notebook.runCodeCell(3, { codeFile: 'resources/python-code/simple-pyplot.py' });
+    const cell3OutputText = await notebook.runCodeCell(3, { codeFile: 'resources/python-code/git-ignore-check.py' });
+    expect(cell3OutputText.endsWith('success')).toBeTruthy();
+
+    await notebook.runCodeCell(4, { codeFile: 'resources/python-code/simple-pyplot.py' });
 
     // Verify plot is the output.
-    const cell = notebook.findCell(3);
+    const cell = notebook.findCell(4);
     const cellOutputElement = await cell.findOutputElementHandle();
     const [imgElement] = await cellOutputElement.$x('./img[@src]');
     expect(imgElement).toBeTruthy(); // plot format is a img.
 
     const codeSnippet = '!jupyter kernelspec list';
-    const codeSnippetOutput = await notebook.runCodeCell(4, { code: codeSnippet });
-    expect(codeSnippetOutput).toEqual(expect.stringContaining('/usr/local/share/jupyter/kernels/python3'));
+    const codeSnippetOutput = await notebook.runCodeCell(5, { code: codeSnippet });
+    expect(codeSnippetOutput).toEqual(expect.stringContaining('python3'));
 
     // Save, exit notebook then come back from Analysis page.
     await notebook.save();

--- a/e2e/tests/notebook/notebook-create-python.spec.ts
+++ b/e2e/tests/notebook/notebook-create-python.spec.ts
@@ -62,7 +62,10 @@ describe('Create python kernel notebook', () => {
     // toContain() is not a strong enough check: error text also includes "success" because it's in the code
     expect(cell2OutputText.endsWith('success')).toBeTruthy();
 
-    const cell3OutputText = await notebook.runCodeCell(3, { codeFile: 'resources/python-code/git-ignore-check.py' });
+    const cell3OutputText = await notebook.runCodeCell(3, {
+      codeFile: 'resources/python-code/git-ignore-check.py',
+      markdownWorkaround: true
+    });
     expect(cell3OutputText.endsWith('success')).toBeTruthy();
 
     await notebook.runCodeCell(4, { codeFile: 'resources/python-code/simple-pyplot.py' });


### PR DESCRIPTION
- Update nbextension interactions to be consistent with Leo's usage
- Drop kernel uninstalls, no longer do anything
- Reintegrate gitignore check applied here: https://github.com/DataBiosphere/terra-docker/pull/232/files#r666388427
- Add puppeteer coverage of gitignore interactions

Note: Puppeteer will fail on the last point, since this code change isn't pushed yet.

Puppeteer passes locally