### PR TITLE
[no ticket][risk=low]Don't set CT if CT requirement is NOACCESS

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -473,6 +473,10 @@ public class InstitutionServiceImpl implements InstitutionService {
     if (institutionRequest.getTierConfigs() != null) {
       List<DbAccessTier> dbAccessTiers = accessTierDao.findAll();
       for (InstitutionTierConfig institutionTierConfig : institutionRequest.getTierConfigs()) {
+        if(institutionTierConfig.getMembershipRequirement() == InstitutionMembershipRequirement.NO_ACCESS) {
+          // Skip if is NO_ACCESS
+          continue;
+        }
         // All tier need to be present in API if tier requirement is present.
         getAccessTierByShortNameOrThrow(
             dbAccessTiers, institutionTierConfig.getAccessTierShortName());

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -232,7 +232,8 @@ public class InstitutionServiceImpl implements InstitutionService {
     if (!tierConfig.isPresent()) {
       logMsg =
           String.format(
-              "Cannot validate email because the membership requirement for institution '%s' and tier '%s' is NO_ACCESS",
+              "Cannot validate email because the membership requirement for institution '%s' and "
+                  + "tier '%s' not in DB",
               institution.getShortName(), accessTierShortName);
       validated = false;
     } else {
@@ -241,7 +242,8 @@ public class InstitutionServiceImpl implements InstitutionService {
           validated = false;
           logMsg =
               String.format(
-                  "Cannot validate email because the membership requirement for institution '%s' and tier '%s' is NO_ACCESS",
+                  "Cannot validate email because the membership requirement for institution '%s' "
+                      + "and tier '%s' is NO_ACCESS",
                   institution.getShortName(), accessTierShortName);
           break;
         case ADDRESSES:

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -473,7 +473,8 @@ public class InstitutionServiceImpl implements InstitutionService {
     if (institutionRequest.getTierConfigs() != null) {
       List<DbAccessTier> dbAccessTiers = accessTierDao.findAll();
       for (InstitutionTierConfig institutionTierConfig : institutionRequest.getTierConfigs()) {
-        if(institutionTierConfig.getMembershipRequirement() == InstitutionMembershipRequirement.NO_ACCESS) {
+        if (institutionTierConfig.getMembershipRequirement()
+            == InstitutionMembershipRequirement.NO_ACCESS) {
           // Skip if is NO_ACCESS
           continue;
         }

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -574,6 +574,30 @@ public class InstitutionServiceTest extends SpringTest {
   }
 
   @Test
+  public void test_emailValidation_no_access() {
+    final Institution inst =
+        service.createInstitution(
+            new Institution()
+                .shortName("Broad")
+                .displayName("The Broad Institute")
+                .organizationTypeEnum(OrganizationType.ACADEMIC_RESEARCH_INSTITUTION)
+                .tierConfigs(
+                    ImmutableList.of(
+                        rtTierConfig
+                            .membershipRequirement(InstitutionMembershipRequirement.NO_ACCESS)
+                            .eraRequired(false)
+                            .accessTierShortName(registeredTier.getShortName())
+                            .emailDomains(ImmutableList.of("broad.org", "verily.com"))
+                            .emailAddresses(
+                                ImmutableList.of(
+                                    "external-researcher@sanger.uk", "science@aol.com")))));
+
+    // fail even if address or domain matches
+    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk")).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com")).isFalse();
+  }
+
+  @Test
   public void test_emailValidation_domain_ignoreCase() {
     final Institution inst =
         service.createInstitution(

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -571,30 +571,6 @@ public class InstitutionServiceTest extends SpringTest {
   }
 
   @Test
-  public void test_emailValidation_no_access() {
-    final Institution inst =
-        service.createInstitution(
-            new Institution()
-                .shortName("Broad")
-                .displayName("The Broad Institute")
-                .organizationTypeEnum(OrganizationType.ACADEMIC_RESEARCH_INSTITUTION)
-                .tierConfigs(
-                    ImmutableList.of(
-                        rtTierConfig
-                            .membershipRequirement(InstitutionMembershipRequirement.NO_ACCESS)
-                            .eraRequired(false)
-                            .accessTierShortName(registeredTier.getShortName())
-                            .emailDomains(ImmutableList.of("broad.org", "verily.com"))
-                            .emailAddresses(
-                                ImmutableList.of(
-                                    "external-researcher@sanger.uk", "science@aol.com")))));
-
-    // fail even if address or domain matches
-    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk")).isFalse();
-    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com")).isFalse();
-  }
-
-  @Test
   public void test_emailValidation_null_requirement() {
     assertThrows(
         ServerErrorException.class,

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -114,6 +114,38 @@ public class InstitutionServiceTest extends SpringTest {
   }
 
   @Test
+  public void testCreateInstitutionError_accessTierNotFound() {
+    final Institution anotherInst =
+        new Institution()
+            .shortName("otherInst")
+            .displayName("An Institution for Testing")
+            .addTierConfigsItem(
+                rtTierConfig
+                    .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
+                    .eraRequired(false)
+                    .accessTierShortName("non exist tier"))
+            .organizationTypeEnum(OrganizationType.INDUSTRY);
+
+    assertThrows(NotFoundException.class, () -> service.createInstitution(anotherInst));
+  }
+
+  @Test
+  public void testCreateInstitution_accessTierNotFound_noAccessRequirement() {
+    final Institution anotherInst =
+        new Institution()
+            .shortName("otherInst")
+            .displayName("An Institution for Testing")
+            .addTierConfigsItem(
+                rtTierConfig
+                    .membershipRequirement(InstitutionMembershipRequirement.NO_ACCESS)
+                    .eraRequired(false)
+                    .accessTierShortName("non exist tier"))
+            .organizationTypeEnum(OrganizationType.INDUSTRY);
+
+    assertThat(service.createInstitution(anotherInst).getTierConfigs()).isEmpty();
+  }
+
+  @Test
   public void test_deleteInstitution() {
     service.deleteInstitution(testInst.getShortName());
     assertThat(service.getInstitutions()).isEmpty();

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -336,6 +336,35 @@ public class InstitutionServiceTest extends SpringTest {
         .isEmpty();
   }
 
+  @Test
+  public void test_updateInstitution_tierRequirement_changetoNoAccess() {
+    final Institution existingInst =
+        new Institution()
+            .shortName("test_updateInstitution_tierRequirement")
+            .displayName("test_updateInstitution_tierRequirement")
+            .addTierConfigsItem(
+                rtTierConfig
+                    .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
+                    .eraRequired(false)
+                    .accessTierShortName(registeredTier.getShortName()))
+            .organizationTypeEnum(OrganizationType.INDUSTRY);
+    assertThat(service.createInstitution(existingInst)).isEqualTo(existingInst);
+
+    final Institution instWithNewTierRequirement =
+        existingInst.tierConfigs(
+            ImmutableList.of(
+                rtTierConfig
+                    .membershipRequirement(InstitutionMembershipRequirement.NO_ACCESS)
+                    .eraRequired(false)
+                    .accessTierShortName(registeredTier.getShortName())));
+    assertThat(
+            service
+                .updateInstitution(existingInst.getShortName(), instWithNewTierRequirement)
+                .get()
+                .getTierConfigs())
+        .isEmpty();
+  }
+
   // we uniquify Email Addresses and Domains in the DB per-institution
   @Test
   public void test_uniqueEmailPatterns() {

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -23,7 +23,6 @@ import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
-import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.model.Institution;
 import org.pmiops.workbench.model.InstitutionMembershipRequirement;
 import org.pmiops.workbench.model.InstitutionTierConfig;
@@ -625,17 +624,13 @@ public class InstitutionServiceTest extends SpringTest {
 
   @Test
   public void test_emailValidation_null_requirement() {
-    assertThrows(
-        ServerErrorException.class,
-        () -> {
-          final Institution inst =
-              service.createInstitution(
-                  new Institution()
-                      .shortName("Broad")
-                      .displayName("The Broad Institute")
-                      .organizationTypeEnum(OrganizationType.ACADEMIC_RESEARCH_INSTITUTION));
-          service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk");
-        });
+    final Institution inst =
+        service.createInstitution(
+            new Institution()
+                .shortName("Broad")
+                .displayName("The Broad Institute")
+                .organizationTypeEnum(OrganizationType.ACADEMIC_RESEARCH_INSTITUTION));
+    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk")).isFalse();
   }
 
   @Test

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -369,12 +369,26 @@ export const AdminInstitutionEdit = withUrlParams()(class extends React.Componen
   async saveInstitution() {
     const {institution, institutionMode} = this.state;
     const rtConfig: InstitutionTierConfig = getRegisteredTierConfig(institution);
+    const ctConfig: InstitutionTierConfig = getControlledTierConfig(institution);
     if (institution && rtConfig) {
       if (rtConfig.membershipRequirement === InstitutionMembershipRequirement.DOMAINS) {
         rtConfig.emailAddresses = [];
       } else if (rtConfig.membershipRequirement === InstitutionMembershipRequirement.ADDRESSES) {
         rtConfig.emailDomains = [];
       }
+    }
+    if (institution && ctConfig) {
+      if (ctConfig.membershipRequirement === InstitutionMembershipRequirement.DOMAINS) {
+        ctConfig.emailAddresses = [];
+      } else if (ctConfig.membershipRequirement === InstitutionMembershipRequirement.ADDRESSES) {
+        ctConfig.emailDomains = [];
+      }
+    }
+    if (ctConfig.membershipRequirement === InstitutionMembershipRequirement.NOACCESS) {
+      // Don't set CT if CT is NOACCESS
+      institution.tierConfigs = [rtConfig];
+    } else {
+      institution.tierConfigs = [rtConfig, ctConfig];
     }
     if (institution && institution.organizationTypeEnum !== OrganizationType.OTHER) {
       institution.organizationTypeOtherText = null;


### PR DESCRIPTION
Description:
PROD is broken because of no CT.
But in UI, we set CT to NOACCESS when calling API. API would fail because CT not found in AccessTier table
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
