### PR TITLE
[no ticket][risk=low]Don't set CT if CT requirement is NOACCESS

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -473,6 +473,10 @@ public class InstitutionServiceImpl implements InstitutionService {
     if (institutionRequest.getTierConfigs() != null) {
       List<DbAccessTier> dbAccessTiers = accessTierDao.findAll();
       for (InstitutionTierConfig institutionTierConfig : institutionRequest.getTierConfigs()) {
+        if(institutionTierConfig.getMembershipRequirement() == InstitutionMembershipRequirement.NO_ACCESS) {
+          // Skip if is NO_ACCESS
+          continue;
+        }
         // All tier need to be present in API if tier requirement is present.
         getAccessTierByShortNameOrThrow(
             dbAccessTiers, institutionTierConfig.getAccessTierShortName());

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -386,7 +386,8 @@ export const AdminInstitutionEdit = withUrlParams()(class extends React.Componen
       }
     }
     if(ctConfig.membershipRequirement === InstitutionMembershipRequirement.NOACCESS) {
-      this.setState(fp.set(['institution', 'tierConfigs'], [getRegisteredTierConfig(this.state.institution)]));
+      // Don't set CT if CT is NOACCESS
+      this.setState(fp.set(['institution', 'tierConfigs'], [rtConfig]));
     } else {
       this.setState(fp.set(['institution', 'tierConfigs'], [rtConfig, ctConfig]));
     }

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -385,7 +385,7 @@ export const AdminInstitutionEdit = withUrlParams()(class extends React.Componen
         ctConfig.emailDomains = [];
       }
     }
-    if(ctConfig.membershipRequirement === InstitutionMembershipRequirement.NOACCESS) {
+    if (ctConfig.membershipRequirement === InstitutionMembershipRequirement.NOACCESS) {
       // Don't set CT if CT is NOACCESS
       institution.tierConfigs = [rtConfig];
     } else {

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -387,9 +387,9 @@ export const AdminInstitutionEdit = withUrlParams()(class extends React.Componen
     }
     if(ctConfig.membershipRequirement === InstitutionMembershipRequirement.NOACCESS) {
       // Don't set CT if CT is NOACCESS
-      this.setState(fp.set(['institution', 'tierConfigs'], [rtConfig]));
+      institution.tierConfigs = [rtConfig];
     } else {
-      this.setState(fp.set(['institution', 'tierConfigs'], [rtConfig, ctConfig]));
+      institution.tierConfigs = [rtConfig, ctConfig];
     }
     if (institution && institution.organizationTypeEnum !== OrganizationType.OTHER) {
       institution.organizationTypeOtherText = null;

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -24,7 +24,8 @@ import {
   getControlledTierEmailDomains,
   getRegisteredTierConfig,
   getRegisteredTierEmailAddresses,
-  getRegisteredTierEmailDomains, getTierConfig,
+  getRegisteredTierEmailDomains,
+  getTierConfig,
   getTierEmailAddresses,
   getTierEmailDomains,
   updateCtEmailAddresses,
@@ -369,12 +370,25 @@ export const AdminInstitutionEdit = withUrlParams()(class extends React.Componen
   async saveInstitution() {
     const {institution, institutionMode} = this.state;
     const rtConfig: InstitutionTierConfig = getRegisteredTierConfig(institution);
+    const ctConfig: InstitutionTierConfig = getControlledTierConfig(institution);
     if (institution && rtConfig) {
       if (rtConfig.membershipRequirement === InstitutionMembershipRequirement.DOMAINS) {
         rtConfig.emailAddresses = [];
       } else if (rtConfig.membershipRequirement === InstitutionMembershipRequirement.ADDRESSES) {
         rtConfig.emailDomains = [];
       }
+    }
+    if (institution && ctConfig) {
+      if (ctConfig.membershipRequirement === InstitutionMembershipRequirement.DOMAINS) {
+        ctConfig.emailAddresses = [];
+      } else if (ctConfig.membershipRequirement === InstitutionMembershipRequirement.ADDRESSES) {
+        ctConfig.emailDomains = [];
+      }
+    }
+    if(ctConfig.membershipRequirement === InstitutionMembershipRequirement.NOACCESS) {
+      this.setState(fp.set(['institution', 'tierConfigs'], [getRegisteredTierConfig(this.state.institution)]));
+    } else {
+      this.setState(fp.set(['institution', 'tierConfigs'], [rtConfig, ctConfig]));
     }
     if (institution && institution.organizationTypeEnum !== OrganizationType.OTHER) {
       institution.organizationTypeOtherText = null;


### PR DESCRIPTION
Description:
PROD is broken because of no CT. 
But in UI, we set CT to NOACCESS when calling API. API would fail because CT not found in AccessTier table
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
