### PR TITLE
[risk=no][RW-7015] Remove admin-user-profile bypass toggles from e2e testing

### DIFF
--- a/e2e/app/page/admin-user-profile-info.ts
+++ b/e2e/app/page/admin-user-profile-info.ts
@@ -8,7 +8,6 @@ import Button from 'app/element/button';
 import { LinkText } from 'app/text-labels';
 import SelectMenu from 'app/component/select-menu';
 import { ElementType } from 'app/xpath-options';
-import { getPropValue } from 'utils/element-utils';
 
 const PageTitle = 'User Admin | All of Us Researcher Workbench';
 
@@ -150,62 +149,6 @@ export default class UserProfileInfo extends AuthenticatedPage {
   async getFreeCreditsLimitValue(): Promise<string> {
     const freeCreditsDropdown = SelectMenu.findByName(this.page, { dataTestId: DataTestIdAlias.FreeCreditLimit });
     return await freeCreditsDropdown.getSelectedValue();
-  }
-
-  // get each modules checkbox status
-  async getEachBypassToggle(toggleAccessText: string): Promise<boolean> {
-    const xpath = `//div[@data-test-id='${toggleAccessText}']//input[@type='checkbox']`;
-    const btn = new Checkbox(this.page, xpath);
-    const btnStatus = await getPropValue<boolean>(await btn.asElementHandle(), 'checked');
-    return btnStatus;
-  }
-
-  // get the module name and the status of each modules in test env
-  async getBypassTest(): Promise<boolean[]> {
-    const bypassProfileTest = [
-      'twoFactorAuthBypassToggle',
-      'complianceTrainingBypassToggle',
-      'eraCommonsBypassToggle',
-      'dataUseAgreementBypassToggle',
-      'rasLinkLoginGovBypassToggle'
-    ];
-    const moduleNames: string[] = [];
-    let i: number;
-    const btnStatus: boolean[] = [];
-    for (i = 0; i < bypassProfileTest.length; i++) {
-      moduleNames.push(bypassProfileTest[i]);
-      btnStatus.push(await this.getEachBypassToggle(moduleNames[i]));
-    }
-    return btnStatus;
-  }
-
-  // get the module name and the status of each modules in staging env
-  async getBypassStaging(): Promise<boolean[]> {
-    const bypassProfileStaging = [
-      'twoFactorAuthBypassToggle',
-      'eraCommonsBypassToggle',
-      'dataUseAgreementBypassToggle',
-      'complianceTrainingBypassToggle'
-    ];
-    const moduleNames: string[] = [];
-    let i: number;
-    const btnStatus: boolean[] = [];
-    for (i = 0; i < bypassProfileStaging.length; i++) {
-      moduleNames.push(bypassProfileStaging[i]);
-      btnStatus.push(await this.getEachBypassToggle(moduleNames[i]));
-    }
-    return btnStatus;
-  }
-
-  // check the env and run the respective function to get the module status
-  async getBypassProfileEnv(): Promise<boolean[]> {
-    const checkEnv = process.env.WORKBENCH_ENV;
-    switch (checkEnv) {
-      case 'test':
-        return this.getBypassTest();
-      case 'staging':
-        return this.getBypassStaging();
-    }
   }
 
   // select a different Verified Institution to verify email match with institution

--- a/e2e/tests/nightly/admin/user-admin-ui.spec.ts
+++ b/e2e/tests/nightly/admin/user-admin-ui.spec.ts
@@ -13,7 +13,7 @@ describe('Admin', () => {
     await navigation.navMenu(page, NavLink.USER_ADMIN);
   });
 
-  test('verify admin-user-profile page reflect the same modules and active status as on admin-table', async () => {
+  test('verify admin-user-profile page reflects the same modules and active statuses as on admin-table', async () => {
     const userAdminPage = new UserAdminPage(page);
     await userAdminPage.waitForLoad();
 
@@ -42,7 +42,6 @@ describe('Admin', () => {
     const userProfileInfo = await userAdminPage.clickNameLink(1, nameColIndex);
     //navigate to admin-user-profile page
     await userProfileInfo.waitForLoad();
-    await userProfileInfo.getBypassProfileEnv();
   });
 
   test('Verify admin-user-profile page ui, update freeCredits and update institution', async () => {


### PR DESCRIPTION
I broke the nightly tests by removing some functionality in #5593.  This also removes it from the test.

Note: the bypass toggles weren't functional anyway.

Passing test locally: `yarn test-nightly tests/nightly/admin/user-admin-ui.spec.ts`

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
