### PR TITLE
[RW-7575 ][risk=no] UX for admin-locked workspaces - Disable share button

### DIFF
--- a/ui/src/app/pages/workspace/workspace-about.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.spec.tsx
@@ -90,6 +90,14 @@ describe('WorkspaceAbout', () => {
       .toBeTruthy();
   });
 
+  it('should disable the share button is workspace is adminLocked', async () => {
+    currentWorkspaceStore.getValue().adminLocked = true;
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(wrapper.find('[data-test-id="workspaceShareButton"]')
+        .getElement().props.disabled).toBeTruthy();
+  });
+
   it('should display cdr version', async () => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -254,10 +254,13 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withCdrVersions())
           <TooltipTrigger content={ShareTooltipText()}>
             <InfoIcon style={{margin: '0 0.3rem'}}/>
           </TooltipTrigger>
+          <TooltipTrigger content={<div>Workspace compliance action is required</div>}
+                          disabled={!workspace?.adminLocked}>
           <Button style={{height: '22px', fontSize: 12, marginRight: '0.5rem',
-            maxWidth: '13px'}} disabled={workspaceUserRoles.length === 0}
+            maxWidth: '13px'}} disabled={workspaceUserRoles.length === 0 || workspace?.adminLocked}
                   data-test-id='workspaceShareButton'
                   onClick={() => this.setState({sharing: true})}>Share</Button>
+          </TooltipTrigger>
         </div>
         {workspaceUserRoles.length > 0 ?
           <React.Fragment>


### PR DESCRIPTION

<img width="1658" alt="Screen Shot 2021-11-17 at 12 04 57 PM" src="https://user-images.githubusercontent.com/34481816/142248537-a69820f4-1803-465f-af0f-e3569783c597.png">



---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
