### PR TITLE
[risk=low][no ticket] Friendlier UX for Inst Admin Edit

### DIFF
--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -32,10 +32,16 @@ const findRTDomainInput = (wrapper) => wrapper.find('[data-test-id="registered-e
 const findCTAddressInput = (wrapper) => wrapper.find('[data-test-id="controlled-email-address-input"]');
 const findCTDomainInput = (wrapper) => wrapper.find('[data-test-id="controlled-email-domain-input"]');
 
-const findRTAddressError = (wrapper) => wrapper.find('[data-test-id="registered-email-address-error"]');
-const findRTDomainError = (wrapper) => wrapper.find('[data-test-id="registered-email-domain-error"]');
-const findCTAddressError = (wrapper) => wrapper.find('[data-test-id="controlled-email-address-error"]');
-const findCTDomainError = (wrapper) => wrapper.find('[data-test-id="controlled-email-domain-error"]');
+// const findSaveDisabledTooltip = (wrapper) => wrapper.find('[data-test-id="tooltip"]');
+// const findSaveDisabledTooltipErrorText = (wrapper) =>
+//     findSaveDisabledTooltip(wrapper).first().props().children;
+
+const findSaveButtonDisabledX = (wrapper) => wrapper.find('[data-test-id="save-institution-button"]').first().props().disabled;
+
+const findRTAddressError = (wrapper) => findSaveButtonDisabledX(wrapper).registeredTierEmailAddresses[0];
+const findRTDomainError = (wrapper) => findSaveButtonDisabledX(wrapper).registeredTierEmailDomains[0];
+const findCTAddressError = (wrapper) => findSaveButtonDisabledX(wrapper).controlledTierEmailAddresses[0];
+const findCTDomainError = (wrapper) => findSaveButtonDisabledX(wrapper).controlledTierEmailDomains[0];
 
 describe('AdminInstitutionEditSpec - edit mode', () => {
 
@@ -225,13 +231,17 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
 
     await simulateComponentChange(wrapper, findRTDropdown(wrapper), InstitutionMembershipRequirement.ADDRESSES);
 
-    expect(findRTAddressError(wrapper).exists()).toBeFalsy();
+    expect(findRTAddressError(wrapper)).toBeTruthy();
+    expect(findRTAddressError(wrapper))
+        .toBe('Registered tier email addresses should not be empty');
 
     // In case of a single entry which is not in the correct format
     findRTAddressInput(wrapper).first().simulate('change', {target: {value: 'rtInvalidEmail@domain'}});
     findRTAddressInput(wrapper).first().simulate('blur');
-    expect(findRTAddressError(wrapper).first().props().children)
-        .toBe('Following Email Addresses are not valid : rtInvalidEmail@domain');
+
+    expect(findRTAddressError(wrapper)).toBeTruthy();
+    expect(findRTAddressError(wrapper))
+        .toBe('Registered tier email addresses are not valid: rtInvalidEmail@domain');
 
     // Multiple Email Address entries with a mix of correct (someEmail@broadinstitute.org') and incorrect format
     findRTAddressInput(wrapper).first()

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -32,16 +32,13 @@ const findRTDomainInput = (wrapper) => wrapper.find('[data-test-id="registered-e
 const findCTAddressInput = (wrapper) => wrapper.find('[data-test-id="controlled-email-address-input"]');
 const findCTDomainInput = (wrapper) => wrapper.find('[data-test-id="controlled-email-domain-input"]');
 
-// const findSaveDisabledTooltip = (wrapper) => wrapper.find('[data-test-id="tooltip"]');
-// const findSaveDisabledTooltipErrorText = (wrapper) =>
-//     findSaveDisabledTooltip(wrapper).first().props().children;
+const findSaveButton = (wrapper) => wrapper.find('[data-test-id="save-institution-button"]');
+const findSaveButtonDisabled = (wrapper) => findSaveButton(wrapper).first().props().disabled;
 
-const findSaveButtonDisabledX = (wrapper) => wrapper.find('[data-test-id="save-institution-button"]').first().props().disabled;
-
-const findRTAddressError = (wrapper) => findSaveButtonDisabledX(wrapper).registeredTierEmailAddresses[0];
-const findRTDomainError = (wrapper) => findSaveButtonDisabledX(wrapper).registeredTierEmailDomains[0];
-const findCTAddressError = (wrapper) => findSaveButtonDisabledX(wrapper).controlledTierEmailAddresses[0];
-const findCTDomainError = (wrapper) => findSaveButtonDisabledX(wrapper).controlledTierEmailDomains[0];
+const findRTAddressError = (wrapper) => findSaveButtonDisabled(wrapper).registeredTierEmailAddresses;
+const findRTDomainError = (wrapper) => findSaveButtonDisabled(wrapper).registeredTierEmailDomains;
+const findCTAddressError = (wrapper) => findSaveButtonDisabled(wrapper).controlledTierEmailAddresses;
+const findCTDomainError = (wrapper) => findSaveButtonDisabled(wrapper).controlledTierEmailDomains;
 
 describe('AdminInstitutionEditSpec - edit mode', () => {
 
@@ -232,7 +229,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await simulateComponentChange(wrapper, findRTDropdown(wrapper), InstitutionMembershipRequirement.ADDRESSES);
 
     expect(findRTAddressError(wrapper)).toBeTruthy();
-    expect(findRTAddressError(wrapper))
+    expect(findRTAddressError(wrapper)[0])
         .toBe('Registered tier email addresses should not be empty');
 
     // In case of a single entry which is not in the correct format
@@ -240,7 +237,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     findRTAddressInput(wrapper).first().simulate('blur');
 
     expect(findRTAddressError(wrapper)).toBeTruthy();
-    expect(findRTAddressError(wrapper))
+    expect(findRTAddressError(wrapper)[0])
         .toBe('Registered tier email addresses are not valid: rtInvalidEmail@domain');
 
     // Multiple Email Address entries with a mix of correct (someEmail@broadinstitute.org') and incorrect format
@@ -258,13 +255,14 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
         }
       });
     findRTAddressInput(wrapper).first().simulate('blur');
-    expect(findRTAddressError(wrapper).first().props().children)
-        .toBe('Following Email Addresses are not valid : invalidEmail@domain@org , invalidEmail , justDomain.org , nope@just#plain#wrong');
+    expect(findRTAddressError(wrapper)[0])
+        .toBe('Registered tier email addresses are not valid: invalidEmail@domain@org, invalidEmail, ' +
+            'justDomain.org, nope@just#plain#wrong');
 
     // Single correct format Email Address entries
     findRTAddressInput(wrapper).first().simulate('change', {target: {value: 'correctEmail@domain.com'}});
     findRTAddressInput(wrapper).first().simulate('blur');
-    expect(findRTAddressError(wrapper).exists()).toBeFalsy();
+    expect(findRTAddressError(wrapper)).toBeFalsy();
   });
 
   it('Should display error in case of invalid email Address Format in Controlled Tier requirement', async() => {
@@ -275,13 +273,13 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await simulateComponentChange(wrapper, findCTEnabled(wrapper), true);
     await simulateComponentChange(wrapper, findCTDropdown(wrapper), InstitutionMembershipRequirement.ADDRESSES);
 
-    expect(findCTAddressError(wrapper).exists()).toBeFalsy();
+    expect(findCTAddressError(wrapper)).toBeFalsy();
 
     // In case of a single entry which is not in the correct format
     findCTAddressInput(wrapper).first().simulate('change', {target: {value: 'ctInvalidEmail@domain'}});
     findCTAddressInput(wrapper).first().simulate('blur');
-    expect(findCTAddressError(wrapper).first().props().children)
-        .toBe('Following Email Addresses are not valid : ctInvalidEmail@domain');
+    expect(findCTAddressError(wrapper)[0])
+        .toBe('Controlled tier email addresses are not valid: ctInvalidEmail@domain');
 
     // Multiple Email Address entries with a mix of correct (someEmail@broadinstitute.org') and incorrect format
     findCTAddressInput(wrapper).first()
@@ -298,13 +296,14 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
       }
     });
     findCTAddressInput(wrapper).first().simulate('blur');
-    expect(findCTAddressError(wrapper).first().props().children)
-        .toBe('Following Email Addresses are not valid : invalidEmail@domain@org , invalidEmail , justDomain.org , nope@just#plain#wrong');
+    expect(findCTAddressError(wrapper)[0])
+        .toBe('Controlled tier email addresses are not valid: invalidEmail@domain@org, invalidEmail, ' +
+            'justDomain.org, nope@just#plain#wrong');
 
     // Single correct format Email Address entries
     findCTAddressInput(wrapper).first().simulate('change', {target: {value: 'correctEmail@domain.com'}});
     findCTAddressInput(wrapper).first().simulate('blur');
-    expect(findCTAddressError(wrapper).exists()).toBeFalsy();
+    expect(findCTAddressError(wrapper)).toBeFalsy();
   });
 
   it('Should display error in case of invalid email Domain Format in Registered Tier requirement', async() => {
@@ -314,14 +313,14 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
 
     await simulateComponentChange(wrapper, findRTDropdown(wrapper), InstitutionMembershipRequirement.DOMAINS);
 
-    expect(findRTDomainError(wrapper).exists()).toBeFalsy();
+    expect(findRTDomainError(wrapper)).toBeFalsy();
 
     // Single Entry with incorrect Email Domain format
     findRTDomainInput(wrapper).first()
         .simulate('change', {target: {value: 'invalidEmail@domain'}});
     findRTDomainInput(wrapper).first().simulate('blur');
-    expect(findRTDomainError(wrapper).first().props().children)
-      .toBe('Following Email Domains are not valid : invalidEmail@domain');
+    expect(findRTDomainError(wrapper)[0])
+      .toBe('Registered tier email domains are not valid: invalidEmail@domain');
 
     // Multiple Entries with correct and incorrect Email Domain format
     findRTDomainInput(wrapper).first()
@@ -336,15 +335,15 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
         }
       });
     findRTDomainInput(wrapper).first().simulate('blur');
-    expect(findRTDomainError(wrapper).first().props().children)
-      .toBe('Following Email Domains are not valid : someEmailAddress@domain@org , ' +
-        'justSomeText , broadinstitute.org#wrongTest');
+    expect(findRTDomainError(wrapper)[0])
+      .toBe('Registered tier email domains are not valid: someEmailAddress@domain@org, ' +
+        'justSomeText, broadinstitute.org#wrongTest');
 
 
     findRTDomainInput(wrapper).first()
       .simulate('change', {target: {value: 'domain.com'}});
     findRTDomainInput(wrapper).first().simulate('blur');
-    expect(findRTDomainError(wrapper).exists()).toBeFalsy();
+    expect(findRTDomainError(wrapper)).toBeFalsy();
   });
 
   it('Should display error in case of invalid email Domain Format in Controlled Tier requirement', async() => {
@@ -355,13 +354,15 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await simulateComponentChange(wrapper, findCTEnabled(wrapper), true);
     await simulateComponentChange(wrapper, findCTDropdown(wrapper), InstitutionMembershipRequirement.DOMAINS);
 
-    expect(findCTDomainError(wrapper).exists()).toBeFalsy();
+    expect(findCTDomainError(wrapper)).toBeTruthy();
+    expect(findCTDomainError(wrapper)[0])
+        .toBe('Controlled tier email domains should not be empty');
 
     // Single Entry with incorrect Email Domain format
     findCTDomainInput(wrapper).first().simulate('change', {target: {value: 'invalidEmail@domain'}});
     findCTDomainInput(wrapper).first().simulate('blur');
-    expect(findCTDomainError(wrapper).first().props().children)
-        .toBe('Following Email Domains are not valid : invalidEmail@domain');
+    expect(findCTDomainError(wrapper)[0])
+        .toBe('Controlled tier email domains are not valid: invalidEmail@domain');
 
     // Multiple Entries with correct and incorrect Email Domain format
     findCTDomainInput(wrapper).first()
@@ -376,13 +377,13 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
       }
     });
     findCTDomainInput(wrapper).first().simulate('blur');
-    expect(findCTDomainError(wrapper).first().props().children)
-        .toBe('Following Email Domains are not valid : someEmailAddress@domain@org , ' +
-            'justSomeText , broadinstitute.org#wrongTest');
+    expect(findCTDomainError(wrapper)[0])
+        .toBe('Controlled tier email domains are not valid: someEmailAddress@domain@org, ' +
+            'justSomeText, broadinstitute.org#wrongTest');
 
     findCTDomainInput(wrapper).first().simulate('change', {target: {value: 'domain.com'}});
     findCTDomainInput(wrapper).first().simulate('blur');
-    expect(findCTDomainError(wrapper).exists()).toBeFalsy();
+    expect(findCTDomainError(wrapper)).toBeFalsy();
   });
 
   it('Should ignore empty string in email Domain in Registered Tier requirement', async() => {
@@ -399,7 +400,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     expect(findRTDomainInput(wrapper).first().prop('value'))
       .toBe('validEmail.com,\njustSomeRandom.domain');
 
-    expect(findRTDomainError(wrapper).exists()).toBeFalsy();
+    expect(findRTDomainError(wrapper)).toBeFalsy();
   });
 
   it('Should ignore empty string in email Domain in Controlled Tier requirement', async() => {
@@ -418,7 +419,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     findCTDomainInput(wrapper).first().simulate('blur');
     expect(findCTDomainInput(wrapper).first().prop('value')).toBe('validEmail.com,\njustSomeRandom.domain');
 
-    expect(findCTDomainError(wrapper).exists()).toBeFalsy();
+    expect(findCTDomainError(wrapper)).toBeFalsy();
   });
 
   it('Should ignore whitespaces in email domains in Registered Tier requirement', async() => {
@@ -435,7 +436,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     expect(findRTDomainInput(wrapper).first().prop('value'))
       .toBe('someDomain.com,\njustSomeRandom.domain');
 
-    expect(findRTDomainError(wrapper).exists()).toBeFalsy();
+    expect(findRTDomainError(wrapper)).toBeFalsy();
   });
 
   it('Should ignore whitespaces in email domains in Controlled Tier requirement', async() => {
@@ -452,7 +453,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     findCTDomainInput(wrapper).first().simulate('blur');
     expect(findCTDomainInput(wrapper).first().prop('value')).toBe('someDomain.com,\njustSomeRandom.domain');
 
-    expect(findCTDomainError(wrapper).exists()).toBeFalsy();
+    expect(findCTDomainError(wrapper)).toBeFalsy();
   });
 });
 
@@ -574,13 +575,15 @@ describe('AdminInstitutionEditSpec - add mode', () => {
 
     await simulateComponentChange(wrapper, findRTDropdown(wrapper), InstitutionMembershipRequirement.ADDRESSES);
 
-    expect(findRTAddressError(wrapper).exists()).toBeFalsy();
+    expect(findRTAddressError(wrapper)).toBeTruthy();
+    expect(findRTAddressError(wrapper)[0])
+        .toBe('Registered tier email addresses should not be empty');
 
     // In case of a single entry which is not in the correct format
     findRTAddressInput(wrapper).first().simulate('change', {target: {value: 'rtInvalidEmail@domain'}});
     findRTAddressInput(wrapper).first().simulate('blur');
-    expect(findRTAddressError(wrapper).first().props().children)
-        .toBe('Following Email Addresses are not valid : rtInvalidEmail@domain');
+    expect(findRTAddressError(wrapper)[0])
+        .toBe('Registered tier email addresses are not valid: rtInvalidEmail@domain');
 
     // Multiple Email Address entries with a mix of correct (someEmail@broadinstitute.org') and incorrect format
     findRTAddressInput(wrapper).first()
@@ -597,13 +600,14 @@ describe('AdminInstitutionEditSpec - add mode', () => {
           }
         });
     findRTAddressInput(wrapper).first().simulate('blur');
-    expect(findRTAddressError(wrapper).first().props().children)
-        .toBe('Following Email Addresses are not valid : invalidEmail@domain@org , invalidEmail , justDomain.org , nope@just#plain#wrong');
+    expect(findRTAddressError(wrapper)[0])
+        .toBe('Registered tier email addresses are not valid: invalidEmail@domain@org, invalidEmail, ' +
+            'justDomain.org, nope@just#plain#wrong');
 
     // Single correct format Email Address entries
     findRTAddressInput(wrapper).first().simulate('change', {target: {value: 'correctEmail@domain.com'}});
     findRTAddressInput(wrapper).first().simulate('blur');
-    expect(findRTAddressError(wrapper).exists()).toBeFalsy();
+    expect(findRTAddressError(wrapper)).toBeFalsy();
   });
 
   it('Should ignore empty string in email Domain in Controlled Tier requirement', async() => {
@@ -622,6 +626,6 @@ describe('AdminInstitutionEditSpec - add mode', () => {
     findCTDomainInput(wrapper).first().simulate('blur');
     expect(findCTDomainInput(wrapper).first().prop('value')).toBe('validEmail.com,\njustSomeRandom.domain');
 
-    expect(findCTDomainError(wrapper).exists()).toBeFalsy();
+    expect(findCTDomainError(wrapper)).toBeFalsy();
   });
 });

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -191,10 +191,10 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     findRTDomainInput(wrapper).first()
         .simulate('change', {target: {value: 'someDomain.com,\njustSomeRandom.domain,\n,'}});
     findRTDomainInput(wrapper).first().simulate('blur');
+    expect(findRTDomainInput(wrapper).first().prop('value')).toBe('someDomain.com,\njustSomeRandom.domain');
+
     findCTAddressInput(wrapper).first().simulate('change', {target: {value: 'correctEmail@domain.com'}});
     findCTAddressInput(wrapper).first().simulate('blur');
-
-    expect(findRTDomainInput(wrapper).first().prop('value')).toBe('someDomain.com,\njustSomeRandom.domain');
     expect(findCTAddressInput(wrapper).first().prop('value')).toBe('correctEmail@domain.com');
   });
 

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -177,15 +177,10 @@ interface TierConfigProps {
   setTierAddresses: (string) => void;
   filterEmptyDomains: Function;
   setTierDomains: (string) => void;
-  invalidAddress: boolean;
-  invalidAddressMsg: string;
-  invalidDomain: boolean;
-  invalidDomainMsg: string;
 }
 const TierConfig = (props: TierConfigProps) => {
   const {institution, accessTierShortName, TierBadge, setEnableControlledTier, setEraRequired, setTierRequirement,
-    filterEmptyAddresses, setTierAddresses, filterEmptyDomains, setTierDomains,
-    invalidAddress, invalidAddressMsg, invalidDomain, invalidDomainMsg} = props;
+    filterEmptyAddresses, setTierAddresses, filterEmptyDomains, setTierDomains} = props;
 
   const tierConfig = getTierConfig(institution, accessTierShortName);
   const {emailAddresses, emailDomains} = tierConfig;
@@ -217,9 +212,6 @@ const TierConfig = (props: TierConfigProps) => {
               emailAddresses={emailAddresses}
               onBlur={filterEmptyAddresses}
               onChange={setTierAddresses}/>
-            {invalidAddress && <div data-test-id={`${accessTierShortName}-email-address-error`} style={{color: colors.danger}}>
-              {invalidAddressMsg}
-            </div>}
             <p style={{color: colors.primary, fontSize: '12px', lineHeight: '18px'}}>
               Enter one email address per line.  <br/>
             </p>
@@ -232,9 +224,6 @@ const TierConfig = (props: TierConfigProps) => {
                 emailDomains={emailDomains}
                 onBlur={filterEmptyDomains}
                 onChange={setTierDomains}/>
-            {invalidDomain && <div data-test-id={`${accessTierShortName}-email-domain-error`} style={{color: colors.danger}}>
-              {invalidDomainMsg}
-            </div>}
             <p style={{color: colors.primary, fontSize: '12px', lineHeight: '18px'}}>
               Enter one domain per line. <br/>
               Note that subdomains are not included, so “university.edu” <br/>
@@ -280,14 +269,6 @@ interface InstitutionEditState {
   institutionMode: InstitutionMode;
   institution: Institution;
   institutionBeforeEdits: Institution;
-  invalidRtEmailAddress: boolean;
-  invalidRtEmailAddressMsg: string;
-  invalidCtEmailAddress: boolean;
-  invalidCtEmailAddressMsg: string;
-  invalidRtEmailDomain: boolean;
-  invalidRtEmailDomainsMsg: string;
-  invalidCtEmailDomain: boolean;
-  invalidCtEmailDomainsMsg: string;
   showOtherInstitutionTextBox: boolean;
   showBackButtonWarning: boolean;
   showApiError: boolean;
@@ -307,14 +288,6 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
          organizationTypeEnum: null,
       },
       institutionBeforeEdits: null,
-      invalidRtEmailAddress: false,
-      invalidRtEmailAddressMsg: '',
-      invalidCtEmailAddress: false,
-      invalidCtEmailAddressMsg: '',
-      invalidRtEmailDomain: false,
-      invalidRtEmailDomainsMsg: '',
-      invalidCtEmailDomain: false,
-      invalidCtEmailDomainsMsg: '',
       showOtherInstitutionTextBox: false,
       showBackButtonWarning: false,
       showApiError: false,
@@ -673,11 +646,7 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
               filterEmptyAddresses={() => this.filterEmptyRtEmailAddresses()}
               setTierAddresses={(addrs) => this.setRegisteredTierEmails(addrs)}
               filterEmptyDomains={() => this.filterEmptyRtEmailDomains()}
-              setTierDomains={(domains) => this.setRegisteredTierDomains(domains)}
-              invalidAddress={this.state.invalidRtEmailAddress}
-              invalidAddressMsg={this.state.invalidRtEmailAddressMsg}
-              invalidDomain={this.state.invalidRtEmailDomain}
-              invalidDomainMsg={this.state.invalidRtEmailDomainsMsg}/>
+              setTierDomains={(domains) => this.setRegisteredTierDomains(domains)}/>
           <TierConfig
               institution={institution}
               accessTierShortName={AccessTierShortNames.Controlled}
@@ -688,11 +657,7 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
               filterEmptyAddresses={() => this.filterEmptyCtEmailAddresses()}
               setTierAddresses={(addrs) => this.setControlledTierEmails(addrs)}
               filterEmptyDomains={() => this.filterEmptyCtEmailDomains()}
-              setTierDomains={(domains) => this.setControlledTierDomains(domains)}
-              invalidAddress={this.state.invalidCtEmailAddress}
-              invalidAddressMsg={this.state.invalidCtEmailAddressMsg}
-              invalidDomain={this.state.invalidCtEmailDomain}
-              invalidDomainMsg={this.state.invalidCtEmailDomainsMsg}/>
+              setTierDomains={(domains) => this.setControlledTierDomains(domains)}/>
          </FlexRow>
         <FlexRow style={{justifyContent: 'flex-start', marginRight: '1rem'}}>
           <div>

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -626,7 +626,6 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
                       options={OrganizationTypeOptions}
                       value={institution.organizationTypeEnum}
                       onChange={v => this.updateInstitutionRole(v.value)}/>
-            <div style={{color: colors.danger}}>{institution.organizationTypeEnum && errors && errors.organizationTypeEnum}</div>
             {showOtherInstitutionTextBox && <TextInputWithLabel
               value={institution.organizationTypeOtherText}
               onChange={v => this.setState(fp.set(['institution', 'organizationTypeOtherText'], v))}
@@ -675,13 +674,12 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
             <TooltipTrigger data-test-id='tooltip' content={
               errors && this.disableSave(errors) && <div>Please correct the following errors
                 <BulletAlignedUnorderedList>
-                  {errors.displayName && <li>{errors.displayName}</li>}
-                  {errors.organizationTypeEnum && <li>Organization Type should not be empty</li>}
-                  {errors.organizationTypeOtherText && <li>Organization Type 'Other' text should not be empty</li>}
-                  {errors.registeredTierEmailAddresses && <li>{errors.registeredTierEmailAddresses}</li>}
-                  {errors.registeredTierEmailDomains && <li>{errors.registeredTierEmailDomains}</li>}
-                  {errors.controlledTierEmailAddresses && <li>{errors.controlledTierEmailAddresses}</li>}
-                  {errors.controlledTierEmailDomains && <li>{errors.controlledTierEmailDomains}</li>}
+                  { // map each error with text we want to display to an error <li> if it is present
+                    [errors.displayName, errors.organizationTypeEnum,
+                    errors.registeredTierEmailAddresses, errors.registeredTierEmailDomains,
+                    errors.controlledTierEmailAddresses, errors.controlledTierEmailDomains]
+                        .map(e => e && <li key={e}>{e}</li>)}
+                {errors.organizationTypeOtherText && <li>Organization Type 'Other' requires additional information</li>}
                 </BulletAlignedUnorderedList>
               </div>
             } disable={this.isAddInstitutionMode}>

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -335,25 +335,29 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
   // Filter out empty line or empty email addresses like <email1>,,<email2> for registered tier
   filterEmptyRtEmailAddresses() {
     const updatedEmailAddresses = getRegisteredTierEmailAddresses(this.state.institution).filter(nonEmpty);
-    this.setState(fp.set(['institution', 'tierConfigs'], updateRtEmailAddresses(this.state.institution, updatedEmailAddresses)));
+    this.setState(fp.set(['institution', 'tierConfigs'],
+        updateRtEmailAddresses(this.state.institution, updatedEmailAddresses)));
   }
 
   // Filter out empty line or empty email addresses like <email1>,,<email2> for controlled tier
   filterEmptyCtEmailAddresses() {
     const updatedEmailAddresses = getControlledTierEmailAddresses(this.state.institution).filter(nonEmpty);
-    this.setState(fp.set(['institution', 'tierConfigs'], updateCtEmailAddresses(this.state.institution, updatedEmailAddresses)));
+    this.setState(fp.set(['institution', 'tierConfigs'],
+        updateCtEmailAddresses(this.state.institution, updatedEmailAddresses)));
   }
 
   // Filter out empty line or empty email addresses like <email1>,,<email2> for registered tier
   filterEmptyRtEmailDomains() {
     const updatedEmailDomains = getRegisteredTierEmailDomains(this.state.institution).filter(nonEmpty);
-    this.setState(fp.set(['institution', 'tierConfigs'], updateRtEmailDomains(this.state.institution, updatedEmailDomains)));
+    this.setState(fp.set(['institution', 'tierConfigs'],
+        updateRtEmailDomains(this.state.institution, updatedEmailDomains)));
   }
 
   // Filter out empty line or empty email addresses like <email1>,,<email2> for controlled tier
   filterEmptyCtEmailDomains() {
     const updatedEmailDomains = getControlledTierEmailDomains(this.state.institution).filter(nonEmpty);
-    this.setState(fp.set(['institution', 'tierConfigs'], updateCtEmailDomains(this.state.institution, updatedEmailDomains)));
+    this.setState(fp.set(['institution', 'tierConfigs'],
+        updateCtEmailDomains(this.state.institution, updatedEmailDomains)));
   }
 
   setRegisteredTierRequirement(membershipRequirement: InstitutionMembershipRequirement) {
@@ -361,7 +365,8 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
       ...getRegisteredTierConfig(this.state.institution),
       membershipRequirement: membershipRequirement,
     };
-    this.setState(fp.set(['institution', 'tierConfigs'], [rtTierConfig, getControlledTierConfig(this.state.institution)]));
+    this.setState(fp.set(['institution', 'tierConfigs'],
+        [rtTierConfig, getControlledTierConfig(this.state.institution)]));
   }
 
   setControlledTierRequirement(membershipRequirement: InstitutionMembershipRequirement) {
@@ -369,7 +374,8 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
       ...getControlledTierConfig(this.state.institution),
       membershipRequirement: membershipRequirement,
     };
-    this.setState(fp.set(['institution', 'tierConfigs'], [getRegisteredTierConfig(this.state.institution), ctTierConfig]));
+    this.setState(fp.set(['institution', 'tierConfigs'],
+        [getRegisteredTierConfig(this.state.institution), ctTierConfig]));
   }
 
   setRtRequireEra(eRAEnabled: boolean) {
@@ -377,7 +383,8 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
       ...getRegisteredTierConfig(this.state.institution),
       eraRequired: eRAEnabled
     };
-    this.setState(fp.set(['institution', 'tierConfigs'], [rtTierConfig, getControlledTierConfig(this.state.institution)]));
+    this.setState(fp.set(['institution', 'tierConfigs'],
+        [rtTierConfig, getControlledTierConfig(this.state.institution)]));
   }
 
   setCtRequireEra(eRAEnabled: boolean) {
@@ -385,7 +392,8 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
       ...getControlledTierConfig(this.state.institution),
       eraRequired: eRAEnabled
     };
-    this.setState(fp.set(['institution', 'tierConfigs'], [getRegisteredTierConfig(this.state.institution), ctTierConfig]));
+    this.setState(fp.set(['institution', 'tierConfigs'],
+        [getRegisteredTierConfig(this.state.institution), ctTierConfig]));
   }
 
   setEnableControlledTier(enableCtAccess: boolean) {
@@ -395,7 +403,8 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
       membershipRequirement: enableCtAccess === true ?
           InstitutionMembershipRequirement.DOMAINS : InstitutionMembershipRequirement.NOACCESS,
     };
-    this.setState(fp.set(['institution', 'tierConfigs'], [getRegisteredTierConfig(this.state.institution), ctTierConfig]));
+    this.setState(fp.set(['institution', 'tierConfigs'],
+        [getRegisteredTierConfig(this.state.institution), ctTierConfig]));
   }
 
   trimEmails(emails: string): Array<string> {
@@ -506,6 +515,7 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
     }
     this.setState({apiErrorMsg: errorMsg, showApiError: true});
   }
+
   updateInstitutionRole(institutionRole) {
     this.setState({showOtherInstitutionTextBox: institutionRole === OrganizationType.OTHER});
     this.setState(fp.set(['institution', 'organizationTypeEnum'], institutionRole));
@@ -546,7 +556,7 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
         }
         const invalid = getInvalidEmailAddresses(addresses);
         if (invalid.length > 0) {
-          return 'are not valid: ' + invalid.join(',');
+          return 'are not valid: ' + invalid.join(', ');
         }
       }
     };
@@ -560,7 +570,7 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
         }
         const invalid = getInvalidEmailDomains(domains);
         if (invalid.length > 0) {
-          return 'are not valid: ' + invalid.join(',');
+          return 'are not valid: ' + invalid.join(', ');
         }
       }
     };

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -674,11 +674,13 @@ export const AdminInstitutionEdit = fp.flow(withNavigation, withRouter)(class ex
             <TooltipTrigger data-test-id='tooltip' content={
               errors && this.disableSave(errors) && <div>Please correct the following errors
                 <BulletAlignedUnorderedList>
-                  { // map each error with text we want to display to an error <li> if it is present
-                    [errors.displayName, errors.organizationTypeEnum,
-                    errors.registeredTierEmailAddresses, errors.registeredTierEmailDomains,
-                    errors.controlledTierEmailAddresses, errors.controlledTierEmailDomains]
-                        .map(e => e && <li key={e}>{e}</li>)}
+                  {[errors.displayName,
+                    errors.organizationTypeEnum,
+                    errors.registeredTierEmailAddresses,
+                    errors.registeredTierEmailDomains,
+                    errors.controlledTierEmailAddresses,
+                    errors.controlledTierEmailDomains
+                  ].map(e => e && <li key={e}>{e}</li>)}
                 {errors.organizationTypeOtherText && <li>Organization Type 'Other' requires additional information</li>}
                 </BulletAlignedUnorderedList>
               </div>


### PR DESCRIPTION
Replace the awkward `onBlur` validation with `validate.js` for a much nicer user experience and a resolution to some related UX bugs.  Inspired by testing from @chavanr2019 demonstrating problems.

Before:

![Inst Admin Before](https://user-images.githubusercontent.com/2701406/134729786-039e7d53-c163-4a24-a413-65c943d2609c.gif)

After:

![Inst Admin After](https://user-images.githubusercontent.com/2701406/134729790-8ce3d9a8-4a74-4132-8f22-114936cec67d.gif)

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
