### PR TITLE
[risk=low][RW-7089] Extract ProfileAccessModules from Profile

### DIFF
--- a/ui/src/app/pages/profile/profile-access-modules.spec.tsx
+++ b/ui/src/app/pages/profile/profile-access-modules.spec.tsx
@@ -1,0 +1,15 @@
+import {mount} from 'enzyme';
+import * as React from 'react';
+
+import {ProfileAccessModules} from "./profile-access-modules";
+
+describe('Profile Access Modules', () => {
+    const component = (props = {}) => {
+        return mount(<ProfileAccessModules {...props}/>);
+    };
+
+    it('Should render', async () => {
+        const wrapper = component();
+        expect(wrapper.exists()).toBeTruthy();
+    });
+});

--- a/ui/src/app/pages/profile/profile-access-modules.spec.tsx
+++ b/ui/src/app/pages/profile/profile-access-modules.spec.tsx
@@ -22,4 +22,10 @@ describe('Profile Access Modules', () => {
         const wrapper = component();
         expect(wrapper.exists()).toBeTruthy();
     });
+
+    it('should display all modules as incomplete by default', async() => {
+        const wrapper = component();
+        const profileCardCompleteButtons = wrapper.find('[data-test-id="incomplete-button"]');
+        expect(profileCardCompleteButtons.length).toBe(4);
+    });
 });

--- a/ui/src/app/pages/profile/profile-access-modules.spec.tsx
+++ b/ui/src/app/pages/profile/profile-access-modules.spec.tsx
@@ -2,10 +2,20 @@ import {mount} from 'enzyme';
 import * as React from 'react';
 
 import {ProfileAccessModules} from "./profile-access-modules";
+import {ProfileStubVariables} from 'testing/stubs/profile-api-stub';
+import {Profile} from 'generated/fetch';
+import {serverConfigStore} from 'app/utils/stores';
+import defaultServerConfig from 'testing/default-server-config';
+
+const profile = ProfileStubVariables.PROFILE_STUB as Profile;
 
 describe('Profile Access Modules', () => {
-    const component = (props = {}) => {
-        return mount(<ProfileAccessModules {...props}/>);
+    beforeEach(async() => {
+        serverConfigStore.set({config: defaultServerConfig});
+    });
+
+    const component = () => {
+        return mount(<ProfileAccessModules profile={profile}/>);
     };
 
     it('Should render', async () => {

--- a/ui/src/app/pages/profile/profile-access-modules.tsx
+++ b/ui/src/app/pages/profile/profile-access-modules.tsx
@@ -8,7 +8,6 @@ import {getRegistrationTasksMap} from 'app/utils/access-utils';
 import {useNavigation} from 'app/utils/navigation';
 import {serverConfigStore, useStore} from 'app/utils/stores';
 import {Profile} from 'generated/fetch';
-import {DataAccessPanel} from './data-access-panel';
 import {ProfileRegistrationStepStatus} from './profile-registration-step-status';
 import {styles} from './profile-styles';
 
@@ -134,7 +133,6 @@ export const ProfileAccessModules = (props: {profile: Profile}) => {
   const controlledTierEnabled = false, controlledTierBypassTime = null, controlledTierCompletionTime = null;
 
   return <React.Fragment>
-        {controlledTierEnabled && <DataAccessPanel tiers={profile.accessTierShortNames}/>}
         <div style={styles.title}>
             Requirements for <AoU/> Workbench access
         </div>

--- a/ui/src/app/pages/profile/profile-access-modules.tsx
+++ b/ui/src/app/pages/profile/profile-access-modules.tsx
@@ -37,16 +37,16 @@ const bypassedText = (bypassTime: number): JSX.Element => {
 
 const getCompleteOrBypassContent = ({bypassTime, completionTime}: CompletionTime): JSX.Element => {
   switch (getRegistrationStatus(completionTime, bypassTime)) {
-      case RegistrationStepStatus.COMPLETED:
-        return <React.Fragment>
+    case RegistrationStepStatus.COMPLETED:
+      return <React.Fragment>
                 <div>Completed on:</div>
                 <div>{displayDateWithoutHours(completionTime)}</div>
             </React.Fragment>;
-      case RegistrationStepStatus.BYPASSED:
-        return bypassedText(bypassTime);
-      default:
-        return;
-    }
+    case RegistrationStepStatus.BYPASSED:
+      return bypassedText(bypassTime);
+    default:
+      return;
+  }
 };
 
 const getDUCCText = (profile: Profile) => {
@@ -55,28 +55,28 @@ const getDUCCText = (profile: Profile) => {
         View code of conduct
     </a>;
   switch (getRegistrationStatus(profile.dataUseAgreementCompletionTime, profile.dataUseAgreementBypassTime)) {
-      case RegistrationStepStatus.COMPLETED:
-        return <React.Fragment>
+    case RegistrationStepStatus.COMPLETED:
+      return <React.Fragment>
                 <div>Signed On:</div>
                 <div>
                     {displayDateWithoutHours(profile.dataUseAgreementCompletionTime)}
                 </div>
                 {universalText}
             </React.Fragment>;
-      case RegistrationStepStatus.BYPASSED:
-        return <React.Fragment>
+    case RegistrationStepStatus.BYPASSED:
+      return <React.Fragment>
                 {bypassedText(profile.dataUseAgreementBypassTime)}
                 {universalText}
             </React.Fragment>;
-      case RegistrationStepStatus.UNCOMPLETE:
-        return universalText;
-    }
+    case RegistrationStepStatus.UNCOMPLETE:
+      return universalText;
+  }
 };
 
 const getEraCommonsCardText = (profile: Profile) => {
   switch (getRegistrationStatus(profile.eraCommonsCompletionTime, profile.eraCommonsBypassTime)) {
-      case RegistrationStepStatus.COMPLETED:
-        return <div>
+    case RegistrationStepStatus.COMPLETED:
+      return <div>
                 {profile.eraCommonsLinkedNihUsername != null && <React.Fragment>
                     <div> Username:</div>
                     <div> {profile.eraCommonsLinkedNihUsername} </div>
@@ -91,25 +91,25 @@ const getEraCommonsCardText = (profile: Profile) => {
                     </div>
                 </React.Fragment>}
             </div>;
-      case RegistrationStepStatus.BYPASSED:
-        return bypassedText(profile.twoFactorAuthBypassTime);
-      default:
-        return;
-    }
+    case RegistrationStepStatus.BYPASSED:
+      return bypassedText(profile.twoFactorAuthBypassTime);
+    default:
+      return;
+  }
 };
 
 const getComplianceTrainingText = (profile: Profile) => {
   switch (getRegistrationStatus(profile.complianceTrainingCompletionTime, profile.complianceTrainingBypassTime)) {
-      case RegistrationStepStatus.COMPLETED:
-        return <React.Fragment>
+    case RegistrationStepStatus.COMPLETED:
+      return <React.Fragment>
                 <div>Training Completed</div>
                 <div>{displayDateWithoutHours(profile.complianceTrainingCompletionTime)}</div>
             </React.Fragment>;
-      case RegistrationStepStatus.BYPASSED:
-        return bypassedText(profile.complianceTrainingBypassTime);
-      default:
-        return;
-    }
+    case RegistrationStepStatus.BYPASSED:
+      return bypassedText(profile.complianceTrainingBypassTime);
+    default:
+      return;
+  }
 };
 
 const focusCompletionProps = lensOnProps(['completionTime', 'bypassTime']);

--- a/ui/src/app/pages/profile/profile-access-modules.tsx
+++ b/ui/src/app/pages/profile/profile-access-modules.tsx
@@ -49,30 +49,6 @@ const getCompleteOrBypassContent = ({bypassTime, completionTime}: CompletionTime
   }
 };
 
-const getDUCCText = (profile: Profile) => {
-  const [navigate, ] = useNavigation();
-  const universalText = <a onClick={getRegistrationTasksMap(navigate)['dataUserCodeOfConduct'].onClick}>
-        View code of conduct
-    </a>;
-  switch (getRegistrationStatus(profile.dataUseAgreementCompletionTime, profile.dataUseAgreementBypassTime)) {
-    case RegistrationStepStatus.COMPLETED:
-      return <React.Fragment>
-                <div>Signed On:</div>
-                <div>
-                    {displayDateWithoutHours(profile.dataUseAgreementCompletionTime)}
-                </div>
-                {universalText}
-            </React.Fragment>;
-    case RegistrationStepStatus.BYPASSED:
-      return <React.Fragment>
-                {bypassedText(profile.dataUseAgreementBypassTime)}
-                {universalText}
-            </React.Fragment>;
-    case RegistrationStepStatus.UNCOMPLETE:
-      return universalText;
-  }
-};
-
 const getEraCommonsCardText = (profile: Profile) => {
   switch (getRegistrationStatus(profile.eraCommonsCompletionTime, profile.eraCommonsBypassTime)) {
     case RegistrationStepStatus.COMPLETED:
@@ -112,6 +88,30 @@ const getComplianceTrainingText = (profile: Profile) => {
   }
 };
 
+const getDUCCText = (profile: Profile) => {
+  const [navigate, ] = useNavigation();
+  const universalText = <a onClick={getRegistrationTasksMap(navigate)['dataUserCodeOfConduct'].onClick}>
+        View code of conduct
+    </a>;
+  switch (getRegistrationStatus(profile.dataUseAgreementCompletionTime, profile.dataUseAgreementBypassTime)) {
+    case RegistrationStepStatus.COMPLETED:
+      return <React.Fragment>
+              <div>Signed On:</div>
+              <div>
+                  {displayDateWithoutHours(profile.dataUseAgreementCompletionTime)}
+              </div>
+              {universalText}
+          </React.Fragment>;
+    case RegistrationStepStatus.BYPASSED:
+      return <React.Fragment>
+              {bypassedText(profile.dataUseAgreementBypassTime)}
+              {universalText}
+          </React.Fragment>;
+    case RegistrationStepStatus.UNCOMPLETE:
+      return universalText;
+  }
+};
+
 const focusCompletionProps = lensOnProps(['completionTime', 'bypassTime']);
 
 const getTwoFactorContent = fp.flow(
@@ -124,10 +124,7 @@ const getControlledTierContent = fp.flow(
   getCompleteOrBypassContent
 );
 
-interface Props {
-  profile: Profile;
-}
-export const ProfileAccessModules = (props: Props) => {
+export const ProfileAccessModules = (props: {profile: Profile}) => {
   const {profile} = props;
   const [navigate, ] = useNavigation();
   const {config: {enableComplianceTraining, enableEraCommons}} = useStore(serverConfigStore);

--- a/ui/src/app/pages/profile/profile-access-modules.tsx
+++ b/ui/src/app/pages/profile/profile-access-modules.tsx
@@ -1,0 +1,204 @@
+import * as fp from 'lodash/fp';
+import * as React from 'react';
+
+import {ControlledTierBadge} from 'app/components/icons';
+import {AoU} from 'app/components/text-wrappers';
+import {displayDateWithoutHours, lensOnProps} from 'app/utils';
+import {getRegistrationTasksMap} from 'app/utils/access-utils';
+import {useNavigation} from 'app/utils/navigation';
+import {serverConfigStore, useStore} from 'app/utils/stores';
+import {Profile} from 'generated/fetch';
+import {DataAccessPanel} from './data-access-panel';
+import {ProfileRegistrationStepStatus} from './profile-registration-step-status';
+import {styles} from './profile-styles';
+
+enum RegistrationStepStatus {
+    COMPLETED,
+    BYPASSED,
+    UNCOMPLETE
+}
+
+interface CompletionTime {
+  completionTime: number;
+  bypassTime: number;
+}
+
+const getRegistrationStatus = (completionTime: number, bypassTime: number) => {
+  return completionTime !== null && completionTime !== undefined ? RegistrationStepStatus.COMPLETED :
+        bypassTime !== null && completionTime !== undefined ? RegistrationStepStatus.BYPASSED : RegistrationStepStatus.UNCOMPLETE;
+};
+
+const bypassedText = (bypassTime: number): JSX.Element => {
+  return <React.Fragment>
+        <div>Bypassed on:</div>
+        <div>{displayDateWithoutHours(bypassTime)}</div>
+    </React.Fragment>;
+};
+
+const getCompleteOrBypassContent = ({bypassTime, completionTime}: CompletionTime): JSX.Element => {
+  switch (getRegistrationStatus(completionTime, bypassTime)) {
+      case RegistrationStepStatus.COMPLETED:
+        return <React.Fragment>
+                <div>Completed on:</div>
+                <div>{displayDateWithoutHours(completionTime)}</div>
+            </React.Fragment>;
+      case RegistrationStepStatus.BYPASSED:
+        return bypassedText(bypassTime);
+      default:
+        return;
+    }
+};
+
+const getDUCCText = (profile: Profile) => {
+  const [navigate, ] = useNavigation();
+  const universalText = <a onClick={getRegistrationTasksMap(navigate)['dataUserCodeOfConduct'].onClick}>
+        View code of conduct
+    </a>;
+  switch (getRegistrationStatus(profile.dataUseAgreementCompletionTime, profile.dataUseAgreementBypassTime)) {
+      case RegistrationStepStatus.COMPLETED:
+        return <React.Fragment>
+                <div>Signed On:</div>
+                <div>
+                    {displayDateWithoutHours(profile.dataUseAgreementCompletionTime)}
+                </div>
+                {universalText}
+            </React.Fragment>;
+      case RegistrationStepStatus.BYPASSED:
+        return <React.Fragment>
+                {bypassedText(profile.dataUseAgreementBypassTime)}
+                {universalText}
+            </React.Fragment>;
+      case RegistrationStepStatus.UNCOMPLETE:
+        return universalText;
+    }
+};
+
+const getEraCommonsCardText = (profile: Profile) => {
+  switch (getRegistrationStatus(profile.eraCommonsCompletionTime, profile.eraCommonsBypassTime)) {
+      case RegistrationStepStatus.COMPLETED:
+        return <div>
+                {profile.eraCommonsLinkedNihUsername != null && <React.Fragment>
+                    <div> Username:</div>
+                    <div> {profile.eraCommonsLinkedNihUsername} </div>
+                </React.Fragment>}
+                {profile.eraCommonsLinkExpireTime != null &&
+                //  Firecloud returns eraCommons link expiration as 0 if there is no linked account.
+                profile.eraCommonsLinkExpireTime !== 0
+                && <React.Fragment>
+                    <div> Completed on:</div>
+                    <div>
+                        {displayDateWithoutHours(profile.eraCommonsCompletionTime)}
+                    </div>
+                </React.Fragment>}
+            </div>;
+      case RegistrationStepStatus.BYPASSED:
+        return bypassedText(profile.twoFactorAuthBypassTime);
+      default:
+        return;
+    }
+};
+
+const getComplianceTrainingText = (profile: Profile) => {
+  switch (getRegistrationStatus(profile.complianceTrainingCompletionTime, profile.complianceTrainingBypassTime)) {
+      case RegistrationStepStatus.COMPLETED:
+        return <React.Fragment>
+                <div>Training Completed</div>
+                <div>{displayDateWithoutHours(profile.complianceTrainingCompletionTime)}</div>
+            </React.Fragment>;
+      case RegistrationStepStatus.BYPASSED:
+        return bypassedText(profile.complianceTrainingBypassTime);
+      default:
+        return;
+    }
+};
+
+const focusCompletionProps = lensOnProps(['completionTime', 'bypassTime']);
+
+const getTwoFactorContent = fp.flow(
+  focusCompletionProps(['twoFactorAuthCompletionTime', 'twoFactorAuthBypassTime']),
+  getCompleteOrBypassContent
+);
+
+const getControlledTierContent = fp.flow(
+  focusCompletionProps(['controlledTierCompletionTime', 'controlledTierBypassTime']),
+  getCompleteOrBypassContent
+);
+
+interface Props {
+  profile: Profile;
+}
+export const ProfileAccessModules = (props: Props) => {
+  const {profile} = props;
+  const [navigate, ] = useNavigation();
+  const {config: {enableComplianceTraining, enableEraCommons}} = useStore(serverConfigStore);
+
+    // these have never been enabled for the user profile, and the component will be deleted before this happens.
+    // see https://precisionmedicineinitiative.atlassian.net/browse/RW-7256
+  const controlledTierEnabled = false, controlledTierBypassTime = null, controlledTierCompletionTime = null;
+
+  return <React.Fragment>
+        {controlledTierEnabled && <DataAccessPanel tiers={profile.accessTierShortNames}/>}
+        <div style={styles.title}>
+            Requirements for <AoU/> Workbench access
+        </div>
+        <hr style={{...styles.verticalLine}}/>
+        <div style={{display: 'grid', gap: '10px', gridAutoRows: '225px', gridTemplateColumns: '220px 220px'}}>
+            {controlledTierEnabled && <ProfileRegistrationStepStatus
+                title={<span><AoU/> Controlled Tier Data Training</span>}
+                wasBypassed={!!controlledTierBypassTime}
+                incompleteButtonText={'Get Started'}
+                completedButtonText={'Completed'}
+                isComplete={!!(controlledTierCompletionTime || controlledTierBypassTime)}
+                // TODO: link to the training modules once they are available
+                completeStep={() => null}
+                content={getControlledTierContent({controlledTierCompletionTime, controlledTierBypassTime})}
+            >
+                <div>
+                    {!(controlledTierCompletionTime || controlledTierBypassTime) && <div>To be completed</div>}
+                    <ControlledTierBadge/>
+                </div>
+            </ProfileRegistrationStepStatus>}
+            <ProfileRegistrationStepStatus
+                title='Turn on Google 2-Step Verification'
+                wasBypassed={!!profile.twoFactorAuthBypassTime}
+                incompleteButtonText='Set Up'
+                completedButtonText={getRegistrationTasksMap(navigate)['twoFactorAuth'].completedText}
+                isComplete={!!(getRegistrationTasksMap(navigate)['twoFactorAuth'].completionTimestamp(profile))}
+                completeStep={getRegistrationTasksMap(navigate)['twoFactorAuth'].onClick}
+                content={getTwoFactorContent(profile)}
+            >
+            </ProfileRegistrationStepStatus>
+            {enableEraCommons && <ProfileRegistrationStepStatus
+                title='Connect Your eRA Commons Account'
+                wasBypassed={!!profile.eraCommonsBypassTime}
+                incompleteButtonText='Link'
+                completedButtonText={getRegistrationTasksMap(navigate)['eraCommons'].completedText}
+                isComplete={!!(getRegistrationTasksMap(navigate)['eraCommons'].completionTimestamp(profile))}
+                completeStep={getRegistrationTasksMap(navigate)['eraCommons'].onClick}
+                content={getEraCommonsCardText(profile)}
+            >
+            </ProfileRegistrationStepStatus>}
+            {enableComplianceTraining && <ProfileRegistrationStepStatus
+                title={<span><AoU/> Responsible Conduct of Research Training</span>}
+                wasBypassed={!!profile.complianceTrainingBypassTime}
+                incompleteButtonText='Access Training'
+                completedButtonText={getRegistrationTasksMap(navigate)['complianceTraining'].completedText}
+                isComplete={!!(getRegistrationTasksMap(navigate)['complianceTraining'].completionTimestamp(profile))}
+                completeStep={getRegistrationTasksMap(navigate)['complianceTraining'].onClick}
+                content={getComplianceTrainingText(profile)}
+            >
+            </ProfileRegistrationStepStatus>}
+            <ProfileRegistrationStepStatus
+                title='Sign Data User Code Of Conduct'
+                wasBypassed={!!profile.dataUseAgreementBypassTime}
+                incompleteButtonText='Sign'
+                completedButtonText={getRegistrationTasksMap(navigate)['dataUserCodeOfConduct'].completedText}
+                isComplete={!!(getRegistrationTasksMap(navigate)['dataUserCodeOfConduct'].completionTimestamp(profile))}
+                completeStep={getRegistrationTasksMap(navigate)['dataUserCodeOfConduct'].onClick}
+                childrenStyle={{marginLeft: 0}}
+                content={getDUCCText(profile)}
+            >
+            </ProfileRegistrationStepStatus>
+        </div>
+    </React.Fragment>;
+};

--- a/ui/src/app/pages/profile/profile-component.spec.tsx
+++ b/ui/src/app/pages/profile/profile-component.spec.tsx
@@ -113,23 +113,4 @@ describe('ProfilePageComponent', () => {
 
     expect(getSaveProfileButton(wrapper).first().prop('disabled')).toBe(true);
   });
-
-  it('should not display controlled tier card when there is no controlled tier', async() => {
-    const wrapper = component();
-    const profileCardCompleteButtons = wrapper.find('[data-test-id="incomplete-button"]');
-    expect(profileCardCompleteButtons.length).toBe(4);
-  });
-
-  it('should display a controlled tier card when there is a controlled tier', async() => {
-    const wrapper = component({controlledTierEnabled: true});
-    const profileCardCompleteButtons = wrapper.find('[data-test-id="incomplete-button"]');
-    expect(profileCardCompleteButtons.length).toBe(5);
-  });
-
-  it('should display a controlled tier card with a complete button when the user has completed training', async() => {
-    const wrapper = component({controlledTierEnabled: true, controlledTierCompletionTime: 1});
-    const profileCardCompleteButtons = wrapper.find('[data-test-id="completed-button"]');
-    expect(profileCardCompleteButtons.length).toBe(1);
-  });
-
 });

--- a/ui/src/app/pages/profile/profile-component.tsx
+++ b/ui/src/app/pages/profile/profile-component.tsx
@@ -23,7 +23,8 @@ import {institutionApi, profileApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
   displayDateWithoutHours,
-  formatFreeCreditsUSD, withUserProfile
+  formatFreeCreditsUSD,
+  withUserProfile
 } from 'app/utils';
 import {wasReferredFromRenewal} from 'app/utils/access-utils';
 import {convertAPIError, reportError} from 'app/utils/errors';
@@ -441,6 +442,7 @@ export const ProfileComponent = fp.flow(
                   <div style={{fontWeight: 600}}>{formatFreeCreditsUSD(profile.freeTierDollarQuota - profile.freeTierUsage)}</div>
                 </FlexColumn>
             </FlexRow>}
+            {/* controlledTierEnabled && <DataAccessPanel tiers={profile.accessTierShortNames}/> */}
             <ProfileAccessModules profile={profile}/>
             <div style={{marginTop: '1rem', marginLeft: '1rem'}}>
               <div style={styles.title}>Optional Demographics Survey</div>

--- a/ui/src/app/pages/profile/profile-component.tsx
+++ b/ui/src/app/pages/profile/profile-component.tsx
@@ -1,11 +1,12 @@
 import * as fp from 'lodash/fp';
+import {Dropdown} from 'primereact/dropdown';
 import * as React from 'react';
 import * as validate from 'validate.js';
 
 import {Button} from 'app/components/buttons';
 import {FadeBox} from 'app/components/containers';
 import {FlexColumn, FlexRow} from 'app/components/flex';
-import {ControlledTierBadge, ExclamationTriangle} from 'app/components/icons';
+import {ExclamationTriangle} from 'app/components/icons';
 import {TextAreaWithLengthValidationMessage, TextInput, ValidationError} from 'app/components/inputs';
 import {BulletAlignedUnorderedList} from 'app/components/lists';
 import {Modal} from 'app/components/modals';
@@ -16,26 +17,21 @@ import {AoU} from 'app/components/text-wrappers';
 import {withProfileErrorModal, WithProfileErrorModalProps} from 'app/components/with-error-modal';
 import {WithSpinnerOverlayProps} from 'app/components/with-spinner-overlay';
 import {AccountCreationOptions} from 'app/pages/login/account-creation/account-creation-options';
-import {DataAccessPanel} from 'app/pages/profile/data-access-panel';
 import {DemographicSurvey} from 'app/pages/profile/demographic-survey';
-import {ProfileRegistrationStepStatus} from 'app/pages/profile/profile-registration-step-status';
 import {styles} from 'app/pages/profile/profile-styles';
 import {institutionApi, profileApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
   displayDateWithoutHours,
-  formatFreeCreditsUSD,
-  lensOnProps, withUserProfile
+  formatFreeCreditsUSD, withUserProfile
 } from 'app/utils';
-import {getRegistrationTasksMap} from 'app/utils/access-utils';
 import {wasReferredFromRenewal} from 'app/utils/access-utils';
 import {convertAPIError, reportError} from 'app/utils/errors';
 import {NavigationProps} from 'app/utils/navigation';
-import {serverConfigStore} from 'app/utils/stores';
 import {withNavigation} from 'app/utils/with-navigation-hoc';
 import {AccessModule, InstitutionalRole, Profile} from 'generated/fetch';
 import {PublicInstitutionDetails} from 'generated/fetch';
-import {Dropdown} from 'primereact/dropdown';
+import {ProfileAccessModules} from './profile-access-modules';
 
 
 // validators for validate.js
@@ -59,74 +55,18 @@ const validators = {
   country: {...required, ...notTooLong(95)}
 };
 
-enum RegistrationStepStatus {
-  COMPLETED,
-  BYPASSED,
-  UNCOMPLETE
-}
-
 interface ProfilePageProps extends WithProfileErrorModalProps, WithSpinnerOverlayProps, NavigationProps {
   profileState: {
     profile: Profile;
     reload: () => {};
   };
-  controlledTierProfile: {
-    controlledTierCompletionTime?: number
-    controlledTierBypassTime?: number
-    controlledTierEnabled?: boolean
-  };
 }
-
 interface ProfilePageState {
   currentProfile: Profile;
   institutions: Array<PublicInstitutionDetails>;
   showDemographicSurveyModal: boolean;
   updating: boolean;
 }
-
-interface CompletionTime {
-  completionTime: number;
-  bypassTime: number;
-}
-
-const getRegistrationStatus = (completionTime: number, bypassTime: number) => {
-  return completionTime !== null && completionTime !== undefined ? RegistrationStepStatus.COMPLETED :
-  bypassTime !== null && completionTime !== undefined ? RegistrationStepStatus.BYPASSED : RegistrationStepStatus.UNCOMPLETE;
-};
-
-const bypassedText = (bypassTime: number): JSX.Element => {
-  return <React.Fragment>
-  <div>Bypassed on:</div>
-  <div>{displayDateWithoutHours(bypassTime)}</div>
-</React.Fragment>;
-};
-
-const getCompleteOrBypassContent = ({bypassTime, completionTime}: CompletionTime): JSX.Element => {
-  switch (getRegistrationStatus(completionTime, bypassTime)) {
-    case RegistrationStepStatus.COMPLETED:
-      return <React.Fragment>
-      <div>Completed on:</div>
-      <div>{displayDateWithoutHours(completionTime)}</div>
-    </React.Fragment>;
-    case RegistrationStepStatus.BYPASSED:
-      return bypassedText(bypassTime);
-    default:
-      return;
-  }
-};
-
-const focusCompletionProps = lensOnProps(['completionTime', 'bypassTime']);
-
-const getTwoFactorContent = fp.flow(
-  focusCompletionProps(['twoFactorAuthCompletionTime', 'twoFactorAuthBypassTime']),
-  getCompleteOrBypassContent
-);
-
-const getControlledTierContent = fp.flow(
-  focusCompletionProps(['controlledTierCompletionTime', 'controlledTierBypassTime']),
-  getCompleteOrBypassContent
-);
-
 export const ProfileComponent = fp.flow(
   withUserProfile(),
   withProfileErrorModal,
@@ -259,85 +199,13 @@ export const ProfileComponent = fp.flow(
       }
     }
 
-    private getEraCommonsCardText(profile) {
-      switch (getRegistrationStatus(profile.eraCommonsCompletionTime, profile.eraCommonsBypassTime)) {
-        case RegistrationStepStatus.COMPLETED:
-          return <div>
-          {profile.eraCommonsLinkedNihUsername != null && <React.Fragment>
-              <div> Username:</div>
-              <div> {profile.eraCommonsLinkedNihUsername} </div>
-          </React.Fragment>}
-          {profile.eraCommonsLinkExpireTime != null &&
-          //  Firecloud returns eraCommons link expiration as 0 if there is no linked account.
-          profile.eraCommonsLinkExpireTime !== 0
-          && <React.Fragment>
-              <div> Completed on:</div>
-              <div>
-                {displayDateWithoutHours(profile.eraCommonsCompletionTime)}
-              </div>
-          </React.Fragment>}
-        </div>;
-        case RegistrationStepStatus.BYPASSED:
-          return bypassedText(profile.twoFactorAuthBypassTime);
-        default:
-          return;
-      }
-    }
-
-    private getComplianceTrainingText(profile) {
-      switch (getRegistrationStatus(profile.complianceTrainingCompletionTime, profile.complianceTrainingBypassTime)) {
-        case RegistrationStepStatus.COMPLETED:
-          return <React.Fragment>
-          <div>Training Completed</div>
-          <div>{displayDateWithoutHours(profile.complianceTrainingCompletionTime)}</div>
-        </React.Fragment>;
-        case RegistrationStepStatus.BYPASSED:
-          return bypassedText(profile.complianceTrainingBypassTime);
-        default:
-          return;
-      }
-    }
-
-    getRegistrationTasksMap() {
-      return getRegistrationTasksMap(this.props.navigate);
-    }
-
-    private getDUCCText(profile) {
-      const universalText = <a onClick={this.getRegistrationTasksMap()['dataUserCodeOfConduct'].onClick}>
-      View code of conduct
-    </a>;
-      switch (getRegistrationStatus(profile.dataUseAgreementCompletionTime, profile.dataUseAgreementBypassTime)) {
-        case RegistrationStepStatus.COMPLETED:
-          return <React.Fragment>
-          <div>Signed On:</div>
-          <div>
-            {displayDateWithoutHours(profile.dataUseAgreementCompletionTime)}
-          </div>
-          {universalText}
-        </React.Fragment>;
-        case RegistrationStepStatus.BYPASSED:
-          return <React.Fragment>
-          {bypassedText(profile.dataUseAgreementBypassTime)}
-          {universalText}
-        </React.Fragment>;
-        case RegistrationStepStatus.UNCOMPLETE:
-          return universalText;
-      }
-    }
-
     render() {
       const {
         profileState: {
           profile
         },
-        // TODO: when the controlled tier data is available fetch it from the profile
-        controlledTierProfile: {
-          controlledTierEnabled = false, controlledTierBypassTime = null, controlledTierCompletionTime = null
-        } = {}
       } = this.props;
       const {currentProfile, updating, showDemographicSurveyModal} = this.state;
-      const {enableComplianceTraining, enableEraCommons} =
-      serverConfigStore.get().config;
       const {
       givenName, familyName, areaOfResearch, professionalUrl,
         address: {
@@ -573,71 +441,8 @@ export const ProfileComponent = fp.flow(
                   <div style={{fontWeight: 600}}>{formatFreeCreditsUSD(profile.freeTierDollarQuota - profile.freeTierUsage)}</div>
                 </FlexColumn>
             </FlexRow>}
-            {controlledTierEnabled && <DataAccessPanel tiers={profile.accessTierShortNames}/>}
-            <div style={styles.title}>
-              Requirements for <AoU/> Workbench access
-            </div>
-            <hr style={{...styles.verticalLine}}/>
-            <div style={{display: 'grid', gap: '10px', gridAutoRows: '225px', gridTemplateColumns: '220px 220px'}}>
-              {controlledTierEnabled && <ProfileRegistrationStepStatus
-                title={<span><AoU/> Controlled Tier Data Training</span>}
-                wasBypassed={!!controlledTierBypassTime}
-                incompleteButtonText={'Get Started'}
-                completedButtonText={'Completed'}
-                isComplete={!!(controlledTierCompletionTime || controlledTierBypassTime)}
-                // TODO: link to the training modules once they are available
-                completeStep={() => null}
-                content={getControlledTierContent({controlledTierCompletionTime, controlledTierBypassTime})}
-                >
-                <div>
-                  {!(controlledTierCompletionTime || controlledTierBypassTime) && <div>To be completed</div>}
-                  <ControlledTierBadge/>
-                </div>
-              </ProfileRegistrationStepStatus>}
-              <ProfileRegistrationStepStatus
-                title='Turn on Google 2-Step Verification'
-                wasBypassed={!!profile.twoFactorAuthBypassTime}
-                incompleteButtonText='Set Up'
-                completedButtonText={this.getRegistrationTasksMap()['twoFactorAuth'].completedText}
-                isComplete={!!(this.getRegistrationTasksMap()['twoFactorAuth'].completionTimestamp(profile))}
-                completeStep={this.getRegistrationTasksMap()['twoFactorAuth'].onClick}
-                content={getTwoFactorContent(profile)}
-                >
-              </ProfileRegistrationStepStatus>
-              {enableEraCommons && <ProfileRegistrationStepStatus
-                  title='Connect Your eRA Commons Account'
-                  wasBypassed={!!profile.eraCommonsBypassTime}
-                  incompleteButtonText='Link'
-                  completedButtonText={this.getRegistrationTasksMap()['eraCommons'].completedText}
-                  isComplete={!!(this.getRegistrationTasksMap()['eraCommons'].completionTimestamp(profile))}
-                  completeStep={this.getRegistrationTasksMap()['eraCommons'].onClick}
-                  content={this.getEraCommonsCardText(profile)}
-                >
-              </ProfileRegistrationStepStatus>}
-              {enableComplianceTraining && <ProfileRegistrationStepStatus
-                  title={<span><AoU/> Responsible Conduct of Research Training</span>}
-                  wasBypassed={!!profile.complianceTrainingBypassTime}
-                  incompleteButtonText='Access Training'
-                  completedButtonText={this.getRegistrationTasksMap()['complianceTraining'].completedText}
-                  isComplete={!!(this.getRegistrationTasksMap()['complianceTraining'].completionTimestamp(profile))}
-                  completeStep={this.getRegistrationTasksMap()['complianceTraining'].onClick}
-                  content={this.getComplianceTrainingText(profile)}
-                >
-              </ProfileRegistrationStepStatus>}
-              <ProfileRegistrationStepStatus
-                  title='Sign Data User Code Of Conduct'
-                  wasBypassed={!!profile.dataUseAgreementBypassTime}
-                  incompleteButtonText='Sign'
-                  completedButtonText={this.getRegistrationTasksMap()['dataUserCodeOfConduct'].completedText}
-                  isComplete={!!(this.getRegistrationTasksMap()['dataUserCodeOfConduct'].completionTimestamp(profile))}
-                  completeStep={this.getRegistrationTasksMap()['dataUserCodeOfConduct'].onClick}
-                  childrenStyle={{marginLeft: 0}}
-                  content={this.getDUCCText(profile)}
-                >
-              </ProfileRegistrationStepStatus>
-            </div>
+            <ProfileAccessModules profile={profile}/>
             <div style={{marginTop: '1rem', marginLeft: '1rem'}}>
-
               <div style={styles.title}>Optional Demographics Survey</div>
               <hr style={{...styles.verticalLine}}/>
               <div style={{color: colors.primary, fontSize: '14px'}}>


### PR DESCRIPTION
As part of the Data Access Requirements work ([mocks](https://projects.invisionapp.com/d/main#/console/21472057/455216387/preview)) we are removing the Access Modules / Registration Tasks from the Profile page.

This PR doesn't do that - it simply extracts the relevant section into a new functional component to make the transition easier.

Tested locally.  I observed no changes.
 
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
