### PR TITLE
[risk=low][RW-7575] Workspace Action Menu actions disabled if admin-locked 

### DIFF
--- a/ui/src/app/pages/workspace/workspace-actions-menu.tsx
+++ b/ui/src/app/pages/workspace/workspace-actions-menu.tsx
@@ -41,7 +41,7 @@ export const WorkspaceActionsMenu = (props: WorkspaceActionsProps) => {
 
   const ownerTip = 'Requires owner permission';
   const lockedTip = 'Workspace is locked by admin';
-  
+
   return <React.Fragment>
     <div style={styles.dropdownHeader}>Workspace Actions</div>
     <MenuItem

--- a/ui/src/app/pages/workspace/workspace-actions-menu.tsx
+++ b/ui/src/app/pages/workspace/workspace-actions-menu.tsx
@@ -36,35 +36,39 @@ interface WorkspaceActionsProps {
   onDelete: Function,
 }
 export const WorkspaceActionsMenu = (props: WorkspaceActionsProps) => {
-  const {workspace, workspace: {accessLevel}, onDuplicate, onEdit, onShare, onDelete } = props;
+  const {workspace, workspace: {accessLevel, adminLocked}, onDuplicate, onEdit, onShare, onDelete } = props;
   const isNotOwner = !workspace || accessLevel !== WorkspaceAccessLevel.OWNER;
-  const tooltip = isNotOwner && 'Requires owner permission';
 
+  const ownerTip = 'Requires owner permission';
+  const lockedTip = 'Workspace is locked by admin';
+  
   return <React.Fragment>
     <div style={styles.dropdownHeader}>Workspace Actions</div>
     <MenuItem
       icon='copy'
+      tooltip={adminLocked && lockedTip}
+      disabled={adminLocked}
       onClick={() => onDuplicate()}>
       Duplicate
     </MenuItem>
     <MenuItem
       icon='pencil'
-      tooltip={tooltip}
+      tooltip={isNotOwner && ownerTip}
       disabled={isNotOwner}
       onClick={() => onEdit()}>
       Edit
     </MenuItem>
     <MenuItem
       icon='share'
-      tooltip={tooltip}
-      disabled={isNotOwner}
+      tooltip={(isNotOwner && ownerTip) || (adminLocked && lockedTip)}
+      disabled={isNotOwner || adminLocked}
       onClick={() => onShare()}>
       Share
     </MenuItem>
     <MenuItem
       icon='trash'
-      tooltip={tooltip}
-      disabled={isNotOwner}
+      tooltip={(isNotOwner && ownerTip) || (adminLocked && lockedTip)}
+      disabled={isNotOwner || adminLocked}
       onClick={() => onDelete()}>
       Delete
     </MenuItem>

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -98,7 +98,7 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
     closeOnClick
     content={
       <React.Fragment>
-        <TooltipTrigger content={lockedTip}
+        <TooltipTrigger content={<div data-test-id='workspace-duplicate-disabled-tooltip'>{lockedTip}</div>}
                         disabled={!workspace.adminLocked}>
         <MenuItem icon='copy'
                   onClick={() => {
@@ -113,7 +113,7 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
           Duplicate
         </MenuItem>
         </TooltipTrigger>
-        <TooltipTrigger content={ownerTip}
+        <TooltipTrigger content={<div data-test-id='workspace-edit-disabled-tooltip'>{ownerTip}</div>}
                         disabled={WorkspacePermissionsUtil.isOwner(accessLevel)}>
           <MenuItem icon='pencil'
                     onClick={() => {
@@ -124,7 +124,7 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
             Edit
           </MenuItem>
         </TooltipTrigger>
-        <TooltipTrigger content={workspace.adminLocked ? lockedTip : ownerTip}
+        <TooltipTrigger content={<div data-test-id='workspace-share-disabled-tooltip'>{workspace.adminLocked ? lockedTip : ownerTip}</div>}
                         disabled={!(!WorkspacePermissionsUtil.isOwner(accessLevel) || workspace.adminLocked)}>
           <MenuItem icon='pencil'
                     onClick={() => {
@@ -135,7 +135,7 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
             Share
           </MenuItem>
         </TooltipTrigger>
-        <TooltipTrigger content={workspace.adminLocked ? lockedTip : ownerTip}
+        <TooltipTrigger content={<div data-test-id='workspace-delete-disabled-tooltip'>{workspace.adminLocked ? lockedTip : ownerTip}</div>}
                         disabled={!(!WorkspacePermissionsUtil.isOwner(accessLevel) || workspace.adminLocked)}>
           <MenuItem icon='trash'
                     onClick={() => {

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -90,19 +90,15 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
 
   const wsPathPrefix = 'workspaces/' + workspace.namespace + '/' + workspace.id;
 
-  const getTooltipContents = (isAdminLocked: boolean): string => {
-    if (isAdminLocked) {
-      return 'Workspace is locked by admin';
-    }
-    return 'Requires Owner Permission';
-  }
+  const lockedTip = 'Workspace is locked by admin';
+  const ownerTip = 'Requires Owner Permission';
 
   return <PopupTrigger
     side='bottom'
     closeOnClick
     content={
       <React.Fragment>
-        <TooltipTrigger content={<div data-test-id='workspace-duplicate-disabled-tooltip'>{getTooltipContents(workspace.adminLocked)}</div>}
+        <TooltipTrigger content={lockedTip}
                         disabled={!workspace.adminLocked}>
         <MenuItem icon='copy'
                   onClick={() => {
@@ -117,7 +113,7 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
           Duplicate
         </MenuItem>
         </TooltipTrigger>
-        <TooltipTrigger content={<div>Requires Owner Permission</div>}
+        <TooltipTrigger content={ownerTip}
                         disabled={WorkspacePermissionsUtil.isOwner(accessLevel)}>
           <MenuItem icon='pencil'
                     onClick={() => {
@@ -128,7 +124,7 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
             Edit
           </MenuItem>
         </TooltipTrigger>
-        <TooltipTrigger content={<div data-test-id='workspace-share-disabled-tooltip'>{getTooltipContents(workspace.adminLocked)}</div>}
+        <TooltipTrigger content={workspace.adminLocked ? lockedTip : ownerTip}
                         disabled={!(!WorkspacePermissionsUtil.isOwner(accessLevel) || workspace.adminLocked)}>
           <MenuItem icon='pencil'
                     onClick={() => {
@@ -139,7 +135,7 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
             Share
           </MenuItem>
         </TooltipTrigger>
-        <TooltipTrigger content={<div>{getTooltipContents(workspace.adminLocked)}</div>}
+        <TooltipTrigger content={workspace.adminLocked ? lockedTip : ownerTip}
                         disabled={!(!WorkspacePermissionsUtil.isOwner(accessLevel) || workspace.adminLocked)}>
           <MenuItem icon='trash'
                     onClick={() => {

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -90,11 +90,20 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
 
   const wsPathPrefix = 'workspaces/' + workspace.namespace + '/' + workspace.id;
 
+  const getTooltipContents = (isAdminLocked: boolean): string => {
+    if (isAdminLocked) {
+      return 'Workspace is locked by admin';
+    }
+    return 'Requires Owner Permission';
+  }
+
   return <PopupTrigger
     side='bottom'
     closeOnClick
     content={
       <React.Fragment>
+        <TooltipTrigger content={<div data-test-id='workspace-duplicate-disabled-tooltip'>{getTooltipContents(workspace.adminLocked)}</div>}
+                        disabled={!workspace.adminLocked}>
         <MenuItem icon='copy'
                   onClick={() => {
                     // Using workspace.published here to identify Featured Workspaces. At some point, we will need a separate property for
@@ -103,9 +112,11 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
                       AnalyticsTracker.Workspaces.DuplicateFeatured(workspace.name) :
                       AnalyticsTracker.Workspaces.OpenDuplicatePage('Card');
                     navigate([wsPathPrefix, 'duplicate']);
-                  }}>
+                  }}
+                  disabled={workspace.adminLocked}>
           Duplicate
         </MenuItem>
+        </TooltipTrigger>
         <TooltipTrigger content={<div>Requires Owner Permission</div>}
                         disabled={WorkspacePermissionsUtil.isOwner(accessLevel)}>
           <MenuItem icon='pencil'
@@ -117,25 +128,25 @@ const WorkspaceCardMenu: React.FunctionComponent<WorkspaceCardMenuProps> = ({
             Edit
           </MenuItem>
         </TooltipTrigger>
-        <TooltipTrigger content={<div data-test-id='workspace-share-disabled-tooltip'>Requires Owner Permission</div>}
-                        disabled={WorkspacePermissionsUtil.isOwner(accessLevel)}>
+        <TooltipTrigger content={<div data-test-id='workspace-share-disabled-tooltip'>{getTooltipContents(workspace.adminLocked)}</div>}
+                        disabled={!(!WorkspacePermissionsUtil.isOwner(accessLevel) || workspace.adminLocked)}>
           <MenuItem icon='pencil'
                     onClick={() => {
                       AnalyticsTracker.Workspaces.OpenShareModal('Card');
                       onShare();
                     }}
-                    disabled={!WorkspacePermissionsUtil.isOwner(accessLevel)}>
+                    disabled={!WorkspacePermissionsUtil.isOwner(accessLevel) || workspace.adminLocked}>
             Share
           </MenuItem>
         </TooltipTrigger>
-        <TooltipTrigger content={<div>Requires Owner Permission</div>}
-                        disabled={WorkspacePermissionsUtil.isOwner(accessLevel)}>
+        <TooltipTrigger content={<div>{getTooltipContents(workspace.adminLocked)}</div>}
+                        disabled={!(!WorkspacePermissionsUtil.isOwner(accessLevel) || workspace.adminLocked)}>
           <MenuItem icon='trash'
                     onClick={() => {
                       AnalyticsTracker.Workspaces.OpenDeleteModal('Card');
                       onDelete();
                     }}
-                    disabled={!WorkspacePermissionsUtil.isOwner(accessLevel)}>
+                    disabled={!WorkspacePermissionsUtil.isOwner(accessLevel) || workspace.adminLocked}>
             Delete
           </MenuItem>
         </TooltipTrigger>


### PR DESCRIPTION
Workspaces and Sidebar have a Workspace Actions Menu.  Update both so these actions are disabled if the workspace is admin-locked:
* copy
* share
* delete

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
