### PR TITLE
[risk=no] Fix ExceptionAdvice for wrapped exception handling

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionAdvice.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionAdvice.java
@@ -25,42 +25,34 @@ public class ExceptionAdvice {
 
   @ExceptionHandler({Exception.class})
   public ResponseEntity<?> serverError(Exception e) {
-    ErrorResponse errorResponse = WorkbenchException.errorResponse();
-    // if this error was thrown by another error, get the info from that exception
-    Throwable relevantError = e;
-    if (e.getCause() != null) {
-      relevantError = e.getCause();
-    }
-
     final int statusCode;
     // if exception class has an HTTP status associated with it, grab it
-    if (relevantError.getClass().getAnnotation(ResponseStatus.class) != null) {
-      statusCode = relevantError.getClass().getAnnotation(ResponseStatus.class).value().value();
+    if (e.getClass().getAnnotation(ResponseStatus.class) != null) {
+      statusCode = e.getClass().getAnnotation(ResponseStatus.class).value().value();
     } else {
       statusCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
     }
 
-    if (relevantError instanceof WorkbenchException) {
-      // Only include Exception details on Workbench errors.
-      errorResponse.setMessage(relevantError.getMessage());
-      errorResponse.setErrorClassName(relevantError.getClass().getName());
-      WorkbenchException workbenchException = (WorkbenchException) relevantError;
-      if (workbenchException.getErrorResponse() != null
-          && workbenchException.getErrorResponse().getErrorCode() != null) {
-        errorResponse.setErrorCode(workbenchException.getErrorResponse().getErrorCode());
+    ErrorResponse errorResponse = WorkbenchException.errorResponse().statusCode(statusCode);
+
+    // Only include Exception details on Workbench errors.
+    if (e instanceof WorkbenchException) {
+      errorResponse.setErrorClassName(e.getClass().getName());
+      ErrorResponse thrownErrorResponse = ((WorkbenchException) e).getErrorResponse();
+      if (thrownErrorResponse != null) {
+        errorResponse
+            .message(thrownErrorResponse.getMessage())
+            .errorCode(thrownErrorResponse.getErrorCode());
       }
     }
 
     // only log error if it's a server error
     if (statusCode >= HttpStatus.INTERNAL_SERVER_ERROR.value()) {
       final String logMessage =
-          String.format(
-              "ErrorId %s: %s",
-              errorResponse.getErrorUniqueId(), relevantError.getClass().getName());
+          String.format("ErrorId %s: %s", errorResponse.getErrorUniqueId(), e.getClass().getName());
       log.log(Level.SEVERE, logMessage, e);
     }
 
-    errorResponse.setStatusCode(statusCode);
     return ResponseEntity.status(statusCode).body(errorResponse);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/exceptions/ExceptionAdviceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/exceptions/ExceptionAdviceTest.java
@@ -1,0 +1,59 @@
+package org.pmiops.workbench.exceptions;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pmiops.workbench.model.ErrorCode;
+import org.pmiops.workbench.model.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+
+public class ExceptionAdviceTest {
+
+  private ExceptionAdvice exceptionAdvice;
+
+  @BeforeEach
+  public void setUp() {
+    exceptionAdvice = new ExceptionAdvice();
+  }
+
+  private static Stream<Arguments> serverErrorParameters() {
+    return Stream.of(
+        Arguments.of(new BadRequestException(), 400, null, null),
+        Arguments.of(new ConflictException(), 409, null, null),
+        Arguments.of(new FailedPreconditionException(), 412, null, null),
+        Arguments.of(new TooManyRequestsException(), 429, null, null),
+        Arguments.of(new ServerErrorException(), 500, null, null),
+        Arguments.of(new NullPointerException(), 500, null, null),
+        Arguments.of(new TooManyRequestsException(new Exception("inner")), 429, null, null),
+        Arguments.of(new GatewayTimeoutException("foo"), 504, "foo", null),
+        Arguments.of(new Exception("internal message not shown"), 500, null, null),
+        Arguments.of(
+            new ForbiddenException(
+                WorkbenchException.errorResponse("disabled", ErrorCode.USER_DISABLED)),
+            403,
+            "disabled",
+            ErrorCode.USER_DISABLED));
+  }
+
+  @ParameterizedTest
+  @MethodSource("serverErrorParameters")
+  public void serverError(
+      Exception e,
+      int wantStatusCode,
+      @Nullable String wantMessage,
+      @Nullable ErrorCode wantErrorCode) {
+    ResponseEntity<?> resp = exceptionAdvice.serverError(e);
+    assertThat(resp).isNotNull();
+    assertThat(resp.getStatusCodeValue()).isEqualTo(wantStatusCode);
+
+    ErrorResponse errResponse = (ErrorResponse) resp.getBody();
+    assertThat(errResponse).isNotNull();
+    assertThat(errResponse.getMessage()).isEqualTo(wantMessage);
+    assertThat(errResponse.getErrorCode()).isEqualTo(wantErrorCode);
+  }
+}


### PR DESCRIPTION
I noticed we were getting a 500 instead of 429 for a buffer empty error.

Turns out this change was the proximal cause, which should have been a fine change: https://github.com/all-of-us/workbench/commit/fc76ba68856b4a0c668e925d4e3dcc7f7c32dc4c#diff-b00e6ea4bd2cf1d5df057e2fd60045129b526ed53372577cec4b4f999f857596R217

The `ExceptionAdvice` class has had this dubious logic for a long time. The exception unwrapping here was flawed - I don't know why we did that.

Also, now we only grab the external-facing message from the `WorkbenchException.getErrorResponse()`. This will only contain the external message - it will not potentially have inner exception messages included (`exception.getMessage()` shows the cause message if the main exception message is null).