### PR TITLE
[no ticket][risk=no] adding incompatible dataset

### DIFF
--- a/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
+++ b/api/db-cdr/generate-cdr/validate-prerequisites-exist.sh
@@ -40,7 +40,7 @@ DEPENDENT_TABLES=("activity_summary"
             "visit_occurrence"
             "visit_occurrence_ext"
             "vocabulary")
-INCOMPATIBLE_DATASETS=("R2019Q4R3" "R2019Q4R4")
+INCOMPATIBLE_DATASETS=("R2019Q4R3" "R2019Q4R4", "R2020Q4R3")
 
 function loadCSVFile() {
   local file=$1


### PR DESCRIPTION
adding older R2020Q4R3 CDR to list of datasets not allowed to run with current CDR indices build.