### PR TITLE
[RW-6934][risk=low] Check user emails when calculating user access tier. And make eRA commons optional if login.gov enabled.

### DIFF
--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -98,11 +98,11 @@
   "featureFlags": {
     "unsafeAllowDeleteUser": true,
     "unsafeAllowAccessToAllTiersForRegisteredUsers": true,
-    "enableBillingUpgrade": true,
+    "enableBillingUpgrade": false,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
     "enableGenomicExtraction": false,
-    "enableFireCloudV2Billing" : true,
+    "enableFireCloudV2Billing" : false,
     "enableAccessModuleRewrite" : false,
     "enableStandardSourceDomains": false
   },

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -98,11 +98,11 @@
   "featureFlags": {
     "unsafeAllowDeleteUser": true,
     "unsafeAllowAccessToAllTiersForRegisteredUsers": true,
-    "enableBillingUpgrade": false,
+    "enableBillingUpgrade": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
     "enableGenomicExtraction": false,
-    "enableFireCloudV2Billing" : false,
+    "enableFireCloudV2Billing" : true,
     "enableAccessModuleRewrite" : false,
     "enableStandardSourceDomains": false
   },

--- a/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.api;
 
+import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHORT_NAME;
+
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
@@ -85,7 +87,7 @@ public class InstitutionController implements InstitutionApiDelegate {
         new CheckEmailResponse()
             .isValidMember(
                 institutionService.validateInstitutionalEmail(
-                    getInstitutionImpl(shortName), request.getContactEmail())));
+                    getInstitutionImpl(shortName), request.getContactEmail(), REGISTERED_TIER_SHORT_NAME)));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/InstitutionController.java
@@ -87,7 +87,9 @@ public class InstitutionController implements InstitutionApiDelegate {
         new CheckEmailResponse()
             .isValidMember(
                 institutionService.validateInstitutionalEmail(
-                    getInstitutionImpl(shortName), request.getContactEmail(), REGISTERED_TIER_SHORT_NAME)));
+                    getInstitutionImpl(shortName),
+                    request.getContactEmail(),
+                    REGISTERED_TIER_SHORT_NAME)));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -344,35 +344,29 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     boolean profileConfirmationComplete =
         accessModuleService.isModuleCompliant(user, AccessModuleName.PROFILE_CONFIRMATION);
 
-    Institution institution = institutionService.getByUser(user).orElseThrow(() -> new ServerErrorException("Institution not found for the given user"));
+    Institution institution =
+        institutionService
+            .getByUser(user)
+            .orElseThrow(
+                () -> new ServerErrorException("Institution not found for the given user"));
 
     // eRA is required when login.gov linking is not enabled or user institution requires that in
     // tier requirement.
-    boolean eRARequiredForRegisteredTier = !configProvider.get().access.enableRasLoginGovLinking
-        || institutionService.eRaRequiredForTier(institution, REGISTERED_TIER_SHORT_NAME);
-    boolean institutionalEmailValid = institutionService.validateInstitutionalEmail(institution, user.getContactEmail(), REGISTERED_TIER_SHORT_NAME);
+    boolean eRARequiredForRegisteredTier =
+        !configProvider.get().access.enableRasLoginGovLinking
+            || institutionService.eRaRequiredForTier(institution, REGISTERED_TIER_SHORT_NAME);
+    boolean institutionalEmailValid =
+        institutionService.validateInstitutionalEmail(
+            institution, user.getContactEmail(), REGISTERED_TIER_SHORT_NAME);
 
-    System.out.println("~~~~~~!!!!!!!");
-    System.out.println("~~~~~~!!!!!!!");
-    System.out.println(institution);
-    System.out.println("~~~~~~!!!!!!!");
-    System.out.println("~~~~~~!!!!!!!");
-    System.out.println("~~~~~~!!!!!!!");
-    System.out.println(configProvider.get().access.enableRasLoginGovLinking);
-    System.out.println(institutionService.eRaRequiredForTier(institution, REGISTERED_TIER_SHORT_NAME));
-    System.out.println(eRARequiredForRegisteredTier);
-    System.out.println(eRACommonsComplete);
-    System.out.println("~~~~~~!!!!!!!22222");
-    System.out.println("~~~~~~!!!!!!!22222");
-    System.out.println((!eRARequiredForRegisteredTier || eRACommonsComplete));
-    System.out.println(institutionalEmailValid);
     return !user.getDisabled()
         && twoFactorAuthComplete
         && (!eRARequiredForRegisteredTier || eRACommonsComplete)
         && complianceTrainingComplete
         && dataUseAgreementTrainingComplete
         && publicationConfirmationComplete
-        && profileConfirmationComplete && institutionalEmailValid;
+        && profileConfirmationComplete
+        && institutionalEmailValid;
   }
 
   private boolean isServiceAccount(DbUser user) {

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -53,7 +53,8 @@ public interface InstitutionService {
    * @param accessTierShortName the name of the access tier to verify.
    * @return boolean – is the contact email a valid member
    */
-  boolean validateInstitutionalEmail(Institution institution, String contactEmail, String accessTierShortName);
+  boolean validateInstitutionalEmail(
+      Institution institution, String contactEmail, String accessTierShortName);
 
   /**
    * Retrieve the optional text block of user instructions to fill the instructions email sent after

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -50,9 +50,10 @@ public interface InstitutionService {
    *
    * @param institution the institution to validate against
    * @param contactEmail contact email to validate
+   * @param accessTierShortName the name of the access tier to verify.
    * @return boolean – is the contact email a valid member
    */
-  boolean validateInstitutionalEmail(Institution institution, String contactEmail);
+  boolean validateInstitutionalEmail(Institution institution, String contactEmail, String accessTierShortName);
 
   /**
    * Retrieve the optional text block of user instructions to fill the instructions email sent after
@@ -109,4 +110,7 @@ public interface InstitutionService {
    * @return the list of {@link InstitutionTierConfig} for each tier.
    */
   List<InstitutionTierConfig> getTierConfigs(String institutionShortName);
+
+  /** Returns {@code true} if eRA commons is required for given tier. */
+  boolean eRaRequiredForTier(Institution institution, String accessTierShortName);
 }

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
+import liquibase.util.BooleanUtils;
 import org.jetbrains.annotations.Nullable;
 import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.InstitutionDao;
@@ -139,11 +140,21 @@ public class InstitutionServiceImpl implements InstitutionService {
 
   @Override
   public Institution createInstitution(final Institution institutionToCreate) {
+    System.out.println("~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution");
+    System.out.println("~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution");
+    System.out.println("~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution");
+    System.out.println("~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution");
     validateInstitution(institutionToCreate);
+    System.out.println("~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution2222222222");
     try {
       final DbInstitution dbInstitution =
           institutionDao.save(institutionMapper.modelToDb(institutionToCreate));
+      System.out.println("~~~~~~~!!!!!!!createInstitution33333333322222222");
+      System.out.println("~~~~~~~!!!!!!!createInstitution33333333322222222");
+      System.out.println("~~~~~~~!!!!!!!createInstitution33333333322222222");
+      System.out.println("~~~~~~~!!!!!!!createInstitution33333333322222222");
       populateAuxTables(institutionToCreate, dbInstitution);
+      System.out.println("~~~~~~~!!!!!!!createInstituti44444444444on33333333322222222");
       return toModel(dbInstitution);
     } catch (DataIntegrityViolationException ex) {
       throw new ConflictException(
@@ -201,11 +212,20 @@ public class InstitutionServiceImpl implements InstitutionService {
     if (dbAffiliation == null) {
       return false;
     }
-    return validateInstitutionalEmail(toModel(dbAffiliation.getInstitution()), contactEmail);
+    // As of now, RT's short name is hard coded in AccessTierService. We may need a better way
+    // to pull RT short name from config or database.
+    return validateInstitutionalEmail(toModel(dbAffiliation.getInstitution()), contactEmail, REGISTERED_TIER_SHORT_NAME);
   }
 
   @Override
-  public boolean validateInstitutionalEmail(Institution institution, String contactEmail) {
+  public boolean eRaRequiredForTier(Institution institution, String accessTierShortName) {
+    Optional<InstitutionTierConfig> tierConfig =
+        getTierConfigByTier(institution, accessTierShortName);
+    return tierConfig.isPresent() && BooleanUtils.isTrue(tierConfig.get().getEraRequired());
+  }
+
+  @Override
+  public boolean validateInstitutionalEmail(Institution institution, String contactEmail, String accessTierShortName) {
     try {
       // TODO RW-4489: UserService should handle initial email validation
       new InternetAddress(contactEmail).validate();
@@ -222,9 +242,6 @@ public class InstitutionServiceImpl implements InstitutionService {
       return false;
     }
 
-    // As of now, RT's short name is hard coded in AccessTierService. We may need a better way
-    // to pull RT short name from config or database.
-    final String accessTierShortName = REGISTERED_TIER_SHORT_NAME;
     Optional<InstitutionTierConfig> tierConfig =
         getTierConfigByTier(institution, accessTierShortName);
     final boolean validated;
@@ -508,7 +525,7 @@ public class InstitutionServiceImpl implements InstitutionService {
 
   public Optional<Institution> getFirstMatchingInstitution(final String contactEmail) {
     return getInstitutions().stream()
-        .filter(institution -> validateInstitutionalEmail(institution, contactEmail))
+        .filter(institution -> validateInstitutionalEmail(institution, contactEmail, REGISTERED_TIER_SHORT_NAME))
         .findFirst();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -140,22 +140,11 @@ public class InstitutionServiceImpl implements InstitutionService {
 
   @Override
   public Institution createInstitution(final Institution institutionToCreate) {
-    System.out.println("~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution");
-    System.out.println("~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution");
-    System.out.println("~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution");
-    System.out.println("~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution");
     validateInstitution(institutionToCreate);
-    System.out.println(
-        "~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution2222222222");
     try {
       final DbInstitution dbInstitution =
           institutionDao.save(institutionMapper.modelToDb(institutionToCreate));
-      System.out.println("~~~~~~~!!!!!!!createInstitution33333333322222222");
-      System.out.println("~~~~~~~!!!!!!!createInstitution33333333322222222");
-      System.out.println("~~~~~~~!!!!!!!createInstitution33333333322222222");
-      System.out.println("~~~~~~~!!!!!!!createInstitution33333333322222222");
       populateAuxTables(institutionToCreate, dbInstitution);
-      System.out.println("~~~~~~~!!!!!!!createInstituti44444444444on33333333322222222");
       return toModel(dbInstitution);
     } catch (DataIntegrityViolationException ex) {
       throw new ConflictException(

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
-import liquibase.util.BooleanUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.jetbrains.annotations.Nullable;
 import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.InstitutionDao;

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -145,7 +145,8 @@ public class InstitutionServiceImpl implements InstitutionService {
     System.out.println("~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution");
     System.out.println("~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution");
     validateInstitution(institutionToCreate);
-    System.out.println("~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution2222222222");
+    System.out.println(
+        "~~~~~~~!!!!!!!createInstitutioncreateInstitutioncreateInstitution2222222222");
     try {
       final DbInstitution dbInstitution =
           institutionDao.save(institutionMapper.modelToDb(institutionToCreate));
@@ -214,7 +215,8 @@ public class InstitutionServiceImpl implements InstitutionService {
     }
     // As of now, RT's short name is hard coded in AccessTierService. We may need a better way
     // to pull RT short name from config or database.
-    return validateInstitutionalEmail(toModel(dbAffiliation.getInstitution()), contactEmail, REGISTERED_TIER_SHORT_NAME);
+    return validateInstitutionalEmail(
+        toModel(dbAffiliation.getInstitution()), contactEmail, REGISTERED_TIER_SHORT_NAME);
   }
 
   @Override
@@ -225,7 +227,8 @@ public class InstitutionServiceImpl implements InstitutionService {
   }
 
   @Override
-  public boolean validateInstitutionalEmail(Institution institution, String contactEmail, String accessTierShortName) {
+  public boolean validateInstitutionalEmail(
+      Institution institution, String contactEmail, String accessTierShortName) {
     try {
       // TODO RW-4489: UserService should handle initial email validation
       new InternetAddress(contactEmail).validate();
@@ -525,7 +528,9 @@ public class InstitutionServiceImpl implements InstitutionService {
 
   public Optional<Institution> getFirstMatchingInstitution(final String contactEmail) {
     return getInstitutions().stream()
-        .filter(institution -> validateInstitutionalEmail(institution, contactEmail, REGISTERED_TIER_SHORT_NAME))
+        .filter(
+            institution ->
+                validateInstitutionalEmail(institution, contactEmail, REGISTERED_TIER_SHORT_NAME))
         .findFirst();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -942,7 +942,6 @@ public class UserServiceAccessTest {
               institution.getShortName(),
               institution.tierConfigs(
                   ImmutableList.of(rtTierConfig.emailDomains(null).emailAddresses(null))));
-          ;
           return userDao.save(user);
         });
   }

--- a/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AuthDomainControllerTest.java
@@ -28,6 +28,7 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupWithMembers;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.AuthDomainCreatedResponse;
 import org.pmiops.workbench.model.UpdateUserDisabledRequest;
@@ -65,6 +66,7 @@ public class AuthDomainControllerTest extends SpringTest {
   @Mock private UserServiceAuditor mockUserServiceAuditAdapter;
   @Mock private UserTermsOfServiceDao userTermsOfServiceDao;
   @Mock private VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
+  @Mock private InstitutionService mockInstitutionService;
 
   private AuthDomainController authDomainController;
 
@@ -98,7 +100,7 @@ public class AuthDomainControllerTest extends SpringTest {
             complianceService,
             directoryService,
             accessTierService,
-            mailService);
+            mailService, mockInstitutionService);
     this.authDomainController =
         new AuthDomainController(
             fireCloudService, userService, userDao, mockAuthDomainAuditAdapter);

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -41,7 +41,6 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.institution.InstitutionService;
-import org.pmiops.workbench.institution.InstitutionServiceImpl;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.Institution;
@@ -154,8 +153,11 @@ public class UserServiceTest extends SpringTest {
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
     Institution institution = new Institution();
     when(mockInstitutionService.getByUser(user)).thenReturn(Optional.of(institution));
-    when(mockInstitutionService.eRaRequiredForTier(institution, REGISTERED_TIER_SHORT_NAME)).thenReturn(false);
-    when(mockInstitutionService.validateInstitutionalEmail(institution, user.getContactEmail(), REGISTERED_TIER_SHORT_NAME)).thenReturn(true);
+    when(mockInstitutionService.eRaRequiredForTier(institution, REGISTERED_TIER_SHORT_NAME))
+        .thenReturn(false);
+    when(mockInstitutionService.validateInstitutionalEmail(
+            institution, user.getContactEmail(), REGISTERED_TIER_SHORT_NAME))
+        .thenReturn(true);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHORT_NAME;
 
 import java.sql.Timestamp;
 import java.time.Clock;
@@ -39,8 +40,11 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionService;
+import org.pmiops.workbench.institution.InstitutionServiceImpl;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.Authority;
+import org.pmiops.workbench.model.Institution;
 import org.pmiops.workbench.moodle.ApiException;
 import org.pmiops.workbench.moodle.model.BadgeDetailsV2;
 import org.pmiops.workbench.test.FakeClock;
@@ -79,6 +83,7 @@ public class UserServiceTest extends SpringTest {
   @MockBean private DirectoryService mockDirectoryService;
   @MockBean private UserServiceAuditor mockUserServiceAuditAdapter;
   @MockBean private UserTermsOfServiceDao mockUserTermsOfServiceDao;
+  @MockBean private InstitutionService mockInstitutionService;
 
   @Autowired private UserService userService;
   @Autowired private UserDao userDao;
@@ -147,6 +152,10 @@ public class UserServiceTest extends SpringTest {
     // is the only working approach I've seen.
     PROVIDED_CLOCK.setInstant(START_INSTANT);
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
+    Institution institution = new Institution();
+    when(mockInstitutionService.getByUser(user)).thenReturn(Optional.of(institution));
+    when(mockInstitutionService.eRaRequiredForTier(institution, REGISTERED_TIER_SHORT_NAME)).thenReturn(false);
+    when(mockInstitutionService.validateInstitutionalEmail(institution, user.getContactEmail(), REGISTERED_TIER_SHORT_NAME)).thenReturn(true);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.institution;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHORT_NAME;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
@@ -497,9 +498,9 @@ public class InstitutionServiceTest extends SpringTest {
                             .emailAddresses(
                                 ImmutableList.of(
                                     "external-researcher@sanger.uk", "science@aol.com")))));
-    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk")).isTrue();
+    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME)).isTrue();
     // Fail even when domain matches, because the requirement is ADDRESSES.
-    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com")).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME)).isFalse();
   }
 
   @Test
@@ -520,9 +521,9 @@ public class InstitutionServiceTest extends SpringTest {
                             .emailAddresses(
                                 ImmutableList.of(
                                     "EXternal-rEsearcher@sanger.UK", "science@aol.com")))));
-    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk")).isTrue();
+    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME)).isTrue();
     // Fail even when domain matches, because the requirement is ADDRESSES.
-    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com")).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME)).isFalse();
   }
 
   @Test
@@ -543,7 +544,7 @@ public class InstitutionServiceTest extends SpringTest {
                             .emailAddresses(
                                 ImmutableList.of(
                                     "external-researcher@sanger.uk", "science@aol.com")))));
-    assertThat(service.validateInstitutionalEmail(inst, null)).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, null, REGISTERED_TIER_SHORT_NAME)).isFalse();
   }
 
   @Test
@@ -565,11 +566,11 @@ public class InstitutionServiceTest extends SpringTest {
                                 ImmutableList.of(
                                     "external-researcher@sanger.uk", "science@aol.com")))));
 
-    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com")).isTrue();
+    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME)).isTrue();
     // malformed
-    assertThat(service.validateInstitutionalEmail(inst, "yy@hacker@verily.org")).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, "yy@hacker@verily.org", REGISTERED_TIER_SHORT_NAME)).isFalse();
     // Fail even when domain matches, because the requirement is DOMAINS.
-    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk")).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME)).isFalse();
   }
 
   @Test
@@ -592,8 +593,8 @@ public class InstitutionServiceTest extends SpringTest {
                                     "external-researcher@sanger.uk", "science@aol.com")))));
 
     // fail even if address or domain matches
-    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk")).isFalse();
-    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com")).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME)).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME)).isFalse();
   }
 
   @Test
@@ -615,11 +616,11 @@ public class InstitutionServiceTest extends SpringTest {
                                 ImmutableList.of(
                                     "external-researcher@sanger.uk", "science@aol.com")))));
 
-    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com")).isTrue();
+    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME)).isTrue();
     // malformed
-    assertThat(service.validateInstitutionalEmail(inst, "yy@hacker@verily.org")).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, "yy@hacker@verily.org", REGISTERED_TIER_SHORT_NAME)).isFalse();
     // Fail even when domain matches, because the requirement is DOMAINS.
-    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk")).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME)).isFalse();
   }
 
   @Test
@@ -630,7 +631,7 @@ public class InstitutionServiceTest extends SpringTest {
                 .shortName("Broad")
                 .displayName("The Broad Institute")
                 .organizationTypeEnum(OrganizationType.ACADEMIC_RESEARCH_INSTITUTION));
-    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk")).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME)).isFalse();
   }
 
   @Test
@@ -873,6 +874,48 @@ public class InstitutionServiceTest extends SpringTest {
             service.updateInstitution(
                 institution_WithUserInstructions.getShortName(), institutionNoUserInstruction))
         .hasValue(expectedUpdateInstitution);
+  }
+
+  @Test
+  public void testERARequired_tierRequirementNotExist() {
+    final Institution existingInst =
+        new Institution()
+            .shortName("existingInst")
+            .displayName("existingInst")
+            .organizationTypeEnum(OrganizationType.INDUSTRY);
+
+    assertThat(service.eRaRequiredForTier(existingInst, REGISTERED_TIER_SHORT_NAME)).isEqualTo(false);
+  }
+
+  @Test
+  public void testERARequired_booleanIsNull() {
+    final Institution existingInst =
+        new Institution()
+            .shortName("existingInst")
+            .displayName("existingInst")
+            .addTierConfigsItem(
+                rtTierConfig
+                    .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
+                    .accessTierShortName(registeredTier.getShortName()))
+            .organizationTypeEnum(OrganizationType.INDUSTRY);
+
+    assertThat(service.eRaRequiredForTier(existingInst, REGISTERED_TIER_SHORT_NAME)).isEqualTo(false);
+  }
+
+  @Test
+  public void testERARequired() {
+    final Institution existingInst =
+        new Institution()
+            .shortName("existingInst")
+            .displayName("existingInst")
+            .addTierConfigsItem(
+                rtTierConfig
+                    .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
+                    .eraRequired(true)
+                    .accessTierShortName(registeredTier.getShortName()))
+            .organizationTypeEnum(OrganizationType.INDUSTRY);
+
+    assertThat(service.eRaRequiredForTier(existingInst, REGISTERED_TIER_SHORT_NAME)).isEqualTo(true);
   }
 
   private DbUser createUser(String contactEmail) {

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -498,9 +498,14 @@ public class InstitutionServiceTest extends SpringTest {
                             .emailAddresses(
                                 ImmutableList.of(
                                     "external-researcher@sanger.uk", "science@aol.com")))));
-    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME)).isTrue();
+    assertThat(
+            service.validateInstitutionalEmail(
+                inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME))
+        .isTrue();
     // Fail even when domain matches, because the requirement is ADDRESSES.
-    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME)).isFalse();
+    assertThat(
+            service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME))
+        .isFalse();
   }
 
   @Test
@@ -521,9 +526,14 @@ public class InstitutionServiceTest extends SpringTest {
                             .emailAddresses(
                                 ImmutableList.of(
                                     "EXternal-rEsearcher@sanger.UK", "science@aol.com")))));
-    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME)).isTrue();
+    assertThat(
+            service.validateInstitutionalEmail(
+                inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME))
+        .isTrue();
     // Fail even when domain matches, because the requirement is ADDRESSES.
-    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME)).isFalse();
+    assertThat(
+            service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME))
+        .isFalse();
   }
 
   @Test
@@ -544,7 +554,8 @@ public class InstitutionServiceTest extends SpringTest {
                             .emailAddresses(
                                 ImmutableList.of(
                                     "external-researcher@sanger.uk", "science@aol.com")))));
-    assertThat(service.validateInstitutionalEmail(inst, null, REGISTERED_TIER_SHORT_NAME)).isFalse();
+    assertThat(service.validateInstitutionalEmail(inst, null, REGISTERED_TIER_SHORT_NAME))
+        .isFalse();
   }
 
   @Test
@@ -566,11 +577,19 @@ public class InstitutionServiceTest extends SpringTest {
                                 ImmutableList.of(
                                     "external-researcher@sanger.uk", "science@aol.com")))));
 
-    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME)).isTrue();
+    assertThat(
+            service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME))
+        .isTrue();
     // malformed
-    assertThat(service.validateInstitutionalEmail(inst, "yy@hacker@verily.org", REGISTERED_TIER_SHORT_NAME)).isFalse();
+    assertThat(
+            service.validateInstitutionalEmail(
+                inst, "yy@hacker@verily.org", REGISTERED_TIER_SHORT_NAME))
+        .isFalse();
     // Fail even when domain matches, because the requirement is DOMAINS.
-    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME)).isFalse();
+    assertThat(
+            service.validateInstitutionalEmail(
+                inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME))
+        .isFalse();
   }
 
   @Test
@@ -593,8 +612,13 @@ public class InstitutionServiceTest extends SpringTest {
                                     "external-researcher@sanger.uk", "science@aol.com")))));
 
     // fail even if address or domain matches
-    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME)).isFalse();
-    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME)).isFalse();
+    assertThat(
+            service.validateInstitutionalEmail(
+                inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME))
+        .isFalse();
+    assertThat(
+            service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME))
+        .isFalse();
   }
 
   @Test
@@ -616,11 +640,19 @@ public class InstitutionServiceTest extends SpringTest {
                                 ImmutableList.of(
                                     "external-researcher@sanger.uk", "science@aol.com")))));
 
-    assertThat(service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME)).isTrue();
+    assertThat(
+            service.validateInstitutionalEmail(inst, "yy@verily.com", REGISTERED_TIER_SHORT_NAME))
+        .isTrue();
     // malformed
-    assertThat(service.validateInstitutionalEmail(inst, "yy@hacker@verily.org", REGISTERED_TIER_SHORT_NAME)).isFalse();
+    assertThat(
+            service.validateInstitutionalEmail(
+                inst, "yy@hacker@verily.org", REGISTERED_TIER_SHORT_NAME))
+        .isFalse();
     // Fail even when domain matches, because the requirement is DOMAINS.
-    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME)).isFalse();
+    assertThat(
+            service.validateInstitutionalEmail(
+                inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME))
+        .isFalse();
   }
 
   @Test
@@ -631,7 +663,10 @@ public class InstitutionServiceTest extends SpringTest {
                 .shortName("Broad")
                 .displayName("The Broad Institute")
                 .organizationTypeEnum(OrganizationType.ACADEMIC_RESEARCH_INSTITUTION));
-    assertThat(service.validateInstitutionalEmail(inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME)).isFalse();
+    assertThat(
+            service.validateInstitutionalEmail(
+                inst, "external-researcher@sanger.uk", REGISTERED_TIER_SHORT_NAME))
+        .isFalse();
   }
 
   @Test
@@ -884,7 +919,8 @@ public class InstitutionServiceTest extends SpringTest {
             .displayName("existingInst")
             .organizationTypeEnum(OrganizationType.INDUSTRY);
 
-    assertThat(service.eRaRequiredForTier(existingInst, REGISTERED_TIER_SHORT_NAME)).isEqualTo(false);
+    assertThat(service.eRaRequiredForTier(existingInst, REGISTERED_TIER_SHORT_NAME))
+        .isEqualTo(false);
   }
 
   @Test
@@ -899,7 +935,8 @@ public class InstitutionServiceTest extends SpringTest {
                     .accessTierShortName(registeredTier.getShortName()))
             .organizationTypeEnum(OrganizationType.INDUSTRY);
 
-    assertThat(service.eRaRequiredForTier(existingInst, REGISTERED_TIER_SHORT_NAME)).isEqualTo(false);
+    assertThat(service.eRaRequiredForTier(existingInst, REGISTERED_TIER_SHORT_NAME))
+        .isEqualTo(false);
   }
 
   @Test
@@ -915,7 +952,8 @@ public class InstitutionServiceTest extends SpringTest {
                     .accessTierShortName(registeredTier.getShortName()))
             .organizationTypeEnum(OrganizationType.INDUSTRY);
 
-    assertThat(service.eRaRequiredForTier(existingInst, REGISTERED_TIER_SHORT_NAME)).isEqualTo(true);
+    assertThat(service.eRaRequiredForTier(existingInst, REGISTERED_TIER_SHORT_NAME))
+        .isEqualTo(true);
   }
 
   private DbUser createUser(String contactEmail) {

--- a/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
@@ -109,7 +109,7 @@ public class RasLinkServiceTest extends SpringTest {
       new TokenResponse().setAccessToken(ACCESS_TOKEN).set(Id_TOKEN_FIELD_NAME, ID_TOKEN_JWT_IAL_2);
 
   private long userId;
-  private Institution institution;
+  private Institution institution = new Institution();
   private static DbUser currentUser;
   private static List<DbAccessModule> accessModules;
 
@@ -123,9 +123,9 @@ public class RasLinkServiceTest extends SpringTest {
   @Autowired private AccessModuleService accessModuleService;
   @Mock private static OpenIdConnectClient mockOidcClient;
   @Mock private static Provider<OpenIdConnectClient> mockOidcClientProvider;
-  @Mock private static InstitutionService mockInstitutionService;
   @Mock private static HttpTransport mockHttpTransport;
   @Mock private OpenIdConnectClient mockRasOidcClient;
+  @MockBean private InstitutionService mockInstitutionService;
 
   @TestConfiguration
   @Import({

--- a/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
@@ -2,7 +2,11 @@ package org.pmiops.workbench.ras;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHORT_NAME;
 import static org.pmiops.workbench.ras.RasLinkConstants.ACR_CLAIM;
 import static org.pmiops.workbench.ras.RasLinkConstants.Id_TOKEN_FIELD_NAME;
 import static org.pmiops.workbench.ras.RasLinkConstants.RAS_AUTH_CODE_SCOPES;
@@ -44,7 +48,9 @@ import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.mail.MailService;
+import org.pmiops.workbench.model.Institution;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.test.FakeLongRandom;
 import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
@@ -103,6 +109,7 @@ public class RasLinkServiceTest extends SpringTest {
       new TokenResponse().setAccessToken(ACCESS_TOKEN).set(Id_TOKEN_FIELD_NAME, ID_TOKEN_JWT_IAL_2);
 
   private long userId;
+  private Institution institution;
   private static DbUser currentUser;
   private static List<DbAccessModule> accessModules;
 
@@ -116,6 +123,7 @@ public class RasLinkServiceTest extends SpringTest {
   @Autowired private AccessModuleService accessModuleService;
   @Mock private static OpenIdConnectClient mockOidcClient;
   @Mock private static Provider<OpenIdConnectClient> mockOidcClientProvider;
+  @Mock private static InstitutionService mockInstitutionService;
   @Mock private static HttpTransport mockHttpTransport;
   @Mock private OpenIdConnectClient mockRasOidcClient;
 
@@ -181,6 +189,10 @@ public class RasLinkServiceTest extends SpringTest {
   public void setUp() throws Exception {
     rasLinkService = new RasLinkService(accessModuleService, userService, mockOidcClientProvider);
     when(mockOidcClientProvider.get()).thenReturn(mockOidcClient);
+    when(mockInstitutionService.getByUser(any(DbUser.class))).thenReturn(Optional.of(institution));
+    when(mockInstitutionService.validateInstitutionalEmail(
+            eq(institution), anyString(), eq(REGISTERED_TIER_SHORT_NAME)))
+        .thenReturn(true);
 
     currentUser = new DbUser();
     currentUser.setUsername("mock@mock.com");


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
