### PR TITLE
[RW-7152][risk=no] Increase default disk to match presets

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -167,9 +167,11 @@ describe('RuntimePanel', () => {
 
     const wrapper = await component();
 
+    // TODO(RW-7152): This test is incorrectly depending on "default" values in runtime-panel, and
+    // not general analysis. Ensure this test passes for the right reasons when fixing.
     const computeDefaults = wrapper.find('#compute-resources').first();
-    // defaults to generalAnalysis preset, which is a n1-standard-4 machine with a 50GB disk
-    expect(computeDefaults.text()).toEqual('- Default: compute size of 4 CPUs, 15 GB memory, and a 50 GB disk')
+    // defaults to generalAnalysis preset, which is a n1-standard-4 machine with a 100GB disk
+    expect(computeDefaults.text()).toEqual('- Default: compute size of 4 CPUs, 15 GB memory, and a 100 GB disk')
   });
 
   it('should allow creation when no runtime exists with defaults', async() => {

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -154,7 +154,7 @@ const styles = reactStyles({
 
 const defaultMachineName = 'n1-standard-4';
 const defaultMachineType: Machine = findMachineByName(defaultMachineName);
-const defaultDiskSize = 50;
+const defaultDiskSize = 100;
 
 // Returns true if two runtimes are equivalent in terms of the fields which are
 // affected by runtime presets.


### PR DESCRIPTION
In some scenarios, this default appears to be picked up - in particular when the panel is opened while the runtime is still loading. This should probably be reworked to just depend on presets, but at least increase this for now to avoid errors and puppeteer failures.

These defaults are very broken and should be fixed. This change papers over the issue: https://precisionmedicineinitiative.atlassian.net/browse/RW-7155