### PR TITLE
[RW-7314][risk=low] Implement a compute security suspension state for a user

### DIFF
--- a/api/db/changelog/db.changelog-178-add-compute-security-suspended-column.xml
+++ b/api/db/changelog/db.changelog-178-add-compute-security-suspended-column.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="calbach" id="changelog-178-add-compute-security-suspended">
+    <addColumn tableName="user">
+      <column name="compute_security_suspended_until" type="datetime" />
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -187,6 +187,7 @@
   <include file="changelog/db.changelog-175-add-ct-training-access-module.xml"/>
   <include file="changelog/db.changelog-176-drop-dua-type-column.xml"/>
   <include file="changelog/db.changelog-177-add-egress-event-table.xml"/>
+  <include file="changelog/db.changelog-178-add-compute-security-suspended-column.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -3,6 +3,9 @@ package org.pmiops.workbench.api;
 import com.google.common.collect.ImmutableList;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -24,6 +27,7 @@ import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.exceptions.FailedPreconditionException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
@@ -34,6 +38,8 @@ import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeStatus;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.EmptyResponse;
+import org.pmiops.workbench.model.ErrorCode;
+import org.pmiops.workbench.model.ErrorResponse;
 import org.pmiops.workbench.model.GceWithPdConfig;
 import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
 import org.pmiops.workbench.model.ListRuntimeResponse;
@@ -42,6 +48,7 @@ import org.pmiops.workbench.model.Runtime;
 import org.pmiops.workbench.model.RuntimeLocalizeRequest;
 import org.pmiops.workbench.model.RuntimeLocalizeResponse;
 import org.pmiops.workbench.model.RuntimeStatus;
+import org.pmiops.workbench.model.SecuritySuspendedErrorParameters;
 import org.pmiops.workbench.model.UpdateRuntimeRequest;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.notebooks.LeonardoNotebooksClient;
@@ -70,6 +77,7 @@ public class RuntimeController implements RuntimeApiDelegate {
 
   private static final Logger log = Logger.getLogger(RuntimeController.class.getName());
 
+  private final Clock clock;
   private final LeonardoRuntimeAuditor leonardoRuntimeAuditor;
   private final LeonardoNotebooksClient leonardoNotebooksClient;
   private final Provider<DbUser> userProvider;
@@ -82,6 +90,7 @@ public class RuntimeController implements RuntimeApiDelegate {
 
   @Autowired
   RuntimeController(
+      Clock clock,
       LeonardoRuntimeAuditor leonardoRuntimeAuditor,
       LeonardoNotebooksClient leonardoNotebooksClient,
       Provider<DbUser> userProvider,
@@ -91,6 +100,7 @@ public class RuntimeController implements RuntimeApiDelegate {
       Provider<WorkbenchConfig> workbenchConfigProvider,
       UserRecentResourceService userRecentResourceService,
       LeonardoMapper leonardoMapper) {
+    this.clock = clock;
     this.leonardoRuntimeAuditor = leonardoRuntimeAuditor;
     this.leonardoNotebooksClient = leonardoNotebooksClient;
     this.userProvider = userProvider;
@@ -171,9 +181,12 @@ public class RuntimeController implements RuntimeApiDelegate {
         workspaceNamespace, firecloudWorkspaceName, WorkspaceAccessLevel.WRITER);
     workspaceAuthService.validateActiveBilling(workspaceNamespace, firecloudWorkspaceName);
 
+    DbUser user = userProvider.get();
+    enforceComputeSecuritySuspension(user);
+
     try {
       LeonardoGetRuntimeResponse leoRuntimeResponse =
-          leonardoNotebooksClient.getRuntime(googleProject, userProvider.get().getRuntimeName());
+          leonardoNotebooksClient.getRuntime(googleProject, user.getRuntimeName());
       if (LeonardoRuntimeStatus.ERROR.equals(leoRuntimeResponse.getStatus())) {
         log.warning(
             String.format(
@@ -276,10 +289,13 @@ public class RuntimeController implements RuntimeApiDelegate {
         workspaceNamespace, firecloudWorkspaceName, WorkspaceAccessLevel.WRITER);
     workspaceAuthService.validateActiveBilling(workspaceNamespace, firecloudWorkspaceName);
 
-    runtime.setGoogleProject(dbWorkspace.getGoogleProject());
-    runtime.setRuntimeName(userProvider.get().getRuntimeName());
+    DbUser user = userProvider.get();
+    enforceComputeSecuritySuspension(user);
 
-    leonardoNotebooksClient.createRuntime(runtime, workspaceNamespace, firecloudWorkspaceName);
+    leonardoNotebooksClient.createRuntime(
+        runtime.googleProject(dbWorkspace.getGoogleProject()).runtimeName(user.getRuntimeName()),
+        workspaceNamespace,
+        firecloudWorkspaceName);
     return ResponseEntity.ok(new EmptyResponse());
   }
 
@@ -306,10 +322,14 @@ public class RuntimeController implements RuntimeApiDelegate {
         workspaceNamespace, firecloudWorkspaceName, WorkspaceAccessLevel.WRITER);
     workspaceAuthService.validateActiveBilling(workspaceNamespace, firecloudWorkspaceName);
 
-    runtimeRequest.getRuntime().setGoogleProject(dbWorkspace.getGoogleProject());
-    runtimeRequest.getRuntime().setRuntimeName(userProvider.get().getRuntimeName());
+    DbUser user = userProvider.get();
+    enforceComputeSecuritySuspension(user);
 
-    leonardoNotebooksClient.updateRuntime(runtimeRequest.getRuntime());
+    leonardoNotebooksClient.updateRuntime(
+        runtimeRequest
+            .getRuntime()
+            .googleProject(dbWorkspace.getGoogleProject())
+            .runtimeName(user.getRuntimeName()));
 
     return ResponseEntity.ok(new EmptyResponse());
   }
@@ -322,9 +342,12 @@ public class RuntimeController implements RuntimeApiDelegate {
     workspaceAuthService.enforceWorkspaceAccessLevel(
         workspaceNamespace, firecloudWorkspaceName, WorkspaceAccessLevel.WRITER);
 
+    DbUser user = userProvider.get();
+    enforceComputeSecuritySuspension(user);
+
     leonardoNotebooksClient.deleteRuntime(
         dbWorkspace.getGoogleProject(),
-        userProvider.get().getRuntimeName(),
+        user.getRuntimeName(),
         Optional.ofNullable(deleteDisk).orElse(false));
     return ResponseEntity.ok(new EmptyResponse());
   }
@@ -339,6 +362,9 @@ public class RuntimeController implements RuntimeApiDelegate {
         WorkspaceAccessLevel.WRITER);
     workspaceAuthService.validateActiveBilling(
         dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
+
+    DbUser user = userProvider.get();
+    enforceComputeSecuritySuspension(user);
 
     final FirecloudWorkspace firecloudWorkspace;
     try {
@@ -377,7 +403,7 @@ public class RuntimeController implements RuntimeApiDelegate {
 
     leonardoNotebooksClient.createStorageLink(
         googleProjectId,
-        userProvider.get().getRuntimeName(),
+        user.getRuntimeName(),
         new StorageLink()
             .cloudStorageDirectory(gcsNotebooksDir)
             .localBaseDirectory(editDir)
@@ -407,6 +433,21 @@ public class RuntimeController implements RuntimeApiDelegate {
 
     // This is the Jupyer-server-root-relative path, the style used by the Jupyter REST API.
     return ResponseEntity.ok(new RuntimeLocalizeResponse().runtimeLocalDirectory(targetDir));
+  }
+
+  private void enforceComputeSecuritySuspension(DbUser user) throws FailedPreconditionException {
+    Optional<Instant> suspendedUntil =
+        Optional.ofNullable(user.getComputeSecuritySuspendedUntil()).map(Timestamp::toInstant);
+    if (suspendedUntil.isPresent() && clock.instant().isBefore(suspendedUntil.get())) {
+      throw new FailedPreconditionException(
+          new ErrorResponse()
+              .errorCode(ErrorCode.COMPUTE_SECURITY_SUSPENDED)
+              .message("user is suspended from compute for security reasons")
+              .parameters(
+                  new SecuritySuspendedErrorParameters()
+                      // Instant.toString() yields ISO-8601
+                      .suspendedUntil(suspendedUntil.get().toString())));
+    }
   }
 
   private String jsonToDataUri(JSONObject json) {

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -174,15 +174,15 @@ public class RuntimeController implements RuntimeApiDelegate {
 
   @Override
   public ResponseEntity<Runtime> getRuntime(String workspaceNamespace) {
+    DbUser user = userProvider.get();
+    enforceComputeSecuritySuspension(user);
+
     DbWorkspace dbWorkspace = lookupWorkspace(workspaceNamespace);
     String firecloudWorkspaceName = dbWorkspace.getFirecloudName();
     String googleProject = dbWorkspace.getGoogleProject();
     workspaceAuthService.enforceWorkspaceAccessLevel(
         workspaceNamespace, firecloudWorkspaceName, WorkspaceAccessLevel.WRITER);
     workspaceAuthService.validateActiveBilling(workspaceNamespace, firecloudWorkspaceName);
-
-    DbUser user = userProvider.get();
-    enforceComputeSecuritySuspension(user);
 
     try {
       LeonardoGetRuntimeResponse leoRuntimeResponse =
@@ -283,14 +283,14 @@ public class RuntimeController implements RuntimeApiDelegate {
           "Exactly one of GceConfig or DataprocConfig or GceWithPdConfig must be provided");
     }
 
+    DbUser user = userProvider.get();
+    enforceComputeSecuritySuspension(user);
+
     DbWorkspace dbWorkspace = lookupWorkspace(workspaceNamespace);
     String firecloudWorkspaceName = dbWorkspace.getFirecloudName();
     workspaceAuthService.enforceWorkspaceAccessLevel(
         workspaceNamespace, firecloudWorkspaceName, WorkspaceAccessLevel.WRITER);
     workspaceAuthService.validateActiveBilling(workspaceNamespace, firecloudWorkspaceName);
-
-    DbUser user = userProvider.get();
-    enforceComputeSecuritySuspension(user);
 
     leonardoNotebooksClient.createRuntime(
         runtime.googleProject(dbWorkspace.getGoogleProject()).runtimeName(user.getRuntimeName()),
@@ -316,14 +316,14 @@ public class RuntimeController implements RuntimeApiDelegate {
       throw new BadRequestException("Only one of GceConfig or DataprocConfig must be provided");
     }
 
+    DbUser user = userProvider.get();
+    enforceComputeSecuritySuspension(user);
+
     DbWorkspace dbWorkspace = lookupWorkspace(workspaceNamespace);
     String firecloudWorkspaceName = dbWorkspace.getFirecloudName();
     workspaceAuthService.enforceWorkspaceAccessLevel(
         workspaceNamespace, firecloudWorkspaceName, WorkspaceAccessLevel.WRITER);
     workspaceAuthService.validateActiveBilling(workspaceNamespace, firecloudWorkspaceName);
-
-    DbUser user = userProvider.get();
-    enforceComputeSecuritySuspension(user);
 
     leonardoNotebooksClient.updateRuntime(
         runtimeRequest
@@ -337,13 +337,13 @@ public class RuntimeController implements RuntimeApiDelegate {
   @Override
   public ResponseEntity<EmptyResponse> deleteRuntime(
       String workspaceNamespace, Boolean deleteDisk) {
+    DbUser user = userProvider.get();
+    enforceComputeSecuritySuspension(user);
+
     DbWorkspace dbWorkspace = lookupWorkspace(workspaceNamespace);
     String firecloudWorkspaceName = dbWorkspace.getFirecloudName();
     workspaceAuthService.enforceWorkspaceAccessLevel(
         workspaceNamespace, firecloudWorkspaceName, WorkspaceAccessLevel.WRITER);
-
-    DbUser user = userProvider.get();
-    enforceComputeSecuritySuspension(user);
 
     leonardoNotebooksClient.deleteRuntime(
         dbWorkspace.getGoogleProject(),
@@ -355,6 +355,9 @@ public class RuntimeController implements RuntimeApiDelegate {
   @Override
   public ResponseEntity<RuntimeLocalizeResponse> localize(
       String workspaceNamespace, RuntimeLocalizeRequest body) {
+    DbUser user = userProvider.get();
+    enforceComputeSecuritySuspension(user);
+
     DbWorkspace dbWorkspace = lookupWorkspace(workspaceNamespace);
     workspaceAuthService.enforceWorkspaceAccessLevel(
         dbWorkspace.getWorkspaceNamespace(),
@@ -362,9 +365,6 @@ public class RuntimeController implements RuntimeApiDelegate {
         WorkspaceAccessLevel.WRITER);
     workspaceAuthService.validateActiveBilling(
         dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
-
-    DbUser user = userProvider.get();
-    enforceComputeSecuritySuspension(user);
 
     final FirecloudWorkspace firecloudWorkspace;
     try {

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -92,8 +92,9 @@ public class DbUser {
   private Timestamp twoFactorAuthBypassTime;
 
   private Timestamp profileLastConfirmedTime;
-
   private Timestamp publicationsLastConfirmedTime;
+
+  private Timestamp computeSecuritySuspendedUntil;
 
   // potentially obsolete access module fields.  These are likely to be deleted in the near future.
   // Moodle badges are indexed by username, not this value.  See ComplianceService.
@@ -517,6 +518,15 @@ public class DbUser {
 
   public void setPublicationsLastConfirmedTime(Timestamp publicationsLastConfirmedTime) {
     this.publicationsLastConfirmedTime = publicationsLastConfirmedTime;
+  }
+
+  @Column(name = "compute_security_suspended_until")
+  public Timestamp getComputeSecuritySuspendedUntil() {
+    return computeSecuritySuspendedUntil;
+  }
+
+  public void setComputeSecuritySuspendedUntil(Timestamp computeSecuritySuspendedUntil) {
+    this.computeSecuritySuspendedUntil = computeSecuritySuspendedUntil;
   }
 
   // null-friendly versions of equals() and hashCode() for DbVerifiedInstitutionalAffiliation

--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionAdvice.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionAdvice.java
@@ -42,7 +42,8 @@ public class ExceptionAdvice {
       if (thrownErrorResponse != null) {
         errorResponse
             .message(thrownErrorResponse.getMessage())
-            .errorCode(thrownErrorResponse.getErrorCode());
+            .errorCode(thrownErrorResponse.getErrorCode())
+            .parameters(thrownErrorResponse.getParameters());
       }
     }
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -704,6 +704,10 @@ paths:
           description: No runtime exists for this user and workspace.
           schema:
             "$ref": "#/definitions/ErrorResponse"
+        412:
+          description: Compute is temporarily suspended for security reasons.
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
     post:
       summary: Create a workspace runtime.
       description: |
@@ -729,6 +733,10 @@ paths:
           description: A runtime for this user and workspace already exists.
           schema:
             "$ref": "#/definitions/EmptyResponse"
+        412:
+          description: Compute is temporarily suspended for security reasons.
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
     patch:
       summary: Updates the configuration of a runtime
       description: In order to update the configuration of a runtime, it must first be running or paused
@@ -748,6 +756,10 @@ paths:
             "$ref": "#/definitions/EmptyResponse"
         400:
           description: Bad Request
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
+        412:
+          description: Compute is temporarily suspended for security reasons.
           schema:
             "$ref": "#/definitions/ErrorResponse"
         500:
@@ -778,6 +790,10 @@ paths:
           description: No runtime exists for this user and workspace.
           schema:
             "$ref": "#/definitions/ErrorResponse"
+        412:
+          description: Compute is temporarily suspended for security reasons.
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
   "/v1/runtimes/{workspaceNamespace}/localize":
     post:
       summary: Localize files to the user's runtime.
@@ -803,6 +819,10 @@ paths:
             "$ref": "#/definitions/RuntimeLocalizeResponse"
         404:
           description: Runtime or Workspace not found
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
+        412:
+          description: Compute is temporarily suspended for security reasons.
           schema:
             "$ref": "#/definitions/ErrorResponse"
         500:
@@ -4224,6 +4244,12 @@ definitions:
       category:
         "$ref": "#/definitions/FeaturedWorkspaceCategory"
         description: The category that this workspace belongs to
+  SecuritySuspendedErrorParameters:
+    type: object
+    properties:
+      suspendedUntil:
+        type: string
+        description: The time at which the security suspension will end, if any, in ISO 8601 format.
   ErrorResponse:
     type: object
     properties:
@@ -4242,12 +4268,17 @@ definitions:
         type: string
         description: Unique ID for this error response, for correlation with backend
           logs
+      parameters:
+        type: object
+        description: Additional structured error parameters, specific to the error code.
+        additionalProperties: true
   ErrorCode:
     type: string
     description: Short parsable error descriptions
     enum:
     - PARSE_ERROR
     - USER_DISABLED
+    - COMPUTE_SECURITY_SUSPENDED
   StatusResponse:
     type: object
     required:


### PR DESCRIPTION
- Add database support for the column
- Add API support for disabling compute endpoints, with error plumbing
- Add a new `parameters` field to the error response for error-specific structured data. This will be used for rendering the "until" timestamp appropriately on the client

Not part of this PR:
- A service method for suspending a user
- UI handling of the suspended error status

Tested manually by setting the column locally:
```
update user set compute_security_suspended_until=date_add(NOW(), interval 1 minute) where user_id=1;
Query OK, 1 row affected (0.01 sec)
```

![image](https://user-images.githubusercontent.com/822298/135942105-33187fec-0573-42f9-9524-a34d88804812.png)
