### PR TITLE
[RW-7544][risk=no]  Read and set an "admin locked" state for a workspace - Add audit logs 

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/AdminAuditor.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/AdminAuditor.kt
@@ -1,7 +1,12 @@
 package org.pmiops.workbench.actionaudit.auditors
 
 import org.pmiops.workbench.model.AccessReason
+import org.pmiops.workbench.model.AdminLockingRequest
 
 interface AdminAuditor {
     fun fireViewNotebookAction(workspaceNamespace: String, workspaceName: String, notebookFilename: String, accessReason: AccessReason)
+
+    fun fireLockWorkspaceAction(workspaceId: Long, access: AdminLockingRequest)
+
+    fun fireUnlockWorkspaceAction(workspaceId: Long)
 }

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/AdminAuditor.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/AdminAuditor.kt
@@ -6,7 +6,7 @@ import org.pmiops.workbench.model.AdminLockingRequest
 interface AdminAuditor {
     fun fireViewNotebookAction(workspaceNamespace: String, workspaceName: String, notebookFilename: String, accessReason: AccessReason)
 
-    fun fireLockWorkspaceAction(workspaceId: Long, access: AdminLockingRequest)
+    fun fireLockWorkspaceAction(workspaceId: Long, adminLockingRequest: AdminLockingRequest)
 
     fun fireUnlockWorkspaceAction(workspaceId: Long)
 }

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/AdminAuditorImpl.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/AdminAuditorImpl.kt
@@ -52,15 +52,15 @@ constructor(
         actionAuditService.send(events)
     }
 
-    override fun fireLockWorkspaceAction(workspaceId: Long, access: AdminLockingRequest) {
+    override fun fireLockWorkspaceAction(workspaceId: Long, adminLockingRequest: AdminLockingRequest) {
         val dbUser = userProvider.get()
         val actionId = actionIdProvider.get()
         val timestamp = clock.millis()
-        val requestTimestamp = Date(access.requestDateInMillis).toString()
+        val requestTimestamp = Date(adminLockingRequest.requestDateInMillis).toString()
 
         val props = mapOf(
                 "locked" to "true",
-                "reason" to access.requestReason,
+                "reason" to adminLockingRequest.requestReason,
                 "request_date" to requestTimestamp
         )
 
@@ -85,12 +85,7 @@ constructor(
         val actionId = actionIdProvider.get()
         val timestamp = clock.millis()
 
-        val props = mapOf(
-                "locked" to "false"
-        )
-
-        val events = props.map {
-            ActionAuditEvent(
+        val event = ActionAuditEvent(
                     actionId = actionId,
                     actionType = ActionType.EDIT,
                     agentType = AgentType.ADMINISTRATOR,
@@ -98,11 +93,11 @@ constructor(
                     agentIdMaybe = dbUser.userId,
                     targetType = TargetType.WORKSPACE,
                     targetIdMaybe = workspaceId,
-                    targetPropertyMaybe = it.key,
-                    newValueMaybe = it.value,
-                    timestamp = timestamp) }
+                    targetPropertyMaybe = "locked",
+                    newValueMaybe = "false",
+                    timestamp = timestamp)
 
-        actionAuditService.send(events)
+        actionAuditService.send(event)
     }
 
     companion object {

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -1,13 +1,12 @@
 package org.pmiops.workbench.api;
 
 import java.util.List;
-import java.util.Optional;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.AccessReason;
-import org.pmiops.workbench.model.AdminLockedState;
+import org.pmiops.workbench.model.AdminLockingRequest;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.CloudStorageTraffic;
 import org.pmiops.workbench.model.EmptyResponse;
@@ -88,28 +87,24 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
         workspaceAdminService.deleteRuntimesInWorkspace(workspaceNamespace, runtimesToDelete));
   }
 
-  private boolean toPrimitive(Boolean value) {
-    return Optional.ofNullable(value).orElse(false);
-  }
-
   @Override
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
   public ResponseEntity<EmptyResponse> setAdminLockedState(
-      String workspaceNamespace, AdminLockedState lockedState) {
-    if (lockedState.getRequestDateInMillis() == null
-        || lockedState.getRequestDateInMillis() == 0
-        || StringUtils.isBlank(lockedState.getRequestReason())) {
+      String workspaceNamespace, AdminLockingRequest lockingRequest) {
+    if (lockingRequest.getRequestDateInMillis() == null
+        || lockingRequest.getRequestDateInMillis() == 0
+        || StringUtils.isBlank(lockingRequest.getRequestReason())) {
       throw new BadRequestException(
           String.format("Cannot have empty Request reason or Request Date"));
     }
-    workspaceAdminService.setAdminLockedState(workspaceNamespace, toPrimitive(true));
+    workspaceAdminService.setAdminLockedState(workspaceNamespace, lockingRequest);
     return ResponseEntity.ok().build();
   }
 
   @Override
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
   public ResponseEntity<EmptyResponse> setAdminUnlockedState(String workspaceNamespace) {
-    workspaceAdminService.setAdminLockedState(workspaceNamespace, false);
+    workspaceAdminService.setAdminUnlockedState(workspaceNamespace);
     return ResponseEntity.ok().build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -30,8 +30,6 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
 
   private final WorkspaceAdminService workspaceAdminService;
 
-  private String ADMIN_LOCK_REQUEST_DATE_FORMAT = "MM-dd-yyyy";
-
   @Autowired
   public WorkspaceAdminController(WorkspaceAdminService workspaceAdminService) {
     this.workspaceAdminService = workspaceAdminService;

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -1,8 +1,5 @@
 package org.pmiops.workbench.api;
 
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -99,17 +96,11 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
   public ResponseEntity<EmptyResponse> setAdminLockedState(
       String workspaceNamespace, AdminLockedState lockedState) {
-    if (StringUtils.isBlank(lockedState.getRequestDate())
+    if (lockedState.getRequestDateInMillis() == null
+        || lockedState.getRequestDateInMillis() == 0
         || StringUtils.isBlank(lockedState.getRequestReason())) {
       throw new BadRequestException(
           String.format("Cannot have empty Request reason or Request Date"));
-    }
-    try {
-      // Example for date: '2011-12-03'
-      LocalDate requestDate =
-          LocalDate.parse(lockedState.getRequestDate(), DateTimeFormatter.ISO_DATE);
-    } catch (DateTimeParseException e) {
-      throw new BadRequestException(String.format("Request Date should be in correct format"));
     }
     workspaceAdminService.setAdminLockedState(workspaceNamespace, toPrimitive(true));
     return ResponseEntity.ok().build();

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.AccessReason;
+import org.pmiops.workbench.model.AdminLockingRequest;
 import org.pmiops.workbench.model.AdminWorkspaceCloudStorageCounts;
 import org.pmiops.workbench.model.AdminWorkspaceObjectsCounts;
 import org.pmiops.workbench.model.CloudStorageTraffic;
@@ -40,5 +41,7 @@ public interface WorkspaceAdminService {
   List<ListRuntimeResponse> deleteRuntimesInWorkspace(
       String workspaceNamespace, ListRuntimeDeleteRequest req);
 
-  void setAdminLockedState(String workspaceNamespace, boolean desiredLockState);
+  void setAdminLockedState(String workspaceNamespace, AdminLockingRequest adminLockingRequest);
+
+  void setAdminUnlockedState(String workspaceNamespace);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1471,7 +1471,7 @@ paths:
         - workspaceAdmin
       consumes:
         - application/json
-      description: Set admin locked or unlocked state for the workspace
+      description: Set admin locked state for the workspace
       operationId: setAdminLockedState
       parameters:
         - in: body
@@ -1481,7 +1481,7 @@ paths:
             type: object
             required:
               - requestReason
-              - requestDate
+              - requestDateInMillis
             properties:
               requestReason:
                 type: string
@@ -1497,7 +1497,7 @@ paths:
           description: Bad request
           schema:
             "$ref": "#/definitions/ErrorResponse"
-  "/v1/admin/workspaces/{workspaceNamespace}/unlock":
+  "/v1/admin/workspaces/{workspaceNamespace}/unlocked":
     parameters:
       - "$ref": "#/parameters/workspaceNamespace"
     post:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1485,8 +1485,9 @@ paths:
             properties:
               requestReason:
                 type: string
-              requestDate:
-                type: string
+              requestDateInMillis:
+                type: integer
+                format: int64
       responses:
         200:
           description: success

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1475,7 +1475,7 @@ paths:
       operationId: setAdminLockedState
       parameters:
         - in: body
-          name: AdminLockedState
+          name: AdminLockingRequest
           required: true
           schema:
             type: object

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1480,10 +1480,32 @@ paths:
           schema:
             type: object
             required:
-              - value
+              - requestReason
+              - requestDate
             properties:
-              value:
-                type: boolean
+              requestReason:
+                type: string
+              requestDate:
+                type: string
+      responses:
+        200:
+          description: success
+          schema:
+            "$ref": "#/definitions/EmptyResponse"
+        400:
+          description: Bad request
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
+  "/v1/admin/workspaces/{workspaceNamespace}/unlock":
+    parameters:
+      - "$ref": "#/parameters/workspaceNamespace"
+    post:
+      tags:
+        - workspaceAdmin
+      consumes:
+        - application/json
+      description: Set admin unlocked state for the workspace
+      operationId: setAdminUnlockedState
       responses:
         200:
           description: success

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4466,6 +4466,7 @@ definitions:
       namespace: "aou-rw-test-11112222"
       googleProject: "aou-rw-test-11112222"
       published: false
+      adminLocked: false
       researchPurpose:
         additionalNotes: null
         ancestry: false
@@ -4539,6 +4540,10 @@ definitions:
       published:
         type: boolean
         default: false
+      adminLocked:
+        type: boolean
+        default: false
+        description: Whether an administrator has prevented most actions on the workspace for all users
       googleProject:
         type: string
         description: the google project used by the workspace for compute and storage

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
@@ -21,6 +21,7 @@ import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.conceptset.mapper.ConceptSetMapperImpl;
 import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceDetails;
@@ -28,6 +29,7 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.CloudMonitoringService;
 import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
+import org.pmiops.workbench.model.AdminLockedState;
 import org.pmiops.workbench.model.AdminWorkspaceCloudStorageCounts;
 import org.pmiops.workbench.model.AdminWorkspaceObjectsCounts;
 import org.pmiops.workbench.model.AuditLogEntry;
@@ -176,5 +178,63 @@ public class WorkspaceAdminControllerTest {
     assertThrows(
         NotFoundException.class,
         () -> workspaceAdminController.getWorkspaceAdminView(NONSENSE_NAMESPACE));
+  }
+
+  @Test
+  public void getWorkspaceAdmin_setAdminLock_noRequestDate() {
+    AdminLockedState adminLockedState = new AdminLockedState();
+    adminLockedState.setRequestDate("");
+    adminLockedState.setRequestReason("Some reason to lock");
+    assertThrows(
+        BadRequestException.class,
+        () -> workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState));
+  }
+
+  @Test
+  public void getWorkspaceAdmin_setAdminLock_noRequestReason() {
+    AdminLockedState adminLockedState = new AdminLockedState();
+    adminLockedState.setRequestDate("2021-10-10");
+    adminLockedState.setRequestReason("");
+    assertThrows(
+        BadRequestException.class,
+        () -> workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState));
+  }
+
+  @Test
+  public void getWorkspaceAdmin_setAdminLock_incorrectRequestDateFormat() {
+    AdminLockedState adminLockedState = new AdminLockedState();
+    adminLockedState.setRequestDate("20-21-10");
+    adminLockedState.setRequestReason("Some reason for ");
+    assertThrows(
+        BadRequestException.class,
+        () -> workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState));
+  }
+
+  @Test
+  public void getWorkspaceAdmin_setAdminLock_nullRequestDate() {
+    AdminLockedState adminLockedState = new AdminLockedState();
+    adminLockedState.setRequestDate(null);
+    adminLockedState.setRequestReason("Some reason for Locking Workspace");
+    assertThrows(
+        BadRequestException.class,
+        () -> workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState));
+  }
+
+  @Test
+  public void getWorkspaceAdmin_setAdminLock_nullRequestReason() {
+    AdminLockedState adminLockedState = new AdminLockedState();
+    adminLockedState.setRequestDate("20-21-10");
+    adminLockedState.setRequestReason(null);
+    assertThrows(
+        BadRequestException.class,
+        () -> workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState));
+  }
+
+  @Test
+  public void getWorkspaceAdmin_setAdminLock_correctRequestDateFormat() {
+    AdminLockedState adminLockedState = new AdminLockedState();
+    adminLockedState.setRequestDate("2021-03-03");
+    adminLockedState.setRequestReason("Some reason for Locking Workspace");
+    workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.api;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -29,7 +30,7 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.CloudMonitoringService;
 import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
-import org.pmiops.workbench.model.AdminLockedState;
+import org.pmiops.workbench.model.AdminLockingRequest;
 import org.pmiops.workbench.model.AdminWorkspaceCloudStorageCounts;
 import org.pmiops.workbench.model.AdminWorkspaceObjectsCounts;
 import org.pmiops.workbench.model.AuditLogEntry;
@@ -182,49 +183,60 @@ public class WorkspaceAdminControllerTest {
 
   @Test
   public void getWorkspaceAdmin_setAdminLock_noRequestDate() {
-    AdminLockedState adminLockedState = new AdminLockedState();
-    adminLockedState.setRequestDateInMillis(0l);
-    adminLockedState.setRequestReason("Some reason to lock");
+    AdminLockingRequest adminLockingRequest = new AdminLockingRequest();
+    adminLockingRequest.setRequestDateInMillis(0l);
+    adminLockingRequest.setRequestReason("Some reason to lock");
     assertThrows(
         BadRequestException.class,
-        () -> workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState));
+        () ->
+            workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockingRequest));
   }
 
   @Test
   public void getWorkspaceAdmin_setAdminLock_noRequestReason() {
-    AdminLockedState adminLockedState = new AdminLockedState();
-    adminLockedState.setRequestDateInMillis(23456l);
-    adminLockedState.setRequestReason("");
+    AdminLockingRequest adminLockingRequest = new AdminLockingRequest();
+    adminLockingRequest.setRequestDateInMillis(23456l);
+    adminLockingRequest.setRequestReason("");
     assertThrows(
         BadRequestException.class,
-        () -> workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState));
+        () ->
+            workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockingRequest));
   }
 
   @Test
   public void getWorkspaceAdmin_setAdminLock_nullRequestDate() {
-    AdminLockedState adminLockedState = new AdminLockedState();
-    adminLockedState.setRequestDateInMillis(null);
-    adminLockedState.setRequestReason("Some reason for Locking Workspace");
+    AdminLockingRequest adminLockingRequest = new AdminLockingRequest();
+    adminLockingRequest.setRequestDateInMillis(null);
+    adminLockingRequest.setRequestReason("Some reason for Locking Workspace");
     assertThrows(
         BadRequestException.class,
-        () -> workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState));
+        () ->
+            workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockingRequest));
   }
 
   @Test
   public void getWorkspaceAdmin_setAdminLock_nullRequestReason() {
-    AdminLockedState adminLockedState = new AdminLockedState();
-    adminLockedState.setRequestDateInMillis((long) 123456);
-    adminLockedState.setRequestReason(null);
+    AdminLockingRequest adminLockingRequest = new AdminLockingRequest();
+    adminLockingRequest.setRequestDateInMillis((long) 123456);
+    adminLockingRequest.setRequestReason(null);
     assertThrows(
         BadRequestException.class,
-        () -> workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState));
+        () ->
+            workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockingRequest));
   }
 
   @Test
-  public void getWorkspaceAdmin_setAdminLock_correctAdminLockedStateRequest() {
-    AdminLockedState adminLockedState = new AdminLockedState();
-    adminLockedState.setRequestDateInMillis(654321l);
-    adminLockedState.setRequestReason("Some reason for Locking Workspace");
-    workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState);
+  public void getWorkspaceAdmin_setAdminLock_correctAdminLockingRequest() {
+    AdminLockingRequest adminLockingRequest = new AdminLockingRequest();
+    adminLockingRequest.setRequestDateInMillis(654321l);
+    adminLockingRequest.setRequestReason("Some reason for Locking Workspace");
+    workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockingRequest);
+    verify(mockWorkspaceAdminService).setAdminLockedState(WORKSPACE_NAMESPACE, adminLockingRequest);
+  }
+
+  @Test
+  public void getWorkspace_setAdminUnlock() {
+    workspaceAdminController.setAdminUnlockedState(WORKSPACE_NAMESPACE);
+    verify(mockWorkspaceAdminService).setAdminUnlockedState(WORKSPACE_NAMESPACE);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
@@ -183,7 +183,7 @@ public class WorkspaceAdminControllerTest {
   @Test
   public void getWorkspaceAdmin_setAdminLock_noRequestDate() {
     AdminLockedState adminLockedState = new AdminLockedState();
-    adminLockedState.setRequestDate("");
+    adminLockedState.setRequestDateInMillis(0l);
     adminLockedState.setRequestReason("Some reason to lock");
     assertThrows(
         BadRequestException.class,
@@ -193,18 +193,8 @@ public class WorkspaceAdminControllerTest {
   @Test
   public void getWorkspaceAdmin_setAdminLock_noRequestReason() {
     AdminLockedState adminLockedState = new AdminLockedState();
-    adminLockedState.setRequestDate("2021-10-10");
+    adminLockedState.setRequestDateInMillis(23456l);
     adminLockedState.setRequestReason("");
-    assertThrows(
-        BadRequestException.class,
-        () -> workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState));
-  }
-
-  @Test
-  public void getWorkspaceAdmin_setAdminLock_incorrectRequestDateFormat() {
-    AdminLockedState adminLockedState = new AdminLockedState();
-    adminLockedState.setRequestDate("20-21-10");
-    adminLockedState.setRequestReason("Some reason for ");
     assertThrows(
         BadRequestException.class,
         () -> workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState));
@@ -213,7 +203,7 @@ public class WorkspaceAdminControllerTest {
   @Test
   public void getWorkspaceAdmin_setAdminLock_nullRequestDate() {
     AdminLockedState adminLockedState = new AdminLockedState();
-    adminLockedState.setRequestDate(null);
+    adminLockedState.setRequestDateInMillis(null);
     adminLockedState.setRequestReason("Some reason for Locking Workspace");
     assertThrows(
         BadRequestException.class,
@@ -223,7 +213,7 @@ public class WorkspaceAdminControllerTest {
   @Test
   public void getWorkspaceAdmin_setAdminLock_nullRequestReason() {
     AdminLockedState adminLockedState = new AdminLockedState();
-    adminLockedState.setRequestDate("20-21-10");
+    adminLockedState.setRequestDateInMillis((long) 123456);
     adminLockedState.setRequestReason(null);
     assertThrows(
         BadRequestException.class,
@@ -231,9 +221,9 @@ public class WorkspaceAdminControllerTest {
   }
 
   @Test
-  public void getWorkspaceAdmin_setAdminLock_correctRequestDateFormat() {
+  public void getWorkspaceAdmin_setAdminLock_correctAdminLockedStateRequest() {
     AdminLockedState adminLockedState = new AdminLockedState();
-    adminLockedState.setRequestDate("2021-03-03");
+    adminLockedState.setRequestDateInMillis(654321l);
     adminLockedState.setRequestReason("Some reason for Locking Workspace");
     workspaceAdminController.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockedState);
   }

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -54,6 +54,7 @@ import org.pmiops.workbench.leonardo.model.LeonardoAuditInfo;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeStatus;
+import org.pmiops.workbench.model.AdminLockingRequest;
 import org.pmiops.workbench.model.AdminWorkspaceCloudStorageCounts;
 import org.pmiops.workbench.model.AdminWorkspaceObjectsCounts;
 import org.pmiops.workbench.model.AdminWorkspaceResources;
@@ -106,6 +107,7 @@ public class WorkspaceAdminServiceTest {
   @MockBean private WorkspaceDao mockWorkspaceDao;
   @MockBean LeonardoRuntimeAuditor mockLeonardoRuntimeAuditor;
   @MockBean LeonardoNotebooksClient mockLeonardoNotebooksClient;
+  @MockBean private AdminAuditor mockAdminAuditor;
   @Autowired private WorkspaceAdminService workspaceAdminService;
 
   @TestConfiguration
@@ -408,5 +410,20 @@ public class WorkspaceAdminServiceTest {
             listRuntimeResponseList.stream()
                 .map(LeonardoListRuntimeResponse::getRuntimeName)
                 .collect(Collectors.toList()));
+  }
+
+  @Test
+  public void testSetAdminLockedStateCallsAuditor() throws Exception {
+    AdminLockingRequest adminLockingRequest = new AdminLockingRequest();
+    adminLockingRequest.setRequestReason("To test auditor");
+    adminLockingRequest.setRequestDateInMillis(12345677l);
+    workspaceAdminService.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockingRequest);
+    verify(mockAdminAuditor).fireLockWorkspaceAction(DB_WORKSPACE_ID, adminLockingRequest);
+  }
+
+  @Test
+  public void testSetAdminUnlockedStateCallsAuditor() throws Exception {
+    workspaceAdminService.setAdminUnlockedState(WORKSPACE_NAMESPACE);
+    verify(mockAdminAuditor).fireUnlockWorkspaceAction(DB_WORKSPACE_ID);
   }
 }


### PR DESCRIPTION
This PR:
Audit logs will save:
1)  Request reason and date when the workspace is locked
2) Workspace state as unlocked in case of AdminUnlock request

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
