### PR TITLE
[risk=low][no ticket] Bump Jackson and Kotlin

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -13,10 +13,9 @@ buildscript {
     ext {
         GAE_VERSION = '1.9.92'
         GSON_VERSION = '2.8.9'
-        JACKSON_DATABIND_VERSION = '2.11.3'
-        JACKSON_VERSION = '2.11.3'
+        JACKSON_VERSION = '2.13.0'
         JODA_VERSION = '2.10'
-        KOTLIN_VERSION = '1.3.50'
+        KOTLIN_VERSION = '1.4.32'
         MAPSTRUCT_VERSION = '1.4.2.Final'
         MOCKITO_KOTLIN_VERSION = '2.2.0'
         OKHTTP_VERSION = '2.7.5'
@@ -381,7 +380,7 @@ dependencies {
     compile "ch.qos.logback:logback-classic:1.2.7"
     compile "com.fasterxml.jackson.core:jackson-annotations:$project.ext.JACKSON_VERSION"
     compile "com.fasterxml.jackson.core:jackson-core:$project.ext.JACKSON_VERSION"
-    compile "com.fasterxml.jackson.core:jackson-databind:$project.ext.JACKSON_DATABIND_VERSION"
+    compile "com.fasterxml.jackson.core:jackson-databind:$project.ext.JACKSON_VERSION"
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$project.ext.JACKSON_VERSION"
     compile "com.fasterxml.jackson.module:jackson-module-kotlin:$project.ext.JACKSON_VERSION"
     compile "com.github.java-json-tools:json-patch:1.13"
@@ -504,7 +503,7 @@ dependencies {
     testCompile 'com.h2database:h2:1.4.194'
     testCompile 'org.liquibase:liquibase-core:3.10.0'
     testCompile 'org.bitbucket.radistao.test:before-after-spring-test-runner:0.1.0'
-    testCompile "org.jetbrains.kotlin:kotlin-test:1.3.21"
+    testCompile "org.jetbrains.kotlin:kotlin-test:$project.ext.KOTLIN_VERSION"
 
     // Use Mockito for testing only.
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$project.ext.MOCKITO_KOTLIN_VERSION"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         GSON_VERSION = '2.8.9'
         JACKSON_VERSION = '2.13.0'
         JODA_VERSION = '2.10'
-        KOTLIN_VERSION = '1.4.32'
+        KOTLIN_VERSION = '1.5.32'
         MAPSTRUCT_VERSION = '1.4.2.Final'
         MOCKITO_KOTLIN_VERSION = '2.2.0'
         OKHTTP_VERSION = '2.7.5'


### PR DESCRIPTION
Jackson is a frequent source of vulnerabilities.  There's no active vuln that I'm aware of, but I figured it was a good idea to be proactive here.

This introduces an incompatibility with our older version of Kotlin, so that gets a bump too.

Tested by running a local API+UI and confirming that our Kotlin-based Workspace Auditing is functional.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
