### PR TITLE
[RW-6752][risk=no] Ensure we use a different string on profile update test

### DIFF
--- a/e2e/tests/profile/profile-page.spec.ts
+++ b/e2e/tests/profile/profile-page.spec.ts
@@ -2,7 +2,7 @@ import ProfilePage, { MissingErrorAlias } from 'app/page/profile-page';
 import { signInWithAccessToken } from 'utils/test-utils';
 import { logger } from 'libs/logger';
 import navigation, { NavLink } from 'app/component/navigation';
-import { makeString, makeUrl } from 'utils/str-utils';
+import { makeString, makeDifferentStringSameLength, makeUrl } from 'utils/str-utils';
 import Button from 'app/element/button';
 
 describe('Profile', () => {
@@ -106,7 +106,8 @@ describe('Profile', () => {
     const researchBackground = profilePage.getResearchBackgroundTextarea();
 
     // make a change, causing the Save button to activate
-    await researchBackground.paste(makeString(10));
+    // Note: this must be a different length than the original, as makeString is not guaranteed to be unique.
+    await researchBackground.paste(makeString(15));
 
     // save button is enabled and no error message is displayed
     await waitForSaveButton(true);
@@ -132,8 +133,6 @@ describe('Profile', () => {
 
     // note: Professional URL and Address2 are optional fields
 
-    const testText = makeString(10);
-
     for (const { element, missingError } of [
       { element: firstName, missingError: MissingErrorAlias.FirstName },
       { element: lastName, missingError: MissingErrorAlias.LastName },
@@ -145,6 +144,9 @@ describe('Profile', () => {
       { element: country, missingError: MissingErrorAlias.Country }
     ]) {
       const originalValue = await element.getValue();
+
+      // Ensure testText is distinct from the original value.
+      const testText = makeDifferentStringSameLength(originalValue);
 
       logger.info(
         `missingness test '${originalValue}' -> '${testText}' -> (empty), for element xpath: ${element.getXpath()}`

--- a/e2e/utils/str-utils.ts
+++ b/e2e/utils/str-utils.ts
@@ -20,7 +20,7 @@ export function makeString(charLimit?: number): string {
 // Makes a different string of the same length.
 export function makeDifferentStringSameLength(original: string): string {
   if (!original) {
-    throw Error('cannot make a different empty string')
+    throw Error('cannot make a different empty string');
   }
 
   let out = '';

--- a/e2e/utils/str-utils.ts
+++ b/e2e/utils/str-utils.ts
@@ -3,6 +3,9 @@ import { Page } from 'puppeteer';
 
 import faker from 'faker';
 
+// Warning: this function produces values in a fixed range. This has a ~.11%
+// chance of creating two identical values; tests should not depend on this
+// being random.
 export function makeString(charLimit?: number): string {
   let loremStr: string = faker.lorem.paragraphs();
   if (charLimit === undefined) {
@@ -12,6 +15,19 @@ export function makeString(charLimit?: number): string {
     loremStr = loremStr.slice(0, charLimit);
   }
   return loremStr;
+}
+
+// Makes a different string of the same length.
+export function makeDifferentStringSameLength(original: string): string {
+  if (!original) {
+    throw Error('cannot make a different empty string')
+  }
+
+  let out = '';
+  do {
+    out = makeString(original.length);
+  } while (original === out);
+  return out;
 }
 
 export function makeUrl(charLimit?: number): string {


### PR DESCRIPTION
This eliminates a flaky scenario where we would `makeString(10)` one of the same values we previously generated / saved onto the profile in another test case. This caused the test to fail, as the test is expecting this value to be different from the existing profile field.

- This flake would occur on ~1% of runs, by my approximation
- `makeString(10)` has a .11% chance of generating the same value twice in a row