### PR TITLE
[risk=low][no ticket] Use MapStruct to populate ConfigResponse

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConfigController.java
@@ -1,13 +1,9 @@
 package org.pmiops.workbench.api;
 
-import java.math.BigDecimal;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.inject.Provider;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.leonardo.model.LeonardoRuntimeConfig.CloudServiceEnum;
+import org.pmiops.workbench.config.WorkbenchConfigMapper;
 import org.pmiops.workbench.model.ConfigResponse;
-import org.pmiops.workbench.model.RuntimeImage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,55 +12,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class ConfigController implements ConfigApiDelegate {
 
   private final Provider<WorkbenchConfig> configProvider;
+  private final WorkbenchConfigMapper configMapper;
 
   @Autowired
-  ConfigController(Provider<WorkbenchConfig> configProvider) {
+  ConfigController(Provider<WorkbenchConfig> configProvider, WorkbenchConfigMapper configMapper) {
     this.configProvider = configProvider;
+    this.configMapper = configMapper;
   }
 
   @Override
   public ResponseEntity<ConfigResponse> getConfig() {
-    WorkbenchConfig config = configProvider.get();
-    return ResponseEntity.ok(
-        new ConfigResponse()
-            .accessRenewalLookback(BigDecimal.valueOf(config.accessRenewal.lookbackPeriod))
-            .gsuiteDomain(config.googleDirectoryService.gSuiteDomain)
-            .projectId(config.server.projectId)
-            .firecloudURL(config.firecloud.baseUrl)
-            .publicApiKeyForErrorReports(config.server.publicApiKeyForErrorReports)
-            .shibbolethUiBaseUrl(config.firecloud.shibbolethUiBaseUrl)
-            .defaultFreeCreditsDollarLimit(config.billing.defaultFreeCreditsDollarLimit)
-            .enableComplianceTraining(config.access.enableComplianceTraining)
-            .complianceTrainingHost(config.moodle.host)
-            .enableEraCommons(config.access.enableEraCommons)
-            .unsafeAllowSelfBypass(config.access.unsafeAllowSelfBypass)
-            .enableBillingUpgrade(config.featureFlags.enableBillingUpgrade)
-            .enableEventDateModifier(config.featureFlags.enableEventDateModifier)
-            .enableResearchReviewPrompt(config.featureFlags.enableResearchPurposePrompt)
-            .enableRasLoginGovLinking(config.access.enableRasLoginGovLinking)
-            .enforceRasLoginGovLinking(config.access.enforceRasLoginGovLinking)
-            .enableGenomicExtraction(config.featureFlags.enableGenomicExtraction)
-            .enableEgressAlertingV2(config.featureFlags.enableEgressAlertingV2)
-            .enableGpu(config.featureFlags.enableGpu)
-            .enablePersistentDisk(config.featureFlags.enablePersistentDisk)
-            .rasHost(config.ras.host)
-            .rasClientId(config.ras.clientId)
-            .rasLogoutUrl(config.ras.logoutUrl)
-            .freeTierBillingAccountId(config.billing.accountId)
-            .runtimeImages(
-                Stream.concat(
-                        config.firecloud.runtimeImages.dataproc.stream()
-                            .map(
-                                imageName ->
-                                    new RuntimeImage()
-                                        .cloudService(CloudServiceEnum.DATAPROC.toString())
-                                        .name(imageName)),
-                        config.firecloud.runtimeImages.gce.stream()
-                            .map(
-                                imageName ->
-                                    new RuntimeImage()
-                                        .cloudService(CloudServiceEnum.GCE.toString())
-                                        .name(imageName)))
-                    .collect(Collectors.toList())));
+    return ResponseEntity.ok(configMapper.toModel(configProvider.get()));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -6,7 +6,6 @@ import org.mapstruct.BeforeMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
-import org.mapstruct.Named;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeConfig.CloudServiceEnum;
 import org.pmiops.workbench.model.ConfigResponse;
 import org.pmiops.workbench.model.RuntimeImage;
@@ -14,12 +13,10 @@ import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
 @Mapper(config = MapStructConfig.class)
 public interface WorkbenchConfigMapper {
-  @Named("dataprocToModel")
   default RuntimeImage dataprocToModel(String imageName) {
     return new RuntimeImage().cloudService(CloudServiceEnum.DATAPROC.toString()).name(imageName);
   }
 
-  @Named("gceToModel")
   default RuntimeImage gceToModel(String imageName) {
     return new RuntimeImage().cloudService(CloudServiceEnum.GCE.toString()).name(imageName);
   }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -12,11 +12,7 @@ import org.pmiops.workbench.model.ConfigResponse;
 import org.pmiops.workbench.model.RuntimeImage;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
-@Mapper(
-    config = MapStructConfig.class,
-    uses = {
-      // CommonMappers.class,
-    })
+@Mapper(config = MapStructConfig.class)
 public interface WorkbenchConfigMapper {
   @Named("dataprocToModel")
   default RuntimeImage dataprocToModel(String imageName) {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -1,0 +1,71 @@
+package org.pmiops.workbench.config;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.mapstruct.BeforeMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
+import org.pmiops.workbench.leonardo.model.LeonardoRuntimeConfig.CloudServiceEnum;
+import org.pmiops.workbench.model.ConfigResponse;
+import org.pmiops.workbench.model.RuntimeImage;
+import org.pmiops.workbench.utils.mappers.MapStructConfig;
+
+@Mapper(
+    config = MapStructConfig.class,
+    uses = {
+      // CommonMappers.class,
+    })
+public interface WorkbenchConfigMapper {
+  @Named("dataprocToModel")
+  default RuntimeImage dataprocToModel(String imageName) {
+    return new RuntimeImage().cloudService(CloudServiceEnum.DATAPROC.toString()).name(imageName);
+  }
+
+  @Named("gceToModel")
+  default RuntimeImage gceToModel(String imageName) {
+    return new RuntimeImage().cloudService(CloudServiceEnum.GCE.toString()).name(imageName);
+  }
+
+  @BeforeMapping
+  default void mapRuntimeImages(WorkbenchConfig source, @MappingTarget ConfigResponse target) {
+    target.runtimeImages(
+        Stream.concat(
+                source.firecloud.runtimeImages.dataproc.stream().map(this::dataprocToModel),
+                source.firecloud.runtimeImages.gce.stream().map(this::gceToModel))
+            .collect(Collectors.toList()));
+  }
+
+  // handled by mapRuntimeImages()
+  @Mapping(target = "runtimeImages", ignore = true)
+  @Mapping(target = "accessRenewalLookback", source = "accessRenewal.lookbackPeriod")
+  @Mapping(target = "gsuiteDomain", source = "googleDirectoryService.gSuiteDomain")
+  @Mapping(target = "projectId", source = "server.projectId")
+  @Mapping(target = "firecloudURL", source = "firecloud.baseUrl")
+  @Mapping(target = "publicApiKeyForErrorReports", source = "server.publicApiKeyForErrorReports")
+  @Mapping(target = "shibbolethUiBaseUrl", source = "firecloud.shibbolethUiBaseUrl")
+  @Mapping(
+      target = "defaultFreeCreditsDollarLimit",
+      source = "billing.defaultFreeCreditsDollarLimit")
+  @Mapping(target = "enableComplianceTraining", source = "access.enableComplianceTraining")
+  @Mapping(target = "complianceTrainingHost", source = "moodle.host")
+  @Mapping(target = "enableEraCommons", source = "access.enableEraCommons")
+  @Mapping(target = "unsafeAllowSelfBypass", source = "access.unsafeAllowSelfBypass")
+  @Mapping(target = "enableBillingUpgrade", source = "featureFlags.enableBillingUpgrade")
+  @Mapping(target = "enableEventDateModifier", source = "featureFlags.enableEventDateModifier")
+  @Mapping(
+      target = "enableResearchReviewPrompt",
+      source = "featureFlags.enableResearchPurposePrompt")
+  @Mapping(target = "enableRasLoginGovLinking", source = "access.enableRasLoginGovLinking")
+  @Mapping(target = "enforceRasLoginGovLinking", source = "access.enforceRasLoginGovLinking")
+  @Mapping(target = "enableGenomicExtraction", source = "featureFlags.enableGenomicExtraction")
+  @Mapping(target = "enableEgressAlertingV2", source = "featureFlags.enableEgressAlertingV2")
+  @Mapping(target = "enableGpu", source = "featureFlags.enableGpu")
+  @Mapping(target = "enablePersistentDisk", source = "featureFlags.enablePersistentDisk")
+  @Mapping(target = "rasHost", source = "ras.host")
+  @Mapping(target = "rasClientId", source = "ras.clientId")
+  @Mapping(target = "rasLogoutUrl", source = "ras.logoutUrl")
+  @Mapping(target = "freeTierBillingAccountId", source = "billing.accountId")
+  ConfigResponse toModel(WorkbenchConfig config);
+}


### PR DESCRIPTION
Inspired by #5962 

On master it fails like:
```
> Task :compileJava
/Users/thibault/src/aou/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java:69: error: Unmapped target property: "accessRenewalExpiry".
  ConfigResponse toModel(WorkbenchConfig config);
```

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
