### PR TITLE
[RW-7022][risk=low] Add manifest checks to genomic codegen extraction

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -906,12 +906,29 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
         + extractionDir;
   }
 
+  private String generateExtractionManifestPollingCode(String qualifier) {
+    return "import os\n"
+        + "import subprocess\n\n"
+        + "# The extraction workflow outputs a manifest file upon completion.\n"
+        + "manifest_file = os.environ['"
+        + generateVcfDirEnvName(qualifier)
+        + "'] + '/manifest.txt'\n\n"
+        + "assert subprocess.run(['gsutil', '-q', 'stat', manifest_file]) == 0, (\n"
+        + "  \"!\" * 100 + \"\\n\\n\" +\n"
+        + "  \"VCF extraction has not completed.\\n\" +\n"
+        + "  \"Please monitor the extraction sidepanel for completion before continuing.\\n\\n\" +\n"
+        + "  \"!\" * 100\n"
+        + ")\n\n"
+        + "print(\"VCF extraction has completed, continuing\")\n";
+  }
+
   private List<String> generateHailCode(
       String qualifier, DataSetExportRequest dataSetExportRequest) {
     final String matrixName = "mt_" + qualifier;
 
     return ImmutableList.of(
         generateExtractionDirCode(qualifier, dataSetExportRequest),
+        generateExtractionManifestPollingCode(qualifier),
         "# Confirm Spark is installed.\n"
             + "try:\n"
             + "    import pyspark\n"
@@ -984,6 +1001,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     // TODO: Add a check to see if sufficient disk space is available in the Runtime
     return ImmutableList.of(
         generateExtractionDirCode(qualifier, dataSetExportRequest),
+        generateExtractionManifestPollingCode(qualifier),
         "%%bash\n"
             + "\n"
             + "# Download VCFs\n"


### PR DESCRIPTION
- Log an assertion failure if the manifest doesn't exist, within extraction codegen.

Example:
```
import os
import subprocess

# The extraction workflow outputs a manifest file upon completion.
manifest_file = os.environ['DATASET_25865791_VCF_DIR'] + '/manifest.txt'

assert subprocess.run(['gsutil', '-q', 'stat', manifest_file]) == 0, (
  "!" * 100 + "\n\n" +
  "VCF extraction has not completed.\n" +
  "Please monitor the extraction sidepanel for completion before continuing.\n\n" +
  "!" * 100
)

print("VCF extraction has completed, continuing")
```

## Alternative considered
Polling until the extraction file exists. Rejected because we don't have a mechanism to detect an extraction failure within the notebook. We could build this, but it would require callbacks into the RW API from notebooks, which is a threshold I don't wish to cross at this time. Directing them to the sidepanel will allow them to better monitor progress, and see failures.