### PR TITLE
[no ticket][risk=no] Fix CircleCI workflow blocking script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,7 +632,7 @@ workflows:
       # Running two or more build-test-deploy workflows concurrently may result in failures to
       #  puppeteer-test, api-deploy-to-test or/and ui-deploy-to-test jobs.
       - wait_until_previous_workflow_done:
-          <<: *filter-master-branch
+          <<: *filter-pr-branch
       # Always run basic test/lint/compilation (open PRs, master branch merge)
       # Note: by default tags are not picked up.
       - api-local-test
@@ -655,12 +655,13 @@ workflows:
       - puppeteer-env-setup
       - puppeteer-test:
           <<: *filter-pr-branch
-          env_name: "local"
+          env_name: "test"
           parallel_num: 4
           optional_steps:
             - halt-puppeteer-check
           requires:
             - puppeteer-env-setup
+            - wait_until_previous_workflow_done
       # On master branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully
       - puppeteer-test:
           parallel_num: 4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,7 +632,7 @@ workflows:
       # Running two or more build-test-deploy workflows concurrently may result in failures to
       #  puppeteer-test, api-deploy-to-test or/and ui-deploy-to-test jobs.
       - wait_until_previous_workflow_done:
-          <<: *filter-pr-branch
+          <<: *filter-master-branch
       # Always run basic test/lint/compilation (open PRs, master branch merge)
       # Note: by default tags are not picked up.
       - api-local-test
@@ -655,13 +655,12 @@ workflows:
       - puppeteer-env-setup
       - puppeteer-test:
           <<: *filter-pr-branch
-          env_name: "test"
+          env_name: "local"
           parallel_num: 4
           optional_steps:
             - halt-puppeteer-check
           requires:
             - puppeteer-env-setup
-            - wait_until_previous_workflow_done
       # On master branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully
       - puppeteer-test:
           parallel_num: 4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -631,8 +631,7 @@ workflows:
     jobs:
       # Running two or more build-test-deploy workflows concurrently may result in failures to
       #  puppeteer-test, api-deploy-to-test or/and ui-deploy-to-test jobs.
-      - wait_until_previous_workflow_done:
-          <<: *filter-master-branch
+      - wait_until_previous_workflow_done
       # Always run basic test/lint/compilation (open PRs, master branch merge)
       # Note: by default tags are not picked up.
       - api-local-test
@@ -661,6 +660,8 @@ workflows:
             - halt-puppeteer-check
           requires:
             - puppeteer-env-setup
+            # PR commits e2e tests waits for workflow triggered by master branch merge to finish.
+            - wait_until_previous_workflow_done
       # On master branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully
       - puppeteer-test:
           parallel_num: 4

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -121,7 +121,7 @@ if [[ -z $pipeline_workflow_ids ]]; then
 fi
 
 # Wait as long as "pipelines" variable is not empty until max time has reached.
-# Max check time on a workflow is 45 minutes because e2e tests may take a long time to finish.
+# Max wait time until workflows have finished is 45 minutes because e2e tests may take a long time to finish.
 # DISCLAIMER This max time may not be enough.
 max_time=$((45 * 60))
 is_running=true
@@ -136,10 +136,10 @@ while [[ "${is_running}" == "true" ]]; do
     is_running=false
     fetch_pipeline_jobs "${id}"
     active_workflow=$__
-    printf "\n%s\n%s\n" "Active workflow:" "${active_workflow}"
+    printf "\n%s\n%s\n" "Active workflow:" "${active_workflow:=\{\}}"
 
     if [[ $active_workflow ]]; then
-      printf "%s\n" "Waiting for previously submitted pipelines to finish. sleep ${sleep_time}. Please wait..."
+      printf "\n%s\n" "Waiting for previously submitted pipelines to finish. sleep ${sleep_time}. Please wait..."
       sleep $sleep_time
       waited_time=$((sleep_time_counter + waited_time))
       is_running=true
@@ -149,7 +149,8 @@ while [[ "${is_running}" == "true" ]]; do
 
   printf "%s\n" "Has been waiting for ${waited_time} seconds."
   if [ $waited_time -gt $max_time ]; then
-    printf "\n\n%s\n\n" "***** Max wait time (${max_time} seconds) exceeded. Stop waiting for running builds to complete."
+    # Do not fail script.
+    printf "\n\n%s\n\n" "***** WARNING: Max wait time (${max_time} seconds) exceeded. Stop waiting for running builds to complete."
     is_running=false
   fi
 done

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -107,7 +107,7 @@ found_all_jobs() {
   printf '%s\n' "Check if all jobs have started."
   for name in ${JOBS}; do
     printf '%s\n' "name: ${name}"
-    if [[ ! " ${$1[*]} " =~ " ${name} " ]]; then
+    if [[ ! " ${1[*]} " =~ " ${name} " ]]; then
       false
     fi
   done

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -78,7 +78,7 @@ fetch_older_pipelines() {
   jq_filter="(.status | test(\"running|pending|queued\")) "
   jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\""
 
-  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | .workflow_id")
+  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | .workflows.workflow_id")
 }
 
 poll_active_pipeline() {

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -52,7 +52,7 @@ circle_get() {
 # Function returns current pipeline's start_time. It is used for comparison of start_time values.
 fetch_current_pipeline_start_time() {
   printf '%s\n' "Fetching current pipeline start_time."
-  local get_path="project/${PROJECT_SLUG}/tree/${BRANCH}?filter=running&shallow=true"
+  local get_path="project/${PROJECT_SLUG}?filter=running&shallow=true"
   local curl_result=$(circle_get "${get_path}")
   __=$(echo "${curl_result}" | jq -r ".[] | select(.build_num==$CIRCLE_BUILD_NUM) | .start_time")
 }

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -71,7 +71,7 @@ fetch_older_pipelines() {
   jq_filter=".branch==\"${BRANCH}\" and (.status | test(\"running|pending|queued\")) "
   jq_filter+="and .workflows.workflow_name==\"${WORKFLOW_NAME}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\""
 
-  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | [.workflows.workflow_id] | unique")
+  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | unique_by(.workflows.workflow_id)")
 }
 
 fetch_pipeline_jobs() {
@@ -136,7 +136,7 @@ while [[ "${is_running}" == "true" ]]; do
     is_running=false
     fetch_pipeline_jobs "${id}"
     active_workflow=$__
-    printf "\n%s\n%s\n" "Active workflow:" "${active_workflow:=\{\}}"
+    printf "\n%s\n%s\n" "Active workflow:" "${active_workflow}"
 
     if [[ $active_workflow ]]; then
       printf "\n%s\n" "Waiting for previously submitted pipelines to finish. sleep ${sleep_time}. Please wait..."

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -163,7 +163,6 @@ for id in ${workflow_ids}; do
 
     # Find running/queued jobs only.
     running_jobs=$(echo "${created_jobs}" | jq ". | select((.status | test(\"running|queued\")))")
-    printf "\n%s\n%s\n%s\n" "--------" "Running/queued jobs:" "${running_jobs}"
 
     # Find if any job has not been created.
     # V1 "/project/" api response does not show jobs that have not been created.
@@ -176,11 +175,12 @@ for id in ${workflow_ids}; do
       | sed 's/ /\n/g' \
       | sort \
       | uniq -u )
-    printf "\n%s\n%s\n%s\n" "--------" "Not created jobs:" "${not_created_jobs}"
 
     # Wait while some jobs in running/queued OR some jobs that have not been created.
     if [[ $running_jobs ]] || [[ $not_created_jobs ]]; then
       printf "\n%s\n" "Waiting for previously submitted pipelines to finish. sleep ${sleep_time}. Please wait..."
+      printf "%s\n%s\n%s\n" "--------" "Running/queued jobs:" "${running_jobs}"
+      printf "%s\n%s\n%s\n" "--------" "Not created jobs:" "${not_created_jobs}"
       sleep $sleep_time
       waited_time=$((sleep_time_counter + waited_time))
       is_running=true

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -71,7 +71,7 @@ fetch_older_pipelines() {
   jq_filter=".branch==\"${BRANCH}\" and (.status | test(\"running|pending|queued\")) "
   jq_filter+="and .workflows.workflow_name==\"${WORKFLOW_NAME}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\""
 
-  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | unique_by(.workflows.workflow_id)")
+  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | map(.workflows.workflow_id)  | flatten | unique")
 }
 
 fetch_pipeline_jobs() {

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -71,7 +71,7 @@ fetch_older_pipelines() {
   jq_filter=".branch==\"${BRANCH}\" and (.status | test(\"running|pending|queued\")) "
   jq_filter+="and .workflows.workflow_name==\"${WORKFLOW_NAME}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\""
 
-  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | .workflows.workflow_id")
+  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | .workflows.workflow_id | unique")
 }
 
 fetch_pipeline_jobs() {

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -118,32 +118,6 @@ fetch_running_jobs() {
   __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | ${jq_object}")
 }
 
-compare_arrays() {
-  arg1=$1[@]
-  array1=("${!arg1}")
-
-  arg2=$2[@]
-  array2=("${!arg2}")
-
-  # ${#array1[*]} returns the number of elements in array
-  if [ ${#array1[*]} != ${#array2[*]} ]; then
-    printf "%s\n" "arrays size are not equals"
-    false; return
-  fi
-  printf "%s\n" "arrays size are equals"
-
-  # ${!array1[*]} which returns a list of indexes.
-  for ii in ${!array1[*]}; do
-    if [ "${array1[$ii]}" != "${array2[$ii]}" ]; then
-      printf "%s\n" "arrays are not equals"
-      false; return
-    fi
-  done
-
-  printf "%s\n" "arrays are equals"
-  true; return
-}
-
 #********************
 # RUNNING
 # *******************

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -122,8 +122,12 @@ fi
 
 fetch_older_pipelines "${current_pipeline_start_time}"
 pipeline_workflow_ids=$__
-printf "%s\n\n" "Older pipeline workflow id are: ${pipeline_workflow_ids}"
+printf "%s\n\n" "Currently running pipeline workflow id are: ${pipeline_workflow_ids}"
 
+if [[ -z $pipeline_workflow_ids ]]; then
+  printf "%s\n" "No workflows currently running."
+  exit 0
+fi
 
 # Wait as long as "pipelines" variable is not empty until max time has reached.
 is_running=true
@@ -132,6 +136,7 @@ wait="30s"
 
 while [[ "${is_running}" == "true" ]]; do
   printf "\n***\n"
+
   for id in ${pipeline_workflow_ids}; do
     is_running=false
     poll_active_pipeline "${id}"

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -71,7 +71,7 @@ fetch_older_pipelines() {
   jq_filter=".branch==\"${BRANCH}\" and (.status | test(\"running|pending|queued\")) "
   jq_filter+="and .workflows.workflow_name==\"${WORKFLOW_NAME}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\""
 
-  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | .workflows.workflow_id | unique")
+  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | [.workflows.workflow_id] | unique")
 }
 
 fetch_pipeline_jobs() {

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -136,7 +136,7 @@ while [[ "${is_running}" == "true" ]]; do
     is_running=false
     fetch_pipeline_jobs "${id}"
     active_workflow=$__
-    printf "\n%s\n%s\n" "Active workflow:" "${active_workflow}"
+    printf "\n%s\n%s\n" "Active workflow and job:" "${active_workflow}"
 
     if [[ $active_workflow ]]; then
       printf "\n%s\n" "Waiting for previously submitted pipelines to finish. sleep ${sleep_time}. Please wait..."

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -82,18 +82,17 @@ fetch_older_pipelines() {
 }
 
 poll_active_pipeline() {
-  printf '%s\n' "Fetching workflow_id \"${id}\" on \"${branch}\" branch that is either running, pending or queued."
+  printf '%s\n' "Fetching workflow_id \"${id}\" on \"${branch}\" branch."
     # TODO local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
     local get_path="project/${project_slug}?filter=running&shallow=true"
     local curl_result=$(circle_get "${get_path}")
     if [[ ! "${curl_result}" ]]; then
-      printf "Fetching active older pipelines failed."
+      printf "Fetching workflow_id \"${id}\" failed."
       exit 1
     fi
     # TODO jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
     jq_filter="(.status | test(\"running|pending|queued\")) "
     jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id==\"${1}\""
-
     jq_object="{ workflow_name: .workflows.workflow_name, workflow_id: .workflows.workflow_id, "
     jq_object+="job_name: .workflows.job_name, build_num, start_time, status }"
 
@@ -132,7 +131,7 @@ fi
 # Wait as long as "pipelines" variable is not empty until max time has reached.
 is_running=true
 waited_time=0
-wait="30s"
+wait="10s"
 
 while [[ "${is_running}" == "true" ]]; do
   printf "\n***\n"

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -144,7 +144,7 @@ for id in ${workflow_ids}; do
   is_running=true
 
   while [[ "${is_running}" == "true" ]]; do
-    printf "%s\n" "*** Polling workflow id ${id} ***"
+    printf "\n\n%s\n" "*** Polling workflow id ${id} ***"
     is_running=false
 
     # Find jobs that have been created (listed jobs in api response):
@@ -186,7 +186,7 @@ for id in ${workflow_ids}; do
       is_running=true
     fi
 
-    printf "%s\n" "Has been waiting for ${waited_time} seconds."
+    printf "\n%s\n" ">>> Has been waiting for ${waited_time} seconds."
     if [ $waited_time -gt $max_time ]; then
       # End wait but do not fail script.
       printf "\n\n%s\n\n" "****** Max wait time (${max_time} seconds) exceeded. Stop waiting for running builds to complete."

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -78,7 +78,7 @@ fetch_older_pipelines() {
   jq_filter="(.status | test(\"running|pending|queued\")) "
   jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\""
 
-  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | .[].workflow_id")
+  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | .workflow_id")
 }
 
 poll_active_pipeline() {

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -156,7 +156,7 @@ while [[ "${is_running}" == "true" ]]; do
     created_job_names=$(echo "${created_jobs}" | jq -r ".job_name")
 
     # Find failed jobs only.
-    jq_job_filter="(.status | test(\"failed\")) and (.job_name | test(\"ui-deploy-to-test|api-deploy-to-test\")))"
+    jq_job_filter="(.status | test(\"failed\")) and (.job_name | test([\"ui-deploy-to-test\"]|[\"api-deploy-to-test\"])))"
     failed_jobs=$(echo "${created_jobs}" | jq ". | select(${jq_job_filter})")
 
     # Find running/queued jobs only.

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -129,7 +129,7 @@ if [[ -z $pipeline_workflow_ids ]]; then
 fi
 
 # Filter out duplicate workflow id.
-workflow_ids=$(echo $pipeline_workflow_ids | tr ' ' '\n' | sort --u)
+workflow_ids=$(echo "${pipeline_workflow_ids}" | tr ' ' '\n' | sort --u)
 printf "%s\n%s\n\n" "Currently running workflow_ids:" "${workflow_ids}"
 
 
@@ -153,19 +153,19 @@ while [[ "${is_running}" == "true" ]]; do
     # Created jobs have status running, queued, failed, or success.
     fetch_jobs "${id}"
     created_jobs=$__
-    created_job_names=$(echo ${created_jobs} | jq -r ".job_name")
+    created_job_names=$(echo "${created_jobs}" | jq -r ".job_name")
 
     # Find failed jobs only.
-    failed_jobs=$(echo ${created_jobs} | jq ". | select((.status | test(\"failed\")))")
+    failed_jobs=$(echo "${created_jobs}" | jq ". | select((.status | test(\"failed\")))")
 
     # Find running/queued jobs only.
-    running_jobs=$(echo ${created_jobs} | jq ". | select((.status | test(\"running|queued\")))")
+    running_jobs=$(echo "${created_jobs}" | jq ". | select((.status | test(\"running|queued\")))")
     printf "\n%s\n%s\n\n" "Find jobs that are running or queued:" "${running_jobs}"
 
     # Find out if any job has not been created.
     # V1 "/project/" api response does not show jobs that have not been created.
     # We need to compare created jobs list against expected jobs list.
-    not_created_jobs=(`echo ${JOB_LIST[@]} ${created_job_names[@]} | tr ' ' '\n' | sort | uniq -u `)
+    not_created_jobs=(`echo "${JOB_LIST[@]}" "${created_job_names[@]}" | tr ' ' '\n' | sort | uniq -u `)
 
     # Wait while there are jobs in running/queued OR there are jobs that have not been created and no failed jobs.
     if [[ $running_jobs ]] || ( [[ -z $failed_jobs ]] && [[ $not_created_jobs ]] ); then

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -139,7 +139,7 @@ while [[ "${is_running}" == "true" ]]; do
     is_running=false
     poll_active_pipeline_detail "${id}"
     active_workflow=$__
-    printf "\n%s\n\%s\n" "Active workflow id:", "${active_workflow}"
+    printf "\n%s\n%s\n" "Active workflow id:" "${active_workflow}"
     if [[ $active_workflow ]]; then
       printf "%s\n" "Waiting for previously submitted pipelines to finish. sleep ${sleep_time}. Please wait..."
       sleep $sleep_time

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -156,7 +156,7 @@ while [[ "${is_running}" == "true" ]]; do
     created_job_names=$(echo "${created_jobs}" | jq -r ".job_name")
 
     # Find failed jobs only.
-    jq_job_filter="(.status | test(\"failed\")) and (.job_name | test(\"ui-deploy-to-test\"|\"api-deploy-to-test\")))"
+    jq_job_filter="(.status | test(\"failed\")) and (.job_name | test(\"ui-deploy-to-test\"|\"api-deploy-to-test\"))"
     failed_jobs=$(echo "${created_jobs}" | jq ". | select(${jq_job_filter})")
 
     # Find running/queued jobs only.

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -105,9 +105,10 @@ fetch_active_jobs() {
 # We need to check all expected jobs are found api response.
 found_all_jobs() {
   printf '%s\n' "Check if all jobs have started."
+  running_jobs=${1}
   for name in ${JOBS}; do
     printf '%s\n' "name: ${name}"
-    if [[ ! " ${1[*]} " =~ " ${name} " ]]; then
+    if [[ ! " ${running_jobs[*]} " =~ " ${name} " ]]; then
       false
     fi
   done

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -156,7 +156,7 @@ while [[ "${is_running}" == "true" ]]; do
     created_job_names=$(echo "${created_jobs}" | jq -r ".job_name")
 
     # Find failed jobs only.
-    jq_job_filter="(.status | test(\"failed\")) and (.job_name | test([\"ui-deploy-to-test\"]|[\"api-deploy-to-test\"])))"
+    jq_job_filter="(.status | test(\"failed\")) and (.job_name | test(\"ui-deploy-to-test\"|\"api-deploy-to-test\")))"
     failed_jobs=$(echo "${created_jobs}" | jq ". | select(${jq_job_filter})")
 
     # Find running/queued jobs only.

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -106,6 +106,7 @@ fetch_active_jobs() {
 found_all_jobs() {
   printf '%s\n' "Check if all jobs have started."
   for name in ${JOBS}; do
+    printf '%s\n' "name: ${name}"
     if [[ ! " ${$1[*]} " =~ " ${name} " ]]; then
       false
     fi
@@ -168,7 +169,7 @@ while [[ "${is_running}" == "true" ]]; do
     printf "\n%s\n%s\n" "Active workflow and jobs:" "${active_jobs}"
 
     # Is there any job that has not started at all?
-    jobs=$(echo $active_jobs | jq .[] | .job_name)
+    jobs=$(echo $active_jobs | jq .job_name)
     printf "\n%s\n" "jobs:" "${jobs}"
 
     found_all_jobs ${jobs}

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -73,7 +73,7 @@ fetch_older_pipelines() {
   __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | .workflows.workflow_id")
 }
 
-poll_active_pipeline_detail() {
+fetch_pipeline_detail() {
   printf '%s\n' "Fetching workflow_id \"${id}\" on \"${branch}\" branch."
     local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
     local curl_result=$(circle_get "${get_path}")
@@ -111,10 +111,10 @@ fi
 
 fetch_older_pipelines "${current_pipeline_start_time}"
 pipeline_workflow_ids=$__
-printf "%s\n\n" "Currently running pipeline workflow id are: ${pipeline_workflow_ids}"
+printf "%s\n%s\n\n" "Currently running workflow_id are:" "${pipeline_workflow_ids}"
 
 if [[ -z $pipeline_workflow_ids ]]; then
-  printf "%s\n" "No workflows currently running."
+  printf "%s\n" "No workflow currently running."
   exit 0
 fi
 
@@ -132,9 +132,10 @@ while [[ "${is_running}" == "true" ]]; do
 
   for id in ${pipeline_workflow_ids}; do
     is_running=false
-    poll_active_pipeline_detail "${id}"
+    fetch_pipeline_detail "${id}"
     active_workflow=$__
-    printf "\n%s\n%s\n" "Active workflow id:" "${active_workflow}"
+    printf "\n%s\n%s\n" "Active workflow:" "${active_workflow}"
+
     if [[ $active_workflow ]]; then
       printf "%s\n" "Waiting for previously submitted pipelines to finish. sleep ${sleep_time}. Please wait..."
       sleep $sleep_time

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -71,7 +71,7 @@ fetch_older_pipelines() {
   jq_filter=".branch==\"${BRANCH}\" and (.status | test(\"running|pending|queued\")) "
   jq_filter+="and .workflows.workflow_name==\"${WORKFLOW_NAME}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\""
 
-  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | map(.workflows.workflow_id)  | flatten | unique")
+  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | unique_by(.workflows.workflow_id) | .workflows.workflow_id")
 }
 
 fetch_pipeline_jobs() {

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -82,7 +82,7 @@ fetch_older_pipelines() {
 }
 
 poll_active_pipeline() {
-  printf '%s\n' "Fetching active older pipelines on \"${branch}\" branch that are running, pending or queued."
+  printf '%s\n' "Fetching workflow_id \"${id}\" on \"${branch}\" branch that is either running, pending or queued."
     # TODO local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
     local get_path="project/${project_slug}?filter=running&shallow=true"
     local curl_result=$(circle_get "${get_path}")
@@ -92,7 +92,7 @@ poll_active_pipeline() {
     fi
     # TODO jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
     jq_filter="(.status | test(\"running|pending|queued\")) "
-    jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\" and .workflows.workflow_id==\"${1}\""
+    jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id==\"${1}\""
 
     jq_object="{ workflow_name: .workflows.workflow_name, workflow_id: .workflows.workflow_id, "
     jq_object+="job_name: .workflows.job_name, build_num, start_time, status }"

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -81,7 +81,7 @@ fetch_older_pipelines() {
   __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | .workflows.workflow_id")
 }
 
-poll_active_pipeline() {
+poll_active_pipeline_detail() {
   printf '%s\n' "Fetching workflow_id \"${id}\" on \"${branch}\" branch."
     # TODO local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
     local get_path="project/${project_slug}?filter=running&shallow=true"
@@ -131,18 +131,18 @@ fi
 # Wait as long as "pipelines" variable is not empty until max time has reached.
 is_running=true
 waited_time=0
-wait="10s"
+sleep_time="10s"
 
 while [[ "${is_running}" == "true" ]]; do
   printf "\n***\n"
 
   for id in ${pipeline_workflow_ids}; do
     is_running=false
-    poll_active_pipeline "${id}"
+    poll_active_pipeline_detail "${id}"
     active_workflow=$__
     printf "\n%s\n" "Active workflow id: ${active_workflow}"
     if [[ $active_workflow ]]; then
-      printf "%s\n" "Waiting for previously submitted pipelines to finish. sleep ${wait} seconds. Please wait..."
+      printf "%s\n" "Waiting for previously submitted pipelines to finish. sleep ${sleep_time}. Please wait..."
       sleep $sleep_time
       waited_time=$((sleep_time + waited_time))
       is_running=true

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -156,6 +156,7 @@ while [[ "${is_running}" == "true" ]]; do
     created_job_names=$(echo "${created_jobs}" | jq -r ".job_name")
 
     # Find failed jobs only.
+    # (jq: If the key contains special characters or starts with a digit, need to surround it with double quotes)
     jq_job_filter="(.status | test(\"failed\")) and (.job_name | test(\"ui-deploy-to-test\"|\"api-deploy-to-test\"))"
     failed_jobs=$(echo "${created_jobs}" | jq ". | select(${jq_job_filter})")
 

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -169,10 +169,10 @@ for id in ${workflow_ids}; do
     # V1 "/project/" api response does not show jobs that have not been created.
     # Get list of elements that appear in $JOB_LIST but are not in $created_job_names.
     not_created_jobs=$( \
-      echo ${JOB_LIST[@]} ${created_job_names[@]} \
+      echo ${created_job_names[@]} ${JOB_LIST[@]} \
       | sed 's/ /\n/g' \
       | sort | uniq -d \
-      | xargs echo ${created_job_names[@]} \
+      | xargs echo ${JOB_LIST[@]} \
       | sed 's/ /\n/g' \
       | sort \
       | uniq -u )

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -139,7 +139,7 @@ while [[ "${is_running}" == "true" ]]; do
     is_running=false
     poll_active_pipeline_detail "${id}"
     active_workflow=$__
-    printf "\n%s\n" "Active workflow id: ${active_workflow}"
+    printf "\n%s\n\%s\n" "Active workflow id:", "${active_workflow}"
     if [[ $active_workflow ]]; then
       printf "%s\n" "Waiting for previously submitted pipelines to finish. sleep ${sleep_time}. Please wait..."
       sleep $sleep_time

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -14,11 +14,6 @@ branch="master"
 workflow_name="build-test-deploy"
 project_slug="all-of-us/workbench"
 
-# Max check time on a workflow is 45 minutes because e2e tests may take a long time to finish.
-# DISCLAIMER This max time may not be enough.
-max_time=$((45 * 60))
-sleep_time=30
-
 #********************
 # FUNCTIONS
 # *******************
@@ -129,9 +124,13 @@ if [[ -z $pipeline_workflow_ids ]]; then
 fi
 
 # Wait as long as "pipelines" variable is not empty until max time has reached.
+# Max check time on a workflow is 45 minutes because e2e tests may take a long time to finish.
+# DISCLAIMER This max time may not be enough.
+max_time=$((45 * 60))
 is_running=true
 waited_time=0
 sleep_time="10s"
+sleep_time_counter=10
 
 while [[ "${is_running}" == "true" ]]; do
   printf "\n***\n"
@@ -144,7 +143,7 @@ while [[ "${is_running}" == "true" ]]; do
     if [[ $active_workflow ]]; then
       printf "%s\n" "Waiting for previously submitted pipelines to finish. sleep ${sleep_time}. Please wait..."
       sleep $sleep_time
-      waited_time=$((sleep_time + waited_time))
+      waited_time=$((sleep_time_counter + waited_time))
       is_running=true
       break
     fi

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -71,7 +71,7 @@ fetch_older_pipelines() {
   jq_filter=".branch==\"${BRANCH}\" and (.status | test(\"running|pending|queued\")) "
   jq_filter+="and .workflows.workflow_name==\"${WORKFLOW_NAME}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\""
 
-  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | unique_by(.workflows.workflow_id) | .workflows.workflow_id")
+  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | [{workflow_id: .workflows.workflow_id}] | unique | .[] | .workflow_id")
 }
 
 fetch_pipeline_jobs() {

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -77,9 +77,8 @@ fetch_older_pipelines() {
   # TODO jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
   jq_filter="(.status | test(\"running|pending|queued\")) "
   jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\""
-  jq_object="{ workflow_name: .workflows.workflow_name, workflow_id: .workflows.workflow_id, "
-  jq_object+="job_name: .workflows.job_name, build_num, start_time, status }"
-  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | ${jq_object} | workflow_id")
+
+  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | .[].workflow_id")
 }
 
 poll_active_pipeline() {
@@ -94,7 +93,11 @@ poll_active_pipeline() {
     # TODO jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
     jq_filter="(.status | test(\"running|pending|queued\")) "
     jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id!=\"${1}\""
-    __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter})")
+
+    jq_object="{ workflow_name: .workflows.workflow_name, workflow_id: .workflows.workflow_id, "
+    jq_object+="job_name: .workflows.job_name, build_num, start_time, status }"
+
+    __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | ${jq_object}")
 }
 
 #********************

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -77,8 +77,8 @@ fetch_older_pipelines() {
   # TODO jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
   jq_filter="(.status | test(\"running|pending|queued\")) "
   jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\""
-  jq_object="[{ workflow_name: .workflows.workflow_name, workflow_id: .workflows.workflow_id, "
-  jq_object+="job_name: .workflows.job_name, build_num, start_time, status }]"
+  jq_object="{ workflow_name: .workflows.workflow_name, workflow_id: .workflows.workflow_id, "
+  jq_object+="job_name: .workflows.job_name, build_num, start_time, status }"
   __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | ${jq_object} | workflow_id")
 }
 

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -170,7 +170,7 @@ while [[ "${is_running}" == "true" ]]; do
     not_created_jobs=$(echo "${JOB_LIST[@]}" "${created_job_names[@]}" | tr ' ' '\n' | sort | uniq -u)
 
     # Wait while there are jobs in running/queued OR there are jobs that have not been created and no failed jobs.
-    if [[ $running_jobs ]] || ( [[ -z $failed_jobs ]] && [[ $not_created_jobs ]] ); then
+    if [[ $running_jobs ]] || ( [[ $failed_jobs ]] && [[ $not_created_jobs ]] ); then
       printf "\n%s\n" "Waiting for previously submitted pipelines to finish. sleep ${sleep_time}. Please wait..."
       sleep $sleep_time
       waited_time=$((sleep_time_counter + waited_time))

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -156,7 +156,8 @@ while [[ "${is_running}" == "true" ]]; do
     created_job_names=$(echo "${created_jobs}" | jq -r ".job_name")
 
     # Find failed jobs only.
-    failed_jobs=$(echo "${created_jobs}" | jq ". | select((.status | test(\"failed\")))")
+    jq_job_filter="(.status | test(\"failed\")) and (.job_name | test(\"ui-deploy-to-test|api-deploy-to-test\")))"
+    failed_jobs=$(echo "${created_jobs}" | jq ". | select(${jq_job_filter})")
 
     # Find running/queued jobs only.
     running_jobs=$(echo "${created_jobs}" | jq ". | select((.status | test(\"running|queued\")))")
@@ -165,7 +166,7 @@ while [[ "${is_running}" == "true" ]]; do
     # Find out if any job has not been created.
     # V1 "/project/" api response does not show jobs that have not been created.
     # We need to compare created jobs list against expected jobs list.
-    not_created_jobs=(`echo "${JOB_LIST[@]}" "${created_job_names[@]}" | tr ' ' '\n' | sort | uniq -u `)
+    not_created_jobs=$(echo "${JOB_LIST[@]}" "${created_job_names[@]}" | tr ' ' '\n' | sort | uniq -u)
 
     # Wait while there are jobs in running/queued OR there are jobs that have not been created and no failed jobs.
     if [[ $running_jobs ]] || ( [[ -z $failed_jobs ]] && [[ $not_created_jobs ]] ); then

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -57,7 +57,8 @@ circle_get() {
 # Function returns current pipeline's start_time. It is used for comparison of start_time values.
 fetch_current_pipeline_start_time() {
   printf '%s\n' "Fetch current pipeline start time."
-  local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
+  # TODO local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
+  local get_path="project/${project_slug}?filter=running&shallow=true"
   local curl_result=$(circle_get "${get_path}")
   __=$(echo "${curl_result}" | jq -r ".[] | select(.build_num==$CIRCLE_BUILD_NUM) | .start_time")
 }
@@ -66,13 +67,15 @@ fetch_current_pipeline_start_time() {
 # Fetch list of builds on master branch that are running, pending or queued.
 fetch_older_pipelines() {
   printf '%s\n' "Fetch pipeline workflow id (older than ${1}) on \"${branch}\" branch that are running, pending or queued."
-  local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
+  # TODO local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
+  local get_path="project/${project_slug}?filter=running&shallow=true"
   local curl_result=$(circle_get "${get_path}")
   if [[ ! "${curl_result}" ]]; then
     printf "Fetch all older pipelines failed."
     exit 1
   fi
-  jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
+  # TODO jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
+  jq_filter="(.status | test(\"running|pending|queued\")) "
   jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\""
   jq_object="[{ workflow_name: .workflows.workflow_name, workflow_id: .workflows.workflow_id, "
   jq_object+="job_name: .workflows.job_name, build_num, start_time, status }]"
@@ -81,13 +84,15 @@ fetch_older_pipelines() {
 
 poll_active_pipeline() {
   printf '%s\n' "Fetch active older pipelines on \"${branch}\" branch that are running, pending or queued."
-    local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
+    # TODO local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
+    local get_path="project/${project_slug}?filter=running&shallow=true"
     local curl_result=$(circle_get "${get_path}")
     if [[ ! "${curl_result}" ]]; then
       printf "Fetch active older pipelines failed."
       exit 1
     fi
-    jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
+    # TODO jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
+    jq_filter="(.status | test(\"running|pending|queued\")) "
     jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id!=\"${1}\""
     __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter})")
 }

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -14,9 +14,8 @@ BRANCH="master"
 WORKFLOW_NAME="build-test-deploy"
 PROJECT_SLUG="all-of-us/workbench"
 
-# List of jobs in build-test-deploy workflow on master branch.
-JOB_LIST=("puppeteer-test-2-1" "ui-deploy-to-test" "api-deploy-to-test" "api-integration-test" "api-local-test")
-JOB_LIST+=("api-unit-test" "wait_until_previous_workflow_done" "ui-unit-test" "puppeteer-env-setup" "api-bigquery-test")
+# List of jobs that have depend on upstream jobs in build-test-deploy workflow on master branch.
+JOB_LIST=("puppeteer-test-2-1" "ui-deploy-to-test" "api-deploy-to-test")
 
 
 #********************
@@ -76,11 +75,10 @@ fetch_older_pipelines() {
   # Explanation:
   # .why=="github": Exclude jobs manually triggered via ssh by users.
   # .dont_build!="prs-only": Commits to github branch but a Pull Request has not been created.
-  jq_filter=".branch==\"${BRANCH}\" "
-  jq_filter+=" and .why==\"github\" and .dont_build!=\"prs-only\" "
+  jq_filter=".branch==\"${BRANCH}\" and .why==\"github\" and .dont_build!=\"prs-only\" "
   jq_filter+=" and .workflows.workflow_name==\"${WORKFLOW_NAME}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\""
 
-  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | [{workflow_id: .workflows.workflow_id}] | unique | .[] | .workflow_id")
+  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | [{workflow_id: .workflows.workflow_id}] | .[] | .workflow_id")
 }
 
 fetch_jobs() {
@@ -100,23 +98,6 @@ fetch_jobs() {
   __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | ${jq_object}")
 }
 
-fetch_running_jobs() {
-  printf '%s\n' "Fetching running jobs in workflow_id \"${1}\" on \"${BRANCH}\" branch."
-  local get_path="project/${PROJECT_SLUG}/tree/${BRANCH}?shallow=true"
-  local curl_result=$(circle_get "${get_path}")
-
-  if [[ ! "${curl_result}" ]]; then
-    printf "Curl request failed. workflow_id \"${1}\"."
-    exit 1
-  fi
-
-  jq_object="{ workflow_name: .workflows.workflow_name, workflow_id: .workflows.workflow_id, "
-  jq_object+="job_name: .workflows.job_name, build_num, start_time, status, branch, build_url }"
-  jq_filter=".branch==\"${BRANCH}\" and (.status | test(\"running|queued\")) "
-  jq_filter+=" and .workflows.workflow_name==\"${WORKFLOW_NAME}\" and .workflows.workflow_id==\"${1}\""
-
-  __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | ${jq_object}")
-}
 
 #********************
 # RUNNING
@@ -132,9 +113,9 @@ printf "%s\n\n" "Current pipeline CIRCLE_WORKFLOW_ID: ${CIRCLE_WORKFLOW_ID}"
 
 fetch_current_pipeline_start_time
 current_pipeline_start_time=$__
-printf "%s\n\n" "Current pipeline start_at time: ${current_pipeline_start_time}"
+
 if [[ ! "${current_pipeline_start_time}" ]]; then
-  printf "Value of current_pipeline_start_time is not valid."
+  printf "%s\n\n" "Invalid (current) pipeline start_at time: ${current_pipeline_start_time}"
   exit 1
 fi
 
@@ -146,6 +127,7 @@ if [[ -z $pipeline_workflow_ids ]]; then
   printf "%s\n" "No workflow currently running on master branch."
   exit 0
 fi
+
 # Filter out duplicate workflow id.
 workflow_ids=$(echo $pipeline_workflow_ids | tr ' ' '\n' | sort --u)
 printf "%s\n%s\n\n" "Currently running workflow_ids:" "${workflow_ids}"
@@ -167,28 +149,26 @@ while [[ "${is_running}" == "true" ]]; do
   for id in ${workflow_ids}; do
     is_running=false
 
-    # Find jobs that have been created (listed jobs in api response): Include jobs with status running, queued, failed, success.
+    # Find jobs that have been created (listed jobs in api response):
+    # Created jobs have status running, queued, failed, or success.
     fetch_jobs "${id}"
     created_jobs=$__
+    created_job_names=$(echo ${created_jobs} | jq -r ".job_name")
 
     # Find failed jobs only.
     failed_jobs=$(echo ${created_jobs} | jq ". | select((.status | test(\"failed\")))")
-    printf "\n%s\n%s\n\n" "Find jobs that have failed:" "${failed_jobs}"
 
     # Find running/queued jobs only.
     running_jobs=$(echo ${created_jobs} | jq ". | select((.status | test(\"running|queued\")))")
     printf "\n%s\n%s\n\n" "Find jobs that are running or queued:" "${running_jobs}"
 
-    # Find job names that have not been created: Include downstream jobs.
-    created_job_names=$(echo ${created_jobs} | jq -r ".job_name")
-
+    # Find out if any job has not been created.
     # V1 "/project/" api response does not show jobs that have not been created.
     # We need to compare created jobs list against expected jobs list.
     not_created_jobs=(`echo ${JOB_LIST[@]} ${created_job_names[@]} | tr ' ' '\n' | sort | uniq -u `)
-    printf "\n%s\n" "Jobs that have not been created:" "${not_created_jobs}"
 
     # Wait while there are jobs in running/queued OR there are jobs that have not been created and no failed jobs.
-    if [[ $running_jobs ]] || ( [[ ! $failed_jobs ]] && [[ $not_created_jobs ]] ); then
+    if [[ $running_jobs ]] || ( [[ -z $failed_jobs ]] && [[ $not_created_jobs ]] ); then
       printf "\n%s\n" "Waiting for previously submitted pipelines to finish. sleep ${sleep_time}. Please wait..."
       sleep $sleep_time
       waited_time=$((sleep_time_counter + waited_time))

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -52,8 +52,7 @@ circle_get() {
 # Function returns current pipeline's start_time. It is used for comparison of start_time values.
 fetch_current_pipeline_start_time() {
   printf '%s\n' "Fetching current pipeline start time."
-  # TODO local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
-  local get_path="project/${project_slug}?filter=running&shallow=true"
+  local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
   local curl_result=$(circle_get "${get_path}")
   __=$(echo "${curl_result}" | jq -r ".[] | select(.build_num==$CIRCLE_BUILD_NUM) | .start_time")
 }
@@ -62,15 +61,13 @@ fetch_current_pipeline_start_time() {
 # Fetch list of builds on master branch that are running, pending or queued.
 fetch_older_pipelines() {
   printf '%s\n' "Fetching pipeline workflow id (older than ${1}) on \"${branch}\" branch that are running, pending or queued."
-  # TODO local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
-  local get_path="project/${project_slug}?filter=running&shallow=true"
+  local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
   local curl_result=$(circle_get "${get_path}")
   if [[ ! "${curl_result}" ]]; then
     printf "Fetching all older pipelines failed."
     exit 1
   fi
-  # TODO jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
-  jq_filter="(.status | test(\"running|pending|queued\")) "
+  jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
   jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\""
 
   __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | select(.start_time < \"${1}\") | .workflows.workflow_id")
@@ -78,15 +75,13 @@ fetch_older_pipelines() {
 
 poll_active_pipeline_detail() {
   printf '%s\n' "Fetching workflow_id \"${id}\" on \"${branch}\" branch."
-    # TODO local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
-    local get_path="project/${project_slug}?filter=running&shallow=true"
+    local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
     local curl_result=$(circle_get "${get_path}")
     if [[ ! "${curl_result}" ]]; then
       printf "Fetching workflow_id \"${id}\" failed."
       exit 1
     fi
-    # TODO jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
-    jq_filter="(.status | test(\"running|pending|queued\")) "
+    jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
     jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id==\"${1}\""
     jq_object="{ workflow_name: .workflows.workflow_name, workflow_id: .workflows.workflow_id, "
     jq_object+="job_name: .workflows.job_name, build_num, start_time, status, branch }"

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -101,6 +101,8 @@ fetch_active_jobs() {
   __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | ${jq_object}")
 }
 
+# V1 "/project/" api response does not show jobs that have not been queued or started.
+# We need to check all expected jobs are found api response.
 found_all_jobs() {
   printf '%s\n' "Check if all jobs have started."
   for name in ${JOBS}; do
@@ -134,15 +136,16 @@ fi
 
 fetch_older_pipelines "${current_pipeline_start_time}"
 pipeline_workflow_ids=$__
-printf "%s\n%s\n\n" "Currently running workflow_id are:" "${pipeline_workflow_ids}"
 
-unique_workflow_id=$(echo $pipeline_workflow_ids | sort --u)
-printf "%s\n%s\n\n" "Unique workflow_id are:" "${unique_workflow_id}"
-
+# Exit if there are no running workflows on master branch.
 if [[ -z $pipeline_workflow_ids ]]; then
-  printf "%s\n" "No workflow currently running."
+  printf "%s\n" "No workflow currently running on master branch."
   exit 0
 fi
+
+unique_workflow_id=$(echo $pipeline_workflow_ids | sort --u)
+printf "%s\n%s\n\n" "Currently running workflow_id are:" "${unique_workflow_id}"
+
 
 # Wait as long as "pipelines" variable is not empty until max time has reached.
 # Max wait time until workflows have finished is 45 minutes because e2e tests may take a long time to finish.

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -94,7 +94,7 @@ poll_active_pipeline() {
     jq_filter="(.status | test(\"running|pending|queued\")) "
     jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id==\"${1}\""
     jq_object="{ workflow_name: .workflows.workflow_name, workflow_id: .workflows.workflow_id, "
-    jq_object+="job_name: .workflows.job_name, build_num, start_time, status }"
+    jq_object+="job_name: .workflows.job_name, build_num, start_time, status, branch }"
 
     __=$(echo "${curl_result}" | jq -r ".[] | select(${jq_filter}) | ${jq_object}")
 }

--- a/.circleci/workflow-queue-v1.sh
+++ b/.circleci/workflow-queue-v1.sh
@@ -56,7 +56,7 @@ circle_get() {
 
 # Function returns current pipeline's start_time. It is used for comparison of start_time values.
 fetch_current_pipeline_start_time() {
-  printf '%s\n' "Fetch current pipeline start time."
+  printf '%s\n' "Fetching current pipeline start time."
   # TODO local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
   local get_path="project/${project_slug}?filter=running&shallow=true"
   local curl_result=$(circle_get "${get_path}")
@@ -66,12 +66,12 @@ fetch_current_pipeline_start_time() {
 # Function takes start_time parameter.
 # Fetch list of builds on master branch that are running, pending or queued.
 fetch_older_pipelines() {
-  printf '%s\n' "Fetch pipeline workflow id (older than ${1}) on \"${branch}\" branch that are running, pending or queued."
+  printf '%s\n' "Fetching pipeline workflow id (older than ${1}) on \"${branch}\" branch that are running, pending or queued."
   # TODO local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
   local get_path="project/${project_slug}?filter=running&shallow=true"
   local curl_result=$(circle_get "${get_path}")
   if [[ ! "${curl_result}" ]]; then
-    printf "Fetch all older pipelines failed."
+    printf "Fetching all older pipelines failed."
     exit 1
   fi
   # TODO jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
@@ -82,17 +82,17 @@ fetch_older_pipelines() {
 }
 
 poll_active_pipeline() {
-  printf '%s\n' "Fetch active older pipelines on \"${branch}\" branch that are running, pending or queued."
+  printf '%s\n' "Fetching active older pipelines on \"${branch}\" branch that are running, pending or queued."
     # TODO local get_path="project/${project_slug}/tree/${branch}?filter=running&shallow=true"
     local get_path="project/${project_slug}?filter=running&shallow=true"
     local curl_result=$(circle_get "${get_path}")
     if [[ ! "${curl_result}" ]]; then
-      printf "Fetch active older pipelines failed."
+      printf "Fetching active older pipelines failed."
       exit 1
     fi
     # TODO jq_filter=".branch==\"${branch}\" and (.status | test(\"running|pending|queued\")) "
     jq_filter="(.status | test(\"running|pending|queued\")) "
-    jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id!=\"${1}\""
+    jq_filter+="and .workflows.workflow_name==\"${workflow_name}\" and .workflows.workflow_id!=\"${CIRCLE_WORKFLOW_ID}\" and .workflows.workflow_id==\"${1}\""
 
     jq_object="{ workflow_name: .workflows.workflow_name, workflow_id: .workflows.workflow_id, "
     jq_object+="job_name: .workflows.job_name, build_num, start_time, status }"


### PR DESCRIPTION
Address a bug in the workflow blocking script.

The `project/all-of-us/workbench/tree/master?filter=running&shallow=true` api response does not include jobs that haven't started in an active workflow. Queued jobs in a currently running pipeline are not caught by the blocking script.

New logics to fix the script issue:
- Exclude self, find all currently running jobs on master branch.
- Save (unique) workflow IDs from running jobs. 
- Iterate through workflow IDs. Wait as long as there is a running job in each workflow.

