### PR TITLE
[RW-7518][risk=low] Integrate CT training module within registration

### DIFF
--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -21,7 +21,7 @@ import {
   getAccessModuleConfig,
   isExpiring,
   maybeDaysRemaining,
-  redirectToTraining,
+  redirectToRegisteredTraining,
 } from 'app/utils/access-utils';
 import {useNavigation} from 'app/utils/navigation';
 import {profileStore, serverConfigStore, useStore} from 'app/utils/stores';
@@ -320,7 +320,7 @@ export const AccessRenewal = fp.flow(
               moduleStatus={modules.find(m => m.moduleName === AccessModule.COMPLIANCETRAINING)}
               onClick={() => {
                 setRefreshButtonDisabled(false);
-                redirectToTraining();
+                redirectToRegisteredTraining();
               }}/>
           {isExpiringAndNotBypassed(AccessModule.COMPLIANCETRAINING, modules) && <Button
             disabled={refreshButtonDisabled}

--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -7,7 +7,7 @@ import {
     allModules,
     DataAccessRequirements,
     getActiveModule,
-    getVisibleModules,
+    getEligibleModules,
     requiredModules
 } from './data-access-requirements';
 import {InstitutionApiStub} from 'testing/stubs/institution-api-stub';
@@ -70,37 +70,37 @@ describe('DataAccessRequirements', () => {
 
 
     it('should return all modules from getVisibleModules by default (all FFs enabled)', () => {
-        const enabledModules = getVisibleModules(allModules, profile);
+        const enabledModules = getEligibleModules(allModules, profile);
         allModules.forEach(module => expect(enabledModules.includes(module)).toBeTruthy());
     });
 
     it('should not return the RAS module from getVisibleModules when its feature flag is disabled', () => {
         serverConfigStore.set({config: {...defaultServerConfig, enableRasLoginGovLinking: false, enforceRasLoginGovLinking: false}});
-        const enabledModules = getVisibleModules(allModules, profile);
+        const enabledModules = getEligibleModules(allModules, profile);
         expect(enabledModules.includes(AccessModule.RASLINKLOGINGOV)).toBeFalsy();
     });
 
     it('should return the RAS module from getVisibleModules when ' +
         'enforceRasLoginGovLinking is enabled, enableRasLoginGovLinking is not', () => {
         serverConfigStore.set({config: {...defaultServerConfig, enableRasLoginGovLinking: false, enforceRasLoginGovLinking: true}});
-        const enabledModules = getVisibleModules(allModules, profile);
+        const enabledModules = getEligibleModules(allModules, profile);
         expect(enabledModules.includes(AccessModule.RASLINKLOGINGOV)).toBeTruthy();
     });
 
     it('should not return the ERA module from getVisibleModules when its feature flag is disabled', () => {
         serverConfigStore.set({config: {...defaultServerConfig, enableEraCommons: false}});
-        const enabledModules = getVisibleModules(allModules, profile);
+        const enabledModules = getEligibleModules(allModules, profile);
         expect(enabledModules.includes(AccessModule.ERACOMMONS)).toBeFalsy();
     });
 
     it('should not return the Compliance module from getVisibleModules when its feature flag is disabled', () => {
         serverConfigStore.set({config: {...defaultServerConfig, enableComplianceTraining: false}});
-        const enabledModules = getVisibleModules(allModules, profile);
+        const enabledModules = getEligibleModules(allModules, profile);
         expect(enabledModules.includes(AccessModule.COMPLIANCETRAINING)).toBeFalsy();
     });
 
     it('should return the first module (2FA) from getActiveModule when no modules have been completed', () => {
-        const enabledModules = getVisibleModules(requiredModules, profile);
+        const enabledModules = getEligibleModules(requiredModules, profile);
         const activeModule = getActiveModule(enabledModules, profile);
 
         expect(activeModule).toEqual(requiredModules[0]);
@@ -118,7 +118,7 @@ describe('DataAccessRequirements', () => {
             }
         };
 
-        const enabledModules = getVisibleModules(requiredModules, profile);
+        const enabledModules = getEligibleModules(requiredModules, profile);
         const activeModule = getActiveModule(enabledModules, testProfile);
 
         expect(activeModule).toEqual(requiredModules[1]);
@@ -136,7 +136,7 @@ describe('DataAccessRequirements', () => {
             }
         };
 
-        const enabledModules = getVisibleModules(requiredModules, profile);
+        const enabledModules = getEligibleModules(requiredModules, profile);
         const activeModule = getActiveModule(enabledModules, testProfile);
 
         expect(activeModule).toEqual(requiredModules[1]);
@@ -157,7 +157,7 @@ describe('DataAccessRequirements', () => {
             }
         };
 
-        const enabledModules = getVisibleModules(requiredModules, profile);
+        const enabledModules = getEligibleModules(requiredModules, profile);
         const activeModule = getActiveModule(enabledModules, testProfile);
 
         // update this if the order changes
@@ -182,7 +182,7 @@ describe('DataAccessRequirements', () => {
             }
         };
 
-        const enabledModules = getVisibleModules(requiredModules, profile);
+        const enabledModules = getEligibleModules(requiredModules, profile);
         const activeModule = getActiveModule(enabledModules, testProfile);
 
         expect(activeModule).toEqual(requiredModules[3]);
@@ -200,7 +200,7 @@ describe('DataAccessRequirements', () => {
             }
         };
 
-        const enabledModules = getVisibleModules(requiredModules, profile);
+        const enabledModules = getEligibleModules(requiredModules, profile);
         const activeModule = getActiveModule(enabledModules, testProfile);
 
         expect(activeModule).toBeUndefined();
@@ -220,7 +220,7 @@ describe('DataAccessRequirements', () => {
             }
         };
 
-        const enabledModules = getVisibleModules(requiredModules, profile);
+        const enabledModules = getEligibleModules(requiredModules, profile);
 
         let activeModule = getActiveModule(enabledModules, testProfile);
         expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV)

--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -6,7 +6,7 @@ import {AccessModule, InstitutionApi, Profile, ProfileApi} from 'generated/fetch
 import {
     allModules,
     DataAccessRequirements,
-    getNextModule,
+    getNextActiveModule,
     getEligibleModules,
     requiredModules
 } from './data-access-requirements';
@@ -100,9 +100,9 @@ describe('DataAccessRequirements', () => {
         expect(enabledModules.includes(AccessModule.COMPLIANCETRAINING)).toBeFalsy();
     });
 
-    it('should return the first module (2FA) from getNextModule when no modules have been completed', () => {
+    it('should return the first module (2FA) from getNextActiveModule when no modules have been completed', () => {
         const enabledModules = getEligibleModules(requiredModules, profile);
-        const activeModule = getNextModule(enabledModules, profile);
+        const activeModule = getNextActiveModule(enabledModules, profile);
 
         expect(activeModule).toEqual(requiredModules[0]);
         expect(activeModule).toEqual(enabledModules[0]);
@@ -111,7 +111,7 @@ describe('DataAccessRequirements', () => {
         expect(activeModule).toEqual(AccessModule.TWOFACTORAUTH)
     });
 
-    it('should return the second module (RAS) from getNextModule when the first module (2FA) has been completed', () => {
+    it('should return the second module (RAS) from getNextActiveModule when the first module (2FA) has been completed', () => {
         const testProfile = {
             ...profile,
             accessModules: {
@@ -120,7 +120,7 @@ describe('DataAccessRequirements', () => {
         };
 
         const enabledModules = getEligibleModules(requiredModules, profile);
-        const activeModule = getNextModule(enabledModules, testProfile);
+        const activeModule = getNextActiveModule(enabledModules, testProfile);
 
         expect(activeModule).toEqual(requiredModules[1]);
         expect(activeModule).toEqual(enabledModules[1]);
@@ -129,7 +129,7 @@ describe('DataAccessRequirements', () => {
         expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV)
     });
 
-    it('should return the second module (RAS) from getNextModule when the first module (2FA) has been bypassed', () => {
+    it('should return the second module (RAS) from getNextActiveModule when the first module (2FA) has been bypassed', () => {
         const testProfile = {
             ...profile,
             accessModules: {
@@ -138,7 +138,7 @@ describe('DataAccessRequirements', () => {
         };
 
         const enabledModules = getEligibleModules(requiredModules, profile);
-        const activeModule = getNextModule(enabledModules, testProfile);
+        const activeModule = getNextActiveModule(enabledModules, testProfile);
 
         expect(activeModule).toEqual(requiredModules[1]);
         expect(activeModule).toEqual(enabledModules[1]);
@@ -147,7 +147,7 @@ describe('DataAccessRequirements', () => {
         expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV)
     });
 
-    it('should return the second enabled module (ERA, not RAS) from getNextModule' +
+    it('should return the second enabled module (ERA, not RAS) from getNextActiveModule' +
       ' when the first module (2FA) has been completed and RAS is disabled', () => {
         serverConfigStore.set({config: {...defaultServerConfig, enableRasLoginGovLinking: false, enforceRasLoginGovLinking: false}});
 
@@ -159,7 +159,7 @@ describe('DataAccessRequirements', () => {
         };
 
         const enabledModules = getEligibleModules(requiredModules, profile);
-        const activeModule = getNextModule(enabledModules, testProfile);
+        const activeModule = getNextActiveModule(enabledModules, testProfile);
 
         // update this if the order changes
         expect(activeModule).toEqual(AccessModule.ERACOMMONS)
@@ -171,7 +171,7 @@ describe('DataAccessRequirements', () => {
         expect(activeModule).toEqual(requiredModules[2]);
     });
 
-    it('should return the fourth module (Compliance) from getNextModule when the first 3 modules have been completed', () => {
+    it('should return the fourth module (Compliance) from getNextActiveModule when the first 3 modules have been completed', () => {
         const testProfile = {
             ...profile,
             accessModules: {
@@ -184,7 +184,7 @@ describe('DataAccessRequirements', () => {
         };
 
         const enabledModules = getEligibleModules(requiredModules, profile);
-        const activeModule = getNextModule(enabledModules, testProfile);
+        const activeModule = getNextActiveModule(enabledModules, testProfile);
 
         expect(activeModule).toEqual(requiredModules[3]);
         expect(activeModule).toEqual(enabledModules[3]);
@@ -193,7 +193,7 @@ describe('DataAccessRequirements', () => {
         expect(activeModule).toEqual(AccessModule.COMPLIANCETRAINING)
     });
 
-    it('should return undefined from getNextModule when all modules have been completed', () => {
+    it('should return undefined from getNextActiveModule when all modules have been completed', () => {
         const testProfile = {
             ...profile,
             accessModules: {
@@ -202,7 +202,7 @@ describe('DataAccessRequirements', () => {
         };
 
         const enabledModules = getEligibleModules(requiredModules, profile);
-        const activeModule = getNextModule(enabledModules, testProfile);
+        const activeModule = getNextActiveModule(enabledModules, testProfile);
 
         expect(activeModule).toBeUndefined();
     });
@@ -223,7 +223,7 @@ describe('DataAccessRequirements', () => {
 
         const enabledModules = getEligibleModules(requiredModules, profile);
 
-        let activeModule = getNextModule(enabledModules, testProfile);
+        let activeModule = getNextActiveModule(enabledModules, testProfile);
         expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV)
 
         // simulate handleRasCallback() by updating the profile
@@ -238,7 +238,7 @@ describe('DataAccessRequirements', () => {
             }
         };
 
-        activeModule = getNextModule(enabledModules, updatedProfile);
+        activeModule = getNextActiveModule(enabledModules, updatedProfile);
         expect(activeModule).toBeUndefined();
     });
 

--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -6,7 +6,7 @@ import {AccessModule, InstitutionApi, Profile, ProfileApi} from 'generated/fetch
 import {
     allModules,
     DataAccessRequirements,
-    getNextActiveModule,
+    getActiveModule,
     getEligibleModules,
     requiredModules
 } from './data-access-requirements';
@@ -52,7 +52,7 @@ describe('DataAccessRequirements', () => {
     const findControlledTierCard = (wrapper) => wrapper.find('[data-test-id="controlled-card"]')
     const findEligibleText = (wrapper) => wrapper.find('[data-test-id="eligible-text"]');
     const findIneligibleText = (wrapper) => wrapper.find('[data-test-id="ineligible-text"]');
-    const findActiveModuleText = (wrapper, module: AccessModule) => wrapper.find(`[data-test-id="module-${module}-active-text"]`);
+    const findClickableModuleText = (wrapper, module: AccessModule) => wrapper.find(`[data-test-id="module-${module}-clickable-text"]`);
 
     const findContactUs = (wrapper) => wrapper.find('[data-test-id="contact-us"]');
 
@@ -100,9 +100,9 @@ describe('DataAccessRequirements', () => {
         expect(enabledModules.includes(AccessModule.COMPLIANCETRAINING)).toBeFalsy();
     });
 
-    it('should return the first module (2FA) from getNextActiveModule when no modules have been completed', () => {
+    it('should return the first module (2FA) from getActiveModule when no modules have been completed', () => {
         const enabledModules = getEligibleModules(requiredModules, profile);
-        const activeModule = getNextActiveModule(enabledModules, profile);
+        const activeModule = getActiveModule(enabledModules, profile);
 
         expect(activeModule).toEqual(requiredModules[0]);
         expect(activeModule).toEqual(enabledModules[0]);
@@ -111,7 +111,7 @@ describe('DataAccessRequirements', () => {
         expect(activeModule).toEqual(AccessModule.TWOFACTORAUTH)
     });
 
-    it('should return the second module (RAS) from getNextActiveModule when the first module (2FA) has been completed', () => {
+    it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been completed', () => {
         const testProfile = {
             ...profile,
             accessModules: {
@@ -120,7 +120,7 @@ describe('DataAccessRequirements', () => {
         };
 
         const enabledModules = getEligibleModules(requiredModules, profile);
-        const activeModule = getNextActiveModule(enabledModules, testProfile);
+        const activeModule = getActiveModule(enabledModules, testProfile);
 
         expect(activeModule).toEqual(requiredModules[1]);
         expect(activeModule).toEqual(enabledModules[1]);
@@ -129,7 +129,7 @@ describe('DataAccessRequirements', () => {
         expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV)
     });
 
-    it('should return the second module (RAS) from getNextActiveModule when the first module (2FA) has been bypassed', () => {
+    it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been bypassed', () => {
         const testProfile = {
             ...profile,
             accessModules: {
@@ -138,7 +138,7 @@ describe('DataAccessRequirements', () => {
         };
 
         const enabledModules = getEligibleModules(requiredModules, profile);
-        const activeModule = getNextActiveModule(enabledModules, testProfile);
+        const activeModule = getActiveModule(enabledModules, testProfile);
 
         expect(activeModule).toEqual(requiredModules[1]);
         expect(activeModule).toEqual(enabledModules[1]);
@@ -147,7 +147,7 @@ describe('DataAccessRequirements', () => {
         expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV)
     });
 
-    it('should return the second enabled module (ERA, not RAS) from getNextActiveModule' +
+    it('should return the second enabled module (ERA, not RAS) from getActiveModule' +
       ' when the first module (2FA) has been completed and RAS is disabled', () => {
         serverConfigStore.set({config: {...defaultServerConfig, enableRasLoginGovLinking: false, enforceRasLoginGovLinking: false}});
 
@@ -159,7 +159,7 @@ describe('DataAccessRequirements', () => {
         };
 
         const enabledModules = getEligibleModules(requiredModules, profile);
-        const activeModule = getNextActiveModule(enabledModules, testProfile);
+        const activeModule = getActiveModule(enabledModules, testProfile);
 
         // update this if the order changes
         expect(activeModule).toEqual(AccessModule.ERACOMMONS)
@@ -171,7 +171,7 @@ describe('DataAccessRequirements', () => {
         expect(activeModule).toEqual(requiredModules[2]);
     });
 
-    it('should return the fourth module (Compliance) from getNextActiveModule when the first 3 modules have been completed', () => {
+    it('should return the fourth module (Compliance) from getActiveModule when the first 3 modules have been completed', () => {
         const testProfile = {
             ...profile,
             accessModules: {
@@ -184,7 +184,7 @@ describe('DataAccessRequirements', () => {
         };
 
         const enabledModules = getEligibleModules(requiredModules, profile);
-        const activeModule = getNextActiveModule(enabledModules, testProfile);
+        const activeModule = getActiveModule(enabledModules, testProfile);
 
         expect(activeModule).toEqual(requiredModules[3]);
         expect(activeModule).toEqual(enabledModules[3]);
@@ -193,7 +193,7 @@ describe('DataAccessRequirements', () => {
         expect(activeModule).toEqual(AccessModule.COMPLIANCETRAINING)
     });
 
-    it('should return undefined from getNextActiveModule when all modules have been completed', () => {
+    it('should return undefined from getActiveModule when all modules have been completed', () => {
         const testProfile = {
             ...profile,
             accessModules: {
@@ -202,7 +202,7 @@ describe('DataAccessRequirements', () => {
         };
 
         const enabledModules = getEligibleModules(requiredModules, profile);
-        const activeModule = getNextActiveModule(enabledModules, testProfile);
+        const activeModule = getActiveModule(enabledModules, testProfile);
 
         expect(activeModule).toBeUndefined();
     });
@@ -223,7 +223,7 @@ describe('DataAccessRequirements', () => {
 
         const enabledModules = getEligibleModules(requiredModules, profile);
 
-        let activeModule = getNextActiveModule(enabledModules, testProfile);
+        let activeModule = getActiveModule(enabledModules, testProfile);
         expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV)
 
         // simulate handleRasCallback() by updating the profile
@@ -238,7 +238,7 @@ describe('DataAccessRequirements', () => {
             }
         };
 
-        activeModule = getNextActiveModule(enabledModules, updatedProfile);
+        activeModule = getActiveModule(enabledModules, updatedProfile);
         expect(activeModule).toBeUndefined();
     });
 
@@ -991,7 +991,7 @@ describe('DataAccessRequirements', () => {
     wrapper = component();
     await waitOneTickAndUpdate(wrapper);
 
-    expect(findActiveModuleText(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()).toBeTruthy();
-    expect(findActiveModuleText(wrapper, AccessModule.DATAUSERCODEOFCONDUCT).exists()).toBeTruthy();
+    expect(findClickableModuleText(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()).toBeTruthy();
+    expect(findClickableModuleText(wrapper, AccessModule.DATAUSERCODEOFCONDUCT).exists()).toBeTruthy();
   });
 });

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -491,10 +491,9 @@ const MaybeModule = ({profile, moduleName, active, spinnerProps}: ModuleProps): 
     }]);
 
   const {DARTitleComponent, refreshAction, isEnabledInEnvironment} = getAccessModuleConfig(moduleName);
-
+  const eligible = isEligibleModule(moduleName, profile);
   const Module = ({profile}) => {
     const status = getAccessModuleStatusByName(profile, moduleName)
-
     return <FlexRow data-test-id={`module-${moduleName}`}>
       <FlexRow style={styles.moduleCTA}>
         {active && ((showRefresh && refreshAction)
@@ -503,10 +502,15 @@ const MaybeModule = ({profile, moduleName, active, spinnerProps}: ModuleProps): 
                 showSpinner={spinnerProps.showSpinner}/>
             : <Next/>)}
       </FlexRow>
-      <ModuleBox clickable={active} action={() => { setShowRefresh(true); moduleAction(); }}>
-        <ModuleIcon moduleName={moduleName} completedOrBypassed={isCompliant(status)}/>
+      <ModuleBox clickable={active} action={() => {
+        setShowRefresh(true);
+        moduleAction();
+      }}>
+        <ModuleIcon moduleName={moduleName} eligible={eligible} completedOrBypassed={isCompliant(status)}/>
         <FlexColumn>
-          <div style={active ? styles.clickableModuleText : styles.backgroundModuleText}>
+          <div
+              data-test-id={`module-${moduleName}-${active ? 'active' : 'inactive'}-text`}
+              style={active ? styles.clickableModuleText : styles.backgroundModuleText}>
             <DARTitleComponent/>
             {(moduleName === AccessModule.RASLINKLOGINGOV) && <LoginGovHelpText profile={profile} afterInitialClick={showRefresh}/>}
           </div>

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -249,6 +249,8 @@ const rtModules = [
 const ctModule = AccessModule.CTCOMPLIANCETRAINING;
 const duccModule = AccessModule.DATAUSERCODEOFCONDUCT;
 
+// in display order
+// exported for test
 export const requiredModules: AccessModule[] = [
   ...rtModules,
   duccModule
@@ -336,10 +338,13 @@ const isEraCommonsModuleRequiredByInstitution = (profile: Profile, moduleNames: 
 
 const isEligibleModule = (module: AccessModule, profile: Profile) => {
   if (module !== AccessModule.CTCOMPLIANCETRAINING) {
+    // Currently a user can only be ineligible for CT modules.
+    // Note: eRA Commons is an edge case which is handled elsewhere. It is
+    // technically also possible for CT eRA commons to be ineligible.
     return true;
   }
   const controlledTierEligibility = profile.tierEligibilities.find(tier=> tier.accessTierShortName === AccessTierShortNames.Controlled);
-  return !!(controlledTierEligibility?.eligible);
+  return !!controlledTierEligibility?.eligible;
 }
 
 
@@ -762,7 +767,8 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)((spinnerPro
   // At any given time, at most two modules will be active in the list:
   //  1. The next module, which we visually direct the user to with a CTA
   //  2. The next required module, which may diverge when the next module is optional.
-  // The first element of the nextModules list gets preferential UX treatment.
+  // This configuration allows the user to skip the optional CT section. The
+  // first element of the nextModules list gets the preferential CTA.
   const [nextModules, setNextModules] = useState([]);
 
   const getNext = (modules: AccessModule[]) => getNextModule(getEligibleModules(modules, profile), profile);

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -648,7 +648,8 @@ const RegisteredTierCard = (props: {profile: Profile, nextModules: AccessModule[
   </FlexRow>;
 };
 
-const ControlledTierCard = (props: {profile: Profile, nextModules: AccessModule[], reload: Function, spinnerProps: WithSpinnerOverlayProps}) => {
+const ControlledTierCard = (props: {profile: Profile, nextModules: AccessModule[],
+    reload: Function, spinnerProps: WithSpinnerOverlayProps}) => {
   const {profile, nextModules, spinnerProps} = props;
   const controlledTierEligibility = profile.tierEligibilities.find(tier=> tier.accessTierShortName === AccessTierShortNames.Controlled);
   const registeredTierEligibility = profile.tierEligibilities.find(tier=> tier.accessTierShortName === AccessTierShortNames.Registered);
@@ -778,7 +779,8 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)((spinnerPro
   const showCtCard = environment.accessTiersVisibleToUsers.includes(AccessTierShortNames.Controlled)
 
   const rtCard = <RegisteredTierCard key='rt' profile={profile} nextModules={nextModules} spinnerProps={spinnerProps}/>
-  const ctCard = showCtCard ? <ControlledTierCard key='ct' profile={profile} nextModules={nextModules} reload={reload} spinnerProps={spinnerProps}/> : null
+  const ctCard = showCtCard ?
+      <ControlledTierCard key='ct' profile={profile} nextModules={nextModules} reload={reload} spinnerProps={spinnerProps}/> : null
   const dCard = <DuccCard
     key='dt'
     profile={profile}

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -25,11 +25,20 @@ import {environment} from 'environments/environment';
 
 const {useState, useEffect} = React;
 
-export async function redirectToTraining() {
-  AnalyticsTracker.Registration.EthicsTraining();
+
+export async function redirectToRegisteredTraining() {
+  AnalyticsTracker.Registration.RegisteredTraining();
   await profileApi().updatePageVisits({page: 'moodle'});
   const {config: {complianceTrainingHost}} = serverConfigStore.get();
   const url = `https://${complianceTrainingHost}/static/data-researcher.html?saml=on'`;
+  window.open(url, '_blank');
+}
+
+export async function redirectToControlledTraining() {
+  AnalyticsTracker.Registration.ControlledTraining();
+  await profileApi().updatePageVisits({page: 'moodle'});
+  const {config: {complianceTrainingHost}} = serverConfigStore.get();
+  const url = `https://${complianceTrainingHost}/static/data-researcher-controlled.html?saml=on'`;
   window.open(url, '_blank');
 }
 
@@ -138,8 +147,9 @@ export const getAccessModuleConfig = (moduleName: AccessModule): AccessModuleCon
     [AccessModule.CTCOMPLIANCETRAINING, () => ({
       moduleName,
       isEnabledInEnvironment: enableComplianceTraining,
-      DARTitleComponent: () => <div>[{environment.displayTag}] Bypass <AoU/> research Controlled Tier training </div>
-      //  TODO: implement externalSyncAction and refreshAction for CT Complaince training
+      DARTitleComponent: () => <div>Complete <AoU/> research Controlled Tier training </div>,
+      externalSyncAction: async () => await profileApi().syncComplianceTrainingStatus(),
+      refreshAction: async () => await profileApi().syncComplianceTrainingStatus(),
     })],
 
     [AccessModule.DATAUSERCODEOFCONDUCT, () => ({

--- a/ui/src/app/utils/analytics.ts
+++ b/ui/src/app/utils/analytics.ts
@@ -104,7 +104,8 @@ export const AnalyticsTracker = {
     DemographicSurvey: () =>
       triggerEvent('Registration', 'Clicked \'Next\' in step 3/3 in registration process', 'Demographic survey completed'),
     TwoFactorAuth: () => triggerEvent('Registration', 'Clicked on \'2FA\' button', '2FA'),
-    EthicsTraining: () => triggerEvent('Registration', 'Clicked on \'Ethics training\' button', 'Training'),
+    RegisteredTraining: () => triggerEvent('Registration', 'Clicked on \'Ethics training\' button', 'Training'),
+    ControlledTraining: () => triggerEvent('Registration', 'Clicked on \'Controlled tier training\' button', 'Training'),
     ERACommons: () => triggerEvent('Registration', 'Clicked on eRA commons button', 'eRA commons'),
     RasLoginGov: () => triggerEvent('Registration', 'Clicked on RAS LoginGov linking button', 'RAS LoginGov'),
     EnterDUCC: () => triggerEvent('Registration', 'Clicked in DUCC button', 'Entered DUCC'),


### PR DESCRIPTION
Updated per UX discussion:

- added clickableModules, containing distinct([nextModule, nextRequiredModule])
- the active module is always included as a clickableModule
- all clickableModules are interactive, but only the activeModule gets the CTA
- Specifically, if a CT module is available, it receives the CTA - but the DUCC is still interactive as CT modules are optional

## Finished RT, ineligible for CT

![image](https://user-images.githubusercontent.com/822298/142083112-4b8650df-8b77-4064-ad44-a6d9a878473e.png)

## Finished RT, eligible for CT

![image](https://user-images.githubusercontent.com/822298/142083143-6767a875-6119-4614-bc17-957737d163cf.png)

