### PR TITLE
[risk=no] Add node debugger command to yarn

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -6,6 +6,7 @@
     "start": "BROWSER='none' PORT=4200 react-app-rewired start",
     "dev-up": "yarn && yarn run codegen && yarn start",
     "build": "react-app-rewired build",
+    "test:debug": "react-app-rewired --inspect-brk test --watchAll=false --run-in-band",
     "test": "react-app-rewired test --watchAll=false",
     "lint": "yarn eslint src --ext .ts,.tsx",
     "codegen": "yarn run codegen-clean && yarn run codegen-swagger && yarn run notebooks-codegen-swagger",


### PR DESCRIPTION
This method allows you to step through jest test code via the chrome inspector, similar to how one can debug code when running a local UI server. This is an adaptation of the general instructions found here: https://jestjs.io/docs/troubleshooting.

Node is referenced here because Jest runs via a node process. There is no browser configured by default, and therefore there is no way of using a browser-based debugger by default. With some additional flags, you can configure Chrome to connect to the running node process and use the Chrome inspector to set breakpoints etc normally.

Usage:

1. Add debugger; to code (or set a breakpoint later). Recommended: use `fit()` instead of `it()` to run an isolated test.

2.
```
yarn test:debug ...
```

3. Open chrome inspector (in any chrome tab), click "dedicated Node devtools":

![image](https://user-images.githubusercontent.com/822298/139907058-b176557d-da11-42e8-82e1-6a608690338d.png)

4. Use the debugger as normal.