### PR TITLE
[risk=low][RW-7575] adminLocked workspace routing / disable tabs

### DIFF
--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -47,13 +47,68 @@ describe('WorkspaceNavBar', () => {
   it('should navigate on tab click', () => {
     const wrapper = component();
 
+    wrapper.find({'data-test-id': 'Analysis'}).first().simulate('click');
+    expect(mockNavigate).toHaveBeenCalledWith(
+      ['workspaces', workspaceDataStub.namespace, workspaceDataStub.id, 'notebooks']);
+
     wrapper.find({'data-test-id': 'Data'}).first().simulate('click');
     expect(mockNavigate).toHaveBeenCalledWith(
       ['workspaces', workspaceDataStub.namespace, workspaceDataStub.id, 'data']);
+
+    wrapper.find({'data-test-id': 'About'}).first().simulate('click');
+    expect(mockNavigate).toHaveBeenCalledWith(
+      ['workspaces', workspaceDataStub.namespace, workspaceDataStub.id, 'about']);
+  });
+
+  it('should not navigate on tab click if tab is disabled because it needs review', () => {
+    // disables Data and Analysis tabs - see restrictTab()
+    workspaceDataStub.researchPurpose.needsReviewPrompt = true;
+    const wrapper = component();
+
+    wrapper.find({'data-test-id': 'Data'}).first().simulate('click');
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      ['workspaces', workspaceDataStub.namespace, workspaceDataStub.id, 'data']);
+
+    wrapper.find({'data-test-id': 'Analysis'}).first().simulate('click');
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      ['workspaces', workspaceDataStub.namespace, workspaceDataStub.id, 'notebooks']);
+  });
+
+  it('should not navigate on tab click if tab is disabled because it is admin-locked', () => {
+    workspaceDataStub.adminLocked = true;
+    const wrapper = component();
+
+    wrapper.find({'data-test-id': 'Data'}).first().simulate('click');
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      ['workspaces', workspaceDataStub.namespace, workspaceDataStub.id, 'data']);
+
+    wrapper.find({'data-test-id': 'Analysis'}).first().simulate('click');
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      ['workspaces', workspaceDataStub.namespace, workspaceDataStub.id, 'notebooks']);
   });
 
   it('should disable Data and Analysis tab if workspace require review research purpose', () => {
     workspaceDataStub.researchPurpose.needsReviewPrompt = true;
+
+    const wrapper = component();
+
+    expect(wrapper.find({'data-test-id': 'Data'}).first().props().disabled).toBeTruthy();
+    expect(wrapper.find({'data-test-id': 'Analysis'}).first().props().disabled).toBeTruthy();
+    expect(wrapper.find({'data-test-id': 'About'}).first().props().disabled).toBeFalsy();
+  });
+
+  it('should not disable Data and Analysis tab if workspace does not require review research purpose', () => {
+    workspaceDataStub.researchPurpose.needsReviewPrompt = false;
+
+    const wrapper = component();
+
+    expect(wrapper.find({'data-test-id': 'Data'}).first().props().disabled).toBeFalsy();
+    expect(wrapper.find({'data-test-id': 'Analysis'}).first().props().disabled).toBeFalsy();
+    expect(wrapper.find({'data-test-id': 'About'}).first().props().disabled).toBeFalsy();
+  });
+
+  it('should disable Data and Analysis tab if the workspace is admin-locked', () => {
+    workspaceDataStub.adminLocked = true;
 
     const wrapper = component();
 

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -60,9 +60,19 @@ describe('WorkspaceNavBar', () => {
       ['workspaces', workspaceDataStub.namespace, workspaceDataStub.id, 'about']);
   });
 
+  const setNeedsReviewPrompt = (needsReviewPrompt: boolean) => {
+    const researchPurpose = {...workspaceDataStub.researchPurpose, needsReviewPrompt};
+    currentWorkspaceStore.next({...workspaceDataStub, researchPurpose});
+  }
+
+  const setAdminLocked = (adminLocked: boolean) => {
+    currentWorkspaceStore.next({...workspaceDataStub, adminLocked});
+  }
+
   it('should not navigate on tab click if tab is disabled because it needs review', () => {
     // disables Data and Analysis tabs - see restrictTab()
-    workspaceDataStub.researchPurpose.needsReviewPrompt = true;
+    setNeedsReviewPrompt(true);
+
     const wrapper = component();
 
     wrapper.find({'data-test-id': 'Data'}).first().simulate('click');
@@ -75,7 +85,8 @@ describe('WorkspaceNavBar', () => {
   });
 
   it('should not navigate on tab click if tab is disabled because it is admin-locked', () => {
-    workspaceDataStub.adminLocked = true;
+    setAdminLocked(true);
+
     const wrapper = component();
 
     wrapper.find({'data-test-id': 'Data'}).first().simulate('click');
@@ -88,7 +99,7 @@ describe('WorkspaceNavBar', () => {
   });
 
   it('should disable Data and Analysis tab if workspace require review research purpose', () => {
-    workspaceDataStub.researchPurpose.needsReviewPrompt = true;
+    setNeedsReviewPrompt(true);
 
     const wrapper = component();
 
@@ -98,7 +109,7 @@ describe('WorkspaceNavBar', () => {
   });
 
   it('should not disable Data and Analysis tab if workspace does not require review research purpose', () => {
-    workspaceDataStub.researchPurpose.needsReviewPrompt = false;
+    setNeedsReviewPrompt(false);
 
     const wrapper = component();
 
@@ -108,7 +119,7 @@ describe('WorkspaceNavBar', () => {
   });
 
   it('should disable Data and Analysis tab if the workspace is admin-locked', () => {
-    workspaceDataStub.adminLocked = true;
+    setAdminLocked(true);
 
     const wrapper = component();
 

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -162,7 +162,6 @@ export const WorkspaceNavBar = fp.flow(
         aria-selected={selected}
         disabled={disabled}
         style={{...styles.tab, ...(selected ? styles.active : {}), ...(disabled ? styles.disabled : {})}}
-        hover={(!disabled && {color: styles.active.color})}
         onClick={() => navigate(['workspaces', ns, wsid, link])}
       >
         {name}

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -132,8 +132,15 @@ const tabs = [
 const navSeparator = <div style={styles.separator}/>;
 
 function restrictTab(workspace, tab) {
-  return serverConfigStore.get().config.enableResearchReviewPrompt && workspace && workspace.accessLevel === 'OWNER'
-      && workspace.researchPurpose.needsReviewPrompt && tab.name !== 'About';
+  // restrict tab if workspace owner and this workspace needs a review
+  const needsReview = serverConfigStore.get().config.enableResearchReviewPrompt
+    && (workspace?.accessLevel === 'OWNER')
+    && !!workspace?.researchPurpose.needsReviewPrompt;
+
+  // also restrict if the ws is admin-locked
+  const shouldRestrictToAboutTab = needsReview || !!workspace?.adminLocked;
+
+  return shouldRestrictToAboutTab && (tab.name !== 'About');
 }
 
 export const WorkspaceNavBar = fp.flow(
@@ -155,7 +162,7 @@ export const WorkspaceNavBar = fp.flow(
         aria-selected={selected}
         disabled={disabled}
         style={{...styles.tab, ...(selected ? styles.active : {}), ...(disabled ? styles.disabled : {})}}
-        hover={{color: styles.active.color}}
+        hover={(!disabled && {color: styles.active.color})}
         onClick={() => navigate(['workspaces', ns, wsid, link])}
       >
         {name}

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -135,10 +135,10 @@ function restrictTab(workspace, tab) {
   // restrict tab if workspace owner and this workspace needs a review
   const needsReview = serverConfigStore.get().config.enableResearchReviewPrompt
     && (workspace?.accessLevel === 'OWNER')
-    && !!workspace?.researchPurpose.needsReviewPrompt;
+    && workspace?.researchPurpose.needsReviewPrompt;
 
   // also restrict if the ws is admin-locked
-  const shouldRestrictToAboutTab = needsReview || !!workspace?.adminLocked;
+  const shouldRestrictToAboutTab = needsReview || workspace?.adminLocked;
 
   return shouldRestrictToAboutTab && (tab.name !== 'About');
 }

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -96,7 +96,7 @@ export const WorkspaceWrapper = fp.flow(
           {!routeData.minimizeChrome && <WorkspaceNavBar tabPath={routeData.workspaceNavBarTab}/>}
           <HelpSidebar pageKey={routeData.pageKey}/>
           <div style={{marginRight: '45px', height: !routeData.contentFullHeightOverride ? 'auto' : '100%'}}>
-            <WorkspaceRoutes/>
+            <WorkspaceRoutes adminLocked={workspace.adminLocked}/>
           </div>
         </React.Fragment>
         : <div style={{display: 'flex', height: '100%', width: '100%', justifyContent: 'center', alignItems: 'center'}}>

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -96,7 +96,7 @@ export const WorkspaceWrapper = fp.flow(
           {!routeData.minimizeChrome && <WorkspaceNavBar tabPath={routeData.workspaceNavBarTab}/>}
           <HelpSidebar pageKey={routeData.pageKey}/>
           <div style={{marginRight: '45px', height: !routeData.contentFullHeightOverride ? 'auto' : '100%'}}>
-            <WorkspaceRoutes adminLocked={workspace.adminLocked}/>
+            <WorkspaceRoutes/>
           </div>
         </React.Fragment>
         : <div style={{display: 'flex', height: '100%', width: '100%', justifyContent: 'center', alignItems: 'center'}}>

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -27,13 +27,11 @@ export const expiredGuard: Guard = {
   allowed: (): boolean => !profileStore.get().profile.accessModules.anyModuleHasExpired,
   redirectPath: '/access-renewal'
 };
+
 export const adminLockedGuard = (): Guard => {
   const {ns, wsid} = useParams<MatchParams>();
   return ({
     allowed: (): boolean => (!currentWorkspaceStore.getValue().adminLocked),
     redirectPath: `/workspaces/${ns}/${wsid}/about`
   });
-}
-  allowed: (): boolean => (!currentWorkspaceStore.getValue().adminLocked),
-  redirectPath: `/workspaces/${useParams()['ns']}/${useParams()['wsid']}/about`
-});
+};

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -27,8 +27,7 @@ export const expiredGuard: Guard = {
   allowed: (): boolean => !profileStore.get().profile.accessModules.anyModuleHasExpired,
   redirectPath: '/access-renewal'
 };
-export const workspaceLockGuard = (adminLock: boolean): Guard => ({
-  // allowed: (): boolean => (!adminLock),
+export const adminLockedGuard = (): Guard => ({
   allowed: (): boolean => (!currentWorkspaceStore.getValue().adminLocked),
   redirectPath: `/workspaces/${useParams()['ns']}/${useParams()['wsid']}/about`
 });

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -1,7 +1,9 @@
 import {Guard} from 'app/components/app-router';
 import {hasRegisteredTierAccess} from 'app/utils/access-tiers';
-import {authStore, profileStore} from 'app/utils/stores';
+import {authStore, MatchParams, profileStore} from 'app/utils/stores';
 import {eligibleForRegisteredTier} from 'app/utils/access-utils';
+import {useParams} from 'react-router-dom';
+import {currentWorkspaceStore} from 'app/utils/navigation';
 
 export const signInGuard: Guard = {
   allowed: (): boolean => {
@@ -25,3 +27,8 @@ export const expiredGuard: Guard = {
   allowed: (): boolean => !profileStore.get().profile.accessModules.anyModuleHasExpired,
   redirectPath: '/access-renewal'
 };
+export const workspaceLockGuard = (adminLock: boolean): Guard => ({
+  // allowed: (): boolean => (!adminLock),
+  allowed: (): boolean => (!currentWorkspaceStore.getValue().adminLocked),
+  redirectPath: `/workspaces/${useParams()['ns']}/${useParams()['wsid']}/about`
+});

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -27,7 +27,13 @@ export const expiredGuard: Guard = {
   allowed: (): boolean => !profileStore.get().profile.accessModules.anyModuleHasExpired,
   redirectPath: '/access-renewal'
 };
-export const adminLockedGuard = (): Guard => ({
+export const adminLockedGuard = (): Guard => {
+  const {ns, wsid} = useParams<MatchParams>();
+  return ({
+    allowed: (): boolean => (!currentWorkspaceStore.getValue().adminLocked),
+    redirectPath: `/workspaces/${ns}/${wsid}/about`
+  });
+}
   allowed: (): boolean => (!currentWorkspaceStore.getValue().adminLocked),
   redirectPath: `/workspaces/${useParams()['ns']}/${useParams()['wsid']}/about`
 });

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -21,7 +21,7 @@ import {LeoApplicationType} from 'app/pages/analysis/leonardo-app-launcher';
 import {BreadcrumbType} from 'app/utils/navigation';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
-import {Redirect, Switch, useRouteMatch} from 'react-router-dom';
+import {Redirect, Switch, useParams, useRouteMatch} from 'react-router-dom';
 
 const CohortPagePage = fp.flow(withRouteData, withRoutingSpinner)(CohortPage);
 const CohortActionsPage = fp.flow(withRouteData, withRoutingSpinner)(CohortActions);
@@ -40,10 +40,24 @@ const QueryReportPage = fp.flow(withRouteData, withRoutingSpinner)(QueryReport);
 const WorkspaceAboutPage = fp.flow(withRouteData, withRoutingSpinner)(WorkspaceAbout);
 const WorkspaceEditPage = fp.flow(withRouteData, withRoutingSpinner)(WorkspaceEdit);
 
-export const WorkspaceRoutes = () => {
+export const WorkspaceRoutes = (props: {adminLocked: boolean}) => {
+  const {adminLocked} = props;
   const { path } = useRouteMatch();
 
+  const AppRouteWithAdminLocking = (props) => {
+
+    // TODO there is probably a more idiomatic way to do this
+
+    const params = useParams();
+    const redirectToAboutPath = `/workspaces/${params['ns']}/${params['wsid']}/about`;
+    
+    return adminLocked
+      ? <Redirect to={redirectToAboutPath}/>
+      : <AppRoute {...props}/>;
+  }
+
   return <Switch>
+    {/* admin-locked workspaces are redirected to /about in most cases */}
     <AppRoute exact path={`${path}/about`}>
       <WorkspaceAboutPage
           routeData={{
@@ -54,7 +68,7 @@ export const WorkspaceRoutes = () => {
           }}
       />
     </AppRoute>
-    <AppRoute exact path={`${path}/duplicate`}>
+    <AppRouteWithAdminLocking exact path={`${path}/duplicate`}>
       <WorkspaceEditPage
           routeData={{
             title: 'Duplicate Workspace',
@@ -63,7 +77,8 @@ export const WorkspaceRoutes = () => {
           }}
           workspaceEditMode={WorkspaceEditMode.Duplicate}
       />
-    </AppRoute>
+    </AppRouteWithAdminLocking>
+    {/* admin-locked workspaces can still be edited */}
     <AppRoute exact path={`${path}/edit`}>
       <WorkspaceEditPage
           routeData={{
@@ -74,15 +89,15 @@ export const WorkspaceRoutes = () => {
           workspaceEditMode={WorkspaceEditMode.Edit}
       />
     </AppRoute>
-    <AppRoute exact path={`${path}/notebooks`}>
+    <AppRouteWithAdminLocking exact path={`${path}/notebooks`}>
       <NotebookListPage routeData={{
         title: 'View Notebooks',
         pageKey: 'notebooks',
         workspaceNavBarTab: 'notebooks',
         breadcrumb: BreadcrumbType.Workspace
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/notebooks/preview/:nbName`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/notebooks/preview/:nbName`}>
       <InteractiveNotebookPage routeData={{
         pathElementForTitle: 'nbName',
         breadcrumb: BreadcrumbType.Notebook,
@@ -90,8 +105,8 @@ export const WorkspaceRoutes = () => {
         workspaceNavBarTab: 'notebooks',
         minimizeChrome: true
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/notebooks/:nbName`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/notebooks/:nbName`}>
       <LeonardoAppRedirectPage
           routeData={{
             pathElementForTitle: 'nbName',
@@ -106,8 +121,8 @@ export const WorkspaceRoutes = () => {
           }}
           leoAppType={LeoApplicationType.Notebook}
       />
-    </AppRoute>
-    <AppRoute exact path={`${path}/terminals`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/terminals`}>
       <LeonardoAppRedirectPage
           routeData={{
             breadcrumb: BreadcrumbType.Workspace,
@@ -121,111 +136,111 @@ export const WorkspaceRoutes = () => {
           }}
           leoAppType={LeoApplicationType.Terminal}
       />
-    </AppRoute>
-    <AppRoute exact path={`${path}/data`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/data`}>
       <DataComponentPage routeData={{
         title: 'Data Page',
         breadcrumb: BreadcrumbType.Workspace,
         workspaceNavBarTab: 'data',
         pageKey: 'data'
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/data/data-sets`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/data/data-sets`}>
       <DataSetComponentPage routeData={{
         title: 'Dataset Page',
         breadcrumb: BreadcrumbType.Dataset,
         workspaceNavBarTab: 'data',
         pageKey: 'datasetBuilder'
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/data/data-sets/:dataSetId`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/data/data-sets/:dataSetId`}>
       <DataSetComponentPage routeData={{
         title: 'Edit Dataset',
         breadcrumb: BreadcrumbType.Dataset,
         workspaceNavBarTab: 'data',
         pageKey: 'datasetBuilder'
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/data/cohorts/build`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/data/cohorts/build`}>
       <CohortPagePage routeData={{
         title: 'Build Cohort Criteria',
         breadcrumb: BreadcrumbType.CohortAdd,
         workspaceNavBarTab: 'data',
         pageKey: 'cohortBuilder'
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/data/cohorts/:cid/actions`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/data/cohorts/:cid/actions`}>
       <CohortActionsPage routeData={{
         title: 'Cohort Actions',
         breadcrumb: BreadcrumbType.Cohort,
         workspaceNavBarTab: 'data',
         pageKey: 'cohortBuilder'
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/data/cohorts/:cid/review/participants`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/data/cohorts/:cid/review/participants`}>
       <ParticipantsTablePage routeData={{
         title: 'Review Cohort Participants',
         breadcrumb: BreadcrumbType.Cohort,
         workspaceNavBarTab: 'data',
         pageKey: 'reviewParticipants'
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/data/cohorts/:cid/review/participants/:pid`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/data/cohorts/:cid/review/participants/:pid`}>
       <DetailPagePage routeData={{
         title: 'Participant Detail',
         breadcrumb: BreadcrumbType.Participant,
         workspaceNavBarTab: 'data',
         pageKey: 'reviewParticipantDetail'
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/data/cohorts/:cid/review/cohort-description`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/data/cohorts/:cid/review/cohort-description`}>
       <QueryReportPage routeData={{
         title: 'Review Cohort Description',
         breadcrumb: BreadcrumbType.Cohort,
         workspaceNavBarTab: 'data',
         pageKey: 'cohortDescription'
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/data/cohorts/:cid/review`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/data/cohorts/:cid/review`}>
       <CohortReviewPage routeData={{
         title: 'Review Cohort Participants',
         breadcrumb: BreadcrumbType.Cohort,
         workspaceNavBarTab: 'data',
         pageKey: 'reviewParticipants'
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/data/concepts`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/data/concepts`}>
       <ConceptHomepagePage routeData={{
         title: 'Search Concepts',
         breadcrumb: BreadcrumbType.SearchConcepts,
         workspaceNavBarTab: 'data',
         pageKey: 'searchConceptSets'
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/data/concepts/sets/:csid`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/data/concepts/sets/:csid`}>
       <ConceptSearchPage routeData={{
         title: 'Concept Set',
         breadcrumb: BreadcrumbType.ConceptSet,
         workspaceNavBarTab: 'data',
         pageKey: 'conceptSets'
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/data/concepts/:domain`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/data/concepts/:domain`}>
       <ConceptSearchPage routeData={{
         title: 'Search Concepts',
         breadcrumb: BreadcrumbType.SearchConcepts,
         workspaceNavBarTab: 'data',
         pageKey: 'conceptSets'
       }}/>
-    </AppRoute>
-    <AppRoute exact path={`${path}/data/concepts/sets/:csid/actions`}>
+    </AppRouteWithAdminLocking>
+    <AppRouteWithAdminLocking exact path={`${path}/data/concepts/sets/:csid/actions`}>
       <ConceptSetActionsPage routeData={{
         title: 'Concept Set Actions',
         breadcrumb: BreadcrumbType.ConceptSet,
         workspaceNavBarTab: 'data',
         pageKey: 'conceptSetActions'
       }}/>
-    </AppRoute>
+    </AppRouteWithAdminLocking>
     <AppRoute exact={false} path={`${path}`}>
       <Redirect to={'/not-found'}/>
     </AppRoute>

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -24,7 +24,7 @@ import {WorkspaceEdit, WorkspaceEditMode} from 'app/pages/workspace/workspace-ed
 import {LeoApplicationType} from 'app/pages/analysis/leonardo-app-launcher';
 import {BreadcrumbType} from 'app/utils/navigation';
 import {MatchParams} from 'app/utils/stores';
-import {workspaceLockGuard} from 'app/routing/guards';
+import {adminLockedGuard} from 'app/routing/guards';
 
 const CohortPagePage = fp.flow(withRouteData, withRoutingSpinner)(CohortPage);
 const CohortActionsPage = fp.flow(withRouteData, withRoutingSpinner)(CohortActions);
@@ -43,20 +43,8 @@ const QueryReportPage = fp.flow(withRouteData, withRoutingSpinner)(QueryReport);
 const WorkspaceAboutPage = fp.flow(withRouteData, withRoutingSpinner)(WorkspaceAbout);
 const WorkspaceEditPage = fp.flow(withRouteData, withRoutingSpinner)(WorkspaceEdit);
 
-export const WorkspaceRoutes = (props: {adminLocked: boolean}) => {
-  const {adminLocked} = props;
+export const WorkspaceRoutes = () => {
   const { path } = useRouteMatch();
-
-  const AppRouteWithAdminLocking = (props) => {
-
-    // TODO there is probably a more idiomatic way to do this
-    const {ns, wsid} = useParams<MatchParams>();
-    const redirectToAboutPath = `/workspaces/${ns}/${wsid}/about`;
-
-    return adminLocked
-      ? <Redirect to={redirectToAboutPath}/>
-      : <AppRoute {...props}/>;
-  }
 
   return <Switch>
     {/* admin-locked workspaces are redirected to /about in most cases */}
@@ -70,7 +58,7 @@ export const WorkspaceRoutes = (props: {adminLocked: boolean}) => {
           }}
       />
     </AppRoute>
-    <AppRouteWithAdminLocking exact path={`${path}/duplicate`}>
+    <AppRoute exact path={`${path}/duplicate`} guards={[adminLockedGuard()]}>
       <WorkspaceEditPage
           routeData={{
             title: 'Duplicate Workspace',
@@ -79,7 +67,7 @@ export const WorkspaceRoutes = (props: {adminLocked: boolean}) => {
           }}
           workspaceEditMode={WorkspaceEditMode.Duplicate}
       />
-    </AppRouteWithAdminLocking>
+    </AppRoute>
     {/* admin-locked workspaces can still be edited */}
     <AppRoute exact path={`${path}/edit`}>
       <WorkspaceEditPage
@@ -91,7 +79,7 @@ export const WorkspaceRoutes = (props: {adminLocked: boolean}) => {
           workspaceEditMode={WorkspaceEditMode.Edit}
       />
     </AppRoute>
-    <AppRoute exact path={`${path}/notebooks`} guards={[workspaceLockGuard(adminLocked)]}>
+    <AppRoute exact path={`${path}/notebooks`} guards={[adminLockedGuard()]}>
       <NotebookListPage routeData={{
         title: 'View Notebooks',
         pageKey: 'notebooks',
@@ -99,7 +87,7 @@ export const WorkspaceRoutes = (props: {adminLocked: boolean}) => {
         breadcrumb: BreadcrumbType.Workspace
       }}/>
     </AppRoute>
-    <AppRouteWithAdminLocking exact path={`${path}/notebooks/preview/:nbName`}>
+    <AppRoute exact path={`${path}/notebooks/preview/:nbName`} guards={[adminLockedGuard()]}>
       <InteractiveNotebookPage routeData={{
         pathElementForTitle: 'nbName',
         breadcrumb: BreadcrumbType.Notebook,
@@ -107,8 +95,8 @@ export const WorkspaceRoutes = (props: {adminLocked: boolean}) => {
         workspaceNavBarTab: 'notebooks',
         minimizeChrome: true
       }}/>
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/notebooks/:nbName`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/notebooks/:nbName`} guards={[adminLockedGuard()]}>
       <LeonardoAppRedirectPage
           routeData={{
             pathElementForTitle: 'nbName',
@@ -123,8 +111,8 @@ export const WorkspaceRoutes = (props: {adminLocked: boolean}) => {
           }}
           leoAppType={LeoApplicationType.Notebook}
       />
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/terminals`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/terminals`} guards={[adminLockedGuard()]}>
       <LeonardoAppRedirectPage
           routeData={{
             breadcrumb: BreadcrumbType.Workspace,
@@ -138,111 +126,111 @@ export const WorkspaceRoutes = (props: {adminLocked: boolean}) => {
           }}
           leoAppType={LeoApplicationType.Terminal}
       />
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/data`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/data`} guards={[adminLockedGuard()]}>
       <DataComponentPage routeData={{
         title: 'Data Page',
         breadcrumb: BreadcrumbType.Workspace,
         workspaceNavBarTab: 'data',
         pageKey: 'data'
       }}/>
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/data/data-sets`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/data/data-sets`} guards={[adminLockedGuard()]}>
       <DataSetComponentPage routeData={{
         title: 'Dataset Page',
         breadcrumb: BreadcrumbType.Dataset,
         workspaceNavBarTab: 'data',
         pageKey: 'datasetBuilder'
       }}/>
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/data/data-sets/:dataSetId`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/data/data-sets/:dataSetId`} guards={[adminLockedGuard()]}>
       <DataSetComponentPage routeData={{
         title: 'Edit Dataset',
         breadcrumb: BreadcrumbType.Dataset,
         workspaceNavBarTab: 'data',
         pageKey: 'datasetBuilder'
       }}/>
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/data/cohorts/build`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/data/cohorts/build`} guards={[adminLockedGuard()]}>
       <CohortPagePage routeData={{
         title: 'Build Cohort Criteria',
         breadcrumb: BreadcrumbType.CohortAdd,
         workspaceNavBarTab: 'data',
         pageKey: 'cohortBuilder'
       }}/>
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/data/cohorts/:cid/actions`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/data/cohorts/:cid/actions`} guards={[adminLockedGuard()]}>
       <CohortActionsPage routeData={{
         title: 'Cohort Actions',
         breadcrumb: BreadcrumbType.Cohort,
         workspaceNavBarTab: 'data',
         pageKey: 'cohortBuilder'
       }}/>
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/data/cohorts/:cid/review/participants`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/data/cohorts/:cid/review/participants`} guards={[adminLockedGuard()]}>
       <ParticipantsTablePage routeData={{
         title: 'Review Cohort Participants',
         breadcrumb: BreadcrumbType.Cohort,
         workspaceNavBarTab: 'data',
         pageKey: 'reviewParticipants'
       }}/>
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/data/cohorts/:cid/review/participants/:pid`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/data/cohorts/:cid/review/participants/:pid`} guards={[adminLockedGuard()]}>
       <DetailPagePage routeData={{
         title: 'Participant Detail',
         breadcrumb: BreadcrumbType.Participant,
         workspaceNavBarTab: 'data',
         pageKey: 'reviewParticipantDetail'
       }}/>
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/data/cohorts/:cid/review/cohort-description`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/data/cohorts/:cid/review/cohort-description`} guards={[adminLockedGuard()]}>
       <QueryReportPage routeData={{
         title: 'Review Cohort Description',
         breadcrumb: BreadcrumbType.Cohort,
         workspaceNavBarTab: 'data',
         pageKey: 'cohortDescription'
       }}/>
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/data/cohorts/:cid/review`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/data/cohorts/:cid/review`} guards={[adminLockedGuard()]}>
       <CohortReviewPage routeData={{
         title: 'Review Cohort Participants',
         breadcrumb: BreadcrumbType.Cohort,
         workspaceNavBarTab: 'data',
         pageKey: 'reviewParticipants'
       }}/>
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/data/concepts`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/data/concepts`} guards={[adminLockedGuard()]}>
       <ConceptHomepagePage routeData={{
         title: 'Search Concepts',
         breadcrumb: BreadcrumbType.SearchConcepts,
         workspaceNavBarTab: 'data',
         pageKey: 'searchConceptSets'
       }}/>
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/data/concepts/sets/:csid`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/data/concepts/sets/:csid`} guards={[adminLockedGuard()]}>
       <ConceptSearchPage routeData={{
         title: 'Concept Set',
         breadcrumb: BreadcrumbType.ConceptSet,
         workspaceNavBarTab: 'data',
         pageKey: 'conceptSets'
       }}/>
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/data/concepts/:domain`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/data/concepts/:domain`} guards={[adminLockedGuard()]}>
       <ConceptSearchPage routeData={{
         title: 'Search Concepts',
         breadcrumb: BreadcrumbType.SearchConcepts,
         workspaceNavBarTab: 'data',
         pageKey: 'conceptSets'
       }}/>
-    </AppRouteWithAdminLocking>
-    <AppRouteWithAdminLocking exact path={`${path}/data/concepts/sets/:csid/actions`}>
+    </AppRoute>
+    <AppRoute exact path={`${path}/data/concepts/sets/:csid/actions`} guards={[adminLockedGuard()]}>
       <ConceptSetActionsPage routeData={{
         title: 'Concept Set Actions',
         breadcrumb: BreadcrumbType.ConceptSet,
         workspaceNavBarTab: 'data',
         pageKey: 'conceptSetActions'
       }}/>
-    </AppRouteWithAdminLocking>
+    </AppRoute>
     <AppRoute exact={false} path={`${path}`}>
       <Redirect to={'/not-found'}/>
     </AppRoute>

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -24,6 +24,7 @@ import {WorkspaceEdit, WorkspaceEditMode} from 'app/pages/workspace/workspace-ed
 import {LeoApplicationType} from 'app/pages/analysis/leonardo-app-launcher';
 import {BreadcrumbType} from 'app/utils/navigation';
 import {MatchParams} from 'app/utils/stores';
+import {workspaceLockGuard} from 'app/routing/guards';
 
 const CohortPagePage = fp.flow(withRouteData, withRoutingSpinner)(CohortPage);
 const CohortActionsPage = fp.flow(withRouteData, withRoutingSpinner)(CohortActions);
@@ -90,14 +91,14 @@ export const WorkspaceRoutes = (props: {adminLocked: boolean}) => {
           workspaceEditMode={WorkspaceEditMode.Edit}
       />
     </AppRoute>
-    <AppRouteWithAdminLocking exact path={`${path}/notebooks`}>
+    <AppRoute exact path={`${path}/notebooks`} guards={[workspaceLockGuard(adminLocked)]}>
       <NotebookListPage routeData={{
         title: 'View Notebooks',
         pageKey: 'notebooks',
         workspaceNavBarTab: 'notebooks',
         breadcrumb: BreadcrumbType.Workspace
       }}/>
-    </AppRouteWithAdminLocking>
+    </AppRoute>
     <AppRouteWithAdminLocking exact path={`${path}/notebooks/preview/:nbName`}>
       <InteractiveNotebookPage routeData={{
         pathElementForTitle: 'nbName',

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -1,3 +1,7 @@
+import * as fp from 'lodash/fp';
+import * as React from 'react';
+import {Redirect, Switch, useParams, useRouteMatch} from 'react-router-dom';
+
 import {CohortPage} from 'app/cohort-search/cohort-page/cohort-page.component';
 import {AppRoute, withRouteData} from 'app/components/app-router';
 import {LEONARDO_APP_PAGE_KEY} from 'app/components/help-sidebar';
@@ -19,9 +23,7 @@ import {WorkspaceAbout} from 'app/pages/workspace/workspace-about';
 import {WorkspaceEdit, WorkspaceEditMode} from 'app/pages/workspace/workspace-edit';
 import {LeoApplicationType} from 'app/pages/analysis/leonardo-app-launcher';
 import {BreadcrumbType} from 'app/utils/navigation';
-import * as fp from 'lodash/fp';
-import * as React from 'react';
-import {Redirect, Switch, useParams, useRouteMatch} from 'react-router-dom';
+import {MatchParams} from 'app/utils/stores';
 
 const CohortPagePage = fp.flow(withRouteData, withRoutingSpinner)(CohortPage);
 const CohortActionsPage = fp.flow(withRouteData, withRoutingSpinner)(CohortActions);
@@ -47,10 +49,9 @@ export const WorkspaceRoutes = (props: {adminLocked: boolean}) => {
   const AppRouteWithAdminLocking = (props) => {
 
     // TODO there is probably a more idiomatic way to do this
+    const {ns, wsid} = useParams<MatchParams>();
+    const redirectToAboutPath = `/workspaces/${ns}/${wsid}/about`;
 
-    const params = useParams();
-    const redirectToAboutPath = `/workspaces/${params['ns']}/${params['wsid']}/about`;
-    
     return adminLocked
       ? <Redirect to={redirectToAboutPath}/>
       : <AppRoute {...props}/>;


### PR DESCRIPTION
A few pieces of RW-7575: disable adminLocked workspaces' Data and Analysis tabs, and redirect most WorkspaceRoutes to About if adminLocked

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
