### PR TITLE
[RW-7221][risk=no] Enable enableStandardSourceDomains config flag for local and test

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -106,7 +106,7 @@
     "enablePersistentDisk": true,
     "enableAccessModuleRewrite" : true,
     "enableUnifiedUserAccessCron": true,
-    "enableStandardSourceDomains": false
+    "enableStandardSourceDomains": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-local",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -106,7 +106,7 @@
     "enablePersistentDisk": true,
     "enableAccessModuleRewrite": true,
     "enableUnifiedUserAccessCron": true,
-    "enableStandardSourceDomains": false
+    "enableStandardSourceDomains": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",


### PR DESCRIPTION
Tested puppeteer locally and this _shouldn't_ affect any of the current tests.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
