### PR TITLE
[risk=no][no ticket] code reuse for getCdrVersion() in dataset-page

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -33,6 +33,7 @@ import {WorkspaceData} from 'app/utils/workspace-data';
 import {WorkspacePermissionsUtil} from 'app/utils/workspace-permissions';
 import {openZendeskWidget, supportUrls} from 'app/utils/zendesk';
 import {
+  CdrVersion,
   CdrVersionTiersResponse,
   Cohort,
   ConceptSet,
@@ -582,8 +583,13 @@ export const DatasetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), wi
       });
     }
 
+    private getCdrVersion(): CdrVersion {
+      const {workspace, cdrVersionTiersResponse} = this.props;
+      return getCdrVersion(workspace, cdrVersionTiersResponse)
+    }
+
     updatePrepackagedDomains() {
-      if (getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).hasFitbitData) {
+      if (this.getCdrVersion().hasFitbitData) {
         PREPACKAGED_DOMAINS =   {
           ...PREPACKAGED_SURVEY_PERSON_DOMAIN,
           ...PREPACKAGED_WITH_FITBIT_DOMAINS
@@ -593,14 +599,14 @@ export const DatasetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), wi
       // data extraction is possible, since extraction is the only action that
       // can be taken on genomics variant data from the dataset builder.
       if (serverConfigStore.get().config.enableGenomicExtraction &&
-        getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).hasWgsData) {
+        this.getCdrVersion().hasWgsData) {
         PREPACKAGED_DOMAINS = {
           ...PREPACKAGED_DOMAINS,
           ...PREPACKAGED_WITH_WHOLE_GENOME
         };
       }
       // Add Zipcode Socioeconomic status data if were in controlled tier dataset
-      if (getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).accessTierShortName === 'controlled') {
+      if (this.getCdrVersion().accessTierShortName === 'controlled') {
         PREPACKAGED_DOMAINS = {
           ...PREPACKAGED_DOMAINS,
           ...PREPACKAGED_WITH_ZIP_CODE_SOCIOECONOMIC
@@ -751,15 +757,15 @@ export const DatasetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), wi
 
     getPrePackagedList() {
       let prepackagedList = Object.keys(PrepackagedConceptSet);
-      if (!getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).hasFitbitData) {
+      if (!this.getCdrVersion().hasFitbitData) {
         prepackagedList = prepackagedList
             .filter(prepack => !fp.startsWith('FITBIT', prepack));
       }
       if (!serverConfigStore.get().config.enableGenomicExtraction ||
-          !getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).hasWgsData) {
+          !this.getCdrVersion().hasWgsData) {
         prepackagedList = prepackagedList.filter(prepack => prepack !== 'WHOLEGENOME');
       }
-      if (getCdrVersion(this.props.workspace, this.props.cdrVersionTiersResponse).accessTierShortName !== 'controlled') {
+      if (this.getCdrVersion().accessTierShortName !== 'controlled') {
         prepackagedList = prepackagedList.filter(prepack => prepack !== 'ZIPCODESOCIOECONOMIC');
       }
       return prepackagedList;

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -598,15 +598,14 @@ export const DatasetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), wi
       // Only allow selection of genomics prepackaged concept sets if genomics
       // data extraction is possible, since extraction is the only action that
       // can be taken on genomics variant data from the dataset builder.
-      if (serverConfigStore.get().config.enableGenomicExtraction &&
-        this.getCdrVersion().hasWgsData) {
+      if (serverConfigStore.get().config.enableGenomicExtraction && this.getCdrVersion().hasWgsData) {
         PREPACKAGED_DOMAINS = {
           ...PREPACKAGED_DOMAINS,
           ...PREPACKAGED_WITH_WHOLE_GENOME
         };
       }
       // Add Zipcode Socioeconomic status data if were in controlled tier dataset
-      if (this.getCdrVersion().accessTierShortName === 'controlled') {
+      if (this.props.workspace.accessTierShortName === 'controlled') {
         PREPACKAGED_DOMAINS = {
           ...PREPACKAGED_DOMAINS,
           ...PREPACKAGED_WITH_ZIP_CODE_SOCIOECONOMIC
@@ -761,11 +760,10 @@ export const DatasetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), wi
         prepackagedList = prepackagedList
             .filter(prepack => !fp.startsWith('FITBIT', prepack));
       }
-      if (!serverConfigStore.get().config.enableGenomicExtraction ||
-          !this.getCdrVersion().hasWgsData) {
+      if (!serverConfigStore.get().config.enableGenomicExtraction || !this.getCdrVersion().hasWgsData) {
         prepackagedList = prepackagedList.filter(prepack => prepack !== 'WHOLEGENOME');
       }
-      if (this.getCdrVersion().accessTierShortName !== 'controlled') {
+      if (this.props.workspace.accessTierShortName !== 'controlled') {
         prepackagedList = prepackagedList.filter(prepack => prepack !== 'ZIPCODESOCIOECONOMIC');
       }
       return prepackagedList;


### PR DESCRIPTION
small refactoring as I happened to look at this file

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
