### PR TITLE
[risk=low][RW-7461] Add LoginGovHelpText component

### DIFF
--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -3,12 +3,7 @@ import {mount} from "enzyme";
 
 import defaultServerConfig from 'testing/default-server-config';
 import {AccessModule, InstitutionApi, Profile, ProfileApi} from 'generated/fetch';
-import {
-    allModules,
-    DataAccessRequirements,
-    getActiveModule,
-    getVisibleModules
-} from './data-access-requirements';
+import {allModules, DataAccessRequirements, getActiveModule, getVisibleModules} from './data-access-requirements';
 import {InstitutionApiStub} from 'testing/stubs/institution-api-stub';
 import {ProfileApiStub, ProfileStubVariables} from 'testing/stubs/profile-api-stub';
 import {profileApi, registerApiClient} from 'app/services/swagger-fetch-clients';
@@ -49,6 +44,8 @@ describe('DataAccessRequirements', () => {
       .find('[data-test-id="ineligible"]');
 
     const findControlledTierCard = (wrapper) => wrapper.find('[data-test-id="controlled-card"]')
+
+    const findContactUs = (wrapper) => wrapper.find('[data-test-id="contact-us"]');
 
     beforeEach(async() => {
         registerApiClient(InstitutionApi, new InstitutionApiStub());
@@ -486,7 +483,7 @@ describe('DataAccessRequirements', () => {
         expect(spyCompliance).toHaveBeenCalledTimes(0);
     });
 
-    it ('Should not show Era Commons Module for Registered Tier if the institution does not require eRa', async() => {
+    it('Should not show Era Commons Module for Registered Tier if the institution does not require eRa', async() => {
         let wrapper = component();
         await waitOneTickAndUpdate(wrapper);
         expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeTruthy();
@@ -526,7 +523,7 @@ describe('DataAccessRequirements', () => {
         expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeTruthy();
     });
 
-    it ("Should display Institution has signed agreement when the user has a Tier Eligibility object for CT", async() => {
+    it("Should display Institution has signed agreement when the user has a Tier Eligibility object for CT", async() => {
         let wrapper = component();
         await waitOneTickAndUpdate(wrapper);
 
@@ -548,7 +545,7 @@ describe('DataAccessRequirements', () => {
         expect(findControlledSignedStepIneligible(wrapper).exists()).toBeFalsy();
     });
 
-    it ("Should not display Institution has signed agreement when the user doesn't have a Tier Eligibility object for CT", async() => {
+    it("Should not display Institution has signed agreement when the user doesn't have a Tier Eligibility object for CT", async() => {
         let wrapper = component();
         await waitOneTickAndUpdate(wrapper);
 
@@ -570,7 +567,7 @@ describe('DataAccessRequirements', () => {
         expect(findControlledSignedStepIneligible(wrapper).exists()).toBeTruthy();
     });
 
-    it ("Should display Institution allows you to access CT when the user's CT Tier Eligibility object has eligible=true", async() => {
+    it("Should display Institution allows you to access CT when the user's CT Tier Eligibility object has eligible=true", async() => {
         let wrapper = component();
         await waitOneTickAndUpdate(wrapper);
 
@@ -593,7 +590,7 @@ describe('DataAccessRequirements', () => {
         expect(findControlledUserIneligible(wrapper).exists()).toBeFalsy();
     });
 
-    it ("Should not display Institution allows you to access CT when the user's CT Tier Eligibility object has eligible=false", async() => {
+    it("Should not display Institution allows you to access CT when the user's CT Tier Eligibility object has eligible=false", async() => {
         let wrapper = component();
         await waitOneTickAndUpdate(wrapper);
 
@@ -616,7 +613,7 @@ describe('DataAccessRequirements', () => {
         expect(findControlledUserIneligible(wrapper).exists()).toBeTruthy();
     });
 
-    it ("Should not display Institution allows you to access CT when the user does not have a CT Tier Eligibility object", async() => {
+    it("Should not display Institution allows you to access CT when the user does not have a CT Tier Eligibility object", async() => {
         let wrapper = component();
         await waitOneTickAndUpdate(wrapper);
 
@@ -640,7 +637,7 @@ describe('DataAccessRequirements', () => {
         expect(findControlledUserIneligible(wrapper).exists()).toBeTruthy();
     });
 
-    it ("Should display the CT card when the environment has a Controlled Tier", async() => {
+    it("Should display the CT card when the environment has a Controlled Tier", async() => {
         environment.accessTiersVisibleToUsers = [AccessTierShortNames.Registered, AccessTierShortNames.Controlled];
 
         let wrapper = component();
@@ -648,7 +645,7 @@ describe('DataAccessRequirements', () => {
         expect(findControlledTierCard(wrapper).exists()).toBeTruthy();
     });
 
-    it ("Should not display the CT card when the environment does not have a Controlled Tier", async() => {
+    it("Should not display the CT card when the environment does not have a Controlled Tier", async() => {
         environment.accessTiersVisibleToUsers = [AccessTierShortNames.Registered];
 
         let wrapper = component();
@@ -657,7 +654,7 @@ describe('DataAccessRequirements', () => {
     });
 
 
-    it ("Should display eraCommons module in CT card " +
+    it("Should display eraCommons module in CT card " +
         "when the user institution has signed agreement and CT requires eraCommons and RT does not", async() => {
         environment.accessTiersVisibleToUsers = [AccessTierShortNames.Registered, AccessTierShortNames.Controlled];
         let wrapper = component();
@@ -685,7 +682,7 @@ describe('DataAccessRequirements', () => {
         expect(findModule(findControlledTierCard(wrapper), AccessModule.ERACOMMONS).exists()).toBeTruthy();
     });
 
-    it ("Should not display eraCommons module in CT card " +
+    it("Should not display eraCommons module in CT card " +
         "when RT requires eraCommons", async() => {
         let wrapper = component();
         await waitOneTickAndUpdate(wrapper);
@@ -712,7 +709,7 @@ describe('DataAccessRequirements', () => {
         expect(findModule(findControlledTierCard(wrapper), AccessModule.ERACOMMONS).exists()).toBeFalsy();
     });
 
-    it ("Should not display eraCommons module in CT card " +
+    it("Should not display eraCommons module in CT card " +
         "when user's institution has not signed CT Institution agreement", async() => {
         let wrapper = component();
         await waitOneTickAndUpdate(wrapper);
@@ -736,7 +733,7 @@ describe('DataAccessRequirements', () => {
         expect(findModule(findControlledTierCard(wrapper), AccessModule.ERACOMMONS).exists()).toBeFalsy();
     });
 
-    it ("Should not display eraCommons module in CT card " +
+    it("Should not display eraCommons module in CT card " +
         "when eraCommons is disabled via the environment config", async() => {
         serverConfigStore.set({config: {...defaultServerConfig, enableEraCommons: false}});
 
@@ -763,5 +760,37 @@ describe('DataAccessRequirements', () => {
         wrapper = component();
         await waitOneTickAndUpdate(wrapper);
         expect(findModule(findControlledTierCard(wrapper), AccessModule.ERACOMMONS).exists()).toBeFalsy();
+    });
+
+    it("Should show the RAS help text component when it is incomplete", async() => {
+        const wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+
+        expect(findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeFalsy();
+        expect(findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeTruthy();
+
+        expect(findContactUs(wrapper).exists()).toBeTruthy();
+    });
+
+    it("Should not show the RAS help text component when it is complete", async() => {
+
+        profileStore.set({
+            profile: {
+                ...ProfileStubVariables.PROFILE_STUB,
+                accessModules: {
+                    modules: [{moduleName: AccessModule.RASLINKLOGINGOV, completionEpochMillis: 1}]
+                }
+            },
+            load,
+            reload,
+            updateCache});
+
+        const wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+
+        expect(findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeTruthy();
+        expect(findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()).toBeFalsy();
+
+        expect(findContactUs(wrapper).exists()).toBeFalsy();
     });
 });

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -397,6 +397,40 @@ const TemporaryRASModule = () => {
   </FlexRow>;
 };
 
+const ContactUs = (props: {profile: Profile}) => {
+  const {profile: {givenName, familyName, username, contactEmail}} = props;
+  return <div data-test-id='contact-us'>
+        <span style={styles.link} onClick={(e) => {
+          openZendeskWidget(givenName, familyName, username, contactEmail);
+          // prevents the enclosing Clickable's onClick() from triggering instead
+          e.stopPropagation();
+        }}>Contact us</span> if you’re having trouble completing this step.
+  </div>;
+}
+
+const LoginGovHelpText = (props: {profile: Profile, afterInitialClick: boolean}) => {
+  const {profile, afterInitialClick} = props;
+
+  // don't return help text if complete or bypassed
+  const needsHelp = !isCompliant(getAccessModuleStatusByName(profile, AccessModule.RASLINKLOGINGOV));
+
+  return needsHelp &&
+    (afterInitialClick
+      ? <div style={styles.loginGovHelp}>
+        <div>
+          Looks like you still need to complete this action, please try again.
+        </div>
+        <ContactUs profile={profile}/>
+      </div>
+      : <div style={styles.loginGovHelp}>
+        <div>
+          Verifying your identity helps us keep participant data safe.
+          You’ll need to provide your state ID, social security number, and phone number.
+        </div>
+        <ContactUs profile={profile}/>
+      </div>);
+}
+
 interface ModuleProps {
   profile: Profile,
   moduleName: AccessModule;
@@ -439,21 +473,6 @@ const MaybeModule = ({profile, moduleName, active, spinnerProps}: ModuleProps): 
 
   const Module = ({profile}) => {
     const status = getAccessModuleStatusByName(profile, moduleName)
-    const {givenName, familyName, username, contactEmail} = profile;
-    // RW-7461
-    const loginGovHelpText = <div style={styles.loginGovHelp}>
-      <div>
-        Verifying your identity helps us keep participant data safe.
-        You’ll need to provide your state ID, social security number, and phone number.
-      </div>
-      <div>
-        <span style={styles.link} onClick={(e) => {
-          openZendeskWidget(givenName, familyName, username, contactEmail);
-          // prevents the enclosing Clickable's onClick() from triggering instead
-          e.stopPropagation();
-        }}>Contact us</span> if you’re having trouble completing this step.
-      </div>
-    </div>;
 
     return <FlexRow data-test-id={`module-${moduleName}`}>
       <FlexRow style={styles.moduleCTA}>
@@ -468,7 +487,7 @@ const MaybeModule = ({profile, moduleName, active, spinnerProps}: ModuleProps): 
         <FlexColumn>
           <div style={active ? styles.activeModuleText : styles.inactiveModuleText}>
             <DARTitleComponent/>
-            {(moduleName === AccessModule.RASLINKLOGINGOV) && loginGovHelpText}
+            {(moduleName === AccessModule.RASLINKLOGINGOV) && <LoginGovHelpText profile={profile} afterInitialClick={showRefresh}/>}
           </div>
           {isCompliant(status) && <div style={styles.moduleDate}>{getStatusText(status)}</div>}
         </FlexColumn>


### PR DESCRIPTION
Update the LoginGov help text behavior based on where a user is in the process of completing the module

Incomplete
<img width="711" alt="Before 7461" src="https://user-images.githubusercontent.com/2701406/138774354-c437d5e6-2688-4d7b-a967-3c778fed48a2.png">

User has clicked but has not yet completed
<img width="721" alt="After 7461" src="https://user-images.githubusercontent.com/2701406/138774415-5e50b590-2fa2-4bb0-b4fc-fa775f63fa93.png">


Completed or bypassed
<img width="632" alt="Complete 7461" src="https://user-images.githubusercontent.com/2701406/138774427-bc56b0bd-3a9f-4cdc-912b-23a2cf3b1ee4.png">


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
