### PR TITLE
[risk=no] Increase Leo read timeout for CLI to be consistent with API

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ManageLeonardoRuntimes.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ManageLeonardoRuntimes.java
@@ -42,7 +42,7 @@ import org.springframework.context.annotation.Configuration;
 public class ManageLeonardoRuntimes {
 
   private static final Logger log = Logger.getLogger(ManageLeonardoRuntimes.class.getName());
-  private static final String[] BILLING_SCOPES =
+  private static final String[] LEO_SCOPES =
       new String[] {
         "https://www.googleapis.com/auth/userinfo.profile",
         "https://www.googleapis.com/auth/userinfo.email"
@@ -61,7 +61,7 @@ public class ManageLeonardoRuntimes {
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(apiUrl);
     apiClient.setAccessToken(
-        ServiceAccounts.getScopedServiceAccessToken(Arrays.asList(BILLING_SCOPES)));
+        ServiceAccounts.getScopedServiceAccessToken(Arrays.asList(LEO_SCOPES)));
     apiClient.setReadTimeout(60 * 1000);
     RuntimesApi api = new RuntimesApi();
     api.setApiClient(apiClient);

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ManageLeonardoRuntimes.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ManageLeonardoRuntimes.java
@@ -62,7 +62,7 @@ public class ManageLeonardoRuntimes {
     apiClient.setBasePath(apiUrl);
     apiClient.setAccessToken(
         ServiceAccounts.getScopedServiceAccessToken(Arrays.asList(BILLING_SCOPES)));
-    apiClient.setDebugging(true);
+    apiClient.setReadTimeout(60 * 1000);
     RuntimesApi api = new RuntimesApi();
     api.setApiClient(apiClient);
     return api;


### PR DESCRIPTION
This was resulting in a read timeout on `./project.rb list-runtimes --project all-of-us-workbench-test`

Also turn off debugging, this shouldn't be on.