### PR TITLE
[RW-7240][risk=no] Improve e2e type function

### DIFF
--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -176,7 +176,7 @@ export default class BaseElement {
    * @param newValue The text string.
    * @param options The typing options.
    */
-  async type(newValue: string, { delay = 10 } = {}): Promise<this> {
+  async type(newValue: string, { delay = 10, confidence = 2 } = {}): Promise<this> {
     if (newValue === undefined) {
       throw new Error('type() function parameter "newValue" is undefined.');
     }
@@ -184,15 +184,21 @@ export default class BaseElement {
     const clearAndType = async (txt: string): Promise<string> => {
       await this.clear();
       await this.asElementHandle().then((handle: ElementHandle) => handle.type(txt, { delay }));
+      await this.pressTab();
       return this.getProperty<string>('value');
     };
 
-    let maxRetries = 3;
+    let maxRetries = 4;
+    let confidenceCounter = 0;
     const typeAndCheck = async () => {
       const actualValue = await clearAndType(newValue);
       if (actualValue === newValue) {
-        await this.pressTab();
-        return; // success
+        confidenceCounter++;
+        if (confidenceCounter >= confidence) {
+          return; // success
+        }
+      } else {
+        confidenceCounter = confidenceCounter > 0 ? confidenceCounter-- : 0;
       }
       if (maxRetries <= 0) {
         throw new Error(`Failed to type "${newValue}". Actual text: "${actualValue}"`);

--- a/e2e/app/page/conceptset-actions-page.ts
+++ b/e2e/app/page/conceptset-actions-page.ts
@@ -46,7 +46,7 @@ export default class ConceptSetActionsPage extends AuthenticatedPage {
 
   async openConceptSet(conceptName: string): Promise<ConceptSetPage> {
     const link = new Link(this.page, `//a[text()="${conceptName}"]`);
-    await link.click();
+    await link.clickAndWait();
     const conceptSetPage = new ConceptSetPage(this.page);
     await conceptSetPage.waitForLoad();
     return conceptSetPage;

--- a/e2e/app/page/conceptset-page.ts
+++ b/e2e/app/page/conceptset-page.ts
@@ -67,12 +67,6 @@ export default class ConceptSetPage extends AuthenticatedPage {
       const xpath = '//*[@data-test-id="edit-name"]';
       const nameInput = new Textbox(this.page, xpath);
       await nameInput.type(newConceptName);
-      // DON'T DELETE. Value sometimes overridden by old value. To prevent test from failing, verify new value entered successfully.
-      // If new value is not found, re-type once more.
-      const actualValue = await nameInput.getValue();
-      if (actualValue.trim().toLowerCase() !== newConceptName.trim().toLowerCase()) {
-        await nameInput.type(newConceptName);
-      }
     }
 
     // Enter description
@@ -84,6 +78,7 @@ export default class ConceptSetPage extends AuthenticatedPage {
 
     await saveButton.click();
     await this.getEditButton().then((butn) => butn.waitUntilEnabled());
+    await waitWhileLoading(this.page);
   }
 
   /**


### PR DESCRIPTION
Test debug log example that indicates new workaround had worked: 

```
    console.log
      maxRetries: 3

    console.log
      [8/31/2021, 10:18:25] - Request finished: 200 GET https://api-dot-all-of-us-*********-test.appspot.com/v1/workspaces/aou-rw-test-e436c18e/e2eeditrenameconceptsetstest/concept-sets/44118

    console.log
      [8/31/2021, 10:18:26] - Request finished: 200 GET https://api-dot-all-of-us-*********-test.appspot.com/v1/workspaces/aou-rw-test-e436c18e/e2eeditrenameconceptsetstest/concept-sets/44118

    console.log
      [8/31/2021, 10:18:27] - Request finished: 200 GET https://api-dot-all-of-us-*********-test.appspot.com/v1/workspaces/aou-rw-test-e436c18e/e2eeditrenameconceptsetstest/concept-sets/44118

    console.log
      maxRetries: 2

    console.log
      type successful. confidenceCounter 1

    console.log
      maxRetries: 1

    console.log
      type successful. confidenceCounter 2

    console.log
      Exiting edit function

```