### PR TITLE
[risk=low][no ticket] Allow registration to continue when RAS is complete or bypassed

### DIFF
--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -303,7 +303,7 @@ export const Homepage = fp.flow(withUserProfile(), withNavigation)(class extends
               .completionTimestamp(profile)))() : true),
         rasLoginGovLinked: (serverConfigStore.get().config.enableRasLoginGovLinking ?
             (() => !!(this.getRegistrationTasksMap()['rasLoginGov']
-                .completionTimestamp(profile)))() : true),
+              .completionTimestamp(profile)))() : true),
         dataUserCodeOfConductCompleted:
           (() => !!(this.getRegistrationTasksMap()['dataUserCodeOfConduct']
             .completionTimestamp(profile)))()

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -301,6 +301,9 @@ export const Homepage = fp.flow(withUserProfile(), withNavigation)(class extends
         eraCommonsLinked: (serverConfigStore.get().config.enableEraCommons ?
             (() => !!(this.getRegistrationTasksMap()['eraCommons']
               .completionTimestamp(profile)))() : true),
+        rasLoginGovLinked: (serverConfigStore.get().config.enableRasLoginGovLinking ?
+            (() => !!(this.getRegistrationTasksMap()['rasLoginGov']
+                .completionTimestamp(profile)))() : true),
         dataUserCodeOfConductCompleted:
           (() => !!(this.getRegistrationTasksMap()['dataUserCodeOfConduct']
             .completionTimestamp(profile)))()


### PR DESCRIPTION
Description:

There was a bug in the Homepage -> Registration Dashboard logic: if RAS linking was complete (or bypassed) but another module was incomplete, then RAS would show as incomplete and full registration would not be possible.

Before
<img width="1128" alt="RAS Complete before" src="https://user-images.githubusercontent.com/2701406/130648088-24c4e21c-1a77-43fe-9d86-b9c1477525c5.png">

After (tested for both bypass and completion state - the appearance is the same)
<img width="1135" alt="RAS Complete after" src="https://user-images.githubusercontent.com/2701406/130648115-fd7a0bbd-3f93-4fb9-a497-937ff6397a57.png">

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
