### PR TITLE
[risk=no] Fix physical measurements in concept search

### DIFF
--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -280,7 +280,7 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
         hoverId: undefined,
         loading: false,
         searching: false,
-        searchSource: false,
+        searchSource: props.searchContext.domain === Domain.PHYSICALMEASUREMENTCSS,
         searchTerms: props.searchTerms,
         standardOnly: false,
         sourceMatch: undefined,


### PR DESCRIPTION
Sets the correct default for `searchSource` when entering the physical measurements domain in concept search.