### PR TITLE
[risk=no][no ticket] Workspace Edit: check if UI error has message before accessing it

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -882,7 +882,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
           let errorMsg;
           if (error.statusCode === 429) {
             errorMsg = 'Server is overloaded. Please try again in a few minutes.';
-          } else if (error.message.includes('billing account is closed')) {
+          } else if (error.message && error.message.includes('billing account is closed')) {
             errorMsg = error.message;
           } else {
             errorMsg = `Could not


### PR DESCRIPTION
Saw this while debugging today's Create Workspace outage on Dev:

<img width="893" alt="Screen Shot 2021-09-21 at 9 52 22 AM" src="https://user-images.githubusercontent.com/2701406/134187504-90304b8e-c480-48db-a081-e39395a88cf3.png">



<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
