### PR TITLE
[risk=low][no ticket] Allow users to continue after RAS completion

### DIFF
--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -10,6 +10,7 @@ import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {profileStore, serverConfigStore} from 'app/utils/stores';
 import {MemoryRouter} from 'react-router-dom';
 import {useNavigation} from 'app/utils/navigation';
+import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 
 const profile = ProfileStubVariables.PROFILE_STUB as Profile;
 const load = jest.fn();
@@ -96,35 +97,6 @@ describe('DataAccessRequirements', () => {
         expect(activeModule).toEqual(AccessModule.ERACOMMONS)
     });
 
-    // update this if the order changes
-    it('should return the second enabled module (ERA, not RAS) from getActiveModule' +
-        ' when the first module (2FA) has been completed and RAS is disabled', () => {
-        serverConfigStore.set({config: {...defaultServerConfig, enableRasLoginGovLinking: false}});
-
-        const testProfile = {
-            ...profile,
-            accessModules: {
-                modules: [{moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1}]
-            }
-        };
-
-        const [navigate, ] = useNavigation();
-        const enabledModules = getEnabledModules(allModules, navigate);
-        const activeModule = getActiveModule(enabledModules, testProfile);
-
-        // update this if the order changes
-        expect(activeModule).toEqual(AccessModule.ERACOMMONS)
-
-        // 2FA (module 0) is complete, so enabled #1 is active
-        expect(activeModule).toEqual(enabledModules[1]);
-
-        // eRA is the next module.
-        expect(activeModule).toEqual(allModules[1]);
-        // TODO(RW-7301): Revert this back.
-        // // but we skip allModules[1] because it's RAS and is not enabled
-        // expect(activeModule).toEqual(allModules[2]);
-    });
-
     it('should return the second module (ERA) from getActiveModule when the first module (2FA) has been bypassed', () => {
         const testProfile = {
             ...profile,
@@ -144,6 +116,57 @@ describe('DataAccessRequirements', () => {
         expect(activeModule).toEqual(AccessModule.ERACOMMONS)
     });
 
+    // TODO(RW-7301)
+    // restore the intended module order [2FA, RAS, ERA] from the temporary version [2FA, ERA, RAS]
+
+    it('should return the second enabled module (RAS, not ERA) from getActiveModule' +
+        ' when the first module (2FA) has been completed and ERA is disabled', () => {
+        serverConfigStore.set({config: {...defaultServerConfig, enableEraCommons: false}});
+
+        const testProfile = {
+            ...profile,
+            accessModules: {
+                modules: [{moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1}]
+            }
+        };
+
+        const [navigate, ] = useNavigation();
+        const enabledModules = getEnabledModules(allModules, navigate);
+        const activeModule = getActiveModule(enabledModules, testProfile);
+
+        // update this if the order changes
+        expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV)
+
+        // 2FA (module 0) is complete, so enabled #1 is active
+        expect(activeModule).toEqual(enabledModules[1]);
+
+        // but we skip allModules[1] because it's ERA and is not enabled
+        expect(activeModule).toEqual(allModules[2]);
+    });
+
+    it('should return the fourth module (Compliance) from getActiveModule when the first 3 modules have been completed', () => {
+        const testProfile = {
+            ...profile,
+            accessModules: {
+                modules: [
+                    {moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1},
+                    {moduleName: AccessModule.ERACOMMONS, completionEpochMillis: 1},
+                    {moduleName: AccessModule.RASLINKLOGINGOV, completionEpochMillis: 1},
+                ]
+             }
+        };
+
+        const [navigate, ] = useNavigation();
+        const enabledModules = getEnabledModules(allModules, navigate);
+        const activeModule = getActiveModule(enabledModules, testProfile);
+
+        expect(activeModule).toEqual(allModules[3]);
+        expect(activeModule).toEqual(enabledModules[3]);
+
+        // update this if the order changes
+        expect(activeModule).toEqual(AccessModule.COMPLIANCETRAINING)
+    });
+
     it('should return undefined from getActiveModule when all modules have been completed', () => {
         const testProfile = {
             ...profile,
@@ -156,6 +179,42 @@ describe('DataAccessRequirements', () => {
         const enabledModules = getEnabledModules(allModules, navigate);
         const activeModule = getActiveModule(enabledModules, testProfile);
 
+        expect(activeModule).toBeUndefined();
+    });
+
+    it('should not indicate the RAS module as active when a user has completed it', () => {
+        // initially, the user has completed all modules except RAS (the standard case at RAS launch time)
+        const testProfile = {
+            ...profile,
+            accessModules: {
+                modules: [
+                    {moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1},
+                    {moduleName: AccessModule.ERACOMMONS, completionEpochMillis: 1},
+                    {moduleName: AccessModule.COMPLIANCETRAINING, completionEpochMillis: 1},
+                    {moduleName: AccessModule.DATAUSERCODEOFCONDUCT, completionEpochMillis: 1},
+                ]
+            }
+        };
+
+        const [navigate, ] = useNavigation();
+        const enabledModules = getEnabledModules(allModules, navigate);
+
+        let activeModule = getActiveModule(enabledModules, testProfile);
+        expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV)
+
+        // simulate handleRasCallback() by updating the profile
+
+        const updatedProfile = {
+            ...testProfile,
+            accessModules: {
+                modules: [
+                    ...testProfile.accessModules.modules,
+                    {moduleName: AccessModule.RASLINKLOGINGOV, completionEpochMillis: 1},
+                ]
+            }
+        };
+
+        activeModule = getActiveModule(enabledModules, updatedProfile);
         expect(activeModule).toBeUndefined();
     });
 
@@ -221,6 +280,65 @@ describe('DataAccessRequirements', () => {
         });
         expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
     });
+
+    // RAS launch bug
+    it('should render all modules as complete by transitioning to all complete', async() => {
+
+        // initially, the user has completed all modules except RAS (the standard case at RAS launch time)
+
+        const allExceptRas = allModules.filter(m => m !== AccessModule.RASLINKLOGINGOV);
+        profileStore.set({
+            profile: {
+                ...ProfileStubVariables.PROFILE_STUB,
+                accessModules: {
+                    modules: allExceptRas.map(module => ({moduleName: module, completionEpochMillis: 1}))
+                }
+            },
+            load,
+            reload,
+            updateCache});
+
+        const wrapper = component();
+        allExceptRas.forEach(module => {
+            expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
+
+            expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
+            expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+        });
+
+        // RAS is not complete
+        expect(findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeTruthy();
+
+        expect(findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeFalsy();
+        expect(findIneligibleModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeFalsy();
+
+        expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
+
+        // now all modules are complete
+
+        profileStore.set({
+            profile: {
+                ...ProfileStubVariables.PROFILE_STUB,
+                accessModules: {
+                    modules: allModules.map(module => ({moduleName: module, completionEpochMillis: 1}))
+                }
+            },
+            load,
+            reload,
+            updateCache});
+
+        await waitOneTickAndUpdate(wrapper);
+
+        allModules.forEach(module => {
+            expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
+
+            expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
+            expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+        });
+
+        expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
+    });
+
 
     it('should render all modules as complete when the profile accessModules are all bypassed', () => {
         profileStore.set({

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -31,7 +31,6 @@ import {
   GetStartedButton,
   redirectToRas,
 } from 'app/utils/access-utils';
-import {isAbortError} from 'app/utils/errors';
 import {useNavigation} from 'app/utils/navigation';
 import {profileStore, serverConfigStore, useStore} from 'app/utils/stores';
 import {AccessModule, AccessModuleStatus, Profile} from 'generated/fetch';
@@ -569,10 +568,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)((spinnerPro
 
   // whenever the profile changes, setActiveModule(the first incomplete enabled module)
   useEffect(() => {
-    const activeModule = getActiveModule(enabledModules, profile);
-    if (activeModule) {
-      setActiveModule(activeModule);
-    }
+    setActiveModule(getActiveModule(enabledModules, profile));
   }, [profile]);
 
   const {config: {unsafeAllowSelfBypass}} = useStore(serverConfigStore);


### PR DESCRIPTION
When DAR is initially loaded or the user hits Refresh which triggers a reload, DAR derives the `activeModule` by checking the user's Profile.  The `Next` and `Refresh` indicators are attached to the activeModule, and the completion banner is triggered by the "no active module" state.

When the user completes a module, the Profile is reloaded and the `activeModule` is recalculated.  This works in all cases except the last: when all modules are complete and DAR should transition to "no active module" (complete), it does not.

The fix is very simple: always set the active module, even when the module is "none", instead of only setting the active module when it has a valid value.

Added a test for this case as well as some other tests. 

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
