### PR TITLE
[RW-7413][risk=no] Try a retry policy in BQ integration tests

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/testconfig/TestBigQueryConfig.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/testconfig/TestBigQueryConfig.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.testconfig;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.bigquery.BigQuery;
@@ -28,6 +29,13 @@ public class TestBigQueryConfig {
     return BigQueryOptions.newBuilder()
         .setProjectId("all-of-us-workbench-test")
         .setCredentials(credentials)
+        // Note: Later we may want to apply similar settings to the real server. See RW-7413.
+        .setRetrySettings(
+            RetrySettings.newBuilder()
+                .setMaxAttempts(3)
+                .setInitialRpcTimeout(org.threeten.bp.Duration.ofSeconds(20L))
+                .setInitialRetryDelay(org.threeten.bp.Duration.ofSeconds(1L))
+                .build())
         .build()
         .getService();
   }


### PR DESCRIPTION
My previous fix was not sufficient, we saw this read timeout again. Try instead to add a BigQuery RetryPolicy on all outgoing service calls. This sets a tighter deadline on the initial request, and should automatically retry if we encounter similar request errors.

The error here actually appears to be at the network request timeout level; rather than the Job timeout as I had previously assumed in my last PR.