### PR TITLE
[risk=low][no ticket] Fix broken Admin Add Institution regression

### DIFF
--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -550,9 +550,7 @@ describe('AdminInstitutionEditSpec - add mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
-    expect(wrapper.find('[data-test-id="registered-email-domain-input"]').exists()).toBeTruthy();
-    expect(wrapper.find('[data-test-id="registered-email-domain-input"]').first().prop('value')).toBe('');
-
+    expect(wrapper.find('[data-test-id="registered-email-domain-input"]').exists()).toBeFalsy();
     expect(wrapper.find('[data-test-id="registered-email-address-input"]').exists()).toBeFalsy();
     expect(wrapper.find('[data-test-id="controlled-email-address-input"]').exists()).toBeFalsy();
     expect(wrapper.find('[data-test-id="controlled-email-domain-input"]').exists()).toBeFalsy();

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -550,21 +550,30 @@ describe('AdminInstitutionEditSpec - add mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
-    expect(wrapper.find('[data-test-id="registered-email-address-input"]').length).toBe(0);
-    expect(wrapper.find('[data-test-id="registered-email-domain-input"]').length).toBe(0);
-    expect(wrapper.find('[data-test-id="controlled-email-address-input"]').length).toBe(0);
-    expect(wrapper.find('[data-test-id="controlled-email-domain-input"]').length).toBe(0);
+    expect(wrapper.find('[data-test-id="registered-email-domain-input"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-test-id="registered-email-domain-input"]').first().prop('value')).toBe('');
+
+    expect(wrapper.find('[data-test-id="registered-email-address-input"]').exists()).toBeFalsy();
+    expect(wrapper.find('[data-test-id="controlled-email-address-input"]').exists()).toBeFalsy();
+    expect(wrapper.find('[data-test-id="controlled-email-domain-input"]').exists()).toBeFalsy();
 
     const agreementTypeDropDown = wrapper.find('[data-test-id="registered-agreement-dropdown"]').instance() as Dropdown;
-    await simulateComponentChange(wrapper, agreementTypeDropDown, InstitutionMembershipRequirement.DOMAINS);
+    await simulateComponentChange(wrapper, agreementTypeDropDown, InstitutionMembershipRequirement.ADDRESSES);
 
-    wrapper.find('[data-test-id="registered-email-domain-input"]').first()
-        .simulate('change', {target: {value: 'domain.com'}});
-    wrapper.find('[data-test-id="registered-email-domain-input"]').first()
+    expect(wrapper.find('[data-test-id="registered-email-address-input"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-test-id="registered-email-address-input"]').first().prop('value')).toBe('');
+
+    expect(wrapper.find('[data-test-id="registered-email-domain-input"]').exists()).toBeFalsy();
+    expect(wrapper.find('[data-test-id="controlled-email-address-input"]').exists()).toBeFalsy();
+    expect(wrapper.find('[data-test-id="controlled-email-domain-input"]').exists()).toBeFalsy();
+
+    wrapper.find('[data-test-id="registered-email-address-input"]').first()
+        .simulate('change', {target: {value: 'user@domain.com'}});
+    wrapper.find('[data-test-id="registered-email-address-input"]').first()
         .simulate('blur');
 
     // RT no change
-    expect(wrapper.find('[data-test-id="registered-email-domain-input"]').first().prop('value'))
-        .toBe('domain.com');
+    expect(wrapper.find('[data-test-id="registered-email-address-input"]').first().prop('value'))
+        .toBe('user@domain.com');
   });
 });

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -26,6 +26,7 @@ import {reactStyles} from 'app/utils';
 import {AccessTierShortNames, displayNameForTier} from 'app/utils/access-tiers';
 import {convertAPIError} from 'app/utils/errors';
 import {
+  defaultTierConfig,
   getControlledTierConfig,
   getControlledTierEmailAddresses,
   getControlledTierEmailDomains,
@@ -291,7 +292,11 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
       institution: {
         shortName: '',
         displayName: '',
-        organizationTypeEnum: null
+        organizationTypeEnum: null,
+        tierConfigs: [{
+          ...defaultTierConfig(AccessTierShortNames.Registered),
+          membershipRequirement: InstitutionMembershipRequirement.DOMAINS,
+        }]
       },
       institutionToEdit: null,
       invalidRtEmailAddress: false,

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -295,7 +295,7 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
         organizationTypeEnum: null,
         tierConfigs: [{
           ...defaultTierConfig(AccessTierShortNames.Registered),
-          membershipRequirement: InstitutionMembershipRequirement.DOMAINS,
+          membershipRequirement: null,  // the default is NOACCESS which also means "don't render the card"
         }]
       },
       institutionToEdit: null,

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -66,20 +66,20 @@ export const getRoleOptions = (institutions: Array<PublicInstitutionDetails>, in
   );
 };
 
+export const defaultTierConfig = (accessTier: string): InstitutionTierConfig => ({
+  accessTierShortName: accessTier,
+  membershipRequirement: InstitutionMembershipRequirement.NOACCESS,
+  eraRequired: true,
+  emailAddresses: [],
+  emailDomains: []
+});
+
 export function getTierConfig(institution: Institution, accessTier: string): InstitutionTierConfig {
-  const defaultTierConfig: InstitutionTierConfig = {
-    accessTierShortName: accessTier,
-    membershipRequirement: InstitutionMembershipRequirement.NOACCESS,
-    eraRequired: true,
-    emailAddresses: [],
-    emailDomains: []
-  };
-
   if (!institution.tierConfigs) {
-    return defaultTierConfig;
+    return defaultTierConfig(accessTier);
   }
-  return institution.tierConfigs.find(t => t.accessTierShortName === accessTier) || defaultTierConfig;
 
+  return institution.tierConfigs.find(t => t.accessTierShortName === accessTier) || defaultTierConfig(accessTier);
 }
 
 export function getRegisteredTierConfig(institution: Institution): InstitutionTierConfig {


### PR DESCRIPTION
Add Institution populates an inst with no Registered Tier, and no way to enable one.  Insts w/o RT are useless, so this effectively blocked inst creation.  This is another regression caused by #5611.

Added a few basic Add Mode tests, which would have caught this.

I'll add more tests in a future PR.  I want to get this one merged ASAP.
 

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
