### PR TITLE
[RW-7365][risk=no] add tooltip to source standard toggle

### DIFF
--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -11,6 +11,7 @@ import {ClrIcon} from 'app/components/icons';
 import {TextInput} from 'app/components/inputs';
 import {TooltipTrigger} from 'app/components/popups';
 import {Spinner, SpinnerOverlay} from 'app/components/spinners';
+import {AoU} from 'app/components/text-wrappers';
 import {cohortBuilderApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, validateInputForMySQL, withCdrVersions, withCurrentConcept, withCurrentWorkspace} from 'app/utils';
@@ -231,6 +232,13 @@ const columns = [
 ];
 
 const searchTrigger = 2;
+const sourceStandardTooltip = <span>
+  The <AoU/> program receives EHR data from a number of healthcare provider sources across the United States. These sources may code
+  patient health data using a variety of vocabularies, such as ICD10 or SNOMED for conditions. To simplify analysis, the <AoU/> dataset
+  offers a single standardized vocabulary for each domain (e.g. SNOMED for conditions), and corresponding codes from all source
+  vocabularies are mapped to the standard. Therefore, we recommend most users use the standardized items in defining their dataset.
+  However, if you do not wish to rely on this standardization, you may select concepts as coded in the source data.
+</span>;
 
 interface Props {
   cdrVersionTiersResponse: CdrVersionTiersResponse;
@@ -603,6 +611,9 @@ export const ListSearch = fp.flow(withCdrVersions(), withCurrentWorkspace(), wit
                 <span style={{float: 'right'}}>
                   <span style={{display: 'table-cell', paddingRight: '0.35rem'}}>
                     Show results as source concepts (ICD9, ICD10{domain === Domain.PROCEDURE && <span>, CPT</span>})
+                    <TooltipTrigger side='top' content={<div>{sourceStandardTooltip}</div>}>
+                      <ClrIcon style={styles.infoIcon} className='is-solid' shape='info-standard'/>
+                    </TooltipTrigger>
                   </span>
                   <InputSwitch checked={searchSource}
                                disabled={loading}


### PR DESCRIPTION
Add info icon to source/standard toggle in Conditions and Procedures searches with explanation on the difference between searching source and standard concepts.
![Screen Shot 2021-12-01 at 9 17 29 AM](https://user-images.githubusercontent.com/40036095/144262212-16567aee-3c82-4908-9f3d-9a963d99c351.png)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
