### PR TITLE
[risk=no][RW-6972] rm compliance_training_expiration_time from DbUser and ReportingUser

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -186,7 +186,6 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "  u.area_of_research,\n"
                 + "  uamrt.compliance_training_bypass_time,\n"
                 + "  uamrt.compliance_training_completion_time,\n"
-                + "  u.compliance_training_expiration_time,\n"
                 + "  u.contact_email,\n"
                 + "  u.creation_time,\n"
                 + "  uamd.data_use_agreement_bypass_time,\n"
@@ -313,8 +312,6 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                     offsetDateTimeUtc(rs.getTimestamp("compliance_training_bypass_time")))
                 .complianceTrainingCompletionTime(
                     offsetDateTimeUtc(rs.getTimestamp("compliance_training_completion_time")))
-                .complianceTrainingExpirationTime(
-                    offsetDateTimeUtc(rs.getTimestamp("compliance_training_expiration_time")))
                 .contactEmail(rs.getString("contact_email"))
                 .creationTime(offsetDateTimeUtc(rs.getTimestamp("creation_time")))
                 .accessTierShortNames(rs.getString("access_tier_short_names"))

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -307,20 +307,6 @@ public class DbUser {
     this.dataUseAgreementSignedVersion = dataUseAgreementSignedVersion;
   }
 
-  // TODO(RW-6972): remove
-  @Deprecated
-  @Column(name = "compliance_training_expiration_time")
-  public Timestamp getRegisteredTierComplianceTrainingExpirationTime() {
-    return complianceTrainingExpirationTime;
-  }
-
-  // TODO(RW-6972): remove
-  @Deprecated
-  public void setRegisteredTierComplianceTrainingExpirationTime(
-      Timestamp complianceTrainingExpirationTime) {
-    this.complianceTrainingExpirationTime = complianceTrainingExpirationTime;
-  }
-
   @OneToOne(
       cascade = CascadeType.ALL,
       orphanRemoval = true,

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
@@ -20,9 +20,6 @@ public enum UserColumnValueExtractor implements ColumnValueExtractor<ReportingUs
   COMPLIANCE_TRAINING_COMPLETION_TIME(
       "compliance_training_completion_time",
       u -> toInsertRowString(u.getComplianceTrainingCompletionTime())),
-  COMPLIANCE_TRAINING_EXPIRATION_TIME(
-      "compliance_training_expiration_time",
-      u -> toInsertRowString(u.getComplianceTrainingExpirationTime())),
   CONTACT_EMAIL("contact_email", ReportingUser::getContactEmail),
   CREATION_TIME("creation_time", u -> toInsertRowString(u.getCreationTime())),
   DATA_USE_AGREEMENT_BYPASS_TIME(

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8876,11 +8876,6 @@ definitions:
         type: string
         format: date-time
         description: Time Compliance Training completed, or null if never completed.
-      complianceTrainingExpirationTime:
-        type: string
-        format: date-time
-        description: Time  User's compliance training will expire, or null training
-          not taken or if bypassed
       contactEmail:
         type: string
         description: User's external email address on file.

--- a/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
@@ -50,8 +50,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
       Timestamp.from(Instant.parse("2015-05-07T00:00:00.00Z"));
   public static final Timestamp USER__COMPLIANCE_TRAINING_COMPLETION_TIME =
       Timestamp.from(Instant.parse("2015-05-08T00:00:00.00Z"));
-  public static final Timestamp USER__COMPLIANCE_TRAINING_EXPIRATION_TIME =
-      Timestamp.from(Instant.parse("2015-05-09T00:00:00.00Z"));
   public static final String USER__CONTACT_EMAIL = "foo_5";
   public static final Timestamp USER__CREATION_TIME =
       Timestamp.from(Instant.parse("2015-05-11T00:00:00.00Z"));
@@ -113,8 +111,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
     assertTimeApprox(user.getComplianceTrainingBypassTime(), USER__COMPLIANCE_TRAINING_BYPASS_TIME);
     assertTimeApprox(
         user.getComplianceTrainingCompletionTime(), USER__COMPLIANCE_TRAINING_COMPLETION_TIME);
-    assertTimeApprox(
-        user.getComplianceTrainingExpirationTime(), USER__COMPLIANCE_TRAINING_EXPIRATION_TIME);
     assertThat(user.getContactEmail()).isEqualTo(USER__CONTACT_EMAIL);
     assertThat(user.getAccessTierShortNames()).isEqualTo(USER__ACCESS_TIER_SHORT_NAMES);
     assertTimeApprox(user.getDataUseAgreementBypassTime(), USER__DATA_USE_AGREEMENT_BYPASS_TIME);
@@ -161,8 +157,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
   public DbUser createEntity() {
     final DbUser user = new DbUser();
     user.setAreaOfResearch(USER__AREA_OF_RESEARCH);
-    user.setRegisteredTierComplianceTrainingExpirationTime(
-        USER__COMPLIANCE_TRAINING_EXPIRATION_TIME);
     user.setContactEmail(USER__CONTACT_EMAIL);
     user.setCreationTime(USER__CREATION_TIME);
     user.setDataUseAgreementSignedVersion(USER__DATA_USE_AGREEMENT_SIGNED_VERSION);
@@ -189,8 +183,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
         .complianceTrainingBypassTime(offsetDateTimeUtc(USER__COMPLIANCE_TRAINING_BYPASS_TIME))
         .complianceTrainingCompletionTime(
             offsetDateTimeUtc(USER__COMPLIANCE_TRAINING_COMPLETION_TIME))
-        .complianceTrainingExpirationTime(
-            offsetDateTimeUtc(USER__COMPLIANCE_TRAINING_EXPIRATION_TIME))
         .contactEmail(USER__CONTACT_EMAIL)
         .creationTime(offsetDateTimeUtc(USER__CREATION_TIME))
         .dataUseAgreementBypassTime(offsetDateTimeUtc(USER__DATA_USE_AGREEMENT_BYPASS_TIME))


### PR DESCRIPTION
Matches terraform change in https://github.com/all-of-us/workbench-terraform-modules/pull/35 - can be merged in either order

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
