### PR TITLE
[risk=no] Enable genomic extraction in staging+perf

### DIFF
--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -100,7 +100,7 @@
     "enableBillingUpgrade": false,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
-    "enableGenomicExtraction": false,
+    "enableGenomicExtraction": true,
     "enableFireCloudV2Billing" : true,
     "enableGpu": false,
     "enablePersistentDisk": false,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -100,7 +100,7 @@
     "enableBillingUpgrade": false,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,
-    "enableGenomicExtraction": false,
+    "enableGenomicExtraction": true,
     "enableFireCloudV2Billing" : true,
     "enableGpu": false,
     "enablePersistentDisk": false,


### PR DESCRIPTION
This will be necessary for genomic e2e nightly tests to pass in staging. It is OK to enable here at this point, since preprod users are currently using this feature.