### PR TITLE
[RW-7151][RW-7107][risk=moderate] Enable Spark console, fix pyspark

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.notebooks;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -95,42 +96,39 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     WorkbenchConfig config = workbenchConfigProvider.get();
     String assetsBaseUrl = config.server.apiBaseUrl + "/static";
 
-    Map<String, String> nbExtensions = new HashMap<>();
-    nbExtensions.put("aou-snippets-menu", assetsBaseUrl + "/aou-snippets-menu.js");
-    nbExtensions.put("aou-download-extension", assetsBaseUrl + "/aou-download-policy-extension.js");
-    nbExtensions.put(
-        "aou-activity-checker-extension", assetsBaseUrl + "/activity-checker-extension.js");
-    nbExtensions.put(
-        "aou-upload-policy-extension", assetsBaseUrl + "/aou-upload-policy-extension.js");
+    Map<String, String> nbExtensions =
+        new ImmutableMap.Builder()
+            .put("aou-snippets-menu", assetsBaseUrl + "/aou-snippets-menu.js")
+            .put("aou-download-extension", assetsBaseUrl + "/aou-download-policy-extension.js")
+            .put("aou-activity-checker-extension", assetsBaseUrl + "/activity-checker-extension.js")
+            .put("aou-upload-policy-extension", assetsBaseUrl + "/aou-upload-policy-extension.js")
+            .build();
 
-    Map<String, String> runtimeLabels = new HashMap<>();
-    runtimeLabels.put(LeonardoMapper.RUNTIME_LABEL_AOU, "true");
-    runtimeLabels.put(LeonardoMapper.RUNTIME_LABEL_CREATED_BY, userEmail);
+    Map<String, String> runtimeLabels =
+        new ImmutableMap.Builder()
+            .put(LeonardoMapper.RUNTIME_LABEL_AOU, "true")
+            .put(LeonardoMapper.RUNTIME_LABEL_CREATED_BY, userEmail)
+            .putAll(buildRuntimeConfigurationLabels(runtime.getConfigurationType()))
+            .build();
 
-    runtimeLabels.putAll(buildRuntimeConfigurationLabels(runtime.getConfigurationType()));
-
-    LeonardoCreateRuntimeRequest request =
-        new LeonardoCreateRuntimeRequest()
-            .labels(runtimeLabels)
-            .defaultClientId(config.server.oauthClientId)
-            // Note: Filenames must be kept in sync with files in api/src/main/webapp/static.
-            .jupyterUserScriptUri(assetsBaseUrl + "/initialize_notebook_runtime.sh")
-            .jupyterStartUserScriptUri(assetsBaseUrl + "/start_notebook_runtime.sh")
-            .userJupyterExtensionConfig(
-                new LeonardoUserJupyterExtensionConfig().nbExtensions(nbExtensions))
-            // Matches Terra UI's scopes, see RW-3531 for rationale.
-            .addScopesItem("https://www.googleapis.com/auth/cloud-platform")
-            .addScopesItem("https://www.googleapis.com/auth/userinfo.email")
-            .addScopesItem("https://www.googleapis.com/auth/userinfo.profile")
-            .toolDockerImage(workbenchConfigProvider.get().firecloud.jupyterDockerImage)
-            // Note: DockerHub must be used over GCR here, since VPC-SC restricts
-            // pulling external images via GCR (since it counts as GCS traffic).
-            .welderRegistry(WelderRegistryEnum.DOCKERHUB)
-            .customEnvironmentVariables(customEnvironmentVariables);
-
-    request.setRuntimeConfig(buildRuntimeConfig(runtime));
-
-    return request;
+    return new LeonardoCreateRuntimeRequest()
+        .labels(runtimeLabels)
+        .defaultClientId(config.server.oauthClientId)
+        // Note: Filenames must be kept in sync with files in api/src/main/webapp/static.
+        .jupyterUserScriptUri(assetsBaseUrl + "/initialize_notebook_runtime.sh")
+        .jupyterStartUserScriptUri(assetsBaseUrl + "/start_notebook_runtime.sh")
+        .userJupyterExtensionConfig(
+            new LeonardoUserJupyterExtensionConfig().nbExtensions(nbExtensions))
+        // Matches Terra UI's scopes, see RW-3531 for rationale.
+        .addScopesItem("https://www.googleapis.com/auth/cloud-platform")
+        .addScopesItem("https://www.googleapis.com/auth/userinfo.email")
+        .addScopesItem("https://www.googleapis.com/auth/userinfo.profile")
+        .toolDockerImage(workbenchConfigProvider.get().firecloud.jupyterDockerImage)
+        // Note: DockerHub must be used over GCR here, since VPC-SC restricts
+        // pulling external images via GCR (since it counts as GCS traffic).
+        .welderRegistry(WelderRegistryEnum.DOCKERHUB)
+        .customEnvironmentVariables(customEnvironmentVariables)
+        .runtimeConfig(buildRuntimeConfig(runtime));
   }
 
   private Object buildRuntimeConfig(Runtime runtime) {
@@ -177,6 +175,9 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
 
     // See RW-6079
     customEnvironmentVariables.put(JUPYTER_DEBUG_LOGGING_ENV_KEY, "true");
+
+    // See RW-7107
+    customEnvironmentVariables.put("PYSPARK_PYTHON", "/usr/local/bin/python3");
 
     leonardoRetryHandler.run(
         (context) -> {

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -48,11 +48,15 @@ public interface LeonardoMapper {
 
   @Mapping(target = "cloudService", ignore = true)
   @Mapping(target = "properties", ignore = true)
+  @Mapping(target = "componentGatewayEnabled", ignore = true)
   LeonardoMachineConfig toLeonardoMachineConfig(DataprocConfig dataprocConfig);
 
   @AfterMapping
-  default void addCloudServiceEnum(@MappingTarget LeonardoMachineConfig leonardoMachineConfig) {
-    leonardoMachineConfig.setCloudService(LeonardoMachineConfig.CloudServiceEnum.DATAPROC);
+  default void addMachineConfigDefaults(
+      @MappingTarget LeonardoMachineConfig leonardoMachineConfig) {
+    leonardoMachineConfig
+        .cloudService(LeonardoMachineConfig.CloudServiceEnum.DATAPROC)
+        .componentGatewayEnabled(true);
   }
 
   GceConfig toGceConfig(LeonardoGceConfig leonardoGceConfig);

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -2765,6 +2765,13 @@ components:
           type: object
           additionalProperties:
             type: string
+        componentGatewayEnabled:
+          type: boolean
+          description: >
+            Optional, specifies whether to enable Dataproc Component Gateway on the cluster.
+            This can be used for accessing Spark web UIs. See
+            https://cloud.google.com/dataproc/docs/concepts/accessing/dataproc-gateways for more details.
+            Defaults to false.
     UserJupyterExtensionConfig:
       description: Specification of Jupyter Extensions to be installed on the cluster
       properties:


### PR DESCRIPTION
- Enable Spark console endpoints, per [Leo design](https://docs.google.com/document/d/1Zr6qzICStrrJwYkfoIE7fTf9Ziu3f6JmhdA9Ao3Y8Bo/edit#)
- Fix pyspark driver version, per RW-7107. See notes [here](https://docs.google.com/document/d/1vawIVby1cckPXH-Y0gPSk5RV5mXeEay2MM_SWV4FeOs/edit#heading=h.begvagrbeuc6)
- Minor code cleanup in the Leo client

The spark console cannot be accessed directly currently, because iframe auth is needed, and we don't have a page for this, nor do we have direct links from the Jupyter UI. However, this change is still useful, as users can run the following code snippet to generate Spark console links from a notebook:

```
from IPython.core.display import HTML
import os

spark_links = [
    {'name': 'Yarn Resource Manager', 'path': 'yarn'},
    {'name': 'MapReduce Job History', 'path': 'jobhistory'},
    {'name': 'YARN Application Timeline', 'path': 'apphistory'},
    {'name': 'Spark History Server', 'path': 'sparkhistory'},
    {'name': 'HDFS NameNode', 'path': 'hdfs'}
]

base_url = f"/proxy/{os.getenv('GOOGLE_PROJECT')}/{os.getenv('RUNTIME_NAME')}"
html_links = [f"<li><a href=\"{base_url}/{link['path']}\">{link['name']}</a>" for link in spark_links]

HTML('<h3>Spark Console links</h3><br/>' + '\n'.join(html_links))
```