### PR TITLE
[no ticket][risk=no] e2e wait for request

### DIFF
--- a/e2e/app/modal/share-modal.ts
+++ b/e2e/app/modal/share-modal.ts
@@ -59,7 +59,12 @@ export default class ShareModal extends Modal {
       const nameWithoutDomain = name.split('@')[0];
       for (const char of nameWithoutDomain) {
         const input = await this.waitForSearchBox().asElementHandle();
-        await input.type(char, { delay: 20 });
+        const waitForResponsePromise = this.page.waitForResponse((response) => {
+          return response.url().includes('/userSearch/registered/') && response.request().method() === 'GET'
+        });
+        await input.type(char);
+        // Wait for GET /userSearch request to finish. Sometimes it takes several seconds.
+        await waitForResponsePromise;
         const foundDropdown = await existsDropDown(timeout);
         const foundAddIcon = await addIcon.exists(timeout);
         if (foundDropdown && foundAddIcon) {


### PR DESCRIPTION
Explicitly wait for `/userSearch` request to finish immediately after type a character in Name Search textbox. Because request can take a short while to finish. Long request time subsequently causes the e2e tests to have unexpected results.

e.g.

```
[7/29/2021, 21:09:32] - Request issued: GET https://api-dot-all-of-us-workbench-test.appspot.com/v1/userSearch/registered/puppeteer-reader-1%40fake-research-ao

[7/29/2021, 21:09:37] - Request finished: 200 GET https://api-dot-all-of-us-workbench-test.appspot.com/v1/userSearch/registered/puppeteer-reader-1%40fake-research-ao

```