### PR TITLE
[RW-6931][RW-7218] remove old access module accessors from tests

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -393,7 +393,6 @@ public class UserServiceAccessTest {
   public void test_updateUserWithRetries_dua_unbypassed_aar_expired_noncompliant() {
     testUnregistration(
         user -> {
-          user.setDataUseAgreementBypassTime(null);
           final Timestamp willExpire = Timestamp.from(START_INSTANT);
           accessModuleService.updateBypassTime(
               dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);

--- a/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
@@ -213,7 +213,6 @@ public class RasLinkServiceTest extends SpringTest {
 
     assertThat(userDao.findUserByUserId(userId).getRasLinkLoginGovUsername())
         .isEqualTo(LOGIN_GOV_USERNAME);
-    assertThat(userDao.findUserByUserId(userId).getRasLinkLoginGovCompletionTime()).isEqualTo(NOW);
     assertModuleCompletionTime(AccessModuleName.RAS_LOGIN_GOV, NOW);
     assertModuleCompletionTime(AccessModuleName.ERA_COMMONS, null);
   }
@@ -228,7 +227,6 @@ public class RasLinkServiceTest extends SpringTest {
 
     assertThat(userDao.findUserByUserId(userId).getRasLinkLoginGovUsername())
         .isEqualTo(LOGIN_GOV_USERNAME);
-    assertThat(userDao.findUserByUserId(userId).getRasLinkLoginGovCompletionTime()).isEqualTo(NOW);
     assertThat(userDao.findUserByUserId(userId).getEraCommonsLinkedNihUsername())
         .isEqualTo("eraUserId");
     assertModuleCompletionTime(AccessModuleName.RAS_LOGIN_GOV, NOW);
@@ -248,7 +246,6 @@ public class RasLinkServiceTest extends SpringTest {
 
     assertThat(userDao.findUserByUserId(userId).getRasLinkLoginGovUsername())
         .isEqualTo(LOGIN_GOV_USERNAME);
-    assertThat(userDao.findUserByUserId(userId).getRasLinkLoginGovCompletionTime()).isEqualTo(NOW);
     assertModuleCompletionTime(AccessModuleName.RAS_LOGIN_GOV, NOW);
     assertModuleCompletionTime(AccessModuleName.ERA_COMMONS, eRATime);
   }
@@ -273,10 +270,10 @@ public class RasLinkServiceTest extends SpringTest {
         () -> rasLinkService.linkRasLoginGovAccount(AUTH_CODE, REDIRECT_URL));
   }
 
-  private void assertModuleCompletionTime(AccessModuleName module, Timestamp timestamp) {
+  private void assertModuleCompletionTime(AccessModuleName moduleName, Timestamp timestamp) {
     Optional<DbUserAccessModule> dbAccessModule =
         userAccessModuleDao.getByUserAndAccessModule(
-            currentUser, accessModuleDao.findOneByName(module).get());
+            currentUser, accessModuleDao.findOneByName(moduleName).get());
     if (!dbAccessModule.isPresent()) {
       assertThat(timestamp).isNull();
     } else {

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -116,26 +116,7 @@ export class ProfileApiStub extends ProfileApi {
 
   public bypassAccessRequirement(
     userId: number, bypassed?: AccessBypassRequest, options?: any): Promise<EmptyResponse> {
-    return new Promise<EmptyResponse>(resolve => {
-      let valueToSet;
-      if (bypassed.isBypassed) {
-        valueToSet = 1;
-      } else {
-        valueToSet = null;
-      }
-      switch (bypassed.moduleName) {
-        case AccessModule.COMPLIANCETRAINING:
-          this.profile.complianceTrainingBypassTime = valueToSet;
-          break;
-        case AccessModule.ERACOMMONS:
-          this.profile.eraCommonsBypassTime = valueToSet;
-          break;
-        case AccessModule.RASLINKLOGINGOV:
-          this.profile.rasLinkLoginGovBypassTime = valueToSet;
-          break;
-      }
-      resolve({});
-    });
+    return new Promise<EmptyResponse>(() => {});
   }
 
   public submitDUCC(duccVersion: number) {


### PR DESCRIPTION
Partial completion of RW-6931 and RW-7218.  This one is strictly tests, for easier review.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
