### PR TITLE
[RW-7406][risk=no] Fix overlapping names in Dataset Builder

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -199,6 +199,18 @@ export const styles = reactStyles({
     fontSize: '12px',
     padding: '0.5rem',
     borderRadius: '0.5em'
+  },
+  cohortItemName: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap'
+  },
+  listItemName: {
+    lineHeight: '1.5rem',
+    color: colors.primary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap'
   }
 });
 
@@ -246,10 +258,14 @@ export const COMPARE_DOMAINS_FOR_DISPLAY = (a: Domain, b: Domain) => {
 
 const ImmutableListItem: React.FunctionComponent <{
   name: string, onChange: Function, checked: boolean}> = ({name, onChange, checked}) => {
+  const [showNameTooltip, setShowNameTooltip] = useState(false);
     return <div style={styles.listItem}>
       <input type='checkbox' value={name} onChange={() => onChange()}
              style={styles.listItemCheckbox} checked={checked}/>
-      <div style={{lineHeight: '1.5rem', color: colors.primary}}>{name}</div>
+      <TooltipTrigger disabled={!showNameTooltip} content={<div>{name}</div>}>
+        <div style={styles.listItemName}
+             onMouseOver={(e) => setShowNameTooltip(checkNameWidth(e.target as HTMLDivElement))}>{name}</div>
+      </TooltipTrigger>
     </div>;
   };
 
@@ -262,10 +278,8 @@ const ImmutableWorkspaceCohortListItem: React.FunctionComponent<{
                style={styles.listItemCheckbox} checked={checked}/>
         <FlexRow style={{lineHeight: '1.5rem', color: colors.primary, width: '100%', minWidth: 0}}>
           <TooltipTrigger disabled={!showNameTooltip} content={<div>{name}</div>}>
-            <div style={{overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'}}
-                 onMouseOver={(e) => setShowNameTooltip(checkNameWidth(e.target as HTMLDivElement))}>
-              {name}
-            </div>
+            <div style={styles.cohortItemName}
+                 onMouseOver={(e) => setShowNameTooltip(checkNameWidth(e.target as HTMLDivElement))}>{name}</div>
           </TooltipTrigger>
           <div style={{marginLeft: 'auto', paddingRight: '1rem'}}>
             <a href={'/workspaces/' + namespace + '/' + wid + '/data/cohorts/' + cohortId + '/review/cohort-description'}


### PR DESCRIPTION
Fixes issue in Dataset Builder where cohort and concept items with long names overlap to the next item. Also added a tooltip for items where the name is cut off. 

Before:
![Screen Shot 2021-10-27 at 10 50 05 AM](https://user-images.githubusercontent.com/40036095/139101876-8059f26f-3909-43dd-b586-19406b0b5844.png)

After:
![Screen Shot 2021-10-27 at 10 50 32 AM](https://user-images.githubusercontent.com/40036095/139101967-0d5d3cbf-f14c-4a06-83c7-5bb12468fc18.png)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
