### PR TITLE
[risk=no][no ticket] Fix nightly AAR test

### DIFF
--- a/e2e/tests/nightly/user-access.spec.ts
+++ b/e2e/tests/nightly/user-access.spec.ts
@@ -14,7 +14,7 @@ import HomePage from 'app/page/home-page';
 
 describe('User Access', () => {
   beforeEach(async () => {
-    await signInWithAccessToken(page, config.ACCESS_TEST_ACCESS_TOKEN_FILE);
+    await signInWithAccessToken(page, config.ACCESS_TEST_ACCESS_TOKEN_FILE, new AccessRenewalPage(page));
   });
 
   // note that this test is "destructive" in that it brings the user to a state

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -15,6 +15,7 @@ import { makeWorkspaceName } from './str-utils';
 import { config } from 'resources/workbench-config';
 import { logger } from 'libs/logger';
 import { authenticator } from 'otplib';
+import AuthenticatedPage from 'app/page/authenticated-page';
 
 export async function signOut(page: Page): Promise<void> {
   await page.evaluate(() => {
@@ -31,7 +32,9 @@ declare const window: Window &
     setTestAccessTokenOverride: any;
   };
 
-export async function signInWithAccessToken(page: Page, tokenFilename = config.USER_ACCESS_TOKEN_FILE): Promise<void> {
+export async function signInWithAccessToken(page: Page,
+                                            tokenFilename = config.USER_ACCESS_TOKEN_FILE,
+                                            postSignInPage: AuthenticatedPage = new HomePage(page)): Promise<void> {
   const token = fs.readFileSync(tokenFilename, 'ascii');
   logger.info('Sign in with access token to Workbench application');
   const homePage = new HomePage(page);
@@ -53,7 +56,10 @@ export async function signInWithAccessToken(page: Page, tokenFilename = config.U
   // is unlikely to be captured.
   await homePage.reloadPage();
   await homePage.gotoUrl(PageUrl.Home);
-  await homePage.waitForLoad();
+
+  // normally the user is routed to the homepage after sign-in, so that's the default here.
+  // tests can override this.
+  await postSignInPage.waitForLoad();
 }
 
 /**

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -32,9 +32,11 @@ declare const window: Window &
     setTestAccessTokenOverride: any;
   };
 
-export async function signInWithAccessToken(page: Page,
-                                            tokenFilename = config.USER_ACCESS_TOKEN_FILE,
-                                            postSignInPage: AuthenticatedPage = new HomePage(page)): Promise<void> {
+export async function signInWithAccessToken(
+  page: Page,
+  tokenFilename = config.USER_ACCESS_TOKEN_FILE,
+  postSignInPage: AuthenticatedPage = new HomePage(page)
+): Promise<void> {
   const token = fs.readFileSync(tokenFilename, 'ascii');
   logger.info('Sign in with access token to Workbench application');
   const homePage = new HomePage(page);

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -54,7 +54,9 @@ export async function waitForDocumentTitle(page: Page, titleSubstr: string): Pro
     );
     return (await jsHandle.jsonValue()) as boolean;
   } catch (err) {
-    logger.error(`Failed to find the document title contains "${titleSubstr}". Actual page title is "${await page.title()}"`);
+    logger.error(
+      `Failed to find the document title contains "${titleSubstr}". Actual page title is "${await page.title()}"`
+    );
     logger.error(err.stack);
     throw new Error(err);
   }

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -54,7 +54,7 @@ export async function waitForDocumentTitle(page: Page, titleSubstr: string): Pro
     );
     return (await jsHandle.jsonValue()) as boolean;
   } catch (err) {
-    logger.error(`Failed find document title contains "${titleSubstr}". Actual page title is "${await page.title()}"`);
+    logger.error(`Failed to find the document title contains "${titleSubstr}". Actual page title is "${await page.title()}"`);
     logger.error(err.stack);
     throw new Error(err);
   }


### PR DESCRIPTION
Allow tests to specify an alternate sign-in destination (which AAR needs).

Tested locally by running a successful AAR test with alt sign-in, and a different test with standard Homepage sign-in.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
