### PR TITLE
[no ticket][risk=no] e2e exclude log of some requests

### DIFF
--- a/e2e/libs/page-events-helper.ts
+++ b/e2e/libs/page-events-helper.ts
@@ -73,7 +73,10 @@ export const shouldLogResponse = (request: Request): boolean => {
     '/user-recent-workspaces',
     '/user-recent-resources',
     '/profile',
-    '/data-set/'
+    '/data-set/',
+    '/data-sets/',
+    '/resources',
+    '/concept-sets/'
   ];
   return !filters.some((partialUrl) => request && request.url().includes(partialUrl));
 };


### PR DESCRIPTION
Exclude few more requests' response from being logged in test log. Their long response makes test log harder to find useful info.