### PR TITLE
[RW-7381][risk=no] adding exact match for synonyms

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -164,16 +164,14 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
         standardConceptIds.stream().map(Object::toString).collect(Collectors.toList());
     if (!sourceIds.isEmpty()) {
       criteriaList.addAll(
-          cbCriteriaDao
-              .findCriteriaByDomainIdAndStandardAndConceptIds(domainId, false, sourceIds)
+          cbCriteriaDao.findCriteriaByDomainIdAndStandardAndConceptIds(domainId, false, sourceIds)
               .stream()
               .map(cohortBuilderMapper::dbModelToClient)
               .collect(Collectors.toList()));
     }
     if (!standardConceptIds.isEmpty()) {
       criteriaList.addAll(
-          cbCriteriaDao
-              .findCriteriaByDomainIdAndStandardAndConceptIds(domainId, true, standardIds)
+          cbCriteriaDao.findCriteriaByDomainIdAndStandardAndConceptIds(domainId, true, standardIds)
               .stream()
               .map(cohortBuilderMapper::dbModelToClient)
               .collect(Collectors.toList()));

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -66,7 +66,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   private static final Integer DEFAULT_TREE_SEARCH_LIMIT = 100;
   private static final Integer DEFAULT_CRITERIA_SEARCH_LIMIT = 250;
   private static final ImmutableList<String> MYSQL_FULL_TEXT_CHARS =
-      ImmutableList.of("\"", "+", "-", "*", "(", ")");
+      ImmutableList.of("\"", "+", "-", "*");
 
   private final BigQueryService bigQueryService;
   private final CohortQueryBuilder cohortQueryBuilder;
@@ -164,14 +164,16 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
         standardConceptIds.stream().map(Object::toString).collect(Collectors.toList());
     if (!sourceIds.isEmpty()) {
       criteriaList.addAll(
-          cbCriteriaDao.findCriteriaByDomainIdAndStandardAndConceptIds(domainId, false, sourceIds)
+          cbCriteriaDao
+              .findCriteriaByDomainIdAndStandardAndConceptIds(domainId, false, sourceIds)
               .stream()
               .map(cohortBuilderMapper::dbModelToClient)
               .collect(Collectors.toList()));
     }
     if (!standardConceptIds.isEmpty()) {
       criteriaList.addAll(
-          cbCriteriaDao.findCriteriaByDomainIdAndStandardAndConceptIds(domainId, true, standardIds)
+          cbCriteriaDao
+              .findCriteriaByDomainIdAndStandardAndConceptIds(domainId, true, standardIds)
               .stream()
               .map(cohortBuilderMapper::dbModelToClient)
               .collect(Collectors.toList()));
@@ -502,16 +504,12 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   private String modifyTermMatch(String term) {
     term = removeStopWords(term);
     if (MYSQL_FULL_TEXT_CHARS.stream().anyMatch(term::contains)) {
-      return Arrays.stream(term.split("\\s+"))
-          .map(
-              s -> {
-                if (s.startsWith("(")
-                    || (!s.startsWith("+") && !s.startsWith("-") && !s.endsWith(")"))) {
-                  return "+" + s;
-                }
-                return s;
-              })
-          .collect(Collectors.joining(" "));
+      // doesn't start with special char so find exact match
+      if (term.matches("^[a-zA-Z0-9].*")) {
+        return "+\"" + term + "\"";
+      }
+      // starts with a special char so don't mutate.
+      return term;
     }
 
     String[] keywords = term.split("\\W+");

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -464,10 +464,9 @@ export const withAsyncErrorHandling = fp.curry(
 
 
 // Takes a search string and validates for the most common MySQL use cases.
-// Checks for unbalanced (), unclosed "", trailing + or -, and breaking special characters.
+// Checks for unclosed "", trailing + or -, and breaking special characters.
 export function validateInputForMySQL(searchString: string): Array<string> {
   const inputErrors = new Set<string>(); // use Set to prevent duplicate messages
-  let openParensCount = 0;
   let unclosedQuotes = false;
   for (let i = 0; i < searchString.length; i++) {
     const character = searchString[i];
@@ -480,8 +479,8 @@ export function validateInputForMySQL(searchString: string): Array<string> {
       continue;
     }
     // Check for characters that break search
-    if ('~@[]|<>'.indexOf(character) > -1) {
-      inputErrors.add('The following characters are not allowed in the search string: ~ @ [ ] | < >');
+    if ('~@[]|<>()'.indexOf(character) > -1) {
+      inputErrors.add('The following characters are not allowed in the search string: ~ @ [ ] | < > ( )');
       continue;
     }
     // Check for trailing + or -
@@ -489,25 +488,6 @@ export function validateInputForMySQL(searchString: string): Array<string> {
       inputErrors.add(`Trailing ${character} characters are not allowed in the search string`);
       continue;
     }
-    const parenPosition = '()'.indexOf(character);
-    if (parenPosition === -1) {
-      // Parens are the last character check, so we can continue if it's something else
-      continue;
-    }
-    if (parenPosition === 0) {
-      openParensCount++; // increment the number of unclosed parens
-    } else {
-      if (openParensCount === 0) {
-        // too many closing parens
-        inputErrors.add('There are too many ) characters in the search string');
-        continue;
-      }
-      openParensCount--; // decrement the number of unclosed parens
-    }
-  }
-  if (openParensCount > 0) {
-    // unclosed paren
-    inputErrors.add('There is an unclosed ( in the search string');
   }
   if (unclosedQuotes) {
     // unclosed quote


### PR DESCRIPTION
Search terms with dashes(Sars-Cov-2) aren't returning matches in CB search. Had to add  double quotes around the search term for mysql full text index to match on words containing dashes. Also, removed use of parentheses as it was causing to many problems.