### PR TITLE
[RW-7410][risk=no] Prevent saving dataset with no columns selected

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -470,6 +470,11 @@ const PREPACKAGED_WITH_ZIP_CODE_SOCIOECONOMIC = {
 };
 let PREPACKAGED_DOMAINS = PREPACKAGED_SURVEY_PERSON_DOMAIN;
 
+// Temp workaround to prevent errors from mismatched upper and lower case values
+function domainValuePairsToLowercase(domainValuePairs: DomainValuePair[]) {
+  return domainValuePairs.map(({domain, value}) => ({domain, value: value.toLowerCase()}));
+}
+
 interface DataSetPreviewInfo {
   isLoading: boolean;
   errorText: JSX.Element;
@@ -571,7 +576,7 @@ export const DatasetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), wi
         includesAllParticipants: dataset.includesAllParticipants,
         selectedConceptSetIds: dataset.conceptSets.map(cs => cs.id),
         selectedCohortIds: dataset.cohorts.map(c => c.id),
-        selectedDomainValuePairs: dataset.domainValuePairs,
+        selectedDomainValuePairs: domainValuePairsToLowercase(dataset.domainValuePairs),
         selectedDomains: this.getDomainsFromDataSet(dataset),
         selectedPrepackagedConceptSets: this.apiEnumToPrePackageConceptSets(dataset.prePackagedConceptSet)
       });


### PR DESCRIPTION
- Convert all column values to lower case to prevent conflicting upper and lower case values. 
- Fixes issue that can occur in datasets of duplicated workspaces

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
