### PR TITLE
[RW-7608][risk=no]  Behavior for URL access by non-CT users to CT workspaces/resources

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditor;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.cohortbuilder.CohortBuilderService;
@@ -120,6 +121,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     WorkspaceAuthService.class
   })
   @MockBean({
+    AccessTierService.class,
     BillingProjectAuditor.class,
     CohortBuilderService.class,
     CohortFactory.class,

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -176,7 +176,7 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
   @Override
   public WorkspaceResponse getWorkspace(String workspaceNamespace, String workspaceId) {
     DbWorkspace dbWorkspace = workspaceDao.getRequired(workspaceNamespace, workspaceId);
-    validateControlledTierAccess(dbWorkspace);
+    validateWorkspaceTierAccess(dbWorkspace);
 
     FirecloudWorkspaceResponse fcResponse;
     FirecloudWorkspaceDetails fcWorkspace;
@@ -335,24 +335,18 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
   }
 
   /**
-   * Throw ForbiddenException if : a) The workspace being access if Controlled Tier and b) The
-   * logged in user doesnt have controlled Tier Access
+   * Throw ForbiddenException if logged in user doesnt have the same Tier Access as that of
+   * workspace
    *
    * @param dbWorkspace
    */
-  private void validateControlledTierAccess(DbWorkspace dbWorkspace) {
-    // Return if the workspace is not Controlled Tier
-    if (!dbWorkspace
-        .getCdrVersion()
-        .getAccessTier()
-        .getShortName()
-        .equals(AccessTierService.CONTROLLED_TIER_SHORT_NAME)) {
-      return;
-    }
-    // Get logged in user's access Tiers
+  private void validateWorkspaceTierAccess(DbWorkspace dbWorkspace) {
+    String workspaceAccessTier = dbWorkspace.getCdrVersion().getAccessTier().getShortName();
+
     List<String> accessTiers = accessTierService.getAccessTierShortNamesForUser(userProvider.get());
-    if (!accessTiers.contains(AccessTierService.CONTROLLED_TIER_SHORT_NAME)) {
-      throw new ForbiddenException("User does not have access to control tier");
+
+    if (!accessTiers.contains(workspaceAccessTier)) {
+      throw new ForbiddenException("User does not have access to the workspace tier");
     }
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -176,9 +176,10 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
   @Override
   public WorkspaceResponse getWorkspace(String workspaceNamespace, String workspaceId) {
     DbWorkspace dbWorkspace = workspaceDao.getRequired(workspaceNamespace, workspaceId);
+    validateControlledTierAccess(dbWorkspace);
+
     FirecloudWorkspaceResponse fcResponse;
     FirecloudWorkspaceDetails fcWorkspace;
-    validateControlledTierAccess(dbWorkspace);
     WorkspaceResponse workspaceResponse = new WorkspaceResponse();
 
     // This enforces access controls.

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -931,6 +931,10 @@ paths:
           description: A workspace response containing workspace and access level
           schema:
             "$ref": "#/definitions/WorkspaceResponse"
+        403:
+          description: User doesnt have the correct access tier as workspace
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
     patch:
       tags:
       - workspaces

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -932,7 +932,7 @@ paths:
           schema:
             "$ref": "#/definitions/WorkspaceResponse"
         403:
-          description: User doesnt have the correct access tier as workspace
+          description: User doesnt have access to the workspace's access tier
           schema:
             "$ref": "#/definitions/ErrorResponse"
     patch:

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -236,6 +236,7 @@ public class WorkspacesControllerTest {
   @Autowired private WorkspacesController workspacesController;
   @Autowired FakeClock fakeClock;
 
+  @MockBean AccessTierService accessTierService;
   @MockBean FreeTierBillingService mockFreeTierBillingService;
   @MockBean CloudBillingClient mockCloudBillingClient;
   @MockBean IamService mockIamService;
@@ -275,6 +276,7 @@ public class WorkspacesControllerTest {
     WorkspaceServiceImpl.class,
   })
   @MockBean({
+    AccessTierService.class,
     BigQueryService.class,
     BillingProjectAuditor.class,
     CdrBigQuerySchemaConfigService.class,
@@ -293,7 +295,6 @@ public class WorkspacesControllerTest {
     UserService.class,
     GenomicExtractionService.class,
     WorkspaceAuditor.class,
-    AccessTierService.class,
     CdrVersionService.class,
   })
   static class Configuration {
@@ -351,7 +352,6 @@ public class WorkspacesControllerTest {
 
     testMockFactory = new TestMockFactory();
     currentUser = createUser(LOGGED_IN_USER_EMAIL);
-
     accessTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
     cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao, 1);
@@ -376,6 +376,9 @@ public class WorkspacesControllerTest {
 
     when(mockCloudBillingClient.pollUntilBillingAccountLinked(any(), any()))
         .thenReturn(new ProjectBillingInfo().setBillingEnabled(true));
+
+    when(accessTierService.getAccessTierShortNamesForUser(currentUser))
+        .thenReturn(Arrays.asList(AccessTierService.REGISTERED_TIER_SHORT_NAME));
   }
 
   private DbUser createUser(String email) {

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditor;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.cohortreview.mapper.CohortReviewMapperImpl;
@@ -77,6 +78,7 @@ public class WorkspaceServiceTest {
     WorkspaceAuthService.class
   })
   @MockBean({
+    AccessTierService.class,
     BillingProjectAuditor.class,
     CohortCloningService.class,
     CohortService.class,

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -223,12 +223,7 @@ public class WorkspaceServiceTest {
       WorkspaceActiveStatus activeStatus) {
 
     FirecloudWorkspaceResponse mockWorkspaceResponse =
-        mockFirecloudWorkspaceResponse(
-            Long.toString(workspaceId), workspaceName, workspaceNamespace, accessLevel);
-    firecloudWorkspaceResponses.add(mockWorkspaceResponse);
-    doReturn(mockWorkspaceResponse)
-        .when(mockFireCloudService)
-        .getWorkspace(workspaceNamespace, workspaceName);
+        mockFirecloudWorkspaceResponse(workspaceId, workspaceName, workspaceNamespace, accessLevel);
 
     DbWorkspace dbWorkspace =
         workspaceDao.save(
@@ -244,20 +239,30 @@ public class WorkspaceServiceTest {
 
   private DbWorkspace addMockedWorkspace(DbWorkspace dbWorkspace) {
 
-    FirecloudWorkspaceResponse mockWorkspaceResponse =
-        mockFirecloudWorkspaceResponse(
-            Long.toString(dbWorkspace.getWorkspaceId()),
-            dbWorkspace.getName(),
-            dbWorkspace.getWorkspaceNamespace(),
-            WorkspaceAccessLevel.OWNER);
-    firecloudWorkspaceResponses.add(mockWorkspaceResponse);
-    doReturn(mockWorkspaceResponse)
-        .when(mockFireCloudService)
-        .getWorkspace(dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getName());
+    mockFirecloudWorkspaceResponse(
+        dbWorkspace.getWorkspaceId(),
+        dbWorkspace.getName(),
+        dbWorkspace.getWorkspaceNamespace(),
+        WorkspaceAccessLevel.OWNER);
 
     workspaceDao.save(dbWorkspace);
     dbWorkspaces.add(dbWorkspace);
     return dbWorkspace;
+  }
+
+  private FirecloudWorkspaceResponse mockFirecloudWorkspaceResponse(
+      long workspaceId,
+      String workspaceName,
+      String workspaceNamespace,
+      WorkspaceAccessLevel accessLevel) {
+    FirecloudWorkspaceResponse mockWorkspaceResponse =
+        mockFirecloudWorkspaceResponse(
+            Long.toString(workspaceId), workspaceName, workspaceNamespace, accessLevel);
+    firecloudWorkspaceResponses.add(mockWorkspaceResponse);
+    doReturn(mockWorkspaceResponse)
+        .when(mockFireCloudService)
+        .getWorkspace(workspaceNamespace, workspaceName);
+    return mockWorkspaceResponse;
   }
 
   @Test
@@ -550,7 +555,7 @@ public class WorkspaceServiceTest {
     DbWorkspace dbWorkspace =
         buildDbWorkspace(
             workspaceIdIncrementer.getAndIncrement(),
-            "Controlled Tier Es",
+            "Controlled Tier Workspace",
             DEFAULT_WORKSPACE_NAMESPACE,
             WorkspaceActiveStatus.ACTIVE);
     DbCdrVersion dbCdrVersion =

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -551,7 +551,7 @@ public class WorkspaceServiceTest {
   }
 
   @Test
-  public void userWithNoCtTierAccessCTWorkspace() {
+  public void userWithoutCtTierAccessCTWorkspace() {
     DbWorkspace dbWorkspace =
         buildDbWorkspace(
             workspaceIdIncrementer.getAndIncrement(),

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -570,6 +570,21 @@ public class WorkspaceServiceTest {
   }
 
   @Test
+  public void userWithoutRegisterTierAccessRTWorkspace() {
+    DbWorkspace dbWorkspace = dbWorkspaces.get(0);
+    DbCdrVersion dbCdrVersion =
+        TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+    dbWorkspace.setCdrVersion(dbCdrVersion);
+    when(accessTierService.getAccessTierShortNamesForUser(currentUser))
+        .thenReturn(Collections.singletonList(AccessTierService.CONTROLLED_TIER_SHORT_NAME));
+    assertThrows(
+        ForbiddenException.class,
+        () ->
+            workspaceService.getWorkspace(
+                DEFAULT_WORKSPACE_NAMESPACE, dbWorkspace.getFirecloudName()));
+  }
+
+  @Test
   public void userWithCtTierAccessCTWorkspace() {
     DbWorkspace dbWorkspace =
         buildDbWorkspace(

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteWorkspaces.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteWorkspaces.java
@@ -12,6 +12,7 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditor;
 import org.pmiops.workbench.auth.ServiceAccounts;
 import org.pmiops.workbench.db.dao.UserDao;
@@ -74,6 +75,7 @@ public class DeleteWorkspaces {
 
   @Bean
   public WorkspaceService workspaceService(
+      AccessTierService accessTierService,
       BillingProjectAuditor billingProjectAuditor,
       Clock clock,
       FireCloudService fireCloudService,
@@ -82,6 +84,7 @@ public class DeleteWorkspaces {
       UserRecentWorkspaceDao userRecentWorkspaceDao,
       WorkspaceDao workspaceDao) {
     return new WorkspaceServiceImpl(
+        accessTierService,
         billingProjectAuditor,
         clock,
         null,

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -11,7 +11,11 @@ import {
   LeoRuntimeInitializationAbortedError,
   LeoRuntimeInitializer
 } from 'app/utils/leo-runtime-initializer';
-import {currentWorkspaceStore, nextWorkspaceWarmupStore} from 'app/utils/navigation';
+import {
+  currentWorkspaceStore,
+  navigateSignOut,
+  nextWorkspaceWarmupStore, useNavigation
+} from 'app/utils/navigation';
 import {diskStore, MatchParams, routeDataStore, runtimeStore, useStore} from 'app/utils/stores';
 import * as fp from 'lodash/fp';
 import * as React from 'react';
@@ -23,6 +27,8 @@ export const WorkspaceWrapper = fp.flow(
 )(({workspace, hideSpinner}) => {
   useEffect(() => hideSpinner(), []);
   const routeData = useStore(routeDataStore);
+  const [navigate, ] = useNavigation();
+
 
   const [pollAborter, setPollAborter] = useState(new AbortController());
   const params = useParams<MatchParams>();
@@ -57,16 +63,20 @@ export const WorkspaceWrapper = fp.flow(
         }
       }
     };
-
     const getWorkspaceAndUpdateStores = async(namespace, id) => {
-      // No destructuring because otherwise it shadows the workspace in props
-      const wsResponse = await workspacesApi().getWorkspace(namespace, id);
-      currentWorkspaceStore.next({
-        ...wsResponse.workspace,
-        accessLevel: wsResponse.accessLevel
-      });
-
-      updateStores(wsResponse.workspace.namespace);
+       try {
+         // No destructuring because otherwise it shadows the workspace in props
+         const wsResponse = await workspacesApi().getWorkspace(namespace, id)
+         currentWorkspaceStore.next({
+           ...wsResponse.workspace,
+           accessLevel: wsResponse.accessLevel
+         });
+         updateStores(wsResponse.workspace.namespace);
+       } catch(ex) {
+         if (ex.status === 403) {
+           navigate(['/workspaces']);
+         }
+       }
     };
 
     if (

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -27,7 +27,7 @@ export const WorkspaceWrapper = fp.flow(
 )(({workspace, hideSpinner}) => {
   useEffect(() => hideSpinner(), []);
   const routeData = useStore(routeDataStore);
-  const [navigate, ] = useNavigation();
+  const [navigate] = useNavigation();
 
 
   const [pollAborter, setPollAborter] = useState(new AbortController());


### PR DESCRIPTION

If user without CT access tries to access a CT Workspace directly via  a link, they will be redirected to workspace List page.

https://user-images.githubusercontent.com/34481816/144875191-4065b31a-7a43-4470-a632-208732fa44a8.mov



---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
