### PR TITLE
[no ticket][risk=no] Improve e2e cohort tests

### DIFF
--- a/e2e/app/page/base-page.ts
+++ b/e2e/app/page/base-page.ts
@@ -1,4 +1,4 @@
-import { Page, Response } from 'puppeteer';
+import { Page } from 'puppeteer';
 import { logger } from 'libs/logger';
 import { waitWhileLoading } from 'utils/waits-utils';
 
@@ -16,8 +16,13 @@ export default abstract class BasePage {
   /**
    * Reload current page.
    */
-  async reloadPage(): Promise<Response> {
-    return this.page.reload({ waitUntil: ['networkidle0', 'load', 'domcontentloaded'] });
+  async reloadPage(): Promise<void> {
+    const response = await this.page.reload({ waitUntil: ['networkidle0', 'load', 'domcontentloaded'] });
+    if (response && !response.ok()) {
+      // Log response if status is not OK
+      logger.info(`Reload page: Response status: ${response.status()}\n${await response.text()}`);
+    }
+    await waitWhileLoading(this.page);
   }
 
   /**

--- a/e2e/app/page/cohort-participants-group.ts
+++ b/e2e/app/page/cohort-participants-group.ts
@@ -189,9 +189,7 @@ export default class CohortParticipantsGroup {
   async deleteCriteria(criteriaName: string): Promise<void> {
     await this.clickCriteriaSnowmanIcon(criteriaName);
     await this.selectSnowmanMenu(MenuOption.DeleteCriteria);
-    const xpath = `${this.rootXpath}//*[normalize-space()="UNDO" and @role="button"]`;
-    const undoButton = new Button(this.page, xpath);
-    await undoButton.waitForXPath(); // Find the UNDO button but do not click.
+    await waitWhileLoading(this.page);
   }
 
   /**

--- a/e2e/app/page/cohort-participants-group.ts
+++ b/e2e/app/page/cohort-participants-group.ts
@@ -505,8 +505,15 @@ export default class CohortParticipantsGroup {
 
   async searchCriteria(searchWord: string): Promise<Table> {
     const searchFilterTextbox = Textbox.findByName(this.page, { dataTestId: 'list-search-input' });
+    const waitForResponsePromise = this.page.waitForResponse(
+      (response) => {
+        return response.url().includes('/criteria/') && response.request().method() === 'GET';
+      },
+      { timeout: 60000 }
+    );
     await searchFilterTextbox.type(searchWord);
     await searchFilterTextbox.pressReturn();
+    await waitForResponsePromise;
     await waitWhileLoading(this.page);
     return new Table(this.page, `${this.criteriaSearchContainerXpath}//table[@class="p-datatable"]`);
   }

--- a/e2e/tests/cohorts/cohort-edit.spec.ts
+++ b/e2e/tests/cohorts/cohort-edit.spec.ts
@@ -1,27 +1,63 @@
+import { Page } from 'puppeteer';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import { findOrCreateWorkspace, signInWithAccessToken } from 'utils/test-utils';
 import CohortBuildPage from 'app/page/cohort-build-page';
-import { makeRandomName, makeWorkspaceName } from 'utils/str-utils';
-import { waitWhileLoading } from 'utils/waits-utils';
+import { makeWorkspaceName } from 'utils/str-utils';
 import { MenuOption, ResourceCard } from 'app/text-labels';
 import DataResourceCard from 'app/component/data-resource-card';
 import Link from 'app/element/link';
+import { Visits } from 'app/page/cohort-participants-group';
 
-describe('Editing Cohort tests', () => {
+describe('Editing Cohort Test', () => {
+  // Tests require one and same workspace
+  const workspaceName = makeWorkspaceName();
+  let workspaceUrl: string;
+  let cohortName: string;
+
   beforeEach(async () => {
     await signInWithAccessToken(page);
   });
 
-  // Tests require one and same workspace
-  const workspace = makeWorkspaceName();
-  let workspaceUrl;
+  // Include all visit types in a single Include Group.
+  test('Create Cohort from all visits', async () => {
+    await loadWorkspaceUrl(page, workspaceName);
 
-  test('Discard changes', async () => {
-    await findAWorkspace();
+    // Add new Cohort.
+    const cohortBuildPage = await new WorkspaceDataPage(page).clickAddCohortsButton();
 
+    const group1 = cohortBuildPage.findIncludeParticipantsGroup('Group 1');
+    await group1.includeVisits([
+      Visits.AmbulanceVisit,
+      Visits.AmbulatoryClinicCenter,
+      Visits.AmbulatoryRehabilitationVisit,
+      Visits.EmergencyRoomVisit,
+      Visits.EmergencyRoomAndInpatientVisit,
+      Visits.HomeVisit,
+      Visits.InpatientVisit,
+      Visits.LaboratoryVisit,
+      Visits.NonhospitalInstitutionVisit,
+      Visits.OfficeVisit,
+      Visits.OutpatientVisit,
+      Visits.PharmacyVisit
+    ]);
+    const group1Count = await group1.getGroupCount();
+    const totalCount = await cohortBuildPage.getTotalCount();
+    expect(group1Count).toEqual(totalCount);
+    expect(Number.isNaN(group1Count)).toBe(false);
+
+    // Save new cohort.
+    cohortName = await cohortBuildPage.createCohort();
+
+    // Delete cohort in Cohort Build page.
+    // await new CohortActionsPage(page).deleteCohort();
+  });
+
+  test('Discard changes during editing', async () => {
+    await loadWorkspaceUrl(page, workspaceName);
+
+    // Open previously created Cohort.
     const dataPage = new WorkspaceDataPage(page);
-    const cohortCard = await dataPage.findOrCreateCohort();
-    const cohortName = await cohortCard.getResourceName();
+    const cohortCard = await dataPage.findCohortCard(cohortName);
     await cohortCard.clickResourceName();
 
     const cohortBuildPage = new CohortBuildPage(page);
@@ -30,6 +66,7 @@ describe('Editing Cohort tests', () => {
     // Wait for Total Count that also indicates page load is ready.
     await cohortBuildPage.getTotalCount();
 
+    // Start making some changes. All changes won't be saved.
     // Switch on Temporal in Group 1.
     const group1 = cohortBuildPage.findIncludeParticipantsGroupByIndex();
     await group1.clickTemporalSwitch(true);
@@ -39,34 +76,17 @@ describe('Editing Cohort tests', () => {
 
     await cohortBuildPage.discardChangesConfirmationDialog();
 
-    // Back to Data page.
+    // Discard changes brings user back to the Data page.
     await dataPage.waitForLoad();
-    const resourceCard = new DataResourceCard(page);
-    expect(await resourceCard.findCard(cohortName, ResourceCard.Cohort)).toBeTruthy();
   });
 
-  test('Delete cohort', async () => {
-    const cohortName = await setUpWorkspaceAndCohort().then((cohort: DataResourceCard) => cohort.clickResourceName());
+  test('Save As another new cohort', async () => {
+    await loadWorkspaceUrl(page, workspaceName);
 
-    const cohortBuildPage = new CohortBuildPage(page);
-    await cohortBuildPage.waitForLoad();
-
-    // Delete cohort while inside the Cohort Build page
-    const modalContent = await cohortBuildPage.deleteCohort();
-    expect(modalContent).toContain(`Are you sure you want to delete Cohort: ${cohortName}?`);
-
-    // Back to the Data page.
+    // Open previously created Cohort.
     const dataPage = new WorkspaceDataPage(page);
-    await dataPage.waitForLoad();
-
-    const resourceCard = new DataResourceCard(page);
-    expect(await resourceCard.findCard(cohortName, ResourceCard.Cohort)).toBeFalsy();
-  });
-
-  test('Save as cohort', async () => {
-    const originalCohortName = await setUpWorkspaceAndCohort().then((cohort: DataResourceCard) =>
-      cohort.clickResourceName()
-    );
+    const cohortCard = await dataPage.findCohortCard(cohortName);
+    await cohortCard.clickResourceName();
 
     const cohortBuildPage = new CohortBuildPage(page);
     await cohortBuildPage.waitForLoad();
@@ -75,11 +95,11 @@ describe('Editing Cohort tests', () => {
     const totalCount = await cohortBuildPage.getTotalCount();
 
     // Save as.
-    const cohortName = await cohortBuildPage.saveChanges(MenuOption.SaveAs);
-    console.log(`Saved as Cohort: "${cohortName}"`);
+    const newCohortName = await cohortBuildPage.saveChanges(MenuOption.SaveAs);
+    console.log(`Saved as Cohort: "${newCohortName}"`);
 
     // Click new cohort name link. Open Cohort Build page.
-    const cohortLink = Link.findByName(page, { name: cohortName });
+    const cohortLink = Link.findByName(page, { name: newCohortName });
     await cohortLink.clickAndWait();
 
     // Total Count should be unchanged.
@@ -87,74 +107,26 @@ describe('Editing Cohort tests', () => {
 
     // Delete cohort while inside the Cohort Build page
     const modalContent = await cohortBuildPage.deleteCohort();
-    expect(modalContent).toContain(`Are you sure you want to delete Cohort: ${cohortName}?`);
+    expect(modalContent).toContain(`Are you sure you want to delete Cohort: ${newCohortName}?`);
 
     // Back to the Data page.
-    const dataPage = new WorkspaceDataPage(page);
     await dataPage.waitForLoad();
 
     const resourceCard = new DataResourceCard(page);
     // Save as cohort is gone.
-    expect(await resourceCard.findCard(cohortName, ResourceCard.Cohort)).toBeFalsy();
+    expect(await resourceCard.findCard(newCohortName, ResourceCard.Cohort)).toBeFalsy();
     // Original cohort remains.
-    expect(await resourceCard.findCard(originalCohortName, ResourceCard.Cohort)).toBeTruthy();
+    expect(await resourceCard.findCard(cohortName, ResourceCard.Cohort)).toBeTruthy();
   });
 
   // Helper functions
-  async function findAWorkspace(): Promise<void> {
+  async function loadWorkspaceUrl(page: Page, workspaceName: string): Promise<void> {
     if (workspaceUrl) {
-      // Faster: Load previously saved URL instead clicks thru pages to open workspace data page.
-      await page.goto(workspaceUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'] });
+      // Faster: Load previously saved URL instead clicks thru links to open workspace data page.
+      await page.goto(workspaceUrl, { waitUntil: ['load', 'networkidle0'] });
       return;
     }
-    await findOrCreateWorkspace(page, { workspaceName: workspace });
-    workspaceUrl = page.url();
-  }
-
-  async function setUpWorkspaceAndCohort(): Promise<DataResourceCard> {
-    await findAWorkspace();
-    await deleteAllCohort('Duplicate');
-    const dataPage = new WorkspaceDataPage(page);
-    const cohortCard = await dataPage.findOrCreateCohort();
-    return duplicateCohort(cohortCard);
-  }
-
-  // Make a duplicate of an existing cohort to avoid hitting issue of concurrent data editing.
-  async function duplicateCohort(cohortCard: DataResourceCard): Promise<DataResourceCard> {
-    const cohortName = await cohortCard.getResourceName();
-    const snowmanMenu = await cohortCard.getSnowmanMenu();
-    await snowmanMenu.select(MenuOption.Duplicate, { waitForNav: false });
-    await waitWhileLoading(page);
-    const duplicateCohortName = `Duplicate of ${cohortName}`;
-    const dataPage = new WorkspaceDataPage(page);
-    // Rename duplicate Cohort name
-    const newCohortName = makeRandomName();
-    await dataPage.renameResource(duplicateCohortName, newCohortName, ResourceCard.Cohort);
-    // Verify rename successful.
-    expect(await DataResourceCard.findCard(page, newCohortName)).toBeTruthy();
-    expect(await DataResourceCard.findCard(page, cohortName)).toBeTruthy();
-    return dataPage.findCohortCard(newCohortName);
-  }
-
-  // Delete existing Cohorts with name contains 'Duplicate' string.
-  async function deleteAllCohort(pattern: string): Promise<void> {
-    const dataResourceCard = new DataResourceCard(page);
-    const cards = await dataResourceCard.getResourceCard(ResourceCard.Cohort);
-
-    const cardNames = [];
-    for (const card of cards) {
-      const name = await card.getResourceName();
-      if (name.includes(pattern)) {
-        cardNames.push(await card.getResourceName());
-      }
-    }
-
-    for (const name of cardNames) {
-      const modalTextContent = await new WorkspaceDataPage(page).deleteResource(name, ResourceCard.Cohort);
-      // Verify Delete Confirmation modal text
-      expect(modalTextContent).toContain(`Are you sure you want to delete Cohort: ${name}?`);
-      expect(await DataResourceCard.findCard(page, name, 2000)).toBeFalsy();
-      console.log(`deleted cohort ${name}`);
-    }
+    await findOrCreateWorkspace(page, { workspaceName });
+    workspaceUrl = page.url(); // Save URL for load workspace directly without search.
   }
 });

--- a/e2e/tests/cohorts/cohort-edit.spec.ts
+++ b/e2e/tests/cohorts/cohort-edit.spec.ts
@@ -52,7 +52,7 @@ describe('Editing Cohort Test', () => {
     // await new CohortActionsPage(page).deleteCohort();
   });
 
-  test('Discard changes during editing', async () => {
+  test('Discard changes', async () => {
     await loadWorkspaceUrl(page, workspaceName);
 
     // Open previously created Cohort.
@@ -80,7 +80,7 @@ describe('Editing Cohort Test', () => {
     await dataPage.waitForLoad();
   });
 
-  test('Save As another new cohort', async () => {
+  test('Save as cohort', async () => {
     await loadWorkspaceUrl(page, workspaceName);
 
     // Open previously created Cohort.

--- a/e2e/tests/ui/cohort-ui.spec.ts
+++ b/e2e/tests/ui/cohort-ui.spec.ts
@@ -7,6 +7,7 @@ import { PhysicalMeasurementsCriteria } from 'app/page/cohort-participants-group
 import ReviewCriteriaSidebar from 'app/component/review-criteria-sidebar';
 import * as fp from 'lodash/fp';
 import { logger } from 'libs/logger';
+import {Page} from "puppeteer";
 
 describe('Cohort UI Test', () => {
   beforeEach(async () => {
@@ -15,16 +16,8 @@ describe('Cohort UI Test', () => {
 
   // Test reuse workspace that is older than 10 min. Test does not create new workspace.
   test('Cancel Build Cohort', async () => {
-    // Find all workspaces that are older than 10 min.
-    const allWorkspaceCards = await findAllCards(page, 1000 * 60 * 10);
-    if (allWorkspaceCards.length === 0) {
-      logger.info('Cannot find a suitable existing workspace (created at least 10 min ago). Test end early.');
-      return;
-    }
-
-    // Open one workspace.
-    const aWorkspaceCard = fp.shuffle(allWorkspaceCards)[0];
-    await aWorkspaceCard.clickWorkspaceName();
+    // Find and open one workspace.
+    await openWorkspace(page);
 
     const dataPage = new WorkspaceDataPage(page);
     await dataPage.clickAddCohortsButton();
@@ -87,4 +80,19 @@ describe('Cohort UI Test', () => {
     // Changes are discarded, back to the Data page.
     await dataPage.waitForLoad();
   });
+
+  async function openWorkspace(page: Page): Promise<string> {
+    // Find all workspaces that are older than 10 min.
+    const allWorkspaceCards = await findAllCards(page, 1000 * 60 * 10);
+    if (allWorkspaceCards.length === 0) {
+    logger.info('Cannot find a suitable existing workspace (created at least 10 min ago). Test end early.');
+    return;
+  }
+
+  // Open one workspace.
+  const aWorkspaceCard = fp.shuffle(allWorkspaceCards)[0];
+    const workspaceName = aWorkspaceCard.getWorkspaceName();
+  await aWorkspaceCard.clickWorkspaceName();
+  return workspaceName
+  }
 });

--- a/e2e/tests/ui/cohort-ui.spec.ts
+++ b/e2e/tests/ui/cohort-ui.spec.ts
@@ -106,7 +106,7 @@ describe('Cohort UI Test', () => {
 
     const resultsTable = await group1.getSearchResultsTable();
     const originalRowNum = (await resultsTable.getRows()).length;
-    console.log(`originalRowNum: ${originalRowNum}`);
+    expect(originalRowNum).toBeGreaterThanOrEqual(1);
 
     // Search by description.
     const description = 'surgical pathology';

--- a/e2e/tests/ui/cohort-ui.spec.ts
+++ b/e2e/tests/ui/cohort-ui.spec.ts
@@ -10,7 +10,6 @@ import { logger } from 'libs/logger';
 import { Page } from 'puppeteer';
 import { waitWhileLoading } from 'utils/waits-utils';
 import expect from 'expect';
-import Table from 'app/component/table';
 
 describe('Cohort UI Test', () => {
   beforeEach(async () => {
@@ -18,7 +17,7 @@ describe('Cohort UI Test', () => {
   });
 
   // Test reuse workspace that is older than 10 min. Test does not create new workspace.
-  xtest('Cancel Build Cohort', async () => {
+  test('Cancel Build Cohort', async () => {
     // Find and open one workspace.
     const workspaceName = await openWorkspace(page);
     if (!workspaceName) {
@@ -110,19 +109,24 @@ describe('Cohort UI Test', () => {
     console.log(`originalRowNum: ${originalRowNum}`);
 
     // Search by description.
-    const description = 'Surgical pathology';
+    const description = 'surgical pathology';
     await group1.searchCriteria(description);
-    await searchAndVerifyResults(resultsTable, description);
+    // Verify getting any results for a valid search.
+    let resultsRow = await resultsTable.getRowCount();
+    expect(resultsRow).toBeGreaterThanOrEqual(1);
 
     // Search by code.
     const code = '128927009';
     await group1.searchCriteria(code);
-    await searchAndVerifyResults(resultsTable, code, 5);
+    // Verify getting any results for a valid search.
+    resultsRow = await resultsTable.getRowCount();
+    expect(resultsRow).toBeGreaterThanOrEqual(1);
 
-    // Search by Concept ID. DOESN'T WORK!
+    // Search by Concept ID. DOESN'T RETURN ANY RESULT!
     const conceptId = '2213280';
     await group1.searchCriteria(conceptId);
-    const resultsRow = await resultsTable.getRowCount();
+    // Verify no results for an invalid search.
+    resultsRow = await resultsTable.getRowCount();
     expect(resultsRow).toEqual(0);
   });
 
@@ -141,20 +145,5 @@ describe('Cohort UI Test', () => {
     await aWorkspaceCard.clickWorkspaceName();
     3;
     return workspaceName;
-  }
-
-  // Verify search results contain search word.
-  async function searchAndVerifyResults(resultsTable: Table, keyword: string, columnIndx = 1): Promise<void> {
-    const searchResultsRowNum = (await resultsTable.getRows()).length;
-    console.log(`searchResultsRowNum: ${searchResultsRowNum}`);
-
-    expect(searchResultsRowNum).toBeGreaterThan(1);
-    // Verify first 3 results contain the search keyword.
-    const size = searchResultsRowNum > 3 ? 3 : searchResultsRowNum;
-    for (let i = 0; i < size; i++) {
-      await resultsTable.getCell(i + 1, 1).then((cell) => cell.hover());
-      const cellValue = await resultsTable.getCellValue(i + 1, columnIndx);
-      expect(cellValue).toMatch(new RegExp(keyword, 'i'));
-    }
   }
 });

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -131,7 +131,7 @@ export async function createWorkspace(
   const workspacesPage = new WorkspacesPage(page);
   await workspacesPage.load();
   await workspacesPage.createWorkspace(workspaceName, cdrVersionName);
-  console.log(`Created workspace "${workspaceName}" with CDR version "${cdrVersionName}"`);
+  logger.info(`Created workspace "${workspaceName}" with CDR version "${cdrVersionName}"`);
   return workspaceName;
 }
 

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -14,10 +14,9 @@ import Navigation, { NavLink } from 'app/component/navigation';
 import { makeWorkspaceName } from './str-utils';
 import { config } from 'resources/workbench-config';
 import { logger } from 'libs/logger';
-import { waitWhileLoading } from './waits-utils';
 
 export async function signOut(page: Page): Promise<void> {
-  await page.evaluate(async () => {
+  await page.evaluate(() => {
     return 'window.setTestAccessTokenOverride(null)';
   });
 
@@ -25,18 +24,25 @@ export async function signOut(page: Page): Promise<void> {
   await page.waitForTimeout(1000);
 }
 
+// Resolve typescript error: TS2339: Property 'setTestAccessTokenOverride' does not exist on type 'Window & typeof globalThis'.
+declare const window: Window &
+  typeof globalThis & {
+    setTestAccessTokenOverride: any;
+  };
+
 export async function signInWithAccessToken(page: Page, tokenFilename = config.USER_ACCESS_TOKEN_FILE): Promise<void> {
   const token = fs.readFileSync(tokenFilename, 'ascii');
   logger.info('Sign in with access token to Workbench application');
   const homePage = new HomePage(page);
   await homePage.gotoUrl(PageUrl.Home);
-  await page.waitForTimeout(1000);
 
   // Once ready, initialize the token on the page (this is stored in local storage).
   // See sign-in.service.ts for details.
+
   await page.waitForFunction('!!window["setTestAccessTokenOverride"]');
-  await page.evaluate(`window.setTestAccessTokenOverride('${token}')`);
-  await page.waitForTimeout(1000);
+  await page.evaluate((token) => {
+    window.setTestAccessTokenOverride(token);
+  }, token);
 
   // Force a page reload; auth will be re-initialized with the token now that
   // localstorage has been updated.
@@ -45,10 +51,8 @@ export async function signInWithAccessToken(page: Page, tokenFilename = config.U
   // Puppeteer. Any console.log() within the above global function, for example,
   // is unlikely to be captured.
   await homePage.reloadPage();
-  await homePage.waitForLoad().catch(() => {
-    homePage.gotoUrl(PageUrl.Home);
-  });
-  await waitWhileLoading(page);
+  await homePage.gotoUrl(PageUrl.Home);
+  await homePage.waitForLoad();
 }
 
 /**

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -383,6 +383,13 @@ export async function waitWhileLoading(
     waitForRuntime ? '' : ':not([aria-hidden="true"]):not([data-test-id="runtime-status-icon"])'
   }`;
 
+  // Prevent checking on Login page.
+  await page.waitForSelector('[data-test-id="sign-in-page"]', { timeout: 1000 }).catch(() => {
+    // Ignore error because this is not a signed-in page.
+    console.log('Unauthenticated');
+    return;
+  });
+
   // To prevent checking on blank page, wait for elements exist in DOM.
   await Promise.race([page.waitForSelector(notBlankPageSelector), page.waitForSelector(spinElementsSelector)]);
 

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -385,8 +385,6 @@ export async function waitWhileLoading(
 
   // Prevent checking on Login page.
   await page.waitForSelector('[data-test-id="sign-in-page"]', { timeout: 1000 }).catch(() => {
-    // Ignore error because this is not a signed-in page.
-    console.log('Unauthenticated');
     return;
   });
 


### PR DESCRIPTION
Added new teset `Cohort search by code and description` in `cohort-ui.spec` and reorganized `cohort-edit.spec` and `cohort-create.spec` tests to make them run faster.

Sample run times:

Before:
`PASS tests/cohorts/cohort-edit.spec.ts (174.943 s)`
After:
`PASS tests/cohorts/cohort-edit.spec.ts (110.571 s)`

Before:
`PASS tests/cohorts/cohort-create.spec.ts (380.615 s)`
After:
`PASS tests/cohorts/cohort-create.spec.ts (316.047 s)`