### PR TITLE
[risk=low][no ticket] Use location.replace() instead of useNavigate() to go back

### DIFF
--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -728,7 +728,7 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
          </FlexRow>
         <FlexRow style={{justifyContent: 'flex-start', marginRight: '1rem'}}>
           <div>
-            <Button type='secondary' onClick={goBack} style={{marginRight: '1.5rem'}}>Cancel</Button>
+            <Button type='secondary' onClick={() => goBack()} style={{marginRight: '1.5rem'}}>Cancel</Button>
             <TooltipTrigger data-test-id='tooltip' content={
               errors && this.disableSave(errors) && <div>Answer required fields
                 <BulletAlignedUnorderedList>
@@ -750,7 +750,7 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
         </FlexRow>
         {this.state.showBackButtonWarning && <SaveErrorModal
             onFinish={() => this.setState({showBackButtonWarning: false})}
-            onContinue={goBack}
+            onContinue={() => goBack()}
         />}
         {this.state.showApiError && <ApiErrorModal
             errorMsg={this.state.apiErrorMsg}

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -2,7 +2,7 @@ import * as fp from 'lodash/fp';
 import {Dropdown} from 'primereact/dropdown';
 import {InputSwitch} from 'primereact/inputswitch';
 import * as React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import {RouteComponentProps, withRouter} from 'react-router-dom';
 import validate from 'validate.js';
 
 import {Button} from 'app/components/buttons';
@@ -40,7 +40,7 @@ import {
   updateRtEmailAddresses,
   updateRtEmailDomains,
 } from 'app/utils/institutions';
-import {NavigationProps, useNavigation} from 'app/utils/navigation';
+import {NavigationProps} from 'app/utils/navigation';
 import {MatchParams, serverConfigStore, useStore} from 'app/utils/stores';
 import {withNavigation} from 'app/utils/with-navigation-hoc';
 import {
@@ -106,9 +106,8 @@ enum InstitutionMode {
   EDIT
 }
 
-const backNavigate = () => {
-  const [navigate, ] = useNavigation();
-  navigate(['admin', 'institution']);
+const goBack = () => {
+  location.replace('/admin/institution');
 };
 
 const EraRequiredSwitch = (props: {tierConfig: InstitutionTierConfig, onChange: (boolean) => void}) => {
@@ -564,11 +563,11 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
 
     if (institutionMode === InstitutionMode.EDIT) {
       await institutionApi().updateInstitution(this.props.match.params.institutionId, institution)
-        .then(value => backNavigate())
+        .then(() => goBack())
         .catch(reason => this.handleError(reason));
     } else {
       await institutionApi().createInstitution(institution)
-        .then(value => backNavigate())
+        .then(() => goBack())
         .catch(reason => this.handleError(reason));
     }
   }
@@ -590,7 +589,7 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
     if (!this.fieldsNotEdited()) {
       this.setState({showBackButtonWarning: true});
     } else {
-      backNavigate();
+      goBack();
     }
   }
 
@@ -729,7 +728,7 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
          </FlexRow>
         <FlexRow style={{justifyContent: 'flex-start', marginRight: '1rem'}}>
           <div>
-            <Button type='secondary' onClick={backNavigate} style={{marginRight: '1.5rem'}}>Cancel</Button>
+            <Button type='secondary' onClick={goBack} style={{marginRight: '1.5rem'}}>Cancel</Button>
             <TooltipTrigger data-test-id='tooltip' content={
               errors && this.disableSave(errors) && <div>Answer required fields
                 <BulletAlignedUnorderedList>
@@ -751,7 +750,7 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
         </FlexRow>
         {this.state.showBackButtonWarning && <SaveErrorModal
             onFinish={() => this.setState({showBackButtonWarning: false})}
-            onContinue={backNavigate}
+            onContinue={goBack}
         />}
         {this.state.showApiError && <ApiErrorModal
             errorMsg={this.state.apiErrorMsg}


### PR DESCRIPTION
#5611 broke the Inst Admin UI completely.  Debugging revealed the problem: illegal use of a hook outside of a functional component.

I attempted these but was unsuccessful:
* making backNavigate into a component
* using the <Link> component
* using the <Redirect> component


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
