### PR TITLE
[risk=no] Drop start/stop API reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,47 +85,6 @@ Other available operations may be discovered by running:
 ./project.rb
 ```
 
-#### API: Faster API startup for MacOS
-The above steps for starting the API server can take upwards of 8-10 minutes on MacOS, most likely due to performance issues with Docker for Mac. Follow these steps to set up your developer environment to start the API server outside of docker. A full restart should take ~30 seconds with this method.
-
-All commands should be run from `workbench/api`
-
-##### Setup
-* Install Java 8
-* Add following to `~/.bash_profile`. Note:
-    * Your Java8 library directory may be different.  
-      YOUR_WORKBENCH_DIRECTORY_PATH is the pathname to your workbench git repo.
-      ```Shell
-      export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_201.jdk/Contents/Home
-      export WORKBENCH_DIR=[YOUR_WORKBENCH_DIRECTORY_PATH]
-      source $WORKBENCH_DIR/api/db/load_vars.sh
-      ```
-        * If you are using zsh, add the lines above to `~/.zshrc`.
-    * Source your bash profile or open a new terminal
-      ```Shell
-      source `~/.bash_profile`
-      ```
-* Install Java App Engine components
-    * ```Shell
-      gcloud components install app-engine-java
-      ```
-* Generate Google Cloud access token
-    * ```Shell
-      ./project.rb get-test-service-creds
-      ```
-
-##### Usage
-* If you have schema migrations or pending configuration updates, run through the [normal docker developer startup process](#api-dev-appengine-appserver) at least once successfully. This is typically only necessary when switching between branches.
-* Start services required for API server
-    * ```Shell
-      ./project.rb start-api-reqs
-      # the counterpart command is ./project.rb stop-api-reqs
-      ```
-* Start API server through gradle
-    * ```Shell
-      ./gradlew appengineRun
-      ```
-
 #### Hot Code Swapping
 
 While the API is running locally, saving a .java file should cause a recompile and reload of that class. Status is logged to the console. Not all changes reload correctly (e.g., model classes do not appear to reload more than once).

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -146,31 +146,6 @@ Common.register_command({
   :fn => ->(*args) { dev_up("dev-up", args) }
 })
 
-def start_api_reqs()
-  common = Common.new
-  common.status "Starting database..."
-  common.run_inline %W{docker-compose up -d db}
-end
-
-Common.register_command({
-  :invocation => "start-api-reqs",
-  :description => "Starts up the services required for the API server" \
-     "(assumes database and config are already up-to-date.)",
-  :fn => Proc.new { start_api_reqs() }
-})
-
-def stop_api_reqs()
-  common = Common.new
-  common.status "Stopping database..."
-  common.run_inline %W{docker-compose stop db}
-end
-
-Common.register_command({
-  :invocation => "stop-api-reqs",
-  :description => "Stops the services required for the API server",
-  :fn => Proc.new { stop_api_reqs() }
-})
-
 def setup_local_environment()
   ENV.update(Workbench.read_vars_file("db/vars.env"))
   ENV.update(must_get_env_value("local", :gae_vars))


### PR DESCRIPTION
This is no longer necessary, as dev-up now runs the API server outside of docker.