### PR TITLE
[risk=no][ticket=no] Fix auto pause option being pushed out of frame in dataproc config

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -1130,15 +1130,8 @@ export const RuntimePanel = fp.flow(
                            value={selectedCompute || ComputeType.Standard}
                            onChange={({value}) => {setSelectedCompute(value); }}
                  />
-                 {
-                   selectedCompute === ComputeType.Dataproc &&
-                   <DataProcConfigSelector
-                       disabled={disableControls}
-                       onChange={config => setSelectedDataprocConfig(config)}
-                       dataprocConfig={selectedDataprocConfig} />
-                 }
-               </FlexColumn>
 
+               </FlexColumn>
                <FlexColumn>
                  <label style={styles.label} htmlFor='runtime-autopause'>Automatically pause after idle for</label>
                  <Dropdown id='runtime-autopause'
@@ -1150,6 +1143,13 @@ export const RuntimePanel = fp.flow(
                  />
                </FlexColumn>
              </FlexRow>
+             {
+               selectedCompute === ComputeType.Dataproc &&
+               <DataProcConfigSelector
+                   disabled={disableControls}
+                   onChange={config => setSelectedDataprocConfig(config)}
+                   dataprocConfig={selectedDataprocConfig} />
+             }
            </div>
            {runtimeExists && updateMessaging.warn &&
             <WarningMessage iconSize={30} iconPosition={'center'}>


### PR DESCRIPTION
Description:
Before
![image](https://user-images.githubusercontent.com/2770197/130301715-dc232f62-e412-40c2-bdfc-c6de09a733c2.png)

After
![image](https://user-images.githubusercontent.com/2770197/130301733-94c0aa16-471f-4431-a2cd-58a5a4526949.png)


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
