### PR TITLE
[RW-7485][risk=no]  Locked state of a workspace is visible in the UI - icon alignment

### DIFF
--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -298,11 +298,11 @@ export const WorkspaceCard = fp.flow(withNavigation)(
                 <FlexColumn style={{justifyContent: 'flex-end', marginLeft: '0.8rem'}}>
                   <FlexRow style={{alignContent: 'space-between'}}>
                     {adminLocked &&
-                    <FlexColumn data-test-id='workspace-lock' style={{justifyContent: 'flex-end'}}>
+                    <div data-test-id='workspace-lock' style={{justifyContent: 'flex-end'}}>
                       <TooltipTrigger content='Workspace compliance action is required'>
                         <FontAwesomeIcon icon={faLockAlt} style={styles.lockWorkspace}/>
                       </TooltipTrigger>
-                    </FlexColumn>}
+                    </div>}
                     {accessTierShortName === AccessTierShortNames.Controlled &&
                     <ControlledTierBadge/>}
                   </FlexRow>

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -295,14 +295,19 @@ export const WorkspaceCard = fp.flow(withNavigation)(
                     Last Changed: {displayDate(workspace.lastModifiedTime)}
                   </div>
                 </FlexColumn>
-                <FlexColumn style={{justifyContent: 'flex-end', alignItems: 'flex-end', direction: 'rtl', marginLeft: 15}}>
-                  {accessTierShortName === AccessTierShortNames.Controlled && <ControlledTierBadge/>}
+                <FlexColumn style={{justifyContent: 'flex-end', marginLeft: '0.8rem'}}>
+                  <FlexRow style={{alignContent: 'space-between'}}>
+                    {adminLocked &&
+                    <FlexColumn data-test-id='workspace-lock' style={{justifyContent: 'flex-end'}}>
+                      <TooltipTrigger content='Workspace compliance action is required'>
+                        <FontAwesomeIcon icon={faLockAlt} style={styles.lockWorkspace}/>
+                      </TooltipTrigger>
+                    </FlexColumn>}
+                    {accessTierShortName === AccessTierShortNames.Controlled &&
+                    <ControlledTierBadge/>}
+                  </FlexRow>
                 </FlexColumn>
-                {adminLocked && <FlexColumn data-test-id='workspace-lock' style={{justifyContent: 'flex-end'}}>
-                  <TooltipTrigger content='Workspace compliance action is required'>
-                    <FontAwesomeIcon icon={faLockAlt} style={styles.lockWorkspace}/>
-                  </TooltipTrigger>
-                </FlexColumn>}
+
               </FlexRow>
             </FlexColumn>
           </FlexRow>

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -298,11 +298,11 @@ export const WorkspaceCard = fp.flow(withNavigation)(
                 <FlexColumn style={{justifyContent: 'flex-end', marginLeft: '0.8rem'}}>
                   <FlexRow style={{alignContent: 'space-between'}}>
                     {adminLocked &&
-                    <div data-test-id='workspace-lock' style={{justifyContent: 'flex-end'}}>
+                    <FlexColumn data-test-id='workspace-lock' style={{justifyContent: 'flex-end'}}>
                       <TooltipTrigger content='Workspace compliance action is required'>
                         <FontAwesomeIcon icon={faLockAlt} style={styles.lockWorkspace}/>
                       </TooltipTrigger>
-                    </div>}
+                    </FlexColumn>}
                     {accessTierShortName === AccessTierShortNames.Controlled &&
                     <ControlledTierBadge/>}
                   </FlexRow>


### PR DESCRIPTION
<img width="1084" alt="Screen Shot 2021-11-16 at 3 30 40 PM" src="https://user-images.githubusercontent.com/34481816/142061081-12cc90b2-ddc4-4689-9290-f1b0bdce3859.png">



---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
