### PR TITLE
[risk=moderate][RW-7609] experiment: getCdrVersionsByTier() returns RT+CT tiers to RT users

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
@@ -113,13 +113,13 @@ public class CdrVersionService {
   }
 
   public CdrVersionTiersResponse getCdrVersionsByTier() {
-    List<DbAccessTier> tiers = accessTierService.getAllTiers();
-    if (tiers.isEmpty()) {
+    boolean hasRegisteredTierAccess = accessTierService.getAccessTiersForUser(userProvider.get()).stream().anyMatch(tier -> AccessTierService.REGISTERED_TIER_SHORT_NAME.equals(tier.getShortName()));
+    if (!hasRegisteredTierAccess) {
       throw new ForbiddenException("User does not have access to any CDR versions");
     }
 
     return new CdrVersionTiersResponse()
-        .tiers(tiers.stream().map(this::getVersionsForTier).collect(Collectors.toList()));
+        .tiers(accessTierService.getAllTiers().stream().map(this::getVersionsForTier).collect(Collectors.toList()));
   }
 
   private CdrVersionTier getVersionsForTier(DbAccessTier accessTier) {

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
@@ -113,7 +113,7 @@ public class CdrVersionService {
   }
 
   public CdrVersionTiersResponse getCdrVersionsByTier() {
-    List<DbAccessTier> tiers = accessTierService.getAccessTiersForUser(userProvider.get());
+    List<DbAccessTier> tiers = accessTierService.getAllTiers();
     if (tiers.isEmpty()) {
       throw new ForbiddenException("User does not have access to any CDR versions");
     }

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
@@ -11,7 +11,6 @@ import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.ForbiddenException;
-import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.CdrVersionTier;
 import org.pmiops.workbench.model.CdrVersionTiersResponse;
@@ -70,56 +69,24 @@ public class CdrVersionService {
     CdrVersionContext.setCdrVersionNoCheckAuthDomain(version);
   }
 
-  /**
-   * Sets the active CDR version, after checking to ensure that the requester is in the appropriate
-   * authorization domain. If you have already retrieved a workspace for the requester (and thus
-   * implicitly know they are in the authorization domain for its CDR version), you can instead just
-   * call {@link CdrVersionContext#setCdrVersionNoCheckAuthDomain(DbCdrVersion)} directly.
-   *
-   * @param cdrVersionId
-   */
-  public void setCdrVersion(Long cdrVersionId) {
-    this.setCdrVersion(
-        cdrVersionDao
-            .findById(cdrVersionId)
-            .orElseThrow(
-                () ->
-                    new NotFoundException(
-                        String.format("Cdr version %s does not exist", cdrVersionId))));
-  }
-
-  /**
-   * Sets the active CDR version, after checking to ensure that the requester is in the appropriate
-   * authorization domain. If you have already retrieved a workspace for the requester (and thus
-   * implicitly know they are in the authorization domain for its CDR version), you can instead just
-   * call {@link CdrVersionContext#setCdrVersionNoCheckAuthDomain(DbCdrVersion)} directly.
-   *
-   * @param cdrVersionId
-   */
-  public DbCdrVersion findAndSetCdrVersion(Long cdrVersionId) {
-    DbCdrVersion dbCdrVersion =
-        cdrVersionDao
-            .findById(cdrVersionId)
-            .orElseThrow(
-                () ->
-                    new NotFoundException(
-                        String.format("Cdr version %s does not exist", cdrVersionId)));
-    this.setCdrVersion(dbCdrVersion);
-    return dbCdrVersion;
-  }
-
   public Optional<DbCdrVersion> findByCdrVersionId(Long cdrVersionId) {
     return Optional.ofNullable(cdrVersionDao.findByCdrVersionId(cdrVersionId));
   }
 
   public CdrVersionTiersResponse getCdrVersionsByTier() {
-    boolean hasRegisteredTierAccess = accessTierService.getAccessTiersForUser(userProvider.get()).stream().anyMatch(tier -> AccessTierService.REGISTERED_TIER_SHORT_NAME.equals(tier.getShortName()));
+    boolean hasRegisteredTierAccess =
+        accessTierService.getAccessTiersForUser(userProvider.get()).stream()
+            .anyMatch(
+                tier -> AccessTierService.REGISTERED_TIER_SHORT_NAME.equals(tier.getShortName()));
     if (!hasRegisteredTierAccess) {
       throw new ForbiddenException("User does not have access to any CDR versions");
     }
 
     return new CdrVersionTiersResponse()
-        .tiers(accessTierService.getAllTiers().stream().map(this::getVersionsForTier).collect(Collectors.toList()));
+        .tiers(
+            accessTierService.getAllTiers().stream()
+                .map(this::getVersionsForTier)
+                .collect(Collectors.toList()));
   }
 
   private CdrVersionTier getVersionsForTier(DbAccessTier accessTier) {

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
@@ -70,7 +70,7 @@ public class CdrVersionService {
   }
 
   public Optional<DbCdrVersion> findByCdrVersionId(Long cdrVersionId) {
-    return Optional.ofNullable(cdrVersionDao.findByCdrVersionId(cdrVersionId));
+    return cdrVersionDao.findById(cdrVersionId);
   }
 
   public CdrVersionTiersResponse getCdrVersionsByTier() {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/CdrVersionDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/CdrVersionDao.java
@@ -6,9 +6,6 @@ import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.springframework.data.repository.CrudRepository;
 
 public interface CdrVersionDao extends CrudRepository<DbCdrVersion, Long> {
-
-  DbCdrVersion findByCdrVersionId(long id);
-
   DbCdrVersion findByName(String name);
 
   List<DbCdrVersion> findByAccessTierOrderByCreationTimeDesc(DbAccessTier accessTier);

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -911,7 +911,7 @@ public class DataSetControllerTest {
 
   @Test
   public void exportToNotebook_wgsCodegen_cdrCheck() {
-    DbCdrVersion cdrVersion = findVersionOrThrow(workspace.getCdrVersionId());
+    DbCdrVersion cdrVersion = findCdrVersionOrThrow(workspace);
     cdrVersion.setWgsBigqueryDataset(null);
     cdrVersionDao.save(cdrVersion);
 
@@ -931,7 +931,7 @@ public class DataSetControllerTest {
 
   @Test
   public void exportToNotebook_wgsCodegen_kernelCheck() {
-    DbCdrVersion cdrVersion = findVersionOrThrow(workspace.getCdrVersionId());
+    DbCdrVersion cdrVersion = findCdrVersionOrThrow(workspace);
     cdrVersion.setWgsBigqueryDataset("wgs");
     cdrVersionDao.save(cdrVersion);
 
@@ -1201,11 +1201,10 @@ public class DataSetControllerTest {
         .kernelType(KernelTypeEnum.PYTHON);
   }
 
-  private DbCdrVersion findVersionOrThrow(String cdrVersionId) {
+  private DbCdrVersion findCdrVersionOrThrow(Workspace workspace) {
+    String id = workspace.getCdrVersionId();
     return cdrVersionDao
-        .findById(Long.parseLong(cdrVersionId))
-        .orElseThrow(
-            () ->
-                new NotFoundException(String.format("CDR Version ID %s not found", cdrVersionId)));
+        .findById(Long.parseLong(id))
+        .orElseThrow(() -> new NotFoundException(String.format("CDR Version ID %s not found", id)));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -911,8 +911,7 @@ public class DataSetControllerTest {
 
   @Test
   public void exportToNotebook_wgsCodegen_cdrCheck() {
-    DbCdrVersion cdrVersion =
-        cdrVersionDao.findByCdrVersionId(Long.parseLong(workspace.getCdrVersionId()));
+    DbCdrVersion cdrVersion = findVersionOrThrow(workspace.getCdrVersionId());
     cdrVersion.setWgsBigqueryDataset(null);
     cdrVersionDao.save(cdrVersion);
 
@@ -932,8 +931,7 @@ public class DataSetControllerTest {
 
   @Test
   public void exportToNotebook_wgsCodegen_kernelCheck() {
-    DbCdrVersion cdrVersion =
-        cdrVersionDao.findByCdrVersionId(Long.parseLong(workspace.getCdrVersionId()));
+    DbCdrVersion cdrVersion = findVersionOrThrow(workspace.getCdrVersionId());
     cdrVersion.setWgsBigqueryDataset("wgs");
     cdrVersionDao.save(cdrVersion);
 
@@ -1201,5 +1199,13 @@ public class DataSetControllerTest {
         .newNotebook(true)
         .notebookName(notebookName)
         .kernelType(KernelTypeEnum.PYTHON);
+  }
+
+  private DbCdrVersion findVersionOrThrow(String cdrVersionId) {
+    return cdrVersionDao
+        .findById(Long.parseLong(cdrVersionId))
+        .orElseThrow(
+            () ->
+                new NotFoundException(String.format("CDR Version ID %s not found", cdrVersionId)));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
@@ -145,7 +145,7 @@ public class CdrVersionServiceTest {
   @Test
   public void testSetCdrVersionDefaultId() {
     addMembershipForTest(registeredTier);
-    cdrVersionService.setCdrVersion(defaultCdrVersion.getCdrVersionId());
+    cdrVersionService.setCdrVersion(defaultCdrVersion);
     assertThat(CdrVersionContext.getCdrVersion()).isEqualTo(defaultCdrVersion);
   }
 
@@ -153,18 +153,14 @@ public class CdrVersionServiceTest {
   public void testSetCdrVersionDefaultForbiddenNotInTier() {
     assertThrows(
         ForbiddenException.class,
-        () -> {
-          cdrVersionService.setCdrVersion(defaultCdrVersion);
-        });
+        () -> cdrVersionService.setCdrVersion(defaultCdrVersion));
   }
 
   @Test
   public void testSetCdrVersionDefaultIdForbiddenNotInTier() {
     assertThrows(
         ForbiddenException.class,
-        () -> {
-          cdrVersionService.setCdrVersion(defaultCdrVersion.getCdrVersionId());
-        });
+        () -> cdrVersionService.setCdrVersion(defaultCdrVersion));
   }
 
   // these tests fail because the user is in the right tier according to the AoU DB
@@ -192,7 +188,7 @@ public class CdrVersionServiceTest {
           when(fireCloudService.isUserMemberOfGroupWithCache(
                   user.getUsername(), registeredTier.getAuthDomainName()))
               .thenReturn(false);
-          cdrVersionService.setCdrVersion(defaultCdrVersion.getCdrVersionId());
+          cdrVersionService.setCdrVersion(defaultCdrVersion);
         });
   }
 
@@ -206,7 +202,7 @@ public class CdrVersionServiceTest {
   @Test
   public void testSetCdrVersionControlledId() {
     addMembershipForTest(controlledTier);
-    cdrVersionService.setCdrVersion(controlledCdrVersion.getCdrVersionId());
+    cdrVersionService.setCdrVersion(controlledCdrVersion);
     assertThat(CdrVersionContext.getCdrVersion()).isEqualTo(controlledCdrVersion);
   }
 
@@ -214,18 +210,14 @@ public class CdrVersionServiceTest {
   public void testSetCdrVersionControlledForbiddenNotInTier() {
     assertThrows(
         ForbiddenException.class,
-        () -> {
-          cdrVersionService.setCdrVersion(controlledCdrVersion);
-        });
+        () -> cdrVersionService.setCdrVersion(controlledCdrVersion));
   }
 
   @Test
   public void testSetCdrVersionControlledIdForbiddenNotInTier() {
     assertThrows(
         ForbiddenException.class,
-        () -> {
-          cdrVersionService.setCdrVersion(controlledCdrVersion.getCdrVersionId());
-        });
+        () -> cdrVersionService.setCdrVersion(controlledCdrVersion));
   }
 
   // these tests fail because the user is in the right tier according to the AoU DB
@@ -253,7 +245,7 @@ public class CdrVersionServiceTest {
           when(fireCloudService.isUserMemberOfGroupWithCache(
                   user.getUsername(), controlledTier.getAuthDomainName()))
               .thenReturn(false);
-          cdrVersionService.setCdrVersion(controlledCdrVersion.getCdrVersionId());
+          cdrVersionService.setCdrVersion(controlledCdrVersion);
         });
   }
 
@@ -299,15 +291,18 @@ public class CdrVersionServiceTest {
         response.getTiers().stream()
             .map(CdrVersionTier::getAccessTierShortName)
             .collect(Collectors.toList());
-    assertThat(responseTiers).containsExactly(registeredTier.getShortName(), controlledTier.getShortName());
+    assertThat(responseTiers)
+        .containsExactly(registeredTier.getShortName(), controlledTier.getShortName());
 
     List<CdrVersion> responseVersions =
         response.getTiers().stream()
             .map(CdrVersionTier::getVersions)
             .flatMap(List::stream)
             .collect(Collectors.toList());
-    assertThat(responseVersions).containsExactly(cdrVersionMapper.dbModelToClient(defaultCdrVersion),
-        cdrVersionMapper.dbModelToClient(controlledCdrVersion));
+    assertThat(responseVersions)
+        .containsExactly(
+            cdrVersionMapper.dbModelToClient(defaultCdrVersion),
+            cdrVersionMapper.dbModelToClient(controlledCdrVersion));
   }
 
   private void testGetCdrVersionsHasDataType(Predicate<CdrVersion> hasType) {

--- a/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
@@ -152,15 +152,13 @@ public class CdrVersionServiceTest {
   @Test
   public void testSetCdrVersionDefaultForbiddenNotInTier() {
     assertThrows(
-        ForbiddenException.class,
-        () -> cdrVersionService.setCdrVersion(defaultCdrVersion));
+        ForbiddenException.class, () -> cdrVersionService.setCdrVersion(defaultCdrVersion));
   }
 
   @Test
   public void testSetCdrVersionDefaultIdForbiddenNotInTier() {
     assertThrows(
-        ForbiddenException.class,
-        () -> cdrVersionService.setCdrVersion(defaultCdrVersion));
+        ForbiddenException.class, () -> cdrVersionService.setCdrVersion(defaultCdrVersion));
   }
 
   // these tests fail because the user is in the right tier according to the AoU DB
@@ -209,15 +207,13 @@ public class CdrVersionServiceTest {
   @Test
   public void testSetCdrVersionControlledForbiddenNotInTier() {
     assertThrows(
-        ForbiddenException.class,
-        () -> cdrVersionService.setCdrVersion(controlledCdrVersion));
+        ForbiddenException.class, () -> cdrVersionService.setCdrVersion(controlledCdrVersion));
   }
 
   @Test
   public void testSetCdrVersionControlledIdForbiddenNotInTier() {
     assertThrows(
-        ForbiddenException.class,
-        () -> cdrVersionService.setCdrVersion(controlledCdrVersion));
+        ForbiddenException.class, () -> cdrVersionService.setCdrVersion(controlledCdrVersion));
   }
 
   // these tests fail because the user is in the right tier according to the AoU DB


### PR DESCRIPTION
getCdrVersionsByTier() now returns all tiers' versions if the user has RT access.  

Also some misc CDR Version Service/Test/DAO cleanup.

Tested by:
* observing both tiers by calling API as an RT-only user and a CT user
* running local UI and observing no changes to Workspace Edit/Duplicate functionality as an RT-only user or a CT user

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
