### PR TITLE
[risk=no][RW-7255] Prohibit apostrophes in usernames

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -196,8 +196,7 @@ public class ProfileController implements ProfileApiDelegate {
     // On first sign-in, create a FC user, billing project, and set the first sign in time.
     if (dbUser.getFirstSignInTime() == null) {
       // If the user is already registered, their profile will get updated.
-      fireCloudService.registerUser(
-          dbUser.getContactEmail(), dbUser.getGivenName(), dbUser.getFamilyName());
+      fireCloudService.registerUser(dbUser.getGivenName(), dbUser.getFamilyName());
 
       dbUser.setFirstSignInTime(new Timestamp(clock.instant().toEpochMilli()));
       return saveUserWithConflictHandling(dbUser);

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -36,11 +36,10 @@ public interface FireCloudService {
   /**
    * Registers the user in Firecloud.
    *
-   * @param contactEmail an email address that can be used to contact this user
    * @param firstName the user's first name
    * @param lastName the user's last name
    */
-  void registerUser(String contactEmail, String firstName, String lastName);
+  void registerUser(String firstName, String lastName);
 
   /** Creates a billing project owned by AllOfUs. */
   String createAllOfUsBillingProject(String billingProjectName, String servicePerimeter);

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -190,7 +190,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public void registerUser(String contactEmail, String firstName, String lastName) {
+  public void registerUser(String firstName, String lastName) {
     ProfileApi profileApi = profileApiProvider.get();
     FirecloudProfile profile = new FirecloudProfile();
     profile.setFirstName(firstName);

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -545,7 +545,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
     Profile profile = profileController.getMe().getBody();
     assertProfile(profile);
-    verify(mockFireCloudService).registerUser(CONTACT_EMAIL, GIVEN_NAME, FAMILY_NAME);
+    verify(mockFireCloudService).registerUser(GIVEN_NAME, FAMILY_NAME);
     verify(mockProfileAuditor).fireLoginAction(dbUser);
   }
 
@@ -554,7 +554,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     createAccountAndDbUserWithAffiliation();
     Profile profile = profileController.getMe().getBody();
     assertProfile(profile);
-    verify(mockFireCloudService).registerUser(CONTACT_EMAIL, GIVEN_NAME, FAMILY_NAME);
+    verify(mockFireCloudService).registerUser(GIVEN_NAME, FAMILY_NAME);
 
     // An additional call to getMe() should have no effect.
     fakeClock.increment(1);

--- a/ui/src/app/pages/login/account-creation/account-creation.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.spec.tsx
@@ -65,11 +65,12 @@ it('should handle username validity ends with .', () => {
   expect(wrapper.exists('#usernameError')).toBeTruthy();
 });
 
-it('should handle username validity contains special chars', () => {
+test.each(['user@name', '.user', 'user.', 'user..', "O'Riley", '50%', 'no+plus', 'ælfred', 'money$man'])
+('should mark username %s as invalid', (username) => {
   const wrapper = component();
   expect(wrapper.exists('#username')).toBeTruthy();
   expect(wrapper.exists('#usernameError')).toBeFalsy();
-  wrapper.find('input#username').simulate('change', {target: {value: 'user@name'}});
+  wrapper.find('input#username').simulate('change', {target: {value: username}});
   expect(wrapper.exists('#usernameError')).toBeTruthy();
 });
 

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -137,11 +137,17 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
     if (username.trim().length > 64 || username.trim().length < 3) {
       return true;
     }
-    // Include alphanumeric characters, -'s, _'s, apostrophes, and single .'s in a row.
+    // reject these invalid email patterns
     if (username.includes('..') || username.endsWith('.')) {
       return true;
     }
-    return !(new RegExp(/^[\w'-][\w.'-]*$/).test(username));
+
+    // Our intention here is to support alphanumeric characters, -'s, _'s, apostrophes, and single .'s in a row.
+    // Our desired regex is /^[\w'-][\w.'-]*$/ to match more valid emails (including apostrophes)
+    // but Terra does not currently support that (RW-7618)
+    // until they do, we must use Terra's more restrictive regex /^[\w'][\w.']*$/ (no apostrophes)
+
+    return !(new RegExp(/^[\w-][\w.-]*$/).test(username));
   }
 
   usernameChanged(username: string): void {
@@ -313,7 +319,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
           <li>numbers (0-9)</li>
           <li>dashes (-)</li>
           <li>underscores (_)</li>
-          <li>apostrophes (')</li>
+          {/* <li>apostrophes (')</li> temporarily disabled - see RW-7618 */}
           <li>periods (.)</li>
           <li>minimum of 3 characters</li>
           <li>maximum of 64 characters</li>

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -137,15 +137,15 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
     if (username.trim().length > 64 || username.trim().length < 3) {
       return true;
     }
-    // reject these invalid email patterns
+    // reject these usernames because they would generate invalid emails
     if (username.includes('..') || username.endsWith('.')) {
       return true;
     }
 
     // Our intention here is to support alphanumeric characters, -'s, _'s, apostrophes, and single .'s in a row.
-    // Our desired regex is /^[\w'-][\w.'-]*$/ to match more valid emails (including apostrophes)
+    // Our desired regex is /^[\w'-][\w.'-]*$/ to match more valid usernames (including apostrophes)
     // but Terra does not currently support that (RW-7618)
-    // until they do, we must use Terra's more restrictive regex /^[\w'][\w.']*$/ (no apostrophes)
+    // until they do, we must use a more restrictive regex /^[\w'][\w.']*$/ without apostrophes
 
     return !(new RegExp(/^[\w-][\w.-]*$/).test(username));
   }


### PR DESCRIPTION
Terra has overly restrictive email validation, so we can create users in an invalid state.  Until they loosen their restrictions (RW-7618) we need to also prohibit apostrophes.


<img width="432" alt="Screen Shot 2021-12-01 at 10 48 11 AM" src="https://user-images.githubusercontent.com/2701406/144266588-ede5ca26-1e96-4694-94ba-bf0b47750cd0.png">

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
