### PR TITLE
[risk=low][no ticket] Temporary disabled RAS module placeholder for DAR

### DIFF
--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -3,12 +3,13 @@ import {mount} from "enzyme";
 
 import defaultServerConfig from 'testing/default-server-config';
 import {AccessModule, InstitutionApi, Profile, ProfileApi} from 'generated/fetch';
-import {allModules, DataAccessRequirements} from './data-access-requirements';
+import {allModules, DataAccessRequirements, getActiveModule, getEnabledModules} from './data-access-requirements';
 import {InstitutionApiStub} from 'testing/stubs/institution-api-stub';
 import {ProfileApiStub, ProfileStubVariables} from 'testing/stubs/profile-api-stub';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {profileStore, serverConfigStore} from 'app/utils/stores';
-import { MemoryRouter } from 'react-router-dom';
+import {MemoryRouter} from 'react-router-dom';
+import {useNavigation} from 'app/utils/navigation';
 
 const profile = ProfileStubVariables.PROFILE_STUB as Profile;
 const load = jest.fn();
@@ -37,16 +38,102 @@ describe('DataAccessRequirements', () => {
         profileStore.set({profile, load, reload, updateCache});
     });
 
-    it('should render all modules by default', () => {
+    it('should return all modules from getEnabledModules by default (all FFs enabled)', () => {
+        const [navigate, ] = useNavigation();
+        const enabledModules = getEnabledModules(allModules, navigate);
+        allModules.forEach(module => expect(enabledModules.includes(module)).toBeTruthy());
+    });
+
+    it('should not return the RAS module from getEnabledModules when its feature flag is disabled', () => {
+        serverConfigStore.set({config: {...defaultServerConfig, enableRasLoginGovLinking: false}});
+        const [navigate, ] = useNavigation();
+        const enabledModules = getEnabledModules(allModules, navigate);
+        expect(enabledModules.includes(AccessModule.RASLINKLOGINGOV)).toBeFalsy();
+    });
+
+    it('should not return the ERA module from getEnabledModules when its feature flag is disabled', () => {
+        serverConfigStore.set({config: {...defaultServerConfig, enableEraCommons: false}});
+        const [navigate, ] = useNavigation();
+        const enabledModules = getEnabledModules(allModules, navigate);
+        expect(enabledModules.includes(AccessModule.ERACOMMONS)).toBeFalsy();
+     });
+
+    it('should not return the Compliance module from getEnabledModules when its feature flag is disabled', () => {
+        serverConfigStore.set({config: {...defaultServerConfig, enableComplianceTraining: false}});
+        const [navigate, ] = useNavigation();
+        const enabledModules = getEnabledModules(allModules, navigate);
+        expect(enabledModules.includes(AccessModule.COMPLIANCETRAINING)).toBeFalsy();
+    });
+
+    it('should return the first module (2FA) from getActiveModule when no modules have been completed', () => {
+        const [navigate, ] = useNavigation();
+        const enabledModules = getEnabledModules(allModules, navigate);
+        const activeModule = getActiveModule(enabledModules, profile);
+
+        expect(activeModule).toEqual(allModules[0]);
+        expect(activeModule).toEqual(enabledModules[0]);
+
+        // update this if the order changes
+        expect(activeModule).toEqual(AccessModule.TWOFACTORAUTH)
+    });
+
+    it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been completed', () => {
+        const testProfile = {
+            ...profile,
+            accessModules: {
+                modules: [{moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1}]
+            }
+        };
+
+        const [navigate, ] = useNavigation();
+        const enabledModules = getEnabledModules(allModules, navigate);
+        const activeModule = getActiveModule(enabledModules, testProfile);
+
+        expect(activeModule).toEqual(allModules[1]);
+        expect(activeModule).toEqual(enabledModules[1]);
+
+        // update this if the order changes
+        expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV)
+    });
+
+    it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been bypassed', () => {
+        const testProfile = {
+            ...profile,
+            accessModules: {
+                modules: [{moduleName: AccessModule.TWOFACTORAUTH, bypassEpochMillis: 1}]
+            }
+        };
+
+        const [navigate, ] = useNavigation();
+        const enabledModules = getEnabledModules(allModules, navigate);
+        const activeModule = getActiveModule(enabledModules, testProfile);
+
+        expect(activeModule).toEqual(allModules[1]);
+        expect(activeModule).toEqual(enabledModules[1]);
+
+        // update this if the order changes
+        expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV)
+    });
+
+    it('should return undefined from getActiveModule when all modules have been completed', () => {
+        const testProfile = {
+            ...profile,
+            accessModules: {
+                modules: allModules.map(module => ({moduleName: module, completionEpochMillis: 1}))
+            }
+        };
+
+        const [navigate, ] = useNavigation();
+        const enabledModules = getEnabledModules(allModules, navigate);
+        const activeModule = getActiveModule(enabledModules, testProfile);
+
+        expect(activeModule).toBeUndefined();
+    });
+
+    it('should render all modules by default (all FFs enabled)', () => {
         const wrapper = component();
         allModules.forEach(module => expect(findModule(wrapper, module).exists()).toBeTruthy());
     });
-
-    it('should not render the RAS module when its feature flag is disabled', () => {
-        serverConfigStore.set({config: {...defaultServerConfig, enableRasLoginGovLinking: false}});
-        const wrapper = component();
-        expect(findModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeFalsy();
-     });
 
     it('should not render the ERA module when its feature flag is disabled', () => {
         serverConfigStore.set({config: {...defaultServerConfig, enableEraCommons: false}});
@@ -58,6 +145,15 @@ describe('DataAccessRequirements', () => {
         serverConfigStore.set({config: {...defaultServerConfig, enableComplianceTraining: false}});
         const wrapper = component();
         expect(findModule(wrapper, AccessModule.COMPLIANCETRAINING).exists()).toBeFalsy();
+    });
+
+    // Temporary hack Sep 16: when enableRasLoginGovLinking is false, we DO show the module
+    // along with an Ineligible icon and some "technical difficulties" text
+    // and it never becomes an activeModule
+    it('should not render the RAS module when its feature flag is disabled', () => {
+        serverConfigStore.set({config: {...defaultServerConfig, enableRasLoginGovLinking: false}});
+        const wrapper = component();
+        expect(findModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeFalsy();
     });
 
     it('should render all modules as incomplete when the profile accessModules are empty', () => {
@@ -76,7 +172,7 @@ describe('DataAccessRequirements', () => {
             profile: {
                 ...ProfileStubVariables.PROFILE_STUB,
                 accessModules: {
-                    modules: allModules.map(module => {return {moduleName: module, completionEpochMillis: 1}})
+                    modules: allModules.map(module => ({moduleName: module, completionEpochMillis: 1}))
                 }
             },
             load,

--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -97,7 +97,8 @@ describe('DataAccessRequirements', () => {
     });
 
     // update this if the order changes
-    it('should return the second enabled module (ERA, not RAS) from getActiveModule when the first module (2FA) has been completed and RAS is disabled', () => {
+    it('should return the second enabled module (ERA, not RAS) from getActiveModule' +
+        ' when the first module (2FA) has been completed and RAS is disabled', () => {
         serverConfigStore.set({config: {...defaultServerConfig, enableRasLoginGovLinking: false}});
 
         const testProfile = {

--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -150,10 +150,14 @@ describe('DataAccessRequirements', () => {
     // Temporary hack Sep 16: when enableRasLoginGovLinking is false, we DO show the module
     // along with an Ineligible icon and some "technical difficulties" text
     // and it never becomes an activeModule
-    it('should not render the RAS module when its feature flag is disabled', () => {
+    it('should render the RAS module as ineligible when its feature flag is disabled', () => {
         serverConfigStore.set({config: {...defaultServerConfig, enableRasLoginGovLinking: false}});
         const wrapper = component();
-        expect(findModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeFalsy();
+        expect(findModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeTruthy();
+        expect(findIneligibleModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeTruthy();
+
+        expect(findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeFalsy();
+        expect(findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeFalsy();
     });
 
     it('should render all modules as incomplete when the profile accessModules are empty', () => {

--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -96,6 +96,31 @@ describe('DataAccessRequirements', () => {
         expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV)
     });
 
+    // update this if the order changes
+    it('should return the second enabled module (ERA, not RAS) from getActiveModule when the first module (2FA) has been completed and RAS is disabled', () => {
+        serverConfigStore.set({config: {...defaultServerConfig, enableRasLoginGovLinking: false}});
+
+        const testProfile = {
+            ...profile,
+            accessModules: {
+                modules: [{moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1}]
+            }
+        };
+
+        const [navigate, ] = useNavigation();
+        const enabledModules = getEnabledModules(allModules, navigate);
+        const activeModule = getActiveModule(enabledModules, testProfile);
+
+        // update this if the order changes
+        expect(activeModule).toEqual(AccessModule.ERACOMMONS)
+
+        // 2FA (module 0) is complete, so enabled #1 is active
+        expect(activeModule).toEqual(enabledModules[1]);
+
+        // but we skip allModules[1] because it's RAS and is not enabled
+        expect(activeModule).toEqual(allModules[2]);
+    });
+
     it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been bypassed', () => {
         const testProfile = {
             ...profile,

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -338,9 +338,8 @@ const Next = () => <FlexRow style={styles.nextElement}>
   <span style={styles.nextText}>NEXT</span> <ArrowRight style={styles.nextIcon}/>
 </FlexRow>;
 
-const ModuleIcon = (props: {moduleName: AccessModule, completedOrBypassed: boolean}) => {
-  const eligible = true; // TODO RW-7059
-  const {moduleName, completedOrBypassed} = props;
+const ModuleIcon = (props: {moduleName: AccessModule, completedOrBypassed: boolean, eligible?: boolean}) => {
+  const {moduleName, completedOrBypassed, eligible = true} = props;
 
   return <div style={styles.moduleIcon}>
     {cond(
@@ -351,6 +350,22 @@ const ModuleIcon = (props: {moduleName: AccessModule, completedOrBypassed: boole
       [eligible && !completedOrBypassed,
         () => <CheckCircle data-test-id={`module-${moduleName}-incomplete`} style={{color: colors.disabled}}/>])}
   </div>;
+};
+
+// Sep 16 hack while we work out some RAS bugs
+const TemporaryRASModule = () => {
+  return <FlexRow data-test-id={`module-${AccessModule.RASLINKLOGINGOV}`}>
+    <FlexRow style={styles.moduleCTA}/>
+    <FlexRow style={styles.inactiveModuleBox}>
+      <ModuleIcon moduleName={AccessModule.RASLINKLOGINGOV} completedOrBypassed={false} eligible={false}/>
+      <FlexColumn>
+        <div style={styles.inactiveModuleText}>
+          Here are some words
+        </div>
+        <div>here's a second div</div>
+      </FlexColumn>
+    </FlexRow>
+  </FlexRow>;
 };
 
 interface ModuleProps {
@@ -413,6 +428,13 @@ const MaybeModule = ({moduleName, active, spinnerProps}: ModuleProps): JSX.Eleme
     </FlexRow>;
   };
 
+  // temp hack Sep 16: render a special temporary RAS module if disabled
+  if (moduleName === AccessModule.RASLINKLOGINGOV) {
+    const {enableRasLoginGovLinking} = serverConfigStore.get().config;
+    if (!enableRasLoginGovLinking) {
+      return <TemporaryRASModule/>;
+    }
+  }
   const moduleEnabled = !!registrationTask;
   return moduleEnabled ? <Module/> : null;
 };

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -354,16 +354,20 @@ const ModuleIcon = (props: {moduleName: AccessModule, completedOrBypassed: boole
 
 // Sep 16 hack while we work out some RAS bugs
 const TemporaryRASModule = () => {
-  return <FlexRow data-test-id={`module-${AccessModule.RASLINKLOGINGOV}`}>
+  const moduleName = AccessModule.RASLINKLOGINGOV;
+  return <FlexRow data-test-id={`module-${moduleName}`}>
     <FlexRow style={styles.moduleCTA}/>
     <FlexRow style={styles.inactiveModuleBox}>
-      <ModuleIcon moduleName={AccessModule.RASLINKLOGINGOV} completedOrBypassed={false} eligible={false}/>
-      <FlexColumn>
-        <div style={styles.inactiveModuleText}>
-          Here are some words
+      <ModuleIcon moduleName={moduleName} completedOrBypassed={false} eligible={false}/>
+      <FlexColumn style={styles.inactiveModuleText}>
+        <div>
+          {moduleLabels.get(moduleName)}
         </div>
-        <div>here's a second div</div>
-      </FlexColumn>
+        <div style={{fontSize: '14px', marginTop: '0.5em'}}>
+          <b>Temporarily disabled.</b> Due to technical difficulties, this step is disabled.
+          In the future, you'll be prompted to complete identity verification to continue using the workbench.
+        </div>
+     </FlexColumn>
     </FlexRow>
   </FlexRow>;
 };


### PR DESCRIPTION
We want to launch DAR on 9/20 but we are not ready to launch RAS.  However, we have sent out communications regarding the launch of RAS.  So: we need some placeholder text about RAS to avoid user confusion.

When FF enable RAS = false
<img width="1565" alt="Screen Shot 2021-09-16 at 10 43 14 AM" src="https://user-images.githubusercontent.com/2701406/133633632-88b452c7-e0a6-465c-8522-9d9131caa68e.png">

When FF enable RAS = true, works normally.



<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
