### PR TITLE
[RW-7299][risk=medium] Swap the order of eRA and RAS, and enable RAS in prod

### DIFF
--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -92,7 +92,7 @@
     "enableEraCommons": true,
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
-    "enableRasLoginGovLinking": false
+    "enableRasLoginGovLinking": true
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -92,7 +92,7 @@
     "enableEraCommons": true,
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
-    "enableRasLoginGovLinking": false
+    "enableRasLoginGovLinking": true
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -208,8 +208,8 @@ const styles = reactStyles({
 // in display order
 const rtModules = [
   AccessModule.TWOFACTORAUTH,
-  AccessModule.RASLINKLOGINGOV,
   AccessModule.ERACOMMONS,
+  AccessModule.RASLINKLOGINGOV,
   AccessModule.COMPLIANCETRAINING,
 ];
 

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -107,6 +107,21 @@ export const getRegistrationTasks = (navigate): RegistrationTask[] => serverConf
     },
     onClick: redirectToTwoFactorSetup
   }, {
+    key: 'eraCommons',
+    module: AccessModule.ERACOMMONS,
+    completionPropsKey: 'eraCommonsLinked',
+    loadingPropsKey: 'eraCommonsLoading',
+    title: 'Connect Your eRA Commons Account',
+    description: 'Connect your Researcher Workbench account to your eRA Commons account. ' +
+      'There is no exchange of personal data in this step.',
+    featureFlag: serverConfigStore.get().config.enableEraCommons,
+    buttonText: 'Connect',
+    completedText: 'Linked',
+    completionTimestamp: (profile: Profile) => {
+      return profile.eraCommonsCompletionTime || profile.eraCommonsBypassTime;
+    },
+    onClick: redirectToNiH
+  }, {
     key: 'rasLoginGov',
     module: AccessModule.RASLINKLOGINGOV,
     completionPropsKey: 'rasLoginGovLinked',
@@ -120,22 +135,6 @@ export const getRegistrationTasks = (navigate): RegistrationTask[] => serverConf
       return profile.rasLinkLoginGovCompletionTime || profile.rasLinkLoginGovBypassTime;
     },
     onClick: redirectToRas
-  },
-  {
-    key: 'eraCommons',
-    module: AccessModule.ERACOMMONS,
-    completionPropsKey: 'eraCommonsLinked',
-    loadingPropsKey: 'eraCommonsLoading',
-    title: 'Connect Your eRA Commons Account',
-    description: 'Connect your Researcher Workbench account to your eRA Commons account. ' +
-        'There is no exchange of personal data in this step.',
-    featureFlag: serverConfigStore.get().config.enableEraCommons,
-    buttonText: 'Connect',
-    completedText: 'Linked',
-    completionTimestamp: (profile: Profile) => {
-      return profile.eraCommonsCompletionTime || profile.eraCommonsBypassTime;
-    },
-    onClick: redirectToNiH
   }, {
     key: 'complianceTraining',
     module: AccessModule.COMPLIANCETRAINING,


### PR DESCRIPTION
Description:
Mark this as medium risk PR because this changes `access` . But that is optional module, and is not relaxing any access controls
<!--
Replace this temp
![Screen Shot 2021-09-20 at 3 26 09 PM](https://user-images.githubusercontent.com/6351731/134062320-07b10dd6-2bd9-46e4-9c21-95cfb548a30e.png)
late with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
