### PR TITLE
[no ticket] Change v2_billing APIs' interface according to recent FireCloud change

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -33,6 +33,7 @@ import org.pmiops.workbench.firecloud.api.WorkspacesApi;
 import org.pmiops.workbench.firecloud.model.FirecloudBillingProjectMembership;
 import org.pmiops.workbench.firecloud.model.FirecloudBillingProjectStatus;
 import org.pmiops.workbench.firecloud.model.FirecloudCreateRawlsBillingProjectFullRequest;
+import org.pmiops.workbench.firecloud.model.FirecloudCreateRawlsV2BillingProjectFullRequest;
 import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupRef;
 import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupWithMembers;
 import org.pmiops.workbench.firecloud.model.FirecloudMe;
@@ -257,16 +258,12 @@ public class FireCloudServiceImpl implements FireCloudService {
               projectName, WORKSPACE_DELIMITER));
     }
 
-    FirecloudCreateRawlsBillingProjectFullRequest request =
-        new FirecloudCreateRawlsBillingProjectFullRequest()
-            .billingAccount(configProvider.get().billing.freeTierBillingAccountName())
-            .projectName(projectName)
-            .highSecurityNetwork(true)
-            .enableFlowLogs(true)
-            .privateIpGoogleAccess(true)
-            .servicePerimeter(servicePerimeter);
-
     if (isFireCloudBillingV2ApiEnabled()) {
+      FirecloudCreateRawlsV2BillingProjectFullRequest request =
+          new FirecloudCreateRawlsV2BillingProjectFullRequest()
+              .billingAccount(configProvider.get().billing.freeTierBillingAccountName())
+              .projectName(projectName)
+              .servicePerimeter(servicePerimeter);
       BillingV2Api billingV2Api = serviceAccountBillingV2ApiProvider.get();
       retryHandler.run(
           (context) -> {
@@ -274,6 +271,14 @@ public class FireCloudServiceImpl implements FireCloudService {
             return null;
           });
     } else {
+      FirecloudCreateRawlsBillingProjectFullRequest request =
+          new FirecloudCreateRawlsBillingProjectFullRequest()
+              .billingAccount(configProvider.get().billing.freeTierBillingAccountName())
+              .projectName(projectName)
+              .highSecurityNetwork(true)
+              .enableFlowLogs(true)
+              .privateIpGoogleAccess(true)
+              .servicePerimeter(servicePerimeter);
       BillingApi billingApi = billingApiProvider.get();
       retryHandler.run(
           (context) -> {

--- a/api/src/main/resources/firecloud.yaml
+++ b/api/src/main/resources/firecloud.yaml
@@ -101,7 +101,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/CreateRawlsBillingProjectFullRequest'
+              $ref: '#/components/schemas/CreateRawlsV2BillingProjectFullRequest'
         required: true
       responses:
         201:
@@ -1854,6 +1854,25 @@ components:
         allUsersGroup:
           type: boolean
           description: User is a member of the "All Users" group?
+    CreateRawlsV2BillingProjectFullRequest:
+      required:
+        - billingAccount
+        - projectName
+      type: object
+      properties:
+        projectName:
+          type: string
+          description: the name of the project to create
+        billingAccount:
+          type: string
+          description: the id of the billing account to use, must start with 'billingAccounts/'
+        servicePerimeter:
+          type: string
+          description: The fully qualified name of the GCP service perimeter to put
+            this project into in the form accessPolicies/[POLICY NUMBER]/servicePerimeters/[NAME].
+            Caller must have the add_project action for this service perimeter in
+            Sam.
+      description: ""
     ErrorReport:
       required:
         - causes
@@ -2748,6 +2767,21 @@ components:
           items:
             type: string
           description: the roles the caller has on the project
+        workspacesWithIncorrectBillingAccount:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkspaceBillingAccount'
+    WorkspaceBillingAccount:
+      required:
+        - workspaceName
+      type: object
+      properties:
+        workspaceName:
+          type: string
+          description: the name of the workspace
+        currentBillingAccountOnGoogleProject:
+          type: string
+          description: the billing project associated with the workspace
     UpdateRawlsBillingAccountRequest:
       required:
         - billingAccount

--- a/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
@@ -31,6 +31,7 @@ import org.pmiops.workbench.firecloud.api.NihApi;
 import org.pmiops.workbench.firecloud.api.ProfileApi;
 import org.pmiops.workbench.firecloud.api.StatusApi;
 import org.pmiops.workbench.firecloud.model.FirecloudCreateRawlsBillingProjectFullRequest;
+import org.pmiops.workbench.firecloud.model.FirecloudCreateRawlsV2BillingProjectFullRequest;
 import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupWithMembers;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.firecloud.model.FirecloudSystemStatus;
@@ -244,10 +245,10 @@ public class FireCloudServiceImplTest extends SpringTest {
 
     service.createAllOfUsBillingProject("project-name", servicePerimeter);
 
-    ArgumentCaptor<FirecloudCreateRawlsBillingProjectFullRequest> captor =
-        ArgumentCaptor.forClass(FirecloudCreateRawlsBillingProjectFullRequest.class);
+    ArgumentCaptor<FirecloudCreateRawlsV2BillingProjectFullRequest> captor =
+        ArgumentCaptor.forClass(FirecloudCreateRawlsV2BillingProjectFullRequest.class);
     verify(billingV2Api).createBillingProjectFullV2(captor.capture());
-    FirecloudCreateRawlsBillingProjectFullRequest request = captor.getValue();
+    FirecloudCreateRawlsV2BillingProjectFullRequest request = captor.getValue();
 
     // N.B. FireCloudServiceImpl doesn't add the project prefix; this is done by callers such
     // as BillingProjectBufferService.
@@ -255,8 +256,6 @@ public class FireCloudServiceImplTest extends SpringTest {
     // FireCloudServiceImpl always adds the "billingAccounts/" prefix to the billing account
     // from config.
     assertThat(request.getBillingAccount()).isEqualTo("billingAccounts/test-billing-account");
-    assertThat(request.isEnableFlowLogs()).isTrue();
-    assertThat(request.isHighSecurityNetwork()).isTrue();
     assertThat(request.getServicePerimeter()).isEqualTo(servicePerimeter);
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/CreateWgsCohortExtractionBillingProjectWorkspace.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/CreateWgsCohortExtractionBillingProjectWorkspace.java
@@ -25,6 +25,7 @@ import org.pmiops.workbench.firecloud.api.BillingApi;
 import org.pmiops.workbench.firecloud.api.BillingV2Api;
 import org.pmiops.workbench.firecloud.model.FirecloudBillingProjectStatus;
 import org.pmiops.workbench.firecloud.model.FirecloudCreateRawlsBillingProjectFullRequest;
+import org.pmiops.workbench.firecloud.model.FirecloudCreateRawlsV2BillingProjectFullRequest;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspace;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceIngest;
@@ -126,16 +127,19 @@ public class CreateWgsCohortExtractionBillingProjectWorkspace {
       ApiClientFactory apiClientFactory =
           wgsCohortExtractionServiceAccountApiClientFactory(workbenchConfig);
 
-      FirecloudCreateRawlsBillingProjectFullRequest billingProjectRequest =
-          new FirecloudCreateRawlsBillingProjectFullRequest()
-              .billingAccount("billingAccounts/" + workbenchConfig.billing.accountId)
-              .projectName(opts.getOptionValue(billingProjectNameOpt.getLongOpt()));
-
       log.info("Creating billing project");
       if (workbenchConfig.featureFlags.enableFireCloudV2Billing) {
+        FirecloudCreateRawlsV2BillingProjectFullRequest billingProjectRequest =
+            new FirecloudCreateRawlsV2BillingProjectFullRequest()
+                .billingAccount("billingAccounts/" + workbenchConfig.billing.accountId)
+                .projectName(opts.getOptionValue(billingProjectNameOpt.getLongOpt()));
         BillingV2Api billingV2Api = apiClientFactory.billingV2Api();
         billingV2Api.createBillingProjectFullV2(billingProjectRequest);
       } else {
+        FirecloudCreateRawlsBillingProjectFullRequest billingProjectRequest =
+            new FirecloudCreateRawlsBillingProjectFullRequest()
+                .billingAccount("billingAccounts/" + workbenchConfig.billing.accountId)
+                .projectName(opts.getOptionValue(billingProjectNameOpt.getLongOpt()));
         BillingApi billingApi = apiClientFactory.billingApi();
         billingApi.createBillingProjectFull(billingProjectRequest);
 


### PR DESCRIPTION
Description:
Recently I notice there is https://github.com/broadinstitute/firecloud-orchestration/pull/867 
that may break our v2_billing API. 
This PR also update the `getBilliungProject` but it is not used by us yet. This PR just fix breakage for `creatBillingProject` to unblock our upcoming PPW integration testing. 
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
