### PR TITLE
[no ticket][risk=no]; Set bucket location when cloning workspaces for PPW.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -93,7 +93,9 @@ public class FireCloudServiceImpl implements FireCloudService {
   private static final String SAM_STATUS_NAME = "Sam";
   private static final String RAWLS_STATUS_NAME = "Rawls";
   private static final String GOOGLE_BUCKETS_STATUS_NAME = "GoogleBuckets";
-  private static final String GOOGLE_BUCKETS_LOCATION = "US;
+  // The defaul location for AoU buckets. Setting this location when cloning workspaces to avoid destional workspace
+  // to source workspace check. See http://shortn/_n0AEAdujef for more details.
+  private static final String GOOGLE_BUCKETS_LOCATION = "US";
 
   // The set of Google OAuth scopes required for access to FireCloud APIs. If FireCloud ever changes
   // its API scopes (see https://api.firecloud.org/api-docs.yaml), we'll need to update this list.
@@ -411,7 +413,7 @@ public class FireCloudServiceImpl implements FireCloudService {
             .authorizationDomain(
                 ImmutableList.of(new FirecloudManagedGroupRef().membersGroupName(authDomainName)));
     if(isFireCloudBillingV2ApiEnabled()) {
-      cloneRequest.
+      cloneRequest.bucketLocation(GOOGLE_BUCKETS_LOCATION);
     }
     return retryHandler.run(
         (context) -> workspacesApi.cloneWorkspace(cloneRequest, fromProject, fromName));

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -93,6 +93,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   private static final String SAM_STATUS_NAME = "Sam";
   private static final String RAWLS_STATUS_NAME = "Rawls";
   private static final String GOOGLE_BUCKETS_STATUS_NAME = "GoogleBuckets";
+  private static final String GOOGLE_BUCKETS_LOCATION = "US;
 
   // The set of Google OAuth scopes required for access to FireCloud APIs. If FireCloud ever changes
   // its API scopes (see https://api.firecloud.org/api-docs.yaml), we'll need to update this list.
@@ -409,7 +410,9 @@ public class FireCloudServiceImpl implements FireCloudService {
             .copyFilesWithPrefix("notebooks/")
             .authorizationDomain(
                 ImmutableList.of(new FirecloudManagedGroupRef().membersGroupName(authDomainName)));
-
+    if(isFireCloudBillingV2ApiEnabled()) {
+      cloneRequest.
+    }
     return retryHandler.run(
         (context) -> workspacesApi.cloneWorkspace(cloneRequest, fromProject, fromName));
   }

--- a/api/src/main/resources/firecloud.yaml
+++ b/api/src/main/resources/firecloud.yaml
@@ -2111,6 +2111,11 @@ components:
             if no Authorization Domain is set)
           items:
             $ref: '#/components/schemas/ManagedGroupRef'
+        bucketLocation:
+          type: string
+          required: false
+          description: Region (NOT multi-region) in which bucket attached to the workspace should be created. If not
+            provided, the bucket will be created in the 'US' multi-region.
     WorkspaceRequestClone:
       required:
         - attributes
@@ -2138,6 +2143,11 @@ components:
           type: string
           description: Used for clone operations only; the prefix for files to copy
             between source and destination workspace buckets
+        bucketLocation:
+          type: string
+          required: false
+          description: Region (NOT multi-region) in which bucket attached to the workspace should be created. If not
+            provided, the bucket will be created in the 'US' multi-region.
       description: ""
     WorkspaceResponse:
       type: object


### PR DESCRIPTION
Description:
  // The defaul location for AoU buckets. Setting this location when cloning workspaces to avoid destional workspace
  // to source workspace check. See http://shortn/_n0AEAdujef for more details

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
