### PR TITLE
[RW-7322][risk=no] Return totalSize from listEgressEvents

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/EgressEventsAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/EgressEventsAdminController.java
@@ -51,7 +51,7 @@ public class EgressEventsAdminController implements EgressEventsAdminApiDelegate
       ListEgressEventsRequest request) {
     int pageSize = DEFAULT_PAGE_SIZE;
     if (request.getPageSize() != null && request.getPageSize().intValue() > 0) {
-      pageSize = Math.min(request.getPageSize().intValue(), MAX_PAGE_SIZE);
+      pageSize = Math.min(request.getPageSize(), MAX_PAGE_SIZE);
     }
 
     Pageable pageable = PageRequest.of(0, pageSize);
@@ -106,7 +106,8 @@ public class EgressEventsAdminController implements EgressEventsAdminApiDelegate
     return ResponseEntity.ok(
         new ListEgressEventsResponse()
             .events(page.stream().map(egressEventMapper::toApiEvent).collect(Collectors.toList()))
-            .nextPageToken(nextPageToken));
+            .nextPageToken(nextPageToken)
+            .totalSize((int) page.getTotalElements()));
   }
 
   private Object[] toPaginationParams(ListEgressEventsRequest req) {

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6455,7 +6455,7 @@ definitions:
           If specified, only return event which were detected within the given
           workspace.
       pageSize:
-        type: number
+        type: integer
         description: >
           The number of egress events to return, per page. If unspecified, a
           system default is used.
@@ -6476,6 +6476,9 @@ definitions:
         description: >
           If present, this token can be provided to retrieve the next page of results.
           If null or empty, there are no further pages in the result stream.
+      totalSize:
+        type: integer
+        description: Total size of the result set.
   UpdateEgressEventRequest:
     type: object
     properties:

--- a/api/src/test/java/org/pmiops/workbench/api/EgressEventsAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/EgressEventsAdminControllerTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -123,7 +123,7 @@ public class EgressEventsAdminControllerTest {
               }
             }),
         Arguments.of(
-            new ListEgressEventsRequest().pageSize(BigDecimal.valueOf(1)),
+            new ListEgressEventsRequest().pageSize(1),
             new TestEgressEvent[][] {
               {TestEgressEvent.USER_1_WORKSPACE_1},
               {TestEgressEvent.USER_2_WORKSPACE_2},
@@ -132,14 +132,14 @@ public class EgressEventsAdminControllerTest {
               {TestEgressEvent.NO_USER_NO_WORKSPACE}
             }),
         Arguments.of(
-            new ListEgressEventsRequest().pageSize(BigDecimal.valueOf(2)),
+            new ListEgressEventsRequest().pageSize(2),
             new TestEgressEvent[][] {
               {TestEgressEvent.USER_1_WORKSPACE_1, TestEgressEvent.USER_2_WORKSPACE_2},
               {TestEgressEvent.USER_3_WORKSPACE_1, TestEgressEvent.USER_3_WORKSPACE_2},
               {TestEgressEvent.NO_USER_NO_WORKSPACE}
             }),
         Arguments.of(
-            new ListEgressEventsRequest().pageSize(BigDecimal.valueOf(3)),
+            new ListEgressEventsRequest().pageSize(3),
             new TestEgressEvent[][] {
               {
                 TestEgressEvent.USER_1_WORKSPACE_1,
@@ -149,7 +149,7 @@ public class EgressEventsAdminControllerTest {
               {TestEgressEvent.USER_3_WORKSPACE_2, TestEgressEvent.NO_USER_NO_WORKSPACE}
             }),
         Arguments.of(
-            new ListEgressEventsRequest().pageSize(BigDecimal.valueOf(4)),
+            new ListEgressEventsRequest().pageSize(4),
             new TestEgressEvent[][] {
               {
                 TestEgressEvent.USER_1_WORKSPACE_1,
@@ -160,7 +160,7 @@ public class EgressEventsAdminControllerTest {
               {TestEgressEvent.NO_USER_NO_WORKSPACE}
             }),
         Arguments.of(
-            new ListEgressEventsRequest().pageSize(BigDecimal.valueOf(5)),
+            new ListEgressEventsRequest().pageSize(5),
             new TestEgressEvent[][] {
               {
                 TestEgressEvent.USER_1_WORKSPACE_1,
@@ -232,10 +232,13 @@ public class EgressEventsAdminControllerTest {
             .sourceUserEmail(initialRequest.getSourceUserEmail())
             .sourceWorkspaceNamespace(initialRequest.getSourceWorkspaceNamespace())
             .pageSize(initialRequest.getPageSize());
+    int expectedTotalEvents = Arrays.stream(expectedPages).mapToInt(p -> p.length).sum();
 
     List<TestEgressEvent[]> gotPages = new ArrayList<>();
     do {
       ListEgressEventsResponse resp = controller.listEgressEvents(req).getBody();
+      assertThat(resp.getTotalSize()).isEqualTo(expectedTotalEvents);
+
       gotPages.add(
           resp.getEvents().stream()
               .map(e -> egressEventIds.get(e.getEgressEventId()))
@@ -294,7 +297,7 @@ public class EgressEventsAdminControllerTest {
 
     String nextPageToken =
         controller
-            .listEgressEvents(new ListEgressEventsRequest().pageSize(BigDecimal.valueOf(1L)))
+            .listEgressEvents(new ListEgressEventsRequest().pageSize(1))
             .getBody()
             .getNextPageToken();
 
@@ -302,9 +305,7 @@ public class EgressEventsAdminControllerTest {
         BadRequestException.class,
         () ->
             controller.listEgressEvents(
-                new ListEgressEventsRequest()
-                    .pageSize(BigDecimal.valueOf(10L))
-                    .pageToken(nextPageToken)));
+                new ListEgressEventsRequest().pageSize(10).pageToken(nextPageToken)));
   }
 
   @Test


### PR DESCRIPTION
Stacked on #5886 

The total size of the paginated stream is needed in order to render the admin egress events table.

Also fix the type in swagger for a few fields, should be `int` instead of `number`