### PR TITLE
[risk=no] Try reducing GAE test env instance class

### DIFF
--- a/api/libproject/environments.rb
+++ b/api/libproject/environments.rb
@@ -29,7 +29,6 @@ ENVIRONMENTS = {
   "all-of-us-workbench-test" => env_with_defaults("test", {
     :api_endpoint_host => "api-dot-#{TEST_PROJECT}.appspot.com",
     :cdr_sql_instance => "#{TEST_PROJECT}:us-central1:workbenchmaindb",
-    :gae_vars => make_gae_vars(0, 10, 'F4'),
     :publisher_account => "circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com",
     :source_cdr_project => "all-of-us-ehr-dev",
     :source_cdr_wgs_project => "all-of-us-workbench-test",


### PR DESCRIPTION
Trying this again. Original reason for reverting to this is b/c free tier billing was OOMing. That is now happening regardless, so may as well try reducing this again.

Free tier cron is currently disabled per RW-6280.