### PR TITLE
[RW-7521][risk=no] Add new user admin column for ct compliance training

### DIFF
--- a/ui/src/app/pages/admin/admin-users.tsx
+++ b/ui/src/app/pages/admin/admin-users.tsx
@@ -163,6 +163,7 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
         user={{...user}}
         onBypassModuleUpdate={() => this.loadProfiles()}/>,
       complianceTraining: this.accessModuleCellContents(user, 'complianceTraining'),
+      ctComplianceTraining: '?',
       contactEmail: user.contactEmail,
       dataUseAgreement: this.accessModuleCellContents(user, 'dataUseAgreement'),
       eraCommons: this.accessModuleCellContents(user, 'eraCommons'),
@@ -267,8 +268,14 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
           {enableComplianceTraining && <Column field='complianceTraining'
                   bodyStyle={{...styles.colStyle, textAlign: 'center'}}
                   excludeGlobalFilter={true}
-                  header='Training'
+                  header='RT RCR'
                   headerStyle={{...styles.colStyle, width: '80px'}}
+          />}
+          {enableComplianceTraining && <Column field='ctComplianceTraining'
+                  bodyStyle={{...styles.colStyle, textAlign: 'center'}}
+                   excludeGlobalFilter={true}
+                   header='CT RCR'
+                   headerStyle={{...styles.colStyle, width: '80px'}}
           />}
           {enableEraCommons && <Column field='eraCommons'
                   bodyStyle={{...styles.colStyle, textAlign: 'center'}}


### PR DESCRIPTION
First part of story RW-7521: UI work - For environments where `enableComplianceTraining` is true, add a column to the User Admin Table.

New column name is `CT RCR`. We also modified existing column name `Training` to `RT RCR`. (RCR: Responsible Conduct of Research)

<img width="616" alt="Screen Shot 2021-11-01 at 11 06 52 AM" src="https://user-images.githubusercontent.com/35533885/139693833-5b1c915f-7a93-4a75-823c-ad7b032d58dc.png">

