### PR TITLE
[RW-4982][risk=no] Throw on RDR export failures

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -23,6 +23,7 @@ import org.pmiops.workbench.db.model.DbRdrExport;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.db.model.RdrEntityEnums;
+import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.InstitutionalRole;
 import org.pmiops.workbench.model.RdrEntity;
@@ -148,6 +149,7 @@ public class RdrExportServiceImpl implements RdrExportService {
           String.format(
               "Error while sending researcher data to RDR for user IDs [%s]: %s",
               userIds, ex.getResponseBody()));
+      throw new ServerErrorException(ex);
     }
   }
 
@@ -179,13 +181,15 @@ public class RdrExportServiceImpl implements RdrExportService {
           updateDbRdrExport(RdrEntity.WORKSPACE, workspaceIds);
         }
       }
+      log.info(
+          String.format(
+              "successfully exported workspace data for workspace IDs: %s", workspaceIds));
     } catch (ApiException ex) {
       log.severe(
           String.format(
               "Error while sending workspace data to RDR for workspace IDs: %s", workspaceIds));
+      throw new ServerErrorException(ex);
     }
-    log.info(
-        String.format("successfully exported workspace data for workspace IDs: %s", workspaceIds));
   }
 
   // Convert workbench DBUser to RDR Model

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.rdr;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -36,6 +37,7 @@ import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.InstitutionalRole;
@@ -183,7 +185,7 @@ public class RdrExportServiceImplTest extends SpringTest {
     List<Long> userIds = new ArrayList<>();
     userIds.add(dbUserWithEmail.getUserId());
     userIds.add(dbUserWithoutEmail.getUserId());
-    rdrExportService.exportUsers(userIds);
+    assertThrows(ServerErrorException.class, () -> rdrExportService.exportUsers(userIds));
 
     verify(rdrExportService, times(0)).updateDbRdrExport(any(), anyList());
   }


### PR DESCRIPTION
We are already alerting on these task failures, however they didn't actually fail because exceptions were being suppressed. Fail the cloud task instead.