### PR TITLE
[risk=low][RW-7089] don't sync on initial load of DAR - causes state errors

### DIFF
--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -254,7 +254,7 @@ const bypassedOrCompletedText = (status: AccessModuleStatus) => {
   );
 };
 
-const handleTerraShibbolethCallback = (token: string, spinnerProps: WithSpinnerOverlayProps) => {
+const handleTerraShibbolethCallback = (token: string, spinnerProps: WithSpinnerOverlayProps, reloadProfile: Function) => {
   const handler = withErrorModal({
     title: 'Error saving NIH Authentication status.',
     message: 'An error occurred trying to save your NIH Authentication status. Please try again.',
@@ -265,12 +265,13 @@ const handleTerraShibbolethCallback = (token: string, spinnerProps: WithSpinnerO
     spinnerProps.showSpinner();
     await profileApi().updateNihToken({jwt: token});
     spinnerProps.hideSpinner();
+    reloadProfile();
   });
 
   return handler();
 };
 
-const handleRasCallback = (code: string, spinnerProps: WithSpinnerOverlayProps) => {
+const handleRasCallback = (code: string, spinnerProps: WithSpinnerOverlayProps, reloadProfile: Function) => {
   const handler = withErrorModal({
     title: 'Error saving RAS Login.Gov linkage status.',
     message: 'An error occurred trying to save your RAS Login.Gov linkage status. Please try again.',
@@ -281,16 +282,17 @@ const handleRasCallback = (code: string, spinnerProps: WithSpinnerOverlayProps) 
     spinnerProps.showSpinner();
     await profileApi().linkRasAccount({ authCode: code, redirectUrl: buildRasRedirectUrl() });
     spinnerProps.hideSpinner();
+    reloadProfile();
   });
 
   return handler();
 };
 
-const selfBypass = async(spinnerProps: WithSpinnerOverlayProps, reload: Function) => {
+const selfBypass = async(spinnerProps: WithSpinnerOverlayProps, reloadProfile: Function) => {
   spinnerProps.showSpinner();
   await bypassAll(allModules, true);
   spinnerProps.hideSpinner();
-  reload();
+  reloadProfile();
 };
 
 const syncExternalModules = async() => {
@@ -478,12 +480,12 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)((spinnerPro
   const {token, code} = queryParamsStore.getValue();
   useEffect(() => {
     if (token) {
-      handleTerraShibbolethCallback(token, spinnerProps);
+      handleTerraShibbolethCallback(token, spinnerProps, reload);
     }
   }, [token] );
   useEffect(() => {
     if (code) {
-      handleRasCallback(code, spinnerProps);
+      handleRasCallback(code, spinnerProps, reload);
     }
   }, [code]);
 

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -311,9 +311,9 @@ const syncExternalModules = async() => {
 const Refresh = (props: {showSpinner: Function}) => <Button
     type='primary'
     style={styles.refreshButton}
-    onClick={() => {
+    onClick={async() => {
       props.showSpinner();
-      syncExternalModules();
+      await syncExternalModules();
       location.reload();  // will also hide spinner
     }} >
   <Repeat style={styles.refreshIcon}/> Refresh
@@ -517,7 +517,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)((spinnerPro
         <div style={styles.selfBypassText}>[Test environment] Self-service bypass is enabled</div>
         <Button
             style={{marginLeft: '0.5rem'}}
-            onClick={() => selfBypass(spinnerProps, reload)}>Bypass all</Button>
+            onClick={async() => await selfBypass(spinnerProps, reload)}>Bypass all</Button>
       </FlexRow>}
       <FadeBox style={styles.fadeBox}>
         <div style={styles.pleaseComplete}>

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -254,42 +254,42 @@ const bypassedOrCompletedText = (status: AccessModuleStatus) => {
   );
 };
 
-const handleTerraShibbolethCallback = (token: string, spinner: WithSpinnerOverlayProps) => {
+const handleTerraShibbolethCallback = (token: string, spinnerProps: WithSpinnerOverlayProps) => {
   const handler = withErrorModal({
     title: 'Error saving NIH Authentication status.',
     message: 'An error occurred trying to save your NIH Authentication status. Please try again.',
     onDismiss: () => {
-      spinner.hideSpinner();
+      spinnerProps.hideSpinner();
     }
   })(async() => {
-    spinner.showSpinner();
+    spinnerProps.showSpinner();
     await profileApi().updateNihToken({jwt: token});
-    spinner.hideSpinner();
+    spinnerProps.hideSpinner();
   });
 
   return handler();
 };
 
-const handleRasCallback = (code: string, spinner: WithSpinnerOverlayProps) => {
+const handleRasCallback = (code: string, spinnerProps: WithSpinnerOverlayProps) => {
   const handler = withErrorModal({
     title: 'Error saving RAS Login.Gov linkage status.',
     message: 'An error occurred trying to save your RAS Login.Gov linkage status. Please try again.',
     onDismiss: () => {
-      spinner.hideSpinner();
+      spinnerProps.hideSpinner();
     }
   })(async() => {
-    spinner.showSpinner();
+    spinnerProps.showSpinner();
     await profileApi().linkRasAccount({ authCode: code, redirectUrl: buildRasRedirectUrl() });
-    spinner.hideSpinner();
+    spinnerProps.hideSpinner();
   });
 
   return handler();
 };
 
-const selfBypass = async(spinner: WithSpinnerOverlayProps, reload: Function) => {
-  spinner.showSpinner();
+const selfBypass = async(spinnerProps: WithSpinnerOverlayProps, reload: Function) => {
+  spinnerProps.showSpinner();
   await bypassAll(allModules, true);
-  spinner.hideSpinner();
+  spinnerProps.hideSpinner();
   reload();
 };
 
@@ -344,10 +344,10 @@ interface ModuleProps {
 
   // TODO RW-7059
   // eligible: boolean;  // is the user eligible to complete this module (does the inst. allow it)
-  spinner: WithSpinnerOverlayProps;
+  spinnerProps: WithSpinnerOverlayProps;
 }
 // Renders a module when it's enabled via feature flags.  Returns null if not.
-const MaybeModule = ({moduleName, active, spinner}: ModuleProps): JSX.Element => {
+const MaybeModule = ({moduleName, active, spinnerProps}: ModuleProps): JSX.Element => {
   // whether to show the refresh button: this module has been clicked
   const [showRefresh, setShowRefresh] = useState(false);
 
@@ -381,7 +381,7 @@ const MaybeModule = ({moduleName, active, spinner}: ModuleProps): JSX.Element =>
 
     return <FlexRow data-test-id={`module-${moduleName}`}>
       <FlexRow style={styles.moduleCTA}>
-        {active && (showRefresh ? <Refresh showSpinner={spinner.showSpinner}/> : <Next/>)}
+        {active && (showRefresh ? <Refresh showSpinner={spinnerProps.showSpinner}/> : <Next/>)}
       </FlexRow>
       <ModuleBox>
         <ModuleIcon moduleName={moduleName} completedOrBypassed={!!statusTextMaybe}/>
@@ -415,11 +415,11 @@ const Completed = () => <FlexRow data-test-id='dar-completed' style={styles.comp
   <GetStartedButton style={{marginLeft: 'auto'}}/>
 </FlexRow>;
 
-const ModulesForCard = (props: {modules: AccessModule[], activeModule: AccessModule, spinner: WithSpinnerOverlayProps}) => {
-  const {modules, activeModule, spinner} = props;
+const ModulesForCard = (props: {modules: AccessModule[], activeModule: AccessModule, spinnerProps: WithSpinnerOverlayProps}) => {
+  const {modules, activeModule, spinnerProps} = props;
   return <FlexColumn style={styles.modulesContainer}>
     {modules.map(moduleName =>
-        <MaybeModule key={moduleName} moduleName={moduleName} active={moduleName === activeModule} spinner={spinner}/>
+        <MaybeModule key={moduleName} moduleName={moduleName} active={moduleName === activeModule} spinnerProps={spinnerProps}/>
     )}
   </FlexColumn>;
 };
@@ -432,8 +432,8 @@ const DataDetail = (props: {icon: string, text: string}) => {
   </FlexRow>;
 };
 
-const RegisteredTierCard = (props: {activeModule: AccessModule, spinner: WithSpinnerOverlayProps}) => {
-  const {activeModule, spinner} = props;
+const RegisteredTierCard = (props: {activeModule: AccessModule, spinnerProps: WithSpinnerOverlayProps}) => {
+  const {activeModule, spinnerProps} = props;
   return <FlexRow style={styles.card}>
     <FlexColumn>
       <div style={styles.cardStep}>Step 1</div>
@@ -450,27 +450,27 @@ const RegisteredTierCard = (props: {activeModule: AccessModule, spinner: WithSpi
       <DataDetail icon='physical' text='Physical measurements'/>
       <DataDetail icon='wearable' text='Wearable devices'/>
     </FlexColumn>
-    <ModulesForCard modules={rtModules} activeModule={activeModule} spinner={spinner}/>
+    <ModulesForCard modules={rtModules} activeModule={activeModule} spinnerProps={spinnerProps}/>
   </FlexRow>;
 };
 
-const DuccCard = (props: {activeModule: AccessModule, spinner: WithSpinnerOverlayProps}) => {
-  const {activeModule, spinner} = props;
+const DuccCard = (props: {activeModule: AccessModule, spinnerProps: WithSpinnerOverlayProps}) => {
+  const {activeModule, spinnerProps} = props;
   return <FlexRow style={{...styles.card, height: '125px'}}>
     <FlexColumn>
       {/* This will be Step 3 when CT becomes the new Step 2 */}
       <div style={styles.cardStep}>Step 2</div>
       <div style={styles.cardHeader}>Sign the code of conduct</div>
     </FlexColumn>
-    <ModulesForCard modules={[duccModule]} activeModule={activeModule} spinner={spinner}/>
+    <ModulesForCard modules={[duccModule]} activeModule={activeModule} spinnerProps={spinnerProps}/>
   </FlexRow>;
 };
 
-export const DataAccessRequirements = fp.flow(withProfileErrorModal)((spinner: WithSpinnerOverlayProps) => {
+export const DataAccessRequirements = fp.flow(withProfileErrorModal)((spinnerProps: WithSpinnerOverlayProps) => {
   const {profile, reload} = useStore(profileStore);
 
   useEffect(() => {
-    spinner.hideSpinner();
+    spinnerProps.hideSpinner();
   }, []);
 
   // handle the route /nih-callback?token=<token>
@@ -478,12 +478,12 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)((spinner: W
   const {token, code} = queryParamsStore.getValue();
   useEffect(() => {
     if (token) {
-      handleTerraShibbolethCallback(token, spinner);
+      handleTerraShibbolethCallback(token, spinnerProps);
     }
   }, [token] );
   useEffect(() => {
     if (code) {
-      handleRasCallback(code, spinner);
+      handleRasCallback(code, spinnerProps);
     }
   }, [code]);
 
@@ -517,15 +517,15 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)((spinner: W
         <div style={styles.selfBypassText}>[Test environment] Self-service bypass is enabled</div>
         <Button
             style={{marginLeft: '0.5rem'}}
-            onClick={() => selfBypass(spinner, reload)}>Bypass all</Button>
+            onClick={() => selfBypass(spinnerProps, reload)}>Bypass all</Button>
       </FlexRow>}
       <FadeBox style={styles.fadeBox}>
         <div style={styles.pleaseComplete}>
           Please complete the necessary steps to gain access to the <AoU/> datasets.
         </div>
-        <RegisteredTierCard activeModule={activeModule} spinner={spinner}/>
+        <RegisteredTierCard activeModule={activeModule} spinnerProps={spinnerProps}/>
         {/* TODO RW-7059 - Step 2 ControlledTierCard */}
-        <DuccCard activeModule={activeModule} spinner={spinner}/>
+        <DuccCard activeModule={activeModule} spinnerProps={spinnerProps}/>
       </FadeBox>
     </FlexColumn>;
 });

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -254,49 +254,68 @@ const bypassedOrCompletedText = (status: AccessModuleStatus) => {
   );
 };
 
-const handleTerraShibbolethCallback = (token: string, spinnerProps: WithSpinnerOverlayProps) => {
+const handleTerraShibbolethCallback = (token: string, spinner: WithSpinnerOverlayProps) => {
   const handler = withErrorModal({
     title: 'Error saving NIH Authentication status.',
     message: 'An error occurred trying to save your NIH Authentication status. Please try again.',
     onDismiss: () => {
-      spinnerProps.hideSpinner();
+      spinner.hideSpinner();
     }
   })(async() => {
-    spinnerProps.showSpinner();
+    spinner.showSpinner();
     await profileApi().updateNihToken({jwt: token});
-    spinnerProps.hideSpinner();
+    spinner.hideSpinner();
   });
 
   return handler();
 };
 
-const handleRasCallback = (code: string, spinnerProps: WithSpinnerOverlayProps) => {
+const handleRasCallback = (code: string, spinner: WithSpinnerOverlayProps) => {
   const handler = withErrorModal({
     title: 'Error saving RAS Login.Gov linkage status.',
     message: 'An error occurred trying to save your RAS Login.Gov linkage status. Please try again.',
     onDismiss: () => {
-      spinnerProps.hideSpinner();
+      spinner.hideSpinner();
     }
   })(async() => {
-    spinnerProps.showSpinner();
+    spinner.showSpinner();
     await profileApi().linkRasAccount({ authCode: code, redirectUrl: buildRasRedirectUrl() });
-    spinnerProps.hideSpinner();
+    spinner.hideSpinner();
   });
 
   return handler();
 };
 
-const selfBypass = async(spinnerProps: WithSpinnerOverlayProps, reload: Function) => {
-  spinnerProps.showSpinner();
+const selfBypass = async(spinner: WithSpinnerOverlayProps, reload: Function) => {
+  spinner.showSpinner();
   await bypassAll(allModules, true);
-  spinnerProps.hideSpinner();
+  spinner.hideSpinner();
   reload();
 };
 
-const Refresh = () => <Button
+const syncExternalModules = async() => {
+  const aborter = new AbortController();
+  try {
+    await Promise.all([
+      profileApi().syncTwoFactorAuthStatus({signal: aborter.signal}),
+      profileApi().syncComplianceTrainingStatus({signal: aborter.signal}),
+      profileApi().syncEraCommonsStatus({signal: aborter.signal}),
+    ]);
+  } catch (e) {
+    if (!isAbortError(e)) { throw e; }
+  } finally {
+    aborter.abort();
+  }
+};
+
+const Refresh = (props: {showSpinner: Function}) => <Button
     type='primary'
     style={styles.refreshButton}
-    onClick={() => location.reload()} >
+    onClick={() => {
+      props.showSpinner();
+      syncExternalModules();
+      location.reload();  // will also hide spinner
+    }} >
   <Repeat style={styles.refreshIcon}/> Refresh
 </Button>;
 
@@ -325,9 +344,10 @@ interface ModuleProps {
 
   // TODO RW-7059
   // eligible: boolean;  // is the user eligible to complete this module (does the inst. allow it)
+  spinner: WithSpinnerOverlayProps;
 }
 // Renders a module when it's enabled via feature flags.  Returns null if not.
-const MaybeModule = ({moduleName, active}: ModuleProps): JSX.Element => {
+const MaybeModule = ({moduleName, active, spinner}: ModuleProps): JSX.Element => {
   // whether to show the refresh button: this module has been clicked
   const [showRefresh, setShowRefresh] = useState(false);
 
@@ -361,7 +381,7 @@ const MaybeModule = ({moduleName, active}: ModuleProps): JSX.Element => {
 
     return <FlexRow data-test-id={`module-${moduleName}`}>
       <FlexRow style={styles.moduleCTA}>
-        {active && (showRefresh ? <Refresh/> : <Next/>)}
+        {active && (showRefresh ? <Refresh showSpinner={spinner.showSpinner}/> : <Next/>)}
       </FlexRow>
       <ModuleBox>
         <ModuleIcon moduleName={moduleName} completedOrBypassed={!!statusTextMaybe}/>
@@ -395,11 +415,11 @@ const Completed = () => <FlexRow data-test-id='dar-completed' style={styles.comp
   <GetStartedButton style={{marginLeft: 'auto'}}/>
 </FlexRow>;
 
-const ModulesForCard = (props: {modules: AccessModule[], activeModule: AccessModule}) => {
-  const {modules, activeModule} = props;
+const ModulesForCard = (props: {modules: AccessModule[], activeModule: AccessModule, spinner: WithSpinnerOverlayProps}) => {
+  const {modules, activeModule, spinner} = props;
   return <FlexColumn style={styles.modulesContainer}>
     {modules.map(moduleName =>
-        <MaybeModule key={moduleName} moduleName={moduleName} active={moduleName === activeModule}/>
+        <MaybeModule key={moduleName} moduleName={moduleName} active={moduleName === activeModule} spinner={spinner}/>
     )}
   </FlexColumn>;
 };
@@ -412,60 +432,45 @@ const DataDetail = (props: {icon: string, text: string}) => {
   </FlexRow>;
 };
 
-const RegisteredTierCard = (props: {activeModule: AccessModule}) => <FlexRow style={styles.card}>
-  <FlexColumn>
-    <div style={styles.cardStep}>Step 1</div>
-    <div style={styles.cardHeader}>Complete Registration</div>
-    <FlexRow>
-      <RegisteredTierBadge/>
-      <div style={styles.rtData}>Registered Tier data</div>
-    </FlexRow>
-    <div style={styles.rtDataDetails}>Once registered, you’ll have access to:</div>
-    <DataDetail icon='individual' text='Individual (not aggregated) data'/>
-    <DataDetail icon='identifying' text='Identifying information removed'/>
-    <DataDetail icon='electronic' text='Electronic health records'/>
-    <DataDetail icon='survey' text='Survey responses'/>
-    <DataDetail icon='physical' text='Physical measurements'/>
-    <DataDetail icon='wearable' text='Wearable devices'/>
-  </FlexColumn>
-  <ModulesForCard modules={rtModules} activeModule={props.activeModule}/>
-</FlexRow>;
+const RegisteredTierCard = (props: {activeModule: AccessModule, spinner: WithSpinnerOverlayProps}) => {
+  const {activeModule, spinner} = props;
+  return <FlexRow style={styles.card}>
+    <FlexColumn>
+      <div style={styles.cardStep}>Step 1</div>
+      <div style={styles.cardHeader}>Complete Registration</div>
+      <FlexRow>
+        <RegisteredTierBadge/>
+        <div style={styles.rtData}>Registered Tier data</div>
+      </FlexRow>
+      <div style={styles.rtDataDetails}>Once registered, you’ll have access to:</div>
+      <DataDetail icon='individual' text='Individual (not aggregated) data'/>
+      <DataDetail icon='identifying' text='Identifying information removed'/>
+      <DataDetail icon='electronic' text='Electronic health records'/>
+      <DataDetail icon='survey' text='Survey responses'/>
+      <DataDetail icon='physical' text='Physical measurements'/>
+      <DataDetail icon='wearable' text='Wearable devices'/>
+    </FlexColumn>
+    <ModulesForCard modules={rtModules} activeModule={activeModule} spinner={spinner}/>
+  </FlexRow>;
+};
 
-const DuccCard = (props: {activeModule: AccessModule}) => <FlexRow style={{...styles.card, height: '125px'}}>
-  <FlexColumn>
-    {/* This will be Step 3 when CT becomes the new Step 2 */}
-    <div style={styles.cardStep}>Step 2</div>
-    <div style={styles.cardHeader}>Sign the code of conduct</div>
-  </FlexColumn>
-  <ModulesForCard modules={[duccModule]} activeModule={props.activeModule}/>
-</FlexRow>;
+const DuccCard = (props: {activeModule: AccessModule, spinner: WithSpinnerOverlayProps}) => {
+  const {activeModule, spinner} = props;
+  return <FlexRow style={{...styles.card, height: '125px'}}>
+    <FlexColumn>
+      {/* This will be Step 3 when CT becomes the new Step 2 */}
+      <div style={styles.cardStep}>Step 2</div>
+      <div style={styles.cardHeader}>Sign the code of conduct</div>
+    </FlexColumn>
+    <ModulesForCard modules={[duccModule]} activeModule={activeModule} spinner={spinner}/>
+  </FlexRow>;
+};
 
-export const DataAccessRequirements = fp.flow(withProfileErrorModal)((spinnerProps: WithSpinnerOverlayProps) => {
+export const DataAccessRequirements = fp.flow(withProfileErrorModal)((spinner: WithSpinnerOverlayProps) => {
   const {profile, reload} = useStore(profileStore);
 
-  const syncExternalModulesAndReloadProfile = async(aborter: AbortController) => {
-    spinnerProps.showSpinner();
-
-    try {
-      await Promise.all([
-        profileApi().syncTwoFactorAuthStatus({signal: aborter.signal}),
-        profileApi().syncComplianceTrainingStatus({signal: aborter.signal}),
-        profileApi().syncEraCommonsStatus({signal: aborter.signal}),
-      ]);
-    } catch (e) {
-      if (!isAbortError(e)) { throw e; }
-    }
-
-    spinnerProps.hideSpinner();
-    reload();
-  };
-
   useEffect(() => {
-    const aborter = new AbortController();
-    syncExternalModulesAndReloadProfile(aborter);
-
-    // cleanup on unmount
-    return aborter.abort;
+    spinner.hideSpinner();
   }, []);
 
   // handle the route /nih-callback?token=<token>
@@ -473,12 +478,12 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)((spinnerPro
   const {token, code} = queryParamsStore.getValue();
   useEffect(() => {
     if (token) {
-      handleTerraShibbolethCallback(token, spinnerProps);
+      handleTerraShibbolethCallback(token, spinner);
     }
   }, [token] );
   useEffect(() => {
     if (code) {
-      handleRasCallback(code, spinnerProps);
+      handleRasCallback(code, spinner);
     }
   }, [code]);
 
@@ -512,15 +517,15 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)((spinnerPro
         <div style={styles.selfBypassText}>[Test environment] Self-service bypass is enabled</div>
         <Button
             style={{marginLeft: '0.5rem'}}
-            onClick={() => selfBypass(spinnerProps, reload)}>Bypass all</Button>
+            onClick={() => selfBypass(spinner, reload)}>Bypass all</Button>
       </FlexRow>}
       <FadeBox style={styles.fadeBox}>
         <div style={styles.pleaseComplete}>
           Please complete the necessary steps to gain access to the <AoU/> datasets.
         </div>
-        <RegisteredTierCard activeModule={activeModule}/>
+        <RegisteredTierCard activeModule={activeModule} spinner={spinner}/>
         {/* TODO RW-7059 - Step 2 ControlledTierCard */}
-        <DuccCard activeModule={activeModule}/>
+        <DuccCard activeModule={activeModule} spinner={spinner}/>
       </FadeBox>
     </FlexColumn>;
 });


### PR DESCRIPTION
Before: every page load of DAR would sync external modules and reload the profile.  This led to weird state errors like "attempted to update state of unmounted component" at the end of that sync and "illegal invocation of callback" and failure to render the next page navigated to after DAR.

These problems no longer occur now that we only sync external modules when the Refresh button is clicked. 

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
