### PR TITLE
[RW-6998][risk=no] Implement initial tuning of genomics extraction scatter count

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
@@ -459,6 +459,22 @@ public class GenomicExtractionServiceTest {
   }
 
   @Test
+  public void submitExtractionJob_many() throws ApiException {
+    final List<String> largePersonIdList =
+        LongStream.range(1, 3_001).boxed().map(id -> id.toString()).collect(Collectors.toList());
+    when(mockDataSetService.getPersonIdsWithWholeGenome(any())).thenReturn(largePersonIdList);
+    genomicExtractionService.submitGenomicExtractionJob(targetWorkspace, dataset);
+
+    ArgumentCaptor<FirecloudMethodConfiguration> argument =
+        ArgumentCaptor.forClass(FirecloudMethodConfiguration.class);
+
+    verify(methodConfigurationsApi).createWorkspaceMethodConfig(argument.capture(), any(), any());
+    String actualScatter =
+        argument.getValue().getInputs().get(EXTRACT_WORKFLOW_NAME + ".scatter_count");
+    assertThat(actualScatter).isEqualTo("1500");
+  }
+
+  @Test
   public void submitExtractionJob_noWgsData() throws ApiException {
     when(mockDataSetService.getPersonIdsWithWholeGenome(any())).thenReturn(ImmutableList.of());
 


### PR DESCRIPTION
Using this approach:

- 21 samples (1.2GB), 20 workers: 31m
- 557 samples (31.5GB), 278 workers: 1h13  

This seemed to perform better than `samples/5`, but we'll likely need more data points from production to get a better sense. These measurements are very noisy.

Other data points gathered:

- 21 samples (1.2GB), 4 workers: 48m
- 143 samples (7GB), 28 workers: 62m
- 557 samples (31.5GB), 111 workers: 96m
- 557 samples (31.5GB), 557 workers: 61m
