### PR TITLE
[RW-6215][risk=no] resolve workspace build page js console error

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1393,7 +1393,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
             <RadioButton name='population' style={{marginRight: '0.5rem'}}
                          data-test-id='specific-population-yes'
                          onChange={v => this.setState({populationChecked: true})}
-                         checked={populationChecked}/>
+                         checked={populationChecked ?? false}/>
             <label style={styles.text}>Yes, my study will focus on one or more specific
               underrepresented populations, either on their own or in comparison to other groups.</label>
           </div>
@@ -1491,7 +1491,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
                              onChange={() => {
                                this.updateResearchPurpose('reviewRequested', true);
                              }}
-                             checked={reviewRequested}/>
+                             checked={reviewRequested ?? false}/>
                 <label style={{...styles.text, marginLeft: '0.5rem'}}>Yes, I would like to request
                   a review of my research purpose.</label>
                 </FlexRow>


### PR DESCRIPTION
In Workspace Edit page, two radio input are initially `undefined`. 
- `reviewRequested: undefined`
- `populationChecked: undefined`

react treats an (radio) input as an uncontrolled component when the initial state is `undefined`. With JS nullish coalescing operator (`??`), it provides a default value when a variable is undefined.

https://user-images.githubusercontent.com/35533885/137812656-d8fd3b5d-d01b-4036-9fc8-02a5c2f052ff.mov



