### PR TITLE
[risk=no][no ticket] Runtime Panel dataTestId based on icon, not status

### DIFF
--- a/e2e/app/component/runtime-panel.ts
+++ b/e2e/app/component/runtime-panel.ts
@@ -9,7 +9,6 @@ import { logger } from 'libs/logger';
 import RadioButton from 'app/element/radiobutton';
 
 const defaultXpath = '//*[@id="runtime-panel"]';
-const statusIconXpath = '//*[@data-test-id="runtime-status-icon"]';
 
 export enum StartStopIconState {
   Error = 'error',
@@ -140,24 +139,18 @@ export default class RuntimePanel extends BaseHelpSidebar {
     startStopIconState: StartStopIconState,
     timeout: number = 20 * 60 * 1000
   ): Promise<void> {
-    const xpath =
-      `${this.getXpath()}${statusIconXpath}` +
-      `[@data-test-id="${this.buildStatusIconDataTestId(startStopIconState)}"]`;
+    const xpath = `[@data-test-id="${this.buildStatusIconDataTestId(startStopIconState)}"]`;
     await this.page.waitForXPath(xpath, { visible: true, timeout });
   }
 
   async clickPauseRuntimeIcon(): Promise<void> {
-    const xpath =
-      `${this.getXpath()}${statusIconXpath}` +
-      `[@data-test-id="${this.buildStatusIconDataTestId(StartStopIconState.Running)}"]`;
+    const xpath = `[@data-test-id="${this.buildStatusIconDataTestId(StartStopIconState.Running)}"]`;
     const icon = new Button(this.page, xpath);
     await icon.click();
   }
 
   async clickResumeRuntimeIcon(): Promise<void> {
-    const xpath =
-      `${this.getXpath()}${statusIconXpath}` +
-      `[@data-test-id="${this.buildStatusIconDataTestId(StartStopIconState.Stopped)}"]`;
+    const xpath = `[@data-test-id="${this.buildStatusIconDataTestId(StartStopIconState.Stopped)}"]`;
     const icon = new Button(this.page, xpath);
     await icon.click();
   }

--- a/e2e/app/component/runtime-panel.ts
+++ b/e2e/app/component/runtime-panel.ts
@@ -139,18 +139,18 @@ export default class RuntimePanel extends BaseHelpSidebar {
     startStopIconState: StartStopIconState,
     timeout: number = 20 * 60 * 1000
   ): Promise<void> {
-    const xpath = `[@data-test-id="${this.buildStatusIconDataTestId(startStopIconState)}"]`;
+    const xpath = `//*[@data-test-id="${this.buildStatusIconDataTestId(startStopIconState)}"]`;
     await this.page.waitForXPath(xpath, { visible: true, timeout });
   }
 
   async clickPauseRuntimeIcon(): Promise<void> {
-    const xpath = `[@data-test-id="${this.buildStatusIconDataTestId(StartStopIconState.Running)}"]`;
+    const xpath = `//*[@data-test-id="${this.buildStatusIconDataTestId(StartStopIconState.Running)}"]`;
     const icon = new Button(this.page, xpath);
     await icon.click();
   }
 
   async clickResumeRuntimeIcon(): Promise<void> {
-    const xpath = `[@data-test-id="${this.buildStatusIconDataTestId(StartStopIconState.Stopped)}"]`;
+    const xpath = `//*[@data-test-id="${this.buildStatusIconDataTestId(StartStopIconState.Stopped)}"]`;
     const icon = new Button(this.page, xpath);
     await icon.click();
   }

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -48,8 +48,6 @@ describe('RuntimePanel', () => {
   let enablePd: boolean;
   let enableGpu: boolean;
 
-  const iconsDir = '/assets/icons';
-
   const component = async(propOverrides?: object) => {
     const allProps = {...props, ...propOverrides}
     const c = mount(<RuntimePanelWrapper {...allProps}/>);
@@ -836,7 +834,7 @@ describe('RuntimePanel', () => {
     const wrapper = await component();
 
     const costEstimator = () => wrapper.find('[data-test-id="cost-estimator"]');
-    expect(costEstimator()).toBeTruthy();
+    expect(costEstimator().exists()).toBeTruthy();
 
     // Default GCE machine, n1-standard-4, makes the running cost 20 cents an hour and the storage cost less than 1 cent an hour.
     const runningCost = () => costEstimator().find('[data-test-id="running-cost"]');
@@ -891,7 +889,7 @@ describe('RuntimePanel', () => {
     const wrapper = await component();
 
     const costEstimator = () => wrapper.find('[data-test-id="cost-estimator"]');
-    expect(costEstimator()).toBeTruthy();
+    expect(costEstimator().exists()).toBeTruthy();
 
     const runningCost = () => costEstimator().find('[data-test-id="running-cost"]');
     const storageCost = () => costEstimator().find('[data-test-id="storage-cost"]');
@@ -936,14 +934,14 @@ describe('RuntimePanel', () => {
   it('should display the Running runtime status icon in state Running', async() => {
     const wrapper = await component();
 
-    expect(wrapper.find('[data-test-id="runtime-status-icon-Running"]')).toBeTruthy();
+    expect(wrapper.find('[data-test-id="runtime-status-icon-running"]').exists()).toBeTruthy();
   });
 
   it('should display a compute-none when there is no runtime', async() => {
     runtimeApiStub.runtime = null;
     runtimeStoreStub.runtime = null;
     const wrapper = await component();
-    expect(wrapper.find('[data-test-id="runtime-status-icon-None"]')).toBeTruthy();
+    expect(wrapper.find('[data-test-id="runtime-status-icon-none"]').exists()).toBeTruthy();
   });
 
   it('should prevent runtime creation when disk size is invalid', async() => {

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -722,12 +722,13 @@ const StartStopRuntimeButton = ({workspaceNamespace, googleProject}) => {
   const [status, setRuntimeStatus] = useRuntimeStatus(workspaceNamespace, googleProject);
 
   const rotateStyle = {animation: 'rotation 2s infinite linear'};
-  const {altText, iconSrc = null, styleOverrides = {}, onClick = null } = switchCase(status,
+  const {altText, iconSrc, dataTestId, styleOverrides = {}, onClick = null } = switchCase(status,
     [
       RuntimeStatus.Creating,
       () => ({
         altText: 'Runtime creation in progress',
         iconSrc: computeStarting,
+        dataTestId: 'runtime-status-icon-starting',
         styleOverrides: rotateStyle
       })
     ],
@@ -736,6 +737,7 @@ const StartStopRuntimeButton = ({workspaceNamespace, googleProject}) => {
       () => ({
         altText: 'Runtime running, click to pause',
         iconSrc: computeRunning,
+        dataTestId: 'runtime-status-icon-running',
         onClick: () => { setRuntimeStatus(RuntimeStatusRequest.Stop); }
       })
     ],
@@ -744,6 +746,7 @@ const StartStopRuntimeButton = ({workspaceNamespace, googleProject}) => {
       () => ({
         altText: 'Runtime update in progress',
         iconSrc: computeStarting,
+        dataTestId: 'runtime-status-icon-starting',
         styleOverrides: rotateStyle
       })
     ],
@@ -751,7 +754,8 @@ const StartStopRuntimeButton = ({workspaceNamespace, googleProject}) => {
       RuntimeStatus.Error,
       () => ({
         altText: 'Runtime in error state',
-        iconSrc: computeError
+        iconSrc: computeError,
+        dataTestId: 'runtime-status-icon-error',
       })
     ],
     [
@@ -759,6 +763,7 @@ const StartStopRuntimeButton = ({workspaceNamespace, googleProject}) => {
       () => ({
         altText: 'Runtime pause in progress',
         iconSrc: computeStopping,
+        dataTestId: 'runtime-status-icon-stopping',
         styleOverrides: rotateStyle
       })
     ],
@@ -767,6 +772,7 @@ const StartStopRuntimeButton = ({workspaceNamespace, googleProject}) => {
       () => ({
         altText: 'Runtime paused, click to resume',
         iconSrc: computeStopped,
+        dataTestId: 'runtime-status-icon-stopped',
         onClick: () => { setRuntimeStatus(RuntimeStatusRequest.Start); }
       })
     ],
@@ -775,6 +781,7 @@ const StartStopRuntimeButton = ({workspaceNamespace, googleProject}) => {
       () => ({
         altText: 'Runtime resume in progress',
         iconSrc: computeStarting,
+        dataTestId: 'runtime-status-icon-starting',
         styleOverrides: rotateStyle
       })
     ],
@@ -783,6 +790,7 @@ const StartStopRuntimeButton = ({workspaceNamespace, googleProject}) => {
       () => ({
         altText: 'Runtime deletion in progress',
         iconSrc: computeStopping,
+        dataTestId: 'runtime-status-icon-stopping',
         styleOverrides: rotateStyle,
       })
     ],
@@ -790,21 +798,24 @@ const StartStopRuntimeButton = ({workspaceNamespace, googleProject}) => {
       RuntimeStatus.Deleted,
       () => ({
         altText: 'Runtime has been deleted',
-        iconSrc: computeNone
+        iconSrc: computeNone,
+        dataTestId: 'runtime-status-icon-none',
       })
     ],
     [
       RuntimeStatus.Unknown,
       () => ({
         altText: 'Runtime status unknown',
-        iconSrc: computeNone
+        iconSrc: computeNone,
+        dataTestId: 'runtime-status-icon-none',
       })
     ],
     [
       DEFAULT,
       () => ({
         altText: 'No runtime found',
-        iconSrc: computeNone
+        iconSrc: computeNone,
+        dataTestId: 'runtime-status-icon-none',
       })
     ]
   );
@@ -835,7 +846,7 @@ const StartStopRuntimeButton = ({workspaceNamespace, googleProject}) => {
                 alt={altText}
                 src={iconSrc}
                 style={styleOverrides}
-                data-test-id={`runtime-status-icon-${status}`}
+                data-test-id={dataTestId}
             />
           </Clickable>
         </FlexRow>
@@ -847,7 +858,7 @@ const StartStopRuntimeButton = ({workspaceNamespace, googleProject}) => {
               alt={altText}
               src={iconSrc}
               style={styleOverrides}
-              data-test-id={`runtime-status-icon-${status}`}
+              data-test-id={dataTestId}
           />
         </FlexRow>
       </TooltipTrigger>


### PR DESCRIPTION
e2e nightly test `runtime.spec` broke on Sep 9 and #5552 appears to be the culprit.  The e2e test changed from looking for the icon path (which was no longer possible) to a data-test-id based on the runtime status.  However, the icons and the statuses are not 1:1.  This PR changes the data-test-ids to always match the icons.   

Tested locally.

Update: I expect this will resolve the other 2 nightly failures as well.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [x] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
