### PR TITLE
[no ticket][risk=low]: Set the default value when creating new workspace

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -339,6 +339,12 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       // When editing existing workspace, show free tier if that is currently being used or 'User Provided Billing Account'
       // if it is user's billing account.
       if (!serverConfigStore.get().config.enableBillingUpgrade) {
+        if (this.isMode(WorkspaceEditMode.Create) || this.isMode(WorkspaceEditMode.Duplicate)) {
+          this.setState(prevState => fp.set(
+            ['workspace', 'billingAccountName'],
+            freeTierBillingAccount.name,
+            prevState));
+        }
         this.setState({billingAccounts: [freeTierBillingAccount]});
       } else if (serverConfigStore.get().config.enableBillingUpgrade && !hasBillingScope()) {
         if (this.isMode(WorkspaceEditMode.Create) || this.isMode(WorkspaceEditMode.Duplicate)) {


### PR DESCRIPTION
Description:
When creating/cloning workspaces, set the `billingAccountName` to default free tier one. 
Then dropdown is able to populate a default value option on the `billingAccountName` 
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
