### PR TITLE
[risk=no][no ticket] rename cdrVersionToEtag to versionToEtag

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cohortreview/mapper/CohortAnnotationDefinitionMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/mapper/CohortAnnotationDefinitionMapper.java
@@ -19,7 +19,7 @@ import org.pmiops.workbench.utils.mappers.MapStructConfig;
     uses = {CommonMappers.class, DbStorageEnums.class})
 public interface CohortAnnotationDefinitionMapper {
 
-  @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
+  @Mapping(target = "etag", source = "version", qualifiedByName = "versionToEtag")
   @Mapping(target = "enumValues", source = "enumValues")
   CohortAnnotationDefinition dbModelToClient(DbCohortAnnotationDefinition source);
 

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/mapper/CohortReviewMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/mapper/CohortReviewMapper.java
@@ -16,7 +16,7 @@ import org.pmiops.workbench.utils.mappers.MapStructConfig;
     config = MapStructConfig.class,
     uses = {CommonMappers.class, DbStorageEnums.class})
 public interface CohortReviewMapper {
-  @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
+  @Mapping(target = "etag", source = "version", qualifiedByName = "versionToEtag")
   // this fetches all participants, and can be large, we don't want to fetch by
   // default. May be removed from object pending design
   @Mapping(target = "participantCohortStatuses", ignore = true)

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortMapper.java
@@ -20,6 +20,6 @@ public interface CohortMapper {
   DbCohort clientToDbModel(Cohort source);
 
   @Mapping(target = "id", source = "cohortId")
-  @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
+  @Mapping(target = "etag", source = "version", qualifiedByName = "versionToEtag")
   Cohort dbModelToClient(DbCohort destination);
 }

--- a/api/src/main/java/org/pmiops/workbench/conceptset/mapper/ConceptSetMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/mapper/ConceptSetMapper.java
@@ -24,7 +24,7 @@ public interface ConceptSetMapper {
   @Mapping(target = "id", source = "conceptSetId")
   @Mapping(target = "domain", source = "domainEnum")
   @Mapping(target = "survey", source = "surveysEnum")
-  @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
+  @Mapping(target = "etag", source = "version", qualifiedByName = "versionToEtag")
   @Mapping(target = "criteriums", ignore = true)
   @Mapping(target = "participantCount", ignore = true)
   ConceptSet dbModelToClient(DbConceptSet source);
@@ -32,7 +32,7 @@ public interface ConceptSetMapper {
   @Mapping(target = "id", source = "conceptSetId")
   @Mapping(target = "domain", source = "domainEnum")
   @Mapping(target = "survey", source = "surveysEnum")
-  @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
+  @Mapping(target = "etag", source = "version", qualifiedByName = "versionToEtag")
   @Mapping(target = "criteriums", ignore = true)
   @Mapping(target = "participantCount", ignore = true)
   ConceptSet dbModelToClient(

--- a/api/src/main/java/org/pmiops/workbench/dataset/mapper/DataSetMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/mapper/DataSetMapper.java
@@ -39,7 +39,7 @@ public interface DataSetMapper {
   @Mapping(target = "cohorts", ignore = true)
   // This is stored in a subtable, we may not want to fetch all the time
   @Mapping(target = "domainValuePairs", ignore = true)
-  @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
+  @Mapping(target = "etag", source = "version", qualifiedByName = "versionToEtag")
   // TODO (RW-4756): Define a DatasetLight type.
   @Named("dbModelToClientLight")
   DataSet dbModelToClientLight(DbDataset dbDataset);
@@ -63,7 +63,7 @@ public interface DataSetMapper {
   @Mapping(target = "conceptSets", source = "conceptSetIds")
   @Mapping(target = "cohorts", source = "cohortIds")
   @Mapping(target = "domainValuePairs", source = "values")
-  @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
+  @Mapping(target = "etag", source = "version", qualifiedByName = "versionToEtag")
   DataSet dbModelToClient(DbDataset dbDataset);
 
   @AfterMapping

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
@@ -93,8 +93,8 @@ public class CommonMappers {
         .orElse(null);
   }
 
-  @Named("cdrVersionToEtag")
-  public String cdrVersionToEtag(int cdrVersion) {
+  @Named("versionToEtag")
+  public String versionToEtag(int cdrVersion) {
     return Etags.fromVersion(cdrVersion);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
@@ -94,8 +94,8 @@ public class CommonMappers {
   }
 
   @Named("versionToEtag")
-  public String versionToEtag(int cdrVersion) {
-    return Etags.fromVersion(cdrVersion);
+  public String versionToEtag(int version) {
+    return Etags.fromVersion(version);
   }
 
   @Named("etagToCdrVersion")

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -30,7 +30,7 @@ import org.pmiops.workbench.workspaces.resources.WorkspaceResourceMapper;
 public interface WorkspaceMapper {
 
   @Mapping(target = "researchPurpose", source = "dbWorkspace")
-  @Mapping(target = "etag", source = "dbWorkspace.version", qualifiedByName = "cdrVersionToEtag")
+  @Mapping(target = "etag", source = "dbWorkspace.version", qualifiedByName = "versionToEtag")
   @Mapping(target = "name", source = "dbWorkspace.name")
   @Mapping(target = "id", source = "fcWorkspace.name")
   @Mapping(target = "googleBucketName", source = "fcWorkspace.bucketName")
@@ -42,7 +42,7 @@ public interface WorkspaceMapper {
 
   @Mapping(target = "cdrVersionId", source = "cdrVersion")
   @Mapping(target = "creator", source = "creator.username")
-  @Mapping(target = "etag", source = "version", qualifiedByName = "cdrVersionToEtag")
+  @Mapping(target = "etag", source = "version", qualifiedByName = "versionToEtag")
   @Mapping(
       target = "googleBucketName",
       ignore =


### PR DESCRIPTION
This CommonMappers method has a name which causes confusion and doesn't accurately represent what it does.

This always operates on a DB entity `version` rather than a CDR Version.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
