### PR TITLE
[no ticket][risk=no] removing references to enableStandardSourceDomains flag

### DIFF
--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.tsx
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.tsx
@@ -41,7 +41,7 @@ describe('CohortSearch', () => {
   beforeEach(() => {
     currentWorkspaceStore.next(workspaceDataStub);
     registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
-    serverConfigStore.set({config: {...defaultServerConfig, enableStandardSourceDomains: false}});
+    serverConfigStore.set({config: {...defaultServerConfig}});
   });
 
   it('should render', () => {

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.tsx
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.tsx
@@ -3,10 +3,8 @@ import * as React from 'react';
 
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentCohortCriteriaStore, currentCohortSearchContextStore, currentWorkspaceStore} from 'app/utils/navigation';
-import {serverConfigStore} from 'app/utils/stores';
 import {CohortBuilderApi, CriteriaType, Domain} from 'generated/fetch';
 import {MemoryRouter, Router} from 'react-router';
-import defaultServerConfig from 'testing/default-server-config';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {CohortBuilderServiceStub, CriteriaStubVariables} from 'testing/stubs/cohort-builder-service-stub';
 import {workspaceDataStub} from 'testing/stubs/workspaces';
@@ -41,7 +39,6 @@ describe('CohortSearch', () => {
   beforeEach(() => {
     currentWorkspaceStore.next(workspaceDataStub);
     registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
-    serverConfigStore.set({config: {...defaultServerConfig}});
   });
 
   it('should render', () => {

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -21,7 +21,6 @@ import {
   currentCohortSearchContextStore,
   setSidebarActiveIconStore
 } from 'app/utils/navigation';
-import {serverConfigStore} from 'app/utils/stores';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {environment} from 'environments/environment';
 import {

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -599,7 +599,7 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
               {!loading && !!totalCount && <span>
                 There are {totalCount.toLocaleString()} results{!!cdrVersion && <span> in {cdrVersion.name}</span>}
               </span>}
-              {serverConfigStore.get().config.enableStandardSourceDomains && this.checkSource &&
+              {this.checkSource &&
                 <span style={{float: 'right'}}>
                   <span style={{display: 'table-cell', paddingRight: '0.35rem'}}>
                     Show results as source concepts (ICD9, ICD10{domain === Domain.PROCEDURE && <span>, CPT</span>})

--- a/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
@@ -4,13 +4,11 @@ import * as React from 'react';
 import {ConceptHomepage} from 'app/pages/data/concept/concept-homepage';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore} from 'app/utils/navigation';
-import {serverConfigStore} from 'app/utils/stores';
 import {
   CohortBuilderApi,
   ConceptSetsApi,
   WorkspacesApi
 } from 'generated/fetch';
-import defaultServerConfig from 'testing/default-server-config';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {CohortBuilderServiceStub, DomainStubVariables, SurveyStubVariables} from 'testing/stubs/cohort-builder-service-stub';
 import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
@@ -43,7 +41,6 @@ describe('ConceptHomepage', () => {
     registerApiClient(ConceptSetsApi, new ConceptSetsApiStub());
     registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     currentWorkspaceStore.next(workspaceDataStub);
-    serverConfigStore.set({config: {...defaultServerConfig}});
   });
 
   it('should render', () => {

--- a/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
@@ -43,7 +43,7 @@ describe('ConceptHomepage', () => {
     registerApiClient(ConceptSetsApi, new ConceptSetsApiStub());
     registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     currentWorkspaceStore.next(workspaceDataStub);
-    serverConfigStore.set({config: {...defaultServerConfig, enableStandardSourceDomains: false}});
+    serverConfigStore.set({config: {...defaultServerConfig}});
   });
 
   it('should render', () => {

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -23,7 +23,6 @@ import {
   currentConceptStore,
   NavigationProps
 } from 'app/utils/navigation';
-import {serverConfigStore} from 'app/utils/stores';
 import {withNavigation} from 'app/utils/with-navigation-hoc';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {Concept, Domain, DomainCard as ConceptDomainCard, SurveyModule} from 'generated/fetch';

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -238,7 +238,6 @@ export const ConceptHomepage = fp.flow(withCurrentCohortSearchContext(), withCur
       this.setState({conceptDomainCards, conceptSurveysList});
     }
 
-    // Temp function to use the correct endpoint based on the enableStandardSourceDomains config flag
     getDomainCounts(domain: string, standard: boolean) {
       const {id, namespace} = this.props.workspace;
       const {currentInputString} = this.state;

--- a/ui/src/app/pages/data/concept/concept-search.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.spec.tsx
@@ -29,7 +29,7 @@ describe('ConceptSearch', () => {
     currentConceptStore.next([]);
     currentConceptSetStore.next(undefined);
     conceptSet = ConceptSetsApiStub.stubConceptSets()[0];
-    serverConfigStore.set({config: {...defaultServerConfig, enableStandardSourceDomains: false}});
+    serverConfigStore.set({config: {...defaultServerConfig}});
   });
 
   const component = () => {

--- a/ui/src/app/pages/data/concept/concept-search.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.spec.tsx
@@ -9,9 +9,7 @@ import {
   currentConceptStore,
   currentWorkspaceStore
 } from 'app/utils/navigation';
-import {serverConfigStore} from 'app/utils/stores';
 import {ConceptSet, ConceptSetsApi, WorkspacesApi} from 'generated/fetch';
-import defaultServerConfig from 'testing/default-server-config';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 import {ConceptSetsApiStub} from 'testing/stubs/concept-sets-api-stub';
 import {workspaceDataStub} from 'testing/stubs/workspaces';
@@ -29,7 +27,6 @@ describe('ConceptSearch', () => {
     currentConceptStore.next([]);
     currentConceptSetStore.next(undefined);
     conceptSet = ConceptSetsApiStub.stubConceptSets()[0];
-    serverConfigStore.set({config: {...defaultServerConfig}});
   });
 
   const component = () => {


### PR DESCRIPTION
removing references to enableStandardSourceDomains flag


---
**PR checklist**

- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
