### PR TITLE
[risk=low][no ticket] Fix bug in 5359

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -98,17 +98,7 @@ public class BillingProjectBufferService implements GaugeDataCollector {
         billingProjectBufferEntryDao.getBillingBufferGaugeData().stream()
             .collect(
                 Collectors.toMap(
-                    c -> {
-                      String logMsg =
-                          String.format(
-                              "counts Tier %s / Status %s: Count %d",
-                              c.getAccessTier().getShortName(),
-                              c.getStatusEnum().toString(),
-                              c.getNumProjects());
-                      log.info(logMsg);
-
-                      return Pair.of(c.getAccessTier(), c.getStatusEnum());
-                    },
+                    c -> Pair.of(c.getAccessTier(), c.getStatusEnum()),
                     ProjectCountByStatusAndTier::getNumProjects));
 
     // iterate through ALL combinations of access tier and buffer status, counting 0 projects where

--- a/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/BillingProjectBufferService.java
@@ -113,14 +113,6 @@ public class BillingProjectBufferService implements GaugeDataCollector {
 
     // iterate through ALL combinations of access tier and buffer status, counting 0 projects where
     // this combination does not appear in `counts`
-
-    Stream<Pair<DbAccessTier, BufferEntryStatus>> foo =
-        accessTierService.getAllTiers().stream()
-            .flatMap(
-                tier ->
-                    Arrays.stream(BufferEntryStatus.values())
-                        .flatMap(status -> Stream.of(Pair.of(tier, status))));
-
     return accessTierService.getAllTiers().stream()
         .flatMap(
             tier ->
@@ -128,13 +120,6 @@ public class BillingProjectBufferService implements GaugeDataCollector {
                     .flatMap(
                         status -> {
                           final long numProjects = counts.getOrDefault(Pair.of(tier, status), 0L);
-
-                          String logMsg =
-                              String.format(
-                                  "allcombos2  Tier %s / Status %s: Count %d",
-                                  tier.getShortName(), status.toString(), numProjects);
-                          log.info(logMsg);
-
                           return Stream.of(
                               MeasurementBundle.builder()
                                   .addMeasurement(
@@ -144,26 +129,6 @@ public class BillingProjectBufferService implements GaugeDataCollector {
                                   .build());
                         }))
         .collect(Collectors.toList());
-
-    //    return Streams.zip(
-    //            accessTierService.getAllTiers().stream(),
-    //            Arrays.stream(BufferEntryStatus.values()),
-    //            (tier, status) -> {
-    //              final long numProjects = counts.getOrDefault(Pair.of(tier, status), 0L);
-    //
-    //              String logMsg =
-    //                  String.format(
-    //                      "allcombos Tier %s / Status %s: Count %d", tier.getShortName(),
-    // status.toString(), numProjects);
-    //              log.info(logMsg);
-    //
-    //              return MeasurementBundle.builder()
-    //                  .addMeasurement(GaugeMetric.BILLING_BUFFER_PROJECT_COUNT, numProjects)
-    //                  .addTag(MetricLabel.BUFFER_ENTRY_STATUS, status.toString())
-    //                  .addTag(MetricLabel.ACCESS_TIER_SHORT_NAME, tier.getShortName())
-    //                  .build();
-    //            })
-    //        .collect(Collectors.toList());
   }
 
   /**


### PR DESCRIPTION
Description:

Fix a bug in #5359 and **actually** collect metrics for all combinations of access tier and buffer entry status.

Streams.zip() does not produce a stream of MxN combinations - it produces a stream of min(M,N) pairs. So we were missing nearly all of the metrics.

Apologies for not testing this better locally!
  

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
