### PR TITLE
[RW-7186][risk=no] Add source search option to cohort builder and concept search

### DIFF
--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.tsx
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.tsx
@@ -3,8 +3,10 @@ import * as React from 'react';
 
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentCohortCriteriaStore, currentCohortSearchContextStore, currentWorkspaceStore} from 'app/utils/navigation';
+import {serverConfigStore} from 'app/utils/stores';
 import {CohortBuilderApi, CriteriaType, Domain} from 'generated/fetch';
 import {MemoryRouter, Router} from 'react-router';
+import defaultServerConfig from 'testing/default-server-config';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {CohortBuilderServiceStub, CriteriaStubVariables} from 'testing/stubs/cohort-builder-service-stub';
 import {workspaceDataStub} from 'testing/stubs/workspaces';
@@ -39,6 +41,7 @@ describe('CohortSearch', () => {
   beforeEach(() => {
     currentWorkspaceStore.next(workspaceDataStub);
     registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
+    serverConfigStore.set({config: {...defaultServerConfig, enableStandardSourceDomains: false}});
   });
 
   it('should render', () => {

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -500,7 +500,7 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
       this.setState(
         (state) => ({searchSource: !state.searchSource}),
         () => this.getResults(this.state.searchTerms || '')
-        );
+      );
     }
 
     renderRow(row: any, child: boolean, elementId: string) {

--- a/ui/src/app/pages/data/concept/concept-search.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.spec.tsx
@@ -1,6 +1,7 @@
 import {mount} from 'enzyme';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
+import {MemoryRouter} from 'react-router';
 
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {
@@ -9,13 +10,14 @@ import {
   currentWorkspaceStore,
   urlParamsStore
 } from 'app/utils/navigation';
+import {serverConfigStore} from 'app/utils/stores';
 import {ConceptSet, ConceptSetsApi, WorkspacesApi} from 'generated/fetch';
+import defaultServerConfig from 'testing/default-server-config';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
 import {workspaceDataStub, WorkspaceStubVariables} from 'testing/stubs/workspaces';
 import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
 import {ConceptSearch} from './concept-search';
-import {MemoryRouter} from "react-router";
 
 describe('ConceptSearch', () => {
   let conceptSet: ConceptSet;
@@ -33,6 +35,7 @@ describe('ConceptSearch', () => {
       wsid: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
       csid: conceptSet.id
     });
+    serverConfigStore.set({config: {...defaultServerConfig, enableStandardSourceDomains: false}});
   });
 
   const component = () => {


### PR DESCRIPTION
Add switch to enable source search, currently behind `enableStandardSourceDomains` config flag.

https://user-images.githubusercontent.com/40036095/131068704-348f4b06-4540-4324-bd37-abfc98665913.mov

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
