### PR TITLE
[RW-7413][risk=no] Further increase BigQuery timeouts

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/testconfig/TestBigQueryConfig.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/testconfig/TestBigQueryConfig.java
@@ -32,7 +32,7 @@ public class TestBigQueryConfig {
         // Note: Later we may want to apply similar settings to the real server. See RW-7413.
         .setRetrySettings(
             RetrySettings.newBuilder()
-                .setTotalTimeout(org.threeten.bp.Duration.ofMinutes(5))
+                .setTotalTimeout(org.threeten.bp.Duration.ofMinutes(15))
                 .setInitialRpcTimeout(org.threeten.bp.Duration.ofSeconds(20L))
                 .setMaxRpcTimeout(org.threeten.bp.Duration.ofSeconds(30L))
                 .setInitialRetryDelay(org.threeten.bp.Duration.ofSeconds(1L))
@@ -46,7 +46,7 @@ public class TestBigQueryConfig {
   public Duration defaultQueryTimeout() {
     // We're not subject to GAE timeouts in unit tests. Allow queries to run a bit longer to avoid
     // failing on the occasional slow job.
-    return Duration.ofMinutes(3L);
+    return Duration.ofMinutes(5L);
   }
 
   @Bean


### PR DESCRIPTION
In some cases, these queries can take >5m. Here is one case from a recent flake.

Why? Unclear.

![image](https://user-images.githubusercontent.com/822298/138178988-4b238e9d-f37f-4edc-953f-9e4fef534b77.png)
