### PR TITLE
[RW-7334][risk=no] Bump cloud sql db version in prod

### DIFF
--- a/api/config/cdr_config_prod.json
+++ b/api/config/cdr_config_prod.json
@@ -102,7 +102,7 @@
       "creationTime": "2021-08-10 00:00:00Z",
       "releaseNumber": 5,
       "numParticipants": 329070,
-      "cdrDbName": "r_2021q3_1",
+      "cdrDbName": "r_2021q3_3",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"


### PR DESCRIPTION
Bumps version for Registered Tier Dataset v5 from `r_2021q3_1` to `r_2021q3_3`