### PR TITLE
[RW-4780][risk=low]: Ignore case when comparing user contact email with institution domains or addresses

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -248,8 +248,8 @@ public class InstitutionServiceImpl implements InstitutionService {
         break;
       case ADDRESSES:
         validated =
-            getEmailAddressesByTierOrEmptySet(institution, accessTierShortName)
-                .contains(contactEmail);
+            getEmailAddressesByTierOrEmptySet(institution, accessTierShortName).stream()
+                .anyMatch(contactEmail::equalsIgnoreCase);
         logMsg =
             String.format(
                 "Contact email '%s' validated against '%s' tier with ADDRESSES requirement: "
@@ -262,8 +262,8 @@ public class InstitutionServiceImpl implements InstitutionService {
       case DOMAINS:
         final String contactEmailDomain = contactEmail.substring(contactEmail.indexOf("@") + 1);
         validated =
-            getEmailDomainsByTierOrEmptySet(institution, accessTierShortName)
-                .contains(contactEmailDomain);
+            getEmailDomainsByTierOrEmptySet(institution, accessTierShortName).stream()
+                .anyMatch(contactEmailDomain::equalsIgnoreCase);
         logMsg =
             String.format(
                 "Contact email '%s' validated against '%s' tier with DOMAINS requirement '%s': "

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -443,6 +443,29 @@ public class InstitutionServiceTest extends SpringTest {
   }
 
   @Test
+  public void test_emailValidation_address_ignoreCase() {
+    final Institution inst =
+        service.createInstitution(
+            new Institution()
+                .shortName("Broad")
+                .displayName("The Broad Institute")
+                .organizationTypeEnum(OrganizationType.ACADEMIC_RESEARCH_INSTITUTION)
+                .tierConfigs(
+                    ImmutableList.of(
+                        rtTierConfig
+                            .membershipRequirement(InstitutionMembershipRequirement.ADDRESSES)
+                            .eraRequired(false)
+                            .accessTierShortName(registeredTier.getShortName())
+                            .emailDomains(ImmutableList.of("broad.org", "verily.com"))
+                            .emailAddresses(
+                                ImmutableList.of(
+                                    "EXternal-rEsearcher@sanger.UK", "science@aol.com")))));
+    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk")).isTrue();
+    // Fail even when domain matches, because the requirement is ADDRESSES.
+    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com")).isFalse();
+  }
+
+  @Test
   public void test_emailValidation_null_address() {
     final Institution inst =
         service.createInstitution(
@@ -478,6 +501,32 @@ public class InstitutionServiceTest extends SpringTest {
                             .eraRequired(false)
                             .accessTierShortName(registeredTier.getShortName())
                             .emailDomains(ImmutableList.of("broad.org", "verily.com"))
+                            .emailAddresses(
+                                ImmutableList.of(
+                                    "external-researcher@sanger.uk", "science@aol.com")))));
+
+    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com")).isTrue();
+    // malformed
+    assertThat(service.validateInstitutionalEmail(inst, "yy@hacker@verily.org")).isFalse();
+    // Fail even when domain matches, because the requirement is DOMAINS.
+    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk")).isFalse();
+  }
+
+  @Test
+  public void test_emailValidation_domain_ignoreCase() {
+    final Institution inst =
+        service.createInstitution(
+            new Institution()
+                .shortName("Broad")
+                .displayName("The Broad Institute")
+                .organizationTypeEnum(OrganizationType.ACADEMIC_RESEARCH_INSTITUTION)
+                .tierConfigs(
+                    ImmutableList.of(
+                        rtTierConfig
+                            .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
+                            .eraRequired(false)
+                            .accessTierShortName(registeredTier.getShortName())
+                            .emailDomains(ImmutableList.of("BROAD.org", "verily.COM"))
                             .emailAddresses(
                                 ImmutableList.of(
                                     "external-researcher@sanger.uk", "science@aol.com")))));


### PR DESCRIPTION
Description:
Seems contact email in user table is case sensitive but we should ignore the case when doing institution tier access check.

Detailed doc:
https://docs.google.com/document/d/12WurIIiXwTV7xj91otZzfFYh9J2mAtSg-i4NwbxLqaY/edit#

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
