### PR TITLE
[no ticket][risk=no] correcting gender and race names in indexing build

### DIFF
--- a/api/db-cdr/generate-cdr/make-bq-denormalized-search-person.sh
+++ b/api/db-cdr/generate-cdr/make-bq-denormalized-search-person.sh
@@ -38,11 +38,11 @@ SELECT
       p.person_id
     , CASE
         WHEN p.gender_concept_id = 0 THEN 'Unknown'
-        ELSE g.concept_name
+        ELSE regexp_replace(g.concept_name, r'^.+:\s', '')
       END as gender
     , CASE
         WHEN p.sex_at_birth_concept_id = 0 THEN 'Unknown'
-        ELSE s.concept_name
+        ELSE regexp_replace(s.concept_name, r'^.+:\s', '')
       END as sex_at_birth
     , CASE
         WHEN p.race_concept_id = 0 THEN 'Unknown'


### PR DESCRIPTION
When creating the cb_search_person table the race and gender names have semicolons in them. For example PMI:Skip will be corrected to Skip. 