### PR TITLE
[risk=low][no ticket] Force semver-regex bump due to vuln

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -124,12 +124,13 @@
     "webpack": "4.44.2"
   },
   "resolutions": {
-    "node-fetch": "^2.6.1",
-    "node-gyp": "^4",
-    "immer": "^9.0.6",
     "browserslist": "^4.16.5",
     "glob-parent":  "^5.1.2",
+    "immer": "^9.0.6",
+    "node-fetch": "^2.6.1",
+    "node-gyp": "^4",
     "nth-check":  "^2.0.1",
+    "semver-regex": "^3.1.3",
     "set-value": "^4.0.1"
   }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -12635,10 +12635,10 @@ semver-dsl@^1.0.1:
   dependencies:
     semver "^5.3.0"
 
-semver-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
-  integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
+semver-regex@^2.0.0, semver-regex@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.3.tgz#b2bcc6f97f63269f286994e297e229b6245d0dc3"
+  integrity sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==
 
 semver-truncate@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
https://github.com/advisories/GHSA-44c6-4v22-4mhx

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
