### PR TITLE
[risk=no] Lint for focused tests

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -88,6 +88,9 @@ module.exports = {
     /* Maintainability */
     'eol-last': 'warn',
     'max-len': ['warn', {code: 140, ignorePattern: '^import |^export\\{(.*?)\\}', ignoreComments: true}], 
-    // 'prefer-const': ['warn', {'destructuring': 'all'}], 
+    // 'prefer-const': ['warn', {'destructuring': 'all'}],
+
+    /* Jest */
+    'jest/no-focused-tests': 'warn',
   }
 };


### PR DESCRIPTION
This will catch `fit()`, `test.only` etc. I accidentally checked one in recently.

See https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md