### PR TITLE
[risk=no] Support cached tokens, switch filename convention

### DIFF
--- a/e2e/libs/page-manager.ts
+++ b/e2e/libs/page-manager.ts
@@ -97,11 +97,11 @@ export const withPageTest = (launchOpts?: LaunchOptions) => async (
   });
 };
 
-export const withSignIn = (tokenFileName?: string) => async (
+export const withSignIn = (userEmail?: string) => async (
   testFn: (page: Page, browser: Browser) => Promise<void>
 ): Promise<void> => {
   await withPageTest()(async (page, browser) => {
-    await signInWithAccessToken(page, tokenFileName);
+    await signInWithAccessToken(page, userEmail);
     await testFn(page, browser);
   });
 };

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,7 +7,7 @@
   "license": "BSD",
   "scripts": {
     "_create-signin-token-dir": "mkdir -p ../e2e/signin-tokens",
-    "_impersonate-test-users": "yarn _create-signin-token-dir && env-cmd -x ../api/project.rb generate-impersonated-user-tokens --impersonated-usernames \\$USER_NAME,\\$READER_USER,\\$WRITER_USER,\\$COLLABORATOR_USER,\\$ACCESS_TEST_USER,\\$ADMIN_TEST_USER --output-token-filenames ../e2e/signin-tokens/puppeteer-access-token.txt,../e2e/signin-tokens/reader-puppeteer-access-token.txt,../e2e/signin-tokens/writer-puppeteer-access-token.txt,../e2e/signin-tokens/collaborator-puppeteer-access-token.txt,../e2e/signin-tokens/access-test-puppeteer-access-token.txt,../e2e/signin-tokens/admin-test-puppeteer-access-token.txt",
+    "_impersonate-test-users": "yarn _create-signin-token-dir && env-cmd -x ../api/project.rb generate-impersonated-user-tokens --impersonated-usernames \\$USER_NAME,\\$READER_USER,\\$WRITER_USER,\\$COLLABORATOR_USER,\\$ACCESS_TEST_USER,\\$ADMIN_TEST_USER --output-token-dir ../e2e/signin-tokens",
     "_test": "node -r dotenv/config . && yarn _impersonate-test-users && jest --no-color",
     "_test:debugTest": "node -r dotenv/config . && yarn _impersonate-test-users && node --inspect-brk node_modules/.bin/jest --no-color",
     "test": "cross-env WORKBENCH_ENV=test yarn _test --maxWorkers=5",

--- a/e2e/resources/workbench-config.ts
+++ b/e2e/resources/workbench-config.ts
@@ -8,7 +8,7 @@ const userCredential: ICredentialConfig = {
   PASSWORD: process.env.PASSWORD,
   INSTITUTION_CONTACT_EMAIL: 'aou-dev-registration@broadinstitute.org',
   LOGIN_GOV_PASSWORD: process.env.LOGIN_GOV_PASSWORD,
-  LOGIN_GOV_2FA_SECRET: process.env.LOGIN_GOV_2FA_SECRET,
+  LOGIN_GOV_2FA_SECRET: process.env.LOGIN_GOV_2FA_SECRET
 };
 
 const urlPath: IPathConfig = {

--- a/e2e/resources/workbench-config.ts
+++ b/e2e/resources/workbench-config.ts
@@ -9,14 +9,6 @@ const userCredential: ICredentialConfig = {
   INSTITUTION_CONTACT_EMAIL: 'aou-dev-registration@broadinstitute.org',
   LOGIN_GOV_PASSWORD: process.env.LOGIN_GOV_PASSWORD,
   LOGIN_GOV_2FA_SECRET: process.env.LOGIN_GOV_2FA_SECRET,
-  // This is passed via a file to leave open the future option to allow token
-  // refresh during a Puppeteer test run, and also limits logging exposure of the token.
-  USER_ACCESS_TOKEN_FILE: 'signin-tokens/puppeteer-access-token.txt',
-  COLLABORATOR_ACCESS_TOKEN_FILE: 'signin-tokens/collaborator-puppeteer-access-token.txt',
-  READER_ACCESS_TOKEN_FILE: 'signin-tokens/reader-puppeteer-access-token.txt',
-  WRITER_ACCESS_TOKEN_FILE: 'signin-tokens/writer-puppeteer-access-token.txt',
-  ACCESS_TEST_ACCESS_TOKEN_FILE: 'signin-tokens/access-test-puppeteer-access-token.txt',
-  ADMIN_TEST_ACCESS_TOKEN_FILE: 'signin-tokens/admin-test-puppeteer-access-token.txt'
 };
 
 const urlPath: IPathConfig = {

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -66,7 +66,7 @@ describe('Create Dataset', () => {
 
   test('Workspace READER cannot edit dataset', async () => {
     // READER log in in new Incognito page.
-    await signInWithAccessToken(page, config.READER_ACCESS_TOKEN_FILE);
+    await signInWithAccessToken(page, config.READER_USER);
 
     // Find workspace created by previous test. If not found, test will fail.
     const workspaceCard = await findWorkspaceCard(page, workspace);

--- a/e2e/tests/examples/sign-in.spec.ts
+++ b/e2e/tests/examples/sign-in.spec.ts
@@ -25,7 +25,7 @@ describe('login tests', () => {
 
   test('withPage example: Sign in as READER', async () => {
     await withPageTest()(async (page) => {
-      await signInWithAccessToken(page, config.READER_ACCESS_TOKEN_FILE);
+      await signInWithAccessToken(page, config.READER_USER);
       const homePage = new HomePage(page);
       const plusIcon = homePage.getCreateNewWorkspaceLink();
       expect(await plusIcon.asElementHandle()).toBeTruthy();
@@ -58,7 +58,7 @@ describe('login tests', () => {
   });
 
   test('withSignIn example: Entering user email and password', async () => {
-    await withSignIn(config.READER_ACCESS_TOKEN_FILE)(async (page, _browser) => {
+    await withSignIn(config.READER_USER)(async (page, _browser) => {
       const workspacesPage = new WorkspacesPage(page);
       await workspacesPage.load();
       expect(await workspacesPage.isLoaded()).toBe(true);

--- a/e2e/tests/nightly/admin/user-admin-ui.spec.ts
+++ b/e2e/tests/nightly/admin/user-admin-ui.spec.ts
@@ -9,7 +9,7 @@ describe('Admin', () => {
   const userEmail = 'admin_test';
 
   beforeEach(async () => {
-    await signInWithAccessToken(page, config.ADMIN_TEST_ACCESS_TOKEN_FILE);
+    await signInWithAccessToken(page, config.ADMIN_TEST_USER);
     await navigation.navMenu(page, NavLink.USER_ADMIN);
   });
 

--- a/e2e/tests/nightly/user-access.spec.ts
+++ b/e2e/tests/nightly/user-access.spec.ts
@@ -14,7 +14,7 @@ import HomePage from 'app/page/home-page';
 
 describe('User Access', () => {
   beforeEach(async () => {
-    await signInWithAccessToken(page, config.ACCESS_TEST_ACCESS_TOKEN_FILE, new AccessRenewalPage(page));
+    await signInWithAccessToken(page, config.ACCESS_TEST_USER, new AccessRenewalPage(page));
   });
 
   // note that this test is "destructive" in that it brings the user to a state

--- a/e2e/tests/notebook/notebook-reader-actions.spec.ts
+++ b/e2e/tests/notebook/notebook-reader-actions.spec.ts
@@ -57,7 +57,7 @@ describe('Workspace READER Jupyter notebook action tests', () => {
 
   test('Workspace READER copy notebook to another workspace', async () => {
     // READER log in.
-    await signInWithAccessToken(page, config.READER_ACCESS_TOKEN_FILE);
+    await signInWithAccessToken(page, config.READER_USER);
 
     await findOrCreateWorkspace(page, { workspaceName: readerWorkspaceName });
 
@@ -151,7 +151,7 @@ describe('Workspace READER Jupyter notebook action tests', () => {
   // TODO(RW-7287): Re-enable once Terra clone is fixed.
   test.skip('Workspace READER edit copy of notebook in workspace clone', async () => {
     // READER log in.
-    await signInWithAccessToken(page, config.READER_ACCESS_TOKEN_FILE);
+    await signInWithAccessToken(page, config.READER_USER);
 
     // Verify shared Workspace Access Level is READER.
     await new WorkspacesPage(page).load();

--- a/e2e/tests/workspace/workspace-share.spec.ts
+++ b/e2e/tests/workspace/workspace-share.spec.ts
@@ -10,13 +10,11 @@ describe('Workspace Reader and Writer Permission Test', () => {
   const assignAccess = [
     {
       accessRole: WorkspaceAccessLevel.Writer,
-      userEmail: config.WRITER_USER,
-      userAccessTokenFilename: config.WRITER_ACCESS_TOKEN_FILE
+      userEmail: config.WRITER_USER
     },
     {
       accessRole: WorkspaceAccessLevel.Reader,
-      userEmail: config.READER_USER,
-      userAccessTokenFilename: config.READER_ACCESS_TOKEN_FILE
+      userEmail: config.READER_USER
     }
   ];
 
@@ -53,8 +51,7 @@ describe('Workspace Reader and Writer Permission Test', () => {
 
   // Test depends on previous test: Will fail when workspace is not found and share didn't work.
   test.each(assignAccess)('Verify WRITER and READER cannot share, edit or delete workspace', async (assign) => {
-    // Log in could fail if encounters Google Captcha
-    await signInWithAccessToken(page, assign.userAccessTokenFilename);
+    await signInWithAccessToken(page, assign.userEmail);
 
     // Find workspace created by previous test. If not found, test will fail.
     const workspaceCard = await findWorkspaceCard(page, workspace);

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -4,14 +4,6 @@ export interface ICredentialConfig {
   INSTITUTION_CONTACT_EMAIL: string;
   LOGIN_GOV_PASSWORD: string;
   LOGIN_GOV_2FA_SECRET: string;
-  // This is passed via a file to leave open the future option to allow token
-  // refresh during a Puppeteer test run, and also limits logging exposure of the token.
-  USER_ACCESS_TOKEN_FILE: string;
-  COLLABORATOR_ACCESS_TOKEN_FILE: string;
-  READER_ACCESS_TOKEN_FILE: string;
-  WRITER_ACCESS_TOKEN_FILE: string;
-  ACCESS_TEST_ACCESS_TOKEN_FILE: string;
-  ADMIN_TEST_ACCESS_TOKEN_FILE: string;
 }
 
 export interface IPathConfig {

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -34,10 +34,11 @@ declare const window: Window &
 
 export async function signInWithAccessToken(
   page: Page,
-  tokenFilename = config.USER_ACCESS_TOKEN_FILE,
+  userEmail = config.USER_NAME,
   postSignInPage: AuthenticatedPage = new HomePage(page)
 ): Promise<void> {
-  const token = fs.readFileSync(tokenFilename, 'ascii');
+  // Keep file naming convention synchronized with generate-impersonated-user-tokens
+  const token = fs.readFileSync(`signin-tokens/${userEmail}.txt`, 'ascii');
   logger.info('Sign in with access token to Workbench application');
   const homePage = new HomePage(page);
   await homePage.gotoUrl(PageUrl.Home);


### PR DESCRIPTION
If tokens were created within the past 15m, don't regenerate. This speeds up iterative testing cycles.

Filename format for tokens is now:

```
token-dir/{impersonated_email}.txt
```

This change was made to avoid caching bugs. We should regenerate tokens if we, for example, switch between environments.