### PR TITLE
[no ticket][risk=no] Increase e2e genomic-extraction-to-vcf test auto-pause time

### DIFF
--- a/e2e/app/component/runtime-panel.ts
+++ b/e2e/app/component/runtime-panel.ts
@@ -10,6 +10,11 @@ import RadioButton from 'app/element/radiobutton';
 
 const defaultXpath = '//*[@id="runtime-panel"]';
 
+export enum AutoPauseIdleTime {
+  ThirtyMinutes = '30 minutes (default)',
+  EightHours = '8 hours'
+}
+
 export enum StartStopIconState {
   Error = 'error',
   None = 'none',
@@ -76,6 +81,15 @@ export default class RuntimePanel extends BaseHelpSidebar {
   async pickComputeType(computeType: ComputeType): Promise<void> {
     const computeTypeDropdown = this.getComputeTypeSelect();
     return await computeTypeDropdown.select(computeType);
+  }
+
+  getAutoPauseSelect(): SelectMenu {
+    return SelectMenu.findByName(this.page, { id: 'runtime-autopause' }, this);
+  }
+
+  async pickAutoPauseTime(pauseTime: AutoPauseIdleTime): Promise<void> {
+    const autoPauseDropdown = this.getAutoPauseSelect();
+    return await autoPauseDropdown.select(pauseTime);
   }
 
   async pickDataprocNumWorkers(numWorkers: number): Promise<void> {

--- a/e2e/tests/nightly/genomic-extraction-to-vcf.spec.ts
+++ b/e2e/tests/nightly/genomic-extraction-to-vcf.spec.ts
@@ -31,7 +31,7 @@ describe('Genomics Extraction Test', () => {
 
   const maxWaitTime = 50 * 60 * 1000;
   const workspaceName = makeWorkspaceName();
-  const notebookName = makeRandomName('testPyNotebook');
+  const notebookName = makeRandomName('genomicDataToVcf');
 
   test('Export genomics dataset to new notebook', async () => {
     await findOrCreateWorkspace(page, { cdrVersion: config.ALTERNATIVE_CDR_VERSION_NAME, workspaceName });

--- a/e2e/tests/nightly/genomic-extraction-to-vcf.spec.ts
+++ b/e2e/tests/nightly/genomic-extraction-to-vcf.spec.ts
@@ -2,18 +2,18 @@ import { findOrCreateWorkspace, signInWithAccessToken } from 'utils/test-utils';
 import { config } from 'resources/workbench-config';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import {
+  AgeSelectionRadioButton,
   AnalysisTool,
-  Language,
-  LinkText,
   ConceptSetSelectValue,
   DatasetValueSelect,
-  AgeSelectionRadioButton
+  Language,
+  LinkText
 } from 'app/text-labels';
 import CohortActionsPage from 'app/page/cohort-actions-page';
 import { makeRandomName, makeWorkspaceName } from 'utils/str-utils';
 import GenomicsVariantExtractConfirmationModal from 'app/modal/genomic-extract-confirmation-modal';
 import ExportToNotebookModal from 'app/modal/export-to-notebook-modal';
-import RuntimePanel, { ComputeType } from 'app/component/runtime-panel';
+import RuntimePanel, { AutoPauseIdleTime, ComputeType } from 'app/component/runtime-panel';
 import { logger } from 'libs/logger';
 import GenomicExtractionsSidebar from 'app/component/genomic-extractions-sidebar';
 import { Page } from 'puppeteer';
@@ -98,6 +98,10 @@ describe('Genomics Extraction Test', () => {
 
     // Change Compute Type to Dataproc Cluster.
     await runtimePanel.pickComputeType(ComputeType.Dataproc);
+
+    // Increase runtime auto-pause time because runtime will auto. pause after 30 min (default value) of idle
+    // while export to vcf file still in progress.
+    await runtimePanel.pickAutoPauseTime(AutoPauseIdleTime.EightHours);
 
     // Disk (GB) is visible after select Dataproc Cluster.
     expect(await runtimePanel.getDiskGbs()).toBe(100);


### PR DESCRIPTION
The autopause 30 min default can cause test to fail when runtime creation finish quickly but extraction to vcf take a long time.