### PR TITLE
[risk=low][RW-5638] WorkspaceResourceMapper: merge WorkspaceFields and ResourceFields

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/ResourceFields.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/ResourceFields.java
@@ -1,0 +1,68 @@
+package org.pmiops.workbench.workspaces.resources;
+
+import org.pmiops.workbench.model.Cohort;
+import org.pmiops.workbench.model.CohortReview;
+import org.pmiops.workbench.model.ConceptSet;
+import org.pmiops.workbench.model.DataSet;
+import org.pmiops.workbench.model.FileDetail;
+
+/**
+ * A transitional POJO to assist WorkspaceResourceMapper, consisting of the fields sourced from the
+ * resources
+ */
+public class ResourceFields {
+  private Cohort cohort;
+  private CohortReview cohortReview;
+  private FileDetail notebook;
+  private ConceptSet conceptSet;
+  private DataSet dataSet;
+  private long lastModifiedEpochMillis;
+
+  public Cohort getCohort() {
+    return cohort;
+  }
+
+  public void setCohort(Cohort cohort) {
+    this.cohort = cohort;
+  }
+
+  public CohortReview getCohortReview() {
+    return cohortReview;
+  }
+
+  public void setCohortReview(CohortReview cohortReview) {
+    this.cohortReview = cohortReview;
+  }
+
+  public FileDetail getNotebook() {
+    return notebook;
+  }
+
+  public void setNotebook(FileDetail notebook) {
+    this.notebook = notebook;
+  }
+
+  public ConceptSet getConceptSet() {
+    return conceptSet;
+  }
+
+  public void setConceptSet(ConceptSet conceptSet) {
+    this.conceptSet = conceptSet;
+  }
+
+  public DataSet getDataSet() {
+    return dataSet;
+  }
+
+  public void setDataSet(DataSet dataSet) {
+    this.dataSet = dataSet;
+  }
+
+  public long getLastModifiedEpochMillis() {
+    return lastModifiedEpochMillis;
+  }
+
+  public void setLastModifiedEpochMillis(long lastModifiedEpochMillis) {
+    this.lastModifiedEpochMillis = lastModifiedEpochMillis;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/ResourceFields.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/ResourceFields.java
@@ -10,7 +10,7 @@ import org.pmiops.workbench.model.FileDetail;
  * A transitional POJO to assist WorkspaceResourceMapper, consisting of the fields sourced from the
  * resources
  */
-public class ResourceFields {
+class ResourceFields {
   private Cohort cohort;
   private CohortReview cohortReview;
   private FileDetail notebook;

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceFields.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceFields.java
@@ -1,0 +1,82 @@
+package org.pmiops.workbench.workspaces.resources;
+
+import org.pmiops.workbench.model.BillingStatus;
+
+/**
+ * A transitional POJO to assist WorkspaceResourceMapper, consisting of the fields sourced from
+ * DbWorkspace and WorkspaceAccessLevel
+ */
+public class WorkspaceFields {
+  private Long workspaceId;
+  private String workspaceNamespace;
+  private String workspaceFirecloudName;
+  private BillingStatus workspaceBillingStatus;
+  private String cdrVersionId;
+  private String accessTierShortName;
+  private String permission;
+  private boolean adminLocked;
+
+  public Long getWorkspaceId() {
+    return workspaceId;
+  }
+
+  public void setWorkspaceId(Long workspaceId) {
+    this.workspaceId = workspaceId;
+  }
+
+  public String getWorkspaceNamespace() {
+    return workspaceNamespace;
+  }
+
+  public void setWorkspaceNamespace(String workspaceNamespace) {
+    this.workspaceNamespace = workspaceNamespace;
+  }
+
+  public String getWorkspaceFirecloudName() {
+    return workspaceFirecloudName;
+  }
+
+  public void setWorkspaceFirecloudName(String workspaceFirecloudName) {
+    this.workspaceFirecloudName = workspaceFirecloudName;
+  }
+
+  public BillingStatus getWorkspaceBillingStatus() {
+    return workspaceBillingStatus;
+  }
+
+  public void setWorkspaceBillingStatus(BillingStatus workspaceBillingStatus) {
+    this.workspaceBillingStatus = workspaceBillingStatus;
+  }
+
+  public String getCdrVersionId() {
+    return cdrVersionId;
+  }
+
+  public void setCdrVersionId(String cdrVersionId) {
+    this.cdrVersionId = cdrVersionId;
+  }
+
+  public String getAccessTierShortName() {
+    return accessTierShortName;
+  }
+
+  public void setAccessTierShortName(String accessTierShortName) {
+    this.accessTierShortName = accessTierShortName;
+  }
+
+  public String getPermission() {
+    return permission;
+  }
+
+  public void setPermission(String permission) {
+    this.permission = permission;
+  }
+
+  public boolean isAdminLocked() {
+    return adminLocked;
+  }
+
+  public void setAdminLocked(boolean adminLocked) {
+    this.adminLocked = adminLocked;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceFields.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceFields.java
@@ -6,7 +6,7 @@ import org.pmiops.workbench.model.BillingStatus;
  * A transitional POJO to assist WorkspaceResourceMapper, consisting of the fields sourced from
  * DbWorkspace and WorkspaceAccessLevel
  */
-public class WorkspaceFields {
+class WorkspaceFields {
   private Long workspaceId;
   private String workspaceNamespace;
   private String workspaceFirecloudName;

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
@@ -28,9 +28,6 @@ import org.pmiops.workbench.utils.mappers.MapStructConfig;
       DataSetMapper.class,
     })
 public interface WorkspaceResourceMapper {
-  WorkspaceResource mergeWorkspaceAndResourceFields(
-      WorkspaceFields workspaceFields, ResourceFields resourceFields);
-
   @Mapping(target = "workspaceId", source = "dbWorkspace.workspaceId")
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")
   @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace.billingStatus")
@@ -42,72 +39,66 @@ public interface WorkspaceResourceMapper {
 
   // a WorkspaceResource has one resource object.  Assign it and ignore all others (keep as NULL).
 
-  @Mapping(target = "cohort", source = "dbCohort")
   @Mapping(target = "cohortReview", ignore = true)
   @Mapping(target = "conceptSet", ignore = true)
   @Mapping(target = "dataSet", ignore = true)
   @Mapping(target = "notebook", ignore = true)
-  // This should be set when the resource is set
+  @Mapping(target = "cohort", source = "dbCohort")
   @Mapping(target = "lastModifiedEpochMillis", source = "dbCohort.lastModifiedTime")
   ResourceFields workspaceResourceFromDbCohort(DbCohort dbCohort);
 
   @Mapping(target = "cohort", ignore = true)
-  @Mapping(target = "cohortReview", source = "cohortReview")
   @Mapping(target = "conceptSet", ignore = true)
   @Mapping(target = "dataSet", ignore = true)
   @Mapping(target = "notebook", ignore = true)
-  // This should be set when the resource is set
+  @Mapping(target = "cohortReview", source = "cohortReview")
   @Mapping(target = "lastModifiedEpochMillis", source = "cohortReview.lastModifiedTime")
   ResourceFields workspaceResourceFromCohortReview(CohortReview cohortReview);
 
   @Mapping(target = "cohort", ignore = true)
   @Mapping(target = "cohortReview", ignore = true)
-  @Mapping(target = "conceptSet", source = "conceptSet")
   @Mapping(target = "dataSet", ignore = true)
   @Mapping(target = "notebook", ignore = true)
-  // This should be set when the resource is set
+  @Mapping(target = "conceptSet", source = "conceptSet")
   @Mapping(target = "lastModifiedEpochMillis", source = "conceptSet.lastModifiedTime")
   ResourceFields workspaceResourceFromConceptSet(ConceptSet conceptSet);
 
   @Mapping(target = "cohort", ignore = true)
   @Mapping(target = "cohortReview", ignore = true)
   @Mapping(target = "conceptSet", ignore = true)
-  @Mapping(target = "dataSet", source = "dbDataset", qualifiedByName = "dbModelToClientLight")
   @Mapping(target = "notebook", ignore = true)
-  // This should be set when the resource is set
+  @Mapping(target = "dataSet", source = "dbDataset", qualifiedByName = "dbModelToClientLight")
   @Mapping(target = "lastModifiedEpochMillis", source = "dbDataset.lastModifiedTime")
   ResourceFields workspaceResourceFromDbDataset(DbDataset dbDataset);
-  // TODO: can MapStruct generate these automatically?
+
+  WorkspaceResource mergeWorkspaceAndResourceFields(
+      WorkspaceFields workspaceFields, ResourceFields resourceFields);
 
   default WorkspaceResource dbWorkspaceAndDbCohortToWorkspaceResource(
       DbWorkspace dbWorkspace, WorkspaceAccessLevel accessLevel, DbCohort dbCohort) {
-    final WorkspaceFields workspaceFields =
-        workspaceResourceFromWorkspace(dbWorkspace, accessLevel);
-    final ResourceFields resourceFields = workspaceResourceFromDbCohort(dbCohort);
-    return mergeWorkspaceAndResourceFields(workspaceFields, resourceFields);
+    return mergeWorkspaceAndResourceFields(
+        workspaceResourceFromWorkspace(dbWorkspace, accessLevel),
+        workspaceResourceFromDbCohort(dbCohort));
   }
 
   default WorkspaceResource dbWorkspaceAndCohortReviewToWorkspaceResource(
       DbWorkspace dbWorkspace, WorkspaceAccessLevel accessLevel, CohortReview cohortReview) {
-    final WorkspaceFields workspaceFields =
-        workspaceResourceFromWorkspace(dbWorkspace, accessLevel);
-    final ResourceFields resourceFields = workspaceResourceFromCohortReview(cohortReview);
-    return mergeWorkspaceAndResourceFields(workspaceFields, resourceFields);
+    return mergeWorkspaceAndResourceFields(
+        workspaceResourceFromWorkspace(dbWorkspace, accessLevel),
+        workspaceResourceFromCohortReview(cohortReview));
   }
 
   default WorkspaceResource dbWorkspaceAndConceptSetToWorkspaceResource(
       DbWorkspace dbWorkspace, WorkspaceAccessLevel accessLevel, ConceptSet conceptSet) {
-    final WorkspaceFields workspaceFields =
-        workspaceResourceFromWorkspace(dbWorkspace, accessLevel);
-    final ResourceFields resourceFields = workspaceResourceFromConceptSet(conceptSet);
-    return mergeWorkspaceAndResourceFields(workspaceFields, resourceFields);
+    return mergeWorkspaceAndResourceFields(
+        workspaceResourceFromWorkspace(dbWorkspace, accessLevel),
+        workspaceResourceFromConceptSet(conceptSet));
   }
 
   default WorkspaceResource dbWorkspaceAndDbDatasetToWorkspaceResource(
       DbWorkspace dbWorkspace, WorkspaceAccessLevel accessLevel, DbDataset dbDataset) {
-    final WorkspaceFields workspaceFields =
-        workspaceResourceFromWorkspace(dbWorkspace, accessLevel);
-    final ResourceFields resourceFields = workspaceResourceFromDbDataset(dbDataset);
-    return mergeWorkspaceAndResourceFields(workspaceFields, resourceFields);
+    return mergeWorkspaceAndResourceFields(
+        workspaceResourceFromWorkspace(dbWorkspace, accessLevel),
+        workspaceResourceFromDbDataset(dbDataset));
   }
 }


### PR DESCRIPTION
Remove a lot of repeated `@Mapping` annotations from WorkspaceResourceMapper by creating 2 new POJOs `WorkspaceFields` and `ResourceFields`, and mapping these separately before merging into the final WorkspaceResourceMapper object.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
