### PR TITLE
[RW-7126][risk=no] removing unused api call for findDomainCount

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -195,19 +195,6 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
         response.items(cohortBuilderService.findDemoChartInfo(genderOrSexType, ageType, request)));
   }
 
-  //  TODO: Remove this method call once the enableStandardSource flag is enabled
-  @Override
-  public ResponseEntity<DomainCount> findDomainCount(
-      String workspaceNamespace, String workspaceId, String domain, String term) {
-    workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
-        workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
-    validateDomain(domain);
-    validateTerm(term);
-    Long count = cohortBuilderService.findDomainCount(domain, term);
-    return ResponseEntity.ok(
-        new DomainCount().conceptCount(count).domain(Domain.valueOf(domain)).name(domain));
-  }
-
   @Override
   public ResponseEntity<DomainCount> findDomainCountByStandardSource(
       String workspaceNamespace, String workspaceId, String domain, Boolean standard, String term) {

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -180,21 +180,11 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
 
   @Query(
       value =
-          "select count(*) from DbCriteria where match(fullText, concat(:term, '+[', :domain, '_rank1]')) > 0")
-  Long findDomainCount(@Param("term") String term, @Param("domain") String domain);
-
-  @Query(
-      value =
           "select count(*) from DbCriteria where standard =:standard and match(fullText, concat(:term, '+[', :domain, '_rank1]')) > 0")
   Long findDomainCountAndStandard(
       @Param("term") String term,
       @Param("domain") String domain,
       @Param("standard") Boolean standard);
-
-  @Query(
-      value =
-          "select count(*) from DbCriteria where code like upper(concat(:term,'%')) and match(fullText, concat('+[', :domain, '_rank1]')) > 0")
-  Long findDomainCountOnCode(@Param("term") String term, @Param("domain") String domain);
 
   @Query(
       value =

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -70,8 +70,6 @@ public interface CohortBuilderService {
   List<DemoChartInfo> findDemoChartInfo(
       GenderOrSexType genderOrSexType, AgeType ageType, SearchRequest request);
 
-  Long findDomainCount(String domain, String term);
-
   Long findDomainCountByStandard(String domain, String term, Boolean standard);
 
   List<DomainCard> findDomainCards();

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -163,14 +163,16 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
         standardConceptIds.stream().map(Object::toString).collect(Collectors.toList());
     if (!sourceIds.isEmpty()) {
       criteriaList.addAll(
-          cbCriteriaDao.findCriteriaByDomainIdAndStandardAndConceptIds(domainId, false, sourceIds)
+          cbCriteriaDao
+              .findCriteriaByDomainIdAndStandardAndConceptIds(domainId, false, sourceIds)
               .stream()
               .map(cohortBuilderMapper::dbModelToClient)
               .collect(Collectors.toList()));
     }
     if (!standardConceptIds.isEmpty()) {
       criteriaList.addAll(
-          cbCriteriaDao.findCriteriaByDomainIdAndStandardAndConceptIds(domainId, true, standardIds)
+          cbCriteriaDao
+              .findCriteriaByDomainIdAndStandardAndConceptIds(domainId, true, standardIds)
               .stream()
               .map(cohortBuilderMapper::dbModelToClient)
               .collect(Collectors.toList()));
@@ -314,12 +316,6 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
               .count(bigQueryService.getLong(row, rm.get("count"))));
     }
     return demoChartInfos;
-  }
-
-  @Override
-  public Long findDomainCount(String domain, String term) {
-    Long count = cbCriteriaDao.findDomainCountOnCode(term, domain);
-    return count == 0 ? cbCriteriaDao.findDomainCount(modifyTermMatch(term), domain) : count;
   }
 
   @Override

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3343,31 +3343,6 @@ paths:
           description: information on the domains
           schema:
             "$ref": "#/definitions/DomainCardResponse"
-  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/domaininfo/{domain}":
-    parameters:
-      - "$ref": "#/parameters/workspaceNamespace"
-      - "$ref": "#/parameters/workspaceId"
-    get:
-      tags:
-      - cohortBuilder
-      description: 'Returns a count of term matches per domain'
-      operationId: findDomainCount
-      parameters:
-      - in: path
-        name: domain
-        type: string
-        required: true
-        description: the specific type of domain
-      - in: query
-        name: term
-        type: string
-        required: true
-        description: the term to search for
-      responses:
-        200:
-          description: A count of matching concepts in this domain
-          schema:
-            "$ref": "#/definitions/DomainCount"
   "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/domaincard/{domain}/{standard}":
     parameters:
       - "$ref": "#/parameters/workspaceNamespace"

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -323,22 +323,11 @@ public class CBCriteriaDaoTest extends SpringTest {
   }
 
   @Test
-  public void findDomainCount() {
-    assertThat(cbCriteriaDao.findDomainCount("term", Domain.CONDITION.toString())).isEqualTo(1);
-  }
-
-  @Test
   public void findDomainCountAndStandard() {
     assertThat(cbCriteriaDao.findDomainCountAndStandard("term", Domain.CONDITION.toString(), false))
         .isEqualTo(1);
     assertThat(cbCriteriaDao.findDomainCountAndStandard("term", Domain.CONDITION.toString(), true))
         .isEqualTo(0);
-  }
-
-  @Test
-  public void findDomainCountOnCode() {
-    assertThat(cbCriteriaDao.findDomainCountOnCode("120", Domain.CONDITION.toString()))
-        .isEqualTo(2);
   }
 
   @Test

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -242,9 +242,7 @@ export const ConceptHomepage = fp.flow(withCurrentCohortSearchContext(), withCur
     getDomainCounts(domain: string, standard: boolean) {
       const {id, namespace} = this.props.workspace;
       const {currentInputString} = this.state;
-      return serverConfigStore.get().config.enableStandardSourceDomains
-        ? cohortBuilderApi().findDomainCountByStandardSource(namespace, id, domain, standard, currentInputString)
-        : cohortBuilderApi().findDomainCount(namespace, id, domain, currentInputString);
+      return cohortBuilderApi().findDomainCountByStandardSource(namespace, id, domain, standard, currentInputString);
     }
 
     handleSearchKeyPress(e) {


### PR DESCRIPTION
Removing unused api call for findDomainCount.
---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
