### PR TITLE
[RW-7610][risk=no] Unmount enzyme React components after each test case

### DIFF
--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -484,8 +484,7 @@ describe('DataAccessRequirements', () => {
 
     // regression tests for RW-7384: sync external modules to gain access
 
-    // TODO(RW-7610): Fix timeout flake and re-enable.
-    test.skip('should sync incomplete external modules', async() => {
+    it('should sync incomplete external modules', async() => {
         // profile contains no completed modules, so we sync all (2FA, ERA, Compliance)
         const spy2FA = jest.spyOn(profileApi(), 'syncTwoFactorAuthStatus');
         const spyERA = jest.spyOn(profileApi(), 'syncEraCommonsStatus');
@@ -499,8 +498,7 @@ describe('DataAccessRequirements', () => {
         expect(spyCompliance).toHaveBeenCalledTimes(1);
      });
 
-    // TODO(RW-7610): Fix timeout flake and re-enable.
-    test.skip('should not sync complete external modules', async() => {
+    it('should not sync complete external modules', async() => {
         profileStore.set({
             profile: {
                 ...ProfileStubVariables.PROFILE_STUB,

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -8,13 +8,13 @@ require('mutationobserver-shim');
  */
 const enzyme = require("enzyme");
 const Adapter = require("enzyme-adapter-react-16");
+const reactDOM = require("react-dom");
 
 const {setupCustomValidators} = require('app/services/setup');
 const {stubPopupDimensions} = require('app/components/popups');
 
 setupCustomValidators();
 stubPopupDimensions();
-enzyme.configure({ adapter: new Adapter() });
 
 const mockNavigate = jest.fn();
 const mockNavigateByUrl = jest.fn();
@@ -24,6 +24,22 @@ jest.mock('app/utils/navigation', () => ({
   __esModule: true,
   useNavigation: () => [mockNavigate, mockNavigateByUrl],
 }));
+
+// Track all enzyme renderers for teardown.
+// See https://github.com/enzymejs/enzyme/issues/911
+const unmountCallbacks = [];
+
+class ReactAdapterWithMountTracking extends Adapter {
+  constructor(...args) {
+    super(...args);
+  }
+
+  createRenderer(...args) {
+    const renderer = Adapter.prototype.createRenderer.call(this, ...args);
+    unmountCallbacks.push(() => renderer.unmount());
+    return renderer;
+  }
+}
 
 global.beforeEach(() => {
   const appRoot = document.createElement('div');
@@ -36,11 +52,20 @@ global.beforeEach(() => {
 });
 
 global.afterEach(() => {
+  // Unmount react components after each test
+  unmountCallbacks.forEach(unmount => unmount());
+  unmountCallbacks.splice();
+
+  // Remove this last, as unmounting may check the popup root.
   document.body.removeChild(document.getElementById('root'));
   document.body.removeChild(document.getElementById('popup-root'));
 });
 
+enzyme.configure({ adapter: new ReactAdapterWithMountTracking() });
+
+
 module.exports = {
   mockNavigate: mockNavigate,
   mockNavigateByUrl: mockNavigateByUrl
-}
+};
+

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -8,7 +8,6 @@ require('mutationobserver-shim');
  */
 const enzyme = require("enzyme");
 const Adapter = require("enzyme-adapter-react-16");
-const reactDOM = require("react-dom");
 
 const {setupCustomValidators} = require('app/services/setup');
 const {stubPopupDimensions} = require('app/components/popups');


### PR DESCRIPTION
Turns out there is no automated teardown of enzyme provided by our test harness after each test case, per https://github.com/enzymejs/enzyme/issues/911

The solution described above caused some complications, as using  a common DOM root caused an additional unmount on every `mount()` call within the same test case. It's possible that fixing the issues that arise there would be a more pure solution, but it would likely require retrofitting a bunch of our components.

Specifically, it would result in this error when attempting to reattach the component:
```
  console.error                                                                                                                                                                                 
    Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronou
s tasks in a useEffect cleanup function.                                                                                                                                                        
        in Unknown (at with-error-modal.tsx:68)                                                                                                                                                 
        in ProfileErrorWrapper (at with-error-modal.tsx:45)                                                                                                                                     
        in ErrorModalWrapper (at data-access-requirements.spec.tsx:32)                                                                                                                          
        in Router (created by MemoryRouter)                                                                                                                                                     
        in MemoryRouter (created by WrapperComponent)                                                                                                                                           
        in WrapperComponent           
```

This change results in a large decrease in test latency for me locally and specifically reduced data-access-requirements test case runtime significantly, which were seemingly flaking due to large callback cruft build-up. From a few data points on circle appears to reduce test time by about half:

~2m50s -> ~1m20s