### PR TITLE
[risk=no] Fix alt text for CT badge

### DIFF
--- a/ui/src/assets/icons/controlled-tier-badge.svg
+++ b/ui/src/assets/icons/controlled-tier-badge.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="25px" height="27px" viewBox="0 0 25 27" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>Controll tier</title>
+    <title>Controlled tier</title>
     <g id="Controlled-user" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="CT---Share" transform="translate(-399.000000, -492.000000)" fill-rule="nonzero">
             <g id="Group" transform="translate(376.000000, 88.000000)">


### PR DESCRIPTION
This is shown when hovering the CT badge.

![image](https://user-images.githubusercontent.com/822298/144654110-dafff7d1-ef43-481b-8166-a0c18522a66f.png)
