### PR TITLE
Revert "[RW-7617][risk=no] Try reverting NB image upgrade in test"

### DIFF
--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -8,7 +8,7 @@
     "leoBaseUrl": "https:\/\/leonardo.dsde-dev.broadinstitute.org",
     "xAppIdValue": "test-AoU-RW",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.1",
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.4",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev",
     "workspaceLogsProject": "fc-aou-logs-test",


### PR DESCRIPTION
Reverts all-of-us/workbench#5997

With this change, runtimes are failing to start in 30m, resulting in errors at seemingly 100%, presumably due to lack of caching. Revert for now to the prior flaky behavior.

After the Terra release tomorrow, will try to switch cache to 2.0.1 + 2.0.4 and then roll this forward.