### PR TITLE
[RW-6169][risk=low]Disallow create/update workspaces when population details not complete

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -35,6 +35,7 @@ import {ProfileApiStub, ProfileStubVariables} from 'testing/stubs/profile-api-st
 import * as Authentication from 'app/utils/authentication';
 import {mockNavigate} from 'setupTests';
 import {environment} from 'environments/environment';
+import {SpecificPopulationItems} from './workspace-edit-text';
 
 
 type AnyWrapper = (ShallowWrapper|ReactWrapper);
@@ -167,8 +168,6 @@ describe('WorkspaceEdit', () => {
 
   it('should clear all selected specific populations if NO underrepresented populations study is selected',
       async () => {
-    // Set the workspace state to represent a workspace which is studying a
-    // specific population group.
     workspace.researchPurpose.populationDetails = [SpecificPopulationEnum.AGECHILDREN,
       SpecificPopulationEnum.RACEMENA, SpecificPopulationEnum.DISABILITYSTATUS];
 
@@ -196,6 +195,36 @@ describe('WorkspaceEdit', () => {
 
     expect(workspacesApi.workspaces[0].researchPurpose.populationDetails.length).toBe(0);
   });
+
+  it('should disallow create/update workspace when not finishing population details',
+    async () => {
+      workspace.researchPurpose.populationDetails = [SpecificPopulationEnum.AGECHILDREN,
+        SpecificPopulationEnum.RACEMENA, SpecificPopulationEnum.DISABILITYSTATUS];
+
+      workspaceEditMode = WorkspaceEditMode.Edit
+      const wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+
+      expect(wrapper.find('[data-test-id="specific-population-yes"]')
+        .first().prop('checked')).toEqual(true);
+      let saveButton = wrapper.find('[data-test-id="workspace-save-btn"]')
+        .first().prop('disabled');
+      expect(saveButton).toBeTruthy();
+    });
+
+  it('should allow create/update workspace when all population details selected',
+    async () => {
+      workspace.researchPurpose.populationDetails = SpecificPopulationItems.map(s => s.shortName);
+      workspaceEditMode = WorkspaceEditMode.Edit
+      const wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+
+      expect(wrapper.find('[data-test-id="specific-population-yes"]')
+        .first().prop('checked')).toEqual(true);
+      let saveButton = wrapper.find('[data-test-id="workspace-save-btn"]')
+        .first().prop('disabled');
+      expect(saveButton).toBeFalsy();
+    });
 
   it ('should select Research Purpose checkbox if sub category is selected', async () => {
     const wrapper = component();

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -79,7 +79,8 @@ describe('WorkspaceEdit', () => {
         scientificApproach: 'scientificApproach ',
         drugDevelopment: true,
         disseminateResearchFindingList: [DisseminateResearchEnum.PUBLICATIONPERSONALBLOG],
-        researchOutcomeList: [ResearchOutcomeEnum.DECREASEILLNESSBURDEN]
+        researchOutcomeList: [ResearchOutcomeEnum.DECREASEILLNESSBURDEN],
+        populationDetails: SpecificPopulationItems.map(s => s.shortName)
       }
     };
 

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1048,7 +1048,10 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       if (populationChecked) {
         values = {...values, populationDetails};
         constraints['populationDetails'] = {
-          presence: true
+          presence: true,
+          length: {
+            minimum : SpecificPopulationItems.length
+          }
         };
       }
       if (populationDetails &&

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1047,11 +1047,11 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       }
       if (populationChecked) {
         values = {...values, populationDetails};
+        validate.validators.populationDetailsFilled = (filledDetails: [SpecificPopulationEnum]) => {
+          SpecificPopulationItems.every(s => s.subCategory.some(sub => filledDetails.includes(sub.shortName)))
+        };
         constraints['populationDetails'] = {
-          presence: true,
-          length: {
-            minimum : SpecificPopulationItems.length
-          }
+          populationDetailsFilled : true
         };
       }
       if (populationDetails &&

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1047,11 +1047,11 @@ export const WorkspaceEdit = fp.flow(withCurrentWorkspace(), withCdrVersions(), 
       }
       if (populationChecked) {
         values = {...values, populationDetails};
-        validate.validators.populationDetailsFilled = (filledDetails: [SpecificPopulationEnum]) => {
-          SpecificPopulationItems.every(s => s.subCategory.some(sub => filledDetails.includes(sub.shortName)))
+        validate.validators.populationDetailsFilled = (filledDetails: SpecificPopulationEnum[]) => {
+          return SpecificPopulationItems.every(s => s.subCategory.some(sub => filledDetails.includes(sub.shortName)))
         };
         constraints['populationDetails'] = {
-          populationDetailsFilled : true
+          populationDetailsFilled : {}
         };
       }
       if (populationDetails &&


### PR DESCRIPTION
Description:
Today, user is able to click update/create button right after they select "Yes" on population of interest
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
