### PR TITLE
[RW-7567][risk=no] bumping preprod cdr version

### DIFF
--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -98,7 +98,7 @@
       "creationTime": "2021-08-10 00:00:00Z",
       "releaseNumber": 7,
       "numParticipants": 329070,
-      "cdrDbName": "r_2021q3_3",
+      "cdrDbName": "r_2021q3_4",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"
@@ -113,7 +113,7 @@
       "creationTime": "2021-10-06 00:00:00Z",
       "releaseNumber": 8,
       "numParticipants": 331382,
-      "cdrDbName": "c_2021q3_2",
+      "cdrDbName": "c_2021q3_3",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "controlled",


### PR DESCRIPTION
bumping preprod cdr version for next weeks preprod release.  Putting @NehaBroad as reviewer since she is release engineer next week. Updated the Release Playbook with entry on how to determine if [CDR publish is needed](https://docs.google.com/document/d/17YVCqu4BhVV8ai3OutHx8u0m6V5NkdM5H9kLNxTPDdo/edit#bookmark=id.5y2wpcggk65g)

RT publish command for preprod
`db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-preprod 
--bq-dataset R2021Q3R2 --tier registered --table-prefixes cb_,ds_
`

CT publish command for preprod
`db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-preprod --bq-dataset C2021Q3R2 --tier controlled --table-prefixes cb_,ds_`