### PR TITLE
[risk=low][no ticket] Restrict AAR logic to only those modules which can expire

### DIFF
--- a/ui/src/app/pages/access/access-renewal.spec.tsx
+++ b/ui/src/app/pages/access/access-renewal.spec.tsx
@@ -109,11 +109,13 @@ describe('Access Renewal Page', () => {
     setCompletionTimes(() => Date.now() - 1000 * 60 * 60 * 24 * EXPIRY_DAYS);
     await waitOneTickAndUpdate(wrapper);
 
-    expect(findNodesContainingText(wrapper, 'access has expired').length).toBe(1);
     expect(findNodesByExactText(wrapper, 'Review').length).toBe(1)
     expect(findNodesByExactText(wrapper, 'Confirm').length).toBe(1)
     expect(findNodesByExactText(wrapper, 'View & Sign').length).toBe(1)
     expect(findNodesByExactText(wrapper, 'Complete Training').length).toBe(1);
+
+    expect(findNodesContainingText(wrapper, 'access has expired').length).toBe(1);
+    expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(0);
   });
 
   it('should show the correct state when profile is complete', async () => {
@@ -131,6 +133,9 @@ describe('Access Renewal Page', () => {
     expect(findNodesByExactText(wrapper, 'Confirm').length).toBe(1);
     expect(findNodesByExactText(wrapper, 'View & Sign').length).toBe(1)
     expect(findNodesByExactText(wrapper, 'Complete Training').length).toBe(1);
+
+    expect(findNodesContainingText(wrapper, 'access has expired').length).toBe(1);
+    expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(0);
   });
 
   it('should show the correct state when profile and publication are complete', async () => {
@@ -148,6 +153,9 @@ describe('Access Renewal Page', () => {
     // Incomplete
     expect(findNodesByExactText(wrapper, 'View & Sign').length).toBe(1)
     expect(findNodesByExactText(wrapper, 'Complete Training').length).toBe(1);
+
+    expect(findNodesContainingText(wrapper, 'access has expired').length).toBe(1);
+    expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(0);
   });
 
   it('should show the correct state when all items except DUCC are complete', async () => {
@@ -165,6 +173,9 @@ describe('Access Renewal Page', () => {
     expect(findNodesByExactText(wrapper, 'Completed').length).toBe(1);
     // Incomplete
     expect(findNodesByExactText(wrapper, 'View & Sign').length).toBe(1);
+
+    expect(findNodesContainingText(wrapper, 'access has expired').length).toBe(1);
+    expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(0);
   });
 
   it('should show the correct state when all items are complete', async () => {
@@ -185,10 +196,12 @@ describe('Access Renewal Page', () => {
     expect(findNodesByExactText(wrapper, 'Confirmed').length).toBe(2);
     expect(findNodesByExactText(wrapper, 'Completed').length).toBe(2);
     expect(findNodesContainingText(wrapper, `${EXPIRY_DAYS - 1} days`).length).toBe(4);
+
     expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(1);
+    expect(findNodesContainingText(wrapper, 'access has expired').length).toBe(0);
   });
 
-  it('should should ignore modules which are not expirable', async () => {
+  it('should ignore modules which are not expirable', async () => {
     expireAllModules();
 
     const newModules = [
@@ -223,7 +236,9 @@ describe('Access Renewal Page', () => {
     expect(findNodesByExactText(wrapper, 'Confirmed').length).toBe(2);
     expect(findNodesByExactText(wrapper, 'Completed').length).toBe(2);
     expect(findNodesContainingText(wrapper, `${EXPIRY_DAYS - 1} days`).length).toBe(4);
+
     expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(1);
+    expect(findNodesContainingText(wrapper, 'access has expired').length).toBe(0);
   });
 
   it('should show the correct state when items are bypassed', async () => {
@@ -249,6 +264,9 @@ describe('Access Renewal Page', () => {
 
     // State check
     expect(findNodesContainingText(wrapper, 'click the refresh button').length).toBe(0);
+
+    expect(findNodesContainingText(wrapper, 'access has expired').length).toBe(1);
+    expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(0);
   });
 
   it('should show the correct state when all items are complete or bypassed', async () => {
@@ -273,6 +291,7 @@ describe('Access Renewal Page', () => {
     expect(findNodesContainingText(wrapper, `${EXPIRY_DAYS - 1} days`).length).toBe(2);
 
     expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(1);
+    expect(findNodesContainingText(wrapper, 'access has expired').length).toBe(0);
   });
 
   it('should show the correct state when modules are disabled', async () => {
@@ -304,6 +323,7 @@ describe('Access Renewal Page', () => {
 
     // all of the necessary steps = 3 rather than the usual 4
     expect(findNodesByExactText(wrapper, 'Thank you for completing all the necessary steps').length).toBe(1);
+    expect(findNodesContainingText(wrapper, 'access has expired').length).toBe(0);
   });
 
 });

--- a/ui/src/app/pages/access/access-renewal.spec.tsx
+++ b/ui/src/app/pages/access/access-renewal.spec.tsx
@@ -61,7 +61,7 @@ describe('Access Renewal Page', () => {
     profileStore.set({profile: newProfile,  load, reload, updateCache});
   }
 
-  function setBypassTimes(completionFn) {
+  function setBypassTimes(bypassFn) {
     const oldProfile = profileStore.get().profile;
     const newModules = fp.map((moduleStatus) => ({
       ...moduleStatus,
@@ -69,7 +69,7 @@ describe('Access Renewal Page', () => {
           // profile and publication are not bypassable.
           (moduleStatus.moduleName === AccessModule.PROFILECONFIRMATION || moduleStatus.moduleName === AccessModule.PUBLICATIONCONFIRMATION)
           ? null
-          : completionFn(),
+          : bypassFn(),
     }), oldProfile.accessModules.modules);
     const newProfile = fp.set(['accessModules', 'modules'], newModules, oldProfile)
     profileStore.set({profile: newProfile,  load, reload, updateCache});

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -238,6 +238,8 @@ export const AccessRenewal = fp.flow(
   const completeOrBypassed = moduleName => {
     const status = modules.find(m => m.moduleName === moduleName);
     const wasBypassed = !!status.bypassEpochMillis;
+    const tmp = !isExpiring(status.expirationEpochMillis);
+
     return wasBypassed || !isExpiring(status.expirationEpochMillis);
   }
 

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -16,6 +16,7 @@ import {profileApi} from 'app/services/swagger-fetch-clients';
 import colors, {addOpacity, colorWithWhiteness} from 'app/styles/colors';
 import {cond, daysFromNow, displayDateWithoutHours, switchCase, useId, withStyle} from 'app/utils';
 import {
+  expirableAccessModules,
   maybeDaysRemaining,
   redirectToTraining
 } from 'app/utils/access-utils';
@@ -235,15 +236,15 @@ export const AccessRenewal = fp.flow(
     getProfile();
   }, []);
 
+  const expirableModules = modules.filter(moduleStatus => expirableAccessModules.includes(moduleStatus.moduleName));
+
   const completeOrBypassed = moduleName => {
     const status = modules.find(m => m.moduleName === moduleName);
     const wasBypassed = !!status.bypassEpochMillis;
-    const tmp = !isExpiring(status.expirationEpochMillis);
-
     return wasBypassed || !isExpiring(status.expirationEpochMillis);
   }
 
-  const allModulesCompleteOrBypassed = fp.flow(fp.map('moduleName'), fp.all(completeOrBypassed))(modules);
+  const allModulesCompleteOrBypassed = fp.flow(fp.map('moduleName'), fp.all(completeOrBypassed))(expirableModules);
 
   // Render
   return <FadeBox style={{margin: '1rem auto 0', color: colors.primary}}>

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -268,3 +268,11 @@ export const GetStartedButton = ({style = {marginLeft: '0.5rem'}}) => <Button
       location.replace('/');
     }}>Get Started</Button>;
 
+// TODO derive this from DbAccessModules ?
+export const expirableAccessModules = [
+  AccessModule.PROFILECONFIRMATION,
+  AccessModule.PUBLICATIONCONFIRMATION,
+  AccessModule.COMPLIANCETRAINING,    // note: not guaranteed to be present; check the Feature Flag enableComplianceTraining.
+  AccessModule.DATAUSERCODEOFCONDUCT,
+];
+

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -269,7 +269,7 @@ export const GetStartedButton = ({style = {marginLeft: '0.5rem'}}) => <Button
     }}>Get Started</Button>;
 
 // TODO derive this from DbAccessModules ?
-export const expirableAccessModules = [
+export const expirableAccessModules: Array<AccessModule> = [
   AccessModule.PROFILECONFIRMATION,
   AccessModule.PUBLICATIONCONFIRMATION,
   AccessModule.COMPLIANCETRAINING,    // note: not guaranteed to be present; check the Feature Flag enableComplianceTraining.


### PR DESCRIPTION
AAR displays certain text if "all modules are complete or bypassed".  Since the change to the new Access Module structures, it has been evaluating this based on all of a user's access modules, not just those subject to renewal/expiration.

This restores the logic of only checking expirable access modules.

Also a new unit test and some test cleanup.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
