### PR TITLE
[risk=low][RW-7533] Disallow CT workspace sharing with users who are no longer in CT

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -44,10 +44,11 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
       "SELECT dbUser FROM DbUser dbUser "
           + "JOIN DbUserAccessTier uat ON uat.user.userId = dbUser.userId "
           + "JOIN DbAccessTier tier ON uat.accessTier.accessTierId = tier.accessTierId "
-          + "WHERE tier.shortName = :shortName AND "
-          + "  (lower(dbUser.username) LIKE lower(concat('%', :term, '%')) "
-          + "  OR lower(dbUser.familyName) LIKE lower(concat('%', :term, '%')) "
-          + "  OR lower(dbUser.givenName) LIKE lower(concat('%', :term, '%')))")
+          + "WHERE tier.shortName = :shortName "
+          + "  AND uat.tierAccessStatus = 1 " // TierAccessStatus.ENABLED
+          + "  AND (lower(dbUser.username) LIKE lower(concat('%', :term, '%')) "
+          + "    OR lower(dbUser.familyName) LIKE lower(concat('%', :term, '%')) "
+          + "    OR lower(dbUser.givenName) LIKE lower(concat('%', :term, '%')))")
   List<DbUser> findUsersBySearchStringAndTier(
       @Param("term") String term, Sort sort, @Param("shortName") String accessTierShortName);
 


### PR DESCRIPTION
Missed a step in the search query: check if the user/tier association is ENABLED rather than DISABLED.

Tested locally: could share with non-CT user before, can only share with CT users now.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
