### PR TITLE
[RW-6459][risk=no] Add policy warning on Jupyter download from file tree

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -125,7 +125,9 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
             .put("aou-snippets-menu", assetsBaseUrl + "/aou-snippets-menu.js")
             .put("aou-download-extension", assetsBaseUrl + "/aou-download-policy-extension.js")
             .put("aou-activity-checker-extension", assetsBaseUrl + "/activity-checker-extension.js")
-            .put("aou-upload-policy-extension", assetsBaseUrl + "/aou-upload-policy-extension.js")
+            .put(
+                "aou-file-tree-policy-extension",
+                assetsBaseUrl + "/aou-file-tree-policy-extension.js")
             .build();
 
     Map<String, String> runtimeLabels =

--- a/api/src/main/webapp/static/aou-file-tree-policy-extension.js
+++ b/api/src/main/webapp/static/aou-file-tree-policy-extension.js
@@ -1,0 +1,35 @@
+// Workbench policy extension, to show the data use policy before letting user
+// upload or download files.
+
+define([
+  'base/js/namespace'
+], (Jupyter) => {
+
+  const load_upload_extension = () => {
+  // This will open a dialog box when the user clicks Upload Button on the Jupyter File List page.
+  // File will be uploaded only if the user clicks OK else it will just close the dialog box and do nothing.
+
+    $('#notebook_list_info input').click(() => confirm(
+        'It is All of Us data use policy to not upload data or files containing ' +
+        'personally identifiable information (PII). Any external data, files, or software that ' +
+        'is uploaded into the Workspace should be exclusively for the research purpose that was ' +
+        'provided for this Workspace.'));
+
+    // notebook-list.js in the Jupyter UI serves the download by using it's own
+    // jQuery click handler. We have no way of ordering our click handler ahead
+    // of it without digging into jQuery internals. Instead, we insert a span
+    // on top of the button to gain click priority.
+    $('.dynamic-buttons .download-button').empty().append(
+        '<span id="aou-download-button-overlay">Download</span>');
+    $('#aou-download-button-overlay').click(() => confirm(
+        'The All of Us Data Use Policies prohibit you from removing participant-level data from ' +
+        'the workbench. You are also prohibited from publishing or otherwise distributing any data ' +
+        'or aggregate statistics corresponding to fewer than 20 participants unless ' +
+        'expressly permitted by our data use policies. By continuing, you affirm that this ' +
+        'download will be used in accordance with the All of Us data use policy.'));
+  };
+
+  return {
+    'load_ipython_extension': load_upload_extension
+  };
+});

--- a/api/src/main/webapp/static/aou-upload-policy-extension.js
+++ b/api/src/main/webapp/static/aou-upload-policy-extension.js
@@ -1,3 +1,6 @@
+// TODO(calbach): Remove this file 2w after aou-file-tree-policy-extension.js is live.
+// This file is being kept so that old runtimes can continue to reference it.
+
 // Workbench "Upload policy" extension, to show the policy before letting user upload any file
 
 define([

--- a/api/src/main/webapp/static/initialize_notebook_runtime.sh
+++ b/api/src/main/webapp/static/initialize_notebook_runtime.sh
@@ -19,7 +19,7 @@ set -x
 sudo -E -u jupyter /opt/conda/bin/jupyter nbextension enable snippets_menu/main
 
 # Section represents the jupyter page to which the extension will be applied to
-sudo -E -u jupyter /opt/conda/bin/jupyter nbextension enable aou-upload-policy-extension/main --section=tree
+sudo -E -u jupyter /opt/conda/bin/jupyter nbextension enable aou-file-tree-policy-extension/main --section=tree
 
 sudo -E -u jupyter /opt/conda/bin/nbstripout --install --global
 


### PR DESCRIPTION
This extension is a generalization of `aou-upload-policy-extension.js` to now warn on both upload and download - the upload extension will be removed once it is phased out of usage. This warning is shown when clicking download on the file tree. The approach is unfortunately hacky, but we are a bit limited with the changes we can make here. 

![image](https://user-images.githubusercontent.com/822298/144553628-be23ed6c-e3b3-4859-a19c-c685dd88ede4.png)
