### PR TITLE
[RW-7234][risk=no]: Add utility in e2e that can generate 2fa code

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -70,6 +70,7 @@
     "jest-puppeteer": "^4.4.0",
     "jest-stare": "^2.2.2",
     "lodash": "^4.17.20",
+    "otplib": "12.0.0",
     "prettier": "^2.2.1",
     "puppeteer": "^5.5.0",
     "rimraf": "^3.0.2",

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -283,10 +283,8 @@ const asyncFilter = async (arr, predicate) =>
   arr.reduce(async (items, item) => ((await predicate(item)) ? [...(await items), item] : items), []);
 
 /**
- * Is there a element located by CSS selector?
- * @param page Puppeteer.Page
- * @param selector CSS selector
+ * Generates a two factor auth code by given secret.
  */
-export async function generateRas2FACode(rasTotsCode: string) {
-  return authenticator.generate(rasTotsCode);
+export async function generate2FACode(secret: string) {
+  return authenticator.generate(secret);
 }

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -14,6 +14,7 @@ import Navigation, { NavLink } from 'app/component/navigation';
 import { makeWorkspaceName } from './str-utils';
 import { config } from 'resources/workbench-config';
 import { logger } from 'libs/logger';
+import { authenticator } from 'otplib';
 
 export async function signOut(page: Page): Promise<void> {
   await page.evaluate(() => {
@@ -280,3 +281,12 @@ export function isValidDate(date: string) {
 
 const asyncFilter = async (arr, predicate) =>
   arr.reduce(async (items, item) => ((await predicate(item)) ? [...(await items), item] : items), []);
+
+/**
+ * Is there a element located by CSS selector?
+ * @param page Puppeteer.Page
+ * @param selector CSS selector
+ */
+export async function generateRas2FACode(rasTotsCode: string) {
+  return authenticator.generate(rasTotsCode);
+}

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -887,6 +887,44 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
+"@otplib/core@^12.0.0", "@otplib/core@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/core/-/core-12.0.1.tgz#73720a8cedce211fe5b3f683cd5a9c098eaf0f8d"
+  integrity sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==
+
+"@otplib/plugin-crypto@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz#2b42c624227f4f9303c1c041fca399eddcbae25e"
+  integrity sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+
+"@otplib/plugin-thirty-two@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz#5cc9b56e6e89f2a1fe4a2b38900ca4e11c87aa9e"
+  integrity sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    thirty-two "^1.0.2"
+
+"@otplib/preset-default@^12.0.0":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/preset-default/-/preset-default-12.0.1.tgz#cb596553c08251e71b187ada4a2246ad2a3165ba"
+  integrity sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    "@otplib/plugin-crypto" "^12.0.1"
+    "@otplib/plugin-thirty-two" "^12.0.1"
+
+"@otplib/preset-v11@^12.0.0":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/preset-v11/-/preset-v11-12.0.1.tgz#4c7266712e7230500b421ba89252963c838fc96d"
+  integrity sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    "@otplib/plugin-crypto" "^12.0.1"
+    "@otplib/plugin-thirty-two" "^12.0.1"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.2.tgz#858f5c4b48d80778fde4b9d541f27edc0d56488b"
@@ -4641,6 +4679,15 @@ os-homedir@^1.0.1:
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
+otplib@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/otplib/-/otplib-12.0.0.tgz#e170eee47c16a8e906e0f3d61e0ca2932685d566"
+  integrity sha512-i9P9SimOWt/kjpTq3MAWqybwArMWfYfbYJhubV5K1PEadTLm9WkUNUGI0tu6xMRQIzTcglagw9lSWX1BE9a+mw==
+  dependencies:
+    "@otplib/core" "^12.0.0"
+    "@otplib/preset-default" "^12.0.0"
+    "@otplib/preset-v11" "^12.0.0"
+
 p-each-series@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.2.0.tgz#105ab0357ce72b202a8a8b94933672657b5e2a9a"
@@ -5620,6 +5667,11 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+thirty-two@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/thirty-two/-/thirty-two-1.0.2.tgz#4ca2fffc02a51290d2744b9e3f557693ca6b627a"
+  integrity sha1-TKL//AKlEpDSdEueP1V2k8prYno=
 
 throat@^6.0.1:
   version "6.0.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -94,7 +94,7 @@
     "tslib": "^2.3.1",
     "validate.js": "^0.12.0",
     "yarn": "^1.22.0",
-    "zone.js": "0.8.26"
+    "zone.js": "0.8.26"z
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.11.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -94,7 +94,7 @@
     "tslib": "^2.3.1",
     "validate.js": "^0.12.0",
     "yarn": "^1.22.0",
-    "zone.js": "0.8.26"z
+    "zone.js": "0.8.26"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.11.2",

--- a/ui/src/app/components/login-gov-ial2-notification.tsx
+++ b/ui/src/app/components/login-gov-ial2-notification.tsx
@@ -70,7 +70,7 @@ const LoginGovIAL2Notification = () => {
   const [navigate, ] = useNavigation();
   return <FlexRow data-test-id='ial2-notification' style={styles.box}>
     <AlarmExclamation style={styles.icon}/>
-    <div style={styles.text}>Please verify your identity by 10/06/2021.
+    <div style={styles.text}>Please verify your identity by 10/27/2021.
     </div>
     <Button
         type='primary'

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1664,6 +1664,44 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@otplib/core@^12.0.0", "@otplib/core@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/core/-/core-12.0.1.tgz#73720a8cedce211fe5b3f683cd5a9c098eaf0f8d"
+  integrity sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==
+
+"@otplib/plugin-crypto@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz#2b42c624227f4f9303c1c041fca399eddcbae25e"
+  integrity sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+
+"@otplib/plugin-thirty-two@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz#5cc9b56e6e89f2a1fe4a2b38900ca4e11c87aa9e"
+  integrity sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    thirty-two "^1.0.2"
+
+"@otplib/preset-default@^12.0.0":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/preset-default/-/preset-default-12.0.1.tgz#cb596553c08251e71b187ada4a2246ad2a3165ba"
+  integrity sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    "@otplib/plugin-crypto" "^12.0.1"
+    "@otplib/plugin-thirty-two" "^12.0.1"
+
+"@otplib/preset-v11@^12.0.0":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/preset-v11/-/preset-v11-12.0.1.tgz#4c7266712e7230500b421ba89252963c838fc96d"
+  integrity sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    "@otplib/plugin-crypto" "^12.0.1"
+    "@otplib/plugin-thirty-two" "^12.0.1"
+
 "@pmmmwh/react-refresh-webpack-plugin@0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
@@ -10273,6 +10311,15 @@ osenv@0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+otplib@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/otplib/-/otplib-12.0.0.tgz#e170eee47c16a8e906e0f3d61e0ca2932685d566"
+  integrity sha512-i9P9SimOWt/kjpTq3MAWqybwArMWfYfbYJhubV5K1PEadTLm9WkUNUGI0tu6xMRQIzTcglagw9lSWX1BE9a+mw==
+  dependencies:
+    "@otplib/core" "^12.0.0"
+    "@otplib/preset-default" "^12.0.0"
+    "@otplib/preset-v11" "^12.0.0"
+
 outdated-browser-rework@^2.8.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/outdated-browser-rework/-/outdated-browser-rework-2.10.0.tgz#339e537affb9cfc68523c9f89b49df731839bd22"
@@ -13800,6 +13847,11 @@ text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+thirty-two@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/thirty-two/-/thirty-two-1.0.2.tgz#4ca2fffc02a51290d2744b9e3f557693ca6b627a"
+  integrity sha1-TKL//AKlEpDSdEueP1V2k8prYno=
 
 throat@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Description:
The new method should be able to generate 2fa code for any applications if having the secret. Here is the secret when setting up Google login:
![Screen Shot 2021-09-09 at 4 42 11 PM](https://user-images.githubusercontent.com/6351731/132759673-b680f6ce-0955-4bfd-8d59-994578893b1c.png)

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
