### PR TITLE
[risk=no][RW-6861] Add the ACCESS_TEST_USER to the e2e impersonation list

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,7 +7,7 @@
   "license": "BSD",
   "scripts": {
     "create-signin-token-dir": "mkdir -p ../e2e/signin-tokens",
-    "impersonate-test-users": "yarn create-signin-token-dir && env-cmd -x ../api/project.rb generate-impersonated-user-tokens --impersonated-usernames \\$USER_NAME,\\$READER_USER,\\$WRITER_USER,\\$COLLABORATOR_USER --output-token-filenames ../e2e/signin-tokens/puppeteer-access-token.txt,../e2e/signin-tokens/reader-puppeteer-access-token.txt,../e2e/signin-tokens/writer-puppeteer-access-token.txt,../e2e/signin-tokens/collaborator-puppeteer-access-token.txt",
+    "impersonate-test-users": "yarn create-signin-token-dir && env-cmd -x ../api/project.rb generate-impersonated-user-tokens --impersonated-usernames \\$USER_NAME,\\$READER_USER,\\$WRITER_USER,\\$COLLABORATOR_USER,\\$ACCESS_TEST_USER --output-token-filenames ../e2e/signin-tokens/puppeteer-access-token.txt,../e2e/signin-tokens/reader-puppeteer-access-token.txt,../e2e/signin-tokens/writer-puppeteer-access-token.txt,../e2e/signin-tokens/collaborator-puppeteer-access-token.txt,../e2e/signin-tokens/access-test-puppeteer-access-token.txt",
     "_test": "yarn impersonate-test-users && jest --no-color",
     "_test:debugTest": "yarn impersonate-test-users && node --inspect-brk node_modules/.bin/jest --no-color",
     "test": "cross-env WORKBENCH_ENV=test yarn _test --maxWorkers=5",


### PR DESCRIPTION
Missed this in #5293

Included in #5305 but I want to isolate it here

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
