### PR TITLE
[risk=no][RW-6931] rm last instances of Profile completionTime / bypassTime from the UI

### DIFF
--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -26,7 +26,6 @@ interface RegistrationTask {
   description: React.ReactNode;
   buttonText: string;
   completedText: string;
-  completionTimestamp: (profile: Profile) => number;
   onClick: Function;
   featureFlag?: boolean;
 }
@@ -103,9 +102,6 @@ export const getRegistrationTasks = (navigate): RegistrationTask[] => serverConf
         'in addition to your password to verify your identity upon login.',
     buttonText: 'Get Started',
     completedText: 'Completed',
-    completionTimestamp: (profile: Profile) => {
-      return profile.twoFactorAuthCompletionTime || profile.twoFactorAuthBypassTime;
-    },
     onClick: redirectToTwoFactorSetup
   }, {
     key: 'rasLoginGov',
@@ -117,9 +113,6 @@ export const getRegistrationTasks = (navigate): RegistrationTask[] => serverConf
     description: 'Connect your Researcher Workbench account to your login.gov account. ',
     buttonText: 'Connect',
     completedText: 'Linked',
-    completionTimestamp: (profile: Profile) => {
-      return profile.rasLinkLoginGovCompletionTime || profile.rasLinkLoginGovBypassTime;
-    },
     onClick: redirectToRas
   }, {
     key: 'eraCommons',
@@ -132,9 +125,6 @@ export const getRegistrationTasks = (navigate): RegistrationTask[] => serverConf
     featureFlag: serverConfigStore.get().config.enableEraCommons,
     buttonText: 'Connect',
     completedText: 'Linked',
-    completionTimestamp: (profile: Profile) => {
-      return profile.eraCommonsCompletionTime || profile.eraCommonsBypassTime;
-    },
     onClick: redirectToNiH
   }, {
     key: 'complianceTraining',
@@ -146,9 +136,6 @@ export const getRegistrationTasks = (navigate): RegistrationTask[] => serverConf
     buttonText: 'Complete training',
     featureFlag: serverConfigStore.get().config.enableComplianceTraining,
     completedText: 'Completed',
-    completionTimestamp: (profile: Profile) => {
-      return profile.complianceTrainingCompletionTime || profile.complianceTrainingBypassTime;
-    },
     onClick: redirectToTraining
   }, {
     key: 'dataUserCodeOfConduct',
@@ -158,18 +145,6 @@ export const getRegistrationTasks = (navigate): RegistrationTask[] => serverConf
     description: <span>Sign the Data User Code of Conduct consenting to the <AoU/> data use policy.</span>,
     buttonText: 'View & Sign',
     completedText: 'Signed',
-    completionTimestamp: (profile: Profile) => {
-      if (profile.dataUseAgreementBypassTime) {
-        return profile.dataUseAgreementBypassTime;
-      }
-      // The DUCC completion time field tracks the most recent DUCC completion
-      // timestamp, but doesn't specify whether that DUCC is currently active.
-      const requiredDuccVersion = getLiveDUCCVersion();
-      if (profile.dataUseAgreementSignedVersion === requiredDuccVersion) {
-        return profile.dataUseAgreementCompletionTime;
-      }
-      return null;
-    },
     onClick: () => {
       AnalyticsTracker.Registration.EnterDUCC();
       navigate(['data-code-of-conduct']);


### PR DESCRIPTION
These fields are no longer referenced by anything since RegistrationDashboard was removed.

You may notice this pattern remains in admin-user but this is deceptive: it uses AdminTableUser instead of Profile.  AdminTableUser does not need to change at this time.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
