### PR TITLE
[RW-7326][risk=no] Implement security suspension UX

### DIFF
--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -3,7 +3,6 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 
 import {IconButton} from 'app/components/buttons';
-
 import {ClrIcon} from 'app/components/icons';
 import { ErrorMode, NotebookFrameError, SecuritySuspendedMessage } from './notebook-frame-error';
 import {PlaygroundIcon} from 'app/components/icons';
@@ -15,17 +14,25 @@ import {ConfirmPlaygroundModeModal} from 'app/pages/analysis/confirm-playground-
 import {NotebookInUseModal} from 'app/pages/analysis/notebook-in-use-modal';
 import {notebooksApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
-import { switchCase, DEFAULT, hasNewValidProps, reactStyles, withCurrentWorkspace} from 'app/utils';
+import {hasNewValidProps, reactStyles, withCurrentWorkspace} from 'app/utils';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {NavigationProps} from 'app/utils/navigation';
-import { maybeUnwrapSecuritySuspendedError, ComputeSecuritySuspendedError, maybeInitializeRuntime, withRuntimeStore} from 'app/utils/runtime-utils';
+import {
+  maybeUnwrapSecuritySuspendedError,
+  ComputeSecuritySuspendedError,
+  maybeInitializeRuntime,
+  withRuntimeStore
+} from 'app/utils/runtime-utils';
 import {MatchParams, profileStore, RuntimeStore} from 'app/utils/stores';
 import {ACTION_DISABLED_INVALID_BILLING} from 'app/utils/strings';
 import {withNavigation} from 'app/utils/with-navigation-hoc';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 import {BillingStatus, RuntimeStatus} from 'generated/fetch';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import {
+  RouteComponentProps,
+  withRouter
+} from 'react-router-dom';
 
 
 const styles = reactStyles({
@@ -155,8 +162,8 @@ export const InteractiveNotebook = fp.flow(
       try {
         await maybeInitializeRuntime(this.props.match.params.ns, this.pollAborter.signal);
         onRuntimeReady();
-      } catch (err) {
-        this.setState({error: await maybeUnwrapSecuritySuspendedError(err)});
+      } catch (e) {
+        this.setState({error: await maybeUnwrapSecuritySuspendedError(e)});
       }
     }
 

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -3,7 +3,9 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 
 import {IconButton} from 'app/components/buttons';
+
 import {ClrIcon} from 'app/components/icons';
+import {NotebookFrameError, ErrorMode} from './notebook-frame-error'
 import {PlaygroundIcon} from 'app/components/icons';
 import {TooltipTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
@@ -72,31 +74,6 @@ const styles = reactStyles({
     position: 'absolute',
     border: 0
   },
-  previewMessageBase: {
-    marginLeft: 'auto',
-    marginRight: 'auto',
-    marginTop: '56px'
-  },
-  previewInvalid: {
-    color: colorWithWhiteness(colors.dark, .6),
-    fontSize: '18px',
-    fontWeight: 600,
-    lineHeight: '32px',
-    maxWidth: '840px',
-    textAlign: 'center'
-  },
-  previewError: {
-    background: colors.warning,
-    border: '1px solid #ebafa6',
-    borderRadius: '5px',
-    color: colors.white,
-    display: 'flex',
-    fontSize: '14px',
-    fontWeight: 500,
-    maxWidth: '550px',
-    padding: '8px',
-    textAlign: 'left'
-  },
   rotate: {
     animation: 'rotation 2s infinite linear'
   }
@@ -114,14 +91,8 @@ interface State {
   showInUseModal: boolean;
   showPlaygroundModeModal: boolean;
   userRequestedExecutableNotebook: boolean;
-  previewErrorMode: PreviewErrorMode;
+  previewErrorMode: ErrorMode;
   previewErrorMessage: string;
-}
-
-enum PreviewErrorMode {
-  NONE = 'none',
-  INVALID = 'invalid',
-  ERROR = 'error'
 }
 
 export const InteractiveNotebook = fp.flow(
@@ -142,7 +113,7 @@ export const InteractiveNotebook = fp.flow(
         showInUseModal: false,
         showPlaygroundModeModal: false,
         userRequestedExecutableNotebook: false,
-        previewErrorMode: PreviewErrorMode.NONE,
+        previewErrorMode: ErrorMode.NONE,
         previewErrorMessage: ''
       };
     }
@@ -172,11 +143,11 @@ export const InteractiveNotebook = fp.flow(
         const {html} = await notebooksApi().readOnlyNotebook(ns, wsid, nbName);
         this.setState({html: html});
       } catch (e) {
-        let previewErrorMode = PreviewErrorMode.ERROR;
+        let previewErrorMode = ErrorMode.ERROR;
         let previewErrorMessage = 'Failed to render preview due to an unknown error, ' +
             'please try reloading or opening the notebook in edit or playground mode.';
         if (e.status === 412) {
-          previewErrorMode = PreviewErrorMode.INVALID;
+          previewErrorMode = ErrorMode.INVALID;
           previewErrorMessage = 'Notebook is too large to display in preview mode, please use edit mode or ' +
               'playground mode to view this notebook.';
         }
@@ -192,7 +163,12 @@ export const InteractiveNotebook = fp.flow(
     }
 
     private async runRuntime(onRuntimeReady: Function): Promise<void> {
-      await maybeInitializeRuntime(this.props.match.params.ns, this.pollAborter.signal);
+      try {
+        await maybeInitializeRuntime(this.props.match.params.ns, this.pollAborter.signal);
+      } catch (err) {
+
+        debugger;
+      }
       onRuntimeReady();
     }
 
@@ -299,18 +275,12 @@ export const InteractiveNotebook = fp.flow(
       if (html) {
         return (<iframe id='notebook-frame' style={styles.previewFrame} srcDoc={html}/>);
       }
-      switch (previewErrorMode) {
-        case PreviewErrorMode.NONE:
-          return (<SpinnerOverlay/>);
-        case PreviewErrorMode.INVALID:
-          return (<div style={{...styles.previewMessageBase, ...styles.previewInvalid}}>{previewErrorMessage}</div>);
-        case PreviewErrorMode.ERROR:
-          return (<div style={{...styles.previewMessageBase, ...styles.previewError}}>
-            <ClrIcon style={{margin: '0 0.5rem 0 0.25rem'}} className='is-solid'
-                     shape='exclamation-triangle' size='30'/>
-            {previewErrorMessage}
-          </div>);
+      if (previewErrorMode !== ErrorMode.NONE) {
+        return <NotebookFrameError errorMode={previewErrorMode} >
+          {previewErrorMessage}
+        </NotebookFrameError>
       }
+      return <SpinnerOverlay/>;
     }
 
     render() {

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -147,7 +147,7 @@ export const InteractiveNotebook = fp.flow(
         const {html} = await notebooksApi().readOnlyNotebook(ns, wsid, nbName);
         this.setState({html: html});
       } catch (e) {
-        this.setState({error: await maybeUnwrapSecuritySuspendedError(e)});
+        this.setState({error: e});
       }
 
       notebooksApi().getNotebookLockingMetadata(ns, wsid, nbName).then((resp) => {
@@ -163,7 +163,7 @@ export const InteractiveNotebook = fp.flow(
         await maybeInitializeRuntime(this.props.match.params.ns, this.pollAborter.signal);
         onRuntimeReady();
       } catch (e) {
-        this.setState({error: await maybeUnwrapSecuritySuspendedError(e)});
+        this.setState({error: e});
       }
     }
 

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
@@ -7,7 +7,7 @@ import {registerApiClient as registerApiClientNotebooks} from 'app/services/note
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore} from 'app/utils/navigation';
 import {profileStore, runtimeStore, serverConfigStore} from 'app/utils/stores';
-import {RuntimeApi, RuntimeStatus, WorkspaceAccessLevel} from 'generated/fetch';
+import {ErrorCode, RuntimeApi, RuntimeStatus, WorkspaceAccessLevel} from 'generated/fetch';
 import {RuntimesApi as LeoRuntimesApi, JupyterApi, ProxyApi} from 'notebooks-generated/fetch';
 import {waitOneTickAndUpdate, waitForFakeTimersAndUpdate} from 'testing/react-test-helpers';
 import {RuntimeApiStub} from 'testing/stubs/runtime-api-stub';
@@ -27,6 +27,8 @@ import {
 } from 'app/pages/analysis/leonardo-app-launcher';
 import { Route, Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
+import { SecuritySuspendedMessage } from './notebook-frame-error';
+import { ComputeSecuritySuspendedError } from 'app/utils/runtime-utils';
 
 describe('NotebookLauncher', () => {
   const workspace = {
@@ -51,7 +53,6 @@ describe('NotebookLauncher', () => {
                              leoAppType={LeoApplicationType.Notebook}/>
       </Route>
     </Router>);
-    await waitOneTickAndUpdate(c);
     return c;
   };
 
@@ -78,7 +79,7 @@ describe('NotebookLauncher', () => {
     profileStore.set({profile, load, reload, updateCache});
     runtimeStore.set({workspaceNamespace: workspace.namespace, runtime: undefined, runtimeLoaded: true});
 
-    jest.useFakeTimers();
+    jest.useFakeTimers('modern');
   });
 
   afterEach(() => {
@@ -277,6 +278,40 @@ describe('NotebookLauncher', () => {
 
     expect(mockNavigate).not.toHaveBeenCalled();
   });
+
+  it('should show error on initial compute suspension', async() => {
+    runtimeStore.set({
+      workspaceNamespace: workspace.namespace,
+      runtime: undefined,
+      runtimeLoaded: false,
+      loadingError: new ComputeSecuritySuspendedError({
+        suspendedUntil: new Date('2000-01-01 03:00:00').toISOString()
+      })
+    });
+
+    const wrapper = await notebookComponent();
+    await waitForFakeTimersAndUpdate(wrapper);
+
+    expect(wrapper.find(Iframe).exists()).toBeFalsy();
+    expect(wrapper.find(SecuritySuspendedMessage).exists()).toBeTruthy();
+  });
+
+  it('should show error on mid-load compute suspension', async() => {
+    runtimeStub.getRuntime = () => Promise.reject(new Response(JSON.stringify({
+      errorCode: ErrorCode.COMPUTESECURITYSUSPENDED,
+      parameters: {
+        suspendedUntil: new Date('2000-01-01 03:00:00').toISOString()
+      }
+    }), {
+      status: 412
+    }));
+
+    const wrapper = await notebookComponent();
+    await waitForFakeTimersAndUpdate(wrapper);
+
+    expect(wrapper.find(Iframe).exists()).toBeFalsy();
+    expect(wrapper.find(SecuritySuspendedMessage).exists()).toBeTruthy();
+  });
 });
 
 describe('TerminalLauncher', () => {
@@ -336,7 +371,7 @@ describe('TerminalLauncher', () => {
     jest.clearAllMocks();
   });
 
-  it('should display terminal state header correcrly when RuntimeStatus changes', async() => {
+  it('should display terminal state header correctly when RuntimeStatus changes', async() => {
     runtimeStub.runtime.status = RuntimeStatus.Creating;
 
     const wrapper = await terminalComponent();

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -494,15 +494,17 @@ export const LeonardoAppLauncher = fp.flow(
 
 
       if (error) {
-        return <NotebookFrameError>
-          {error instanceof ComputeSecuritySuspendedError ?
-           <SecuritySuspendedMessage error={error} /> :
-           <>
-             Unknown error loading analysis environment, please try again.
-           </>
-          }
-
-        </NotebookFrameError>;
+        if (error instanceof ComputeSecuritySuspendedError) {
+          return <NotebookFrameError errorMode={ErrorMode.FORBIDDEN}>
+            <SecuritySuspendedMessage error={error} />
+          </NotebookFrameError>;
+        } else {
+          return <NotebookFrameError>
+            <>
+              Unknown error loading analysis environment, please try again.
+            </>
+          </NotebookFrameError>;
+        }
       }
       return <React.Fragment>
         {progress !== Progress.Loaded ? <div style={styles.main}>

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -6,11 +6,9 @@ import {NavigationProps} from 'app/utils/navigation';
 import {fetchAbortableRetry} from 'app/utils/retry';
 import {MatchParams, RuntimeStore} from 'app/utils/stores';
 
-
 import {Button} from 'app/components/buttons';
 import {FlexRow} from 'app/components/flex';
 import {ClrIcon} from 'app/components/icons';
-import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
 import {Spinner} from 'app/components/spinners';
 import {WithSpinnerOverlayProps} from 'app/components/with-spinner-overlay';
 import {NotebookIcon} from 'app/icons/notebook-icon';
@@ -24,7 +22,12 @@ import {
   withUserProfile
 } from 'app/utils';
 import {Kernels} from 'app/utils/notebook-kernels';
-import { maybeUnwrapSecuritySuspendedError, ComputeSecuritySuspendedError, maybeInitializeRuntime, withRuntimeStore} from 'app/utils/runtime-utils';
+import {
+  maybeUnwrapSecuritySuspendedError,
+  ComputeSecuritySuspendedError,
+  maybeInitializeRuntime,
+  withRuntimeStore
+} from 'app/utils/runtime-utils';
 import {withNavigation} from 'app/utils/with-navigation-hoc';
 import {WorkspaceData} from 'app/utils/workspace-data';
 import {environment} from 'environments/environment';
@@ -32,8 +35,11 @@ import {Profile, Runtime, RuntimeStatus} from 'generated/fetch';
 import {RouteComponentProps, withRouter} from 'react-router-dom';
 import {appendNotebookFileSuffix, dropNotebookFileSuffix} from './util';
 import {parseQueryParams} from "app/components/app-router";
-import { ErrorMode, NotebookFrameError, SecuritySuspendedMessage } from './notebook-frame-error';
-import { ExceededErrorCountError } from 'app/utils/leo-runtime-initializer';
+import {
+  ErrorMode,
+  NotebookFrameError,
+  SecuritySuspendedMessage
+} from './notebook-frame-error';
 
 export enum LeoApplicationType {
   Notebook,

--- a/ui/src/app/pages/analysis/notebook-frame-error.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-frame-error.spec.tsx
@@ -45,11 +45,11 @@ describe('SecuritySuspendedMessage', () => {
     const wrapper = component(nowPlusFiveMinutes);
     expect(wrapper).toBeTruthy();
 
-    waitForFakeTimersAndUpdate(wrapper);
+    await waitForFakeTimersAndUpdate(wrapper);
     expect(wrapper.text()).toContain('in 5 minutes');
 
     jest.setSystemTime(nowPlusFiveMinutes);
-    waitForFakeTimersAndUpdate(wrapper);
+    await waitForFakeTimersAndUpdate(wrapper);
 
     expect(wrapper.text()).toContain('Reload the page to continue');
   });

--- a/ui/src/app/pages/analysis/notebook-frame-error.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-frame-error.spec.tsx
@@ -1,0 +1,56 @@
+import {mount} from 'enzyme';
+
+import {waitForFakeTimersAndUpdate} from 'testing/react-test-helpers';
+import {ComputeSecuritySuspendedError} from 'app/utils/runtime-utils';
+import {SecuritySuspendedMessage} from './notebook-frame-error';
+
+describe('SecuritySuspendedMessage', () => {
+
+  const now = new Date('2000-01-01 03:00:00');
+  const nowMinus10Minutes = new Date('2000-01-01 02:55:00');
+  const nowPlusFiveMinutes = new Date('2000-01-01 03:05:00');
+
+  const component = (suspendedUntil: Date) => {
+    return mount(
+      <SecuritySuspendedMessage error={new ComputeSecuritySuspendedError({
+        suspendedUntil: suspendedUntil.toISOString()
+      })} />);
+  };
+
+  beforeEach(() => {
+    jest
+      .useFakeTimers('modern')
+      .setSystemTime(now.getTime());
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should show pending suspension', async() => {
+    const wrapper = component(nowPlusFiveMinutes);
+    expect(wrapper).toBeTruthy();
+
+    expect(wrapper.text()).toContain('in 5 minutes');
+  });
+
+  it('should indicate reload for past suspension', async() => {
+    const wrapper = component(nowMinus10Minutes);
+    expect(wrapper).toBeTruthy();
+
+    expect(wrapper.text()).toContain('Reload the page to continue');
+  });
+
+  it('should update estimate over time', async() => {
+    const wrapper = component(nowPlusFiveMinutes);
+    expect(wrapper).toBeTruthy();
+
+    waitForFakeTimersAndUpdate(wrapper);
+    expect(wrapper.text()).toContain('in 5 minutes');
+
+    jest.setSystemTime(nowPlusFiveMinutes);
+    waitForFakeTimersAndUpdate(wrapper);
+
+    expect(wrapper.text()).toContain('Reload the page to continue');
+  });
+});

--- a/ui/src/app/pages/analysis/notebook-frame-error.tsx
+++ b/ui/src/app/pages/analysis/notebook-frame-error.tsx
@@ -3,13 +3,12 @@ import moment from 'moment';
 
 import {ClrIcon} from 'app/components/icons';
 import {StyledExternalLink} from 'app/components/buttons';
-import {hasNewValidProps, reactStyles, withCurrentWorkspace} from 'app/utils';
+import {reactStyles} from 'app/utils';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
-import { SecuritySuspendedErrorParameters } from 'generated/fetch';
-import { ComputeSecuritySuspendedError } from 'app/utils/runtime-utils';
-import { SupportMailto } from 'app/components/support';
+import {ComputeSecuritySuspendedError} from 'app/utils/runtime-utils';
+import {SupportMailto} from 'app/components/support';
 import {TooltipTrigger} from 'app/components/popups';
-import { supportUrls } from 'app/utils/zendesk';
+import {supportUrls} from 'app/utils/zendesk';
 
 const {useState, useEffect} = React;
 

--- a/ui/src/app/pages/analysis/notebook-frame-error.tsx
+++ b/ui/src/app/pages/analysis/notebook-frame-error.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+
+import {ClrIcon} from 'app/components/icons';
+import {StyledExternalLink} from 'app/components/buttons';
+import {hasNewValidProps, reactStyles, withCurrentWorkspace} from 'app/utils';
+import colors, {colorWithWhiteness} from 'app/styles/colors';
+import { SecuritySuspendedErrorParameters } from 'generated/fetch';
+import { ComputeSecuritySuspendedError } from 'app/utils/runtime-utils';
+import { SupportMailto } from 'app/components/support';
+
+const styles = reactStyles({
+  previewMessageBase: {
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    marginTop: '56px'
+  },
+  previewError: {
+    background: colors.warning,
+    border: '1px solid #ebafa6',
+    borderRadius: '5px',
+    color: colors.white,
+    display: 'flex',
+    fontSize: '14px',
+    fontWeight: 500,
+    maxWidth: '550px',
+    padding: '8px',
+    textAlign: 'left'
+  },
+  previewInvalid: {
+    color: colorWithWhiteness(colors.dark, .6),
+    fontSize: '18px',
+    fontWeight: 600,
+    lineHeight: '32px',
+    maxWidth: '840px',
+    textAlign: 'center'
+  },
+})
+
+export enum ErrorMode {
+  NONE = 'none',
+  INVALID = 'invalid',
+  ERROR = 'error'
+}
+
+interface Props {
+  errorMode?: ErrorMode;
+  children: React.ReactNode;
+}
+
+export const NotebookFrameError = ({errorMode = ErrorMode.ERROR, children}: Props) => {
+  switch(errorMode) {
+    case ErrorMode.INVALID:
+      return <div style={{...styles.previewMessageBase, ...styles.previewInvalid}}>
+        {children}
+      </div>;
+    case ErrorMode.ERROR:
+      return <div style={{...styles.previewMessageBase, ...styles.previewError}}>
+        <ClrIcon style={{margin: '0 0.5rem 0 0.25rem'}} className='is-solid'
+                 shape='exclamation-triangle' size='30'/>
+        {children}
+      </div>;
+    default:
+      return null;
+  }
+};
+
+interface SuspendedMessageProps {
+  error: ComputeSecuritySuspendedError
+}
+
+export const SecuritySuspendedMessage = ({error}: SuspendedMessageProps) => {
+  const duration = "TODO"
+  return <>
+    Your runtime has been suspended due to security egress concerns. Your
+    runtime will become available again in {duration}. Please promptly check
+    your contact email to verify your activity.
+
+    To learn how to avoid common causes of accidental egress, please review
+    this
+    <StyledExternalLink href={"TODO"} target='_blank'>
+      support article
+    </StyledExternalLink>, or contact <SupportMailto/> with additional questions.
+  </>
+};

--- a/ui/src/app/pages/analysis/notebook-frame-error.tsx
+++ b/ui/src/app/pages/analysis/notebook-frame-error.tsx
@@ -108,7 +108,9 @@ export const SecuritySuspendedMessage = ({error}: SuspendedMessageProps) => {
     {until.isAfter(new Date()) ?
        <>
          <b>Your analysis environment is suspended due to security egress concerns</b>.&nbsp;
-         Your runtime will become available again&nbsp;
+         Your runtime will become available again
+         {/* Line break here to avoid splitting duration tooltip trigger. */}
+         <br/>
          <TooltipTrigger content={<div>{untilFull}</div>}>
            <b style={{textDecoration: 'underline'}}>{duration}</b>
          </TooltipTrigger>.

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -3,6 +3,7 @@ import {Spinner} from 'app/components/spinners';
 import {WorkspaceNavBar} from 'app/pages/workspace/workspace-nav-bar';
 import {WorkspaceRoutes} from 'app/routing/workspace-app-routing';
 import {workspacesApi} from 'app/services/swagger-fetch-clients';
+import {reportError} from 'app/utils/errors';
 import {withCurrentWorkspace} from 'app/utils';
 import {
   ExceededActionCountError,
@@ -48,7 +49,8 @@ export const WorkspaceWrapper = fp.flow(
         // Also ignore LeoRuntimeInitializationAbortedError - this is expected when navigating
         // away from a page during a poll.
         if (!(e instanceof ExceededActionCountError || e instanceof LeoRuntimeInitializationAbortedError)) {
-          throw e;
+          // Ideally, we would have some top-level error messaginag here.
+          reportError(e);
         }
       }
     };

--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -240,7 +240,7 @@ export class LeoRuntimeInitializer {
   }
 
   private handleUnknownError(e: any) {
-    if (e instanceof Response && e.status >= 500 && e.status < 600) {
+    if (!(e instanceof Response) || e.status >= 500) {
       this.serverErrorCount++;
     }
     reportError(e);

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -1,7 +1,16 @@
 import {leoRuntimesApi} from 'app/services/notebooks-swagger-fetch-clients';
 import {disksApi, runtimeApi} from 'app/services/swagger-fetch-clients';
-import {DEFAULT, switchCase, withAsyncErrorHandling} from 'app/utils';
-import { ExceededActionCountError, ExceededErrorCountError, LeoRuntimeInitializationAbortedError, LeoRuntimeInitializer, } from 'app/utils/leo-runtime-initializer';
+import {
+  DEFAULT,
+  switchCase,
+  withAsyncErrorHandling
+} from 'app/utils';
+import {
+  ExceededActionCountError,
+  ExceededErrorCountError,
+  LeoRuntimeInitializationAbortedError,
+  LeoRuntimeInitializer
+} from 'app/utils/leo-runtime-initializer';
 import {
   AutopauseMinuteThresholds,
   ComputeType,
@@ -19,7 +28,14 @@ import {
   useStore
 } from 'app/utils/stores';
 
-import { DataprocConfig, ErrorCode, GpuConfig, Runtime, RuntimeStatus, SecuritySuspendedErrorParameters} from 'generated/fetch';
+import {
+  DataprocConfig,
+  ErrorCode,
+  GpuConfig,
+  Runtime,
+  RuntimeStatus,
+  SecuritySuspendedErrorParameters
+} from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -123,16 +123,20 @@ export const clearCompoundRuntimeOperations = () => {
 };
 
 // runtime store states: undefined(initial state) -> Runtime (user selected) <--> null (delete only - no recreate)
+// error should be set if there is a failure in initializing the store value. If
+// error is set, runtimeLoaded should be false.
 export interface RuntimeStore {
   workspaceNamespace: string | null | undefined;
   runtime: Runtime | null | undefined;
   runtimeLoaded: boolean;
+  loadingError?: Error;
 }
 
 export const runtimeStore = atom<RuntimeStore>({
   workspaceNamespace: undefined,
   runtime: undefined,
-  runtimeLoaded: false
+  runtimeLoaded: false,
+  loadingError: undefined
 });
 
 // runtime store states: undefined(initial state) -> Runtime (user selected) <--> null (delete only - no recreate)

--- a/ui/src/app/utils/zendesk.ts
+++ b/ui/src/app/utils/zendesk.ts
@@ -5,6 +5,7 @@ interface ZendeskUrls {
   billing: string;
   communityForum: string;
   createBillingAccount: string;
+  egressFaq: string;
   dataDictionary: string;
   faq: string;
   gettingStarted: string;
@@ -56,6 +57,7 @@ export const supportUrls: ZendeskUrls = ((env) => {
       billing: section('360008099991'),
       createBillingAccount: article('360039539411'),
       dataDictionary: article('360033200232'),
+      egressFaq: article('4407354684052'),
       faq: category('360002157532'),
       gettingStarted: category('360002157352'),
       tableOfContents: category('360002625291'),
@@ -67,6 +69,7 @@ export const supportUrls: ZendeskUrls = ((env) => {
       billing: section('360012893532'),
       createBillingAccount: article('360060301171'),
       dataDictionary: article('360058949792'),
+      egressFaq: article('404'),
       faq: category('360005877792'),
       gettingStarted: category('360005884571'),
       tableOfContents: category('360005884591'),
@@ -78,6 +81,7 @@ export const supportUrls: ZendeskUrls = ((env) => {
       billing: section('360009142932'),
       createBillingAccount: article('360044792211'),
       dataDictionary: article('360044793611'),
+      egressFaq: article('404'),
       faq: category('360003453651'),
       gettingStarted: category('360003430652'),
       tableOfContents: category('360003430672'),

--- a/ui/src/testing/react-test-helpers.tsx
+++ b/ui/src/testing/react-test-helpers.tsx
@@ -20,7 +20,6 @@ export async function waitOneTickAndUpdate(wrapper: ReactWrapper) {
 
 // Combining a setTimeout with a delay of 0 (used in UI) and setImmediate can result in a non-deterministic order of events
 // If you are testing code that uses setTimeout this may be a safer choice.
-// If you are using fakeAsync waitOneTickAndUpdate is preferred
 export async function waitOnTimersAndUpdate(wrapper: ReactWrapper){
   const waitForTimeout = () => new Promise<void>(resolve => setTimeout(resolve, 0));
   await act(waitForTimeout);
@@ -31,7 +30,7 @@ export async function waitForFakeTimersAndUpdate(wrapper: ReactWrapper) {
   act(() => {
     jest.runOnlyPendingTimers();
   });
-  await waitOneTickAndUpdate(wrapper);
+  wrapper.update();
 }
 
 export async function simulateSelection(selectElement: ReactWrapper, selection: string) {

--- a/ui/src/testing/react-test-helpers.tsx
+++ b/ui/src/testing/react-test-helpers.tsx
@@ -6,12 +6,6 @@ import {InputSwitch} from "primereact/inputswitch";
 import {MemoryRouter} from 'react-router';
 import {Dropdown} from "primereact/dropdown";
 
-// This file is necessary because angular imports complain if there
-// is no zone, regardless of whether the imports are used.
-// The error is from:
-//   import {ComponentFixture, tick} from '@angular/core/testing';
-// And fails with:
-//   ReferenceError: Zone is not defined
 export async function waitOneTickAndUpdate(wrapper: ReactWrapper) {
   const waitImmediate = () => new Promise<void>(resolve => setImmediate(resolve))
   await act(waitImmediate);
@@ -27,8 +21,9 @@ export async function waitOnTimersAndUpdate(wrapper: ReactWrapper){
 }
 
 export async function waitForFakeTimersAndUpdate(wrapper: ReactWrapper) {
-  act(() => {
+  await act(() => {
     jest.runOnlyPendingTimers();
+    return Promise.resolve();
   });
   wrapper.update();
 }


### PR DESCRIPTION
Related changes:
- `LeoRuntimeInitializer` no longer infinitely retries 400 level errors
- `LeoRuntimeInitializer` returns the last inner error when it exceeds the retry count
- `LeoRuntimeInitializer` treats non HTTP errors as unknown errors for retry purposes

Not included in this PR:
- "suspended" status in the help sidebar

security suspended error:
![image](https://user-images.githubusercontent.com/822298/139495687-dbaa8082-af50-403d-a0fc-1c2b2f626261.png)

suspension time hover:
![image](https://user-images.githubusercontent.com/822298/139496508-157df1b5-bb0d-40a7-99b0-76b905f2dd90.png)

unknown error (notebooks redirect):
![image](https://user-images.githubusercontent.com/822298/139496275-c135b390-6721-4cdc-bb93-d6702cd18934.png)
