### PR TITLE
[no ticket] Modify RAS linked identity path in JSON based on RAS recent update. 

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/ras/RasLinkService.java
+++ b/api/src/main/java/org/pmiops/workbench/ras/RasLinkService.java
@@ -76,7 +76,7 @@ import org.springframework.stereotype.Service;
  * "userId":"user1"
  * "email":"foo@gmail.com"
  * "federated_identities":{
- *    "identities":[
+ *    "identities":
  *    {
  *       "login.gov":{
  *          "firstname":"",
@@ -91,7 +91,6 @@ import org.springframework.stereotype.Service;
  *          "userid":"yyu_pi"
  *       }
  *    }
- *  ]
  *  }
  * }</pre>
  *
@@ -201,7 +200,6 @@ public class RasLinkService {
     return Optional.of(userInfo)
         .map(u -> u.get(FEDERATED_IDENTITIES))
         .map(u -> u.get(IDENTITIES))
-        .map(u -> u.get(0))
         .map(u -> u.get(ERA_COMMONS_PROVIDER_NAME))
         .map(u -> u.get(IDENTITY_USERID))
         .map(JsonNode::asText);

--- a/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
@@ -80,11 +80,11 @@ public class RasLinkServiceTest extends SpringTest {
           + "\",\"email\":\"foo@gmail.com\","
           + "\"federated_identities\":"
           + "{\"identities\":"
-          + "[{\"login.gov\":"
+          + "{\"login.gov\":"
           + "{\"firstname\":\"\",\"lastname\":\"\",\"userid\":\"123\",\"mail\":\"foo@gmail.com\"},"
           + "\"era\":"
           + "{\"firstname\":\"\",\"lastname\":\"\",\"userid\":\"eraUserId\"}"
-          + "}]}}";
+          + "}}}";
   private static final String ID_TOKEN_JWT_IAL_1 =
       JWT.create()
           .withClaim(


### PR DESCRIPTION
Description:
Background: While developing RAS, I realize that the linked identity format is problemtic, it has extra [] that makes it a array which always have single element. I filed a feature request to RAS asking for fix, now the fix is pushed to staging.
https://github.com/NIH-Auth-Services/CIT-IAM-RAS/issues/40

![Screen Shot 2021-08-17 at 7 34 07 PM](https://user-images.githubusercontent.com/6351731/129813944-39c0877d-0eef-42e2-9cee-4ceb46862b01.png)
![Screen Shot 2021-08-17 at 7 34 28 PM](https://user-images.githubusercontent.com/6351731/129813970-8e871c2a-fa84-45e7-956a-dc9b4dfa3d00.png)


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
