### PR TITLE
[risk=low][no ticket] upgrade mysql-socket-factory to latest to address vuln in jnr-posix

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -398,7 +398,7 @@ dependencies {
   compile "com.google.appengine:appengine:$project.ext.GAE_VERSION"
   compile "com.google.auth:google-auth-library-appengine:0.19.0"
   compile "com.google.auth:google-auth-library-oauth2-http:0.19.0"
-  compile "com.google.cloud.sql:mysql-socket-factory:1.0.12"
+  compile "com.google.cloud.sql:mysql-socket-factory:1.3.4"
   compile "com.google.cloud:google-cloud-bigquery:1.122.2"
   compile "com.google.cloud:google-cloud-iamcredentials:0.44.1"
   compile "com.google.cloud:google-cloud-logging:1.102.0"


### PR DESCRIPTION
The fix that Snyk suggested (#5794) for https://snyk.io/vuln/SNYK-JAVA-COMGITHUBJNR-1570422 did not actually do the job.  After checking the dependency tree, I saw that we need to upgrade to 1.3.x to pull in a non-vulnerable jnr-posix transitively.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
