### PR TITLE
[risk=no] Rename fake JPA date time for consistency

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/FakeJpaDateTimeConfiguration.java
+++ b/api/src/test/java/org/pmiops/workbench/FakeJpaDateTimeConfiguration.java
@@ -24,7 +24,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
  */
 @Configuration
 @EnableJpaAuditing(dateTimeProviderRef = "fakeDateTimeProvider")
-public class JpaFakeDateTimeConfiguration {
+public class FakeJpaDateTimeConfiguration {
   @Bean(name = "fakeDateTimeProvider")
   public DateTimeProvider dateTimeProvider(Clock clock) {
     return () -> Optional.of(clock.instant());

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineEgressControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineEgressControllerTest.java
@@ -10,7 +10,7 @@ import java.time.Instant;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
-import org.pmiops.workbench.JpaFakeDateTimeConfiguration;
+import org.pmiops.workbench.FakeJpaDateTimeConfiguration;
 import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.db.dao.EgressEventDao;
 import org.pmiops.workbench.db.model.DbEgressEvent;
@@ -23,7 +23,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
-@Import(JpaFakeDateTimeConfiguration.class)
+@Import(FakeJpaDateTimeConfiguration.class)
 public class OfflineEgressControllerTest {
   private static final Instant TEN_MINUTES_AGO =
       FakeClockConfiguration.NOW.toInstant().minus(Duration.ofMinutes(10));

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -30,7 +30,7 @@ import javax.mail.MessagingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
-import org.pmiops.workbench.JpaFakeDateTimeConfiguration;
+import org.pmiops.workbench.FakeJpaDateTimeConfiguration;
 import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessModuleServiceImpl;
 import org.pmiops.workbench.access.AccessTierService;
@@ -206,7 +206,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     VerifiedInstitutionalAffiliationMapperImpl.class,
     AccessTierServiceImpl.class,
     FakeClockConfiguration.class,
-    JpaFakeDateTimeConfiguration.class,
+    FakeJpaDateTimeConfiguration.class,
   })
   @MockBean({BigQueryService.class})
   static class Configuration {

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
-import org.pmiops.workbench.JpaFakeDateTimeConfiguration;
+import org.pmiops.workbench.FakeJpaDateTimeConfiguration;
 import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessModuleServiceImpl;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
@@ -99,7 +99,7 @@ public class UserServiceTest {
 
   @Import({
     FakeClockConfiguration.class,
-    JpaFakeDateTimeConfiguration.class,
+    FakeJpaDateTimeConfiguration.class,
     UserServiceTestConfiguration.class,
     AccessTierServiceImpl.class,
     AccessModuleServiceImpl.class,

--- a/api/src/test/java/org/pmiops/workbench/exfiltration/EgressEventServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/exfiltration/EgressEventServiceTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.pmiops.workbench.FakeClockConfiguration;
-import org.pmiops.workbench.JpaFakeDateTimeConfiguration;
+import org.pmiops.workbench.FakeJpaDateTimeConfiguration;
 import org.pmiops.workbench.actionaudit.auditors.EgressEventAuditor;
 import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -65,7 +65,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 
 @DataJpaTest
-@Import({FakeClockConfiguration.class, JpaFakeDateTimeConfiguration.class})
+@Import({FakeClockConfiguration.class, FakeJpaDateTimeConfiguration.class})
 public class EgressEventServiceTest {
 
   private static final Instant NOW = Instant.parse("2020-06-11T01:30:00.02Z");

--- a/api/src/test/java/org/pmiops/workbench/exfiltration/EgressRemediationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/exfiltration/EgressRemediationServiceTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.pmiops.workbench.FakeClockConfiguration;
-import org.pmiops.workbench.JpaFakeDateTimeConfiguration;
+import org.pmiops.workbench.FakeJpaDateTimeConfiguration;
 import org.pmiops.workbench.actionaudit.auditors.EgressEventAuditor;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.EgressAlertRemediationPolicy;
@@ -93,7 +93,7 @@ public class EgressRemediationServiceTest {
   @Import({
     EgressRemediationService.class,
     FakeClockConfiguration.class,
-    JpaFakeDateTimeConfiguration.class,
+    FakeJpaDateTimeConfiguration.class,
     JiraService.class
   })
   static class Configuration {


### PR DESCRIPTION
This makes it consistent with `FakeClockConfiguration`, which makes it easier to remember / autocomplete.