### PR TITLE
[risk=no] Refactor DirectoryService.getUser to mitigate NPEs

### DIFF
--- a/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
@@ -47,7 +47,7 @@ public class DirectoryServiceImplIntegrationTest extends BaseIntegrationTest {
             .execute(
                 c -> {
                   Map<String, Map<String, Object>> schemas =
-                      service.getUser(username).getCustomSchemas();
+                      service.getUserOrThrow(username).get().getCustomSchemas();
                   if (schemas == null) {
                     throw new RuntimeException("custom schemas is still null");
                   }

--- a/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
@@ -47,7 +47,7 @@ public class DirectoryServiceImplIntegrationTest extends BaseIntegrationTest {
             .execute(
                 c -> {
                   Map<String, Map<String, Object>> schemas =
-                      service.getUserOrThrow(username).get().getCustomSchemas();
+                      service.getUserOrThrow(username).getCustomSchemas();
                   if (schemas == null) {
                     throw new RuntimeException("custom schemas is still null");
                   }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -391,7 +391,7 @@ public class ProfileController implements ProfileApiDelegate {
   public ResponseEntity<Void> updateContactEmail(
       UpdateContactEmailRequest updateContactEmailRequest) {
     String username = updateContactEmailRequest.getUsername().toLowerCase();
-    User googleUser = directoryService.getUser(username);
+    User googleUser = directoryService.getUserOrThrow(username);
     DbUser user = userService.getByUsernameOrThrow(username);
     checkUserCreationNonce(user, updateContactEmailRequest.getCreationNonce());
     if (userHasEverLoggedIn(googleUser, user)) {
@@ -411,7 +411,7 @@ public class ProfileController implements ProfileApiDelegate {
   @Override
   public ResponseEntity<Void> resendWelcomeEmail(ResendWelcomeEmailRequest resendRequest) {
     String username = resendRequest.getUsername().toLowerCase();
-    User googleUser = directoryService.getUser(username);
+    User googleUser = directoryService.getUserOrThrow(username);
     DbUser user = userService.getByUsernameOrThrow(username);
     checkUserCreationNonce(user, resendRequest.getCreationNonce());
     if (userHasEverLoggedIn(googleUser, user)) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -827,7 +827,9 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   @Override
   public DbUser syncTwoFactorAuthStatus(DbUser targetUser, Agent agent) {
     return syncTwoFactorAuthStatus(
-        targetUser, agent, directoryService.getUser(targetUser.getUsername()).getIsEnrolledIn2Sv());
+        targetUser,
+        agent,
+        directoryService.getUserOrThrow(targetUser.getUsername()).getIsEnrolledIn2Sv());
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
@@ -21,8 +21,14 @@ public interface DirectoryService {
   /** Returns whether the given user prefix corresponds to an existing GSuite user account. */
   boolean isUsernameTaken(String userPrefix);
 
-  /** Returns a user via username lookup. Returns null if no user was found. */
-  User getUser(String username);
+  /** Returns a user via username lookup, if found. */
+  Optional<User> getUser(String username);
+
+  /**
+   * Returns a user via username lookup, or throws a {@link
+   * org.pmiops.workbench.exceptions.NotFoundException} if not found.
+   */
+  User getUserOrThrow(String username);
 
   /**
    * Returns a mapping of researcher username (e.g. foo@researchallofus.org) to that user's 2FA

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -159,8 +159,6 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
                       .setProjection("full")
                       .execute()));
     } catch (GoogleJsonResponseException e) {
-      // Handle the special case where we're looking for a not found user by returning
-      // null.
       if (e.getDetails().getCode() == HttpStatus.NOT_FOUND.value()) {
         return Optional.empty();
       }

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -290,7 +290,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
     DUCC_VERSION = userService.getCurrentDuccVersion();
 
-    when(mockDirectoryService.getUser(FULL_USER_NAME)).thenReturn(googleUser);
+    when(mockDirectoryService.getUserOrThrow(FULL_USER_NAME)).thenReturn(googleUser);
     when(mockDirectoryService.createUser(
             GIVEN_NAME, FAMILY_NAME, USER_PREFIX + "@" + GSUITE_DOMAIN, CONTACT_EMAIL))
         .thenReturn(googleUser);

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -378,7 +378,7 @@ public class UserServiceTest extends SpringTest {
     googleUser.setPrimaryEmail(USERNAME);
     googleUser.setIsEnrolledIn2Sv(true);
 
-    when(mockDirectoryService.getUser(USERNAME)).thenReturn(googleUser);
+    when(mockDirectoryService.getUserOrThrow(USERNAME)).thenReturn(googleUser);
     userService.syncTwoFactorAuthStatus();
     // twoFactorAuthCompletionTime should now be set
     DbUser user = userDao.findUserByUsername(USERNAME);


### PR DESCRIPTION
Noticed this while making the `synchronizeUserAccess` changes, getting NPEs for users who exist in the db, but not gsuite (this is not expected outside of the test env).

- `Optional` instead of `null` sentinel
- Change some non-null-safe usages to throw an appropriate error