### PR TITLE
[RW-7518][RW-6972][risk=low] syncComplianceTraining synchronizes CT training status

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/compliance/ComplianceService.java
+++ b/api/src/main/java/org/pmiops/workbench/compliance/ComplianceService.java
@@ -6,6 +6,11 @@ import org.pmiops.workbench.moodle.model.BadgeDetailsV2;
 
 public interface ComplianceService {
 
+  enum BadgeName {
+    REGISTERED_TIER_TRAINING,
+    CONTROLLED_TIER_TRAINING
+  }
+
   /**
    * Get details about the Research Ethics Training and the Data Use Agreement badges for a user
    *
@@ -13,7 +18,5 @@ public interface ComplianceService {
    * @return map of badge name to badge details
    * @throws ApiException
    */
-  Map<String, BadgeDetailsV2> getUserBadgesByBadgeName(String email) throws ApiException;
-
-  String getResearchEthicsTrainingField();
+  Map<BadgeName, BadgeDetailsV2> getUserBadgesByBadgeName(String email) throws ApiException;
 }

--- a/api/src/main/java/org/pmiops/workbench/compliance/ComplianceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliance/ComplianceServiceImpl.java
@@ -16,9 +16,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class ComplianceServiceImpl implements ComplianceService {
   private static final String RESPONSE_FORMAT = "json";
-  private static final String DUA_BADGE_NAME = "data_use_agreement";
-  private static final String RET_BADGE_NAME =
-      "research_ethics_training"; // 'ret' too much like 'return'
   private static final String MOODLE_EXCEPTION = "moodle_exception";
   private static final String MOODLE_USER_NOT_ALLOWED_ERROR_CODE = "guestsarenotallowed";
 
@@ -47,7 +44,7 @@ public class ComplianceServiceImpl implements ComplianceService {
    *     registered in Moodle.
    */
   @Override
-  public Map<String, BadgeDetailsV2> getUserBadgesByBadgeName(String email) throws ApiException {
+  public Map<BadgeName, BadgeDetailsV2> getUserBadgesByBadgeName(String email) throws ApiException {
     UserBadgeResponseV2 response =
         moodleApiProvider.get().getMoodleBadgeV2(RESPONSE_FORMAT, getToken(), email);
     if (response.getException() != null && response.getException().equals(MOODLE_EXCEPTION)) {
@@ -58,17 +55,15 @@ public class ComplianceServiceImpl implements ComplianceService {
         throw new ApiException(response.getMessage());
       }
     }
-    Map<String, BadgeDetailsV2> userBadgesByName = new HashMap<>();
+    Map<BadgeName, BadgeDetailsV2> userBadgesByName = new HashMap<>();
+    // "dua" and "ret" are confusingly named, but according to Moodle team this mapping is correct.
+    // See RW-7438 for details.
     if (response.getDua() != null) {
-      userBadgesByName.put(DUA_BADGE_NAME, response.getDua());
+      userBadgesByName.put(BadgeName.CONTROLLED_TIER_TRAINING, response.getDua());
     }
     if (response.getRet() != null) {
-      userBadgesByName.put(RET_BADGE_NAME, response.getRet());
+      userBadgesByName.put(BadgeName.REGISTERED_TIER_TRAINING, response.getRet());
     }
     return userBadgesByName;
-  }
-
-  public String getResearchEthicsTrainingField() {
-    return RET_BADGE_NAME;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -307,12 +307,17 @@ public class DbUser {
     this.dataUseAgreementSignedVersion = dataUseAgreementSignedVersion;
   }
 
+  // TODO(RW-6972): remove
+  @Deprecated
   @Column(name = "compliance_training_expiration_time")
-  public Timestamp getComplianceTrainingExpirationTime() {
+  public Timestamp getRegisteredTierComplianceTrainingExpirationTime() {
     return complianceTrainingExpirationTime;
   }
 
-  public void setComplianceTrainingExpirationTime(Timestamp complianceTrainingExpirationTime) {
+  // TODO(RW-6972): remove
+  @Deprecated
+  public void setRegisteredTierComplianceTrainingExpirationTime(
+      Timestamp complianceTrainingExpirationTime) {
     this.complianceTrainingExpirationTime = complianceTrainingExpirationTime;
   }
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -174,7 +174,7 @@ public class UserServiceTest {
 
     userService.syncComplianceTrainingStatusV2();
 
-    // The user should be updated in the database with a non-empty completion and expiration time.
+    // The user should be updated in the database with a non-empty completion.
     DbUser user = userDao.findUserByUsername(USERNAME);
     assertModuleCompletionEqual(
         AccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));

--- a/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
@@ -161,7 +161,8 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
   public DbUser createEntity() {
     final DbUser user = new DbUser();
     user.setAreaOfResearch(USER__AREA_OF_RESEARCH);
-    user.setComplianceTrainingExpirationTime(USER__COMPLIANCE_TRAINING_EXPIRATION_TIME);
+    user.setRegisteredTierComplianceTrainingExpirationTime(
+        USER__COMPLIANCE_TRAINING_EXPIRATION_TIME);
     user.setContactEmail(USER__CONTACT_EMAIL);
     user.setCreationTime(USER__CREATION_TIME);
     user.setDataUseAgreementSignedVersion(USER__DATA_USE_AGREEMENT_SIGNED_VERSION);


### PR DESCRIPTION
Tested locally: `syncComplianceTraining` appears to have the desired effect of setting my CT compliance training module with my user who has received the "dua" badge.

Logical changes:

- We now look at both RT and CT compliance training statuses during `syncComplianceTraining`, these map to `ret` and `dua` respectively, per Moodle team
- completionTime is now updated **according to Moodle's lastissued time**, though it still is set to the current time. Previously, we looked at the expiration time to determine whether the badge data had changed (because we didn't store the exact badge completion time). This was a proxy for "has the badge changed"; and is more directly served by instead asking whether the badge has been re-issued since the user completed the training last.

Incidental changes:

- This stops storing the compliance expiration time in our database, per RW-6972; this is mostly incidental as it would have been awkward to set this field exclusively for RT (and not CT)
- Update the expiration accessor naming and mark deprecated to discourage further use