### PR TITLE
[RW-7591][risk=no] Fix terminal link interactions

### DIFF
--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -24,7 +24,7 @@ import {
   WorkspacesApi
 } from 'generated/fetch';
 import defaultServerConfig from 'testing/default-server-config';
-import {waitForFakeTimersAndUpdate} from 'testing/react-test-helpers';
+import { mountWithRouter, waitForFakeTimersAndUpdate} from 'testing/react-test-helpers';
 import {CohortAnnotationDefinitionServiceStub} from 'testing/stubs/cohort-annotation-definition-service-stub';
 import {CohortReviewServiceStub, cohortReviewStubs} from 'testing/stubs/cohort-review-service-stub';
 import {workspaceDataStub} from 'testing/stubs/workspaces';
@@ -77,7 +77,7 @@ describe('HelpSidebar', () => {
   let props: {};
 
   const component = async() => {
-    const c = mount(<HelpSidebar {...props} />, {attachTo: document.getElementById('root')});
+    const c = mountWithRouter(<HelpSidebar {...props} />, {attachTo: document.getElementById('root')});
     await waitForFakeTimersAndUpdate(c);
     return c;
   };
@@ -145,7 +145,9 @@ describe('HelpSidebar', () => {
     const wrapper = await component();
     await setActiveIcon(wrapper, 'help');
     expect(wrapper.find('[data-test-id="section-title-0"]').text()).toBe(sidebarContent.data[0].title);
-    wrapper.setProps({pageKey: 'cohortBuilder'});
+    wrapper.setProps({
+      children: <HelpSidebar {...props} pageKey="cohortBuilder" />
+    });
     expect(wrapper.find('[data-test-id="section-title-0"]').text()).toBe(sidebarContent.cohortBuilder[0].title);
   });
 

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -86,6 +86,7 @@ import runtime from 'assets/icons/thunderstorm-solid.svg';
 import times from 'assets/icons/times-light.svg';
 import {RuntimeErrorModal} from './runtime-error-modal';
 import {WorkspaceActionsMenu} from 'app/pages/workspace/workspace-actions-menu';
+import { RouteLink } from './app-router';
 
 export const LOCAL_STORAGE_KEY_SIDEBAR_STATE = 'WORKSPACE_SIDEBAR_STATE';
 
@@ -497,11 +498,6 @@ export const HelpSidebar = fp.flow(
       openZendeskWidget(givenName, familyName, username, contactEmail);
     }
 
-    navigateToTerminal() {
-      const {workspace: {id, namespace}} = this.props;
-      this.props.navigate(['workspaces', namespace, id, 'terminals']);
-    }
-
     analyticsEvent(type: string, label?: string) {
       const {pageKey} = this.props;
       const analyticsLabel = pageKeyToAnalyticsLabels[pageKey];
@@ -854,13 +850,13 @@ export const HelpSidebar = fp.flow(
                         ],
                         ['runtime', () => this.displayRuntimeIcon(icon)],
                         ['terminal',
-                          () =>
+                         () => <RouteLink
+                                 path={`/workspaces/${namespace}/${id}/terminals`} >
                              <FontAwesomeIcon
                                  data-test-id={'help-sidebar-icon-' + icon.id}
-                                 icon={icon.faIcon} style={icon.style}
-                                 onClick={() => this.navigateToTerminal()}/>
-
-                          ],
+                                 icon={icon.faIcon} style={icon.style} />
+                          </RouteLink>
+                        ],
                         ['genomicExtractions', () => this.displayExtractionIcon(icon)],
                         [DEFAULT, () => icon.faIcon === null
                               ? <img data-test-id={'help-sidebar-icon-' + icon.id} src={proIcons[icon.id]} style={icon.style} />

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -23,7 +23,6 @@ import {WorkspaceAbout} from 'app/pages/workspace/workspace-about';
 import {WorkspaceEdit, WorkspaceEditMode} from 'app/pages/workspace/workspace-edit';
 import {LeoApplicationType} from 'app/pages/analysis/leonardo-app-launcher';
 import {BreadcrumbType} from 'app/utils/navigation';
-import {MatchParams} from 'app/utils/stores';
 import {adminLockedGuard} from 'app/routing/guards';
 
 const CohortPagePage = fp.flow(withRouteData, withRoutingSpinner)(CohortPage);
@@ -98,6 +97,7 @@ export const WorkspaceRoutes = () => {
     </AppRoute>
     <AppRoute exact path={`${path}/notebooks/:nbName`} guards={[adminLockedGuard()]}>
       <LeonardoAppRedirectPage
+          key="notebook"
           routeData={{
             pathElementForTitle: 'nbName',
             breadcrumb: BreadcrumbType.Notebook,
@@ -114,6 +114,7 @@ export const WorkspaceRoutes = () => {
     </AppRoute>
     <AppRoute exact path={`${path}/terminals`} guards={[adminLockedGuard()]}>
       <LeonardoAppRedirectPage
+          key="terminal"
           routeData={{
             breadcrumb: BreadcrumbType.Workspace,
             pageKey: LEONARDO_APP_PAGE_KEY,

--- a/ui/src/testing/react-test-helpers.tsx
+++ b/ui/src/testing/react-test-helpers.tsx
@@ -1,4 +1,4 @@
-import {mount, ReactWrapper} from 'enzyme';
+import { mount, MountRendererProps, ReactWrapper} from 'enzyme';
 import * as React from 'react';
 import {act} from 'react-dom/test-utils';
 import * as fp from 'lodash/fp';

--- a/ui/src/testing/react-test-helpers.tsx
+++ b/ui/src/testing/react-test-helpers.tsx
@@ -33,12 +33,12 @@ export async function simulateSelection(selectElement: ReactWrapper, selection: 
   await waitOneTickAndUpdate(selectElement);
 }
 
-export function mountWithRouter(children: string | React.ReactNode) {
+export function mountWithRouter(children: string | React.ReactNode, options?: MountRendererProps) {
   // It would be ideal to unwrap down to the child wrapper here, but unfortunately
   // wrapper.update() only works on the root node - and most tests need to call that.
   return mount(<MemoryRouter>
     {children}
-  </MemoryRouter>);
+  </MemoryRouter>, options);
 };
 
 // We only want to check against the actual text node


### PR DESCRIPTION
- Use `key` distinction to avoid reusing the `LeonardoAppRouter` component - it currently does not support reuse. Currently this manifests as a prop change on the same component if you do a direct navigation.
- Switch to RouteLink so users can ctrl+click the terminal icon for a new tab if they want to

I'm out next week, so feel free to merge this for me if you approve.