### PR TITLE
[RW-7317][risk=low] Reintegrate Jira service for Workbench

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -189,7 +189,7 @@ swaggerSources {
             '--model-name-prefix', 'Firecloud'
     ])
     notebooks swagger2JavaClient("notebooks.yaml", "notebooks")
-    jira swagger2JavaClient("jira.yaml", "jira")
+    jira swagger3JavaClient("jira.yaml", "jira")
     mandrill swagger2JavaClient("mandrill.yaml", "mandrill")
     moodle swagger2JavaClient("moodle.yaml", "moodle")
     rdr swagger2JavaClient("rdr.yaml", "rdr")

--- a/api/src/main/java/org/pmiops/workbench/jira/JiraConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/jira/JiraConfig.java
@@ -1,0 +1,55 @@
+package org.pmiops.workbench.jira;
+
+import com.google.common.base.Suppliers;
+import com.google.gson.Gson;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.pmiops.workbench.google.CloudStorageClient;
+import org.pmiops.workbench.jira.api.JiraApi;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Configuration
+public class JiraConfig {
+  private static final String JIRA_CREDS_PATH = "jira-login.json";
+  private static final String JIRA_CREDS_CACHE = "jiraCredsCache";
+
+  /** Corresponds to jira-login JSON file. */
+  private static class JiraCredentials {
+    public String username;
+    public String apiToken;
+  }
+
+  @Bean
+  @RequestScope
+  public JiraApi jiraApi(ApiClient apiClient) {
+    JiraApi api = new JiraApi();
+    api.setApiClient(apiClient);
+    return api;
+  }
+
+  @Bean
+  public ApiClient apiClient(
+      @Qualifier(JIRA_CREDS_CACHE) Supplier<JiraCredentials> jiraCredsCache) {
+    ApiClient client = new ApiClient();
+    JiraCredentials creds = jiraCredsCache.get();
+    client.setUsername(creds.username);
+    client.setPassword(creds.apiToken);
+    return client;
+  }
+
+  @Bean
+  @Qualifier(JIRA_CREDS_CACHE)
+  Supplier<JiraCredentials> getJiraCredsCache(CloudStorageClient storageClient) {
+    return Suppliers.memoizeWithExpiration(
+        () ->
+            new Gson()
+                .fromJson(
+                    storageClient.getCredentialsBucketString(JIRA_CREDS_PATH),
+                    JiraCredentials.class),
+        1,
+        TimeUnit.HOURS);
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/jira/JiraConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/jira/JiraConfig.java
@@ -9,6 +9,7 @@ import org.pmiops.workbench.jira.api.JiraApi;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.web.context.annotation.RequestScope;
 
 @Configuration
@@ -31,6 +32,7 @@ public class JiraConfig {
   }
 
   @Bean
+  @Lazy
   public ApiClient apiClient(
       @Qualifier(JIRA_CREDS_CACHE) Supplier<JiraCredentials> jiraCredsCache) {
     ApiClient client = new ApiClient();
@@ -41,6 +43,7 @@ public class JiraConfig {
   }
 
   @Bean
+  @Lazy
   @Qualifier(JIRA_CREDS_CACHE)
   Supplier<JiraCredentials> getJiraCredsCache(CloudStorageClient storageClient) {
     return Suppliers.memoizeWithExpiration(

--- a/api/src/main/java/org/pmiops/workbench/jira/JiraService.java
+++ b/api/src/main/java/org/pmiops/workbench/jira/JiraService.java
@@ -1,68 +1,163 @@
 package org.pmiops.workbench.jira;
 
+import com.google.common.collect.ImmutableMap;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.pmiops.workbench.jira.api.JiraApi;
+import org.pmiops.workbench.jira.model.AtlassianContent;
+import org.pmiops.workbench.jira.model.AtlassianDocument;
+import org.pmiops.workbench.jira.model.Comment;
 import org.pmiops.workbench.jira.model.CreatedIssue;
-import org.pmiops.workbench.jira.model.EntityProperty;
+import org.pmiops.workbench.jira.model.IssueTypeDetails;
 import org.pmiops.workbench.jira.model.IssueUpdateDetails;
+import org.pmiops.workbench.jira.model.Project;
+import org.pmiops.workbench.jira.model.SearchRequestBean;
+import org.pmiops.workbench.jira.model.SearchResults;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+/**
+ * Service to mediate interactions with the RW Jira project.
+ *
+ * <p>To get the schema for RW issues (including all field names):
+ *
+ * <p><code>
+ * # Get USER / API KEY from credentials bucket.
+ * curl --request GET \
+ *   --url "https://precisionmedicineinitiative.atlassian.net/rest/api/3/issue/createmeta?projectKeys=RW&expand=projects.issuetypes.fields" \
+ *   --header Accept: application/json \
+ *   --user "USER:API_KEY" | jq .
+ *  </code>
+ */
 @Service
 public class JiraService {
   private static final String PROJECT_KEY = "RW";
+  private static final Logger log = Logger.getLogger(JiraService.class.getName());
 
   @Autowired private Provider<JiraApi> apiProvider;
 
-  private enum IssueProperties {
+  public enum IssueProperty {
     DESCRIPTION("description"),
+    EGRESS_VM_PREFIX("Egress VM Prefix[Short text]", "customfield_10795"),
     ISSUE_TYPE("issuetype"),
     LABELS("labels"),
     PROJECT("project"),
+    RW_ENVIRONMENT("RW Environment[Short text]", "customfield_10759"),
     SUMMARY("summary");
 
     private final String key;
+    private final String fieldName;
 
-    IssueProperties(String key) {
-      this.key = key;
+    IssueProperty(String key) {
+      this(key, key);
     }
 
-    String key() {
+    IssueProperty(String key, String fieldName) {
+      this.key = key;
+      this.fieldName = fieldName;
+    }
+
+    public String key() {
       return key;
+    }
+
+    public String fieldName() {
+      return fieldName;
     }
   }
 
   public enum IssueType {
-    TASK("Task"),
-    BUG("Bug"),
-    STORY("Story");
+    TASK("Task", "10001"),
+    BUG("Bug", "10003"),
+    STORY("Story", "10000");
 
-    private final String value;
+    private final String jiraName;
+    private final String jiraId;
 
-    IssueType(String value) {
-      this.value = value;
+    IssueType(String jiraName, String jiraId) {
+      this.jiraName = jiraName;
+      this.jiraId = jiraId;
     }
 
-    String value() {
-      return value;
+    public String jiraName() {
+      return jiraName;
+    }
+
+    public String jiraId() {
+      return jiraId;
     }
   }
 
-  public CreatedIssue createIssue(IssueType type, String summary, String description)
+  public CreatedIssue createIssue(
+      IssueType type, String description, Map<IssueProperty, Object> issueProps)
       throws ApiException {
 
-    return apiProvider
-        .get()
-        .createIssue(
-            new IssueUpdateDetails()
-                .addPropertiesItem(
-                    new EntityProperty().key(IssueProperties.PROJECT.key()).value(PROJECT_KEY))
-                .addPropertiesItem(
-                    new EntityProperty().key(IssueProperties.ISSUE_TYPE.key()).value(type.value()))
-                .addPropertiesItem(
-                    new EntityProperty().key(IssueProperties.SUMMARY.key()).value(summary))
-                .addPropertiesItem(
-                    new EntityProperty().key(IssueProperties.DESCRIPTION.key()).value(description)),
-            false);
+    Map<IssueProperty, Object> mergedProps = new HashMap<>(issueProps);
+    mergedProps.putAll(
+        ImmutableMap.<IssueProperty, Object>builder()
+            .put(IssueProperty.PROJECT, new Project().key(PROJECT_KEY))
+            .put(IssueProperty.ISSUE_TYPE, new IssueTypeDetails().id(type.jiraId()))
+            .put(IssueProperty.DESCRIPTION, textAsMinimalAtlassianDocument(description))
+            .build());
+    try {
+      return apiProvider
+          .get()
+          .createIssue(
+              new IssueUpdateDetails()
+                  .fields(
+                      mergedProps.keySet().stream()
+                          .collect(Collectors.toMap(IssueProperty::fieldName, mergedProps::get))),
+              false);
+    } catch (ApiException e) {
+      logJiraErrorPayload(e);
+      throw e;
+    }
+  }
+
+  public void commentIssue(String issueId, String body) throws ApiException {
+    try {
+      apiProvider
+          .get()
+          .addComment(new Comment().body(textAsMinimalAtlassianDocument(body)), issueId);
+    } catch (ApiException e) {
+      logJiraErrorPayload(e);
+      throw e;
+    }
+  }
+
+  public SearchResults searchIssues(String jqlSubquery) throws ApiException {
+    try {
+      return apiProvider
+          .get()
+          .searchForIssuesUsingJqlPost(
+              new SearchRequestBean()
+                  .jql(String.format("project = %s AND %s", PROJECT_KEY, jqlSubquery)));
+    } catch (ApiException e) {
+      logJiraErrorPayload(e);
+      throw e;
+    }
+  }
+
+  /**
+   * Several fields in the Jira API expect content in the Atlassian Document format, which is fairly
+   * verbose. This method wraps text in a minimal document. See
+   * https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/
+   */
+  private AtlassianDocument textAsMinimalAtlassianDocument(String text) {
+    return new AtlassianDocument()
+        .type("doc")
+        .version(BigDecimal.ONE)
+        .addContentItem(
+            new AtlassianContent()
+                .type("paragraph")
+                .addContentItem(new AtlassianContent().type("text").text(text)));
+  }
+
+  private void logJiraErrorPayload(ApiException e) {
+    log.severe("Jira error payload details: " + e.getResponseBody());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/jira/JiraService.java
+++ b/api/src/main/java/org/pmiops/workbench/jira/JiraService.java
@@ -1,0 +1,68 @@
+package org.pmiops.workbench.jira;
+
+import javax.inject.Provider;
+import org.pmiops.workbench.jira.api.JiraApi;
+import org.pmiops.workbench.jira.model.CreatedIssue;
+import org.pmiops.workbench.jira.model.EntityProperty;
+import org.pmiops.workbench.jira.model.IssueUpdateDetails;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JiraService {
+  private static final String PROJECT_KEY = "RW";
+
+  @Autowired private Provider<JiraApi> apiProvider;
+
+  private enum IssueProperties {
+    DESCRIPTION("description"),
+    ISSUE_TYPE("issuetype"),
+    LABELS("labels"),
+    PROJECT("project"),
+    SUMMARY("summary");
+
+    private final String key;
+
+    IssueProperties(String key) {
+      this.key = key;
+    }
+
+    String key() {
+      return key;
+    }
+  }
+
+  public enum IssueType {
+    TASK("Task"),
+    BUG("Bug"),
+    STORY("Story");
+
+    private final String value;
+
+    IssueType(String value) {
+      this.value = value;
+    }
+
+    String value() {
+      return value;
+    }
+  }
+
+  public CreatedIssue createIssue(IssueType type, String summary, String description)
+      throws ApiException {
+
+    return apiProvider
+        .get()
+        .createIssue(
+            new IssueUpdateDetails()
+                .addPropertiesItem(
+                    new EntityProperty().key(IssueProperties.PROJECT.key()).value(PROJECT_KEY))
+                .addPropertiesItem(
+                    new EntityProperty().key(IssueProperties.ISSUE_TYPE.key()).value(type.value()))
+                .addPropertiesItem(
+                    new EntityProperty().key(IssueProperties.SUMMARY.key()).value(summary))
+                .addPropertiesItem(
+                    new EntityProperty().key(IssueProperties.DESCRIPTION.key()).value(description)),
+            false);
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/jira/JiraService.java
+++ b/api/src/main/java/org/pmiops/workbench/jira/JiraService.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Service;
  *
  * <p>To get the schema for RW issues (including all field names):
  *
- * <p><code>
+ * <pre><code>
  * # Get USER / API KEY from credentials bucket.
  * curl --request GET \
  *   --url "https://precisionmedicineinitiative.atlassian.net/rest/api/3/issue/createmeta?projectKeys=RW&expand=projects.issuetypes.fields" \
@@ -158,6 +158,9 @@ public class JiraService {
   }
 
   private void logJiraErrorPayload(ApiException e) {
+    // Logging at this level and rethrowing is not ideal, but unfortunately the default error
+    // message for ApiException completely omits the error message returned from the API, which is
+    // found in the response body.
     log.severe("Jira error payload details: " + e.getResponseBody());
   }
 }

--- a/api/src/main/resources/jira.yaml
+++ b/api/src/main/resources/jira.yaml
@@ -1,6 +1,12 @@
-#This file provide the end points for jira interactions
+# This file provide the end points for jira interactions
+#
 # Copied from https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json
-
+# The following updates were applied:
+#  - Only the relevant subset of endpoints/models were copied
+#  - all tags switch to "Jira", to consolidate the client interface
+#  - some unused fields were dropped, in particular where they depended on another high
+#    complexity model
+#  - remove all "read-only: true"; this removed the ability to manipulate models for testing
 ---
 openapi: 3.0.1
 info:
@@ -14,7 +20,7 @@ info:
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   version: 1001.0.0-SNAPSHOT
 servers:
-- url: https://precisionmedicineinitiative.atlassian.net
+  - url: https://precisionmedicineinitiative.atlassian.net
 
 ##########################################################################################
 ## PATHS
@@ -24,33 +30,33 @@ paths:
   "/rest/api/3/issue":
     post:
       tags:
-      - jira
+        - jira
       summary: Create issue
       description: |-
         Creates an issue or, where the option to create subtasks is enabled in Jira, a subtask. A transition may be applied, to move the issue or subtask to a workflow step other than the default start step, and issue properties set.
-  
+
         The content of the issue or subtask is defined using `update` and `fields`. The fields that can be set in the issue or subtask are determined using the [ Get create issue metadata](#api-rest-api-3-issue-createmeta-get). These are the same fields that appear on the issue's create screen. Note that the `description`, `environment`, and any `textarea` type custom fields (multi-line text fields) take Atlassian Document Format content. Single line custom fields (`textfield`) accept a string and don't handle Atlassian Document Format content.
-  
+
         Creating a subtask differs from creating an issue as follows:
-  
+
          *  `issueType` must be set to a subtask issue type (use [ Get create issue metadata](#api-rest-api-3-issue-createmeta-get) to find subtask issue types).
          *  `parent` must contain the ID or key of the parent issue.
-  
+
         In a next-gen project any issue may be made a child providing that the parent and child are members of the same project. In a classic project the parent field is only valid for subtasks.
-  
+
         **[Permissions](#permissions) required:** *Browse projects* and *Create issues* [project permissions](https://confluence.atlassian.com/x/yodKLg) for the project in which the issue or subtask is created.
       operationId: createIssue
       parameters:
-      - name: updateHistory
-        in: query
-        description: Whether the project in which the issue is created is added to the
-          user's **Recently viewed** project list, as shown under **Projects** in Jira.
-          When provided, the issue type and request type are added to the user's history
-          for a project. These values are then used to provide defaults on the issue
-          create screen.
-        schema:
-          type: boolean
-          default: false
+        - name: updateHistory
+          in: query
+          description: Whether the project in which the issue is created is added to the
+            user's **Recently viewed** project list, as shown under **Projects** in Jira.
+            When provided, the issue type and request type are added to the user's history
+            for a project. These values are then used to provide defaults on the issue
+            create screen.
+          schema:
+            type: boolean
+            default: false
       requestBody:
         content:
           application/json:
@@ -64,7 +70,7 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/CreatedIssue"
-              example: '{"id":"10000","key":"ED-24","self":"https://your-domain.atlassian.net/rest/api/3/issue/10000","transition":{"status":200,"errorCollection":{"errorMessages":[],"errors":{}}}}'
+              example: '{"jiraId":"10000","key":"ED-24","self":"https://your-domain.atlassian.net/rest/api/3/issue/10000","transition":{"status":200,"errorCollection":{"errorMessages":[],"errors":{}}}}'
         '400':
           description: |-
             Returned if the request:
@@ -95,15 +101,15 @@ paths:
                 "$ref": "#/components/schemas/ErrorCollection"
       deprecated: false
       security:
-      - basicAuth: []
-      - OAuth2:
-        - write:jira-work
-      - {}
+        - basicAuth: [ ]
+        - OAuth2:
+            - write:jira-work
+        - { }
       x-atlassian-connect-scope: WRITE
   "/rest/api/3/issue/{issueIdOrKey}/comment":
     post:
       tags:
-      - Issue comments
+        - jira
       summary: Add comment
       description: |-
         Adds a comment to an issue.
@@ -116,19 +122,12 @@ paths:
          *  If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission to view the issue.
       operationId: addComment
       parameters:
-      - name: issueIdOrKey
-        in: path
-        description: The ID or key of the issue.
-        required: true
-        schema:
-          type: string
-      - name: expand
-        in: query
-        description: Use [expand](#expansion) to include additional information about
-          comments in the response. This parameter accepts `renderedBody`, which returns
-          the comment body rendered in HTML.
-        schema:
-          type: string
+        - name: issueIdOrKey
+          in: path
+          description: The ID or key of the issue.
+          required: true
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -142,13 +141,13 @@ paths:
                 type: doc
                 version: 1
                 content:
-                - type: paragraph
-                  content:
-                  - text: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                      Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis
-                      fermentum. Sed semper quam laoreet nisi egestas at posuere augue
-                      semper.
-                    type: text
+                  - type: paragraph
+                    content:
+                      - text: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                          Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis
+                          fermentum. Sed semper quam laoreet nisi egestas at posuere augue
+                          semper.
+                        type: text
         required: true
       responses:
         '201':
@@ -157,7 +156,7 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Comment"
-              example: '{"self":"https://your-domain.atlassian.net/rest/api/3/issue/10010/comment/10000","id":"10000","author":{"self":"https://your-domain.atlassian.net/rest/api/3/user?accountId=5b10a2844c20165700ede21g","accountId":"5b10a2844c20165700ede21g","displayName":"Mia
+              example: '{"self":"https://your-domain.atlassian.net/rest/api/3/issue/10010/comment/10000","jiraId":"10000","author":{"self":"https://your-domain.atlassian.net/rest/api/3/user?accountId=5b10a2844c20165700ede21g","accountId":"5b10a2844c20165700ede21g","displayName":"Mia
                 Krystof","active":false},"body":{"type":"doc","version":1,"content":[{"type":"paragraph","content":[{"type":"text","text":"Lorem
                 ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget
                 venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper
@@ -172,28 +171,28 @@ paths:
             permission to view it.
       deprecated: false
       security:
-      - basicAuth: []
-      - OAuth2:
-        - write:jira-work
-      - {}
+        - basicAuth: [ ]
+        - OAuth2:
+            - write:jira-work
+        - { }
       x-atlassian-connect-scope: WRITE
   "/rest/api/3/search":
     post:
       tags:
-      - jira
+        - jira
       summary: Search for issues using JQL (POST)
       description: |-
         Searches for issues using [JQL](https://confluence.atlassian.com/x/egORLQ).
-  
+
         There is a [GET](#api-rest-api-3-search-get) version of this resource that can be used for smaller JQL query expressions.
-  
+
         This operation can be accessed anonymously.
-  
+
         **[Permissions](#permissions) required:** Issues are included in the response where the user has:
          *  *Browse projects* [project permission](https://confluence.atlassian.com/x/yodKLg) for the project containing the issue.
          *  If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission to view the issue.
       operationId: searchForIssuesUsingJqlPost
-      parameters: []
+      parameters: [ ]
       requestBody:
         description: A JSON object containing the search request.
         content:
@@ -202,16 +201,16 @@ paths:
               "$ref": "#/components/schemas/SearchRequestBean"
             example:
               expand:
-              - names
-              - schema
-              - operations
+                - names
+                - schema
+                - operations
               jql: project = HSP
               maxResults: 15
               fieldsByKeys: false
               fields:
-              - summary
-              - status
-              - assignee
+                - summary
+                - status
+                - assignee
               startAt: 0
         required: true
       responses:
@@ -226,10 +225,10 @@ paths:
         '401':
           description: Returned if the authentication credentials are incorrect or missing.
       security:
-      - basicAuth: []
-      - OAuth2:
-        - write:jira-work
-      - {}
+        - basicAuth: [ ]
+        - OAuth2:
+            - write:jira-work
+        - { }
       x-atlassian-connect-scope: READ
 
 ##########################################################################################
@@ -245,10 +244,10 @@ components:
           description: Details of a transition. Required when performing a transition,
             optional when creating or editing an issue.
           allOf:
-          - "$ref": "#/components/schemas/IssueTransition"
+            - "$ref": "#/components/schemas/IssueTransition"
         fields:
           type: object
-          additionalProperties: {}
+          additionalProperties: { }
           description: List of issue screen fields to update, specifying the sub-field
             to update and its value for each field. This field provides a straightforward
             option when setting a sub-field. When multiple sub-fields or other operations
@@ -268,7 +267,6 @@ components:
           description: Details of issue properties to be add or update.
           items:
             "$ref": "#/components/schemas/EntityProperty"
-      additionalProperties: true
       description: Details of an issue update request.
     IssueTransition:
       type: object
@@ -280,34 +278,27 @@ components:
         name:
           type: string
           description: The name of the issue transition.
-          readOnly: true
         to:
           description: Details of the issue status after the transition.
-          readOnly: true
           allOf:
-          - "$ref": "#/components/schemas/StatusDetails"
+            - "$ref": "#/components/schemas/StatusDetails"
         hasScreen:
           type: boolean
           description: Whether there is a screen associated with the issue transition.
-          readOnly: true
         isGlobal:
           type: boolean
           description: Whether the issue transition is global, that is, the transition
             is applied to issues regardless of their status.
-          readOnly: true
         isInitial:
           type: boolean
           description: Whether this is the initial issue transition for the workflow.
-          readOnly: true
         isAvailable:
           type: boolean
           description: Whether the transition is available to be performed.
-          readOnly: true
         isConditional:
           type: boolean
           description: Whether the issue has to meet criteria before the issue transition
             is applied.
-          readOnly: true
         fields:
           type: object
           additionalProperties:
@@ -315,12 +306,10 @@ components:
           description: Details of the fields associated with the issue transition
             screen. Use this information to populate `fields` and `update` in a transition
             request.
-          readOnly: true
         expand:
           type: string
           description: Expand options that include additional transition details in
             the response.
-          readOnly: true
         looped:
           type: boolean
       additionalProperties: true
@@ -331,28 +320,22 @@ components:
         self:
           type: string
           description: The URL of the status.
-          readOnly: true
         description:
           type: string
           description: The description of the status.
-          readOnly: true
         iconUrl:
           type: string
           description: The URL of the icon used to represent the status.
-          readOnly: true
         name:
           type: string
           description: The name of the status.
-          readOnly: true
         id:
           type: string
           description: The ID of the status.
-          readOnly: true
         statusCategory:
           description: The category assigned to the status.
-          readOnly: true
           allOf:
-          - "$ref": "#/components/schemas/StatusCategory"
+            - "$ref": "#/components/schemas/StatusCategory"
       additionalProperties: true
       description: A status.
     StatusCategory:
@@ -361,24 +344,19 @@ components:
         self:
           type: string
           description: The URL of the status category.
-          readOnly: true
         id:
           type: integer
           description: The ID of the status category.
           format: int64
-          readOnly: true
         key:
           type: string
           description: The key of the status category.
-          readOnly: true
         colorName:
           type: string
           description: The name of the color used to represent the status category.
-          readOnly: true
         name:
           type: string
           description: The name of the status category.
-          readOnly: true
       additionalProperties: true
       description: A status category.
     FieldUpdateOperation:
@@ -402,91 +380,73 @@ components:
       description: Details of an operation to perform on a field.
     FieldMetadata:
       required:
-      - key
-      - name
-      - operations
-      - required
-      - schema
+        - key
+        - name
+        - operations
+        - required
+        - schema
       type: object
       properties:
         required:
           type: boolean
           description: Whether the field is required.
-          readOnly: true
         schema:
           description: The data type of the field.
-          readOnly: true
           allOf:
-          - "$ref": "#/components/schemas/JsonTypeBean"
+            - "$ref": "#/components/schemas/JsonTypeBean"
         name:
           type: string
           description: The name of the field.
-          readOnly: true
         key:
           type: string
           description: The key of the field.
-          readOnly: true
         autoCompleteUrl:
           type: string
           description: The URL that can be used to automatically complete the field.
-          readOnly: true
         hasDefaultValue:
           type: boolean
           description: Whether the field has a default value.
-          readOnly: true
         operations:
           type: array
           description: The list of operations that can be performed on the field.
-          readOnly: true
           items:
             type: string
-            readOnly: true
         allowedValues:
           type: array
           description: The list of values allowed in the field.
-          readOnly: true
           items:
-            readOnly: true
         defaultValue:
           description: The default value of the field.
-          readOnly: true
       additionalProperties: false
       description: The metadata describing an issue field.
       xml:
         name: availableField
     JsonTypeBean:
       required:
-      - type
+        - type
       type: object
       properties:
         type:
           type: string
           description: The data type of the field.
-          readOnly: true
         items:
           type: string
           description: When the data type is an array, the name of the field items
             within the array.
-          readOnly: true
         system:
           type: string
           description: If the field is a system field, the name of the field.
-          readOnly: true
         custom:
           type: string
           description: If the field is a custom field, the URI of the field.
-          readOnly: true
         customId:
           type: integer
           description: If the field is a custom field, the custom ID of the field.
           format: int64
-          readOnly: true
         configuration:
           type: object
           additionalProperties:
-            readOnly: true
           description: If the field is a custom field, the configuration of the field.
-          readOnly: true
       additionalProperties: false
       description: The schema of a field.
     EntityProperty:
@@ -505,20 +465,16 @@ components:
         id:
           type: string
           description: The ID of the created issue or subtask.
-          readOnly: true
         key:
           type: string
           description: The key of the created issue or subtask.
-          readOnly: true
         self:
           type: string
           description: The URL of the created issue or subtask.
-          readOnly: true
         transition:
           description: The response code and messages related to any requested transition.
-          readOnly: true
           allOf:
-          - "$ref": "#/components/schemas/NestedResponse"
+            - "$ref": "#/components/schemas/NestedResponse"
       additionalProperties: false
       description: Details about a created issue or subtask.
     NestedResponse:
@@ -558,48 +514,38 @@ components:
           type: string
           description: Expand options that include additional search result details in
             the response.
-          readOnly: true
         startAt:
           type: integer
           description: The index of the first item returned on the page.
           format: int32
-          readOnly: true
         maxResults:
           type: integer
           description: The maximum number of results that could be on the page.
           format: int32
-          readOnly: true
         total:
           type: integer
           description: The number of results on the page.
           format: int32
-          readOnly: true
         issues:
           type: array
           description: The list of issues found by the search.
-          readOnly: true
           items:
             "$ref": "#/components/schemas/IssueBean"
         warningMessages:
           type: array
           description: Any warnings related to the JQL query.
-          readOnly: true
           items:
             type: string
-            readOnly: true
         names:
           type: object
           additionalProperties:
             type: string
-            readOnly: true
           description: The ID and name of each field in the search results.
-          readOnly: true
         schema:
           type: object
           additionalProperties:
             "$ref": "#/components/schemas/JsonTypeBean"
           description: The schema describing the field types in the search results.
-          readOnly: true
       additionalProperties: false
       description: The result of a JQL search.
     IssueBean:
@@ -608,51 +554,39 @@ components:
         expand:
           type: string
           description: Expand options that include additional issue details in the response.
-          readOnly: true
           xml:
             attribute: true
         id:
           type: string
           description: The ID of the issue.
-          readOnly: true
         self:
           type: string
           description: The URL of the issue details.
           format: uri
-          readOnly: true
         key:
           type: string
           description: The key of the issue.
-          readOnly: true
         renderedFields:
           type: object
           additionalProperties:
-            readOnly: true
           description: The rendered value of each field present on the issue.
-          readOnly: true
         properties:
           type: object
           additionalProperties:
-            readOnly: true
           description: Details of the issue properties identified in the request.
-          readOnly: true
         names:
           type: object
           additionalProperties:
             type: string
-            readOnly: true
           description: The ID and name of each field present on the issue.
-          readOnly: true
         schema:
           type: object
           additionalProperties:
             "$ref": "#/components/schemas/JsonTypeBean"
           description: The schema describing each field present on the issue.
-          readOnly: true
         transitions:
           type: array
           description: The transitions that can be performed on the issue.
-          readOnly: true
           items:
             "$ref": "#/components/schemas/IssueTransition"
         versionedRepresentations:
@@ -660,15 +594,12 @@ components:
           additionalProperties:
             type: object
             additionalProperties:
-              readOnly: true
-            readOnly: true
           description: The versions of each field on the issue.
-          readOnly: true
         fieldsToInclude:
           "$ref": "#/components/schemas/IncludedFields"
         fields:
           type: object
-          additionalProperties: {}
+          additionalProperties: { }
       additionalProperties: false
       description: Details about an issue.
       xml:
@@ -745,11 +676,11 @@ components:
 
             Note: If the JQL is not correctly formed a 400 response code is returned, regardless of the `validateQuery` value.
           enum:
-          - strict
-          - warn
-          - none
-          - 'true'
-          - 'false'
+            - strict
+            - warn
+            - none
+            - 'true'
+            - 'false'
         expand:
           type: array
           description: |-
@@ -794,20 +725,20 @@ components:
           type: string
           description: Whether the field can be used in a query's `ORDER BY` clause.
           enum:
-          - 'true'
-          - 'false'
+            - 'true'
+            - 'false'
         searchable:
           type: string
           description: Whether the content of this field can be searched.
           enum:
-          - 'true'
-          - 'false'
+            - 'true'
+            - 'false'
         auto:
           type: string
           description: Whether the field provide auto-complete suggestions.
           enum:
-          - 'true'
-          - 'false'
+            - 'true'
+            - 'false'
         cfid:
           type: string
           description: If the item is a custom field, the ID of the custom field.
@@ -829,27 +760,20 @@ components:
         self:
           type: string
           description: The URL of the comment.
-          readOnly: true
         id:
           type: string
           description: The ID of the comment.
-          readOnly: true
         body:
           description: The comment text in [Atlassian Document Format](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/).
         renderedBody:
           type: string
           description: The rendered version of the comment.
-          readOnly: true
         created:
           type: string
           description: The date and time at which the comment was created.
-          format: date-time
-          readOnly: true
         updated:
           type: string
           description: The date and time at which the comment was updated last.
-          format: date-time
-          readOnly: true
         jsdPublic:
           type: boolean
           description: Whether the comment is visible in Jira Service Desk. Defaults
@@ -860,14 +784,47 @@ components:
             Jira Service Desk set to false, use the Jira Service Desk REST API [Create
             request comment](https://developer.atlassian.com/cloud/jira/service-desk/rest/#api-rest-servicedeskapi-request-issueIdOrKey-comment-post)
             operation.
-          readOnly: true
         properties:
           type: array
           description: A list of comment properties. Optional on create and update.
           items:
             "$ref": "#/components/schemas/EntityProperty"
-      additionalProperties: true
       description: A comment.
+    Project:
+      type: object
+      properties:
+        key:
+          type: string
+          description: The key of the project.
+    IssueTypeDetails:
+      type: object
+      properties:
+        id:
+          type: string
+          description: ID of the issue type.
+
+    AtlassianDocument:
+      type: object
+      properties:
+        type:
+          type: string
+        version:
+          type: number
+        content:
+          type: array
+          items:
+            "$ref": "#/components/schemas/AtlassianContent"
+    AtlassianContent:
+      type: object
+      properties:
+        text:
+          type: string
+        type:
+          type: string
+        content:
+          type: array
+          items:
+            "$ref": "#/components/schemas/AtlassianContent"
   securitySchemes:
     basicAuth:
       type: http

--- a/api/src/main/resources/jira.yaml
+++ b/api/src/main/resources/jira.yaml
@@ -1,143 +1,897 @@
 #This file provide the end points for jira interactions
-# JIRA REST API information can be found at :
-# https://developer.atlassian.com/cloud/jira/platform/rest/
+# Copied from https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json
 
-swagger: '2.0'
-
+---
+openapi: 3.0.1
 info:
-  title: Jira
-  description: |
-    Service for Jira Interactions.
-  version: "0.1"
-
-host: "precisionmedicineinitiative.atlassian.net"
-schemes:
-  - "https"
-basePath: /rest/api/2
-
-produces:
-  - application/json
-
-securityDefinitions:
-  AdminSecurity:
-    type: basic
+  title: The Jira Cloud platform REST API
+  description: Jira Cloud platform REST API documentation
+  termsOfService: http://atlassian.com/terms/
+  contact:
+    email: ecosystem@atlassian.com
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1001.0.0-SNAPSHOT
+servers:
+- url: https://precisionmedicineinitiative.atlassian.net
 
 ##########################################################################################
 ## PATHS
 ##########################################################################################
 
 paths:
- /issue:
+  "/rest/api/3/issue":
     post:
-      summary: Create issue in jira.
-      description: "Creates issue in JIRA and return IssueResponse"
       tags:
-        - Jira
-      consumes:
-        - application/json
+      - jira
+      summary: Create issue
+      description: |-
+        Creates an issue or, where the option to create subtasks is enabled in Jira, a subtask. A transition may be applied, to move the issue or subtask to a workflow step other than the default start step, and issue properties set.
+  
+        The content of the issue or subtask is defined using `update` and `fields`. The fields that can be set in the issue or subtask are determined using the [ Get create issue metadata](#api-rest-api-3-issue-createmeta-get). These are the same fields that appear on the issue's create screen. Note that the `description`, `environment`, and any `textarea` type custom fields (multi-line text fields) take Atlassian Document Format content. Single line custom fields (`textfield`) accept a string and don't handle Atlassian Document Format content.
+  
+        Creating a subtask differs from creating an issue as follows:
+  
+         *  `issueType` must be set to a subtask issue type (use [ Get create issue metadata](#api-rest-api-3-issue-createmeta-get) to find subtask issue types).
+         *  `parent` must contain the ID or key of the parent issue.
+  
+        In a next-gen project any issue may be made a child providing that the parent and child are members of the same project. In a classic project the parent field is only valid for subtasks.
+  
+        **[Permissions](#permissions) required:** *Browse projects* and *Create issues* [project permissions](https://confluence.atlassian.com/x/yodKLg) for the project in which the issue or subtask is created.
       operationId: createIssue
       parameters:
-        - name: fields
-          in: body
-          description: Attributes for creating issue
-          schema:
-            $ref: '#/definitions/IssueRequest'
+      - name: updateHistory
+        in: query
+        description: Whether the project in which the issue is created is added to the
+          user's **Recently viewed** project list, as shown under **Projects** in Jira.
+          When provided, the issue type and request type are added to the user's history
+          for a project. These values are then used to provide defaults on the issue
+          create screen.
+        schema:
+          type: boolean
+          default: false
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/IssueUpdateDetails"
+        required: true
       responses:
-        200:
-          description: File saved
-          schema:
-            $ref: '#/definitions/IssueResponse'
-        400:
-          description: Bad request, check the summary/description field
-        500:
-          description: JIRA Internal Error
+        '201':
+          description: Returned if the request is successful.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CreatedIssue"
+              example: '{"id":"10000","key":"ED-24","self":"https://your-domain.atlassian.net/rest/api/3/issue/10000","transition":{"status":200,"errorCollection":{"errorMessages":[],"errors":{}}}}'
+        '400':
+          description: |-
+            Returned if the request:
+
+             *  is missing required fields.
+             *  contains invalid field values.
+             *  contains fields that cannot be set for the issue type.
+             *  is by a user who does not have the necessary permission.
+             *  is to create a subtype in a project different that of the parent issue.
+             *  is for a subtask when the option to create subtasks is disabled.
+             *  is invalid for any other reason.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorCollection"
+              example: '{"errorMessages":["Field ''priority'' is required"],"errors":{}}'
+        '401':
+          description: Returned if the authentication credentials are incorrect or missing.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorCollection"
+        '403':
+          description: Returned if the user does not have the necessary permission.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorCollection"
+      deprecated: false
       security:
-        - AdminSecurity: []
+      - basicAuth: []
+      - OAuth2:
+        - write:jira-work
+      - {}
+      x-atlassian-connect-scope: WRITE
+  "/rest/api/3/issue/{issueIdOrKey}/comment":
+    post:
+      tags:
+      - Issue comments
+      summary: Add comment
+      description: |-
+        Adds a comment to an issue.
 
- /issue/{issueKey}/attachments:
-   post:
-     summary: Add attachment to the jira ticket
-     tags:
-       - Jira
-     operationId: addAttachments
-     consumes:
-       - multipart/form-data
-     parameters:
-       - in: path
-         name: issueKey
-         type: string
-         required: true
-       - name: file
-         in: formData
-         description: Upload file as attachment
-         required: true
-         type: file
-       - in: header
-         name: X-Atlassian-Token
-         type: string
-         default: nocheck
-     responses:
-       200:
-         description: File saved
-       403:
-         description: Attachments are disabled
-       404:
-         description: Issue Not Found/Attachments exceeds the maximum configured attachment size
-       413:
-         description: Attachment is too big
-     security:
-       - AdminSecurity: []
+        This operation can be accessed anonymously.
+
+        **[Permissions](#permissions) required:**
+
+         *  *Browse projects* and *Add comments* [ project permission](https://confluence.atlassian.com/x/yodKLg) for the project that the issue containing the comment is in.
+         *  If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission to view the issue.
+      operationId: addComment
+      parameters:
+      - name: issueIdOrKey
+        in: path
+        description: The ID or key of the issue.
+        required: true
+        schema:
+          type: string
+      - name: expand
+        in: query
+        description: Use [expand](#expansion) to include additional information about
+          comments in the response. This parameter accepts `renderedBody`, which returns
+          the comment body rendered in HTML.
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Comment"
+            example:
+              visibility:
+                type: role
+                value: Administrators
+              body:
+                type: doc
+                version: 1
+                content:
+                - type: paragraph
+                  content:
+                  - text: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                      Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis
+                      fermentum. Sed semper quam laoreet nisi egestas at posuere augue
+                      semper.
+                    type: text
+        required: true
+      responses:
+        '201':
+          description: Returned if the request is successful.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Comment"
+              example: '{"self":"https://your-domain.atlassian.net/rest/api/3/issue/10010/comment/10000","id":"10000","author":{"self":"https://your-domain.atlassian.net/rest/api/3/user?accountId=5b10a2844c20165700ede21g","accountId":"5b10a2844c20165700ede21g","displayName":"Mia
+                Krystof","active":false},"body":{"type":"doc","version":1,"content":[{"type":"paragraph","content":[{"type":"text","text":"Lorem
+                ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget
+                venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper
+                quam laoreet nisi egestas at posuere augue semper."}]}]},"updateAuthor":{"self":"https://your-domain.atlassian.net/rest/api/3/user?accountId=5b10a2844c20165700ede21g","accountId":"5b10a2844c20165700ede21g","displayName":"Mia
+                Krystof","active":false},"created":"2021-11-02T02:26:07.309+0000","updated":"2021-11-02T02:26:07.309+0000","visibility":{"type":"role","value":"Administrators"}}'
+        '400':
+          description: Returned if the request is invalid.
+        '401':
+          description: Returned if the authentication credentials are incorrect.
+        '404':
+          description: Returned if the issue is not found or the user does not have
+            permission to view it.
+      deprecated: false
+      security:
+      - basicAuth: []
+      - OAuth2:
+        - write:jira-work
+      - {}
+      x-atlassian-connect-scope: WRITE
+  "/rest/api/3/search":
+    post:
+      tags:
+      - jira
+      summary: Search for issues using JQL (POST)
+      description: |-
+        Searches for issues using [JQL](https://confluence.atlassian.com/x/egORLQ).
+  
+        There is a [GET](#api-rest-api-3-search-get) version of this resource that can be used for smaller JQL query expressions.
+  
+        This operation can be accessed anonymously.
+  
+        **[Permissions](#permissions) required:** Issues are included in the response where the user has:
+         *  *Browse projects* [project permission](https://confluence.atlassian.com/x/yodKLg) for the project containing the issue.
+         *  If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission to view the issue.
+      operationId: searchForIssuesUsingJqlPost
+      parameters: []
+      requestBody:
+        description: A JSON object containing the search request.
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SearchRequestBean"
+            example:
+              expand:
+              - names
+              - schema
+              - operations
+              jql: project = HSP
+              maxResults: 15
+              fieldsByKeys: false
+              fields:
+              - summary
+              - status
+              - assignee
+              startAt: 0
+        required: true
+      responses:
+        '200':
+          description: Returned if the request is successful.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SearchResults"
+        '400':
+          description: Returned if the JQL query is invalid.
+        '401':
+          description: Returned if the authentication credentials are incorrect or missing.
+      security:
+      - basicAuth: []
+      - OAuth2:
+        - write:jira-work
+      - {}
+      x-atlassian-connect-scope: READ
 
 ##########################################################################################
-## DEFINITIONS
+## COMPONENTS
 ##########################################################################################
-definitions:
-  IssueRequest:
-      description: Details required for creating issue project info, summary, description etc
-      required:
-        - fields
+
+components:
+  schemas:
+    IssueUpdateDetails:
+      type: object
       properties:
+        transition:
+          description: Details of a transition. Required when performing a transition,
+            optional when creating or editing an issue.
+          allOf:
+          - "$ref": "#/components/schemas/IssueTransition"
         fields:
-          $ref: '#/definitions/FieldsDetails'
-
-  FieldsDetails:
-      description: Fields information like project id, issue type etc
-      required:
-        - project
-      properties:
-        project:
-          $ref: '#/definitions/ProjectDetails'
-        summary:
-          type: string
-        description:
-          type: string
-        issuetype:
-          $ref: '#/definitions/IssueType'
-
-  ProjectDetails:
-      description: Project information
-      required:
-        - key
-      properties:
-        key:
-          type: string
-
-  IssueType:
-      required:
-        - name
-      properties:
-        name:
-          type: string
-
-  IssueResponse:
-      required:
-        - id
-        - key
+          type: object
+          additionalProperties: {}
+          description: List of issue screen fields to update, specifying the sub-field
+            to update and its value for each field. This field provides a straightforward
+            option when setting a sub-field. When multiple sub-fields or other operations
+            are required, use `update`. Fields included in here cannot be included in
+            `update`.
+        update:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              "$ref": "#/components/schemas/FieldUpdateOperation"
+          description: A Map containing the field field name and a list of operations
+            to perform on the issue screen field. Note that fields included in here cannot
+            be included in `fields`.
+        properties:
+          type: array
+          description: Details of issue properties to be add or update.
+          items:
+            "$ref": "#/components/schemas/EntityProperty"
+      additionalProperties: true
+      description: Details of an issue update request.
+    IssueTransition:
+      type: object
       properties:
         id:
           type: string
-        key:
+          description: The ID of the issue transition. Required when specifying a
+            transition to undertake.
+        name:
           type: string
+          description: The name of the issue transition.
+          readOnly: true
+        to:
+          description: Details of the issue status after the transition.
+          readOnly: true
+          allOf:
+          - "$ref": "#/components/schemas/StatusDetails"
+        hasScreen:
+          type: boolean
+          description: Whether there is a screen associated with the issue transition.
+          readOnly: true
+        isGlobal:
+          type: boolean
+          description: Whether the issue transition is global, that is, the transition
+            is applied to issues regardless of their status.
+          readOnly: true
+        isInitial:
+          type: boolean
+          description: Whether this is the initial issue transition for the workflow.
+          readOnly: true
+        isAvailable:
+          type: boolean
+          description: Whether the transition is available to be performed.
+          readOnly: true
+        isConditional:
+          type: boolean
+          description: Whether the issue has to meet criteria before the issue transition
+            is applied.
+          readOnly: true
+        fields:
+          type: object
+          additionalProperties:
+            "$ref": "#/components/schemas/FieldMetadata"
+          description: Details of the fields associated with the issue transition
+            screen. Use this information to populate `fields` and `update` in a transition
+            request.
+          readOnly: true
+        expand:
+          type: string
+          description: Expand options that include additional transition details in
+            the response.
+          readOnly: true
+        looped:
+          type: boolean
+      additionalProperties: true
+      description: Details of an issue transition.
+    StatusDetails:
+      type: object
+      properties:
         self:
           type: string
+          description: The URL of the status.
+          readOnly: true
+        description:
+          type: string
+          description: The description of the status.
+          readOnly: true
+        iconUrl:
+          type: string
+          description: The URL of the icon used to represent the status.
+          readOnly: true
+        name:
+          type: string
+          description: The name of the status.
+          readOnly: true
+        id:
+          type: string
+          description: The ID of the status.
+          readOnly: true
+        statusCategory:
+          description: The category assigned to the status.
+          readOnly: true
+          allOf:
+          - "$ref": "#/components/schemas/StatusCategory"
+      additionalProperties: true
+      description: A status.
+    StatusCategory:
+      type: object
+      properties:
+        self:
+          type: string
+          description: The URL of the status category.
+          readOnly: true
+        id:
+          type: integer
+          description: The ID of the status category.
+          format: int64
+          readOnly: true
+        key:
+          type: string
+          description: The key of the status category.
+          readOnly: true
+        colorName:
+          type: string
+          description: The name of the color used to represent the status category.
+          readOnly: true
+        name:
+          type: string
+          description: The name of the status category.
+          readOnly: true
+      additionalProperties: true
+      description: A status category.
+    FieldUpdateOperation:
+      type: object
+      properties:
+        add:
+          description: The value to add to the field.
+          example: triaged
+        set:
+          description: The value to set in the field.
+          example: A new summary
+        remove:
+          description: The value to removed from the field.
+          example: blocker
+        edit:
+          description: The value to edit in the field.
+          example:
+            remainingEstimate: 4d
+            originalEstimate: 1w 1d
+      additionalProperties: false
+      description: Details of an operation to perform on a field.
+    FieldMetadata:
+      required:
+      - key
+      - name
+      - operations
+      - required
+      - schema
+      type: object
+      properties:
+        required:
+          type: boolean
+          description: Whether the field is required.
+          readOnly: true
+        schema:
+          description: The data type of the field.
+          readOnly: true
+          allOf:
+          - "$ref": "#/components/schemas/JsonTypeBean"
+        name:
+          type: string
+          description: The name of the field.
+          readOnly: true
+        key:
+          type: string
+          description: The key of the field.
+          readOnly: true
+        autoCompleteUrl:
+          type: string
+          description: The URL that can be used to automatically complete the field.
+          readOnly: true
+        hasDefaultValue:
+          type: boolean
+          description: Whether the field has a default value.
+          readOnly: true
+        operations:
+          type: array
+          description: The list of operations that can be performed on the field.
+          readOnly: true
+          items:
+            type: string
+            readOnly: true
+        allowedValues:
+          type: array
+          description: The list of values allowed in the field.
+          readOnly: true
+          items:
+            readOnly: true
+        defaultValue:
+          description: The default value of the field.
+          readOnly: true
+      additionalProperties: false
+      description: The metadata describing an issue field.
+      xml:
+        name: availableField
+    JsonTypeBean:
+      required:
+      - type
+      type: object
+      properties:
+        type:
+          type: string
+          description: The data type of the field.
+          readOnly: true
+        items:
+          type: string
+          description: When the data type is an array, the name of the field items
+            within the array.
+          readOnly: true
+        system:
+          type: string
+          description: If the field is a system field, the name of the field.
+          readOnly: true
+        custom:
+          type: string
+          description: If the field is a custom field, the URI of the field.
+          readOnly: true
+        customId:
+          type: integer
+          description: If the field is a custom field, the custom ID of the field.
+          format: int64
+          readOnly: true
+        configuration:
+          type: object
+          additionalProperties:
+            readOnly: true
+          description: If the field is a custom field, the configuration of the field.
+          readOnly: true
+      additionalProperties: false
+      description: The schema of a field.
+    EntityProperty:
+      type: object
+      properties:
+        key:
+          type: string
+          description: The key of the property. Required on create and update.
+        value:
+          description: The value of the property. Required on create and update.
+      additionalProperties: false
+      description: An entity property, for more information see [Entity properties](https://developer.atlassian.com/cloud/jira/platform/jira-entity-properties/).
+    CreatedIssue:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the created issue or subtask.
+          readOnly: true
+        key:
+          type: string
+          description: The key of the created issue or subtask.
+          readOnly: true
+        self:
+          type: string
+          description: The URL of the created issue or subtask.
+          readOnly: true
+        transition:
+          description: The response code and messages related to any requested transition.
+          readOnly: true
+          allOf:
+          - "$ref": "#/components/schemas/NestedResponse"
+      additionalProperties: false
+      description: Details about a created issue or subtask.
+    NestedResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+          format: int32
+        errorCollection:
+          "$ref": "#/components/schemas/ErrorCollection"
+      additionalProperties: false
+    ErrorCollection:
+      type: object
+      properties:
+        errorMessages:
+          type: array
+          description: The list of error messages produced by this operation. For example,
+            "input parameter 'key' must be provided"
+          items:
+            type: string
+        errors:
+          type: object
+          additionalProperties:
+            type: string
+          description: 'The list of errors by parameter returned by the operation. For
+            example,"projectKey": "Project keys must start with an uppercase letter, followed
+            by one or more uppercase alphanumeric characters."'
+        status:
+          type: integer
+          format: int32
+      additionalProperties: false
+      description: Error messages from an operation.
+    SearchResults:
+      type: object
+      properties:
+        expand:
+          type: string
+          description: Expand options that include additional search result details in
+            the response.
+          readOnly: true
+        startAt:
+          type: integer
+          description: The index of the first item returned on the page.
+          format: int32
+          readOnly: true
+        maxResults:
+          type: integer
+          description: The maximum number of results that could be on the page.
+          format: int32
+          readOnly: true
+        total:
+          type: integer
+          description: The number of results on the page.
+          format: int32
+          readOnly: true
+        issues:
+          type: array
+          description: The list of issues found by the search.
+          readOnly: true
+          items:
+            "$ref": "#/components/schemas/IssueBean"
+        warningMessages:
+          type: array
+          description: Any warnings related to the JQL query.
+          readOnly: true
+          items:
+            type: string
+            readOnly: true
+        names:
+          type: object
+          additionalProperties:
+            type: string
+            readOnly: true
+          description: The ID and name of each field in the search results.
+          readOnly: true
+        schema:
+          type: object
+          additionalProperties:
+            "$ref": "#/components/schemas/JsonTypeBean"
+          description: The schema describing the field types in the search results.
+          readOnly: true
+      additionalProperties: false
+      description: The result of a JQL search.
+    IssueBean:
+      type: object
+      properties:
+        expand:
+          type: string
+          description: Expand options that include additional issue details in the response.
+          readOnly: true
+          xml:
+            attribute: true
+        id:
+          type: string
+          description: The ID of the issue.
+          readOnly: true
+        self:
+          type: string
+          description: The URL of the issue details.
+          format: uri
+          readOnly: true
+        key:
+          type: string
+          description: The key of the issue.
+          readOnly: true
+        renderedFields:
+          type: object
+          additionalProperties:
+            readOnly: true
+          description: The rendered value of each field present on the issue.
+          readOnly: true
+        properties:
+          type: object
+          additionalProperties:
+            readOnly: true
+          description: Details of the issue properties identified in the request.
+          readOnly: true
+        names:
+          type: object
+          additionalProperties:
+            type: string
+            readOnly: true
+          description: The ID and name of each field present on the issue.
+          readOnly: true
+        schema:
+          type: object
+          additionalProperties:
+            "$ref": "#/components/schemas/JsonTypeBean"
+          description: The schema describing each field present on the issue.
+          readOnly: true
+        transitions:
+          type: array
+          description: The transitions that can be performed on the issue.
+          readOnly: true
+          items:
+            "$ref": "#/components/schemas/IssueTransition"
+        versionedRepresentations:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              readOnly: true
+            readOnly: true
+          description: The versions of each field on the issue.
+          readOnly: true
+        fieldsToInclude:
+          "$ref": "#/components/schemas/IncludedFields"
+        fields:
+          type: object
+          additionalProperties: {}
+      additionalProperties: false
+      description: Details about an issue.
+      xml:
+        name: issue
+    IncludedFields:
+      type: object
+      properties:
+        excluded:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        included:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        actuallyIncluded:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+    SearchRequestBean:
+      type: object
+      properties:
+        jql:
+          type: string
+          description: A [JQL](https://confluence.atlassian.com/x/egORLQ) expression.
+        startAt:
+          type: integer
+          description: The index of the first item to return in the page of results
+            (page offset). The base index is `0`.
+          format: int32
+        maxResults:
+          type: integer
+          description: The maximum number of items to return per page.
+          format: int32
+          default: 50
+        fields:
+          type: array
+          description: |-
+            A list of fields to return for each issue, use it to retrieve a subset of fields. This parameter accepts a comma-separated list. Expand options include:
 
+             *  `*all` Returns all fields.
+             *  `*navigable` Returns navigable fields.
+             *  Any issue field, prefixed with a minus to exclude.
+
+            The default is `*navigable`.
+
+            Examples:
+
+             *  `summary,comment` Returns the summary and comments fields only.
+             *  `-description` Returns all navigable (default) fields except description.
+             *  `*all,-comment` Returns all fields except comments.
+
+            Multiple `fields` parameters can be included in a request.
+
+            Note: All navigable fields are returned by default. This differs from [GET issue](#api-rest-api-3-issue-issueIdOrKey-get) where the default is all fields.
+          items:
+            type: string
+        validateQuery:
+          type: string
+          description: |-
+            Determines how to validate the JQL query and treat the validation results. Supported values:
+
+             *  `strict` Returns a 400 response code if any errors are found, along with a list of all errors (and warnings).
+             *  `warn` Returns all errors as warnings.
+             *  `none` No validation is performed.
+             *  `true` *Deprecated* A legacy synonym for `strict`.
+             *  `false` *Deprecated* A legacy synonym for `warn`.
+
+            The default is `strict`.
+
+            Note: If the JQL is not correctly formed a 400 response code is returned, regardless of the `validateQuery` value.
+          enum:
+          - strict
+          - warn
+          - none
+          - 'true'
+          - 'false'
+        expand:
+          type: array
+          description: |-
+            Use [expand](em>#expansion) to include additional information about issues in the response. Note that, unlike the majority of instances where `expand` is specified, `expand` is defined as a list of values. The expand options are:
+
+             *  `renderedFields` Returns field values rendered in HTML format.
+             *  `names` Returns the display name of each field.
+             *  `schema` Returns the schema describing a field type.
+             *  `transitions` Returns all possible transitions for the issue.
+             *  `operations` Returns all possible operations for the issue.
+             *  `editmeta` Returns information about how each field can be edited.
+             *  `changelog` Returns a list of recent updates to an issue, sorted by date, starting from the most recent.
+             *  `versionedRepresentations` Instead of `fields`, returns `versionedRepresentations` a JSON array containing each version of a field's value, with the highest numbered item representing the most recent version.
+          items:
+            type: string
+        properties:
+          type: array
+          description: A list of up to 5 issue properties to include in the results.
+            This parameter accepts a comma-separated list.
+          items:
+            type: string
+        fieldsByKeys:
+          type: boolean
+          description: Reference fields by their key (rather than ID). The default
+            is `false`.
+      additionalProperties: false
+    FieldReferenceData:
+      type: object
+      properties:
+        value:
+          type: string
+          description: The field identifier.
+        displayName:
+          type: string
+          description: |-
+            The display name contains the following:
+
+             *  for system fields, the field name. For example, `Summary`.
+             *  for collapsed custom fields, the field name followed by a hyphen and then the field name and field type. For example, `Component - Component[Dropdown]`.
+             *  for other custom fields, the field name followed by a hyphen and then the custom field ID. For example, `Component - cf[10061]`.
+        orderable:
+          type: string
+          description: Whether the field can be used in a query's `ORDER BY` clause.
+          enum:
+          - 'true'
+          - 'false'
+        searchable:
+          type: string
+          description: Whether the content of this field can be searched.
+          enum:
+          - 'true'
+          - 'false'
+        auto:
+          type: string
+          description: Whether the field provide auto-complete suggestions.
+          enum:
+          - 'true'
+          - 'false'
+        cfid:
+          type: string
+          description: If the item is a custom field, the ID of the custom field.
+        operators:
+          type: array
+          description: The valid search operators for the field.
+          items:
+            type: string
+        types:
+          type: array
+          description: The data types of items in the field.
+          items:
+            type: string
+      additionalProperties: false
+      description: Details of a field that can be used in advanced searches.
+    Comment:
+      type: object
+      properties:
+        self:
+          type: string
+          description: The URL of the comment.
+          readOnly: true
+        id:
+          type: string
+          description: The ID of the comment.
+          readOnly: true
+        body:
+          description: The comment text in [Atlassian Document Format](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/).
+        renderedBody:
+          type: string
+          description: The rendered version of the comment.
+          readOnly: true
+        created:
+          type: string
+          description: The date and time at which the comment was created.
+          format: date-time
+          readOnly: true
+        updated:
+          type: string
+          description: The date and time at which the comment was updated last.
+          format: date-time
+          readOnly: true
+        jsdPublic:
+          type: boolean
+          description: Whether the comment is visible in Jira Service Desk. Defaults
+            to true when comments are created in the Jira Cloud Platform. This includes
+            when the site doesn't use Jira Service Desk or the project isn't a Jira
+            Service Desk project and, therefore, there is no Jira Service Desk for
+            the issue to be visible on. To create a comment with its visibility in
+            Jira Service Desk set to false, use the Jira Service Desk REST API [Create
+            request comment](https://developer.atlassian.com/cloud/jira/service-desk/rest/#api-rest-servicedeskapi-request-issueIdOrKey-comment-post)
+            operation.
+          readOnly: true
+        properties:
+          type: array
+          description: A list of comment properties. Optional on create and update.
+          items:
+            "$ref": "#/components/schemas/EntityProperty"
+      additionalProperties: true
+      description: A comment.
+  securitySchemes:
+    basicAuth:
+      type: http
+      description: You can access this resource via basic auth.
+      scheme: basic
+    OAuth2:
+      type: oauth2
+      description: OAuth2 scopes for Jira
+      flows:
+        authorizationCode:
+          authorizationUrl: https://auth.atlassian.com/authorize
+          tokenUrl: https://auth.atlassian.com/oauth/token
+          scopes:
+            read:jira-user: View user information in Jira that you have access to,
+              including usernames, email addresses, and avatars.
+            read:jira-work: Read project and issue data. Search for issues and objects
+              associated with issues (such as attachments and worklogs).
+            write:jira-work: Create and edit issues in Jira, post comments, create
+              worklogs, and delete issues.
+            manage:jira-project: Create and edit project settings and create new project-level
+              objects, for example, versions, components.
+            manage:jira-configuration: Configure Jira settings that require the Jira
+              administrators permission, for example, create projects and custom fields,
+              view workflows, manage issue link types.
+            manage:jira-webhook: Manage Jira webhooks. Enables an OAuth app to register
+              and unregister dynamic webhooks in Jira. It also provides for fetching
+              of registered webhooks.


### PR DESCRIPTION
This is an integration we had a long time ago for Bug Reporting purposes. Adding this back in for egress incidient ticketing.

- Bump to latest v3 Jira API, which has a published Swagger spec
- Copy a subset of this swagger and make some modifications (see comments in jira.yaml)
- Setup initial create/comment/search functionality, which is needed by the EgressRemediationService

See also the follow-up PR https://github.com/all-of-us/workbench/pull/5859  for usage of this client.