### PR TITLE
[risk=no][RW-6952] Remove WorkspaceResource.modifiedTime

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -71,7 +71,6 @@ public class UserMetricsController implements UserMetricsApiDelegate {
         resource.setConceptSet(TO_CLIENT_CONCEPT_SET.apply(userRecentResource.getConceptSet()));
         FileDetail fileDetail = convertStringToFileDetail(userRecentResource.getNotebookName());
         resource.setNotebook(fileDetail);
-        resource.setModifiedTime(userRecentResource.getLastAccessDate().toString());
         resource.setLastModifiedEpochMillis(userRecentResource.getLastAccessDate().getTime());
         resource.setWorkspaceId(userRecentResource.getWorkspaceId());
         return resource;

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
@@ -42,7 +42,6 @@ public interface WorkspaceResourceMapper {
   @Mapping(target = "dataSet", ignore = true)
   @Mapping(target = "notebook", ignore = true)
   // This should be set when the resource is set
-  @Mapping(target = "modifiedTime", source = "dbCohort.lastModifiedTime")
   @Mapping(target = "lastModifiedEpochMillis", source = "dbCohort.lastModifiedTime")
   WorkspaceResource dbWorkspaceAndDbCohortToWorkspaceResource(
       DbWorkspace dbWorkspace, WorkspaceAccessLevel accessLevel, DbCohort dbCohort);
@@ -60,7 +59,6 @@ public interface WorkspaceResourceMapper {
   @Mapping(target = "dataSet", ignore = true)
   @Mapping(target = "notebook", ignore = true)
   // This should be set when the resource is set
-  @Mapping(target = "modifiedTime", source = "cohortReview.lastModifiedTime")
   @Mapping(target = "lastModifiedEpochMillis", source = "cohortReview.lastModifiedTime")
   WorkspaceResource dbWorkspaceAndCohortReviewToWorkspaceResource(
       DbWorkspace dbWorkspace, WorkspaceAccessLevel accessLevel, CohortReview cohortReview);
@@ -78,7 +76,6 @@ public interface WorkspaceResourceMapper {
   @Mapping(target = "dataSet", ignore = true)
   @Mapping(target = "notebook", ignore = true)
   // This should be set when the resource is set
-  @Mapping(target = "modifiedTime", source = "conceptSet.lastModifiedTime")
   @Mapping(target = "lastModifiedEpochMillis", source = "conceptSet.lastModifiedTime")
   WorkspaceResource dbWorkspaceAndConceptSetToWorkspaceResource(
       DbWorkspace dbWorkspace, WorkspaceAccessLevel accessLevel, ConceptSet conceptSet);
@@ -96,7 +93,6 @@ public interface WorkspaceResourceMapper {
   @Mapping(target = "conceptSet", ignore = true)
   @Mapping(target = "notebook", ignore = true)
   // This should be set when the resource is set
-  @Mapping(target = "modifiedTime", source = "dbDataset.lastModifiedTime")
   @Mapping(target = "lastModifiedEpochMillis", source = "dbDataset.lastModifiedTime")
   WorkspaceResource dbWorkspaceAndDbDatasetToWorkspaceResource(
       DbWorkspace dbWorkspace, WorkspaceAccessLevel accessLevel, DbDataset dbDataset);

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6252,9 +6252,6 @@ definitions:
         "$ref": "#/definitions/ConceptSet"
       dataSet:
         "$ref": "#/definitions/DataSet"
-      modifiedTime:
-        description: DEPRECATED because string formatting is ambiguous. Use lastModifiedEpochMillis.
-        type: string
       lastModifiedEpochMillis:
         description: the resource's last modified time, in milliseconds since the epoch
         type: integer


### PR DESCRIPTION
Complete the work of #5791 by waiting until it is released and removing the last instances of `modifiedTime`

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
