### PR TITLE
[risk=low][RW-7520] CreateWorkspace TierUnavailableModal if user doesn't have access

### DIFF
--- a/ui/src/app/pages/workspace/tier-unavailable-modal.tsx
+++ b/ui/src/app/pages/workspace/tier-unavailable-modal.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import {Button} from 'app/components/buttons';
+import {Modal, ModalBody, ModalFooter, ModalTitle} from 'app/components/modals';
+import {displayNameForTier} from 'app/utils/access-tiers';
+
+interface Props {
+  accessTierShortName: string;
+  onCancel: Function;
+}
+
+export const TierUnavailableModal = (props: Props) => {
+  const {accessTierShortName, onCancel} = props;
+  return <Modal onRequestClose={() => onCancel()}>
+        <ModalTitle data-test-id='tier-unavailable-modal'>
+          <div>You have selected the {displayNameForTier(accessTierShortName)} but you don't have access</div>
+        </ModalTitle>
+        <ModalBody>Before creating your workspace, please complete the data access requirements to gain access.</ModalBody>
+        <ModalFooter>
+          <Button type='secondary' onClick={() => onCancel()}>Cancel</Button>
+          <Button type='primary' path='/data-access-requirements'>Get Started</Button>
+        </ModalFooter>
+    </Modal>;
+};

--- a/ui/src/app/pages/workspace/unavailable-tier-modal.tsx
+++ b/ui/src/app/pages/workspace/unavailable-tier-modal.tsx
@@ -9,10 +9,10 @@ interface Props {
   onCancel: Function;
 }
 
-export const TierUnavailableModal = (props: Props) => {
+export const UnavailableTierModal = (props: Props) => {
   const {accessTierShortName, onCancel} = props;
   return <Modal onRequestClose={() => onCancel()}>
-        <ModalTitle data-test-id='tier-unavailable-modal'>
+        <ModalTitle data-test-id='unavailable-tier-modal'>
           <div>You have selected the {displayNameForTier(accessTierShortName)} but you don't have access</div>
         </ModalTitle>
         <ModalBody>Before creating your workspace, please complete the data access requirements to gain access.</ModalBody>

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -378,12 +378,12 @@ describe('WorkspaceEdit', () => {
     const cdrVersionSelectOptions = (): Array<string> => cdrVersionsSelect().children().map(o => o.props().value);
     expect(cdrVersionSelectOptions()).toEqual([defaultCdrVersion.cdrVersionId, altCdrVersion.cdrVersionId]);
 
-    // when Controlled is selected, the Tier Unavailable Modal appears, and the CDR Version dropdown continues to
+    // when Controlled is selected, the UnavailableTierModal appears, and the CDR Version dropdown continues to
     // list the registered tier CDR Versions
 
     await simulateSelection(accessTierSelection, AccessTierShortNames.Controlled);
 
-    expect(wrapper.find('[data-test-id="tier-unavailable-modal"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-test-id="unavailable-tier-modal"]').exists()).toBeTruthy();
 
     expect(cdrVersionsSelect().props().value).toBe(defaultCdrVersion.cdrVersionId);
     expect(cdrVersionSelectOptions()).toEqual([defaultCdrVersion.cdrVersionId, altCdrVersion.cdrVersionId]);

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -2,6 +2,7 @@ import * as fp from 'lodash/fp';
 import * as React from 'react';
 import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
 import {Dropdown} from "primereact/dropdown";
+import {MemoryRouter} from "react-router";
 
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {currentWorkspaceStore} from 'app/utils/navigation';
@@ -35,8 +36,6 @@ import * as Authentication from "app/utils/authentication";
 import {mockNavigate} from 'setupTests';
 import {environment} from 'environments/environment';
 
-import SpyInstance = jest.SpyInstance;
-import {MemoryRouter} from "react-router";
 
 type AnyWrapper = (ShallowWrapper|ReactWrapper);
 
@@ -44,8 +43,8 @@ jest.mock('app/utils/workbench-gapi-client', () => ({
   getBillingAccountInfo: () => new Promise(resolve => resolve({billingAccountName: 'billing-account'}))
 }));
 
-let mockHasBillingScope: SpyInstance;
-let mockEnsureBillingScope: SpyInstance;
+let mockHasBillingScope: jest.SpyInstance;
+let mockEnsureBillingScope: jest.SpyInstance;
 
 function getSaveButtonDisableMsg(wrapper: AnyWrapper, attributeName: string) {
   return wrapper.find('[data-test-id="workspace-save-btn"]').first().prop('disabled')[attributeName];
@@ -316,7 +315,10 @@ describe('WorkspaceEdit', () => {
     const twoTiers = [AccessTierShortNames.Registered, AccessTierShortNames.Controlled];
     environment.accessTiersVisibleToUsers = twoTiers;
     workspaceEditMode = WorkspaceEditMode.Create;
-    profileStore.set({...profileStore.get(), profile: {...profileStore.get().profile, accessTierShortNames: twoTiers}});
+    profileStore.set({...profileStore.get(), profile: {
+      ...profileStore.get().profile,
+        accessTierShortNames: twoTiers
+    }});
 
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1,8 +1,10 @@
 import * as fp from 'lodash/fp';
 import * as React from 'react';
 import validate from 'validate.js';
+import {Dropdown} from 'primereact/dropdown';
+import {OverlayPanel} from 'primereact/overlaypanel';
 
-import {Button, Clickable, LinkButton, StyledExternalLink} from 'app/components/buttons';
+import {Button, LinkButton, StyledExternalLink} from 'app/components/buttons';
 import {FadeBox} from 'app/components/containers';
 import {FlexColumn, FlexRow} from 'app/components/flex';
 import {InfoIcon} from 'app/components/icons';
@@ -16,7 +18,6 @@ import {AoU, AouTitle} from 'app/components/text-wrappers';
 import {WithSpinnerOverlayProps} from 'app/components/with-spinner-overlay';
 import {CreateBillingAccountModal} from 'app/pages/workspace/create-billing-account-modal';
 import {WorkspaceEditSection} from 'app/pages/workspace/workspace-edit-section';
-import {Select} from 'app/components/inputs';
 import {
   disseminateFindings,
   PrimaryPurposeItems,
@@ -44,7 +45,7 @@ import {
   withCurrentWorkspace,
   withUserProfile
 } from 'app/utils';
-import {AccessTierShortNames} from 'app/utils/access-tiers';
+import {AccessTierShortNames, displayNameForTier, hasTierAccess} from 'app/utils/access-tiers';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {
   ensureBillingScope,
@@ -78,9 +79,9 @@ import {
   Workspace,
   WorkspaceAccessLevel
 } from 'generated/fetch';
-import {Dropdown} from 'primereact/dropdown';
-import {OverlayPanel} from 'primereact/overlaypanel';
 import {OldCdrVersionModal} from './old-cdr-version-modal';
+import {environment} from 'environments/environment';
+import {TierUnavailableModal} from "./tier-unavailable-modal";
 
 export const styles = reactStyles({
   categoryRow: {
@@ -295,6 +296,7 @@ export interface WorkspaceEditState {
   workspaceCreationErrorMessage: string;
   workspaceNewAclDelayed: boolean;
   workspaceNewAclDelayedContinueFn: Function;
+  tierUnavailable?: string;
 }
 
 export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), withUserProfile(), withNavigation)(
@@ -1098,9 +1100,27 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
 
     // show the Access Tiers selection dropdown only when there are multiple tiers to choose from
     enableAccessTierSelection(): boolean {
-      const {tiers} = this.props.cdrVersionTiersResponse || {tiers: []};
-      return tiers.length > 1;
+      return environment.accessTiersVisibleToUsers.length > 1;
     }
+
+    onAccessTierChange(profile: Profile, cdrVersionTiersResponse: CdrVersionTiersResponse) {
+      return (v: React.FormEvent<HTMLSelectElement>) => {
+        const selectedTier = v.currentTarget.value;
+
+        if (hasTierAccess(profile, selectedTier)) {
+          this.setState(fp.flow(
+            fp.set(['tierUnavailable'], ''),
+            fp.set(['workspace', 'accessTierShortName'], selectedTier),
+            fp.set(['cdrVersions'], this.getCdrVersions(selectedTier)),
+            fp.set(['workspace', 'cdrVersionId'],
+              getDefaultCdrVersionForTier(selectedTier, cdrVersionTiersResponse).cdrVersionId)
+          ));
+        } else {
+          this.setState({tierUnavailable: selectedTier});
+        }
+      };
+    }
+
 
     render() {
       const {enableBillingUpgrade} = serverConfigStore.get().config;
@@ -1129,9 +1149,11 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
         workspaceCreationConflictError,
         workspaceCreationError,
         workspaceCreationErrorMessage,
-        workspaceNewAclDelayed
+        workspaceNewAclDelayed,
+        tierUnavailable,
       } = this.state;
-      const {cdrVersionTiersResponse, profileState: {profile: {freeTierDollarQuota, freeTierUsage}}} = this.props;
+      const {cdrVersionTiersResponse, profileState: {profile}} = this.props;
+      const {freeTierDollarQuota, freeTierUsage} = profile;
       const freeTierCreditsBalance = freeTierDollarQuota - freeTierUsage;
       // defined below in the OverlayPanel declaration
       let freeTierBalancePanel: OverlayPanel;
@@ -1154,6 +1176,9 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
               destWorkspace={this.state.workspace}
               cdrVersionTiersResponse={cdrVersionTiersResponse}
           />}
+          {tierUnavailable && <TierUnavailableModal
+            accessTierShortName={tierUnavailable}
+            onCancel={() => this.setState({tierUnavailable: ''})}/>}
           <WorkspaceEditSection header={this.renderHeader()} tooltip={toolTipText.header}
                                 style={{marginTop: '24px'}} largeHeader
                                 required={!this.isMode(WorkspaceEditMode.Duplicate)}>
@@ -1184,18 +1209,11 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
                   <div data-test-id='select-access-tier' style={{...styles.select, ...styles.accessTierSpacing}}>
                     <select style={{...styles.selectInput, ...styles.accessTierSpacing}}
                             value={accessTierShortName}
-                            onChange={(v: React.FormEvent<HTMLSelectElement>) => {
-                              const selectedTier = v.currentTarget.value;
-                              this.setState(fp.flow(
-                                fp.set(['workspace', 'accessTierShortName'], selectedTier),
-                                fp.set(['cdrVersions'], this.getCdrVersions(selectedTier)),
-                                fp.set(['workspace', 'cdrVersionId'],
-                                  getDefaultCdrVersionForTier(selectedTier, cdrVersionTiersResponse).cdrVersionId)));
-                            }}
+                            onChange={this.onAccessTierChange(profile, cdrVersionTiersResponse)}
                             disabled={!this.isMode(WorkspaceEditMode.Create)}>
-                      {cdrVersionTiersResponse.tiers.map((tier, i) => (
-                          <option key={tier.accessTierShortName} value={tier.accessTierShortName}>
-                            {tier.accessTierDisplayName}
+                      {environment.accessTiersVisibleToUsers.map((shortName, i) => (
+                          <option key={shortName} value={shortName}>
+                            {displayNameForTier(shortName)}
                           </option>
                       ))}
                     </select>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -81,7 +81,7 @@ import {
 } from 'generated/fetch';
 import {OldCdrVersionModal} from './old-cdr-version-modal';
 import {environment} from 'environments/environment';
-import {TierUnavailableModal} from "./tier-unavailable-modal";
+import {UnavailableTierModal} from "./unavailable-tier-modal";
 
 export const styles = reactStyles({
   categoryRow: {
@@ -296,7 +296,7 @@ export interface WorkspaceEditState {
   workspaceCreationErrorMessage: string;
   workspaceNewAclDelayed: boolean;
   workspaceNewAclDelayedContinueFn: Function;
-  tierUnavailable?: string;
+  unavailableTier?: string;
 }
 
 export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), withUserProfile(), withNavigation)(
@@ -1116,7 +1116,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
               getDefaultCdrVersionForTier(selectedTier, cdrVersionTiersResponse).cdrVersionId)
           ));
         } else {
-          this.setState({tierUnavailable: selectedTier});
+          this.setState({unavailableTier: selectedTier});
         }
       };
     }
@@ -1150,7 +1150,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
         workspaceCreationError,
         workspaceCreationErrorMessage,
         workspaceNewAclDelayed,
-        tierUnavailable,
+        unavailableTier,
       } = this.state;
       const {cdrVersionTiersResponse, profileState: {profile}} = this.props;
       const {freeTierDollarQuota, freeTierUsage} = profile;
@@ -1176,9 +1176,9 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
               destWorkspace={this.state.workspace}
               cdrVersionTiersResponse={cdrVersionTiersResponse}
           />}
-          {tierUnavailable && <TierUnavailableModal
-            accessTierShortName={tierUnavailable}
-            onCancel={() => this.setState({tierUnavailable: ''})}/>}
+          {unavailableTier && <UnavailableTierModal
+            accessTierShortName={unavailableTier}
+            onCancel={() => this.setState({unavailableTier: ''})}/>}
           <WorkspaceEditSection header={this.renderHeader()} tooltip={toolTipText.header}
                                 style={{marginTop: '24px'}} largeHeader
                                 required={!this.isMode(WorkspaceEditMode.Duplicate)}>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1103,24 +1103,21 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       return environment.accessTiersVisibleToUsers.length > 1;
     }
 
-    onAccessTierChange(profile: Profile, cdrVersionTiersResponse: CdrVersionTiersResponse) {
-      return (v: React.FormEvent<HTMLSelectElement>) => {
-        const selectedTier = v.currentTarget.value;
+    onAccessTierChange(v: React.FormEvent<HTMLSelectElement>, profile: Profile, cdrVersionTiersResponse: CdrVersionTiersResponse) {
+      const selectedTier = v.currentTarget.value;
 
-        if (hasTierAccess(profile, selectedTier)) {
-          this.setState(fp.flow(
-            fp.set(['tierUnavailable'], ''),
-            fp.set(['workspace', 'accessTierShortName'], selectedTier),
-            fp.set(['cdrVersions'], this.getCdrVersions(selectedTier)),
-            fp.set(['workspace', 'cdrVersionId'],
-              getDefaultCdrVersionForTier(selectedTier, cdrVersionTiersResponse).cdrVersionId)
-          ));
-        } else {
-          this.setState({unavailableTier: selectedTier});
-        }
-      };
+      if (hasTierAccess(profile, selectedTier)) {
+        this.setState(fp.flow(
+          fp.set(['tierUnavailable'], ''),
+          fp.set(['workspace', 'accessTierShortName'], selectedTier),
+          fp.set(['cdrVersions'], this.getCdrVersions(selectedTier)),
+          fp.set(['workspace', 'cdrVersionId'],
+            getDefaultCdrVersionForTier(selectedTier, cdrVersionTiersResponse).cdrVersionId)
+        ));
+      } else {
+        this.setState({unavailableTier: selectedTier});
+      }
     }
-
 
     render() {
       const {enableBillingUpgrade} = serverConfigStore.get().config;
@@ -1209,7 +1206,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
                   <div data-test-id='select-access-tier' style={{...styles.select, ...styles.accessTierSpacing}}>
                     <select style={{...styles.selectInput, ...styles.accessTierSpacing}}
                             value={accessTierShortName}
-                            onChange={this.onAccessTierChange(profile, cdrVersionTiersResponse)}
+                            onChange={(value) => this.onAccessTierChange(value, profile, cdrVersionTiersResponse)}
                             disabled={!this.isMode(WorkspaceEditMode.Create)}>
                       {environment.accessTiersVisibleToUsers.map((shortName, i) => (
                           <option key={shortName} value={shortName}>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1108,7 +1108,7 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
 
       if (hasTierAccess(profile, selectedTier)) {
         this.setState(fp.flow(
-          fp.set(['tierUnavailable'], ''),
+          fp.set(['unavailableTier'], ''),
           fp.set(['workspace', 'accessTierShortName'], selectedTier),
           fp.set(['cdrVersions'], this.getCdrVersions(selectedTier)),
           fp.set(['workspace', 'cdrVersionId'],


### PR DESCRIPTION
Old behavior -> for users without CT access, no tier dropdown appears in Create Workspace

New behavior -> if CT exists in an env, it always appears in Create Workspace.  users without access get a modal directing them to DAR if they select CT (and the selection is forced back to RT)

<img width="465" alt="Create Workspace Tier 2" src="https://user-images.githubusercontent.com/2701406/140568696-1292418e-2e95-4666-b882-1e8c7ed6bcb4.png">

![Create_Workspace_Tier_2](https://user-images.githubusercontent.com/2701406/140568706-7e74b44d-32f4-4185-9c32-c6a143a21c8e.gif)


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
