### PR TITLE
[risk=no][no ticket] Set hasFitbitData and hasCopeSurveyData to false for older CDR Versions

### DIFF
--- a/api/config/cdr_config_perf.json
+++ b/api/config/cdr_config_perf.json
@@ -28,7 +28,9 @@
       "releaseNumber": 1,
       "numParticipants": 0,
       "cdrDbName": "synth_r_2020q1_3",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 2,
@@ -40,7 +42,9 @@
       "releaseNumber": 2,
       "numParticipants": 0,
       "cdrDbName": "synth_r_2020q1_3",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 3,

--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -29,7 +29,9 @@
       "releaseNumber": 3,
       "numParticipants": 224143,
       "cdrDbName": "r_2019q4_10",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 2,
@@ -40,7 +42,9 @@
       "releaseNumber": 4,
       "numParticipants": 224001,
       "cdrDbName": "r_2019q4_10",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 3,

--- a/api/config/cdr_config_prod.json
+++ b/api/config/cdr_config_prod.json
@@ -21,7 +21,9 @@
       "releaseNumber": 1,
       "numParticipants": 0,
       "cdrDbName": "synth_r_2020q1_1",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 2,
@@ -33,7 +35,9 @@
       "releaseNumber": 1,
       "numParticipants": 0,
       "cdrDbName": "r_2019q1_4",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 3,
@@ -45,7 +49,9 @@
       "releaseNumber": 2,
       "numParticipants": 0,
       "cdrDbName": "r_2019q2_2",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 4,
@@ -57,7 +63,9 @@
       "releaseNumber": 2,
       "numParticipants": 0,
       "cdrDbName": "r_2019q2_2",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 5,
@@ -68,7 +76,9 @@
       "creationTime": "2019-10-04 00:00:00Z",
       "releaseNumber": 3,
       "numParticipants": 224143,
-      "cdrDbName": "r_2019q4_10"
+      "cdrDbName": "r_2019q4_10",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 6,

--- a/api/config/cdr_config_stable.json
+++ b/api/config/cdr_config_stable.json
@@ -21,7 +21,9 @@
       "releaseNumber": 1,
       "numParticipants": 0,
       "cdrDbName": "synth_r_2020q1_3",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 2,
@@ -33,7 +35,9 @@
       "releaseNumber": 1,
       "numParticipants": 0,
       "cdrDbName": "synth_r_2020q1_3",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 3,
@@ -45,7 +49,9 @@
       "releaseNumber": 1,
       "numParticipants": 0,
       "cdrDbName": "synth_r_2020q1_3",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 4,
@@ -57,7 +63,9 @@
       "releaseNumber": 1,
       "numParticipants": 0,
       "cdrDbName": "synth_r_2020q1_3",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 5,

--- a/api/config/cdr_config_staging.json
+++ b/api/config/cdr_config_staging.json
@@ -30,7 +30,9 @@
       "releaseNumber": 1,
       "numParticipants": 0,
       "cdrDbName": "synth_r_2020q1_3",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 2,
@@ -42,7 +44,9 @@
       "releaseNumber": 1,
       "numParticipants": 0,
       "cdrDbName": "synth_r_2020q1_3",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 3,
@@ -54,7 +58,9 @@
       "releaseNumber": 1,
       "numParticipants": 0,
       "cdrDbName": "synth_r_2020q1_3",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 4,
@@ -66,7 +72,9 @@
       "releaseNumber": 1,
       "numParticipants": 0,
       "cdrDbName": "synth_r_2020q1_3",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 5,

--- a/api/config/cdr_config_test.json
+++ b/api/config/cdr_config_test.json
@@ -30,7 +30,9 @@
       "releaseNumber": 1,
       "numParticipants": 0,
       "cdrDbName": "synth_r_2020q1_3",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 2,
@@ -42,7 +44,9 @@
       "releaseNumber": 2,
       "numParticipants": 0,
       "cdrDbName": "synth_r_2020q1_3",
-      "accessTier": "registered"
+      "accessTier": "registered",
+      "hasFitbitData": false,
+      "hasCopeSurveyData": false
     },
     {
       "cdrVersionId": 3,


### PR DESCRIPTION
Older CDR Versions have NULLs in the DB for these fields, which functions in the same way as `false`.

However, the UpdateCdrConfig tool attempts to "update" false -> null for these every time it runs.  Let's explicitly set them to false instead.


Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
