### PR TITLE
Update pyspark-usage.md

### DIFF
--- a/api/docs/pyspark-usage.md
+++ b/api/docs/pyspark-usage.md
@@ -66,8 +66,9 @@ import os
 import subprocess
 
 # Take the first 5 VCF files in the bucket for testing.
-input_files = !gsutil ls gs://fc-aou-test-datasets-registered/6/wgs/vcf/merged/*.vcf
-input_files = input_files[:5]
+vcf_path = 'gs://fc-aou-test-datasets-registered/6/wgs/vcf/merged/*.vcf.gz'
+input_files = !gsutil ls {vcf_path}
+input_files[:5]
 
 def unzip_and_wc(input_file):
     name = os.path.basename(input_file)

--- a/api/docs/pyspark-usage.md
+++ b/api/docs/pyspark-usage.md
@@ -68,7 +68,7 @@ import subprocess
 # Take the first 5 VCF files in the bucket for testing.
 vcf_path = 'gs://fc-aou-test-datasets-registered/6/wgs/vcf/merged/*.vcf.gz'
 input_files = !gsutil ls {vcf_path}
-input_files[:5]
+input_files = input_files[:5]
 
 def unzip_and_wc(input_file):
     name = os.path.basename(input_file)


### PR DESCRIPTION
Description:
The version I can get something from gsutil. But I am still getting error in
```
sc.parallelize(input_files).map(script).collect()
```

Error is:
```
Py4JJavaError                             Traceback (most recent call last)
<ipython-input-3-3effdea0b7d9> in <module>
     15     return result.stdout
     16 
---> 17 sc.parallelize(input_files).map(script).collect()

/usr/lib/spark/python/pyspark/rdd.py in collect(self)
    814         """
    815         with SCCallSiteSync(self.context) as css:
--> 816             sock_info = self.ctx._jvm.PythonRDD.collectAndServe(self._jrdd.rdd())
    817         return list(_load_from_socket(sock_info, self._jrdd_deserializer))
    818 

/opt/conda/lib/python3.7/site-packages/py4j/java_gateway.py in __call__(self, *args)
   1308         answer = self.gateway_client.send_command(command)
   1309         return_value = get_return_value(
-> 1310             answer, self.gateway_client, self.target_id, self.name)
   1311 
   1312         for temp_arg in temp_args:

/opt/conda/lib/python3.7/site-packages/py4j/protocol.py in get_return_value(answer, gateway_client, target_id, name)
    326                 raise Py4JJavaError(
    327                     "An error occurred while calling {0}{1}{2}.\n".
--> 328                     format(target_id, ".", name), value)
    329             else:
    330                 raise Py4JError(

Py4JJavaError: An error occurred while calling z:org.apache.spark.api.python.PythonRDD.collectAndServe.
: org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 0.0 failed 4 times, most recent failure: Lost task 0.3 in stage 0.0 (TID 6, all-of-us-3757-w-0.c.terra-vpc-sc-dev-7d50e706.internal, executor 1): org.apache.spark.api.python.PythonException: Traceback (most recent call last):
  File "/usr/lib/spark/python/lib/pyspark.zip/pyspark/worker.py", line 377, in main
    process()
  File "/usr/lib/spark/python/lib/pyspark.zip/pyspark/worker.py", line 372, in process
    serializer.dump_stream(func(split_index, iterator), outfile)
  File "/usr/lib/spark/python/lib/pyspark.zip/pyspark/serializers.py", line 400, in dump_stream
    vs = list(itertools.islice(iterator, batch))
  File "/usr/lib/spark/python/lib/pyspark.zip/pyspark/util.py", line 99, in wrapper
    return f(*args, **kwargs)
  File "<ipython-input-3-3effdea0b7d9>", line 10, in script
  File "/usr/local/lib/python3.7/subprocess.py", line 444, in check_returncode
    self.stderr)
subprocess.CalledProcessError: Command '['hadoop', 'fs', '-get', '-f', 'hdfs:///user/scripts/my_script.sh', '.']' returned non-zero exit status 1.

	at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.handlePythonException(PythonRunner.scala:456)
	at org.apache.spark.api.python.PythonRunner$$anon$1.read(PythonRunner.scala:59
```
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
