### PR TITLE
[RW-7248][risk=no] Do not set autopause boolean parameter if autopause integer parameter is not provided

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -245,7 +245,6 @@ public class RuntimeController implements RuntimeApiDelegate {
       }
     }
 
-
     throw new NotFoundException();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -245,6 +245,7 @@ public class RuntimeController implements RuntimeApiDelegate {
       }
     }
 
+
     throw new NotFoundException();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -111,25 +111,26 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
             .putAll(buildRuntimeConfigurationLabels(runtime.getConfigurationType()))
             .build();
 
-    LeonardoCreateRuntimeRequest createRuntimeRequest = new LeonardoCreateRuntimeRequest()
-        .labels(runtimeLabels)
-        .defaultClientId(config.server.oauthClientId)
-        // Note: Filenames must be kept in sync with files in api/src/main/webapp/static.
-        .jupyterUserScriptUri(assetsBaseUrl + "/initialize_notebook_runtime.sh")
-        .jupyterStartUserScriptUri(assetsBaseUrl + "/start_notebook_runtime.sh")
-        .userJupyterExtensionConfig(
-            new LeonardoUserJupyterExtensionConfig().nbExtensions(nbExtensions))
-        // Matches Terra UI's scopes, see RW-3531 for rationale.
-        .addScopesItem("https://www.googleapis.com/auth/cloud-platform")
-        .addScopesItem("https://www.googleapis.com/auth/userinfo.email")
-        .addScopesItem("https://www.googleapis.com/auth/userinfo.profile")
-        .toolDockerImage(workbenchConfigProvider.get().firecloud.jupyterDockerImage)
-        // Note: DockerHub must be used over GCR here, since VPC-SC restricts
-        // pulling external images via GCR (since it counts as GCS traffic).
-        .welderRegistry(WelderRegistryEnum.DOCKERHUB)
-        .customEnvironmentVariables(customEnvironmentVariables)
-        .autopauseThreshold(runtime.getAutopauseThreshold())
-        .runtimeConfig(buildRuntimeConfig(runtime));
+    LeonardoCreateRuntimeRequest createRuntimeRequest =
+        new LeonardoCreateRuntimeRequest()
+            .labels(runtimeLabels)
+            .defaultClientId(config.server.oauthClientId)
+            // Note: Filenames must be kept in sync with files in api/src/main/webapp/static.
+            .jupyterUserScriptUri(assetsBaseUrl + "/initialize_notebook_runtime.sh")
+            .jupyterStartUserScriptUri(assetsBaseUrl + "/start_notebook_runtime.sh")
+            .userJupyterExtensionConfig(
+                new LeonardoUserJupyterExtensionConfig().nbExtensions(nbExtensions))
+            // Matches Terra UI's scopes, see RW-3531 for rationale.
+            .addScopesItem("https://www.googleapis.com/auth/cloud-platform")
+            .addScopesItem("https://www.googleapis.com/auth/userinfo.email")
+            .addScopesItem("https://www.googleapis.com/auth/userinfo.profile")
+            .toolDockerImage(workbenchConfigProvider.get().firecloud.jupyterDockerImage)
+            // Note: DockerHub must be used over GCR here, since VPC-SC restricts
+            // pulling external images via GCR (since it counts as GCS traffic).
+            .welderRegistry(WelderRegistryEnum.DOCKERHUB)
+            .customEnvironmentVariables(customEnvironmentVariables)
+            .autopauseThreshold(runtime.getAutopauseThreshold())
+            .runtimeConfig(buildRuntimeConfig(runtime));
 
     if (runtime.getAutopauseThreshold() != null) {
       createRuntimeRequest.autopause(true);

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -111,7 +111,7 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
             .putAll(buildRuntimeConfigurationLabels(runtime.getConfigurationType()))
             .build();
 
-    return new LeonardoCreateRuntimeRequest()
+    LeonardoCreateRuntimeRequest createRuntimeRequest = new LeonardoCreateRuntimeRequest()
         .labels(runtimeLabels)
         .defaultClientId(config.server.oauthClientId)
         // Note: Filenames must be kept in sync with files in api/src/main/webapp/static.
@@ -129,8 +129,13 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
         .welderRegistry(WelderRegistryEnum.DOCKERHUB)
         .customEnvironmentVariables(customEnvironmentVariables)
         .autopauseThreshold(runtime.getAutopauseThreshold())
-        .autopause(runtime.getAutopauseThreshold() != null)
         .runtimeConfig(buildRuntimeConfig(runtime));
+
+    if (runtime.getAutopauseThreshold() != null) {
+      createRuntimeRequest.autopause(true);
+    }
+
+    return createRuntimeRequest;
   }
 
   private Object buildRuntimeConfig(Runtime runtime) {

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -2,7 +2,13 @@ import {leoRuntimesApi} from 'app/services/notebooks-swagger-fetch-clients';
 import {disksApi, runtimeApi} from 'app/services/swagger-fetch-clients';
 import {DEFAULT, switchCase, withAsyncErrorHandling} from 'app/utils';
 import {ExceededActionCountError, LeoRuntimeInitializationAbortedError, LeoRuntimeInitializer, } from 'app/utils/leo-runtime-initializer';
-import {AutopauseMinuteThresholds, ComputeType, findMachineByName, Machine} from 'app/utils/machines';
+import {
+  AutopauseMinuteThresholds,
+  ComputeType,
+  DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES,
+  findMachineByName,
+  Machine
+} from 'app/utils/machines';
 import {
   compoundRuntimeOpStore,
   diskStore,
@@ -263,12 +269,8 @@ const compareDataprocNumberOfWorkers = (oldRuntime: RuntimeConfig, newRuntime: R
 };
 
 const compareAutopauseThreshold = (oldRuntime: RuntimeConfig, newRuntime: RuntimeConfig): RuntimeDiff => {
-  const oldAutopauseThreshold = oldRuntime.autopauseThreshold;
-  const newAutopauseThreshold = newRuntime.autopauseThreshold;
-
-  if (!oldAutopauseThreshold || !newAutopauseThreshold) {
-    return null;
-  }
+  const oldAutopauseThreshold = oldRuntime.autopauseThreshold == null ? DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES : oldRuntime.autopauseThreshold;
+  const newAutopauseThreshold = newRuntime.autopauseThreshold == null ? DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES : newRuntime.autopauseThreshold;
 
   return {
     desc: (newAutopauseThreshold < oldAutopauseThreshold ?  'Decrease' : 'Increase') + ' autopause threshold',


### PR DESCRIPTION
This prevents the case where autopause will be set to 0 when one isn't provided.

While I was working on this, I found another bug with the autopause comparison where an autopause value of 0 wouldn't be handled correctly.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
