### PR TITLE
[RW-7121][risk=no] Return Leo runtime errors from RW API

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -9,6 +9,7 @@ import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import org.pmiops.workbench.leonardo.model.LeonardoClusterError;
 import org.pmiops.workbench.leonardo.model.LeonardoDiskConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoDiskStatus;
 import org.pmiops.workbench.leonardo.model.LeonardoGceConfig;
@@ -30,6 +31,7 @@ import org.pmiops.workbench.model.GceWithPdConfig;
 import org.pmiops.workbench.model.ListRuntimeResponse;
 import org.pmiops.workbench.model.Runtime;
 import org.pmiops.workbench.model.RuntimeConfigurationType;
+import org.pmiops.workbench.model.RuntimeError;
 import org.pmiops.workbench.model.RuntimeStatus;
 
 @Mapper(config = MapStructConfig.class)
@@ -108,7 +110,10 @@ public interface LeonardoMapper {
   @Mapping(target = "gceWithPdConfig", ignore = true)
   @Mapping(target = "dataprocConfig", ignore = true)
   @Mapping(target = "diskConfig", ignore = true)
+  @Mapping(target = "errors", ignore = true)
   Runtime toApiRuntime(LeonardoListRuntimeResponse runtime);
+
+  RuntimeError toApiRuntimeError(LeonardoClusterError err);
 
   @AfterMapping
   default void getRuntimeAfterMapper(

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6047,6 +6047,23 @@ definitions:
       diskConfig:
         description: The configuration of a persistent disk
         "$ref": "#/definitions/DiskConfig"
+      errors:
+        type: array
+        description: The list of errors that were encountered on runtime create, if any.
+        items:
+          $ref: "#/definitions/RuntimeError"
+  RuntimeError:
+    description: Errors encountered on runtime create
+    properties:
+      errorMessage:
+        type: string
+        description: Error message
+      errorCode:
+        type: integer
+        description: Error code
+      timestamp:
+        type: string
+        description: timestamp for error in ISO 8601 format
   DiskConfig:
     description: The configuration of a persistent disk, returned in runtime responses
     type: object

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -89,6 +89,7 @@ import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
 import org.pmiops.workbench.model.PersistentDiskRequest;
 import org.pmiops.workbench.model.Runtime;
 import org.pmiops.workbench.model.RuntimeConfigurationType;
+import org.pmiops.workbench.model.RuntimeError;
 import org.pmiops.workbench.model.RuntimeLocalizeRequest;
 import org.pmiops.workbench.model.RuntimeLocalizeResponse;
 import org.pmiops.workbench.model.RuntimeStatus;
@@ -420,7 +421,13 @@ public class RuntimeControllerTest extends SpringTest {
                         new LeonardoClusterError().errorCode(2).errorMessage(null))));
 
     assertThat(runtimeController.getRuntime(WORKSPACE_NS).getBody())
-        .isEqualTo(testRuntime.status(RuntimeStatus.ERROR));
+        .isEqualTo(
+            testRuntime
+                .status(RuntimeStatus.ERROR)
+                .errors(
+                    ImmutableList.of(
+                        new RuntimeError().errorCode(1).errorMessage("foo"),
+                        new RuntimeError().errorCode(2).errorMessage(null))));
   }
 
   @Test


### PR DESCRIPTION
To consistently generate a runtime in the error state, you can do the following:

- Ensure you have >$300 free credits, by increasing your limit via the admin UI
- Pick a dataproc cluster
- Set the worker count to 999 (this is higher than your default project quota)

You should receive a response like this from the `GetRuntime` API:

```
{
...
errors: [{
  errorCode: null
  errorMessage: "Failed to create cluster aou-rw-local1-0af76d8f/all-of-us-1 due to io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Multiple validation errors:\n - Insufficient 'CPUS' quota. Requested 3998.0, available 2400.0.\n 
 Requested image requires minimum boot disk size of 60 GB; requested 30 GB"
}],
...
```