### PR TITLE
NotebookController: use 'workspaceId' everywhere to match api-yaml

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
@@ -51,8 +51,8 @@ public class NotebooksController implements NotebooksApiDelegate {
 
   @Override
   public ResponseEntity<EmptyResponse> deleteNotebook(
-      String workspace, String workspaceName, String notebookName) {
-    notebooksService.deleteNotebook(workspace, workspaceName, notebookName);
+      String workspace, String workspaceId, String notebookName) {
+    notebooksService.deleteNotebook(workspace, workspaceId, notebookName);
     return ResponseEntity.ok(new EmptyResponse());
   }
 
@@ -89,10 +89,10 @@ public class NotebooksController implements NotebooksApiDelegate {
 
   @Override
   public ResponseEntity<FileDetail> cloneNotebook(
-      String workspace, String workspaceName, String notebookName) {
+      String workspace, String workspaceId, String notebookName) {
     FileDetail fileDetail;
     try {
-      fileDetail = notebooksService.cloneNotebook(workspace, workspaceName, notebookName);
+      fileDetail = notebooksService.cloneNotebook(workspace, workspaceId, notebookName);
     } catch (BlobAlreadyExistsException e) {
       throw new BadRequestException("File already exists at copy destination");
     }
@@ -102,22 +102,21 @@ public class NotebooksController implements NotebooksApiDelegate {
 
   @Override
   public ResponseEntity<ReadOnlyNotebookResponse> readOnlyNotebook(
-      String workspaceNamespace, String workspaceName, String notebookName) {
+      String workspaceNamespace, String workspaceId, String notebookName) {
     ReadOnlyNotebookResponse response =
         new ReadOnlyNotebookResponse()
-            .html(
-                notebooksService.getReadOnlyHtml(workspaceNamespace, workspaceName, notebookName));
+            .html(notebooksService.getReadOnlyHtml(workspaceNamespace, workspaceId, notebookName));
     return ResponseEntity.ok(response);
   }
 
   @Override
   public ResponseEntity<FileDetail> renameNotebook(
-      String workspace, String workspaceName, NotebookRename rename) {
+      String workspace, String workspaceId, NotebookRename rename) {
     FileDetail fileDetail;
     try {
       fileDetail =
           notebooksService.renameNotebook(
-              workspace, workspaceName, rename.getName(), rename.getNewName());
+              workspace, workspaceId, rename.getName(), rename.getNewName());
     } catch (BlobAlreadyExistsException e) {
       throw new BadRequestException("File already exists at copy destination");
     }
@@ -127,24 +126,23 @@ public class NotebooksController implements NotebooksApiDelegate {
 
   @Override
   public ResponseEntity<KernelTypeResponse> getNotebookKernel(
-      String workspace, String workspaceName, String notebookName) {
+      String workspace, String workspaceId, String notebookName) {
     workspaceAuthService.enforceWorkspaceAccessLevel(
-        workspace, workspaceName, WorkspaceAccessLevel.READER);
+        workspace, workspaceId, WorkspaceAccessLevel.READER);
 
     return ResponseEntity.ok(
         new KernelTypeResponse()
-            .kernelType(
-                notebooksService.getNotebookKernel(workspace, workspaceName, notebookName)));
+            .kernelType(notebooksService.getNotebookKernel(workspace, workspaceId, notebookName)));
   }
 
   @Override
   public ResponseEntity<NotebookLockingMetadataResponse> getNotebookLockingMetadata(
-      String workspaceNamespace, String workspaceName, String notebookName) {
+      String workspaceNamespace, String workspaceId, String notebookName) {
 
     // Retrieving the workspace is done first, which acts as an access check.
     String bucketName =
         fireCloudService
-            .getWorkspace(workspaceNamespace, workspaceName)
+            .getWorkspace(workspaceNamespace, workspaceId)
             .getWorkspace()
             .getBucketName();
 
@@ -175,7 +173,7 @@ public class NotebooksController implements NotebooksApiDelegate {
 
         Set<String> workspaceUsers =
             workspaceAuthService
-                .getFirecloudWorkspaceAcls(workspaceNamespace, workspaceName)
+                .getFirecloudWorkspaceAcls(workspaceNamespace, workspaceId)
                 .keySet();
 
         response.lastLockedBy(findHashedUser(bucketName, workspaceUsers, lastLockedByHash));


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
