### PR TITLE
[RW-7544][risk: low] Add adminLocked state to database

### DIFF
--- a/api/db/changelog/db.changelog-179-add-workspace-admin-locked-column.xml
+++ b/api/db/changelog/db.changelog-179-add-workspace-admin-locked-column.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="alex" id="changelog-179-add-workspace-admin-locked">
+    <addColumn tableName="workspace">
+      <column name="admin_locked" type="boolean" defaultValueBoolean="false"/>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -188,6 +188,7 @@
   <include file="changelog/db.changelog-176-drop-dua-type-column.xml"/>
   <include file="changelog/db.changelog-177-add-egress-event-table.xml"/>
   <include file="changelog/db.changelog-178-add-compute-security-suspended-column.xml"/>
+  <include file="changelog/db.changelog-179-add-workspace-admin-locked-column.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -87,12 +87,15 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
         workspaceAdminService.deleteRuntimesInWorkspace(workspaceNamespace, runtimesToDelete));
   }
 
+private boolean toPrimitive(Boolean value) {
+  return Optional.ofNullable(value).orElse(false);
+}
+
   @Override
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
   public ResponseEntity<EmptyResponse> setAdminLockedState(
       String workspaceNamespace, AdminLockedState lockedState) {
-    final boolean desiredLockState = Optional.ofNullable(lockedState.getValue()).orElse(false);
-    workspaceAdminService.setAdminLockedState(workspaceNamespace, desiredLockState);
+    workspaceAdminService.setAdminLockedState(workspaceNamespace, toPrimitive(lockedState.getValue()));
     return ResponseEntity.ok().build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -12,7 +12,6 @@ import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
 import org.pmiops.workbench.model.ListRuntimeResponse;
-import org.pmiops.workbench.model.LockedState;
 import org.pmiops.workbench.model.ReadOnlyNotebookResponse;
 import org.pmiops.workbench.model.WorkspaceAdminView;
 import org.pmiops.workbench.model.WorkspaceAuditLogQueryResponse;
@@ -87,15 +86,16 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
         workspaceAdminService.deleteRuntimesInWorkspace(workspaceNamespace, runtimesToDelete));
   }
 
-private boolean toPrimitive(Boolean value) {
-  return Optional.ofNullable(value).orElse(false);
-}
+  private boolean toPrimitive(Boolean value) {
+    return Optional.ofNullable(value).orElse(false);
+  }
 
   @Override
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
   public ResponseEntity<EmptyResponse> setAdminLockedState(
       String workspaceNamespace, AdminLockedState lockedState) {
-    workspaceAdminService.setAdminLockedState(workspaceNamespace, toPrimitive(lockedState.getValue()));
+    workspaceAdminService.setAdminLockedState(
+        workspaceNamespace, toPrimitive(lockedState.getValue()));
     return ResponseEntity.ok().build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -1,14 +1,17 @@
 package org.pmiops.workbench.api;
 
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.model.AccessReason;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.CloudStorageTraffic;
+import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
 import org.pmiops.workbench.model.ListRuntimeResponse;
+import org.pmiops.workbench.model.LockedState;
 import org.pmiops.workbench.model.ReadOnlyNotebookResponse;
 import org.pmiops.workbench.model.WorkspaceAdminView;
 import org.pmiops.workbench.model.WorkspaceAuditLogQueryResponse;
@@ -81,5 +84,14 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
       String workspaceNamespace, ListRuntimeDeleteRequest runtimesToDelete) {
     return ResponseEntity.ok(
         workspaceAdminService.deleteRuntimesInWorkspace(workspaceNamespace, runtimesToDelete));
+  }
+
+  @Override
+  @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
+  public ResponseEntity<EmptyResponse> setWorkspaceLockedState(
+      String workspaceNamespace, LockedState lockedState) {
+    final boolean desiredLockState = Optional.ofNullable(lockedState.getValue()).orElse(false);
+    workspaceAdminService.setLockedState(workspaceNamespace, desiredLockState);
+    return ResponseEntity.ok().build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.model.AccessReason;
+import org.pmiops.workbench.model.AdminLockedState;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.CloudStorageTraffic;
 import org.pmiops.workbench.model.EmptyResponse;
@@ -88,10 +89,10 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
 
   @Override
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
-  public ResponseEntity<EmptyResponse> setWorkspaceLockedState(
-      String workspaceNamespace, LockedState lockedState) {
+  public ResponseEntity<EmptyResponse> setAdminLockedState(
+      String workspaceNamespace, AdminLockedState lockedState) {
     final boolean desiredLockState = Optional.ofNullable(lockedState.getValue()).orElse(false);
-    workspaceAdminService.setLockedState(workspaceNamespace, desiredLockState);
+    workspaceAdminService.setAdminLockedState(workspaceNamespace, desiredLockState);
     return ResponseEntity.ok().build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
@@ -751,7 +751,8 @@ public class DbWorkspace {
     return adminLocked;
   }
 
-  public void setAdminLocked(boolean adminLocked) {
+  public DbWorkspace setAdminLocked(boolean adminLocked) {
     this.adminLocked = adminLocked;
+    return this;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
@@ -125,6 +125,7 @@ public class DbWorkspace {
       DbStorageEnums.billingAccountTypeToStorage(BillingAccountType.FREE_TIER);
   private Short needsRPReviewPrompt;
   private String googleProject;
+  private boolean adminLocked;
 
   public DbWorkspace() {
     setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -743,5 +744,14 @@ public class DbWorkspace {
   public DbWorkspace setNeedsReviewPrompt(Boolean needsReviewRPPrompt) {
     this.needsRPReviewPrompt = (short) (needsReviewRPPrompt ? 0 : 1);
     return this;
+  }
+
+  @Column(name = "admin_locked")
+  public boolean isAdminLocked() {
+    return adminLocked;
+  }
+
+  public void setAdminLocked(boolean adminLocked) {
+    this.adminLocked = adminLocked;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -97,6 +97,7 @@ public interface WorkspaceMapper {
 
   // This method isn't a full conversion, so we need to mask out the values that don't
   // get set here.
+  @Mapping(target = "adminLocked", ignore = true)
   @Mapping(target = "approved", ignore = true)
   @Mapping(target = "billingAccountName", ignore = true)
   @Mapping(target = "billingAccountType", ignore = true)
@@ -111,19 +112,19 @@ public interface WorkspaceMapper {
   @Mapping(target = "disseminateResearchSet", ignore = true)
   @Mapping(target = "firecloudName", ignore = true)
   @Mapping(target = "firecloudUuid", ignore = true)
+  @Mapping(target = "googleProject", ignore = true)
   @Mapping(target = "lastAccessedTime", ignore = true)
   @Mapping(target = "lastModifiedTime", ignore = true)
   @Mapping(target = "name", ignore = true)
+  @Mapping(target = "needsResearchPurposeReviewPrompt", ignore = true)
   @Mapping(target = "published", ignore = true)
   @Mapping(target = "researchOutcomeSet", ignore = true)
   @Mapping(target = "reviewRequested", ignore = true)
-  @Mapping(target = "needsResearchPurposeReviewPrompt", ignore = true)
   @Mapping(target = "timeRequested", ignore = true)
   @Mapping(target = "version", ignore = true)
   @Mapping(target = "workspaceActiveStatusEnum", ignore = true)
   @Mapping(target = "workspaceId", ignore = true)
   @Mapping(target = "workspaceNamespace", ignore = true)
-  @Mapping(target = "googleProject", ignore = true)
   void mergeResearchPurposeIntoWorkspace(
       @MappingTarget DbWorkspace workspace, ResearchPurpose researchPurpose);
 

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
@@ -39,4 +39,6 @@ public interface WorkspaceAdminService {
 
   List<ListRuntimeResponse> deleteRuntimesInWorkspace(
       String workspaceNamespace, ListRuntimeDeleteRequest req);
+
+  void setLockedState(String workspaceNamespace, boolean desiredLockState);
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
@@ -40,5 +40,5 @@ public interface WorkspaceAdminService {
   List<ListRuntimeResponse> deleteRuntimesInWorkspace(
       String workspaceNamespace, ListRuntimeDeleteRequest req);
 
-  void setLockedState(String workspaceNamespace, boolean desiredLockState);
+  void setAdminLockedState(String workspaceNamespace, boolean desiredLockState);
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -325,7 +325,8 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     // TODO but what should I do with it?
 
     Optional<DbWorkspace> dbWorkspaceOptional = getFirstWorkspaceByNamespace(workspaceNamespace);
-    dbWorkspaceOptional.ifPresent(dbWorkspace -> setAdminLockedState(dbWorkspace, desiredLockState));
+    dbWorkspaceOptional.ifPresent(
+        dbWorkspace -> setAdminLockedState(dbWorkspace, desiredLockState));
 
     if (!dbWorkspaceOptional.isPresent()) {
       log.info(
@@ -333,8 +334,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     }
   }
 
-  private void setAdminLockedState(
-      DbWorkspace dbWorkspace, boolean desiredLockState) {
+  private void setAdminLockedState(DbWorkspace dbWorkspace, boolean desiredLockState) {
     log.info(
         String.format(
             "Found workspace in DB: ID %d, Name '%s'",

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -340,14 +340,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
             "Found workspace in DB: ID %d, Name '%s'",
             dbWorkspace.getWorkspaceId(), dbWorkspace.getName()));
 
-  }
-
-  private String printBoolean(Boolean value) {
-    if (value == null) {
-      return "null";
-    } else {
-      return value.toString();
-    }
+    workspaceDao.save(dbWorkspace.setAdminLocked(desiredLockState));
   }
 
   // NOTE: may be an undercount since we only retrieve the first Page of Storage List results

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -315,7 +315,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
   }
 
   @Override
-  public void setLockedState(String workspaceNamespace, boolean desiredLockState) {
+  public void setAdminLockedState(String workspaceNamespace, boolean desiredLockState) {
     // OK I got your request
     log.info(
         String.format(
@@ -325,7 +325,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     // TODO but what should I do with it?
 
     Optional<DbWorkspace> dbWorkspaceOptional = getFirstWorkspaceByNamespace(workspaceNamespace);
-    dbWorkspaceOptional.ifPresent(dbWorkspace -> setLockedState(dbWorkspace, desiredLockState));
+    dbWorkspaceOptional.ifPresent(dbWorkspace -> setAdminLockedState(dbWorkspace, desiredLockState));
 
     if (!dbWorkspaceOptional.isPresent()) {
       log.info(
@@ -333,41 +333,13 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     }
   }
 
-  private FirecloudWorkspaceDetails setLockedState(
+  private void setAdminLockedState(
       DbWorkspace dbWorkspace, boolean desiredLockState) {
     log.info(
         String.format(
             "Found workspace in DB: ID %d, Name '%s'",
             dbWorkspace.getWorkspaceId(), dbWorkspace.getName()));
 
-    FirecloudWorkspaceDetails fcWorkspace =
-        fireCloudService
-            .getWorkspaceAsService(
-                dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName())
-            .getWorkspace();
-
-    log.info(
-        String.format(
-            "Found workspace in Terra: isLocked = %s", printBoolean(fcWorkspace.isIsLocked())));
-
-    if (desiredLockState) {
-      fcWorkspace =
-          fireCloudService
-              .lockWorkspaceAsService(
-                  dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName())
-              .getWorkspace();
-    } else {
-      fcWorkspace =
-          fireCloudService
-              .unlockWorkspaceAsService(
-                  dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName())
-              .getWorkspace();
-    }
-
-    log.info(
-        String.format(
-            "Updated workspace in Terra: isLocked = %s", printBoolean(fcWorkspace.isIsLocked())));
-    return fcWorkspace;
   }
 
   private String printBoolean(Boolean value) {

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -322,18 +322,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
             "called setLockedState on wsns %s with desiredLockState %b",
             workspaceNamespace, desiredLockState));
 
-    // TODO but what should I do with it?
-
     DbWorkspace dbWorkspace = getWorkspaceByNamespaceOrThrow(workspaceNamespace);
-    setAdminLockedState(dbWorkspace, desiredLockState);
-  }
-
-  private void setAdminLockedState(DbWorkspace dbWorkspace, boolean desiredLockState) {
-    log.info(
-        String.format(
-            "Found workspace in DB: ID %d, Name '%s'",
-            dbWorkspace.getWorkspaceId(), dbWorkspace.getName()));
-
     workspaceDao.save(dbWorkspace.setAdminLocked(desiredLockState));
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -324,14 +324,8 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
 
     // TODO but what should I do with it?
 
-    Optional<DbWorkspace> dbWorkspaceOptional = getFirstWorkspaceByNamespace(workspaceNamespace);
-    dbWorkspaceOptional.ifPresent(
-        dbWorkspace -> setAdminLockedState(dbWorkspace, desiredLockState));
-
-    if (!dbWorkspaceOptional.isPresent()) {
-      log.info(
-          "could not find workspace in DB.  Is this wsns invalid, or from a different environment?");
-    }
+    DbWorkspace dbWorkspace = getWorkspaceByNamespaceOrThrow(workspaceNamespace);
+    setAdminLockedState(dbWorkspace, desiredLockState);
   }
 
   private void setAdminLockedState(DbWorkspace dbWorkspace, boolean desiredLockState) {

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1505,11 +1505,11 @@ paths:
         - workspaceAdmin
       consumes:
         - application/json
-      description: Set locked or unlocked state for the workspace
-      operationId: setWorkspaceLockedState
+      description: Set admin locked or unlocked state for the workspace
+      operationId: setAdminLockedState
       parameters:
         - in: body
-          name: lockedState
+          name: AdminLockedState
           required: true
           schema:
             type: object

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1497,6 +1497,33 @@ paths:
           description: success
           schema:
             "$ref": "#/definitions/EmptyResponse"
+  "/v1/admin/workspaces/{workspaceNamespace}/locked":
+    parameters:
+      - "$ref": "#/parameters/workspaceNamespace"
+    post:
+      tags:
+        - workspaceAdmin
+      consumes:
+        - application/json
+      description: Set locked or unlocked state for the workspace
+      operationId: setWorkspaceLockedState
+      parameters:
+        - in: body
+          name: lockedState
+          required: true
+          schema:
+            type: object
+            required:
+              - value
+            properties:
+              value:
+                type: boolean
+      responses:
+        200:
+          description: success
+          schema:
+            "$ref": "#/definitions/EmptyResponse"
+
   "/v1/admin/workspaces/{workspaceNamespace}":
     parameters:
     - "$ref": "#/parameters/workspaceNamespace"

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -45,7 +45,6 @@ import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbWorkspace;
-import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceDetails;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -45,6 +45,7 @@ import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceDetails;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
@@ -121,7 +121,6 @@ public class WorkspaceDaoTest {
     assertThat(ws.isAdminLocked()).isTrue();
   }
 
-
   private DbWorkspace createWorkspace() {
     DbWorkspace workspace = new DbWorkspace();
     workspace.setVersion(1);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
@@ -109,6 +109,19 @@ public class WorkspaceDaoTest {
     }
   }
 
+  @Test
+  public void testAdminLocked() {
+    workspaceDao.deleteAll();
+
+    DbWorkspace ws = new DbWorkspace();
+    assertThat(ws.isAdminLocked()).isFalse();
+
+    ws.setAdminLocked(true);
+    ws = workspaceDao.save(ws);
+    assertThat(ws.isAdminLocked()).isTrue();
+  }
+
+
   private DbWorkspace createWorkspace() {
     DbWorkspace workspace = new DbWorkspace();
     workspace.setVersion(1);


### PR DESCRIPTION
Adds a boolean `adminLocked` to the workspace state and allows changing the value through an admin-accessible API endpoint.


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
