### PR TITLE
[RW-7224][risk=no]Observations domain -- ensure data inserted into criteria table

### DIFF
--- a/api/db-cdr/generate-cdr/make-bq-cb-menu.sh
+++ b/api/db-cdr/generate-cdr/make-bq-cb-menu.sh
@@ -56,7 +56,7 @@ then
   "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_menu\`
       (id,parent_id,category,domain_id,type,name,is_group,sort_order)
   VALUES
-  (5,0,'Program Data','WHOLE_GENOME_VARIANT','','Whole Genome Variant',0,5)"
+  (5,0,'Program Data','WHOLE_GENOME_VARIANT','','Whole Genome Sequence Variant',0,5)"
 fi
 
 echo "Insert cb_criteria_menu"

--- a/api/db-cdr/generate-cdr/make-bq-criteria-tables.sh
+++ b/api/db-cdr/generate-cdr/make-bq-criteria-tables.sh
@@ -5947,6 +5947,7 @@ FROM
         WHERE b.standard_concept = 'S'
             and b.domain_id = 'Observation'
             and a.observation_concept_id != 0
+            and b.vocabulary_id != 'PPI'
         GROUP BY 1,2,3,4
     ) x"
 

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -422,7 +422,7 @@ enum PrepackagedConceptSet {
   FITBITACTIVITY = 'Fitbit Activity Summary',
   FITBITHEARTRATELEVEL = 'Fitbit Heart Rate Level',
   FITBITINTRADAYSTEPS = 'Fitbit Intra Day Steps',
-  WHOLEGENOME = 'All whole genome variant data'
+  WHOLEGENOME = 'All whole genome sequence variant data'
 }
 
 const PREPACKAGED_SURVEY_PERSON_DOMAIN = {


### PR DESCRIPTION
since we are already displaying Observation in concept set, make sure that PPI (which is for survey) doesnt show up as part of observation domain search list

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
