### PR TITLE
[RW-7413][risk=no] Yet another attempt on BigQuery retry settings

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/testconfig/TestBigQueryConfig.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/testconfig/TestBigQueryConfig.java
@@ -32,7 +32,7 @@ public class TestBigQueryConfig {
         // Note: Later we may want to apply similar settings to the real server. See RW-7413.
         .setRetrySettings(
             RetrySettings.newBuilder()
-                .setMaxAttempts(3)
+                .setTotalTimeout(org.threeten.bp.Duration.ofMinutes(5))
                 .setInitialRpcTimeout(org.threeten.bp.Duration.ofSeconds(20L))
                 .setMaxRpcTimeout(org.threeten.bp.Duration.ofSeconds(30L))
                 .setInitialRetryDelay(org.threeten.bp.Duration.ofSeconds(1L))


### PR DESCRIPTION
My most recent change immediately flaked on merge, though it did seem to actually succeed in retrying. Try increasing the timeout further.

Unfortunately this issue appears to be environmental, as I'm unable to reproduce this, even by SSHing into Circle and rerunning.