### PR TITLE
[RW-7413][risk=no] Increase default BigQuery read timeout in integration tests

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/testconfig/TestBigQueryConfig.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/testconfig/TestBigQueryConfig.java
@@ -10,7 +10,9 @@ import com.google.gson.Gson;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.UUID;
+import org.pmiops.workbench.config.BigQueryConfig;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -28,6 +30,13 @@ public class TestBigQueryConfig {
         .setCredentials(credentials)
         .build()
         .getService();
+  }
+
+  @Bean(name = BigQueryConfig.DEFAULT_QUERY_TIMEOUT)
+  public Duration defaultQueryTimeout() {
+    // We're not subject to GAE timeouts in unit tests. Allow queries to run a bit longer to avoid
+    // failing on the occasional slow job.
+    return Duration.ofMinutes(3L);
   }
 
   @Bean

--- a/api/src/main/java/org/pmiops/workbench/api/BigQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/api/BigQueryService.java
@@ -13,6 +13,7 @@ import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +43,7 @@ public class BigQueryService {
 
   @Autowired private Provider<WorkbenchConfig> workbenchConfigProvider;
   @Autowired private BigQuery defaultBigQuery;
+  @Autowired private Duration defaultBigQueryTimeout;
 
   @VisibleForTesting
   protected BigQuery getBigQueryService() {
@@ -60,7 +62,7 @@ public class BigQueryService {
 
   /** Execute the provided query using bigquery. */
   public TableResult executeQuery(QueryJobConfiguration query) {
-    return executeQuery(query, 60000L);
+    return executeQuery(query, defaultBigQueryTimeout.toMillis());
   }
 
   /** Execute the provided query using bigquery. */

--- a/api/src/main/java/org/pmiops/workbench/config/BigQueryConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/BigQueryConfig.java
@@ -2,14 +2,21 @@ package org.pmiops.workbench.config;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
+import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class BigQueryConfig {
+  public static final String DEFAULT_QUERY_TIMEOUT = "bigquery-default-query-timeout";
 
   @Bean
   public BigQuery bigQuery() {
     return BigQueryOptions.getDefaultInstance().getService();
+  }
+
+  @Bean(name = DEFAULT_QUERY_TIMEOUT)
+  public Duration defaultQueryTimeout() {
+    return Duration.ofMinutes(1L);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +24,7 @@ import org.pmiops.workbench.cohortbuilder.FieldSetQueryBuilder;
 import org.pmiops.workbench.cohortbuilder.SearchGroupItemQueryBuilder;
 import org.pmiops.workbench.cohortbuilder.mapper.CohortBuilderMapperImpl;
 import org.pmiops.workbench.cohortreview.AnnotationQueryBuilder;
+import org.pmiops.workbench.config.BigQueryConfig;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfigService;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
@@ -103,6 +105,10 @@ public class CohortMaterializationServiceTest extends SpringTest {
 
   @TestConfiguration
   static class Configuration {
+    @Bean(name = BigQueryConfig.DEFAULT_QUERY_TIMEOUT)
+    public Duration defaultBigQueryTimeout() {
+      return Duration.ofSeconds(1L);
+    }
 
     @Bean
     public WorkbenchConfig workbenchConfig() {

--- a/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -107,7 +107,7 @@ public class CohortMaterializationServiceTest extends SpringTest {
   static class Configuration {
     @Bean(name = BigQueryConfig.DEFAULT_QUERY_TIMEOUT)
     public Duration defaultBigQueryTimeout() {
-      return Duration.ofSeconds(1L);
+      return Duration.ofMinutes(1L);
     }
 
     @Bean


### PR DESCRIPTION
I just use a bean to allow for easy swapping here. It didn't seem necessary to allow this to be tuneable via WorkbenchConfig.