### PR TITLE
[RW-7248][risk=no] Do not set autopause boolean parameter if autopause integer parameter is not provided

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -132,6 +132,9 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
             .autopauseThreshold(runtime.getAutopauseThreshold())
             .runtimeConfig(buildRuntimeConfig(runtime));
 
+    // .autopause is ONLY set if the given .autopauseThreshold value should be respected
+    // setting to .autopause to `false` will turn off autopause completely and create
+    // runtimes that never autopause.
     if (runtime.getAutopauseThreshold() != null) {
       createRuntimeRequest.autopause(true);
     }

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -269,8 +269,10 @@ const compareDataprocNumberOfWorkers = (oldRuntime: RuntimeConfig, newRuntime: R
 };
 
 const compareAutopauseThreshold = (oldRuntime: RuntimeConfig, newRuntime: RuntimeConfig): RuntimeDiff => {
-  const oldAutopauseThreshold = oldRuntime.autopauseThreshold == null ? DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES : oldRuntime.autopauseThreshold;
-  const newAutopauseThreshold = newRuntime.autopauseThreshold == null ? DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES : newRuntime.autopauseThreshold;
+  const oldAutopauseThreshold = oldRuntime.autopauseThreshold === null || oldRuntime.autopauseThreshold === undefined
+    ? DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES : oldRuntime.autopauseThreshold;
+  const newAutopauseThreshold = newRuntime.autopauseThreshold == null || newRuntime.autopauseThreshold === undefined
+    ? DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES : newRuntime.autopauseThreshold;
 
   return {
     desc: (newAutopauseThreshold < oldAutopauseThreshold ?  'Decrease' : 'Increase') + ' autopause threshold',


### PR DESCRIPTION
Code review feedback that I forgot to commit before merging, https://github.com/all-of-us/workbench/pull/5522.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
