### PR TITLE
[no ticket][risk=no] Fix env variable for access test user in nightly test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,6 +337,7 @@ commands:
             cp .env.circleci.<< parameters.env_name >> .env
             echo "export PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}" >> "$BASH_ENV"
             source $BASH_ENV
+            export $(cat .env | sed 's/#.*//g' | xargs)
             echo "PUPPETEER_ACCESS_TEST=${PUPPETEER_ACCESS_TEST}"
       - run:
           working_directory: ~/workbench/api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,6 +322,12 @@ commands:
           dir_names: "ui e2e .circleci"
 
   puppeteer-access-test-user-setup:
+    parameters:
+      env_name:
+        description: The target environment for run Puppeteer end-to-end test. Must be one of "test", "staging", "local", "perf".
+        default: "test"
+        type: enum
+        enum: [ "test", "staging", "local", "perf" ]
     steps:
       - gcloud-auth-login
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,8 +336,9 @@ commands:
           command: |
             cp .env.circleci.<< parameters.env_name >> .env
             echo "export PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}" >> "$BASH_ENV"
-            export $(cat .env | grep -v '#' | awk '/=/ {print $1}')
             source $BASH_ENV
+            set -a; source .env; set +a
+            echo "ACCESS_TEST_USER=${ACCESS_TEST_USER}"
             echo "PUPPETEER_ACCESS_TEST=${PUPPETEER_ACCESS_TEST}"
       - run:
           working_directory: ~/workbench/api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,6 +325,13 @@ commands:
     steps:
       - gcloud-auth-login
       - run:
+          name: "Set environment variable ACCESS_TEST_USER"
+          working_directory: ~/workbench/e2e
+          command: |
+            cp .env.circleci.<< parameters.env_name >> .env
+            echo "export PUPPETEER_ACCESS_TEST=$ACCESS_TEST_USER" >> "$BASH_ENV"
+            source $BASH_ENV
+      - run:
           working_directory: ~/workbench/api
           name: Prep the e2e access test user (in Test env) by setting access module timestamps
           command: ./project.rb set-access-module-timestamps --user ${PUPPETEER_ACCESS_TEST}
@@ -657,10 +664,11 @@ workflows:
       - puppeteer-env-setup
       - puppeteer-test:
           <<: *filter-pr-branch
-          env_name: "local"
+          env_name: "nightly-integration"
           parallel_num: 4
           optional_steps:
             - halt-puppeteer-check
+            - puppeteer-access-test-user-setup
           requires:
             - puppeteer-env-setup
             # PR commits e2e tests waits for workflow triggered by master branch merge to finish.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,13 +337,9 @@ commands:
             cp .env.circleci.<< parameters.env_name >> .env
             source .env
 
-            echo "export PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}" >> $BASH_ENV
             cat .env | awk '{print "export " $0}' >> $BASH_ENV
+            echo "export PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}" >> $BASH_ENV
             source $BASH_ENV
-
-            # set -a; source .env; set +a
-            echo "ACCESS_TEST_USER=${ACCESS_TEST_USER}"
-            echo "PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}"
       - run:
           working_directory: ~/workbench/api
           name: Prep the e2e access test user (in Test env) by setting access module timestamps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,12 +337,11 @@ commands:
             cp .env.circleci.<< parameters.env_name >> .env
             source .env
             cat .env | awk '{print "export " $0}' >> $BASH_ENV
-            echo "export PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}" >> $BASH_ENV
             source $BASH_ENV
       - run:
           working_directory: ~/workbench/api
           name: Prep the e2e access test user (in Test env) by setting access module timestamps
-          command: ./project.rb set-access-module-timestamps --user "${PUPPETEER_ACCESS_TEST}"
+          command: ./project.rb set-access-module-timestamps --user "${ACCESS_TEST_USER}"
 
 # -------------------------
 #        JOBS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -664,8 +664,9 @@ workflows:
       - puppeteer-env-setup
       - puppeteer-test:
           <<: *filter-pr-branch
-          env_name: "nightly-integration"
+          env_name: "local"
           parallel_num: 4
+          test_mode: "nightly-integration"
           optional_steps:
             - halt-puppeteer-check
             - puppeteer-access-test-user-setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,11 +337,11 @@ commands:
             cp .env.circleci.<< parameters.env_name >> .env
             echo "export PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}" >> "$BASH_ENV"
             source $BASH_ENV
-            echo ${PUPPETEER_ACCESS_TEST}
+            echo "PUPPETEER_ACCESS_TEST=${PUPPETEER_ACCESS_TEST}"
       - run:
           working_directory: ~/workbench/api
           name: Prep the e2e access test user (in Test env) by setting access module timestamps
-          command: ./project.rb set-access-module-timestamps --user ${PUPPETEER_ACCESS_TEST}
+          command: ./project.rb set-access-module-timestamps --user "${PUPPETEER_ACCESS_TEST}"
 
 # -------------------------
 #        JOBS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,6 +337,7 @@ commands:
             cp .env.circleci.<< parameters.env_name >> .env
             echo "export PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}" >> "$BASH_ENV"
             source $BASH_ENV
+            echo ${PUPPETEER_ACCESS_TEST}
       - run:
           working_directory: ~/workbench/api
           name: Prep the e2e access test user (in Test env) by setting access module timestamps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,6 @@ commands:
           command: |
             cp .env.circleci.<< parameters.env_name >> .env
             source .env
-
             cat .env | awk '{print "export " $0}' >> $BASH_ENV
             echo "export PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}" >> $BASH_ENV
             source $BASH_ENV
@@ -675,10 +674,8 @@ workflows:
           <<: *filter-pr-branch
           env_name: "local"
           parallel_num: 4
-          test_mode: "nightly-integration"
           optional_steps:
             - halt-puppeteer-check
-            - puppeteer-access-test-user-setup
           requires:
             - puppeteer-env-setup
             # PR commits e2e tests waits for workflow triggered by master branch merge to finish.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,8 +336,8 @@ commands:
           command: |
             cp .env.circleci.<< parameters.env_name >> .env
             echo "export PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}" >> "$BASH_ENV"
+            export $(cat .env | grep -v '#' | awk '/=/ {print $1}')
             source $BASH_ENV
-            export $(cat .env | sed 's/#.*//g' | xargs)
             echo "PUPPETEER_ACCESS_TEST=${PUPPETEER_ACCESS_TEST}"
       - run:
           working_directory: ~/workbench/api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,7 +335,7 @@ commands:
           working_directory: ~/workbench/e2e
           command: |
             cp .env.circleci.<< parameters.env_name >> .env
-            echo "export PUPPETEER_ACCESS_TEST=$ACCESS_TEST_USER" >> "$BASH_ENV"
+            echo "export PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}" >> "$BASH_ENV"
             source $BASH_ENV
       - run:
           working_directory: ~/workbench/api
@@ -748,8 +748,7 @@ workflows:
       - api-bigquery-test
       - puppeteer-env-setup
       - puppeteer-test:
-          parallel_num: 2
-          env_name: "test"
+          parallel_num: 3
           test_mode: "nightly-integration"
           optional_steps:
             - puppeteer-access-test-user-setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,8 +334,7 @@ commands:
           name: "Set environment variable ACCESS_TEST_USER"
           working_directory: ~/workbench/e2e
           command: |
-            cp .env.circleci.<< parameters.env_name >> .env
-            source .env
+            cp ".env.circleci.<< parameters.env_name >>" .env
             cat .env | awk '{print "export " $0}' >> $BASH_ENV
             source $BASH_ENV
       - run:
@@ -672,9 +671,11 @@ workflows:
       - puppeteer-test:
           <<: *filter-pr-branch
           env_name: "local"
-          parallel_num: 4
+          parallel_num: 3
+          test_mode: "nightly-integration"
           optional_steps:
             - halt-puppeteer-check
+            - puppeteer-access-test-user-setup
           requires:
             - puppeteer-env-setup
             # PR commits e2e tests waits for workflow triggered by master branch merge to finish.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,11 +335,15 @@ commands:
           working_directory: ~/workbench/e2e
           command: |
             cp .env.circleci.<< parameters.env_name >> .env
-            echo "export PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}" >> "$BASH_ENV"
+            source .env
+
+            echo "export PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}" >> $BASH_ENV
+            cat .env | awk '{print "export " $0}' >> $BASH_ENV
             source $BASH_ENV
-            set -a; source .env; set +a
+
+            # set -a; source .env; set +a
             echo "ACCESS_TEST_USER=${ACCESS_TEST_USER}"
-            echo "PUPPETEER_ACCESS_TEST=${PUPPETEER_ACCESS_TEST}"
+            echo "PUPPETEER_ACCESS_TEST=${ACCESS_TEST_USER}"
       - run:
           working_directory: ~/workbench/api
           name: Prep the e2e access test user (in Test env) by setting access module timestamps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -671,11 +671,9 @@ workflows:
       - puppeteer-test:
           <<: *filter-pr-branch
           env_name: "local"
-          parallel_num: 3
-          test_mode: "nightly-integration"
+          parallel_num: 4
           optional_steps:
             - halt-puppeteer-check
-            - puppeteer-access-test-user-setup
           requires:
             - puppeteer-env-setup
             # PR commits e2e tests waits for workflow triggered by master branch merge to finish.


### PR DESCRIPTION
Update CircleCI `puppeteer-access-test-user-setup` cmd -- Replace env variable `PUPPETEER_ACCESS_TEST` with `ACCESS_TEST_USER`.  Because Puppeteer env variables were deleted yesterday.