### PR TITLE
[risk=low][RW-4838] Remove submitDataUseAgreement (now submitDUCC)

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -325,15 +325,6 @@ public class ProfileController implements ProfileApiDelegate {
   }
 
   @Override
-  @Deprecated // renamed to submitDUCC()
-  public ResponseEntity<Profile> submitDataUseAgreement(
-      Integer dataUseAgreementSignedVersion, String initials) {
-    DbUser user =
-        userService.submitDUCC(userProvider.get(), dataUseAgreementSignedVersion, initials);
-    return getProfileResponse(saveUserWithConflictHandling(user));
-  }
-
-  @Override
   public ResponseEntity<Profile> submitDUCC(Integer duccSignedVersion, String initials) {
     DbUser user = userService.submitDUCC(userProvider.get(), duccSignedVersion, initials);
     return getProfileResponse(saveUserWithConflictHandling(user));

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -434,28 +434,6 @@ paths:
           description: Bad request
           schema:
             "$ref": "#/definitions/ErrorResponse"
-  "/v1/account/submit-data-use-agreement":
-    post:
-      tags:
-      - profile
-      description: (DEPRECATED.  Renamed to submitDUCC.)  Submits consent to the data use agreement for researchers.
-      operationId: submitDataUseAgreement
-      parameters:
-      - in: query
-        name: dataUseAgreementSignedVersion
-        description: Version \# of the Data Use Agreement that was signed.
-        type: integer
-        required: true
-      - in: query
-        name: initials
-        description: Initials of the user on the form.
-        type: string
-        required: true
-      responses:
-        200:
-          description: The user's profile.
-          schema:
-            "$ref": "#/definitions/Profile"
   "/v1/account/submit-data-user-code-of-conduct":
     post:
       tags:

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -459,10 +459,10 @@ public class ProfileControllerTest extends BaseControllerTest {
   }
 
   @Test
-  public void testSubmitDataUseAgreement_success() {
+  public void testsubmitDUCC_success() {
     createAccountAndDbUserWithAffiliation();
-    String duaInitials = "NIH";
-    assertThat(profileController.submitDataUseAgreement(DUCC_VERSION, duaInitials).getStatusCode())
+    String initials = "NIH";
+    assertThat(profileController.submitDUCC(DUCC_VERSION, initials).getStatusCode())
         .isEqualTo(HttpStatus.OK);
     List<DbUserDataUseAgreement> dbUserDataUseAgreementList =
         userDataUseAgreementDao.findByUserIdOrderByCompletionTimeDesc(dbUser.getUserId());
@@ -470,31 +470,31 @@ public class ProfileControllerTest extends BaseControllerTest {
     DbUserDataUseAgreement dbUserDataUseAgreement = dbUserDataUseAgreementList.get(0);
     assertThat(dbUserDataUseAgreement.getUserFamilyName()).isEqualTo(dbUser.getFamilyName());
     assertThat(dbUserDataUseAgreement.getUserGivenName()).isEqualTo(dbUser.getGivenName());
-    assertThat(dbUserDataUseAgreement.getUserInitials()).isEqualTo(duaInitials);
+    assertThat(dbUserDataUseAgreement.getUserInitials()).isEqualTo(initials);
     assertThat(dbUserDataUseAgreement.getDataUseAgreementSignedVersion()).isEqualTo(DUCC_VERSION);
   }
 
   @Test
-  public void testSubmitDataUseAgreement_wrongVersion_older() {
+  public void testsubmitDUCC_wrongVersion_older() {
     assertThrows(
         BadRequestException.class,
         () -> {
           createAccountAndDbUserWithAffiliation();
-          String duaInitials = "NIH";
-          profileController.submitDataUseAgreement(DUCC_VERSION - 1, duaInitials);
+          String initials = "NIH";
+          profileController.submitDUCC(DUCC_VERSION - 1, initials);
         });
   }
 
   // not really a use case for this, but shows we need an exact match
 
   @Test
-  public void testSubmitDataUseAgreement_wrongVersion_newer() {
+  public void testsubmitDUCC_wrongVersion_newer() {
     assertThrows(
         BadRequestException.class,
         () -> {
           createAccountAndDbUserWithAffiliation();
-          String duaInitials = "NIH";
-          profileController.submitDataUseAgreement(DUCC_VERSION + 1, duaInitials);
+          String initials = "NIH";
+          profileController.submitDUCC(DUCC_VERSION + 1, initials);
         });
   }
 
@@ -525,8 +525,8 @@ public class ProfileControllerTest extends BaseControllerTest {
 
     // sign the current version (A)
 
-    final String duaInitials = "NIH";
-    assertThat(profileController.submitDataUseAgreement(versionA, duaInitials).getStatusCode())
+    final String initials = "NIH";
+    assertThat(profileController.submitDUCC(versionA, initials).getStatusCode())
         .isEqualTo(HttpStatus.OK);
     assertThat(accessTierService.getAccessTiersForUser(dbUser)).contains(registeredTier);
 
@@ -766,7 +766,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     profile.setGivenName("OldGivenName");
     profile.setFamilyName("OldFamilyName");
     profileController.updateProfile(profile);
-    profileController.submitDataUseAgreement(DUCC_VERSION, "O.O.");
+    profileController.submitDUCC(DUCC_VERSION, "O.O.");
     profile.setGivenName("NewGivenName");
     profile.setFamilyName("NewFamilyName");
     profileController.updateProfile(profile);
@@ -1438,7 +1438,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     verify(mockProfileAuditor).fireUpdateAction(original, retrieved1);
     verify(mockProfileAuditor).fireUpdateAction(retrieved1, retrieved2);
 
-    // DUA and COMPLIANCE x2, one for each request
+    // DUCC and COMPLIANCE x2, one for each request
     verify(mockUserServiceAuditor, times(2))
         .fireAdministrativeBypassTime(
             eq(dbUser.getUserId()),

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -459,7 +459,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   }
 
   @Test
-  public void testsubmitDUCC_success() {
+  public void testSubmitDUCC_success() {
     createAccountAndDbUserWithAffiliation();
     String initials = "NIH";
     assertThat(profileController.submitDUCC(DUCC_VERSION, initials).getStatusCode())
@@ -475,7 +475,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   }
 
   @Test
-  public void testsubmitDUCC_wrongVersion_older() {
+  public void testSubmitDUCC_wrongVersion_older() {
     assertThrows(
         BadRequestException.class,
         () -> {
@@ -488,7 +488,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   // not really a use case for this, but shows we need an exact match
 
   @Test
-  public void testsubmitDUCC_wrongVersion_newer() {
+  public void testSubmitDUCC_wrongVersion_newer() {
     assertThrows(
         BadRequestException.class,
         () -> {


### PR DESCRIPTION
Part of RW-4838 - rename all the things w/r/t "Data Use Agreement"

UI was switched over in https://github.com/all-of-us/workbench/pull/5602 then released.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
