### PR TITLE
[no ticket][risk=no] Bring back Puppeteer slowmo

### DIFF
--- a/e2e/jest-puppeteer.config.js
+++ b/e2e/jest-puppeteer.config.js
@@ -6,7 +6,7 @@
 const fp = require('lodash/fp');
 const puppeteer = require('puppeteer');
 const isHeadless = (process.env.PUPPETEER_HEADLESS || 'true') === 'true';
-const slowMotion = parseInt(process.env.PUPPETEER_SLOWMO, 10) || 0;
+const slowMotion = parseInt(process.env.PUPPETEER_SLOWMO, 10) || 10;
 
 const NEW_CHROME_SWITCHES = [
   // Reduce cpu and memory usage. Disables one-site-per-process security policy, dedicated processes for site origins.

--- a/e2e/libs/page-options.ts
+++ b/e2e/libs/page-options.ts
@@ -35,7 +35,7 @@ const ciChromeOptions = fp.concat(chromeOptions, [
 
 export const defaultLaunchOptions = {
   devtools: isDebug,
-  slowMo: 20,
+  slowMo: 10,
   defaultViewport: null,
   ignoreDefaultArgs: true,
   ignoreHTTPSErrors: true,


### PR DESCRIPTION
Set `slowmo` at 10 milliseconds for test stability.