### PR TITLE
[RW-7145][risk=no] Add expect retry in e2e

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -79,6 +79,7 @@
     "ts-node": "^10.0.0",
     "tslib": "^2.3.0",
     "typescript": "^4.1.2",
+    "wait-for-expect": "^3.0.2",
     "winston": "^3.3.3"
   }
 }

--- a/e2e/tests/datasets/export-to-notebook.spec.ts
+++ b/e2e/tests/datasets/export-to-notebook.spec.ts
@@ -13,6 +13,7 @@ import DeleteConfirmationModal from 'app/modal/delete-confirmation-modal';
 import WarningDiscardChangesModal from 'app/modal/warning-discard-changes-modal';
 import ExportToNotebookModal from 'app/modal/export-to-notebook-modal';
 import { TabLabels } from 'app/page/workspace-base';
+import waitForExpect from 'wait-for-expect';
 
 // 30 minutes. Test involves starting of notebook that could take a long time to create.
 jest.setTimeout(30 * 60 * 1000);
@@ -73,7 +74,9 @@ describe('Export dataset to notebook tests', () => {
 
     // Associated dataset is gone after delete cohort.
     await dataPage.openTab(TabLabels.Datasets, { waitPageChange: false });
-    expect(await new DataResourceCard(page).cardExists(datasetName, ResourceCard.Dataset)).toBe(false);
+    await waitForExpect(async () => {
+      expect(await new DataResourceCard(page).cardExists(datasetName, ResourceCard.Dataset)).toBe(false);
+    });
   });
 
   /**

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -5963,6 +5963,11 @@ w3c-xmlserializer@^2.0.0:
   dependencies:
     xml-name-validator "^3.0.0"
 
+wait-for-expect@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
+  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
+
 wait-on@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-3.3.0.tgz#9940981d047a72a9544a97b8b5fca45b2170a082"


### PR DESCRIPTION
Adding [wait-for-expect](https://github.com/TheBrainFamily/wait-for-expect) dev dependency to automatically retry `expect` until true or time out.