### PR TITLE
[RW-6887][risk=no] Fix dataset builder disabled save button bug

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -456,4 +456,22 @@ describe('DataSetPage', () => {
     expect(wrapper.find(GenomicExtractionModal).exists()).toBeTruthy();
   });
 
+  it('should enable Save Dataset button when selecting All Participants prepackaged cohort', async() => {
+    datasetApiStub.getDatasetMock = {
+      ...stubDataSet(),
+      conceptSets: [{id: 345, domain: Domain.PERSON}],
+      cohorts: [{id: 1}],
+      domainValuePairs: [{domain: Domain.PERSON, value: 'person'}],
+    };
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    // Save button is disabled since no changes have been made
+    expect(wrapper.find(Button).find('[data-test-id="save-button"]').first().prop('disabled')).toBeTruthy();
+
+    wrapper.find('[data-test-id="all-participant"]').first().find('input').first().simulate('change');
+    // Save button should enable after selection
+    expect(wrapper.find(Button).find('[data-test-id="save-button"]').first().prop('disabled')).toBeFalsy();
+  });
+
 });

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -825,12 +825,13 @@ export const DatasetPage = fp.flow(withUserProfile(), withCurrentWorkspace(), wi
     }
 
     selectPrePackagedCohort(): void {
-      // Un-select any workspace Cohort if Pre Packaged cohort is selected
-      if (!this.state.includesAllParticipants) {
-        this.setState({includesAllParticipants: !this.state.includesAllParticipants, selectedCohortIds: []});
-      } else {
-        this.setState({includesAllParticipants: !this.state.includesAllParticipants});
-      }
+      const {includesAllParticipants, selectedCohortIds} = this.state;
+      this.setState({
+        dataSetTouched: true,
+        includesAllParticipants: !includesAllParticipants,
+        // Un-select any workspace Cohort if Pre Packaged cohort is selected
+        selectedCohortIds: !includesAllParticipants ? [] : selectedCohortIds
+      });
     }
 
     selectDomainValue(domain: Domain, domainValue: DomainValue): void {


### PR DESCRIPTION
Fixes issue where selecting the prepackaged All Participants cohort on an existing dataset does not enable the save button

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
