### PR TITLE
[no ticket][risk=no] Update e2e night tests

### DIFF
--- a/e2e/tests/nightly/dataproc-to-gce.spec.ts
+++ b/e2e/tests/nightly/dataproc-to-gce.spec.ts
@@ -7,8 +7,6 @@ import { createWorkspace, signInWithAccessToken } from 'utils/test-utils';
 
 // This test could take a long time to run
 jest.setTimeout(40 * 60 * 1000);
-// Retry one more when fails
-jest.retryTimes(1);
 
 describe('Updating runtime compute type', () => {
   beforeEach(async () => {

--- a/e2e/tests/nightly/gce-to-dataproc.spec.ts
+++ b/e2e/tests/nightly/gce-to-dataproc.spec.ts
@@ -7,8 +7,6 @@ import { ResourceCard } from 'app/text-labels';
 
 // This test could take a long time to run
 jest.setTimeout(40 * 60 * 1000);
-// Retry one more when fails
-jest.retryTimes(1);
 
 describe('Updating runtime compute type', () => {
   beforeEach(async () => {

--- a/e2e/tests/nightly/registration.spec.ts
+++ b/e2e/tests/nightly/registration.spec.ts
@@ -1,6 +1,7 @@
 import CreateAccountPage from 'app/page/create-account-page';
 import GoogleLoginPage from 'app/page/google-login';
 import { getPropValue } from 'utils/element-utils';
+import { config} from "resources/workbench-config";
 
 describe('User registration tests:', () => {
   test('Can register new user', async () => {
@@ -56,7 +57,7 @@ describe('User registration tests:', () => {
     }
     expect(textsArray).toContain('Congratulations!');
     expect(textsArray).toContain('Your All of Us research account has been created!');
-    expect(textsArray).toContain(`${userId}@fake-research-aou.org`);
+    expect(textsArray).toContain(`${userId}${config.EMAIL_DOMAIN_NAME}`);
 
     const note =
       'Please note: For full access to the Research Workbench data and tools, ' +


### PR DESCRIPTION
 remove jest-circus retry because it interferes with jest logging: test failure log are not created if test failed.