### PR TITLE
[RW-7262][risk=no] rm unnecessary import, fix admin nb preview

### DIFF
--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 import {useLocation} from 'react-router';
 import {useHistory} from 'react-router-dom';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
-import {URLSearchParams} from 'url';
 
 // This is an optional warmup store which can be populated to avoid redundant
 // requests on navigation, e.g. from workspace creation/clone -> data page. It


### PR DESCRIPTION
`URLSearchParams` is available globally. Importing from `"url"` seems to grab the module instead from the fetch codegen - unclear why. Not sure when this broke.