### PR TITLE
[risk=no] Temporarily disable new puppeteer check while new image phases into test

### DIFF
--- a/e2e/tests/notebook/notebook-create-python.spec.ts
+++ b/e2e/tests/notebook/notebook-create-python.spec.ts
@@ -66,7 +66,7 @@ describe('Create python kernel notebook', () => {
       codeFile: 'resources/python-code/git-ignore-check.py',
       markdownWorkaround: true
     });
-    expect(cell3OutputText.endsWith('success')).toBeTruthy();
+    // TODO(RW-7044): Reintroduce success check after 8/1/21, to allow image upgrade to phase in.
 
     await notebook.runCodeCell(4, { codeFile: 'resources/python-code/simple-pyplot.py' });
 

--- a/e2e/tests/notebook/notebook-create-python.spec.ts
+++ b/e2e/tests/notebook/notebook-create-python.spec.ts
@@ -62,7 +62,7 @@ describe('Create python kernel notebook', () => {
     // toContain() is not a strong enough check: error text also includes "success" because it's in the code
     expect(cell2OutputText.endsWith('success')).toBeTruthy();
 
-    const cell3OutputText = await notebook.runCodeCell(3, {
+    await notebook.runCodeCell(3, {
       codeFile: 'resources/python-code/git-ignore-check.py',
       markdownWorkaround: true
     });


### PR DESCRIPTION
Unfortunately Puppeteer reuses old workspaces, so it  picks up older images sometimes. This will be alleviated after 3d in the test env (after 8/1/21).