### PR TITLE
[RW-7095][RW-7147][risk=low] Re-enable nbstripout, upgrade image in all envs

### DIFF
--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -10,7 +10,7 @@
     "leoBaseUrl": "https:\/\/leonardo.dsde-perf.broadinstitute.org",
     "xAppIdValue": "perf-AoU-RW",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.1.5",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:2.0.1",
     "shibbolethApiBaseUrl": "",
     "shibbolethUiBaseUrl": "",
     "runtimeImages": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -10,7 +10,7 @@
     "leoBaseUrl": "https:\/\/notebooks.firecloud.org",
     "xAppIdValue": "preprod-AoU-RW",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.1.5",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:2.0.1",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
     "runtimeImages": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -10,7 +10,7 @@
     "leoBaseUrl": "https:\/\/notebooks.firecloud.org",
     "xAppIdValue": "AoU-RW",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.1.5",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:2.0.1",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
     "runtimeImages": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -10,7 +10,7 @@
     "leoBaseUrl": "https:\/\/notebooks.firecloud.org",
     "xAppIdValue": "stable-AoU-RW",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.1.5",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:2.0.1",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
     "runtimeImages": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -10,7 +10,7 @@
     "leoBaseUrl": "https:\/\/notebooks.firecloud.org",
     "xAppIdValue": "staging-AoU-RW",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.1.5",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:2.0.1",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
     "runtimeImages": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -10,7 +10,7 @@
     "leoBaseUrl": "https:\/\/leonardo.dsde-dev.broadinstitute.org",
     "xAppIdValue": "test-AoU-RW",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:1.1.5",
+    "jupyterDockerImage": "broadinstitute/terra-jupyter-aou:2.0.1",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev",
     "runtimeImages": {

--- a/api/src/main/webapp/static/initialize_notebook_runtime.sh
+++ b/api/src/main/webapp/static/initialize_notebook_runtime.sh
@@ -17,6 +17,8 @@ sudo -E -u jupyter /opt/conda/bin/jupyter nbextension enable snippets_menu/main
 # Section represents the jupyter page to which the extension will be applied to
 sudo -E -u jupyter /opt/conda/bin/jupyter nbextension enable aou-upload-policy-extension/main --section=tree
 
+nbstripout --install --global
+
 # Setup gitignore to avoid accidental checkin of data on AoU. Ideally this would be
 # configured on the image, per https://github.com/DataBiosphere/terra-docker/pull/234
 # but that's no longer possible as the home directory is mounted at runtime.

--- a/e2e/resources/python-code/git-ignore-check.py
+++ b/e2e/resources/python-code/git-ignore-check.py
@@ -1,6 +1,6 @@
 # Any git repo will do here, workbench-snippets is small and relevant to AoU's
 # notebook images.
-! git clone https://github.com/all-of-us/workbench-snippets.git /tmp/workbench-snippets
+! [ -d /tmp/workbench-snippets/ ] || git clone https://github.com/all-of-us/workbench-snippets /tmp/workbench-snippets
 
 ! touch /tmp/workbench-snippets/should_be_ignored.png
 ! touch /tmp/workbench-snippets/should_be_ignored.csv
@@ -28,5 +28,7 @@ assert len(visible) == 10, f"wrong number of visible files ({len(visible)}): {vi
 
 ignored = list(filter(lambda s : 'should_be_ignored' in s, actual))
 assert len(ignored) == 0, f"found {len(ignored)} files which should have been ignored: {ignored}"
+
+! cd /tmp/workbench-snippets/; git reset HEAD; git clean -f
 
 print("success")

--- a/e2e/resources/python-code/nbstripoutput-filter.py
+++ b/e2e/resources/python-code/nbstripoutput-filter.py
@@ -2,40 +2,36 @@
 # notebook images.
 ! [ -d /tmp/workbench-snippets/ ] || git clone https://github.com/all-of-us/workbench-snippets /tmp/workbench-snippets
 
-import json
-
-
-
-nb = '''
-{
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "97f5ae46",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "my outputs\\r\\n"
-          ]
-        }
-      ],
-      "source": [
-        "!./script.sh my inputs"
-      ]
-    }
-  ],
-  "metadata": {},
-  "nbformat": 4,
-  "nbformat_minor": 5
-}
-'''
+# Jupyter is very finnicky with input formatting, even in Markdown mode.
+# Dictionaries and triple quotes both fail due to Markdown auto-indent.
+nb = ('{'
+'  "cells": ['
+'    {'
+'      "cell_type": "code",'
+'      "execution_count": 1,'
+'      "id": "97f5ae46",'
+'      "metadata": {},'
+'      "outputs": ['
+'        {'
+'          "name": "stdout",'
+'          "output_type": "stream",'
+'          "text": ['
+'            "my outputs\\r\\n"'
+'          ]'
+'        }'
+'      ],'
+'      "source": ['
+'        "!./script.sh my inputs"'
+'      ]'
+'    }'
+'  ],'
+'  "metadata": {},'
+'  "nbformat": 4,'
+'  "nbformat_minor": 5'
+'}')
 
 with open('/tmp/workbench-snippets/notebook.ipynb', 'w') as f:
-  file.write(nb)
+  f.write(nb)
 
 ! cd /tmp/workbench-snippets; git add notebook.ipynb
 lines = !cd /tmp/workbench-snippets/; git diff --staged

--- a/e2e/resources/python-code/nbstripoutput-filter.py
+++ b/e2e/resources/python-code/nbstripoutput-filter.py
@@ -4,34 +4,35 @@
 
 # Jupyter is very finnicky with input formatting, even in Markdown mode.
 # Dictionaries and triple quotes both fail due to Markdown auto-indent.
-nb = ('{'
-'  "cells": ['
-'    {'
-'      "cell_type": "code",'
-'      "execution_count": 1,'
-'      "id": "97f5ae46",'
-'      "metadata": {},'
-'      "outputs": ['
-'        {'
-'          "name": "stdout",'
-'          "output_type": "stream",'
-'          "text": ['
-'            "my outputs\\r\\n"'
-'          ]'
-'        }'
-'      ],'
-'      "source": ['
-'        "!./script.sh my inputs"'
-'      ]'
-'    }'
-'  ],'
-'  "metadata": {},'
-'  "nbformat": 4,'
-'  "nbformat_minor": 5'
+nb = ('{\n'
+'  "cells": [\n'
+'    {\n'
+'      "cell_type": "code",\n'
+'      "execution_count": 1,\n'
+'      "id": "97f5ae46",\n'
+'      "metadata": {},\n'
+'      "outputs": [\n'
+'        {\n'
+'          "name": "stdout",\n'
+'          "output_type": "stream",\n'
+'          "text": [\n'
+'            "my outputs\\r\\n"\n'
+'          ]\n'
+'        }\n'
+'      ],\n'
+'      "source": [\n'
+'        "!./script.sh my inputs"\n'
+'      ]\n'
+'    }\n'
+'  ],\n'
+'  "metadata": {},\n'
+'  "nbformat": 4,\n'
+'  "nbformat_minor": 5\n'
 '}')
 
-with open('/tmp/workbench-snippets/notebook.ipynb', 'w') as f:
-  f.write(nb)
+f = open('/tmp/workbench-snippets/notebook.ipynb', 'w')
+f.write(nb)
+f.close()
 
 ! cd /tmp/workbench-snippets; git add notebook.ipynb
 lines = !cd /tmp/workbench-snippets/; git diff --staged

--- a/e2e/resources/python-code/nbstripoutput-filter.py
+++ b/e2e/resources/python-code/nbstripoutput-filter.py
@@ -1,0 +1,45 @@
+# Any git repo will do here, workbench-snippets is small and relevant to AoU's
+# notebook images.
+! [ -d /tmp/workbench-snippets/ ] || git clone https://github.com/all-of-us/workbench-snippets /tmp/workbench-snippets
+
+import json
+
+nb = {
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "97f5ae46",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "my outputs\r\n"
+          ]
+        }
+      ],
+      "source": [
+        "!./script.sh my inputs"
+      ]
+    }
+  ],
+  "metadata": {},
+  "nbformat": 4,
+  "nbformat_minor": 5
+}
+
+with open('/tmp/workbench-snippets/notebook.ipynb', 'w') as f:
+  json.dump(nb, f)
+
+! cd /tmp/workbench-snippets; git add notebook.ipynb
+lines = !cd /tmp/workbench-snippets/; git diff --staged
+actual = '\n'.join(lines)
+
+assert 'my inputs' in actual, f"notebook should still contain source, got {actual}"
+assert 'my outputs' not in actual, f"notebook should omit outputs, got {actual}"
+
+! cd /tmp/workbench-snippets/; git reset HEAD; git clean -f
+
+print("success")

--- a/e2e/resources/python-code/nbstripoutput-filter.py
+++ b/e2e/resources/python-code/nbstripoutput-filter.py
@@ -4,7 +4,10 @@
 
 import json
 
-nb = {
+
+
+nb = '''
+{
   "cells": [
     {
       "cell_type": "code",
@@ -16,7 +19,7 @@ nb = {
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "my outputs\r\n"
+            "my outputs\\r\\n"
           ]
         }
       ],
@@ -29,9 +32,10 @@ nb = {
   "nbformat": 4,
   "nbformat_minor": 5
 }
+'''
 
 with open('/tmp/workbench-snippets/notebook.ipynb', 'w') as f:
-    json.dump(nb, f)
+  file.write(nb)
 
 ! cd /tmp/workbench-snippets; git add notebook.ipynb
 lines = !cd /tmp/workbench-snippets/; git diff --staged

--- a/e2e/resources/python-code/nbstripoutput-filter.py
+++ b/e2e/resources/python-code/nbstripoutput-filter.py
@@ -31,7 +31,7 @@ nb = {
 }
 
 with open('/tmp/workbench-snippets/notebook.ipynb', 'w') as f:
-  json.dump(nb, f)
+    json.dump(nb, f)
 
 ! cd /tmp/workbench-snippets; git add notebook.ipynb
 lines = !cd /tmp/workbench-snippets/; git diff --staged

--- a/e2e/tests/notebook/notebook-create-python.spec.ts
+++ b/e2e/tests/notebook/notebook-create-python.spec.ts
@@ -83,7 +83,7 @@ describe('Create python kernel notebook', () => {
     expect(imgElement).toBeTruthy(); // plot format is a img.
 
     const codeSnippet = '!jupyter kernelspec list';
-    const codeSnippetOutput = await notebook.runCodeCell(5, { code: codeSnippet });
+    const codeSnippetOutput = await notebook.runCodeCell(6, { code: codeSnippet });
     expect(codeSnippetOutput).toEqual(expect.stringContaining('python3'));
 
     // Save, exit notebook then come back from Analysis page.

--- a/e2e/tests/notebook/notebook-create-python.spec.ts
+++ b/e2e/tests/notebook/notebook-create-python.spec.ts
@@ -54,24 +54,30 @@ describe('Create python kernel notebook', () => {
     const kernelName = await notebook.getKernelName();
     expect(kernelName).toBe('Python 3');
 
-    const cell1OutputText = await notebook.runCodeCell(1, { codeFile: 'resources/python-code/import-os.py' });
+    const cell1OutputText = await notebook.runCodeCell(1, {
+      codeFile: 'resources/python-code/import-os.py'
+    });
     // toContain() is not a strong enough check: error text also includes "success" because it's in the code
-    expect(cell1OutputText.endsWith('success')).toBeTruthy();
+    expect(cell1OutputText).toMatch(/success$/);
 
-    const cell2OutputText = await notebook.runCodeCell(2, { codeFile: 'resources/python-code/import-libs.py' });
-    // toContain() is not a strong enough check: error text also includes "success" because it's in the code
-    expect(cell2OutputText.endsWith('success')).toBeTruthy();
+    expect(await notebook.runCodeCell(2, {
+      codeFile: 'resources/python-code/import-libs.py'
+    })).toMatch(/success$/);
 
-    await notebook.runCodeCell(3, {
+    expect(await notebook.runCodeCell(3, {
       codeFile: 'resources/python-code/git-ignore-check.py',
       markdownWorkaround: true
-    });
-    // TODO(RW-7044): Reintroduce success check after 8/1/21, to allow image upgrade to phase in.
+    })).toMatch(/success$/);
 
-    await notebook.runCodeCell(4, { codeFile: 'resources/python-code/simple-pyplot.py' });
+    expect(await notebook.runCodeCell(4, {
+      codeFile: 'resources/python-code/nbstripoutput-filter.py',
+      markdownWorkaround: true
+    })).toMatch(/success$/);
+
+    await notebook.runCodeCell(5, { codeFile: 'resources/python-code/simple-pyplot.py' });
 
     // Verify plot is the output.
-    const cell = notebook.findCell(4);
+    const cell = notebook.findCell(5);
     const cellOutputElement = await cell.findOutputElementHandle();
     const [imgElement] = await cellOutputElement.$x('./img[@src]');
     expect(imgElement).toBeTruthy(); // plot format is a img.


### PR DESCRIPTION
- Missed the nbstripout requirement from https://github.com/DataBiosphere/terra-docker/pull/232/files , reinstalled this in the initialization script.
- Added test coverage
- Actually upgrade all the images to the latest, meant to do this last week. Disagreement between script and image resulted in a broken snippets menu install.

This time, I will plan to simply manually delete all conflicting puppeteer runtimes in the test env to get puppeteer passing post-merge.

Puppeteer tests pass locally, they will fail on test.