### PR TITLE
[risk=no] Permissions fix for deploy

### DIFF
--- a/deploy/bootstrap-docker.sh
+++ b/deploy/bootstrap-docker.sh
@@ -13,7 +13,7 @@ sudo chgrp circleci /creds/sa-key.json
 sudo chmod g+r /creds/sa-key.json
 sudo chown -R circleci ~/.gradle
 sudo mkdir -p ~/.cache/yarn
-sudo chown -R circleci ~/.cache/yarn
+sudo chown -R circleci ~/.cache
 
 if [[ ! -d ~/workbench/.git ]]; then
   sudo git clone https://github.com/all-of-us/workbench ~/workbench


### PR DESCRIPTION
A new gradle build dependency requires write access to `~/.cache`, which we were initializing with root permissios in the bootstrap script. Going forward, we may want to preload this into the image, so we're not wasting time installing cloud sdk twice.