### PR TITLE
[RW-7248][risk=no] Add oneoff autopause reset script

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -746,6 +746,17 @@ task manageLeonardoRuntimes(type: JavaExec) {
 }
 
 // Called by devs from the command-line:
+// - devstart.rb > reset_default_runtime_autopause
+task resetDefaultRuntimeAutopause(type: JavaExec) {
+  classpath sourceSets.__tools__.runtimeClasspath
+  main = "org.pmiops.workbench.tools.ResetDefaultRuntimeAutopause"
+  systemProperties = commandLineSpringProperties
+  if (project.hasProperty("appArgs")) {
+    args Eval.me(appArgs)
+  }
+}
+
+// Called by devs from the command-line:
 // - devstart.rb > set_authority
 task setAuthority(type: JavaExec) {
   classpath sourceSets.__tools__.runtimeClasspath

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1915,7 +1915,7 @@ def reset_default_runtime_autopause(cmd_name, *args)
   ServiceAccountContext.new(gcc.project).run do
     common.run_inline %W{
        ./gradlew resetDefaultRuntimeAutopause
-      -PappArgs=['#{api_url}',#{op.opts.dry_run}]}
+      -PappArgs=['#{gcc.project}','#{api_url}',#{op.opts.dry_run}]}
   end
 end
 

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1901,7 +1901,7 @@ def reset_default_runtime_autopause(cmd_name, *args)
   op.add_option(
       "--nodry-run",
       ->(opts, _) { opts.dry_run = false},
-      "Actually delete runtimes, defaults to dry run")
+      "Actually update runtimes, defaults to dry run")
 
   gcc = GcloudContextV2.new(op)
   op.parse.validate

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1894,6 +1894,39 @@ Common.register_command({
   :fn => ->(*args) { create_terra_method_snapshot("create-terra-method-snapshot", *args) }
 })
 
+def reset_default_runtime_autopause(cmd_name, *args)
+  common = Common.new
+  op = WbOptionsParser.new(cmd_name, args)
+  op.opts.dry_run = true
+  op.add_option(
+      "--nodry-run",
+      ->(opts, _) { opts.dry_run = false},
+      "Actually delete runtimes, defaults to dry run")
+
+  gcc = GcloudContextV2.new(op)
+  op.parse.validate
+  gcc.validate
+
+  if op.opts.dry_run
+    common.status "DRY RUN -- CHANGES WILL NOT BE PERSISTED"
+  end
+
+  api_url = get_leo_api_url(gcc.project)
+  ServiceAccountContext.new(gcc.project).run do
+    common.run_inline %W{
+       ./gradlew resetDefaultRuntimeAutopause
+      -PappArgs=['#{api_url}',#{op.opts.dry_run}]}
+  end
+end
+
+RESET_DEFAULT_RUNTIME_AUTOPAUSE_CMD = "reset-default-runtime-autopause"
+
+Common.register_command({
+  :invocation => RESET_DEFAULT_RUNTIME_AUTOPAUSE_CMD,
+  :description => "Oneoff reset script for RW-7248",
+  :fn => ->(*args) { reset_default_runtime_autopause(RESET_DEFAULT_RUNTIME_AUTOPAUSE_CMD, *args) }
+})
+
 def delete_runtimes(cmd_name, *args)
   common = Common.new
   op = WbOptionsParser.new(cmd_name, args)

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ResetDefaultRuntimeAutopause.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ResetDefaultRuntimeAutopause.java
@@ -1,0 +1,122 @@
+package org.pmiops.workbench.tools;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.pmiops.workbench.auth.ServiceAccounts;
+import org.pmiops.workbench.leonardo.ApiClient;
+import org.pmiops.workbench.leonardo.ApiException;
+import org.pmiops.workbench.leonardo.api.RuntimesApi;
+import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
+import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
+import org.pmiops.workbench.leonardo.model.LeonardoRuntimeStatus;
+import org.pmiops.workbench.leonardo.model.LeonardoUpdateRuntimeRequest;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.annotation.Bean;
+
+/** Oneoff script to restore default autopause threshold settings in an environment. */
+public class ResetDefaultRuntimeAutopause {
+  private static final Logger log = Logger.getLogger(ResetDefaultRuntimeAutopause.class.getName());
+
+  private static final String[] LEO_SCOPES =
+      new String[] {
+        "https://www.googleapis.com/auth/userinfo.profile",
+        "https://www.googleapis.com/auth/userinfo.email"
+      };
+
+  private static void resetAutopause(String apiUrl, boolean dryRun)
+      throws ApiException, IOException {
+    String dryMsg = dryRun ? "[DRY RUN]: would have... " : "";
+
+    AtomicInteger updated = new AtomicInteger();
+    RuntimesApi api = newApiClient(apiUrl);
+    api.listRuntimes(null, false).stream()
+        .sorted(Comparator.comparing(LeonardoListRuntimeResponse::getRuntimeName))
+        .filter(
+            (r) -> {
+              LeonardoGetRuntimeResponse resp = null;
+              try {
+                resp = api.getRuntime(r.getGoogleProject(), r.getRuntimeName());
+              } catch (ApiException e) {
+                log.log(Level.SEVERE, "failed to get runtime", e);
+                return false;
+              }
+              return resp.getAutopauseThreshold() == 0;
+            })
+        .forEachOrdered(
+            (r) -> {
+              String rid = runtimeId(r);
+              if (!dryRun) {
+                try {
+                  api.updateRuntime(
+                      r.getGoogleProject(),
+                      r.getRuntimeName(),
+                      new LeonardoUpdateRuntimeRequest().autopause(true));
+                } catch (ApiException e) {
+                  log.log(Level.SEVERE, "failed to update runtime " + rid, e);
+                  return;
+                }
+              }
+              updated.getAndIncrement();
+              System.out.println(dryMsg + "reset runtime autopause: " + formatTabular(r));
+            });
+
+    System.out.println(String.format("%supdated %d runtimes", dryMsg, updated.get()));
+  }
+
+  private static RuntimesApi newApiClient(String apiUrl) throws IOException {
+    ApiClient apiClient = new ApiClient();
+    apiClient.setBasePath(apiUrl);
+    apiClient.setAccessToken(
+        ServiceAccounts.getScopedServiceAccessToken(Arrays.asList(LEO_SCOPES)));
+    apiClient.setReadTimeout(60 * 1000);
+    RuntimesApi api = new RuntimesApi();
+    api.setApiClient(apiClient);
+    return api;
+  }
+
+  private static String formatTabular(LeonardoListRuntimeResponse r) {
+    Gson gson = new Gson();
+    JsonObject labels = gson.toJsonTree(r.getLabels()).getAsJsonObject();
+    String creator = "unknown";
+    if (labels.has("created-by")) {
+      creator = labels.get("created-by").getAsString();
+    }
+    LeonardoRuntimeStatus status = LeonardoRuntimeStatus.UNKNOWN;
+    if (r.getStatus() != null) {
+      status = r.getStatus();
+    }
+    return String.format(
+        "%-40.40s %-50.50s %-10s %-15s",
+        runtimeId(r), creator, status, r.getAuditInfo().getCreatedDate());
+  }
+
+  private static String runtimeId(LeonardoListRuntimeResponse r) {
+    return r.getGoogleProject() + "/" + r.getRuntimeName();
+  }
+
+  @Bean
+  public CommandLineRunner run() {
+    return (args) -> {
+      boolean dryRun = Boolean.parseBoolean(args[1]);
+      resetAutopause(args[0], dryRun);
+    };
+  }
+
+  public static void main(String[] args) throws Exception {
+    // This tool doesn't currently need database access, so it doesn't extend the
+    // CommandLineToolConfig. To add database access, extend from that config and update project.rb
+    // to ensure a Cloud SQL proxy is available when this command is run.
+    new SpringApplicationBuilder(ResetDefaultRuntimeAutopause.class)
+        .web(WebApplicationType.NONE)
+        .run(args)
+        .close();
+  }
+}


### PR DESCRIPTION
Pseudocode of what this is doing:

- For a given environment, get all runtimes
- Filter to any runtimes with autopause == 0
- Update the runtime with autopause = true

Update only works while impersonated, cannot be done as the central SA.

No one should intentionally have an autopause setting of 0, so this should be safe in all environments.