### PR TITLE
[risk=no] RDR export access tier casing fix

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrMapper.java
@@ -5,14 +5,17 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.SpecificPopulationEnum;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.pmiops.workbench.rdr.model.RdrWorkspace;
+import org.pmiops.workbench.rdr.model.RdrWorkspace.AccessTierEnum;
 import org.pmiops.workbench.rdr.model.RdrWorkspaceDemographic;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
@@ -35,12 +38,21 @@ public interface RdrMapper {
   // Workspace User will be populated by a call to FireCloud
   // This will be handle in ServiceImpl Class
   @Mapping(target = "workspaceUsers", ignore = true)
-  RdrWorkspace toRdrModel(DbWorkspace employeeDbEntity);
+  RdrWorkspace toRdrModel(DbWorkspace dbWorkspace);
 
   ZoneOffset offset = OffsetDateTime.now().getOffset();
 
-  default OffsetDateTime toModelOffsetTime(Timestamp dbTime) {
+  default OffsetDateTime toModelOffsetTime(@Nullable Timestamp dbTime) {
+    if (dbTime == null) {
+      return null;
+    }
     return dbTime.toLocalDateTime().atOffset(offset);
+  }
+
+  default RdrWorkspace.AccessTierEnum toModelAccessTier(@Nullable String accessTier) {
+    return Optional.ofNullable(accessTier)
+        .map(t -> AccessTierEnum.fromValue(t.toUpperCase()))
+        .orElse(AccessTierEnum.UNSET);
   }
 
   default RdrWorkspace.StatusEnum toModelStatus(WorkspaceActiveStatus workspaceActiveStatus) {

--- a/api/src/main/resources/rdr.yaml
+++ b/api/src/main/resources/rdr.yaml
@@ -157,8 +157,12 @@ definitions:
         $ref: '#/definitions/RdrWorkspaceDemographic'
       cdrVersionName: 
         type: string
-      accessTier: 
+      accessTier:
         type: string
+        enum:
+          - UNSET
+          - REGISTERED
+          - CONTROLLED
 
   RdrWorkspaceDemographic:
     type: object

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrMapperTest.java
@@ -1,0 +1,50 @@
+package org.pmiops.workbench.rdr;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pmiops.workbench.SpringTest;
+import org.pmiops.workbench.db.model.DbAccessTier;
+import org.pmiops.workbench.db.model.DbCdrVersion;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.rdr.model.RdrWorkspace.AccessTierEnum;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+public class RdrMapperTest extends SpringTest {
+
+  @TestConfiguration
+  @Import(RdrMapperImpl.class)
+  static class Configuration {}
+
+  private @Autowired RdrMapper rdrMapper;
+
+  private static Stream<Arguments> accessTierCases() {
+    return Stream.of(
+        Arguments.of("controlled", AccessTierEnum.CONTROLLED),
+        Arguments.of("registered", AccessTierEnum.REGISTERED),
+        Arguments.of(null, AccessTierEnum.UNSET),
+        Arguments.of("asdf", AccessTierEnum.UNSET));
+  }
+
+  @ParameterizedTest
+  @MethodSource("accessTierCases")
+  public void testMapRdrWorkspace_accessTiers(
+      @Nullable String tierShortName, AccessTierEnum wantRdrTier) {
+    DbAccessTier accessTier = new DbAccessTier();
+    accessTier.setShortName(tierShortName);
+
+    DbCdrVersion cdrVersion = new DbCdrVersion();
+    cdrVersion.setAccessTier(accessTier);
+
+    DbWorkspace from = new DbWorkspace();
+    from.setCdrVersion(cdrVersion);
+
+    assertThat(rdrMapper.toRdrModel(from).getAccessTier()).isEqualTo(wantRdrTier);
+  }
+}

--- a/api/tools/src/cron/export-to-rdr.sh
+++ b/api/tools/src/cron/export-to-rdr.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl -X GET 'http://localhost:8081/v1/cron/exportToRdr' \
+  --header "X-AppEngine-Cron: true"


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/ROC-1164

- The bug: RDR wants `"CONTROLLED"`, we're sending `"controlled"`
- Fix RDR yaml
- Add a regression test

### Alternative considered
Pull both constants into a util, make them a more permanent fixture. It seems we have to be opinionated about these specific string constants in order to satisfy this API interaction. There is still a risk that our DB shortnames and their enum diverge in the future. This seemed like a more controversial change as the current `"registered"` constant indicates it is slotted for removal, so I didn't take that on here.