### PR TITLE
[RW-5661][risk=no] Implement egress event audit endpoint

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -11,6 +11,7 @@
     "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.3",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev",
+    "workspaceLogsProject": "fc-aou-logs-test",
     "runtimeImages": {
       "gce": ["test-gce-docker-image"],
       "dataproc": ["test-dataproc-docker-image"]

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -11,6 +11,7 @@
     "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.3",
     "shibbolethApiBaseUrl": "",
     "shibbolethUiBaseUrl": "",
+    "workspaceLogsProject": "fc-aou-logs-perf",
     "runtimeImages": {
       "gce": [],
       "dataproc": []

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -11,6 +11,7 @@
     "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.3",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
+    "workspaceLogsProject": "fc-aou-logs-preprod",
     "runtimeImages": {
       "gce": [],
       "dataproc": []

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -11,6 +11,7 @@
     "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.3",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
+    "workspaceLogsProject": "fc-aou-logs-prod",
     "runtimeImages": {
       "gce": [],
       "dataproc": []

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -11,6 +11,7 @@
     "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.3",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
+    "workspaceLogsProject": "fc-aou-logs-stable",
     "runtimeImages": {
       "gce": [],
       "dataproc": []

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -11,6 +11,7 @@
     "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.3",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
+    "workspaceLogsProject": "fc-aou-logs-staging",
     "runtimeImages": {
       "gce": [],
       "dataproc": []

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -11,6 +11,7 @@
     "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.3",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev",
+    "workspaceLogsProject": "fc-aou-logs-test",
     "runtimeImages": {
       "gce": [],
       "dataproc": []

--- a/api/src/main/java/org/pmiops/workbench/api/EgressEventsAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/EgressEventsAdminController.java
@@ -45,12 +45,28 @@ public class EgressEventsAdminController implements EgressEventsAdminApiDelegate
   private static final Set<EgressEventStatus> updateableStatuses =
       ImmutableSet.of(EgressEventStatus.REMEDIATED, EgressEventStatus.VERIFIED_FALSE_POSITIVE);
 
-  @Autowired private EgressLogService egressLogService;
-  @Autowired private EgressEventMapper egressEventMapper;
-  @Autowired private EgressEventAuditor egressEventAuditor;
-  @Autowired private UserDao userDao;
-  @Autowired private WorkspaceDao workspaceDao;
-  @Autowired private EgressEventDao egressEventDao;
+  private final EgressLogService egressLogService;
+  private final EgressEventMapper egressEventMapper;
+  private final EgressEventAuditor egressEventAuditor;
+  private final UserDao userDao;
+  private final WorkspaceDao workspaceDao;
+  private final EgressEventDao egressEventDao;
+
+  @Autowired
+  public EgressEventsAdminController(
+      EgressLogService egressLogService,
+      EgressEventMapper egressEventMapper,
+      EgressEventAuditor egressEventAuditor,
+      UserDao userDao,
+      WorkspaceDao workspaceDao,
+      EgressEventDao egressEventDao) {
+    this.egressLogService = egressLogService;
+    this.egressEventMapper = egressEventMapper;
+    this.egressEventAuditor = egressEventAuditor;
+    this.userDao = userDao;
+    this.workspaceDao = workspaceDao;
+    this.egressEventDao = egressEventDao;
+  }
 
   @AuthorityRequired(Authority.SECURITY_ADMIN)
   @Override

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -139,6 +139,10 @@ public class WorkbenchConfig {
     // an authentication round trip with eRA Commons.
     public String shibbolethUiBaseUrl;
 
+    // Project containing aggregated BigQuery log sinks for Terra workspace projects. This contains
+    // information such as runtime VM server logs.
+    public String workspaceLogsProject;
+
     public RuntimeImages runtimeImages;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
+++ b/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
@@ -1,0 +1,149 @@
+package org.pmiops.workbench.exfiltration;
+
+import com.google.cloud.bigquery.BigQuery.QueryResultsOption;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.QueryParameterValue;
+import com.google.cloud.bigquery.TableResult;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
+import javax.inject.Provider;
+import org.pmiops.workbench.api.BigQueryService;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.model.DbEgressEvent;
+import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.model.AuditEgressRuntimeLogEntry;
+import org.pmiops.workbench.model.AuditEgressRuntimeLogGroup;
+import org.pmiops.workbench.model.SumologicEgressEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class EgressLogService {
+  /**
+   * Scan logs ahead of the egress window by this amount, in the even that the egress activity
+   * started before or near the beginning. This is not guaranteed to catch all relevant logs.
+   */
+  public static final Duration LOG_START_OFFSET = Duration.ofMinutes(5L);
+
+  public static final int RUNTIME_LOG_LIMIT = 1000;
+
+  public static final List<EgressTerraRuntimeLogPattern> terraRuntimeLogPatterns =
+      ImmutableList.of(
+          new EgressTerraRuntimeLogPattern("Notebook Interactions", "%.ipynb%"),
+          new EgressTerraRuntimeLogPattern("File downloads", "%download%"),
+          new EgressTerraRuntimeLogPattern("Errors", "%error%"));
+
+  @Autowired private Provider<WorkbenchConfig> workbenchConfigProvider;
+  @Autowired private BigQueryService bigQueryService;
+
+  /**
+   * Fetches groups of runtime logs for the given egress events which may be relevant to
+   * investigation of said event. Row count is restricted for performance reason (see totalEntries).
+   * Within each group, logs are sorted by descending timestamp order. All logs returned are
+   * restricted to the approximate time frame of the event.
+   */
+  public List<AuditEgressRuntimeLogGroup> getRuntimeLogGroups(DbEgressEvent event) {
+    Duration windowSize = Duration.ofSeconds(event.getEgressWindowSeconds());
+    Instant endTime = event.getCreationTime().toInstant();
+    Instant startTime =
+        maybeParseSumologicEvent(event.getSumologicEvent())
+            .map(SumologicEgressEvent::getTimeWindowStart)
+            .filter(Objects::nonNull)
+            .map(Instant::ofEpochMilli)
+            .orElse(endTime.minus(windowSize))
+            .minus(Duration.ofMinutes(5L));
+
+    Map<String, QueryParameterValue> baseParams =
+        ImmutableMap.<String, QueryParameterValue>builder()
+            .put("project_id", QueryParameterValue.string(event.getWorkspace().getGoogleProject()))
+            .put("start_time", QueryParameterValue.timestamp(startTime.toEpochMilli()))
+            .put("end_time", QueryParameterValue.timestamp(endTime.toEpochMilli()))
+            .build();
+
+    Map<EgressTerraRuntimeLogPattern, Job> bigQueryLogJobs =
+        terraRuntimeLogPatterns.stream()
+            .collect(
+                Collectors.toMap(
+                    Function.identity(),
+                    (runtimeLogPattern) -> startBigQueryJob(runtimeLogPattern, baseParams)));
+
+    return bigQueryLogJobs.entrySet().stream()
+        .map(
+            (entry) -> {
+              TableResult result;
+              try {
+                result =
+                    entry
+                        .getValue()
+                        .getQueryResults(QueryResultsOption.pageSize(RUNTIME_LOG_LIMIT));
+              } catch (InterruptedException e) {
+                throw new ServerErrorException("failed while waiting for BigQuery job", e);
+              }
+              return toAuditEgressRuntimeLogGroup(entry.getKey(), result);
+            })
+        .collect(Collectors.toList());
+  }
+
+  private Optional<SumologicEgressEvent> maybeParseSumologicEvent(@Nullable String sumologicEvent) {
+    if (sumologicEvent == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(new Gson().fromJson(sumologicEvent, SumologicEgressEvent.class));
+    } catch (JsonSyntaxException e) {
+      return Optional.empty();
+    }
+  }
+
+  private AuditEgressRuntimeLogGroup toAuditEgressRuntimeLogGroup(
+      EgressTerraRuntimeLogPattern logPattern, TableResult result) {
+    return new AuditEgressRuntimeLogGroup()
+        .name(logPattern.getName())
+        .pattern(logPattern.getLogMessagePattern())
+        .entries(
+            StreamSupport.stream(result.getValues().spliterator(), false)
+                .map(this::toRuntimeLogEntry)
+                .collect(Collectors.toList()))
+        .totalEntries((int) result.getTotalRows());
+  }
+
+  private AuditEgressRuntimeLogEntry toRuntimeLogEntry(FieldValueList fvl) {
+    return new AuditEgressRuntimeLogEntry()
+        .timestamp(Instant.ofEpochMilli(fvl.get("timestamp").getTimestampValue()).toString())
+        .message(fvl.get("message").getStringValue());
+  }
+
+  private Job startBigQueryJob(
+      EgressTerraRuntimeLogPattern runtimeLogPattern, Map<String, QueryParameterValue> baseParams) {
+    return bigQueryService.startQuery(
+        QueryJobConfiguration.newBuilder(
+                String.format(
+                    "SELECT timestamp, jsonPayload.message AS message"
+                        + " FROM `%s.WorkspaceRuntimeLogs.cos_containers`"
+                        + " WHERE resource.labels.project_id = @project_id"
+                        + "  AND timestamp BETWEEN @start_time AND @end_time"
+                        + "  AND jsonPayload.message LIKE @log_pattern"
+                        + " ORDER BY timestamp DESC",
+                    workbenchConfigProvider.get().firecloud.workspaceLogsProject))
+            .setNamedParameters(
+                ImmutableMap.<String, QueryParameterValue>builder()
+                    .putAll(baseParams)
+                    .put(
+                        "log_pattern",
+                        QueryParameterValue.string(runtimeLogPattern.getLogMessagePattern()))
+                    .build())
+            .build());
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
+++ b/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
@@ -48,8 +48,15 @@ public class EgressLogService {
           new EgressTerraRuntimeLogPattern("File downloads", "%download%"),
           new EgressTerraRuntimeLogPattern("Errors", "%error%"));
 
-  @Autowired private Provider<WorkbenchConfig> workbenchConfigProvider;
-  @Autowired private BigQueryService bigQueryService;
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
+  private final BigQueryService bigQueryService;
+
+  @Autowired
+  public EgressLogService(
+      Provider<WorkbenchConfig> workbenchConfigProvider, BigQueryService bigQueryService) {
+    this.workbenchConfigProvider = workbenchConfigProvider;
+    this.bigQueryService = bigQueryService;
+  }
 
   /**
    * Fetches groups of runtime logs for the given egress events which may be relevant to

--- a/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
+++ b/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
@@ -88,19 +88,19 @@ public class EgressLogService {
                     Function.identity(),
                     (runtimeLogPattern) -> startBigQueryJob(runtimeLogPattern, baseParams)));
 
-    return bigQueryLogJobs.entrySet().stream()
+    return terraRuntimeLogPatterns.stream()
         .map(
-            (entry) -> {
+            (pattern) -> {
               TableResult result;
               try {
                 result =
-                    entry
-                        .getValue()
+                    bigQueryLogJobs
+                        .get(pattern)
                         .getQueryResults(QueryResultsOption.pageSize(RUNTIME_LOG_LIMIT));
               } catch (InterruptedException e) {
                 throw new ServerErrorException("failed while waiting for BigQuery job", e);
               }
-              return toAuditEgressRuntimeLogGroup(entry.getKey(), result);
+              return toAuditEgressRuntimeLogGroup(pattern, result);
             })
         .collect(Collectors.toList());
   }

--- a/api/src/main/java/org/pmiops/workbench/exfiltration/EgressTerraRuntimeLogPattern.java
+++ b/api/src/main/java/org/pmiops/workbench/exfiltration/EgressTerraRuntimeLogPattern.java
@@ -1,0 +1,43 @@
+package org.pmiops.workbench.exfiltration;
+
+import java.util.Objects;
+
+/** Pattern configuration details for pulling logs from the Terra runtime log sink. */
+public class EgressTerraRuntimeLogPattern {
+  private final String name;
+  private final String logMessagePattern;
+
+  /**
+   * @param name a display name for this configuration, to be shown in an admin view
+   * @param logMessagePattern used in a LIKE expression on jsonPayload.message in the runtime logs
+   */
+  public EgressTerraRuntimeLogPattern(String name, String logMessagePattern) {
+    this.name = name;
+    this.logMessagePattern = logMessagePattern;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getLogMessagePattern() {
+    return logMessagePattern;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    EgressTerraRuntimeLogPattern that = (EgressTerraRuntimeLogPattern) o;
+    return name.equals(that.name) && logMessagePattern.equals(that.logMessagePattern);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, logMessagePattern);
+  }
+}


### PR DESCRIPTION
This endpoint will be used to power an egress event admin page, to be used by the oncall for event investigation. Log entries are sourced from the Terra log sink (currently the SA only has permission in test, https://precisionmedicineinitiative.atlassian.net/browse/PD-6931 tracks permissions in higher environments).