### PR TITLE
[no ticket][risk=no] e2e rework share user func

### DIFF
--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -146,23 +146,25 @@ export default class BaseElement {
       while (Date.now() - startTime < 30 * 1000) {
         const viewport = await element.isIntersectingViewport();
         if (viewport) {
-          const box = await element.boundingBox();
-          const x = box.x + box.width / 2;
-          const y = box.y + box.height / 2;
-          if (previousX !== undefined && previousY !== undefined) {
-            // tslint:disable:triple-equals
-            if (
-              parseFloat(previousX.toFixed(7)) === parseFloat(x.toFixed(7)) &&
-              parseFloat(previousY.toFixed(7)) === parseFloat(y.toFixed(7))
-            ) {
-              break;
+          const boundingBox = await element.boundingBox();
+          const boxModel = await element.boxModel();
+          if (boundingBox && boxModel) {
+            const x = boundingBox.x + boundingBox.width / 2;
+            const y = boundingBox.y + boundingBox.height / 2;
+            if (previousX !== undefined && previousY !== undefined) {
+              if (
+                parseFloat(previousX.toFixed(7)) === parseFloat(x.toFixed(7)) &&
+                parseFloat(previousY.toFixed(7)) === parseFloat(y.toFixed(7))
+              ) {
+                break;
+              }
             }
+            previousX = x;
+            previousY = y;
           }
-          previousX = x;
-          previousY = y;
         }
         await element.hover();
-        await this.page.waitForTimeout(200);
+        await this.page.waitForTimeout(500);
       }
       return element.click(options);
     });
@@ -321,7 +323,7 @@ export default class BaseElement {
   /**
    * Click on element then wait for page navigation to finish.
    */
-  async clickAndWait(timeout: number = 2 * 60 * 1000): Promise<void> {
+  async clickAndWait(timeout = 2 * 60 * 1000): Promise<void> {
     try {
       const navigationPromise = this.page.waitForNavigation({
         waitUntil: ['load', 'domcontentloaded', 'networkidle0'],
@@ -374,9 +376,9 @@ export default class BaseElement {
     return this.waitForXPath(waitOptions);
   }
 
-  async exists(): Promise<boolean> {
+  async exists(timeout = 2000): Promise<boolean> {
     return this.page
-      .waitForXPath(this.xpath, { visible: true, timeout: 2000 })
+      .waitForXPath(this.xpath, { visible: true, timeout })
       .then(() => {
         return true;
       })

--- a/e2e/app/modal/share-modal.ts
+++ b/e2e/app/modal/share-modal.ts
@@ -6,6 +6,7 @@ import Modal from './modal';
 import Button from 'app/element/button';
 import { ElementType } from 'app/xpath-options';
 import ClrIconLink from 'app/element/clr-icon-link';
+import { logger } from 'libs/logger';
 
 const modalText = 'share this workspace';
 
@@ -20,10 +21,20 @@ export default class ShareModal extends Modal {
   }
 
   async shareWithUser(userName: string, level: WorkspaceAccessLevel): Promise<void> {
+    const timeout = 5000;
+    const findCollaboratorAddIcon = (name) => {
+      return ClrIconLink.findByName(
+        this.page,
+        { type: ElementType.Icon, iconShape: 'plus-circle', containsText: name, ancestorLevel: 2 },
+        this
+      );
+    };
+    const addIcon = findCollaboratorAddIcon(userName);
+
     const dropDownXpath = this.getXpath() + '//*[@data-test-id="drop-down"][.//clr-icon[@shape="plus-circle"]]';
-    const existsDropDown = async (): Promise<boolean> => {
+    const existsDropDown = async (timeout): Promise<boolean> => {
       return this.page
-        .waitForXPath(dropDownXpath, { visible: true, timeout: 2000 })
+        .waitForXPath(dropDownXpath, { visible: true, timeout })
         .then(() => {
           return true;
         })
@@ -31,31 +42,30 @@ export default class ShareModal extends Modal {
           return false;
         });
     };
-    const waitForClose = async () => {
+
+    const waitForDropDownClose = async () => {
       await waitWhileLoading(this.page);
       await this.page.waitForXPath(dropDownXpath, { hidden: true });
     };
-    const findCollaboratorAddIcon = () => {
-      return ClrIconLink.findByName(
-        this.page,
-        { type: ElementType.Icon, iconShape: 'plus-circle', containsText: userName, ancestorLevel: 2 },
-        this
-      );
-    };
-    const pickUserRole = async () => {
-      const roleInput = await this.waitForRoleSelectorForUser(userName);
+
+    const pickUserRole = async (name) => {
+      const roleInput = await this.waitForRoleSelectorForUser(name);
       await roleInput.click();
       const ownerOpt = await this.waitForRoleOption(level);
       await ownerOpt.click();
     };
-    const typeAndAddUser = async (name): Promise<boolean> => {
-      const addIcon = findCollaboratorAddIcon();
-      for (const char of name) {
+
+    const typeAndAddUser = async (name: string): Promise<boolean> => {
+      const nameWithoutDomain = name.split('@')[0];
+      for (const char of nameWithoutDomain) {
         const input = await this.waitForSearchBox().asElementHandle();
-        await input.type(char, { delay: 50 });
-        if ((await existsDropDown()) && (await addIcon.exists())) {
+        await input.type(char, { delay: 20 });
+        const foundDropdown = await existsDropDown(timeout);
+        const foundAddIcon = await addIcon.exists(timeout);
+        if (foundDropdown && foundAddIcon) {
           await addIcon.click();
-          await waitForClose();
+          // Test playback runs fast. Wait until dropdown disappears so it is not interfering with next click.
+          await waitForDropDownClose();
           return true;
         }
       }
@@ -64,9 +74,11 @@ export default class ShareModal extends Modal {
 
     const isSuccess = await typeAndAddUser(userName);
     if (!isSuccess) {
-      throw new Error(`Failed to share with user ${userName}.`);
+      const errMsg = `Failed sharing workspace with user ${userName}.`;
+      logger.error(errMsg);
+      throw new Error(errMsg);
     }
-    await pickUserRole();
+    await pickUserRole(userName);
     await this.clickButton(LinkText.Save, { waitForClose: true });
   }
 

--- a/e2e/app/modal/share-modal.ts
+++ b/e2e/app/modal/share-modal.ts
@@ -22,7 +22,7 @@ export default class ShareModal extends Modal {
 
   async shareWithUser(userName: string, level: WorkspaceAccessLevel): Promise<void> {
     const timeout = 5000;
-    const findCollaboratorAddIcon = (name) => {
+    const findCollaboratorAddIcon = (name: string) => {
       return ClrIconLink.findByName(
         this.page,
         { type: ElementType.Icon, iconShape: 'plus-circle', containsText: name, ancestorLevel: 2 },
@@ -32,7 +32,7 @@ export default class ShareModal extends Modal {
     const addIcon = findCollaboratorAddIcon(userName);
 
     const dropDownXpath = this.getXpath() + '//*[@data-test-id="drop-down"][.//clr-icon[@shape="plus-circle"]]';
-    const existsDropDown = async (timeout): Promise<boolean> => {
+    const existsDropDown = async (timeout: number): Promise<boolean> => {
       return this.page
         .waitForXPath(dropDownXpath, { visible: true, timeout })
         .then(() => {
@@ -43,12 +43,12 @@ export default class ShareModal extends Modal {
         });
     };
 
-    const waitForDropDownClose = async () => {
+    const waitForDropDownClose = async (): Promise<void> => {
       await waitWhileLoading(this.page);
       await this.page.waitForXPath(dropDownXpath, { hidden: true });
     };
 
-    const pickUserRole = async (name) => {
+    const pickUserRole = async (name: string): Promise<void> => {
       const roleInput = await this.waitForRoleSelectorForUser(name);
       await roleInput.click();
       const ownerOpt = await this.waitForRoleOption(level);

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -32,10 +32,8 @@ export async function signInWithAccessToken(page: Page, tokenFilename = config.U
 
   // Once ready, initialize the token on the page (this is stored in local storage).
   // See sign-in.service.ts for details.
-  const navigationPromise = page.waitForNavigation({ waitUntil: ['load', 'networkidle0'] });
   await page.waitForFunction('!!window["setTestAccessTokenOverride"]');
   await page.evaluate(`window.setTestAccessTokenOverride('${token}')`);
-  await navigationPromise;
 
   // Force a page reload; auth will be re-initialized with the token now that
   // localstorage has been updated.


### PR DESCRIPTION
Failure e.g. [here](https://app.circleci.com/pipelines/github/all-of-us/workbench/12414/workflows/45610cea-bfec-4552-a40f-783d4bf35802/jobs/154309/tests).
Test failure was caused by not finding the dropdown in Share modal.

Also, remove call to flaky `waitForNavigation` method inside `signInWithAccessToken` method.