### PR TITLE
[risk=low][no ticket] Clean up a few leftover email -> username conversions

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -260,7 +260,7 @@ public class ProfileController implements ProfileApiDelegate {
           userService.createUser(
               profile.getGivenName(),
               profile.getFamilyName(),
-              googleUser.getPrimaryEmail(),
+              gSuiteUsername,
               profile.getContactEmail(),
               profile.getAreaOfResearch(),
               profile.getProfessionalUrl(),
@@ -299,7 +299,7 @@ public class ProfileController implements ProfileApiDelegate {
     final MailService mail = mailServiceProvider.get();
 
     try {
-      mail.sendWelcomeEmail(profile.getContactEmail(), googleUser.getPassword(), googleUser);
+      mail.sendWelcomeEmail(profile.getContactEmail(), googleUser.getPassword(), gSuiteUsername);
     } catch (MessagingException e) {
       throw new WorkbenchException(e);
     }
@@ -440,7 +440,7 @@ public class ProfileController implements ProfileApiDelegate {
     try {
       mailServiceProvider
           .get()
-          .sendWelcomeEmail(user.getContactEmail(), googleUser.getPassword(), googleUser);
+          .sendWelcomeEmail(user.getContactEmail(), googleUser.getPassword(), user.getUsername());
     } catch (MessagingException e) {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.api;
 
+import com.google.api.services.directory.model.User;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import java.sql.Timestamp;
@@ -247,7 +248,7 @@ public class ProfileController implements ProfileApiDelegate {
             + "@"
             + workbenchConfigProvider.get().googleDirectoryService.gSuiteDomain;
 
-    com.google.api.services.directory.model.User googleUser =
+    User googleUser =
         directoryService.createUser(
             profile.getGivenName(),
             profile.getFamilyName(),
@@ -390,7 +391,7 @@ public class ProfileController implements ProfileApiDelegate {
   public ResponseEntity<Void> updateContactEmail(
       UpdateContactEmailRequest updateContactEmailRequest) {
     String username = updateContactEmailRequest.getUsername().toLowerCase();
-    com.google.api.services.directory.model.User googleUser = directoryService.getUser(username);
+    User googleUser = directoryService.getUser(username);
     DbUser user = userService.getByUsernameOrThrow(username);
     checkUserCreationNonce(user, updateContactEmailRequest.getCreationNonce());
     if (userHasEverLoggedIn(googleUser, user)) {
@@ -410,7 +411,7 @@ public class ProfileController implements ProfileApiDelegate {
   @Override
   public ResponseEntity<Void> resendWelcomeEmail(ResendWelcomeEmailRequest resendRequest) {
     String username = resendRequest.getUsername().toLowerCase();
-    com.google.api.services.directory.model.User googleUser = directoryService.getUser(username);
+    User googleUser = directoryService.getUser(username);
     DbUser user = userService.getByUsernameOrThrow(username);
     checkUserCreationNonce(user, resendRequest.getCreationNonce());
     if (userHasEverLoggedIn(googleUser, user)) {
@@ -429,14 +430,12 @@ public class ProfileController implements ProfileApiDelegate {
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
-  private boolean userHasEverLoggedIn(
-      com.google.api.services.directory.model.User googleUser, DbUser user) {
+  private boolean userHasEverLoggedIn(User googleUser, DbUser user) {
     return user.getFirstSignInTime() != null || !googleUser.getChangePasswordAtNextLogin();
   }
 
   private ResponseEntity<Void> resetPasswordAndSendWelcomeEmail(String username, DbUser user) {
-    com.google.api.services.directory.model.User googleUser =
-        directoryService.resetUserPassword(username);
+    User googleUser = directoryService.resetUserPassword(username);
     try {
       mailServiceProvider
           .get()

--- a/api/src/main/java/org/pmiops/workbench/mail/MailService.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailService.java
@@ -1,13 +1,12 @@
 package org.pmiops.workbench.mail;
 
-import com.google.api.services.directory.model.User;
 import java.time.Instant;
 import javax.mail.MessagingException;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.SendBillingSetupEmailRequest;
 
 public interface MailService {
-  void sendWelcomeEmail(final String contactEmail, final String password, final User user)
+  void sendWelcomeEmail(final String contactEmail, final String password, final String username)
       throws MessagingException;
 
   void sendInstitutionUserInstructions(final String contactEmail, final String userInstructions)

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.mail;
 
-import com.google.api.services.directory.model.User;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.html.HtmlEscapers;
@@ -80,16 +79,17 @@ public class MailServiceImpl implements MailService {
   }
 
   @Override
-  public void sendWelcomeEmail(final String contactEmail, final String password, final User user)
+  public void sendWelcomeEmail(
+      final String contactEmail, final String password, final String username)
       throws MessagingException {
 
     final String htmlMessage =
-        buildHtml(WELCOME_RESOURCE, welcomeMessageSubstitutionMap(password, user));
+        buildHtml(WELCOME_RESOURCE, welcomeMessageSubstitutionMap(password, username));
 
     sendWithRetries(
         Collections.singletonList(contactEmail),
         "Your new All of Us Researcher Workbench Account",
-        String.format("Welcome for %s", user.getName()),
+        String.format("Welcome for %s", username),
         htmlMessage);
   }
 
@@ -232,10 +232,10 @@ public class MailServiceImpl implements MailService {
   }
 
   private Map<EmailSubstitutionField, String> welcomeMessageSubstitutionMap(
-      final String password, final User user) {
+      final String password, final String username) {
     final CloudStorageClient cloudStorageClient = cloudStorageClientProvider.get();
     return new ImmutableMap.Builder<EmailSubstitutionField, String>()
-        .put(EmailSubstitutionField.USERNAME, user.getPrimaryEmail())
+        .put(EmailSubstitutionField.USERNAME, username)
         .put(EmailSubstitutionField.PASSWORD, password)
         .put(EmailSubstitutionField.URL, workbenchConfigProvider.get().admin.loginUrl)
         .put(EmailSubstitutionField.HEADER_IMG, getAllOfUsLogo())

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -163,7 +163,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   private static final String GIVEN_NAME = "Bob";
   private static final String GSUITE_DOMAIN = "researchallofus.org";
   private static final String NONCE = Long.toString(NONCE_LONG);
-  private static final String PRIMARY_EMAIL = "bob@researchallofus.org";
+  private static final String FULL_USER_NAME = "bob@researchallofus.org";
   private static final String RESEARCH_PURPOSE = "To test things";
   private static final String STATE = "EX";
   private static final String STREET_ADDRESS = "1 Example Lane";
@@ -282,14 +282,14 @@ public class ProfileControllerTest extends BaseControllerTest {
     createAccountRequest.setCaptchaVerificationToken(CAPTCHA_TOKEN);
 
     googleUser = new com.google.api.services.directory.model.User();
-    googleUser.setPrimaryEmail(PRIMARY_EMAIL);
+    googleUser.setPrimaryEmail(FULL_USER_NAME);
     googleUser.setChangePasswordAtNextLogin(true);
     googleUser.setPassword("testPassword");
     googleUser.setIsEnrolledIn2Sv(true);
 
     DUCC_VERSION = userService.getCurrentDuccVersion();
 
-    when(mockDirectoryService.getUser(PRIMARY_EMAIL)).thenReturn(googleUser);
+    when(mockDirectoryService.getUser(FULL_USER_NAME)).thenReturn(googleUser);
     when(mockDirectoryService.createUser(
             GIVEN_NAME, FAMILY_NAME, USER_PREFIX + "@" + GSUITE_DOMAIN, CONTACT_EMAIL))
         .thenReturn(googleUser);
@@ -402,7 +402,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   public void testCreateAccount_success() {
     createAccountAndDbUserWithAffiliation();
     verify(mockProfileAuditor).fireCreateAction(any(Profile.class));
-    final DbUser dbUser = userDao.findUserByUsername(PRIMARY_EMAIL);
+    final DbUser dbUser = userDao.findUserByUsername(FULL_USER_NAME);
     assertThat(dbUser).isNotNull();
     assertThat(accessTierService.getAccessTierShortNamesForUser(dbUser)).isEmpty();
   }
@@ -412,7 +412,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     createAccountRequest.setTermsOfServiceVersion(1);
     createAccountAndDbUserWithAffiliation();
 
-    final DbUser dbUser = userDao.findUserByUsername(PRIMARY_EMAIL);
+    final DbUser dbUser = userDao.findUserByUsername(FULL_USER_NAME);
     final List<DbUserTermsOfService> tosRows = Lists.newArrayList(userTermsOfServiceDao.findAll());
     assertThat(tosRows.size()).isEqualTo(1);
     assertThat(tosRows.get(0).getTosVersion()).isEqualTo(1);
@@ -1021,10 +1021,12 @@ public class ProfileControllerTest extends BaseControllerTest {
     createAccountAndDbUserWithAffiliation();
 
     profileController.syncEraCommonsStatus();
-    assertThat(userDao.findUserByUsername(PRIMARY_EMAIL).getEraCommonsLinkedNihUsername())
+    assertThat(userDao.findUserByUsername(FULL_USER_NAME).getEraCommonsLinkedNihUsername())
         .isEqualTo(linkedUsername);
-    assertThat(userDao.findUserByUsername(PRIMARY_EMAIL).getEraCommonsLinkExpireTime()).isNotNull();
-    assertThat(userDao.findUserByUsername(PRIMARY_EMAIL).getEraCommonsCompletionTime()).isNotNull();
+    assertThat(userDao.findUserByUsername(FULL_USER_NAME).getEraCommonsLinkExpireTime())
+        .isNotNull();
+    assertThat(userDao.findUserByUsername(FULL_USER_NAME).getEraCommonsCompletionTime())
+        .isNotNull();
   }
 
   @Test
@@ -1106,7 +1108,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     final Profile original = createAccountAndDbUserWithAffiliation();
 
     // valid user but no fields updated
-    final AccountPropertyUpdate request = new AccountPropertyUpdate().username(PRIMARY_EMAIL);
+    final AccountPropertyUpdate request = new AccountPropertyUpdate().username(FULL_USER_NAME);
     final Profile retrieved = profileService.updateAccountProperties(request);
 
     // RW-5257 Demo Survey completion time is incorrectly updated
@@ -1144,7 +1146,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertThat(original.getContactEmail()).isEqualTo(CONTACT_EMAIL);
 
     final AccountPropertyUpdate request =
-        new AccountPropertyUpdate().username(PRIMARY_EMAIL).contactEmail(newContactEmail);
+        new AccountPropertyUpdate().username(FULL_USER_NAME).contactEmail(newContactEmail);
 
     final Profile retrieved = profileService.updateAccountProperties(request);
     assertThat(retrieved.getContactEmail()).isEqualTo(newContactEmail);
@@ -1181,7 +1183,7 @@ public class ProfileControllerTest extends BaseControllerTest {
               createAccountAndDbUserWithAffiliation(affiliation, grantAdminAuthority);
           assertThat(original.getContactEmail()).isEqualTo(CONTACT_EMAIL);
           final AccountPropertyUpdate request =
-              new AccountPropertyUpdate().username(PRIMARY_EMAIL).contactEmail(newContactEmail);
+              new AccountPropertyUpdate().username(FULL_USER_NAME).contactEmail(newContactEmail);
           profileService.updateAccountProperties(request);
         });
   }
@@ -1198,7 +1200,7 @@ public class ProfileControllerTest extends BaseControllerTest {
           createAccountAndDbUserWithAffiliation(grantAdminAuthority);
           final String newContactEmail = "eric.lander@broadinstitute.org";
           final AccountPropertyUpdate request =
-              new AccountPropertyUpdate().username(PRIMARY_EMAIL).contactEmail(newContactEmail);
+              new AccountPropertyUpdate().username(FULL_USER_NAME).contactEmail(newContactEmail);
           profileService.updateAccountProperties(request);
         });
   }
@@ -1236,7 +1238,7 @@ public class ProfileControllerTest extends BaseControllerTest {
             .institutionalRoleEnum(InstitutionalRole.POST_DOCTORAL);
 
     final AccountPropertyUpdate request =
-        new AccountPropertyUpdate().username(PRIMARY_EMAIL).affiliation(newAffiliation);
+        new AccountPropertyUpdate().username(FULL_USER_NAME).affiliation(newAffiliation);
     final Profile retrieved = profileService.updateAccountProperties(request);
     assertThat(retrieved.getVerifiedInstitutionalAffiliation()).isEqualTo(newAffiliation);
 
@@ -1269,7 +1271,7 @@ public class ProfileControllerTest extends BaseControllerTest {
                   .institutionDisplayName(massGeneral.getDisplayName())
                   .institutionalRoleEnum(InstitutionalRole.POST_DOCTORAL);
           final AccountPropertyUpdate request =
-              new AccountPropertyUpdate().username(PRIMARY_EMAIL).affiliation(newAffiliation);
+              new AccountPropertyUpdate().username(FULL_USER_NAME).affiliation(newAffiliation);
           profileService.updateAccountProperties(request);
         });
   }
@@ -1312,7 +1314,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
     final AccountPropertyUpdate request =
         new AccountPropertyUpdate()
-            .username(PRIMARY_EMAIL)
+            .username(FULL_USER_NAME)
             .contactEmail(newContactEmail)
             .affiliation(newAffiliation);
     final Profile retrieved = profileService.updateAccountProperties(request);
@@ -1358,7 +1360,7 @@ public class ProfileControllerTest extends BaseControllerTest {
                   .institutionalRoleEnum(InstitutionalRole.POST_DOCTORAL);
           final AccountPropertyUpdate request =
               new AccountPropertyUpdate()
-                  .username(PRIMARY_EMAIL)
+                  .username(FULL_USER_NAME)
                   .contactEmail(newContactEmail)
                   .affiliation(newAffiliation);
           profileService.updateAccountProperties(request);
@@ -1371,7 +1373,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
     final AccountPropertyUpdate request =
         new AccountPropertyUpdate()
-            .username(PRIMARY_EMAIL)
+            .username(FULL_USER_NAME)
             .accessBypassRequests(Collections.emptyList());
     final Profile retrieved = profileService.updateAccountProperties(request);
 
@@ -1401,7 +1403,7 @@ public class ProfileControllerTest extends BaseControllerTest {
                 .isBypassed(false));
 
     final AccountPropertyUpdate request1 =
-        new AccountPropertyUpdate().username(PRIMARY_EMAIL).accessBypassRequests(bypasses1);
+        new AccountPropertyUpdate().username(FULL_USER_NAME).accessBypassRequests(bypasses1);
     final Profile retrieved1 = profileService.updateAccountProperties(request1);
 
     // this is now bypassed
@@ -1474,7 +1476,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     final Double newQuota = 123.4;
 
     final AccountPropertyUpdate request =
-        new AccountPropertyUpdate().username(PRIMARY_EMAIL).freeCreditsLimit(newQuota);
+        new AccountPropertyUpdate().username(FULL_USER_NAME).freeCreditsLimit(newQuota);
 
     final Profile retrieved = profileService.updateAccountProperties(request);
     assertThat(retrieved.getFreeTierDollarQuota()).isWithin(0.01).of(newQuota);
@@ -1489,7 +1491,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
     final AccountPropertyUpdate request =
         new AccountPropertyUpdate()
-            .username(PRIMARY_EMAIL)
+            .username(FULL_USER_NAME)
             .freeCreditsLimit(original.getFreeTierDollarQuota());
     profileService.updateAccountProperties(request);
 
@@ -1518,7 +1520,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
     final AccountPropertyUpdate request =
         new AccountPropertyUpdate()
-            .username(PRIMARY_EMAIL)
+            .username(FULL_USER_NAME)
             .freeCreditsLimit(config.billing.defaultFreeCreditsDollarLimit);
     profileService.updateAccountProperties(request);
     verify(mockUserServiceAuditor, never())
@@ -1559,7 +1561,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     Profile result = profileController.createAccount(createAccountRequest).getBody();
 
     // initialize the global test dbUser
-    dbUser = userDao.findUserByUsername(PRIMARY_EMAIL);
+    dbUser = userDao.findUserByUsername(FULL_USER_NAME);
 
     if (grantAdminAuthority) {
       dbUser.setAuthoritiesEnum(Collections.singleton(Authority.ACCESS_CONTROL_ADMIN));
@@ -1591,13 +1593,13 @@ public class ProfileControllerTest extends BaseControllerTest {
 
   private void assertProfile(Profile profile) {
     assertThat(profile).isNotNull();
-    assertThat(profile.getUsername()).isEqualTo(PRIMARY_EMAIL);
+    assertThat(profile.getUsername()).isEqualTo(FULL_USER_NAME);
     assertThat(profile.getContactEmail()).isEqualTo(CONTACT_EMAIL);
     assertThat(profile.getFamilyName()).isEqualTo(FAMILY_NAME);
     assertThat(profile.getGivenName()).isEqualTo(GIVEN_NAME);
     assertThat(profile.getAccessTierShortNames()).isEmpty();
 
-    DbUser user = userDao.findUserByUsername(PRIMARY_EMAIL);
+    DbUser user = userDao.findUserByUsername(FULL_USER_NAME);
     assertThat(user).isNotNull();
     assertThat(user.getContactEmail()).isEqualTo(CONTACT_EMAIL);
     assertThat(user.getFamilyName()).isEqualTo(FAMILY_NAME);

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.api.services.directory.model.User;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -174,7 +175,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   private static final double TIME_TOLERANCE_MILLIS = 100.0;
   private static final int CURRENT_TERMS_OF_SERVICE_VERSION = 1;
   private CreateAccountRequest createAccountRequest;
-  private com.google.api.services.directory.model.User googleUser;
+  private User googleUser;
   private static DbUser dbUser;
   private static List<DbAccessModule> accessModules;
 
@@ -281,7 +282,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     createAccountRequest.setProfile(profile);
     createAccountRequest.setCaptchaVerificationToken(CAPTCHA_TOKEN);
 
-    googleUser = new com.google.api.services.directory.model.User();
+    googleUser = new User();
     googleUser.setPrimaryEmail(FULL_USER_NAME);
     googleUser.setChangePasswordAtNextLogin(true);
     googleUser.setPassword("testPassword");

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHORT_NAME;
 
+import com.google.api.services.directory.model.User;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
@@ -373,8 +374,7 @@ public class UserServiceTest extends SpringTest {
 
   @Test
   public void testSyncTwoFactorAuthStatus() {
-    com.google.api.services.directory.model.User googleUser =
-        new com.google.api.services.directory.model.User();
+    User googleUser = new User();
     googleUser.setPrimaryEmail(USERNAME);
     googleUser.setIsEnrolledIn2Sv(true);
 


### PR DESCRIPTION
Long ago, we followed the GSuite convention of "email" to describe the primary way we identify a user.  This made sense at the time because it is indeed an email address.

Since then, the user's institutional contact email has become more important, and this is typically what we mean when we talk about a user's email.  So we renamed the original "email" to "username" in most cases (in #2929) to avoid confusion.

I noticed a few of these that we missed while looking at RW-7008.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
