### PR TITLE
[RW-7575 ][risk=no] UX for admin-locked workspaces - Recent Resources

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -286,6 +286,7 @@ public class UserMetricsController implements UserMetricsApiDelegate {
     resource.setCdrVersionId(commonMappers.cdrVersionToId(dbWorkspace.getCdrVersion()));
     resource.setAccessTierShortName(dbWorkspace.getCdrVersion().getAccessTier().getShortName());
     resource.setWorkspaceBillingStatus(dbWorkspace.getBillingStatus());
+    resource.setAdminLocked(dbWorkspace.isAdminLocked());
   }
 
   private void buildFromFcWorkspace(

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6312,6 +6312,7 @@ definitions:
       - accessTierShortName
       - permission
       - lastModifiedEpochMillis
+      - adminLocked
     properties:
       workspaceId:
         type: integer
@@ -6342,6 +6343,8 @@ definitions:
         description: the resource's last modified time, in milliseconds since the epoch
         type: integer
         format: int64
+      adminLocked:
+        type: boolean
   RecentResourceRequest:
     type: object
     properties:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6345,6 +6345,8 @@ definitions:
         format: int64
       adminLocked:
         type: boolean
+        default: false
+        description: Whether an administrator has prevented most actions on the workspace for all users
   RecentResourceRequest:
     type: object
     properties:

--- a/ui/src/app/components/resource-actions-menu.tsx
+++ b/ui/src/app/components/resource-actions-menu.tsx
@@ -12,14 +12,13 @@ export interface Action {
   hoverText?: string;
 }
 
-export const ResourceActionsMenu = (props: { actions: Action[] }) => {
-  const {actions} = props;
+export const ResourceActionsMenu = (props: { actions: Action[], disabled?: boolean}) => {
+  const {actions, disabled} = props;
   return <PopupTrigger
         data-test-id='resource-card-menu'
         side='bottom'
         closeOnClick
-        content={
-            <React.Fragment>
+        content={!disabled && <React.Fragment>
                 {actions.map((action, i) => {
                   return (
                         <TooltipTrigger key={i} content={action.hoverText}>
@@ -35,6 +34,6 @@ export const ResourceActionsMenu = (props: { actions: Action[] }) => {
             </React.Fragment>
         }
     >
-        <SnowmanButton data-test-id='resource-menu'/>
+        <SnowmanButton data-test-id='resource-menu' disabled={disabled}/>
     </PopupTrigger>;
 };

--- a/ui/src/app/components/resource-card.tsx
+++ b/ui/src/app/components/resource-card.tsx
@@ -103,7 +103,7 @@ interface NavProps {
 }
 
 const ResourceNavigation = (props: NavProps) => {
-  const {resource, linkTestId, style = styles.resourceName, children} = props;
+  const {resource, resource: {adminLocked}, linkTestId, style = styles.resourceName, children} = props;
   const url = stringifyUrl(getResourceUrl(resource));
 
   function canNavigate(): boolean {
@@ -117,11 +117,14 @@ const ResourceNavigation = (props: NavProps) => {
     }
   }
 
-  return <Clickable disabled={!canNavigate()}>
-    <RouterLink to={url} style={style} data-test-id={linkTestId} onClick={() => onNavigate()}>
+  return <div>
+    {adminLocked ? <div>
       {children}
-    </RouterLink>
-  </Clickable>;
+    </div> : <Clickable>
+      <RouterLink to={url} style={style} data-test-id={linkTestId} onClick={() => onNavigate()}>
+        {children}
+      </RouterLink>
+    </Clickable>}</div>;
 };
 
 interface Props {

--- a/ui/src/app/pages/analysis/notebook-resource-card.tsx
+++ b/ui/src/app/pages/analysis/notebook-resource-card.tsx
@@ -182,7 +182,7 @@ export const NotebookResourceCard = fp.flow(
                    existingNames={this.props.existingNameList}/>
       }
       {menuOnly ?
-          <ResourceActionsMenu actions={this.actions}/> :
+          <ResourceActionsMenu actions={this.actions} disabled={resource.adminLocked}/> :
           <ResourceCard resource={resource} actions={this.actions}/>}
     </React.Fragment>;
   }

--- a/ui/src/app/pages/data/cohort-review/cohort-review-resource-card.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-resource-card.tsx
@@ -99,7 +99,7 @@ export const CohortReviewResourceCard = fp.flow(
                    existingNames={this.props.existingNameList}/>
       }
       {menuOnly ?
-          <ResourceActionsMenu actions={this.actions}/> :
+          <ResourceActionsMenu actions={this.actions} disabled={resource.adminLocked}/> :
           <ResourceCard resource={resource} actions={this.actions}/>}
     </React.Fragment>;
   }

--- a/ui/src/app/pages/data/cohort/cohort-resource-card.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-resource-card.tsx
@@ -185,7 +185,7 @@ export const CohortResourceCard = fp.flow(
           }}/>
       }
       {menuOnly ?
-          <ResourceActionsMenu actions={this.actions}/> :
+          <ResourceActionsMenu actions={this.actions} disabled={resource.adminLocked}/> :
           <ResourceCard resource={resource} actions={this.actions}/>}
     </React.Fragment>;
   }

--- a/ui/src/app/pages/data/concept/concept-set-resource-card.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-resource-card.tsx
@@ -160,7 +160,7 @@ export const ConceptSetResourceCard = fp.flow(
           }}/>
       }
       {menuOnly ?
-          <ResourceActionsMenu actions={this.actions}/> :
+          <ResourceActionsMenu actions={this.actions} disabled={resource.adminLocked}/> :
           <ResourceCard resource={resource} actions={this.actions}/>}
     </React.Fragment>;
   }

--- a/ui/src/app/pages/data/data-set/dataset-resource-card.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-resource-card.tsx
@@ -164,7 +164,7 @@ export const DatasetResourceCard = fp.flow(
                    existingNames={this.props.existingNameList}/>
       }
       {menuOnly ?
-          <ResourceActionsMenu actions={this.actions}/> :
+          <ResourceActionsMenu actions={this.actions} disabled={resource.adminLocked}/> :
           <ResourceCard resource={resource} actions={this.actions}/>}
     </React.Fragment>;
   }

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -21,6 +21,10 @@ import {
   WorkspaceResourceResponse,
   WorkspaceResponse
 } from 'generated/fetch';
+import {faLockAlt} from '@fortawesome/pro-solid-svg-icons';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import colors from 'app/styles/colors';
+import {TooltipTrigger} from 'app/components/popups';
 
 const styles = reactStyles({
   column: {
@@ -121,7 +125,11 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
           return {
             menu: renderResourceMenu(r),
             resourceType: <ResourceNavigation resource={r}><StyledResourceType resource={r}/></ResourceNavigation>,
-            resourceName: <ResourceNavigation resource={r} style={styles.navigation}>{getDisplayName(r)}</ResourceNavigation>,
+            resourceName: <ResourceNavigation resource={r} style={styles.navigation}>
+              {r.adminLocked && <TooltipTrigger content={<div>Workspace compliance action required</div>}>
+                <FontAwesomeIcon style={{color: colors.warning, marginRight: '0.5rem'}}size={'sm'} icon={faLockAlt}/>
+              </TooltipTrigger>}
+              {getDisplayName(r)}</ResourceNavigation>,
             workspaceName: <WorkspaceNavigation workspace={getWorkspace(r)} resource={r} style={styles.navigation}/>,
             formattedLastModified: formatWorkspaceResourceDisplayDate(r.lastModifiedEpochMillis),
             cdrVersionName: getCdrVersionName(r),

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -112,7 +112,7 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
       return wsMap.get(r.workspaceFirecloudName);
     };
 
-    const addAdminLock = () => {
+    const addAdminLockToNameColumn = () => {
       return <TooltipTrigger content={<div>Workspace compliance action required</div>}>
         <FontAwesomeIcon style={{color: colors.warning, marginRight: '0.5rem'}}size={'sm'} icon={faLockAlt}/>
       </TooltipTrigger>;
@@ -132,7 +132,9 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
             menu: renderResourceMenu(r),
             resourceType: <ResourceNavigation resource={r}><StyledResourceType resource={r}/></ResourceNavigation>,
             resourceName: <ResourceNavigation resource={r} style={styles.navigation}>
-              {r.adminLocked && addAdminLock()}{getDisplayName(r)}</ResourceNavigation>,
+              {r.adminLocked && addAdminLockToNameColumn()}
+              {getDisplayName(r)}
+            </ResourceNavigation>,
             workspaceName: <WorkspaceNavigation workspace={getWorkspace(r)} resource={r} style={styles.navigation}/>,
             formattedLastModified: formatWorkspaceResourceDisplayDate(r.lastModifiedEpochMillis),
             cdrVersionName: getCdrVersionName(r),

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -112,6 +112,12 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
       return wsMap.get(r.workspaceFirecloudName);
     };
 
+    const addAdminLock = () => {
+      return <TooltipTrigger content={<div>Workspace compliance action required</div>}>
+        <FontAwesomeIcon style={{color: colors.warning, marginRight: '0.5rem'}}size={'sm'} icon={faLockAlt}/>
+      </TooltipTrigger>;
+    }
+
     const getCdrVersionName = (r: WorkspaceResource) => {
       const {cdrVersionTiersResponse} = props;
       const cdrVersion = getCdrVersion(getWorkspace(r), cdrVersionTiersResponse);
@@ -126,10 +132,7 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
             menu: renderResourceMenu(r),
             resourceType: <ResourceNavigation resource={r}><StyledResourceType resource={r}/></ResourceNavigation>,
             resourceName: <ResourceNavigation resource={r} style={styles.navigation}>
-              {r.adminLocked && <TooltipTrigger content={<div>Workspace compliance action required</div>}>
-                <FontAwesomeIcon style={{color: colors.warning, marginRight: '0.5rem'}}size={'sm'} icon={faLockAlt}/>
-              </TooltipTrigger>}
-              {getDisplayName(r)}</ResourceNavigation>,
+              {r.adminLocked && addAdminLock()}{getDisplayName(r)}</ResourceNavigation>,
             workspaceName: <WorkspaceNavigation workspace={getWorkspace(r)} resource={r} style={styles.navigation}/>,
             formattedLastModified: formatWorkspaceResourceDisplayDate(r.lastModifiedEpochMillis),
             cdrVersionName: getCdrVersionName(r),

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -93,7 +93,7 @@ export function convertToResource(
   inputResource: FileDetail | Cohort | CohortReview | ConceptSet | DataSet,
   resourceType: ResourceType,
   workspace: WorkspaceData): WorkspaceResource {
-  const {namespace, id, accessLevel, accessTierShortName, cdrVersionId, billingStatus} = workspace;
+  const {namespace, id, accessLevel, accessTierShortName, adminLocked, cdrVersionId, billingStatus} = workspace;
   return {
     workspaceNamespace: namespace,
     workspaceFirecloudName: id,
@@ -107,7 +107,7 @@ export function convertToResource(
     dataSet: resourceType === ResourceType.DATASET ? inputResource as DataSet : null,
     notebook: resourceType === ResourceType.NOTEBOOK ? inputResource as FileDetail : null,
     lastModifiedEpochMillis: inputResource.lastModifiedTime,
-    adminLocked: workspace.adminLocked
+    adminLocked
   };
 }
 

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -107,6 +107,7 @@ export function convertToResource(
     dataSet: resourceType === ResourceType.DATASET ? inputResource as DataSet : null,
     notebook: resourceType === ResourceType.NOTEBOOK ? inputResource as FileDetail : null,
     lastModifiedEpochMillis: inputResource.lastModifiedTime,
+    adminLocked: workspace.adminLocked
   };
 }
 

--- a/ui/src/testing/stubs/resources-stub.ts
+++ b/ui/src/testing/stubs/resources-stub.ts
@@ -31,4 +31,5 @@ export const stubResource: WorkspaceResource = {
   accessTierShortName: AccessTierShortNames.Registered,
   workspaceBillingStatus: BillingStatus.ACTIVE,
   lastModifiedEpochMillis: 1634763170,
+  adminLocked: false
 };


### PR DESCRIPTION
Recent Resources

- shows a Locked icon similar to Workspace Card

- the resource name is unclickable
 
- the resource actions menu (snowman) is gray and unclickable

<img width="1607" alt="Screen Shot 2021-11-17 at 11 34 30 AM" src="https://user-images.githubusercontent.com/34481816/142244553-3923f847-155b-4099-84ac-e90686f73f14.png">
<img width="1571" alt="Screen Shot 2021-11-17 at 11 36 38 AM" src="https://user-images.githubusercontent.com/34481816/142244557-ef70ee65-552c-4f2f-8b25-e79ba80ad587.png">



---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
