### PR TITLE
[RW-7498][risk=no] Fix FileDetail name mapping

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -16,7 +16,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
@@ -329,10 +328,9 @@ public class UserMetricsController implements UserMetricsApiDelegate {
       log.log(Level.SEVERE, String.format("Invalid notebook file path found: %s", str));
       return null;
     }
-    int pos = str.lastIndexOf('/') + 1;
-    String fileName = str.substring(pos);
-    String replacement = Matcher.quoteReplacement(fileName) + "$";
-    String filePath = str.replaceFirst(replacement, "");
-    return new FileDetail().name(fileName).path(filePath);
+    int filenameStart = str.lastIndexOf('/') + 1;
+    return new FileDetail()
+        .name(str.substring(filenameStart))
+        .path(str.substring(0, filenameStart));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -36,6 +36,7 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.model.Cohort;
 import org.pmiops.workbench.model.Domain;
+import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.RecentResourceRequest;
 import org.pmiops.workbench.model.WorkspaceResource;
 import org.pmiops.workbench.model.WorkspaceResourceResponse;
@@ -270,6 +271,19 @@ public class UserMetricsControllerTest {
     assertThat(recentResources.get(0).getNotebook().getPath())
         .isEqualTo("gs://bucketFile/notebooks/notebook.ipynb/");
     assertThat(recentResources.get(0).getNotebook().getName()).isEqualTo("");
+  }
+
+  // RW-7498 regression test
+  @Test
+  public void testGetUserRecentResource_notebookNameWithParen() {
+    dbUserRecentResource1.setNotebookName("gs://bucketFile/notebooks/notebook :).ipynb");
+    when(mockUserRecentResourceService.findAllResourcesByUser(dbUser.getUserId()))
+        .thenReturn(Collections.singletonList(dbUserRecentResource1));
+
+    WorkspaceResourceResponse recentResources =
+        userMetricsController.getUserRecentResources().getBody();
+    assertThat(recentResources.get(0).getNotebook())
+        .isEqualTo(new FileDetail().path("gs://bucketFile/notebooks/").name("notebook :).ipynb"));
   }
 
   @Test


### PR DESCRIPTION
No idea why it was originally implemented like this. Usage of `String.replaceFirst` was entirely unnecessary and was the cause of this bug.