### PR TITLE
[risk=low][RW-7572] Use Workspace breadcrumbs on the Terminal page

### DIFF
--- a/ui/src/app/components/breadcrumb.spec.tsx
+++ b/ui/src/app/components/breadcrumb.spec.tsx
@@ -1,7 +1,6 @@
 import {getTrail} from 'app/components/breadcrumb'
 import {BreadcrumbType, currentWorkspaceStore} from 'app/utils/navigation';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
-
 import {WorkspacesApi} from 'generated/fetch';
 
 import {cohortReviewStubs} from 'testing/stubs/cohort-review-service-stub';
@@ -29,4 +28,17 @@ describe('getTrail', () => {
     expect(trail[3].url)
       .toEqual('/workspaces/testns/testwsid/data/cohorts/88/review/participants/77');
   });
+
+  // regression test for RW-7572
+  test.each(Object.keys(BreadcrumbType))('handles breadcrumb type %s', (bType: string) => {
+    const trail = getTrail(BreadcrumbType[bType],
+      workspaceDataStub,
+      exampleCohortStubs[0],
+      cohortReviewStubs[0],
+      ConceptSetsApiStub.stubConceptSets()[0],
+      {ns: 'testns', wsid: 'testwsid', cid: '88', pid: '77'}
+    );
+    expect(trail.length).toBeGreaterThan(0);
+  });
+
 });

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -110,7 +110,7 @@ export const WorkspaceRoutes = () => {
     <AppRoute exact path={`${path}/terminals`}>
       <LeonardoAppRedirectPage
           routeData={{
-            breadcrumb: BreadcrumbType.Terminal,
+            breadcrumb: BreadcrumbType.Workspace,
             pageKey: LEONARDO_APP_PAGE_KEY,
             // The iframe we use to display the Jupyter notebook does something strange
             // to the height calculation of the container, which is normally set to auto.

--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -94,7 +94,6 @@ export enum BreadcrumbType {
   WorkspaceEdit = 'WorkspaceEdit',
   WorkspaceDuplicate = 'WorkspaceDuplicate',
   Notebook = 'Notebook',
-  Terminal = 'Terminal',
   ConceptSet = 'ConceptSet',
   Cohort = 'Cohort',
   CohortReview = 'CohortReview',


### PR DESCRIPTION
Not sure if this is the ultimately desired behavior (may want different breadcrumbs), but it's a clear improvement to add missing breadcrumbs.

Also add a regression test for missing breadcrumbs.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
