### PR TITLE
[risk-low][RW-7060] Show a toast-banner when the user is newly eligible for Controlled Tier 

### DIFF
--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4043,6 +4043,7 @@ definitions:
       - accessTierShortName
       - accessTierDisplayName
       - defaultCdrVersionId
+      - defaultCdrVersionCreationTime
       - versions
     properties:
       accessTierShortName:
@@ -4051,7 +4052,12 @@ definitions:
         type: string
       defaultCdrVersionId:
         type: string
+      defaultCdrVersionCreationTime:
+        type: integer
         format: int64
+        description:
+          Milliseconds since the UNIX epoch. This timestamp is derived from the deid dataset name.
+          Ex - deid_output_20191004 -> 2019-10-04 00:00:00Z
       versions:
         type: array
         items:

--- a/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
@@ -283,35 +283,39 @@ public class CdrVersionServiceTest {
   }
 
   private void assertExpectedResponse(CdrVersionTiersResponse response) {
-    List<String> responseTiers =
+    List<String> shortNames =
         response.getTiers().stream()
             .map(CdrVersionTier::getAccessTierShortName)
             .collect(Collectors.toList());
-    assertThat(responseTiers)
+    assertThat(shortNames)
         .containsExactly(registeredTier.getShortName(), controlledTier.getShortName());
 
-    List<CdrVersion> responseVersions =
-        response.getTiers().stream()
-            .map(CdrVersionTier::getVersions)
-            .flatMap(List::stream)
-            .collect(Collectors.toList());
-    assertThat(responseVersions)
-        .containsExactly(
-            cdrVersionMapper.dbModelToClient(defaultCdrVersion),
-            cdrVersionMapper.dbModelToClient(controlledCdrVersion));
+    CdrVersionTier rtResponse = parseTier(response, registeredTier.getShortName());
+    CdrVersion rtExpectedVersion = cdrVersionMapper.dbModelToClient(defaultCdrVersion);
+    assertThat(rtResponse.getVersions()).containsExactly(rtExpectedVersion);
+    assertThat(rtResponse.getDefaultCdrVersionId()).isEqualTo(rtExpectedVersion.getCdrVersionId());
+    assertThat(rtResponse.getDefaultCdrVersionCreationTime())
+        .isEqualTo(rtExpectedVersion.getCreationTime());
+
+    CdrVersionTier ctResponse = parseTier(response, controlledTier.getShortName());
+    CdrVersion ctExpectedVersion = cdrVersionMapper.dbModelToClient(controlledCdrVersion);
+    assertThat(ctResponse.getVersions()).containsExactly(ctExpectedVersion);
+    assertThat(ctResponse.getDefaultCdrVersionId()).isEqualTo(ctExpectedVersion.getCdrVersionId());
+    assertThat(ctResponse.getDefaultCdrVersionCreationTime())
+        .isEqualTo(ctExpectedVersion.getCreationTime());
   }
 
   private void testGetCdrVersionsHasDataType(Predicate<CdrVersion> hasType) {
     addMembershipForTest(registeredTier);
     final List<CdrVersion> cdrVersions =
-        parseRegisteredTier(cdrVersionService.getCdrVersionsByTier());
+        parseTierVersions(cdrVersionService.getCdrVersionsByTier(), registeredTier.getShortName());
     // hasFitBitData, hasCopeSurveyData, hasMicroarrayData, and hasWgsData are false by default
     assertThat(cdrVersions.stream().anyMatch(hasType)).isFalse();
 
     makeCdrVersion(
         3L, true, "Test CDR With Data Types", 123L, registeredTier, "wgs", true, true, "", "");
     final List<CdrVersion> newVersions =
-        parseRegisteredTier(cdrVersionService.getCdrVersionsByTier());
+        parseTierVersions(cdrVersionService.getCdrVersionsByTier(), registeredTier.getShortName());
 
     Optional<CdrVersion> cdrVersionMaybe =
         newVersions.stream()
@@ -321,13 +325,19 @@ public class CdrVersionServiceTest {
     assertThat(hasType.test(cdrVersionMaybe.get())).isTrue();
   }
 
-  private List<CdrVersion> parseRegisteredTier(CdrVersionTiersResponse cdrVersionsByTier) {
+  private CdrVersionTier parseTier(
+      CdrVersionTiersResponse cdrVersionsByTier, String accessTierShortName) {
     Optional<CdrVersionTier> tierVersions =
         cdrVersionsByTier.getTiers().stream()
-            .filter(x -> x.getAccessTierShortName().equals(registeredTier.getShortName()))
+            .filter(x -> x.getAccessTierShortName().equals(accessTierShortName))
             .findFirst();
     assertThat(tierVersions).isPresent();
-    return tierVersions.get().getVersions();
+    return tierVersions.get();
+  }
+
+  private List<CdrVersion> parseTierVersions(
+      CdrVersionTiersResponse cdrVersionsByTier, String accessTierShortName) {
+    return parseTier(cdrVersionsByTier, accessTierShortName).getVersions();
   }
 
   private DbCdrVersion makeCdrVersion(

--- a/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
@@ -5,7 +5,6 @@ import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
-import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -110,55 +109,19 @@ public class CdrVersionServiceTest {
 
     defaultCdrVersion =
         makeCdrVersion(
-            1L,
-            /* isDefault */ true,
-            "Test Registered CDR",
-            123L,
-            registeredTier,
-            null,
-            null,
-            null,
-            "",
-            "");
+            1L, /* isDefault */ true, "Test Registered CDR", registeredTier, null, false, false);
     nonDefaultCdrVersion =
         makeCdrVersion(
-            2L,
-            /* isDefault */ false,
-            "Old Registered CDR",
-            123L,
-            registeredTier,
-            null,
-            null,
-            null,
-            "",
-            "");
+            2L, /* isDefault */ false, "Old Registered CDR", registeredTier, null, false, false);
 
     controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
 
     controlledCdrVersion =
         makeCdrVersion(
-            3L,
-            /* isDefault */ true,
-            "Test Controlled CDR",
-            456L,
-            controlledTier,
-            null,
-            null,
-            null,
-            "gs://lol",
-            "gs://lol");
+            3L, /* isDefault */ true, "Test Controlled CDR", controlledTier, null, false, false);
     controlledNonDefaultCdrVersion =
         makeCdrVersion(
-            4L,
-            /* isDefault */ false,
-            "Old Controlled CDR",
-            456L,
-            controlledTier,
-            null,
-            null,
-            null,
-            "gs://lol",
-            "gs://lol");
+            4L, /* isDefault */ false, "Old Controlled CDR", controlledTier, null, false, false);
   }
 
   @Test
@@ -344,8 +307,7 @@ public class CdrVersionServiceTest {
     // hasFitBitData, hasCopeSurveyData, hasMicroarrayData, and hasWgsData are false by default
     assertThat(cdrVersions.stream().anyMatch(hasType)).isFalse();
 
-    makeCdrVersion(
-        5L, true, "Test CDR With Data Types", 123L, registeredTier, "wgs", true, true, "", "");
+    makeCdrVersion(5L, true, "Test CDR With Data Types", registeredTier, "wgs", true, true);
     final List<CdrVersion> newVersions =
         parseTierVersions(cdrVersionService.getCdrVersionsByTier(), registeredTier.getShortName());
 
@@ -376,29 +338,21 @@ public class CdrVersionServiceTest {
       long cdrVersionId,
       boolean isDefault,
       String name,
-      long creationTime,
       DbAccessTier accessTier,
       String wgsDataset,
-      Boolean hasFitbit,
-      Boolean hasCopeSurveyData,
-      String allSamplesWgsDataBucket,
-      String singleSampleArrayDataBucket) {
+      boolean hasFitbit,
+      boolean hasCopeSurveyData) {
     DbCdrVersion cdrVersion = new DbCdrVersion();
     cdrVersion.setIsDefault(isDefault);
     cdrVersion.setBigqueryDataset("a");
     cdrVersion.setBigqueryProject("b");
     cdrVersion.setCdrDbName("c");
     cdrVersion.setCdrVersionId(cdrVersionId);
-    cdrVersion.setCreationTime(new Timestamp(creationTime));
     cdrVersion.setAccessTier(accessTier);
     cdrVersion.setName(name);
-    cdrVersion.setNumParticipants(123);
-    cdrVersion.setReleaseNumber((short) 1);
     cdrVersion.setWgsBigqueryDataset(wgsDataset);
     cdrVersion.setHasFitbitData(hasFitbit);
     cdrVersion.setHasCopeSurveyData(hasCopeSurveyData);
-    cdrVersion.setAllSamplesWgsDataBucket(allSamplesWgsDataBucket);
-    cdrVersion.setSingleSampleArrayDataBucket(singleSampleArrayDataBucket);
     return cdrVersionDao.save(cdrVersion);
   }
 

--- a/ui/src/app/components/ct-available-banner-maybe.spec.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.spec.tsx
@@ -9,6 +9,7 @@ import {AccessTierShortNames} from 'app/utils/access-tiers';
 import {environment} from 'environments/environment';
 import {CdrVersionTier, Profile, UserTierEligibility} from 'generated/fetch';
 import {cdrVersionTiersResponse} from 'testing/stubs/cdr-versions-api-stub';
+import {waitOneTickAndUpdate} from "../../testing/react-test-helpers";
 
 // 3 times, in order
 const [TIME1, TIME2, TIME3] = [10000, 20000, 30000];
@@ -120,19 +121,22 @@ describe('CTAvailableBannerMaybe', () => {
   }
 
   test.each([
-    ['there is no visible CT', ctNotVisible],
-    ['the user is not CT eligible', userIneligible],
-    ['the user has CT access already', ctAccess],
-    ['the user is too new', userIsNew],
-    ['the user is currently visiting the DAR', darActive],
+    ['there is no visible CT', ctNotVisible, () => {}],
+    ['the user is not CT eligible', userIneligible, () => {}],
+    ['the user has CT access already', ctAccess, () => {}],
+    ['the user is too new', userIsNew, () => {}],
+    ['the user is currently visiting the DAR', () => {}, darActive],
   ])
-  ('should not render if all of the requirements are met, except that %s', (unused, modifier) => {
+  ('should not render if all of the requirements are met, except that %s', (desc, preMountModifier, postMountModifier) => {
     fulfillAllBannerRequirements();
 
-    modifier();
+    preMountModifier();
 
     const wrapper = component();
     expect(wrapper.exists()).toBeTruthy();
+
+    postMountModifier();
+    waitOneTickAndUpdate(wrapper);
 
     expect(ctBannerExists(wrapper)).toBeFalsy();
   })

--- a/ui/src/app/components/ct-available-banner-maybe.spec.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.spec.tsx
@@ -9,7 +9,7 @@ import {AccessTierShortNames} from 'app/utils/access-tiers';
 import {environment} from 'environments/environment';
 import {CdrVersionTier, Profile, UserTierEligibility} from 'generated/fetch';
 import {cdrVersionTiersResponse} from 'testing/stubs/cdr-versions-api-stub';
-import {waitOneTickAndUpdate} from "../../testing/react-test-helpers";
+import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 
 // 3 times, in order
 const [TIME1, TIME2, TIME3] = [10000, 20000, 30000];

--- a/ui/src/app/components/ct-available-banner-maybe.spec.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.spec.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import {MemoryRouter} from 'react-router-dom';
+import {mount} from 'enzyme';
+
+import {CTAvailableBannerMaybe} from './ct-available-banner-maybe';
+import {cdrVersionStore, profileStore} from 'app/utils/stores';
+import {ProfileStubVariables} from 'testing/stubs/profile-api-stub';
+import {AccessTierShortNames} from 'app/utils/access-tiers';
+import {environment} from 'environments/environment';
+import {
+  AccessModule,
+  AccessModuleStatus,
+  CdrVersionTier,
+  Profile,
+  UserTierEligibility
+} from 'generated/fetch';
+import {cdrVersionTiersResponse} from 'testing/stubs/cdr-versions-api-stub';
+
+describe('CTAvailableBannerMaybe', () => {
+  const load = jest.fn();
+  const reload = jest.fn();
+  const updateCache = jest.fn();
+
+  const component = () => {
+    return mount(<MemoryRouter><CTAvailableBannerMaybe/></MemoryRouter>);
+  };
+
+  const ctBannerExists = (wrapper) => wrapper.find('[data-test-id="controlled-tier-available"]').exists();
+
+  const updateProfile = (newTierEligibilities?: UserTierEligibility[], newUserTiers?: string[], newModuleStatus?: AccessModuleStatus) => {
+    const originalProfile = ProfileStubVariables.PROFILE_STUB;
+
+    const unchangedAccessModules: AccessModuleStatus[] =
+      originalProfile.accessModules.modules.filter(m => m.moduleName !== newModuleStatus?.moduleName);
+
+    const profile: Profile = {
+      ...originalProfile,
+      tierEligibilities : newTierEligibilities || originalProfile.tierEligibilities,
+      accessTierShortNames: newUserTiers || originalProfile.accessTierShortNames,
+      accessModules: {
+        modules: [...unchangedAccessModules, newModuleStatus]
+      }
+    }
+
+    profileStore.set({profile, load, reload, updateCache});
+  }
+
+  const updateCdrVersions = (newTier: CdrVersionTier) => {
+    const otherTiers = cdrVersionTiersResponse.tiers.filter(tier => tier.accessTierShortName !== tier.accessTierShortName);
+    cdrVersionStore.set({tiers: [...otherTiers, newTier]});
+  }
+
+  const fulfillAllBannerRequirements = () => {
+    // the user is eligible for the CT
+    const userEligible: UserTierEligibility[] = [
+      {
+        accessTierShortName: AccessTierShortNames.Registered,
+        eraRequired: false,
+        eligible: true
+      },
+      {
+        accessTierShortName: AccessTierShortNames.Controlled,
+        eraRequired: false,
+        eligible: true
+      }
+    ];
+
+    // the user does not currently have CT access
+    const userTiers: string[] = [AccessTierShortNames.Registered];
+
+    // the environment allows users to see the CT (in the UI)
+    environment.accessTiersVisibleToUsers = [AccessTierShortNames.Registered, AccessTierShortNames.Controlled];
+
+    // the user's DUCC access module completion time was before the release of the default CT CDR Version
+    const duccStatus: AccessModuleStatus = {
+      moduleName: AccessModule.DATAUSERCODEOFCONDUCT,
+      completionEpochMillis: 1000
+    }
+    const controlledTierCdrVersions: CdrVersionTier = {
+      ...cdrVersionTiersResponse.tiers.find(t => t.accessTierShortName === AccessTierShortNames.Controlled),
+      defaultCdrVersionCreationTime: 2000
+    }
+
+    // the user is not currently visiting the DAR page
+    window.location.pathname = '/';
+
+    updateProfile(userEligible, userTiers, duccStatus);
+    updateCdrVersions(controlledTierCdrVersions);
+  }
+
+  beforeEach(() => {
+    profileStore.set({profile: ProfileStubVariables.PROFILE_STUB, load, reload, updateCache});
+    cdrVersionStore.set(cdrVersionTiersResponse);
+  });
+
+  it('should render if all of the requirements are met', () => {
+    fulfillAllBannerRequirements();
+
+    const wrapper = component();
+    expect(wrapper.exists()).toBeTruthy();
+
+    expect(ctBannerExists(wrapper)).toBeTruthy();
+  });
+
+  it('should not render if all of the requirements are met, except that the user is not CT eligible', () => {
+    fulfillAllBannerRequirements();
+
+    const userIneligible: UserTierEligibility[] = [
+      {
+        accessTierShortName: AccessTierShortNames.Registered,
+        eraRequired: false,
+        eligible: true
+      }
+    ];
+
+    updateProfile(userIneligible);
+
+    const wrapper = component();
+    expect(wrapper.exists()).toBeTruthy();
+
+    expect(ctBannerExists(wrapper)).toBeFalsy();
+  });
+
+});

--- a/ui/src/app/components/ct-available-banner-maybe.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import {useEffect, useState} from 'react';
+
+import {ToastBanner, ToastType} from './toast-banner';
+import {cookiesEnabled} from 'app/utils/cookies';
+import {StyledRouterLink} from './buttons';
+
+const CT_COOKIE_KEY = 'controlled-tier-available';
+const DAR_PATH = '/data-access-requirements';
+
+const shouldShowBanner = () => {
+  // TODO implement the real logic
+  const shouldShow = window.location.pathname !== DAR_PATH;
+  if (cookiesEnabled()) {
+    const cookie = localStorage.getItem(CT_COOKIE_KEY);
+    return !cookie && shouldShow;
+  } else {
+    return shouldShow;
+  }
+};
+
+export const CTAvailableBannerMaybe = () => {
+  const [showBanner, setShowBanner] = useState(false);
+
+  useEffect(() => setShowBanner(shouldShowBanner()), []);
+
+  const acknowledgeBanner = () => {
+    if (cookiesEnabled()) {
+      localStorage.setItem(CT_COOKIE_KEY, 'acknowledged');
+    }
+    setShowBanner(false);
+  };
+
+  const bannerBody = <div>
+    To access genomic data and more in the <i>All of Us</i> controlled tier,
+    <StyledRouterLink path={DAR_PATH}>complete the necessary steps</StyledRouterLink>.
+  </div>;
+
+  return showBanner
+    ? <ToastBanner
+      title='Controlled tier data now available.'
+      message={bannerBody}
+      footer='You can also do this later from your profile page.'
+      onClose={() => acknowledgeBanner()}
+      toastType={ToastType.INFO}/>
+    : null;
+}

--- a/ui/src/app/components/ct-available-banner-maybe.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.tsx
@@ -63,6 +63,7 @@ export const CTAvailableBannerMaybe = () => {
       message={bannerBody}
       footer='You can also do this later from your profile page.'
       onClose={() => acknowledgeBanner()}
-      toastType={ToastType.INFO}/>
+      toastType={ToastType.INFO}
+      zIndex={200}/>
     : null;
 }

--- a/ui/src/app/components/ct-available-banner-maybe.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.tsx
@@ -4,12 +4,11 @@ import {useEffect, useState} from 'react';
 import {ToastBanner, ToastType} from './toast-banner';
 import {cookiesEnabled} from 'app/utils/cookies';
 import {StyledRouterLink} from './buttons';
-import {environment} from "../../environments/environment";
-import {AccessTierShortNames} from "../utils/access-tiers";
-import {AccessModule, CdrVersionTier, CdrVersionTiersResponse, Profile} from "../../generated/fetch";
-import {eligibleForTier, getAccessModuleStatusByName} from "../utils/access-utils";
-import {getCdrVersionTier} from "../utils/cdr-versions";
-import {cdrVersionStore, profileStore, useStore} from "../utils/stores";
+import {environment} from 'environments/environment';
+import {AccessTierShortNames} from 'app/utils/access-tiers';
+import {AccessModule, CdrVersionTier, Profile} from 'generated/fetch';
+import {eligibleForTier, getAccessModuleStatusByName} from 'app/utils/access-utils';
+import {cdrVersionStore, profileStore, useStore} from 'app/utils/stores';
 
 const CT_COOKIE_KEY = 'controlled-tier-available';
 const DAR_PATH = '/data-access-requirements';

--- a/ui/src/app/components/ct-available-banner-maybe.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.tsx
@@ -9,19 +9,13 @@ import {AccessTierShortNames} from 'app/utils/access-tiers';
 import {CdrVersionTier, Profile} from 'generated/fetch';
 import {eligibleForTier} from 'app/utils/access-utils';
 import {cdrVersionStore, profileStore, useStore} from 'app/utils/stores';
-import {displayDate} from 'app/utils';
 
-const CT_COOKIE_KEY = 'controlled-tier-available';
+// Visible For Testing
 export const DAR_PATH = '/data-access-requirements';
+const CT_COOKIE_KEY = 'controlled-tier-available';
 
 const shouldShowBanner = (profile: Profile, cdrVersionTiers: CdrVersionTier[]) => {
   const ct = cdrVersionTiers?.find(v => v.accessTierShortName === AccessTierShortNames.Controlled);
-
-  console.log('pathname = ' + window.location.pathname);
-  console.log('eligible = ' + eligibleForTier(profile, AccessTierShortNames.Controlled));
-  console.log('access = ' + profile.accessTierShortNames.includes(AccessTierShortNames.Controlled));
-  console.log('firstSignInTime = ' + displayDate(profile.firstSignInTime));
-  console.log('defaultCdrVersionCreationTime = ' + displayDate(ct?.defaultCdrVersionCreationTime));
 
   // all of the following must be true
   const shouldShow = profile && ct &&

--- a/ui/src/app/components/ct-available-banner-maybe.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.tsx
@@ -5,10 +5,11 @@ import {ToastBanner, ToastType} from './toast-banner';
 import {cookiesEnabled} from 'app/utils/cookies';
 import {StyledRouterLink} from './buttons';
 import {environment} from 'environments/environment';
-import {AccessTierShortNames} from 'app/utils/access-tiers';
+import {AccessTierDisplayNames, AccessTierShortNames} from 'app/utils/access-tiers';
 import {CdrVersionTier, Profile} from 'generated/fetch';
 import {eligibleForTier} from 'app/utils/access-utils';
 import {cdrVersionStore, profileStore, useStore} from 'app/utils/stores';
+import {AoU} from './text-wrappers';
 
 // Visible For Testing
 export const DAR_PATH = '/data-access-requirements';
@@ -53,13 +54,13 @@ export const CTAvailableBannerMaybe = () => {
   };
 
   const bannerBody = <div data-test-id='controlled-tier-available'>
-    To access genomic data and more in the <i>All of Us</i> controlled tier,
+    To access genomic data and more in the <AoU/> {AccessTierDisplayNames.Controlled},
     <StyledRouterLink path={DAR_PATH}>complete the necessary steps</StyledRouterLink>.
   </div>;
 
   return showBanner
     ? <ToastBanner
-      title='Controlled tier data now available.'
+      title={`${AccessTierDisplayNames.Controlled} data now available.`}
       message={bannerBody}
       footer='You can also do this later from your profile page.'
       onClose={() => acknowledgeBanner()}

--- a/ui/src/app/components/ct-available-banner-maybe.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.tsx
@@ -50,7 +50,7 @@ export const CTAvailableBannerMaybe = () => {
     setShowBanner(false);
   };
 
-  const bannerBody = <div>
+  const bannerBody = <div data-test-id='controlled-tier-available'>
     To access genomic data and more in the <i>All of Us</i> controlled tier,
     <StyledRouterLink path={DAR_PATH}>complete the necessary steps</StyledRouterLink>.
   </div>;

--- a/ui/src/app/components/ct-available-banner-maybe.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.tsx
@@ -4,13 +4,31 @@ import {useEffect, useState} from 'react';
 import {ToastBanner, ToastType} from './toast-banner';
 import {cookiesEnabled} from 'app/utils/cookies';
 import {StyledRouterLink} from './buttons';
+import {environment} from "../../environments/environment";
+import {AccessTierShortNames} from "../utils/access-tiers";
+import {AccessModule, CdrVersionTier, CdrVersionTiersResponse, Profile} from "../../generated/fetch";
+import {eligibleForTier, getAccessModuleStatusByName} from "../utils/access-utils";
+import {getCdrVersionTier} from "../utils/cdr-versions";
+import {cdrVersionStore, profileStore, useStore} from "../utils/stores";
 
 const CT_COOKIE_KEY = 'controlled-tier-available';
 const DAR_PATH = '/data-access-requirements';
 
-const shouldShowBanner = () => {
-  // TODO implement the real logic
-  const shouldShow = window.location.pathname !== DAR_PATH;
+const shouldShowBanner = (profile: Profile, cdrVersionTiers: CdrVersionTier[]) => {
+  // all of the following must be true
+  const shouldShow =
+    // the user is eligible for the CT
+    eligibleForTier(profile, AccessTierShortNames.Controlled) &&
+    // the user does not currently have CT access
+    !profile.accessTierShortNames.includes(AccessTierShortNames.Controlled) &&
+    // the environment allows users to see the CT (in the UI)
+    environment.accessTiersVisibleToUsers.includes(AccessTierShortNames.Controlled) &&
+    // the user's DUCC access module completion time was before the release of the default CT CDR Version
+    (getAccessModuleStatusByName(profile, AccessModule.DATAUSERCODEOFCONDUCT).completionEpochMillis <
+      cdrVersionTiers.find(v => v.accessTierShortName === AccessTierShortNames.Controlled)?.defaultCdrVersionCreationTime) &&
+    // the user is not currently visiting the DAR page
+    (window.location.pathname !== DAR_PATH);
+
   if (cookiesEnabled()) {
     const cookie = localStorage.getItem(CT_COOKIE_KEY);
     return !cookie && shouldShow;
@@ -21,8 +39,10 @@ const shouldShowBanner = () => {
 
 export const CTAvailableBannerMaybe = () => {
   const [showBanner, setShowBanner] = useState(false);
+  const {profile} = useStore(profileStore);
+  const {tiers} = useStore(cdrVersionStore);
 
-  useEffect(() => setShowBanner(shouldShowBanner()), []);
+  useEffect(() => setShowBanner(shouldShowBanner(profile, tiers)), []);
 
   const acknowledgeBanner = () => {
     if (cookiesEnabled()) {

--- a/ui/src/app/components/ct-available-banner-maybe.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.tsx
@@ -6,15 +6,22 @@ import {cookiesEnabled} from 'app/utils/cookies';
 import {StyledRouterLink} from './buttons';
 import {environment} from 'environments/environment';
 import {AccessTierShortNames} from 'app/utils/access-tiers';
-import {AccessModule, CdrVersionTier, Profile} from 'generated/fetch';
-import {eligibleForTier, getAccessModuleStatusByName} from 'app/utils/access-utils';
+import {CdrVersionTier, Profile} from 'generated/fetch';
+import {eligibleForTier} from 'app/utils/access-utils';
 import {cdrVersionStore, profileStore, useStore} from 'app/utils/stores';
+import {displayDate} from 'app/utils';
 
 const CT_COOKIE_KEY = 'controlled-tier-available';
 export const DAR_PATH = '/data-access-requirements';
 
 const shouldShowBanner = (profile: Profile, cdrVersionTiers: CdrVersionTier[]) => {
   const ct = cdrVersionTiers?.find(v => v.accessTierShortName === AccessTierShortNames.Controlled);
+
+  console.log('pathname = ' + window.location.pathname);
+  console.log('eligible = ' + eligibleForTier(profile, AccessTierShortNames.Controlled));
+  console.log('access = ' + profile.accessTierShortNames.includes(AccessTierShortNames.Controlled));
+  console.log('firstSignInTime = ' + displayDate(profile.firstSignInTime));
+  console.log('defaultCdrVersionCreationTime = ' + displayDate(ct?.defaultCdrVersionCreationTime));
 
   // all of the following must be true
   const shouldShow = profile && ct &&
@@ -31,8 +38,8 @@ const shouldShowBanner = (profile: Profile, cdrVersionTiers: CdrVersionTier[]) =
 
   if (cookiesEnabled()) {
     const cookie = localStorage.getItem(CT_COOKIE_KEY);
-    return !cookie && shouldShow;
-  } else {
+  //   return !cookie && shouldShow;
+  // } else {
     return shouldShow;
   }
 };
@@ -42,7 +49,7 @@ export const CTAvailableBannerMaybe = () => {
   const {profile} = useStore(profileStore);
   const {tiers} = useStore(cdrVersionStore);
 
-  useEffect(() => setShowBanner(shouldShowBanner(profile, tiers)), []);
+  useEffect(() => setShowBanner(shouldShowBanner(profile, tiers)), [profile, tiers]);
 
   const acknowledgeBanner = () => {
     if (cookiesEnabled()) {

--- a/ui/src/app/components/ct-available-banner-maybe.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.tsx
@@ -32,8 +32,8 @@ const shouldShowBanner = (profile: Profile, cdrVersionTiers: CdrVersionTier[]) =
 
   if (cookiesEnabled()) {
     const cookie = localStorage.getItem(CT_COOKIE_KEY);
-  //   return !cookie && shouldShow;
-  // } else {
+    return !cookie && shouldShow;
+  } else {
     return shouldShow;
   }
 };

--- a/ui/src/app/pages/signed-in/nav-bar.tsx
+++ b/ui/src/app/pages/signed-in/nav-bar.tsx
@@ -12,6 +12,7 @@ import {profileStore, ProfileStore, useStore} from 'app/utils/stores';
 import {environment} from 'environments/environment';
 import logo from 'assets/images/all-of-us-logo.svg'
 import {StatusAlertBannerMaybe} from 'app/components/status-alert-banner-maybe';
+import {CTAvailableBannerMaybe} from 'app//components/ct-available-banner-maybe';
 
 const styles = reactStyles({
   headerContainer: {
@@ -157,6 +158,7 @@ export const NavBar = () => {
     {window.location.pathname !== '/access-renewal' && <AccessRenewalNotificationMaybe/>}
     {window.location.pathname !== '/data-access-requirements' && <LoginGovIAL2NotificationMaybe/>}
     <StatusAlertBannerMaybe/>
+    <CTAvailableBannerMaybe/>
     {
       showSideNav
       && <SideNav

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -1,7 +1,7 @@
 import {Guard} from 'app/components/app-router';
-import {hasRegisteredTierAccess} from 'app/utils/access-tiers';
+import {AccessTierShortNames, hasRegisteredTierAccess} from 'app/utils/access-tiers';
 import {authStore, MatchParams, profileStore} from 'app/utils/stores';
-import {eligibleForRegisteredTier} from 'app/utils/access-utils';
+import {eligibleForTier} from 'app/utils/access-utils';
 import {useParams} from 'react-router-dom';
 import {currentWorkspaceStore} from 'app/utils/navigation';
 
@@ -13,7 +13,7 @@ export const signInGuard: Guard = {
 };
 
 const userIsEnabled = (userDisabledInDb: boolean) =>
-    (!userDisabledInDb && eligibleForRegisteredTier(profileStore.get().profile.tierEligibilities));
+  (!userDisabledInDb && eligibleForTier(profileStore.get().profile, AccessTierShortNames.Registered));
 
 export const disabledGuard = (userDisabledInDb: boolean): Guard => ({
   // Show disabled screen when user account is disabled by admin or removed from institution registered tier requirement.

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -305,7 +305,7 @@ export const computeDisplayDates = ({completionEpochMillis, expirationEpochMilli
 
 // return true if user is eligible for registered tier.
 // A user loses tier eligibility when they are removed from institution tier requirement
-export const eligibleForRegisteredTier = (tierEligiblities: Array<UserTierEligibility>): boolean => {
-  const rtEligiblity = tierEligiblities.find(t => t.accessTierShortName === AccessTierShortNames.Registered)
+export const eligibleForTier = (profile: Profile, accessTierShortName: string): boolean => {
+  const rtEligiblity = profile.tierEligibilities.find(t => t.accessTierShortName === accessTierShortName)
   return rtEligiblity?.eligible
 };

--- a/ui/src/testing/stubs/cdr-versions-api-stub.ts
+++ b/ui/src/testing/stubs/cdr-versions-api-stub.ts
@@ -20,6 +20,7 @@ export const cdrVersionTiersResponse: CdrVersionTiersResponse = {
     accessTierShortName: AccessTierShortNames.Registered,
     accessTierDisplayName: AccessTierDisplayNames.Registered,
     defaultCdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
+    defaultCdrVersionCreationTime: 0,
     versions: [
       {
         name: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION,
@@ -44,6 +45,7 @@ export const cdrVersionTiersResponse: CdrVersionTiersResponse = {
       accessTierShortName: AccessTierShortNames.Controlled,
       accessTierDisplayName: AccessTierDisplayNames.Controlled,
       defaultCdrVersionId: CdrVersionsStubVariables.CONTROLLED_TIER_CDR_VERSION_ID,
+      defaultCdrVersionCreationTime: 0,
       versions: [
         {
           name: CdrVersionsStubVariables.CONTROLLED_TIER_CDR_VERSION,


### PR DESCRIPTION
<img width="330" alt="CT Available" src="https://user-images.githubusercontent.com/2701406/144465656-66e52f10-4d59-4761-bfc8-f14fa080f897.png">

Clicking X closes the toast-banner and stores a cookie, preventing the user from ever seeing this again.

Clicking `complete the necessary steps` closes the toast-banner and routes to the DAR page.

Only triggers when all of the following conditions are met.
- the env allows users to see the CT in the UI
- the user does not have CT membership
- the user is CT-eligible
- the user’s first sign in time is BEFORE the creation time of the latest CT CDR
- the user has not yet acked the notification previously

Tested locally.



<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
