### PR TITLE
[no ticket][risk=no] Improve circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,6 +628,12 @@ workflows:
       #  puppeteer-test, api-deploy-to-test or/and ui-deploy-to-test jobs.
       - wait_until_previous_workflow_done:
           <<: *filter-master-branch
+          requires:
+            - api-local-test
+            - api-unit-test
+            - ui-unit-test
+            - api-bigquery-test
+            - api-integration-test
       # Always run basic test/lint/compilation (open PRs, master branch merge)
       # Note: by default tags are not picked up.
       - api-local-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -629,11 +629,8 @@ workflows:
       - wait_until_previous_workflow_done:
           <<: *filter-master-branch
           requires:
-            - api-local-test
             - api-unit-test
             - ui-unit-test
-            - api-bigquery-test
-            - api-integration-test
       # Always run basic test/lint/compilation (open PRs, master branch merge)
       # Note: by default tags are not picked up.
       - api-local-test


### PR DESCRIPTION
`wait_until_previous_workflow_done` should wait for `api-unit-test` and `ui-unit-test` jobs both finish successfully first before start. Because `api-deploy-to-test` requires `api-unit-test` and `ui-deploy-to-test` requires `ui-unit-test`. Without the waiting, `wait_until_previous_workflow_done` job finishes too soon: long before start of `ui-deploy-to-test` or `api-deploy-to-test` job.
