### PR TITLE
[RW-7521][risk=no]  Add CT Compliance Training to User Admin + User Admin Bypass

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -114,6 +114,10 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
 
     Timestamp getComplianceTrainingCompletionTime();
 
+    Timestamp getCtComplianceTrainingBypassTime();
+
+    Timestamp getCtComplianceTrainingCompletionTime();
+
     Timestamp getEraCommonsBypassTime();
 
     Timestamp getEraCommonsCompletionTime();
@@ -151,6 +155,8 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + "uamd.data_use_agreement_completion_time AS dataUseAgreementCompletionTime, "
               + "uamrt.compliance_training_bypass_time AS complianceTrainingBypassTime, "
               + "uamrt.compliance_training_completion_time AS complianceTrainingCompletionTime, "
+              + "uamct.ct_compliance_training_bypass_time AS ctComplianceTrainingBypassTime, "
+              + "uamct.ct_compliance_training_completion_time AS ctComplianceTrainingCompletionTime, "
               + "uame.era_commons_bypass_time AS eraCommonsBypassTime, "
               + "uame.era_commons_completion_time AS eraCommonsCompletionTime, "
               + "uamt.two_factor_auth_bypass_time AS twoFactorAuthBypassTime, "
@@ -194,6 +200,14 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + "  JOIN access_module am ON am.access_module_id=uam.access_module_id "
               + "  WHERE am.name = 'RT_COMPLIANCE_TRAINING' "
               + ") as uamrt ON u.user_id = uamrt.user_id "
+              + "LEFT JOIN ( "
+              + "  SELECT uam.user_id, "
+              + "    uam.bypass_time AS ct_compliance_training_bypass_time, "
+              + "    uam.completion_time AS ct_compliance_training_completion_time "
+              + "  FROM user_access_module uam "
+              + "  JOIN access_module am ON am.access_module_id=uam.access_module_id "
+              + "  WHERE am.name = 'CT_COMPLIANCE_TRAINING' "
+              + ") as uamct ON u.user_id = uamct.user_id "
               + "LEFT JOIN ( "
               + "  SELECT uam.user_id, "
               + "    uam.bypass_time AS data_use_agreement_bypass_time, "

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5543,6 +5543,12 @@ definitions:
       complianceTrainingCompletionTime:
         type: integer
         format: int64
+      ctComplianceTrainingBypassTime:
+        type: integer
+        format: int64
+      ctComplianceTrainingCompletionTime:
+        type: integer
+        format: int64
       dataUseAgreementBypassTime:
         type: integer
         format: int64

--- a/ui/src/app/pages/admin/admin-user-bypass.tsx
+++ b/ui/src/app/pages/admin/admin-user-bypass.tsx
@@ -34,6 +34,7 @@ interface State {
 const getBypassedModules = (user: AdminTableUser): Array<AccessModule> => {
   return [
     ...(user.complianceTrainingBypassTime ? [AccessModule.COMPLIANCETRAINING] : []),
+    ...(user.ctComplianceTrainingBypassTime ? [AccessModule.CTCOMPLIANCETRAINING] : []),
     ...(user.dataUseAgreementBypassTime ? [AccessModule.DATAUSERCODEOFCONDUCT] : []),
     ...(user.eraCommonsBypassTime ? [AccessModule.ERACOMMONS] : []),
     ...(user.twoFactorAuthBypassTime ? [AccessModule.TWOFACTORAUTH] : []),
@@ -126,6 +127,12 @@ export class AdminUserBypass extends React.Component<Props, State> {
                   data-test-id='compliance-training-toggle'
                   onToggle={() => {this.setState({selectedModules:
                       fp.xor(selectedModules, [AccessModule.COMPLIANCETRAINING])}); }}
+          />}
+          {enableComplianceTraining && <Toggle name='CT Compliance Training'
+                  checked={selectedModules.includes(AccessModule.CTCOMPLIANCETRAINING)}
+                  data-test-id='ct-compliance-training-toggle'
+                  onToggle={() => {this.setState({selectedModules:
+                      fp.xor(selectedModules, [AccessModule.CTCOMPLIANCETRAINING])}); }}
           />}
           {enableEraCommons && <Toggle name='eRA Commons Linking'
                   checked={selectedModules.includes(AccessModule.ERACOMMONS)}

--- a/ui/src/app/pages/admin/admin-users.tsx
+++ b/ui/src/app/pages/admin/admin-users.tsx
@@ -163,7 +163,7 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
         user={{...user}}
         onBypassModuleUpdate={() => this.loadProfiles()}/>,
       complianceTraining: this.accessModuleCellContents(user, 'complianceTraining'),
-      ctComplianceTraining: '?',
+      ctComplianceTraining: this.accessModuleCellContents(user, 'ctComplianceTraining'),
       contactEmail: user.contactEmail,
       dataUseAgreement: this.accessModuleCellContents(user, 'dataUseAgreement'),
       eraCommons: this.accessModuleCellContents(user, 'eraCommons'),


### PR DESCRIPTION
Continuing with https://github.com/all-of-us/workbench/pull/5837

With this PR, admin can see the correct status (completion/Bypass/nothing ) for CT Compliance training module for a user on the Admin Page.
<img width="1409" alt="Screen Shot 2021-11-01 at 2 22 08 PM" src="https://user-images.githubusercontent.com/34481816/139721384-aab05625-4792-4ec5-8af2-fef534dd8269.png">


As well as ByPass CT Compliance Training Module
<img width="319" alt="Screen Shot 2021-11-01 at 2 22 18 PM" src="https://user-images.githubusercontent.com/34481816/139721400-d9de1ce9-b68e-4980-bc9a-1c8a06c8d834.png">

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
