### PR TITLE
[RW-7251][risk=no] Require user input for lazy runtime creation

### DIFF
--- a/e2e/app/page/notebook-preview-page.ts
+++ b/e2e/app/page/notebook-preview-page.ts
@@ -5,6 +5,8 @@ import AuthenticatedPage from './authenticated-page';
 import NotebookPage from './notebook-page';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
 import { waitWhileLoading } from 'utils/waits-utils';
+import Button from 'app/element/button';
+import { initializeRuntimeIfModalPresented } from 'utils/runtime-utils';
 
 const Selector = {
   editLink: '//*[contains(normalize-space(text()), "Edit")]',
@@ -34,6 +36,9 @@ export default class NotebookPreviewPage extends AuthenticatedPage {
     const editLink = await this.getEditLink();
     await editLink.waitUntilEnabled();
     await editLink.click();
+
+    await initializeRuntimeIfModalPresented(this.page);
+
     // Restarting notebook server may take a while.
     await waitWhileLoading(this.page, 60 * 20 * 1000);
 

--- a/e2e/app/page/notebook-preview-page.ts
+++ b/e2e/app/page/notebook-preview-page.ts
@@ -5,7 +5,6 @@ import AuthenticatedPage from './authenticated-page';
 import NotebookPage from './notebook-page';
 import WorkspaceAnalysisPage from './workspace-analysis-page';
 import { waitWhileLoading } from 'utils/waits-utils';
-import Button from 'app/element/button';
 import { initializeRuntimeIfModalPresented } from 'utils/runtime-utils';
 
 const Selector = {

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -42,8 +42,6 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
     const headingTextElement = await this.page.waitForSelector(pageHeadingCss, { visible: true });
     const headingText = await getPropValue<string>(headingTextElement, 'textContent');
 
-    await initializeRuntimeIfModalPresented(this.page);
-
     // Log notebook progress text message
     const progressCss = '[data-test-id="current-progress-card"]';
     const progressTextElement = await this.page.waitForSelector(progressCss, { visible: true });
@@ -67,6 +65,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
     const redirectingTextsXpath = `//*[@data-test-id and contains(normalize-space(), "${redirectingTexts}")]`;
 
     await Promise.all([
+      initializeRuntimeIfModalPresented(this.page),
       this.page.waitForXPath(warningTextsXpath, { visible: true }),
       this.page.waitForXPath(authenticateTextsXpath, { visible: true }),
       this.page.waitForXPath(creatingTextsXpath, { visible: true }),

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -8,6 +8,7 @@ import { getPropValue } from 'utils/element-utils';
 import { waitForDocumentTitle, waitWhileLoading } from 'utils/waits-utils';
 import NotebookPage from './notebook-page';
 import WorkspaceBase from './workspace-base';
+import { initializeRuntimeIfModalPresented } from 'utils/runtime-utils';
 
 const PageTitle = 'View Notebooks';
 
@@ -40,6 +41,8 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
     const pageHeadingCss = '[data-test-id="leo-app-launcher"] > h2';
     const headingTextElement = await this.page.waitForSelector(pageHeadingCss, { visible: true });
     const headingText = await getPropValue<string>(headingTextElement, 'textContent');
+
+    await initializeRuntimeIfModalPresented(this.page);
 
     // Log notebook progress text message
     const progressCss = '[data-test-id="current-progress-card"]';

--- a/e2e/utils/runtime-utils.ts
+++ b/e2e/utils/runtime-utils.ts
@@ -2,7 +2,7 @@ import { Page } from 'puppeteer';
 import Button from 'app/element/button';
 
 const Selector = {
-  runtimeInitializerCreateButton: '//*[@data-test-id="runtime-initializer-create")]'
+  runtimeInitializerCreateButton: '//*[@role="dialog"]//*[text()="Create Environment" and @role="button"]'
 };
 
 export async function initializeRuntimeIfModalPresented(page: Page): Promise<void> {

--- a/e2e/utils/runtime-utils.ts
+++ b/e2e/utils/runtime-utils.ts
@@ -3,7 +3,7 @@ import Button from 'app/element/button';
 
 const Selector = {
   runtimeInitializerCreateButton: '//*[data-test-id="runtime-initializer-create")]'
-}
+};
 
 export async function initializeRuntimeIfModalPresented(page: Page): Promise<void> {
   let initializeButton: Button;

--- a/e2e/utils/runtime-utils.ts
+++ b/e2e/utils/runtime-utils.ts
@@ -2,18 +2,18 @@ import { Page } from 'puppeteer';
 import Button from 'app/element/button';
 
 const Selector = {
-  runtimeInitializerCreateButton: '//*[data-test-id="runtime-initializer-create")]'
+  runtimeInitializerCreateButton: '//*[@data-test-id="runtime-initializer-create")]'
 };
 
 export async function initializeRuntimeIfModalPresented(page: Page): Promise<void> {
   let initializeButton: Button;
   try {
     initializeButton = new Button(page, Selector.runtimeInitializerCreateButton);
+    await initializeButton.waitUntilEnabled();
   } catch (e) {
     // Expected if the runtime already exists.
     return;
   }
 
-  await initializeButton.waitUntilEnabled();
   await initializeButton.clickAndWait();
 }

--- a/e2e/utils/runtime-utils.ts
+++ b/e2e/utils/runtime-utils.ts
@@ -1,0 +1,19 @@
+import { Page } from 'puppeteer';
+import Button from 'app/element/button';
+
+const Selector = {
+  runtimeInitializerCreateButton: '//*[data-test-id="runtime-initializer-create")]'
+}
+
+export async function initializeRuntimeIfModalPresented(page: Page): Promise<void> {
+  let initializeButton: Button;
+  try {
+    initializeButton = new Button(page, Selector.runtimeInitializerCreateButton);
+  } catch (e) {
+    // Expected if the runtime already exists.
+    return;
+  }
+
+  await initializeButton.waitUntilEnabled();
+  await initializeButton.clickAndWait();
+}

--- a/ui/src/app/components/messages.tsx
+++ b/ui/src/app/components/messages.tsx
@@ -66,9 +66,9 @@ export const WarningMessage = ({
   iconPosition = 'center',
   children
 }: {
-  iconSize: number,
-  iconPosition: 'top' | 'center' | 'bottom',
-  children
+  iconSize?: number,
+  iconPosition?: 'top' | 'center' | 'bottom',
+  children: string|React.ReactNode
 }) => {
   return <MessageWithIcon
       messageType={'warning'}
@@ -86,7 +86,7 @@ export const ErrorMessage = ({
 }: {
   iconSize?: number,
   iconPosition?: 'top' | 'center' | 'bottom',
-  children
+  children: string|React.ReactNode
 }) => {
   return <MessageWithIcon
       messageType={'error'}

--- a/ui/src/app/components/runtime-cost-estimator.tsx
+++ b/ui/src/app/components/runtime-cost-estimator.tsx
@@ -12,20 +12,23 @@ import {
   machineStorageCostBreakdown,
 } from 'app/utils/machines';
 import {formatUsd} from 'app/utils/numbers';
-import { RuntimeConfig, RuntimeCtx } from 'app/utils/runtime-utils';
+import { RuntimeConfig } from 'app/utils/runtime-utils';
 import { serverConfigStore } from 'app/utils/stores';
+import { CSSProperties } from 'react';
 
 
 interface Props {
   runtimeParameters: RuntimeConfig;
   dataprocExists?: boolean;
   costTextColor?: string;
+  style?: CSSProperties;
 }
 
 export const RuntimeCostEstimator = ({
   runtimeParameters,
   dataprocExists = false,
-  costTextColor = colors.accent
+  costTextColor = colors.accent,
+  style = {}
 }: Props) => {
   const {
     computeType,
@@ -54,7 +57,7 @@ export const RuntimeCostEstimator = ({
   const storageCost = machineStorageCost(costConfig);
   const storageCostBreakdown = machineStorageCostBreakdown(costConfig);
   const costPriceFontSize = enablePersistentDisk ? '12px' : '20px';
-  return <FlexRow>
+  return <FlexRow style={style}>
       <FlexColumn style={{marginRight: '1rem'}}>
         <div style={{fontSize: '10px', fontWeight: 600}}>Cost when running</div>
         <TooltipTrigger content={
@@ -67,7 +70,7 @@ export const RuntimeCostEstimator = ({
               style={{fontSize: costPriceFontSize, color: costTextColor}}
               data-test-id='running-cost'
           >
-            {formatUsd(runningCost)}/hr
+            {formatUsd(runningCost)}/hour
           </div>
         </TooltipTrigger>
       </FlexColumn>
@@ -83,7 +86,7 @@ export const RuntimeCostEstimator = ({
               style={{fontSize: costPriceFontSize, color: costTextColor}}
               data-test-id='storage-cost'
           >
-            {formatUsd(storageCost)}/hr
+            {formatUsd(storageCost)}/hour
           </div>
         </TooltipTrigger>
       </FlexColumn>

--- a/ui/src/app/components/runtime-initializer-modal.tsx
+++ b/ui/src/app/components/runtime-initializer-modal.tsx
@@ -1,21 +1,41 @@
 import {Modal, ModalBody, ModalFooter, ModalTitle} from './modals';
 import * as React from 'react';
-import { Button } from './buttons';
+import { Button, Clickable } from './buttons';
 import { Runtime, RuntimeConfigurationType } from 'generated/fetch';
+import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { RuntimeCostEstimator } from './runtime-cost-estimator';
 import { RuntimeSummary } from './runtime-summary';
 import { toRuntimeConfig } from 'app/utils/runtime-utils';
 
+import {useState} from 'react';
+import { ClrIcon } from './icons';
+import { reactStyles } from 'app/utils';
+import { setSidebarActiveIconStore } from 'app/utils/navigation';
+
+
+const styles = reactStyles({
+  bodyElement: {
+    marginTop: '15px'
+  },
+  runtimeDetails: {
+    border: `1px solid ${colorWithWhiteness(colors.dark, 0.8)}`,
+    borderRadius: '5px',
+    marginTop: '10px',
+    padding: '10px'
+  }
+});
+
 interface Props {
   cancel: () => void;
-  openRuntimePanel: () => void;
-  createDefault: () => void;
+  createAndContinue: () => void;
   defaultRuntime: Runtime;
 }
 
-export const RuntimeInitializerModal = ({cancel, openRuntimePanel, createDefault, defaultRuntime}: Props) => {
+export const RuntimeInitializerModal = ({cancel, createAndContinue, defaultRuntime}: Props) => {
+  const [showDetails, setShowDetails] = useState(false);
+
   const defaultRuntimeConfig = toRuntimeConfig(defaultRuntime);
-  return <Modal>
+  return <Modal width={600}>
     <ModalTitle>Create an Analysis Environment</ModalTitle>
     <ModalBody>
       <div>
@@ -25,8 +45,17 @@ export const RuntimeInitializerModal = ({cancel, openRuntimePanel, createDefault
            'Would you like to continue with this default environment?' :
            'Would you like to continue with your most recently used environment settings in this workspace?'}
       </div>
-      <RuntimeCostEstimator runtimeParameters={defaultRuntimeConfig} />
-      <RuntimeSummary runtimeConfig={defaultRuntimeConfig} />
+      <RuntimeCostEstimator
+        runtimeParameters={defaultRuntimeConfig}
+        style={{...styles.bodyElement, justifyContent: 'space-evenly'}} />
+      <Clickable onClick={() => setShowDetails(!showDetails)} style={styles.bodyElement} >
+        Environment details<ClrIcon shape='angle' style={{transform: showDetails ? 'rotate(180deg)' : 'rotate(90deg)'}} />
+      </Clickable>
+     {showDetails &&
+       <div style={styles.runtimeDetails}>
+         <RuntimeSummary runtimeConfig={defaultRuntimeConfig} />
+         <div style={{marginTop: '10px'}}>To change this configuration, click 'Configure' below.</div>
+       </div>}
     </ModalBody>
     <ModalFooter style={{justifyContent: 'space-between'}}>
       <Button
@@ -38,13 +67,14 @@ export const RuntimeInitializerModal = ({cancel, openRuntimePanel, createDefault
       <Button
           type='secondary'
           onClick={() => {
-            openRuntimePanel();
+            setSidebarActiveIconStore.next('runtime');
+            cancel();
           }}
       >
-        Edit
+        Configure
       </Button>
       <Button onClick={() => {
-        createDefault();
+        createAndContinue();
       }}>
         Create Environment
       </Button>

--- a/ui/src/app/components/runtime-initializer-modal.tsx
+++ b/ui/src/app/components/runtime-initializer-modal.tsx
@@ -1,0 +1,53 @@
+import {Modal, ModalBody, ModalFooter, ModalTitle} from './modals';
+import * as React from 'react';
+import { Button } from './buttons';
+import { Runtime, RuntimeConfigurationType } from 'generated/fetch';
+import { RuntimeCostEstimator } from './runtime-cost-estimator';
+import { RuntimeSummary } from './runtime-summary';
+import { toRuntimeConfig } from 'app/utils/runtime-utils';
+
+interface Props {
+  cancel: () => void;
+  openRuntimePanel: () => void;
+  createDefault: () => void;
+  defaultRuntime: Runtime;
+}
+
+export const RuntimeInitializerModal = ({cancel, openRuntimePanel, createDefault, defaultRuntime}: Props) => {
+  const defaultRuntimeConfig = toRuntimeConfig(defaultRuntime);
+  return <Modal>
+    <ModalTitle>Create an Analysis Environment</ModalTitle>
+    <ModalBody>
+      <div>
+        Continuing with this action requires a cloud analysis environment, which will be charged
+        to this workspace.&nbsp;
+        {defaultRuntime.configurationType === RuntimeConfigurationType.GeneralAnalysis ?
+           'Would you like to continue with this default environment?' :
+           'Would you like to continue with your most recently used environment settings in this workspace?'}
+      </div>
+      <RuntimeCostEstimator runtimeParameters={defaultRuntimeConfig} />
+      <RuntimeSummary runtimeConfig={defaultRuntimeConfig} />
+    </ModalBody>
+    <ModalFooter style={{justifyContent: 'space-between'}}>
+      <Button
+          type='secondary'
+          onClick={() => cancel()}
+      >
+        Cancel
+      </Button>
+      <Button
+          type='secondary'
+          onClick={() => {
+            openRuntimePanel();
+          }}
+      >
+        Edit
+      </Button>
+      <Button onClick={() => {
+        createDefault();
+      }}>
+        Create Environment
+      </Button>
+    </ModalFooter>
+  </Modal>
+}

--- a/ui/src/app/components/runtime-initializer-modal.tsx
+++ b/ui/src/app/components/runtime-initializer-modal.tsx
@@ -11,6 +11,7 @@ import {useState} from 'react';
 import { ClrIcon } from './icons';
 import { reactStyles } from 'app/utils';
 import { setSidebarActiveIconStore } from 'app/utils/navigation';
+import { WarningMessage } from './messages';
 
 
 const styles = reactStyles({
@@ -38,13 +39,13 @@ export const RuntimeInitializerModal = ({cancel, createAndContinue, defaultRunti
   return <Modal width={600}>
     <ModalTitle>Create an Analysis Environment</ModalTitle>
     <ModalBody>
-      <div>
+      <WarningMessage iconPosition="top">
         Continuing with this action requires a cloud analysis environment, which will be charged
         to this workspace.&nbsp;
         {defaultRuntime.configurationType === RuntimeConfigurationType.GeneralAnalysis ?
            'Would you like to continue with this default environment?' :
            'Would you like to continue with your most recently used environment settings in this workspace?'}
-      </div>
+      </WarningMessage>
       <RuntimeCostEstimator
         runtimeParameters={defaultRuntimeConfig}
         style={{...styles.bodyElement, justifyContent: 'space-evenly'}} />

--- a/ui/src/app/components/runtime-initializer-modal.tsx
+++ b/ui/src/app/components/runtime-initializer-modal.tsx
@@ -12,6 +12,7 @@ import { ClrIcon } from './icons';
 import { reactStyles } from 'app/utils';
 import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { WarningMessage } from './messages';
+import { serverConfigStore } from 'app/utils/stores';
 
 
 const styles = reactStyles({
@@ -48,6 +49,7 @@ export const RuntimeInitializerModal = ({cancel, createAndContinue, defaultRunti
       </WarningMessage>
       <RuntimeCostEstimator
         runtimeParameters={defaultRuntimeConfig}
+        usePersistentDisk={serverConfigStore.get().config.enablePersistentDisk}
         style={{...styles.bodyElement, justifyContent: 'space-evenly'}} />
       <Clickable onClick={() => setShowDetails(!showDetails)} style={styles.bodyElement} >
         Environment details<ClrIcon shape='angle' style={{transform: showDetails ? 'rotate(180deg)' : 'rotate(90deg)'}} />
@@ -60,12 +62,14 @@ export const RuntimeInitializerModal = ({cancel, createAndContinue, defaultRunti
     </ModalBody>
     <ModalFooter style={{justifyContent: 'space-between'}}>
       <Button
+          data-test-id='runtime-intializer-cancel'
           type='secondary'
           onClick={() => cancel()}
       >
         Cancel
       </Button>
       <Button
+          data-test-id='runtime-intializer-configure'
           type='secondary'
           onClick={() => {
             setSidebarActiveIconStore.next('runtime');
@@ -74,9 +78,11 @@ export const RuntimeInitializerModal = ({cancel, createAndContinue, defaultRunti
       >
         Configure
       </Button>
-      <Button onClick={() => {
-        createAndContinue();
-      }}>
+      <Button
+        data-test-id='runtime-intializer-create'
+        onClick={() => {
+          createAndContinue();
+        }}>
         Create Environment
       </Button>
     </ModalFooter>

--- a/ui/src/app/components/runtime-summary.tsx
+++ b/ui/src/app/components/runtime-summary.tsx
@@ -1,9 +1,9 @@
-import { reactStyles } from "app/utils";
+import { reactStyles } from 'app/utils';
 import {
   ComputeType,
   findMachineByName,
 } from 'app/utils/machines';
-import { RuntimeConfig } from "app/utils/runtime-utils";
+import { RuntimeConfig } from 'app/utils/runtime-utils';
 
 
 const styles = reactStyles({

--- a/ui/src/app/components/runtime-summary.tsx
+++ b/ui/src/app/components/runtime-summary.tsx
@@ -1,0 +1,37 @@
+import { reactStyles } from "app/utils";
+import {
+  ComputeType,
+  findMachineByName,
+} from 'app/utils/machines';
+import { RuntimeConfig } from "app/utils/runtime-utils";
+
+
+const styles = reactStyles({
+  bold: {
+    fontWeight: 700,
+  }
+});
+
+export const RuntimeSummary = ({runtimeConfig}: {runtimeConfig: RuntimeConfig}) => {
+  return <>
+<label htmlFor='compute-resources' style={{...styles.bold, marginTop: '1rem'}}>Compute Resources</label>
+    <div id='compute-resources'>- Compute size of
+      <b> {runtimeConfig.machine.cpu} CPUs</b>,
+      <b> {runtimeConfig.machine.memory} GB memory</b>, and a
+      <b> {runtimeConfig.diskSize} GB disk</b>
+    </div>
+    {runtimeConfig.computeType === ComputeType.Dataproc && <>
+      <label htmlFor='worker-configuration' style={{...styles.bold, marginTop: '1rem'}}>Worker Configuration</label>
+      <div id='worker-configuration'>-
+        <b> {runtimeConfig.dataprocConfig.numberOfWorkers} worker(s) </b>
+        {
+          runtimeConfig.dataprocConfig.numberOfPreemptibleWorkers > 0 &&
+          <b>and {runtimeConfig.dataprocConfig.numberOfPreemptibleWorkers} preemptible worker(s) </b>
+        }
+        each with compute size of <b>{findMachineByName(runtimeConfig.dataprocConfig.workerMachineType).cpu} CPUs</b>,
+        <b> {findMachineByName(runtimeConfig.dataprocConfig.workerMachineType).memory} GB memory</b>, and a
+        <b> {runtimeConfig.dataprocConfig.workerDiskSize} GB disk</b>
+      </div>
+    </>}
+  </>;
+};

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
@@ -319,6 +319,45 @@ describe('NotebookLauncher', () => {
     expect(wrapper.find(Iframe).exists()).toBeFalsy();
     expect(wrapper.find(SecuritySuspendedMessage).exists()).toBeTruthy();
   });
+
+  it('should show runtime initializer modal if runtime not found', async() => {
+    history.push(notebookInitialUrl + '?kernelType=R?creating=false');
+    runtimeStub.runtime = null;
+
+    const wrapper = await notebookComponent();
+    await waitForFakeTimersAndUpdate(wrapper);
+
+    expect(wrapper.exists({'data-test-id': 'runtime-intializer-create'})).toBeTruthy();
+  });
+
+  test.each(['cancel', 'configure'])(
+      'should show retry message on runtime initializer %s', async(action) => {
+    history.push(notebookInitialUrl + '?kernelType=R?creating=false');
+    runtimeStub.runtime = null;
+
+    const wrapper = await notebookComponent();
+    await waitForFakeTimersAndUpdate(wrapper);
+
+    wrapper.find({'data-test-id': `runtime-intializer-${action}`}).simulate('click');
+    await waitForFakeTimersAndUpdate(wrapper);
+
+    expect(wrapper.exists({'data-test-id': `runtime-intializer-${action}`})).toBeFalsy();
+    expect(wrapper.text()).toContain('This action requires an analysis environment.')
+  });
+
+  it('should create runtime on runtime initializer create', async() => {
+    history.push(notebookInitialUrl + '?kernelType=R?creating=false');
+    runtimeStub.runtime = null;
+
+    const wrapper = await notebookComponent();
+    await waitForFakeTimersAndUpdate(wrapper);
+
+    wrapper.find({'data-test-id': 'runtime-intializer-create'}).simulate('click');
+    await waitForFakeTimersAndUpdate(wrapper);
+
+    expect(wrapper.exists({'data-test-id': 'runtime-intializer-create'})).toBeFalsy();
+    expect(runtimeStub.runtime).toBeTruthy();
+  });
 });
 
 describe('TerminalLauncher', () => {

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -105,7 +105,9 @@ describe('RuntimePanel', () => {
   });
 
   const pickDropdownOption = async(wrapper, id, label) => {
-    wrapper.find(id).first().simulate('click');
+    act(() => {
+      wrapper.find(id).first().simulate('click');
+    });
     const item = wrapper.find(`${id} .p-dropdown-item`).find({'aria-label': label}).first();
     expect(item.exists()).toBeTruthy();
 
@@ -207,7 +209,7 @@ describe('RuntimePanel', () => {
     // not general analysis. Ensure this test passes for the right reasons when fixing.
     const computeDefaults = wrapper.find('#compute-resources').first();
     // defaults to generalAnalysis preset, which is a n1-standard-4 machine with a 100GB disk
-    expect(computeDefaults.text()).toEqual('- Default: compute size of 4 CPUs, 15 GB memory, and a 100 GB disk')
+    expect(computeDefaults.text()).toEqual('- Compute size of 4 CPUs, 15 GB memory, and a 100 GB disk')
   });
 
   it('should allow creation when no runtime exists with defaults', async() => {
@@ -852,25 +854,25 @@ describe('RuntimePanel', () => {
     // Default GCE machine, n1-standard-4, makes the running cost 20 cents an hour and the storage cost less than 1 cent an hour.
     const runningCost = () => costEstimator().find('[data-test-id="running-cost"]');
     const storageCost = () => costEstimator().find('[data-test-id="storage-cost"]');
-    expect(runningCost().text()).toEqual('$0.20/hr');
-    expect(storageCost().text()).toEqual('< $0.01/hr');
+    expect(runningCost().text()).toEqual('$0.20/hour');
+    expect(storageCost().text()).toEqual('< $0.01/hour');
 
     // Change the machine to n1-standard-8 and bump the storage to 300GB. This should make the running cost 40 cents an hour and the storage cost 2 cents an hour.
     await pickMainCpu(wrapper, 8);
     await pickMainRam(wrapper, 30);
     await pickMainDiskSize(wrapper, 300);
-    expect(runningCost().text()).toEqual('$0.40/hr');
-    expect(storageCost().text()).toEqual('$0.02/hr');
+    expect(runningCost().text()).toEqual('$0.40/hour');
+    expect(storageCost().text()).toEqual('$0.02/hour');
 
     // Selecting the General Analysis preset should bring the machine back to n1-standard-4 with 100GB storage.
     await pickPreset(wrapper, {displayName: 'General Analysis'});
-    expect(runningCost().text()).toEqual('$0.20/hr');
-    expect(storageCost().text()).toEqual('< $0.01/hr');
+    expect(runningCost().text()).toEqual('$0.20/hour');
+    expect(storageCost().text()).toEqual('< $0.01/hour');
 
     // After selecting Dataproc, the Dataproc defaults should make the running cost 72 cents an hour. The storage cost increases due to worker disk.
     await pickComputeType(wrapper, ComputeType.Dataproc);
-    expect(runningCost().text()).toEqual('$0.72/hr');
-    expect(storageCost().text()).toEqual('$0.02/hr');
+    expect(runningCost().text()).toEqual('$0.72/hour');
+    expect(storageCost().text()).toEqual('$0.02/hour');
 
     // Bump up all the worker values to increase the price on everything.
     await pickNumWorkers(wrapper, 4);
@@ -878,8 +880,8 @@ describe('RuntimePanel', () => {
     await pickWorkerCpu(wrapper, 8);
     await pickWorkerRam(wrapper, 30);
     await pickWorkerDiskSize(wrapper, 300);
-    expect(runningCost().text()).toEqual('$2.87/hr');
-    expect(storageCost().text()).toEqual('$0.14/hr');
+    expect(runningCost().text()).toEqual('$2.87/hour');
+    expect(storageCost().text()).toEqual('$0.14/hour');
   });
 
   it('should update the cost estimator when master machine changes', async() => {
@@ -906,14 +908,14 @@ describe('RuntimePanel', () => {
 
     const runningCost = () => costEstimator().find('[data-test-id="running-cost"]');
     const storageCost = () => costEstimator().find('[data-test-id="storage-cost"]');
-    expect(runningCost().text()).toEqual('$0.77/hr');
-    expect(storageCost().text()).toEqual('$0.07/hr');
+    expect(runningCost().text()).toEqual('$0.77/hour');
+    expect(storageCost().text()).toEqual('$0.07/hour');
 
     // Switch to n1-highmem-4, double disk size.
     await pickMainRam(wrapper, 26);
     await pickMainDiskSize(wrapper, 2000);
-    expect(runningCost().text()).toEqual('$0.87/hr');
-    expect(storageCost().text()).toEqual('$0.12/hr');
+    expect(runningCost().text()).toEqual('$0.87/hour');
+    expect(storageCost().text()).toEqual('$0.12/hour');
   });
 
   it('should allow runtime deletion', async() => {
@@ -1025,7 +1027,7 @@ describe('RuntimePanel', () => {
 
     await pickComputeType(wrapper, ComputeType.Dataproc);
 
-    // This should make the cost about $50/hr.
+    // This should make the cost about $50/hour.
     await pickNumWorkers(wrapper, 200);
     expect(getCreateButton().prop('disabled')).toBeTruthy();
 
@@ -1047,7 +1049,7 @@ describe('RuntimePanel', () => {
 
     await pickComputeType(wrapper, ComputeType.Dataproc);
 
-    // This should make the cost about $50/hr.
+    // This should make the cost about $50/hour.
     await pickNumWorkers(wrapper, 20000);
     expect(getCreateButton().prop('disabled')).toBeFalsy();
   });
@@ -1067,11 +1069,11 @@ describe('RuntimePanel', () => {
 
     await pickComputeType(wrapper, ComputeType.Dataproc);
 
-    // This should make the cost about $140/hr.
+    // This should make the cost about $140/hour.
     await pickNumWorkers(wrapper, 600);
     expect(getCreateButton().prop('disabled')).toBeFalsy();
 
-    // This should make the cost around $160/hr.
+    // This should make the cost around $160/hour.
     await pickNumWorkers(wrapper, 700);
     // We don't want to disable for user provided billing. Just put a warning.
     expect(getCreateButton().prop('disabled')).toBeFalsy();

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -879,7 +879,7 @@ const CostInfo = ({runtimeChanged, runtimeConfig, currentUser, workspace, creato
     data-test-id='cost-estimator'
   >
     <div style={{minWidth: '250px', margin: '.33rem .5rem'}}>
-      <RuntimeCostEstimator runtimeParameters={runtimeConfig} dataprocExists={runtimeCtx.dataprocExists}/>
+      <RuntimeCostEstimator runtimeParameters={runtimeConfig} usePersistentDisk={runtimeCtx.enablePD && !runtimeCtx.dataprocExists}/>
     </div>
     {
       isUsingFreeTierBillingAccount(workspace)
@@ -936,6 +936,7 @@ const CreatePanel = ({creatorFreeCreditsRemaining, profile, setPanelContent, wor
 const ConfirmUpdatePanel = ({initialRuntimeConfig, newRuntimeConfig, onCancel, updateButton, runtimeCtx}) => {
   const runtimeDiffs = getRuntimeConfigDiffs(initialRuntimeConfig, newRuntimeConfig, runtimeCtx);
   const updateMessaging = diffsToUpdateMessaging(runtimeDiffs);
+  const usePersistentDisk = runtimeCtx.enablePD && !runtimeCtx.dataprocExists;
   return <React.Fragment>
     <div style={styles.controlSection}>
       <h3 style={{...styles.baseHeader, ...styles.sectionHeader, marginTop: '.1rem', marginBottom: '.2rem'}}>Editing your environment</h3>
@@ -953,7 +954,7 @@ const ConfirmUpdatePanel = ({initialRuntimeConfig, newRuntimeConfig, onCancel, u
         <div style={{marginRight: '1rem'}}>
           <b style={{fontSize: 10}}>New estimated cost</b>
           <div style={{...styles.costPredictorWrapper, padding: '.25rem .5rem'}}>
-            <RuntimeCostEstimator runtimeParameters={newRuntimeConfig} dataprocExists={runtimeCtx.dataprocExists}/>
+            <RuntimeCostEstimator runtimeParameters={newRuntimeConfig} usePersistentDisk={usePersistentDisk}/>
           </div>
         </div>
         <div>
@@ -962,7 +963,7 @@ const ConfirmUpdatePanel = ({initialRuntimeConfig, newRuntimeConfig, onCancel, u
             padding: '.25rem .5rem',
             color: 'grey',
             backgroundColor: ''}}>
-            <RuntimeCostEstimator runtimeParameters={initialRuntimeConfig} dataprocExists={runtimeCtx.dataprocExists} costTextColor='grey'/>
+            <RuntimeCostEstimator runtimeParameters={initialRuntimeConfig} usePersistentDisk={usePersistentDisk} costTextColor='grey'/>
           </div>
         </div>
       </FlexRow>

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -29,9 +29,6 @@ import {
   gpuTypeToDisplayName,
   Machine,
   machineRunningCost,
-  machineRunningCostBreakdown,
-  machineStorageCost,
-  machineStorageCostBreakdown,
   validLeoDataprocMasterMachineTypes,
   validLeoDataprocWorkerMachineTypes,
   validLeoGceMachineTypes
@@ -719,6 +716,8 @@ import computeError from 'assets/icons/compute-error.svg';
 import computeStopped from 'assets/icons/compute-stopped.svg';
 import computeNone from 'assets/icons/compute-none.svg';
 import {isUsingFreeTierBillingAccount} from 'app/utils/workspace-utils';
+import { RuntimeCostEstimator } from 'app/components/runtime-cost-estimator';
+import { RuntimeSummary } from 'app/components/runtime-summary';
 
 const StartStopRuntimeButton = ({workspaceNamespace, googleProject}) => {
   const [status, setRuntimeStatus] = useRuntimeStatus(workspaceNamespace, googleProject);
@@ -868,81 +867,6 @@ const StartStopRuntimeButton = ({workspaceNamespace, googleProject}) => {
   </FlexRow>;
 };
 
-const CostEstimator = ({
-  runtimeParameters,
-  runtimeCtx,
-  costTextColor = colors.accent
-}) => {
-  const {
-    computeType,
-    diskSize,
-    pdSize,
-    machine,
-    gpuConfig,
-    dataprocConfig
-  } = runtimeParameters;
-  const {
-    numberOfWorkers = 0,
-    workerMachineType = null,
-    workerDiskSize = null,
-    numberOfPreemptibleWorkers = 0
-  } = dataprocConfig || {};
-  const workerMachine = findMachineByName(workerMachineType);
-  const gpu = gpuConfig ? findGpu(gpuConfig.gpuType, gpuConfig.numOfGpus) : null;
-  const costConfig = {
-    computeType, masterMachine: machine, gpu, masterDiskSize: runtimeCtx.enablePD && !runtimeCtx.dataprocExists ? pdSize : diskSize,
-    numberOfWorkers, numberOfPreemptibleWorkers, workerDiskSize, workerMachine
-  };
-  const runningCost = machineRunningCost(costConfig);
-  const runningCostBreakdown = machineRunningCostBreakdown(costConfig);
-  const storageCost = machineStorageCost(costConfig);
-  const storageCostBreakdown = machineStorageCostBreakdown(costConfig);
-  const costPriceFontSize = runtimeCtx.enablePD ? '12px' : '20px';
-  return <FlexRow>
-      <FlexColumn style={{marginRight: '1rem'}}>
-        <div style={{fontSize: '10px', fontWeight: 600}}>Cost when running</div>
-        <TooltipTrigger content={
-          <div>
-            <div>Cost Breakdown</div>
-            {runningCostBreakdown.map((lineItem, i) => <div key={i}>{lineItem}</div>)}
-          </div>
-        }>
-          <div
-              style={{fontSize: costPriceFontSize, color: costTextColor}}
-              data-test-id='running-cost'
-          >
-            {formatUsd(runningCost)}/hr
-          </div>
-        </TooltipTrigger>
-      </FlexColumn>
-      <FlexColumn style={{marginRight: '1rem'}}>
-        <div style={{fontSize: '10px', fontWeight: 600}}>Cost when paused</div>
-        <TooltipTrigger content={
-          <div>
-            <div>Cost Breakdown</div>
-            {storageCostBreakdown.map((lineItem, i) => <div key={i}>{lineItem}</div>)}
-          </div>
-        }>
-          <div
-              style={{fontSize: costPriceFontSize, color: costTextColor}}
-              data-test-id='storage-cost'
-          >
-            {formatUsd(storageCost)}/hr
-          </div>
-        </TooltipTrigger>
-      </FlexColumn>
-    {runtimeCtx.enablePD && computeType === ComputeType.Standard && <FlexColumn>
-      <div style={{fontSize: '10px', fontWeight: 600}}>Persistent disk cost</div>
-        <div
-            style={{fontSize: costPriceFontSize, color: costTextColor}}
-            data-test-id='pd-cost'
-        >
-          {formatUsd(pdSize * diskPricePerMonth)}/month
-        </div>
-    </FlexColumn>}
-  </FlexRow>;
-};
-
 const CostInfo = ({runtimeChanged, runtimeConfig, currentUser, workspace, creatorFreeCreditsRemaining, runtimeCtx}) => {
   const remainingCredits = creatorFreeCreditsRemaining === null ? <Spinner size={10}/> : formatUsd(creatorFreeCreditsRemaining);
 
@@ -955,7 +879,7 @@ const CostInfo = ({runtimeChanged, runtimeConfig, currentUser, workspace, creato
     data-test-id='cost-estimator'
   >
     <div style={{minWidth: '250px', margin: '.33rem .5rem'}}>
-      <CostEstimator runtimeParameters={runtimeConfig} runtimeCtx={runtimeCtx}/>
+      <RuntimeCostEstimator runtimeParameters={runtimeConfig} dataprocExists={runtimeCtx.dataprocExists}/>
     </div>
     {
       isUsingFreeTierBillingAccount(workspace)
@@ -1005,25 +929,7 @@ const CreatePanel = ({creatorFreeCreditsRemaining, profile, setPanelContent, wor
         Customize
       </Button>
     </FlexRow>
-    <label htmlFor='compute-resources' style={{...styles.bold, marginTop: '1rem'}}>Compute Resources</label>
-    <div id='compute-resources'>- Default: compute size of
-      <b> {runtimeConfig.machine.cpu} CPUs</b>,
-      <b> {runtimeConfig.machine.memory} GB memory</b>, and a
-      <b> {runtimeConfig.diskSize} GB disk</b>
-    </div>
-    {runtimeConfig.computeType === ComputeType.Dataproc && <Fragment>
-      <label htmlFor='worker-configuration' style={{...styles.bold, marginTop: '1rem'}}>Worker Configuration</label>
-      <div id='worker-configuration'>- Default:
-        <b> {runtimeConfig.dataprocConfig.numberOfWorkers} worker(s) </b>
-        {
-          runtimeConfig.dataprocConfig.numberOfPreemptibleWorkers > 0 &&
-          <b>and {runtimeConfig.dataprocConfig.numberOfPreemptibleWorkers} preemptible worker(s) </b>
-        }
-        each with compute size of <b>{findMachineByName(runtimeConfig.dataprocConfig.workerMachineType).cpu} CPUs</b>,
-        <b> {findMachineByName(runtimeConfig.dataprocConfig.workerMachineType).memory} GB memory</b>, and a
-        <b> {runtimeConfig.dataprocConfig.workerDiskSize} GB disk</b>
-      </div>
-    </Fragment>}
+    <RuntimeSummary runtimeConfig={runtimeConfig} />
   </div>;
 };
 
@@ -1047,7 +953,7 @@ const ConfirmUpdatePanel = ({initialRuntimeConfig, newRuntimeConfig, onCancel, u
         <div style={{marginRight: '1rem'}}>
           <b style={{fontSize: 10}}>New estimated cost</b>
           <div style={{...styles.costPredictorWrapper, padding: '.25rem .5rem'}}>
-            <CostEstimator runtimeParameters={newRuntimeConfig} runtimeCtx = {runtimeCtx}/>
+            <RuntimeCostEstimator runtimeParameters={newRuntimeConfig} dataprocExists={runtimeCtx.dataprocExists}/>
           </div>
         </div>
         <div>
@@ -1056,7 +962,7 @@ const ConfirmUpdatePanel = ({initialRuntimeConfig, newRuntimeConfig, onCancel, u
             padding: '.25rem .5rem',
             color: 'grey',
             backgroundColor: ''}}>
-            <CostEstimator runtimeParameters={initialRuntimeConfig} runtimeCtx={runtimeCtx} costTextColor='grey'/>
+            <RuntimeCostEstimator runtimeParameters={initialRuntimeConfig} dataprocExists={runtimeCtx.dataprocExists} costTextColor='grey'/>
           </div>
         </div>
       </FlexRow>

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -7,6 +7,7 @@ import {reportError} from 'app/utils/errors';
 import {withCurrentWorkspace} from 'app/utils';
 import {
   ExceededActionCountError,
+  InitialRuntimeNotFoundError,
   LeoRuntimeInitializationAbortedError,
   LeoRuntimeInitializer
 } from 'app/utils/leo-runtime-initializer';
@@ -48,8 +49,10 @@ export const WorkspaceWrapper = fp.flow(
         // initialization here.
         // Also ignore LeoRuntimeInitializationAbortedError - this is expected when navigating
         // away from a page during a poll.
-        if (!(e instanceof ExceededActionCountError || e instanceof LeoRuntimeInitializationAbortedError)) {
-          // Ideally, we would have some top-level error messaginag here.
+        if (!(e instanceof InitialRuntimeNotFoundError ||
+              e instanceof ExceededActionCountError ||
+              e instanceof LeoRuntimeInitializationAbortedError)) {
+          // Ideally, we would have some top-level error messaging here.
           reportError(e);
         }
       }

--- a/ui/src/app/utils/leo-runtime-initializer.spec.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.spec.tsx
@@ -22,7 +22,6 @@ import SpyInstance = jest.SpyInstance;
 
 let mockGetRuntime: SpyInstance;
 let mockCreateRuntime: SpyInstance;
-let mockDeleteRuntime: SpyInstance;
 let mockStartRuntime: SpyInstance;
 
 const baseRuntime: Runtime = {
@@ -46,7 +45,6 @@ describe('RuntimeInitializer', () => {
 
     mockGetRuntime = jest.spyOn(runtimeApi(), 'getRuntime');
     mockCreateRuntime = jest.spyOn(runtimeApi(), 'createRuntime');
-    mockDeleteRuntime = jest.spyOn(runtimeApi(), 'deleteRuntime');
     mockStartRuntime = jest.spyOn(leoRuntimesApi(), 'startRuntime');
 
     serverConfigStore.set({config: {gsuiteDomain: 'researchallofus.org'}});
@@ -139,7 +137,9 @@ describe('RuntimeInitializer', () => {
       {status: RuntimeStatus.Running}
     ]);
     const statuses = [];
-    await runInitializerAndTimers({onPoll: (runtime) => statuses.push(runtime ? runtime.status : null)});
+    await runInitializerAndTimers({
+      onPoll: (runtime) => statuses.push(runtime ? runtime.status : null)
+    });
 
     expect(statuses).toEqual([
       RuntimeStatus.Stopped,
@@ -147,8 +147,8 @@ describe('RuntimeInitializer', () => {
       // value is changed.
       RuntimeStatus.Starting,
       RuntimeStatus.Starting,
-      RuntimeStatus.Running]
-    );
+      RuntimeStatus.Running
+    ]);
   });
 
   it('should create runtime if it is initially nonexistent', async() => {

--- a/ui/src/app/utils/leo-runtime-initializer.spec.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.spec.tsx
@@ -6,6 +6,7 @@ import {
 } from 'app/services/notebooks-swagger-fetch-clients';
 import {registerApiClient, runtimeApi} from 'app/services/swagger-fetch-clients';
 import {
+  InitialRuntimeNotFoundError,
   LeoRuntimeInitializer,
   LeoRuntimeInitializerOptions
 } from 'app/utils/leo-runtime-initializer';
@@ -132,7 +133,6 @@ describe('RuntimeInitializer', () => {
     mockGetRuntimeCalls([
       {status: RuntimeStatus.Stopped},
     ]);
-    mockGetRuntime.mockRejectedValueOnce(new Response(null, {status: 404}));
     mockGetRuntimeCalls([
       {status: RuntimeStatus.Starting},
       {status: RuntimeStatus.Starting},
@@ -143,8 +143,6 @@ describe('RuntimeInitializer', () => {
 
     expect(statuses).toEqual([
       RuntimeStatus.Stopped,
-      // A null value is passed when a runtime is not found.
-      null,
       // Note: onStatusUpdate will be called for every status received, not just when the status
       // value is changed.
       RuntimeStatus.Starting,
@@ -162,13 +160,15 @@ describe('RuntimeInitializer', () => {
       {status: RuntimeStatus.Starting},
       {status: RuntimeStatus.Running}
     ]);
-    const runtime = await runInitializerAndTimers();
+    const runtime = await runInitializerAndTimers({
+      targetRuntime: runtimePresets.generalAnalysis.runtimeTemplate
+    });
 
     expect(mockCreateRuntime).toHaveBeenCalled();
     expect(runtime.status).toEqual(RuntimeStatus.Running);
   });
 
-  it('should lazily create user\'s most runtime if a valid one exists', async() => {
+  it('should error and suggest user\'s most runtime if a valid one exists', async() => {
     serverConfigStore.set({config: {gsuiteDomain: 'researchallofus.org'}});
     mockGetRuntime.mockImplementation(namespace => {
       return {
@@ -181,20 +181,23 @@ describe('RuntimeInitializer', () => {
         status: RuntimeStatus.Deleted
       }; });
 
-    LeoRuntimeInitializer.initialize({
-      workspaceNamespace: workspaceNamespace,
-    });
-    await new Promise(setImmediate);
-
-    expect(mockCreateRuntime).toHaveBeenCalledWith(workspaceNamespace, expect.objectContaining({
-      gceConfig: {
-        diskSize: 777,
-        machineType: 'n1-standard-16'
-      }
-    }), expect.any(Object));
+    try {
+      await LeoRuntimeInitializer.initialize({
+        workspaceNamespace: workspaceNamespace,
+      });
+      fail('expected initializer to throw an exception');
+    } catch (e) {
+      expect(e).toBeInstanceOf(InitialRuntimeNotFoundError);
+      expect(e.defaultRuntime).toMatchObject({
+        gceConfig: {
+          diskSize: 777,
+          machineType: 'n1-standard-16'
+        }
+      });
+    }
   });
 
-  it('should use preset values during lazy runtime creation if a preset was selected', async() => {
+  it('should error and suggest preset values if a preset was selected for deleted runtime', async() => {
     serverConfigStore.set({config: {gsuiteDomain: 'researchallofus.org'}});
     mockGetRuntime.mockImplementation(namespace => {
       return {
@@ -208,18 +211,21 @@ describe('RuntimeInitializer', () => {
         status: RuntimeStatus.Deleted
       }; });
 
-    LeoRuntimeInitializer.initialize({
-      workspaceNamespace: workspaceNamespace,
-    });
-    await new Promise(setImmediate);
-
-    expect(mockCreateRuntime).toHaveBeenCalledWith(workspaceNamespace, expect.objectContaining({
-      gceConfig: {
-        diskSize: runtimePresets.generalAnalysis.runtimeTemplate.gceConfig.diskSize,
-        machineType: runtimePresets.generalAnalysis.runtimeTemplate.gceConfig.machineType,
-        gpuConfig: null,
-      }
-    }), expect.any(Object));
+    try {
+      await LeoRuntimeInitializer.initialize({
+        workspaceNamespace: workspaceNamespace
+      });
+      fail('expected initializer to throw an exception');
+    } catch (e) {
+      expect(e).toBeInstanceOf(InitialRuntimeNotFoundError);
+      expect(e.defaultRuntime).toMatchObject({
+        gceConfig: {
+          diskSize: runtimePresets.generalAnalysis.runtimeTemplate.gceConfig.diskSize,
+          machineType: runtimePresets.generalAnalysis.runtimeTemplate.gceConfig.machineType,
+          gpuConfig: null,
+        }
+      });
+    }
   });
 
   it('should not automatically delete errored runtimes', async() => {
@@ -306,11 +312,13 @@ describe('RuntimeInitializer', () => {
   it('should respect the maxCreateCount option', async() => {
     // Ensure that the initializer won't take action on a NOT_FOUND runtime if the maxCreateCount
     // is set to disallow create requests.
-    mockGetRuntime.mockRejectedValueOnce(new Response(null, {status: 404}));
+    mockGetRuntime.mockRejectedValue(new Response(null, {status: 404}));
     try {
-      await runInitializerAndTimers({maxCreateCount: 0});
+      await runInitializerAndTimers({
+        maxCreateCount: 0,
+        targetRuntime: runtimePresets.generalAnalysis.runtimeTemplate
+      });
     } catch (error) {
-      expect(mockCreateRuntime).not.toHaveBeenCalled();
       expect(error.message).toMatch(/max runtime create count/i);
     }
   });

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -439,7 +439,7 @@ const useRuntime = (currentWorkspaceNamespace) => {
   }, [currentWorkspaceNamespace]);
 };
 
-export const maybeInitializeRuntime = async(workspaceNamespace: string, signal: AbortSignal): Promise<Runtime> => {
+export const maybeInitializeRuntime = async(workspaceNamespace: string, signal: AbortSignal, targetRuntime?: Runtime): Promise<Runtime> => {
   if (workspaceNamespace in compoundRuntimeOpStore.get()) {
     await new Promise<void>((resolve, reject) => {
       signal.addEventListener('abort', reject);
@@ -454,7 +454,7 @@ export const maybeInitializeRuntime = async(workspaceNamespace: string, signal: 
   }
 
   try {
-    return await LeoRuntimeInitializer.initialize({workspaceNamespace, pollAbortSignal: signal});
+    return await LeoRuntimeInitializer.initialize({workspaceNamespace, pollAbortSignal: signal, targetRuntime});
   } catch (error) {
     throw await maybeUnwrapSecuritySuspendedError(error);
   }

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -347,7 +347,7 @@ const compareAutopauseThreshold = (oldRuntime: RuntimeConfig, newRuntime: Runtim
   };
 };
 
-const toRuntimeConfig = (runtime: Runtime): RuntimeConfig => {
+export const toRuntimeConfig = (runtime: Runtime): RuntimeConfig => {
   if (runtime.gceConfig) {
     return {
       computeType: ComputeType.Standard,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/822298/142294118-3a0ea4c1-0165-4e15-9777-1bb79106c9ee.png)


Changes:

- Factor out the `RuntimeCostEstimator` for reuse
- Factor out `RuntimeSummary` for reuse
- `LeonardoRuntimeInitializer` no longer allows lazy creation, this scenario throws an error instead.
- Add new `RuntimeInitializerModal` which shows a runtime preview and allows the user to confirm their last or default configuration.

For flow control purposes, my approach is the easiest I could come up with, though it may be tricky to follow at first, here is a pseudocode version:

```
try {
  intializeRuntime();
} catch (NotFound) {
  confirmed = await promptUser
  if (confirmed)
   initializeRuntime(default)
  else
    exit
}
```

Screenshares:

- [notebook preview page](https://pmi-engteam.slack.com/files/U5KGPEEPK/F02MLPNKVEF/notebook_preview_lazy_check.webm)
- [notebook redirect page](https://pmi-engteam.slack.com/files/U5KGPEEPK/F02M63ZRNDV/new_notebook_lazy_check.webm)