### PR TITLE
[risk=low][RW-7515] Test+Local unsafeAllowAccessToAllTiersForRegisteredUsers=false

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -97,7 +97,7 @@
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,
-    "unsafeAllowAccessToAllTiersForRegisteredUsers": true,
+    "unsafeAllowAccessToAllTiersForRegisteredUsers": false,
     "enableBillingUpgrade": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -97,7 +97,7 @@
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,
-    "unsafeAllowAccessToAllTiersForRegisteredUsers": true,
+    "unsafeAllowAccessToAllTiersForRegisteredUsers": false,
     "enableBillingUpgrade": true,
     "enableEventDateModifier": false,
     "enableResearchPurposePrompt": false,


### PR DESCRIPTION
Begin the rollout of proper CT access tier checking with Local and Test.

Local and Test users will need to comply with CT access checks to retain access to Controlled Tier instead of automatically receiving it due to their Registered Tier access.

See the new (just merged - https://github.com/all-of-us/workbench/pull/5814) UserServiceImpl.getUserAccessTiersList() for the logic.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
