### PR TITLE
[risk=low][RW-7632] Record audit-log entries for updateProfile() correctly when done by admin

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditor.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditor.kt
@@ -1,12 +1,13 @@
 package org.pmiops.workbench.actionaudit.auditors
 
+import org.pmiops.workbench.actionaudit.Agent
 import org.pmiops.workbench.db.model.DbUser
 import org.pmiops.workbench.model.Profile
 
 interface ProfileAuditor {
     fun fireCreateAction(createdProfile: Profile)
 
-    fun fireUpdateAction(previousProfile: Profile, updatedProfile: Profile)
+    fun fireUpdateAction(previousProfile: Profile, updatedProfile: Profile, agent: Agent)
 
     fun fireDeleteAction(userId: Long, userEmail: String)
 

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -19,6 +19,7 @@ import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.actionaudit.ActionAuditQueryService;
+import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.ProfileAuditor;
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.auth.UserAuthentication;
@@ -477,7 +478,8 @@ public class ProfileController implements ProfileApiDelegate {
       throw new BadRequestException("Cannot update Verified Institutional Affiliation");
     }
 
-    DbUser updatedUser = profileService.updateProfile(user, updatedProfile, previousProfile);
+    DbUser updatedUser =
+        profileService.updateProfile(user, Agent.asUser(user), updatedProfile, previousProfile);
     userService.confirmProfile(updatedUser);
 
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -209,9 +209,10 @@ public class ProfileService {
   /**
    * Updates a profile for a given user and persists all information to the database.
    *
-   * @param user
-   * @param updatedProfile
-   * @param previousProfile
+   * @param user the DbUser whose profile we're updating
+   * @param agent is the user updating their own profile, or is it an admin?
+   * @param updatedProfile new version of profile
+   * @param previousProfile old version of profile
    */
   public DbUser updateProfile(
       DbUser user, Agent agent, Profile updatedProfile, Profile previousProfile) {

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -17,6 +17,7 @@ import org.javers.core.diff.changetype.NewObject;
 import org.javers.core.diff.changetype.PropertyChange;
 import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessTierService;
+import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.ProfileAuditor;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.db.dao.InstitutionDao;
@@ -212,7 +213,8 @@ public class ProfileService {
    * @param updatedProfile
    * @param previousProfile
    */
-  public DbUser updateProfile(DbUser user, Profile updatedProfile, Profile previousProfile) {
+  public DbUser updateProfile(
+      DbUser user, Agent agent, Profile updatedProfile, Profile previousProfile) {
     // Apply cleaning methods to both the previous and updated profile, to avoid false positive
     // field diffs due to null-to-empty-object changes.
     cleanProfile(updatedProfile);
@@ -271,7 +273,7 @@ public class ProfileService {
     this.verifiedInstitutionalAffiliationDao.save(newAffiliation);
 
     final Profile appliedUpdatedProfile = getProfile(user);
-    profileAuditor.fireUpdateAction(previousProfile, appliedUpdatedProfile);
+    profileAuditor.fireUpdateAction(previousProfile, appliedUpdatedProfile, agent);
     return updatedUser;
   }
 
@@ -517,7 +519,7 @@ public class ProfileService {
     Optional.ofNullable(request.getAffiliation())
         .ifPresent(updatedProfile::setVerifiedInstitutionalAffiliation);
 
-    updateProfile(dbUser, updatedProfile, originalProfile);
+    updateProfile(dbUser, Agent.asAdmin(userProvider.get()), updatedProfile, originalProfile);
 
     return getProfile(dbUser);
   }

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditorTest.kt
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/ProfileAuditorTest.kt
@@ -33,8 +33,6 @@ import org.springframework.test.context.junit4.SpringRunner
 
 @RunWith(SpringRunner::class)
 class ProfileAuditorTest {
-
-    private val mockUserProvider = mock<Provider<DbUser>>()
     private val mockActionAuditService = mock<ActionAuditService>()
     private val mockClock = mock<Clock>()
     private val mockActionIdProvider = mock<Provider<String>>()
@@ -49,12 +47,10 @@ class ProfileAuditorTest {
                 .apply { username = USER_EMAIL }
 
         profileAuditAdapter = ProfileAuditorImpl(
-                userProvider = mockUserProvider,
                 actionAuditService = mockActionAuditService,
                 clock = mockClock,
                 actionIdProvider = mockActionIdProvider)
         whenever(mockClock.millis()).thenReturn(Y2K_EPOCH_MILLIS)
-        whenever(mockUserProvider.get()).thenReturn(user)
         whenever(mockActionIdProvider.get()).thenReturn(ACTION_ID)
     }
 

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -37,6 +37,7 @@ import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.access.UserAccessModuleMapperImpl;
 import org.pmiops.workbench.actionaudit.ActionAuditQueryServiceImpl;
+import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.ProfileAuditor;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.actionaudit.targetproperties.BypassTimeTargetProperty;
@@ -1091,7 +1092,8 @@ public class ProfileControllerTest extends BaseControllerTest {
     final Profile retrieved = profileService.updateAccountProperties(request);
     assertThat(retrieved.getContactEmail()).isEqualTo(newContactEmail);
 
-    verify(mockProfileAuditor).fireUpdateAction(original, retrieved);
+    final Agent adminAgent = Agent.asAdmin(userDao.findUserByUserId(original.getUserId()));
+    verify(mockProfileAuditor).fireUpdateAction(original, retrieved, adminAgent);
   }
 
   @Test
@@ -1182,7 +1184,8 @@ public class ProfileControllerTest extends BaseControllerTest {
     final Profile retrieved = profileService.updateAccountProperties(request);
     assertThat(retrieved.getVerifiedInstitutionalAffiliation()).isEqualTo(newAffiliation);
 
-    verify(mockProfileAuditor).fireUpdateAction(original, retrieved);
+    final Agent adminAgent = Agent.asAdmin(userDao.findUserByUserId(original.getUserId()));
+    verify(mockProfileAuditor).fireUpdateAction(original, retrieved, adminAgent);
   }
 
   @Test
@@ -1287,7 +1290,8 @@ public class ProfileControllerTest extends BaseControllerTest {
     final Profile retrieved = profileService.updateAccountProperties(request);
     assertThat(retrieved.getContactEmail()).isEqualTo(newContactEmail);
     assertThat(retrieved.getVerifiedInstitutionalAffiliation()).isEqualTo(newAffiliation);
-    verify(mockProfileAuditor).fireUpdateAction(original, retrieved);
+    final Agent adminAgent = Agent.asAdmin(userDao.findUserByUserId(original.getUserId()));
+    verify(mockProfileAuditor).fireUpdateAction(original, retrieved, adminAgent);
   }
 
   @Test
@@ -1403,8 +1407,9 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertThat(getBypassEpochMillis(retrieved2, AccessModule.TWO_FACTOR_AUTH)).isNotNull();
 
     // TODO(RW-6930): Make Profile contain the new AccessModule block, then read from there.
-    verify(mockProfileAuditor).fireUpdateAction(original, retrieved1);
-    verify(mockProfileAuditor).fireUpdateAction(retrieved1, retrieved2);
+    final Agent adminAgent = Agent.asAdmin(userDao.findUserByUserId(original.getUserId()));
+    verify(mockProfileAuditor).fireUpdateAction(original, retrieved1, adminAgent);
+    verify(mockProfileAuditor).fireUpdateAction(retrieved1, retrieved2, adminAgent);
 
     // DUCC and COMPLIANCE x2, one for each request
     verify(mockUserServiceAuditor, times(2))


### PR DESCRIPTION
Previously, we assumed that all `updateProfile()` calls were done by the user with the profile in question.  This is not the case.

Tested by running locally and observing corrected values in BigQuery.

Does not fully resolve RW-7632 because these audit entries are not visible in the UI.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
