### PR TITLE
[RW-7057][risk=low] Return free tier billing account id in config

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -44,6 +44,7 @@ public class ConfigController implements ConfigApiDelegate {
             .enableStandardSourceDomains(config.featureFlags.enableStandardSourceDomains)
             .rasHost(config.ras.host)
             .rasClientId(config.ras.clientId)
+            .freeTierBillingAccountId(config.billing.accountId)
             .runtimeImages(
                 Stream.concat(
                         config.firecloud.runtimeImages.dataproc.stream()

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4355,6 +4355,9 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/RuntimeImage"
+      freeTierBillingAccountId:
+        type: string
+        description: The free tier billing account id
 
   RuntimeImage:
     type: object


### PR DESCRIPTION
Description:
 this is needed because the billing accounts endpoint requires the billing scope. If this scope is not present, we need a way of identifying and setting the billing account ID from the workspace edit page.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
