### PR TITLE
[RW-7286][risk=no] Bump cdr for registered dataset v5 in preprod

### DIFF
--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -99,7 +99,7 @@
       "creationTime": "2021-08-10 00:00:00Z",
       "releaseNumber": 7,
       "numParticipants": 329070,
-      "cdrDbName": "r_2021q3_1",
+      "cdrDbName": "r_2021q3_2",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"


### PR DESCRIPTION
Moving from `r_2021q3_1` to `r_2021q3_2`