### PR TITLE
[no ticket][risk=no] Increase parallel_num and no_output_time for nightly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -746,12 +746,12 @@ workflows:
       - api-bigquery-test
       - puppeteer-env-setup
       - puppeteer-test:
-          parallel_num: 3
+          parallel_num: 4
           test_mode: "nightly-integration"
           optional_steps:
             - puppeteer-access-test-user-setup
           # genomic-extraction-to-vcf.spec takes long time to run.
-          no_output_timeout: 80m
+          no_output_timeout: 90m
           requires:
             - puppeteer-env-setup
 


### PR DESCRIPTION
CircleCI job failed [here](https://app.circleci.com/pipelines/github/all-of-us/workbench/16001/workflows/2bcf807c-a477-41ce-a963-56d419e783a0/jobs/181645/parallel-runs/1).

Error was `Too long with no output (exceeded 1h20m0s): context deadline exceeded`.