### PR TITLE
[RW-7518][risk=no] Add config-driven CT training path

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -85,7 +85,8 @@
   },
   "moodle": {
     "host": "aoudev.nnlm.gov",
-    "credentialsKeyV2": "moodle-key-v2.txt"
+    "credentialsKeyV2": "moodle-key-v2.txt",
+    "controlledTrainingPath": "/course/view.php?id=84&saml=on"
   },
   "access": {
     "enableComplianceTraining": true,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -85,7 +85,8 @@
   },
   "moodle": {
     "host": "aoudev.nnlm.gov",
-    "credentialsKeyV2": "moodle-key-v2.txt"
+    "credentialsKeyV2": "moodle-key-v2.txt",
+    "controlledTrainingPath": "/course/view.php?id=84&saml=on"
   },
   "access": {
     "enableComplianceTraining": true,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -85,7 +85,8 @@
   },
   "moodle": {
     "host": "aou.nnlm.gov",
-    "credentialsKeyV2": "moodle-key-v2.txt"
+    "credentialsKeyV2": "moodle-key-v2.txt",
+    "controlledTrainingPath": ""
   },
   "access": {
     "enableComplianceTraining": false,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -84,7 +84,8 @@
   },
   "moodle": {
     "host": "aou.nnlm.gov",
-    "credentialsKeyV2": "moodle-key-v2.txt"
+    "credentialsKeyV2": "moodle-key-v2.txt",
+    "controlledTrainingPath": ""
   },
   "access": {
     "enableComplianceTraining": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -84,7 +84,8 @@
   },
   "moodle": {
     "host": "aou.nnlm.gov",
-    "credentialsKeyV2": "moodle-prod-key-v2.txt"
+    "credentialsKeyV2": "moodle-prod-key-v2.txt",
+    "controlledTrainingPath": ""
   },
   "access": {
     "enableComplianceTraining": true,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -85,7 +85,8 @@
   },
   "moodle": {
     "host": "aoudev.nnlm.gov",
-    "credentialsKeyV2": "moodle-key-v2.txt"
+    "credentialsKeyV2": "moodle-key-v2.txt",
+    "controlledTrainingPath": "/course/view.php?id=84&saml=on"
   },
   "access": {
     "enableComplianceTraining": false,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -85,7 +85,8 @@
   },
   "moodle": {
     "host": "aoudev.nnlm.gov",
-    "credentialsKeyV2": "moodle-key-v2.txt"
+    "credentialsKeyV2": "moodle-key-v2.txt",
+    "controlledTrainingPath": "/course/view.php?id=84&saml=on"
   },
   "access": {
     "enableComplianceTraining": true,

--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -36,6 +36,7 @@ public class ConfigController implements ConfigApiDelegate {
             .defaultFreeCreditsDollarLimit(config.billing.defaultFreeCreditsDollarLimit)
             .enableComplianceTraining(config.access.enableComplianceTraining)
             .complianceTrainingHost(config.moodle.host)
+            .complianceTrainingControlledPath(config.moodle.controlledTrainingPath)
             .enableEraCommons(config.access.enableEraCommons)
             .unsafeAllowSelfBypass(config.access.unsafeAllowSelfBypass)
             .enableBillingUpgrade(config.featureFlags.enableBillingUpgrade)

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -208,6 +208,7 @@ public class WorkbenchConfig {
   public static class MoodleConfig {
     public String host;
     public String credentialsKeyV2;
+    public String controlledTrainingPath;
   }
 
   public static class ZendeskConfig {

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4245,6 +4245,12 @@ definitions:
       complianceTrainingHost:
         type: string
         description: The hostname for constructing the compliance training URL.
+      # TODO(RW-7577): remove and use a static path
+      complianceTrainingControlledPath:
+        type: string
+        description: |
+          The URL path to the controlled tier training, to be used in combination with
+          the complianceTrainingHost.
       enableEraCommons:
         type: boolean
         default: false


### PR DESCRIPTION
Rationale:

- The value needs to diverge across the different training environments
- I don't trust this URL, it may need to change on very short notice. Driving it from the config gives us the flexibility to roll out an out of band fix.
- Eventually this will be removed, hopefully once we have a static path - see https://precisionmedicineinitiative.atlassian.net/browse/RW-7577