### PR TITLE
[no ticket][risk=no] e2e fix runCodeCell func

### DIFF
--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -228,8 +228,12 @@ export default class NotebookPage extends NotebookFrame {
     if (code !== undefined && codeFile !== undefined) {
       throw new Error('Code and codeFile parameters are both defined. Only one is required in runCodeCell method.');
     }
-    const notebookCode = code ? code : fs.readFileSync(codeFile, 'ascii');
-    logger.info(`Typing notebook code:\n--------${notebookCode}\n--------`);
+    let notebookCode;
+    if (code !== undefined) {
+      notebookCode = code;
+    } else if (codeFile !== undefined) {
+      notebookCode = fs.readFileSync(codeFile, 'ascii');
+    }
 
     await this.waitForKernelIdle(60000, 5000);
     const codeCell = cellIndex === -1 ? await this.findLastCell() : this.findCell(cellIndex);
@@ -238,14 +242,17 @@ export default class NotebookPage extends NotebookFrame {
     // autoCloseBrackets is true by default for R code cells.
     // Puppeteer types in every character of code, resulting in extra brackets.
     // Workaround: Type code in Markdown cell, then change to Code cell to run.
-    if (markdownWorkaround) {
-      await this.changeToMarkdownCell();
-      const markdownCell = this.findCell(cellIndex, CellType.Markdown);
-      const markdownCellInput = await markdownCell.focus();
-      await markdownCellInput.type(notebookCode);
-      await this.changeToCodeCell();
-    } else {
-      await cellInputTextbox.type(notebookCode);
+    if (notebookCode) {
+      if (markdownWorkaround) {
+        await this.changeToMarkdownCell();
+        const markdownCell = this.findCell(cellIndex, CellType.Markdown);
+        const markdownCellInput = await markdownCell.focus();
+        await markdownCellInput.type(notebookCode);
+        await this.changeToCodeCell();
+      } else {
+        await cellInputTextbox.type(notebookCode);
+      }
+      logger.info(`Type notebook code:\n--------${notebookCode}\n--------`);
     }
 
     await this.run();

--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -225,9 +225,6 @@ export default class NotebookPage extends NotebookFrame {
     opts: { code?: string; codeFile?: string; timeOut?: number; markdownWorkaround?: boolean } = {}
   ): Promise<string> {
     const { code, codeFile, timeOut = 2 * 60 * 1000, markdownWorkaround = false } = opts;
-    if (code === undefined && codeFile === undefined) {
-      throw new Error('Code or codeFile parameter is required in runCodeCell method.');
-    }
     if (code !== undefined && codeFile !== undefined) {
       throw new Error('Code and codeFile parameters are both defined. Only one is required in runCodeCell method.');
     }


### PR DESCRIPTION
`runCellCell` func can be used without `code` or `codeFile` parameter specified. For example: `await notebookPage.runCodeCell(1);`

CircleCI failed [job](https://app.circleci.com/pipelines/github/all-of-us/workbench/13140/workflows/a380afc7-f6d9-486d-8d0c-85df6903f659/jobs/159557/tests).

Remove the check for undefined parameters.

```
failure: [
  'Error: Code or codeFile parameter is required in runCodeCell method.\n' +
    '    at NotebookPage.runCodeCell (/home/circleci/workbench/e2e/app/page/notebook-page.ts:229:13)\n' +
    '    at /home/circleci/workbench/e2e/tests/datasets/export-to-notebook.spec.ts:142:24'
]

```