### PR TITLE
[no ticket][risk=no] Deal with e2e flaky functions

### DIFF
--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -61,7 +61,7 @@ export default class WorkspaceCard extends CardBase {
     );
 
     if (accessLevel !== undefined) {
-      await asyncFilter(
+      return asyncFilter(
         allCards,
         async (card: WorkspaceCard) => accessLevel === (await card.getWorkspaceAccessLevel())
       );

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -8,7 +8,7 @@ import WorkspaceEditPage from 'app/page/workspace-edit-page';
 import { waitForFn, waitWhileLoading } from 'utils/waits-utils';
 import { logger } from 'libs/logger';
 import BaseElement from 'app/element/base-element';
-import { isElementReady } from 'utils/test-utils';
+import { asyncFilter, isElementReady } from 'utils/test-utils';
 
 const WorkspaceCardSelector = {
   cardRootXpath: './/*[child::*[@data-test-id="workspace-card"]]', // finds 'workspace-card' parent container node
@@ -56,15 +56,14 @@ export default class WorkspaceCard extends CardBase {
     });
 
     // Turn elements into WorkspaceCard objects.
-    const allCards: WorkspaceCard[] = await Promise.all(
-      (await page.$x(WorkspaceCardSelector.cardRootXpath)).map((card) => new WorkspaceCard(page).asCard(card))
+    const allCards: WorkspaceCard[] = (await page.$x(WorkspaceCardSelector.cardRootXpath)).map((card) =>
+      new WorkspaceCard(page).asCard(card)
     );
+
     console.log(`allCards:\n${allCards}`);
 
     const visibleCards: WorkspaceCard[] = await Promise.all(
-      allCards.filter(async (card) => {
-        await isElementReady(page, card);
-      })
+      await asyncFilter(allCards, async (card) => await isElementReady(page, card))
     );
     console.log(`visibleCards:\n${visibleCards}`);
 

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -60,14 +60,14 @@ export default class WorkspaceCard extends CardBase {
     );
 
     if (accessLevel !== undefined) {
-      const matchAccessLevelCards: WorkspaceCard[] = [];
+      const filtered: WorkspaceCard[] = [];
       for (const card of allCards) {
         const cardAccessLevel = await card.getWorkspaceAccessLevel();
         if (cardAccessLevel === accessLevel) {
-          matchAccessLevelCards.push(card);
+          filtered.push(card);
         }
       }
-      return matchAccessLevelCards;
+      return filtered;
     }
     return allCards;
   }
@@ -86,7 +86,7 @@ export default class WorkspaceCard extends CardBase {
       ` and normalize-space(text())="${workspaceName}"]]`;
     return page
       .waitForXPath(selector, { timeout, visible: true })
-      .then((element: ElementHandle) => {
+      .then((element) => {
         logger.info(`Found workspace card: "${workspaceName}"`);
         return new WorkspaceCard(page).asCard(element);
       })

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -8,6 +8,7 @@ import WorkspaceEditPage from 'app/page/workspace-edit-page';
 import { waitForFn, waitWhileLoading } from 'utils/waits-utils';
 import { logger } from 'libs/logger';
 import BaseElement from 'app/element/base-element';
+import { asyncFilter } from 'utils/test-utils';
 
 const WorkspaceCardSelector = {
   cardRootXpath: './/*[child::*[@data-test-id="workspace-card"]]', // finds 'workspace-card' parent container node
@@ -60,14 +61,10 @@ export default class WorkspaceCard extends CardBase {
     );
 
     if (accessLevel !== undefined) {
-      const filtered: WorkspaceCard[] = [];
-      for (const card of allCards) {
-        const cardAccessLevel = await card.getWorkspaceAccessLevel();
-        if (cardAccessLevel === accessLevel) {
-          filtered.push(card);
-        }
-      }
-      return filtered;
+      await asyncFilter(
+        allCards,
+        async (card: WorkspaceCard) => accessLevel === (await card.getWorkspaceAccessLevel())
+      );
     }
     return allCards;
   }
@@ -86,7 +83,7 @@ export default class WorkspaceCard extends CardBase {
       ` and normalize-space(text())="${workspaceName}"]]`;
     return page
       .waitForXPath(selector, { timeout, visible: true })
-      .then((element) => {
+      .then((element: ElementHandle) => {
         logger.info(`Found workspace card: "${workspaceName}"`);
         return new WorkspaceCard(page).asCard(element);
       })

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -56,13 +56,17 @@ export default class WorkspaceCard extends CardBase {
     });
 
     // Turn elements into WorkspaceCard objects.
-    const allCards: WorkspaceCard[] = (await page.$x(WorkspaceCardSelector.cardRootXpath)).map((card) =>
-      new WorkspaceCard(page).asCard(card)
+    const allCards: WorkspaceCard[] = await Promise.all(
+      (await page.$x(WorkspaceCardSelector.cardRootXpath)).map((card) => new WorkspaceCard(page).asCard(card))
     );
+    console.log(`allCards:\n${allCards}`);
 
-    const visibleCards: WorkspaceCard[] = allCards.filter(async (card) => {
-      await isElementReady(page, card);
-    });
+    const visibleCards: WorkspaceCard[] = await Promise.all(
+      allCards.filter(async (card) => {
+        await isElementReady(page, card);
+      })
+    );
+    console.log(`visibleCards:\n${visibleCards}`);
 
     if (accessLevel !== undefined) {
       const matchAccessLevelCards: WorkspaceCard[] = [];
@@ -72,6 +76,7 @@ export default class WorkspaceCard extends CardBase {
           matchAccessLevelCards.push(card);
         }
       }
+      console.log(`matchAccessLevelCards:\n${matchAccessLevelCards}`);
       return matchAccessLevelCards;
     }
     return visibleCards;

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -8,6 +8,7 @@ import WorkspaceEditPage from 'app/page/workspace-edit-page';
 import { waitForFn, waitWhileLoading } from 'utils/waits-utils';
 import { logger } from 'libs/logger';
 import BaseElement from 'app/element/base-element';
+import { isElementReady } from 'utils/test-utils';
 
 const WorkspaceCardSelector = {
   cardRootXpath: './/*[child::*[@data-test-id="workspace-card"]]', // finds 'workspace-card' parent container node
@@ -43,27 +44,37 @@ export default class WorkspaceCard extends CardBase {
    * @param {Page} page
    * @throws TimeoutError if fails to find Card.
    */
-  static async findAllCards(page: Page, accessLevel?: WorkspaceAccessLevel): Promise<WorkspaceCard[]> {
+  static async findAllCards(
+    page: Page,
+    opts: { accessLevel?: WorkspaceAccessLevel; timeout?: number } = {}
+  ): Promise<WorkspaceCard[]> {
+    const { accessLevel, timeout = 5000 } = opts;
     await waitWhileLoading(page);
-    await page.waitForXPath(WorkspaceCardSelector.cardRootXpath, { visible: true, timeout: 10000 }).catch(() => {
-      // Blank
+    // Wait until timeout for one card exists and visible. If none, return an empty array.
+    await page.waitForXPath(WorkspaceCardSelector.cardRootXpath, { visible: true, timeout }).catch(() => {
+      return [];
     });
 
-    const workspaceCards: WorkspaceCard[] = (await page.$x(WorkspaceCardSelector.cardRootXpath)).map((card) =>
+    // Turn elements into WorkspaceCard objects.
+    const allCards: WorkspaceCard[] = (await page.$x(WorkspaceCardSelector.cardRootXpath)).map((card) =>
       new WorkspaceCard(page).asCard(card)
     );
 
-    const filtered: WorkspaceCard[] = [];
+    const visibleCards: WorkspaceCard[] = allCards.filter(async (card) => {
+      await isElementReady(page, card);
+    });
+
     if (accessLevel !== undefined) {
-      for (const card of workspaceCards) {
+      const matchAccessLevelCards: WorkspaceCard[] = [];
+      for (const card of visibleCards) {
         const cardAccessLevel = await card.getWorkspaceAccessLevel();
         if (cardAccessLevel === accessLevel) {
-          filtered.push(card);
+          matchAccessLevelCards.push(card);
         }
       }
-      return filtered;
+      return matchAccessLevelCards;
     }
-    return workspaceCards;
+    return visibleCards;
   }
 
   static async findAnyCard(page: Page): Promise<WorkspaceCard> {
@@ -80,7 +91,7 @@ export default class WorkspaceCard extends CardBase {
       ` and normalize-space(text())="${workspaceName}"]]`;
     return page
       .waitForXPath(selector, { timeout, visible: true })
-      .then((element) => {
+      .then((element: ElementHandle) => {
         logger.info(`Found workspace card: "${workspaceName}"`);
         return new WorkspaceCard(page).asCard(element);
       })

--- a/e2e/app/component/workspace-card.ts
+++ b/e2e/app/component/workspace-card.ts
@@ -8,7 +8,6 @@ import WorkspaceEditPage from 'app/page/workspace-edit-page';
 import { waitForFn, waitWhileLoading } from 'utils/waits-utils';
 import { logger } from 'libs/logger';
 import BaseElement from 'app/element/base-element';
-import { asyncFilter, isElementReady } from 'utils/test-utils';
 
 const WorkspaceCardSelector = {
   cardRootXpath: './/*[child::*[@data-test-id="workspace-card"]]', // finds 'workspace-card' parent container node
@@ -60,25 +59,17 @@ export default class WorkspaceCard extends CardBase {
       new WorkspaceCard(page).asCard(card)
     );
 
-    console.log(`allCards:\n${allCards}`);
-
-    const visibleCards: WorkspaceCard[] = await Promise.all(
-      await asyncFilter(allCards, async (card) => await isElementReady(page, card))
-    );
-    console.log(`visibleCards:\n${visibleCards}`);
-
     if (accessLevel !== undefined) {
       const matchAccessLevelCards: WorkspaceCard[] = [];
-      for (const card of visibleCards) {
+      for (const card of allCards) {
         const cardAccessLevel = await card.getWorkspaceAccessLevel();
         if (cardAccessLevel === accessLevel) {
           matchAccessLevelCards.push(card);
         }
       }
-      console.log(`matchAccessLevelCards:\n${matchAccessLevelCards}`);
       return matchAccessLevelCards;
     }
-    return visibleCards;
+    return allCards;
   }
 
   static async findAnyCard(page: Page): Promise<WorkspaceCard> {

--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -1,4 +1,4 @@
-import { ClickOptions, ElementHandle, NavigationOptions, Page, WaitForSelectorOptions } from 'puppeteer';
+import { BoxModel, ClickOptions, ElementHandle, NavigationOptions, Page, WaitForSelectorOptions } from 'puppeteer';
 import { getAttrValue, getPropValue } from 'utils/element-utils';
 import { logger } from 'libs/logger';
 import { waitForFn } from 'utils/waits-utils';
@@ -115,7 +115,7 @@ export default class BaseElement {
    * </pre>
    */
   async isVisible(): Promise<boolean> {
-    const computedStyle = async (element) => {
+    const isDisplayed = async (element): Promise<boolean> => {
       const elementHandle = await this.page
         .evaluateHandle((elem) => {
           const style = window.getComputedStyle(elem);
@@ -127,13 +127,13 @@ export default class BaseElement {
       return (await elementHandle.jsonValue()) as boolean;
     };
 
-    const boxModel = async (element) => {
+    const boxModel = async (element): Promise<BoxModel | null> => {
       return element.boxModel();
     };
 
     return this.asElementHandle()
       .then((element) => {
-        return !!(computedStyle(element) && boxModel(element));
+        return !!(isDisplayed(element) && boxModel(element));
       })
       .catch(() => false);
   }

--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -124,7 +124,7 @@ export default class BaseElement {
         .catch(() => {
           return null;
         });
-      return await elementHandle.jsonValue() as boolean;
+      return (await elementHandle.jsonValue()) as boolean;
     };
 
     const boxModel = async (element) => {

--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -124,7 +124,7 @@ export default class BaseElement {
         .catch(() => {
           return null;
         });
-      return elementHandle.jsonValue();
+      return await elementHandle.jsonValue() as boolean;
     };
 
     const boxModel = async (element) => {

--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -133,7 +133,7 @@ export default class BaseElement {
 
     return this.asElementHandle()
       .then((element) => {
-        return !!(isDisplayed(element) && boxModel(element));
+        return isDisplayed(element) && !!boxModel(element);
       })
       .catch(() => false);
   }

--- a/e2e/jest-puppeteer.config.js
+++ b/e2e/jest-puppeteer.config.js
@@ -43,7 +43,6 @@ module.exports = {
     ignoreDefaultArgs: true,
     args: SWITCHES // Chrome switches to pass to the browser instance
   },
-  browser: 'chromium',
   browserContext: process.env.INCOGNITO || true ? 'incognito' : 'default',
   exitOnPageError: false
 };

--- a/e2e/tests/ui/cohort-ui.spec.ts
+++ b/e2e/tests/ui/cohort-ui.spec.ts
@@ -143,7 +143,6 @@ describe('Cohort UI Test', () => {
     const aWorkspaceCard = fp.shuffle(allWorkspaceCards)[0];
     const workspaceName = aWorkspaceCard.getWorkspaceName();
     await aWorkspaceCard.clickWorkspaceName();
-    3;
     return workspaceName;
   }
 });

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -314,7 +314,7 @@ export function isValidDate(date: string) {
   return d.toISOString().slice(0, 10) === date;
 }
 
-const asyncFilter = async (arr, predicate) =>
+export const asyncFilter = async (arr, predicate) =>
   arr.reduce(async (items, item) => ((await predicate(item)) ? [...(await items), item] : items), []);
 
 /**

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -254,10 +254,12 @@ export async function findAllCards(page: Page, millisAgo = 1000 * 60 * 30): Prom
   });
   // Filter to exclude Workspaces younger than 30 minutes.
   const halfHourAgoMillis = Date.now() - millisAgo;
-  await Promise.all(
-    await asyncFilter(existingCards, async (card) => halfHourAgoMillis > Date.parse(await card.getLastChangedTime()))
+  return Promise.all(
+    await asyncFilter(
+      existingCards,
+      async (card: WorkspaceCard) => halfHourAgoMillis > Date.parse(await card.getLastChangedTime())
+    )
   );
-  return existingCards;
 }
 
 export async function centerPoint(element: ElementHandle): Promise<[number, number]> {

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -91,7 +91,7 @@ export async function isVisibleReady(element: ElementHandle): Promise<boolean> {
     const style = window.getComputedStyle(elem);
     return style && style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
   }, element);
-  const visible = await visibleHandle.jsonValue() as boolean;
+  const visible = (await visibleHandle.jsonValue()) as boolean;
   const box = await element.boxModel();
   return visible && box !== null;
 }

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -81,6 +81,21 @@ export async function exists(page: Page, selector: string): Promise<boolean> {
 }
 
 /**
+ * Is element visible and ready for action.
+ * @param element
+ * @param page
+ */
+export async function isElementReady(page, element) {
+  const isVisibleHandle = await page.evaluateHandle((elem) => {
+    const style = window.getComputedStyle(elem);
+    return style && style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+  }, element);
+  const visible = await isVisibleHandle.jsonValue();
+  const box = await element.boxModel();
+  return visible && box;
+}
+
+/**
  * Perform array of UI actions defined.
  * @param fields
  */
@@ -249,7 +264,9 @@ export async function findOrCreateWorkspaceCard(
  * Find a suitable workspace among existing workspaces with OWNER role and older than specified time difference.
  */
 export async function findAllCards(page: Page, millisAgo = 1000 * 60 * 30): Promise<WorkspaceCard[]> {
-  const existingCards: WorkspaceCard[] = await WorkspaceCard.findAllCards(page, WorkspaceAccessLevel.Owner);
+  const existingCards: WorkspaceCard[] = await WorkspaceCard.findAllCards(page, {
+    accessLevel: WorkspaceAccessLevel.Owner
+  });
   // Filter to exclude Workspaces younger than 30 minutes.
   const halfHourAgoMillis = Date.now() - millisAgo;
   return Promise.all(

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -300,7 +300,7 @@ export function isValidDate(date: string) {
   return d.toISOString().slice(0, 10) === date;
 }
 
-const asyncFilter = async (arr, predicate) =>
+export const asyncFilter = async (arr, predicate) =>
   arr.reduce(async (items, item) => ((await predicate(item)) ? [...(await items), item] : items), []);
 
 /**

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -81,22 +81,6 @@ export async function exists(page: Page, selector: string): Promise<boolean> {
 }
 
 /**
- * Is element visible and ready for action.
- * @param element
- * @param page
- */
-export async function isVisibleReady(element: ElementHandle): Promise<boolean> {
-  const handle = await element.asElement();
-  const visibleHandle = await handle.evaluateHandle((elem) => {
-    const style = window.getComputedStyle(elem);
-    return style && style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
-  }, element);
-  const visible = (await visibleHandle.jsonValue()) as boolean;
-  const box = await element.boxModel();
-  return visible && box !== null;
-}
-
-/**
  * Perform array of UI actions defined.
  * @param fields
  */


### PR DESCRIPTION
Looks like the `findAllCards` function is flaky: clicking on card name fails on rare occasions.

It caused `dataset-ui.spec` to fail in this CircleCI [job](https://app.circleci.com/pipelines/github/all-of-us/workbench/16042/workflows/530d3bd6-a0c3-4bf1-bffb-77e386fe1aa2/jobs/181979/parallel-runs/0?filterBy=FAILED).