### PR TITLE
[RW-7511][risk=no] Move workspace admin endpoints into admin controller

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -14,8 +14,10 @@ import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
 import org.pmiops.workbench.model.ListRuntimeResponse;
 import org.pmiops.workbench.model.ReadOnlyNotebookResponse;
+import org.pmiops.workbench.model.ResearchPurposeReviewRequest;
 import org.pmiops.workbench.model.WorkspaceAdminView;
 import org.pmiops.workbench.model.WorkspaceAuditLogQueryResponse;
+import org.pmiops.workbench.model.WorkspaceListResponse;
 import org.pmiops.workbench.workspaceadmin.WorkspaceAdminService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -105,6 +107,45 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
   public ResponseEntity<EmptyResponse> setAdminUnlockedState(String workspaceNamespace) {
     workspaceAdminService.setAdminUnlockedState(workspaceNamespace);
+    return ResponseEntity.ok(new EmptyResponse());
+  }
+
+  /** Record approval or rejection of research purpose. */
+  @Override
+  @AuthorityRequired({Authority.REVIEW_RESEARCH_PURPOSE})
+  public ResponseEntity<EmptyResponse> reviewWorkspace(
+      String ns, String id, ResearchPurposeReviewRequest review) {
+
+    workspaceAdminService.setResearchPurposeApproved(ns, id, review.getApproved());
+    return ResponseEntity.ok(new EmptyResponse());
+  }
+
+  // Note we do not paginate the workspaces list, since we expect few workspaces
+  // to require review.
+  //
+  // We can add pagination in the DAO by returning Slice<DbWorkspace> if we want the method to
+  // return pagination information (e.g. are there more workspaces to get), and Page<DbWorkspace> if
+  // we want the method to return both pagination information and a total count.
+  @Override
+  @AuthorityRequired({Authority.REVIEW_RESEARCH_PURPOSE})
+  public ResponseEntity<WorkspaceListResponse> getWorkspacesForReview() {
+    return ResponseEntity.ok(
+        new WorkspaceListResponse().items(workspaceAdminService.getWorkspacesForReview()));
+  }
+
+  @Override
+  @AuthorityRequired({Authority.FEATURED_WORKSPACE_ADMIN})
+  public ResponseEntity<EmptyResponse> publishWorkspace(
+      String workspaceNamespace, String workspaceId) {
+    workspaceAdminService.setPublished(workspaceNamespace, workspaceId, true);
+    return ResponseEntity.ok(new EmptyResponse());
+  }
+
+  @Override
+  @AuthorityRequired({Authority.FEATURED_WORKSPACE_ADMIN})
+  public ResponseEntity<EmptyResponse> unpublishWorkspace(
+      String workspaceNamespace, String workspaceId) {
+    workspaceAdminService.setPublished(workspaceNamespace, workspaceId, false);
     return ResponseEntity.ok(new EmptyResponse());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
@@ -12,6 +12,7 @@ import org.pmiops.workbench.model.CloudStorageTraffic;
 import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
 import org.pmiops.workbench.model.ListRuntimeResponse;
+import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAdminView;
 import org.pmiops.workbench.model.WorkspaceAuditLogQueryResponse;
 
@@ -44,4 +45,11 @@ public interface WorkspaceAdminService {
   void setAdminLockedState(String workspaceNamespace, AdminLockingRequest adminLockingRequest);
 
   void setAdminUnlockedState(String workspaceNamespace);
+
+  List<Workspace> getWorkspacesForReview();
+
+  void setResearchPurposeApproved(
+      String workspaceNamespace, String firecloudName, boolean approved);
+
+  DbWorkspace setPublished(String workspaceNamespace, String firecloudName, boolean publish);
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -208,8 +208,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
             dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
 
     final List<ListRuntimeResponse> workbenchListRuntimeResponses =
-        leonardoNotebooksClient
-            .listRuntimesByProjectAsService(dbWorkspace.getGoogleProject())
+        leonardoNotebooksClient.listRuntimesByProjectAsService(dbWorkspace.getGoogleProject())
             .stream()
             .map(leonardoMapper::toApiListRuntimeResponse)
             .collect(Collectors.toList());
@@ -338,8 +337,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     adminAuditor.fireLockWorkspaceAction(dbWorkspace.getWorkspaceId(), adminLockingRequest);
 
     final List<DbUser> owners =
-        workspaceService
-            .getFirecloudUserRoles(workspaceNamespace, dbWorkspace.getFirecloudName())
+        workspaceService.getFirecloudUserRoles(workspaceNamespace, dbWorkspace.getFirecloudName())
             .stream()
             .filter(userRole -> userRole.getRole() == WorkspaceAccessLevel.OWNER)
             .map(UserRole::getEmail)

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -9,6 +9,7 @@ import com.google.protobuf.util.Timestamps;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -33,6 +34,8 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupWithMembers;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceACLUpdate;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceDetails;
 import org.pmiops.workbench.google.CloudMonitoringService;
 import org.pmiops.workbench.google.CloudStorageClient;
@@ -50,6 +53,7 @@ import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
 import org.pmiops.workbench.model.ListRuntimeResponse;
 import org.pmiops.workbench.model.TimeSeriesPoint;
 import org.pmiops.workbench.model.UserRole;
+import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceAdminView;
 import org.pmiops.workbench.model.WorkspaceAuditLogQueryResponse;
@@ -59,6 +63,7 @@ import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
 import org.pmiops.workbench.utils.mappers.UserMapper;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapper;
+import org.pmiops.workbench.workspaces.WorkspaceAuthService;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -203,7 +208,8 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
             dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
 
     final List<ListRuntimeResponse> workbenchListRuntimeResponses =
-        leonardoNotebooksClient.listRuntimesByProjectAsService(dbWorkspace.getGoogleProject())
+        leonardoNotebooksClient
+            .listRuntimesByProjectAsService(dbWorkspace.getGoogleProject())
             .stream()
             .map(leonardoMapper::toApiListRuntimeResponse)
             .collect(Collectors.toList());
@@ -332,7 +338,8 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     adminAuditor.fireLockWorkspaceAction(dbWorkspace.getWorkspaceId(), adminLockingRequest);
 
     final List<DbUser> owners =
-        workspaceService.getFirecloudUserRoles(workspaceNamespace, dbWorkspace.getFirecloudName())
+        workspaceService
+            .getFirecloudUserRoles(workspaceNamespace, dbWorkspace.getFirecloudName())
             .stream()
             .filter(userRole -> userRole.getRole() == WorkspaceAccessLevel.OWNER)
             .map(UserRole::getEmail)
@@ -354,6 +361,67 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     workspaceDao.save(dbWorkspace.setAdminLocked(false));
     adminAuditor.fireUnlockWorkspaceAction(dbWorkspace.getWorkspaceId());
   }
+
+  @Override
+  public void setResearchPurposeApproved(
+      String workspaceNamespace, String firecloudName, boolean approved) {
+    DbWorkspace workspace = workspaceDao.getRequired(workspaceNamespace, firecloudName);
+    if (workspace.getReviewRequested() == null || !workspace.getReviewRequested()) {
+      throw new BadRequestException(
+          String.format(
+              "No review requested for workspace %s/%s.", workspaceNamespace, firecloudName));
+    }
+
+    Boolean existingApproval = workspace.getApproved();
+    if (existingApproval != null) {
+      throw new BadRequestException(
+          String.format(
+              "DbWorkspace %s/%s already %s.",
+              workspaceNamespace, firecloudName, existingApproval ? "approved" : "rejected"));
+    }
+    workspace.setApproved(approved);
+    workspaceDao.saveWithLastModified(workspace);
+
+    // RW-7087 replace with a new workspaceAuditor action (fireReviewAction?)
+    // because this uses the deprecated DbAdminActionHistory
+    userService.logAdminWorkspaceAction(
+        workspace.getWorkspaceId(),
+        "research purpose approval",
+        workspace.getApproved(),
+        existingApproval);
+  }
+
+  @Override
+  public List<Workspace> getWorkspacesForReview() {
+    return workspaceDao.findByApprovedIsNullAndReviewRequestedTrueOrderByTimeRequested().stream()
+        .map(workspaceMapper::toApiWorkspace)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public DbWorkspace setPublished(
+      String workspaceNamespace, String firecloudName, boolean publish) {
+    final DbWorkspace dbWorkspace = workspaceDao.getRequired(workspaceNamespace, firecloudName);
+
+    final WorkspaceAccessLevel accessLevel =
+        publish ? WorkspaceAccessLevel.READER : WorkspaceAccessLevel.NO_ACCESS;
+
+    final FirecloudManagedGroupWithMembers authDomainGroup =
+        fireCloudService.getGroup(dbWorkspace.getCdrVersion().getAccessTier().getAuthDomainName());
+
+    final FirecloudWorkspaceACLUpdate currentUpdate =
+        WorkspaceAuthService.updateFirecloudAclsOnUser(
+            accessLevel, new FirecloudWorkspaceACLUpdate().email(authDomainGroup.getGroupEmail()));
+
+    fireCloudService.updateWorkspaceACL(
+        dbWorkspace.getWorkspaceNamespace(),
+        dbWorkspace.getFirecloudName(),
+        Collections.singletonList(currentUpdate));
+
+    dbWorkspace.setPublished(publish);
+    return workspaceDao.saveWithLastModified(dbWorkspace);
+  }
+
   // NOTE: may be an undercount since we only retrieve the first Page of Storage List results
   private int getNonNotebookFileCount(String bucketName) {
     return (int)

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -39,13 +39,9 @@ public interface WorkspaceService {
    */
   void updateWorkspaceBillingAccount(DbWorkspace workspace, String newBillingAccountName);
 
-  void setResearchPurposeApproved(String ns, String firecloudName, boolean approved);
-
   DbWorkspace saveAndCloneCohortsConceptSetsAndDataSets(DbWorkspace from, DbWorkspace to);
 
   List<UserRole> getFirecloudUserRoles(String workspaceNamespace, String firecloudName);
-
-  DbWorkspace setPublished(String workspaceNamespace, String firecloudName, boolean publish);
 
   List<DbUserRecentWorkspace> getRecentWorkspaces();
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceFakeImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceFakeImpl.java
@@ -30,21 +30,12 @@ public class WorkspaceServiceFakeImpl implements WorkspaceService {
   public void updateWorkspaceBillingAccount(DbWorkspace workspace, String newBillingAccountName) {}
 
   @Override
-  public void setResearchPurposeApproved(String ns, String firecloudName, boolean approved) {}
-
-  @Override
   public DbWorkspace saveAndCloneCohortsConceptSetsAndDataSets(DbWorkspace from, DbWorkspace to) {
     return null;
   }
 
   @Override
   public List<UserRole> getFirecloudUserRoles(String workspaceNamespace, String firecloudName) {
-    return null;
-  }
-
-  @Override
-  public DbWorkspace setPublished(
-      String workspaceNamespace, String firecloudName, boolean publish) {
     return null;
   }
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1102,7 +1102,7 @@ paths:
     - "$ref": "#/parameters/workspaceId"
     post:
       tags:
-      - workspaces
+      - workspaceAdmin
       description: 'Makes a workspace public to all AoU registered users. Requires
         FEATURED_WORKSPACE_ADMIN authority.'
       operationId: publishWorkspace
@@ -1117,7 +1117,7 @@ paths:
     - "$ref": "#/parameters/workspaceId"
     post:
       tags:
-      - workspaces
+      - workspaceAdmin
       description: 'Makes a workspace public to all AoU registered users. Requires
         FEATURED_WORKSPACE_ADMIN authority.'
       operationId: unpublishWorkspace
@@ -1130,7 +1130,7 @@ paths:
   "/v1/admin/workspaces/review":
     get:
       tags:
-      - workspaces
+      - workspaceAdmin
       description: 'Returns workspaces that need research purpose review. Requires
         REVIEW_RESEARCH_PURPOSE authority.'
       operationId: getWorkspacesForReview
@@ -1139,6 +1139,28 @@ paths:
           description: A list of workspaces
           schema:
             "$ref": "#/definitions/WorkspaceListResponse"
+  "/v1/admin/workspaces/{workspaceNamespace}/{workspaceId}/review":
+    parameters:
+    - "$ref": "#/parameters/workspaceNamespace"
+    - "$ref": "#/parameters/workspaceId"
+    post:
+      tags:
+      - workspaceAdmin
+      consumes:
+      - application/json
+      description: Sets a research purpose review result.
+      operationId: reviewWorkspace
+      parameters:
+      - in: body
+        name: review
+        description: result of the research purpose review
+        schema:
+          "$ref": "#/definitions/ResearchPurposeReviewRequest"
+      responses:
+        200:
+          description: success
+          schema:
+            "$ref": "#/definitions/EmptyResponse"
   "/v1/admin/workspaces/{workspaceNamespace}/audit":
     get:
       tags:
@@ -1432,28 +1454,6 @@ paths:
           description: User doesn't have the ACCESS_CONTROL_ADMIN authority
           schema:
             "$ref": "#/definitions/ErrorResponse"
-  "/v1/admin/workspaces/{workspaceNamespace}/{workspaceId}/review":
-    parameters:
-    - "$ref": "#/parameters/workspaceNamespace"
-    - "$ref": "#/parameters/workspaceId"
-    post:
-      tags:
-      - workspaces
-      consumes:
-      - application/json
-      description: Sets a research purpose review result.
-      operationId: reviewWorkspace
-      parameters:
-      - in: body
-        name: review
-        description: result of the research purpose review
-        schema:
-          "$ref": "#/definitions/ResearchPurposeReviewRequest"
-      responses:
-        200:
-          description: success
-          schema:
-            "$ref": "#/definitions/EmptyResponse"
   "/v1/admin/workspaces/{workspaceNamespace}/locked":
     parameters:
       - "$ref": "#/parameters/workspaceNamespace"

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
@@ -7,10 +7,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
@@ -33,11 +31,9 @@ import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.model.AdminLockingRequest;
 import org.pmiops.workbench.model.AdminWorkspaceCloudStorageCounts;
 import org.pmiops.workbench.model.AdminWorkspaceObjectsCounts;
-import org.pmiops.workbench.model.AuditLogEntry;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
-import org.pmiops.workbench.model.WorkspaceAuditLogQueryResponse;
 import org.pmiops.workbench.notebooks.LeonardoNotebooksClient;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.utils.TestMockFactory;
@@ -61,33 +57,6 @@ public class WorkspaceAdminControllerTest {
   private static final String DB_WORKSPACE_FIRECLOUD_NAME = "gonewiththewind";
   private static final String WORKSPACE_NAMESPACE = "aou-rw-12345";
   private static final String NONSENSE_NAMESPACE = "wharrgarbl_wharrgarbl";
-  private static final int QUERY_LIMIT = 50;
-  private static final String ACTION_ID = "b937413e-ff66-4e7b-a639-f7947730b2c0";
-  private static final WorkspaceAuditLogQueryResponse QUERY_RESPONSE =
-      new WorkspaceAuditLogQueryResponse()
-          .logEntries(
-              ImmutableList.of(
-                  new AuditLogEntry()
-                      .actionId(ACTION_ID)
-                      .actionType("CREATE")
-                      .agentId(1111L)
-                      .agentType("ADMINISTRATOR")
-                      .agentUsername(FIRECLOUD_WORKSPACE_CREATOR_USERNAME)
-                      .eventTime(
-                          OffsetDateTime.parse("2020-02-10T01:20+02:00").toInstant().toEpochMilli())
-                      .newValue("true")
-                      .previousValue(null)
-                      .targetId(DB_WORKSPACE_ID)
-                      .targetProperty("approved")
-                      .targetType("WORKSPACE")))
-          .query("select foo from bar")
-          .workspaceDatabaseId(DB_WORKSPACE_ID);
-  private static final WorkspaceAuditLogQueryResponse EMPTY_QUERY_RESPONSE =
-      new WorkspaceAuditLogQueryResponse()
-          .query("select foo from bar")
-          .workspaceDatabaseId(DB_WORKSPACE_ID);
-  private static final DateTime DEFAULT_AFTER_INCLUSIVE = DateTime.parse("2001-02-14T01:20+02:00");
-  private static final DateTime DEFAULT_BEFORE_EXCLUSIVE = DateTime.parse("2020-05-01T01:20+02:00");
 
   @MockBean private ActionAuditQueryService mockActionAuditQueryService;
   @MockBean private CloudMonitoringService mockCloudMonitoringService;

--- a/ui/src/app/pages/admin/admin-review-workspace.spec.tsx
+++ b/ui/src/app/pages/admin/admin-review-workspace.spec.tsx
@@ -7,7 +7,7 @@ import {AdminReviewWorkspace} from './admin-review-workspace';
 import {ProfileApiStub, ProfileStubVariables} from 'testing/stubs/profile-api-stub';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {workspaceStubs} from 'testing/stubs/workspaces';
-import {WorkspaceAdminApiStub} from 'testing/stubs/workspaces-admin-api-stub';
+import {WorkspaceAdminApiStub} from 'testing/stubs/workspace-admin-api-stub';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 
 describe('AdminReviewWorkspace', () => {

--- a/ui/src/app/pages/admin/admin-review-workspace.spec.tsx
+++ b/ui/src/app/pages/admin/admin-review-workspace.spec.tsx
@@ -2,12 +2,12 @@ import {mount} from 'enzyme';
 import * as React from 'react';
 
 import {serverConfigStore} from 'app/utils/stores';
-import {Profile, ProfileApi, WorkspacesApi} from 'generated/fetch';
+import { Profile, ProfileApi, WorkspaceAdminApi} from 'generated/fetch';
 import {AdminReviewWorkspace} from './admin-review-workspace';
 import {ProfileApiStub, ProfileStubVariables} from 'testing/stubs/profile-api-stub';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {workspaceStubs} from 'testing/stubs/workspaces';
-import {WorkspacesApiStub} from 'testing/stubs/workspaces-api-stub';
+import {WorkspaceAdminApiStub} from 'testing/stubs/workspaces-admin-api-stub';
 import {waitOneTickAndUpdate} from 'testing/react-test-helpers';
 
 describe('AdminReviewWorkspace', () => {
@@ -30,7 +30,7 @@ describe('AdminReviewWorkspace', () => {
       showSpinner: () => {}
     };
     registerApiClient(ProfileApi, new ProfileApiStub());
-    registerApiClient(WorkspacesApi, new WorkspacesApiStub());
+    registerApiClient(WorkspaceAdminApi, new WorkspaceAdminApiStub());
   });
 
   it('should render and display a table', async() => {

--- a/ui/src/app/pages/admin/admin-review-workspace.tsx
+++ b/ui/src/app/pages/admin/admin-review-workspace.tsx
@@ -6,7 +6,7 @@ import {BugReportModal} from 'app/components/bug-report';
 import {Button} from 'app/components/buttons';
 import {Spinner, SpinnerOverlay} from 'app/components/spinners';
 import {WithSpinnerOverlayProps} from 'app/components/with-spinner-overlay';
-import {workspacesApi} from 'app/services/swagger-fetch-clients';
+import {workspaceAdminApi} from 'app/services/swagger-fetch-clients';
 import {reactStyles, withUserProfile} from 'app/utils';
 import {Profile, Workspace} from 'generated/fetch';
 
@@ -58,7 +58,7 @@ export const AdminReviewWorkspace = withUserProfile()(class extends React.Compon
   async componentDidMount() {
     this.props.hideSpinner();
     try {
-      const resp = await workspacesApi().getWorkspacesForReview();
+      const resp = await workspaceAdminApi().getWorkspacesForReview();
       this.setState({workspaces: resp.items, contentLoaded: true});
     } catch (error) {
       this.setState({fetchingWorkspaceError: true});
@@ -69,7 +69,7 @@ export const AdminReviewWorkspace = withUserProfile()(class extends React.Compon
     const {workspaces} = this.state;
     this.setState({reviewedWorkspace: workspace});
     try {
-      await workspacesApi()
+      await workspaceAdminApi()
         .reviewWorkspace(workspace.namespace, workspace.id, {approved});
       const i = workspaces.indexOf(workspace, 0);
       if (i >= 0) {

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -10,7 +10,7 @@ import {AoU, AouTitle} from 'app/components/text-wrappers';
 import {WithSpinnerOverlayProps} from 'app/components/with-spinner-overlay';
 import {ResearchPurpose} from 'app/pages/workspace/research-purpose';
 import {WorkspaceShare} from 'app/pages/workspace/workspace-share';
-import {profileApi, workspacesApi} from 'app/services/swagger-fetch-clients';
+import { profileApi, workspaceAdminApi, workspacesApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {reactStyles, withCdrVersions, withUserProfile} from 'app/utils';
 import {AuthorityGuardedAction, hasAuthorityForAction} from 'app/utils/authorities';
@@ -195,9 +195,9 @@ export const WorkspaceAbout = fp.flow(withUserProfile(), withCdrVersions())
     this.setState({publishing: true});
     try {
       if (publish) {
-        await workspacesApi().publishWorkspace(namespace, id);
+        await workspaceAdminApi().publishWorkspace(namespace, id);
       } else {
-        await workspacesApi().unpublishWorkspace(namespace, id);
+        await workspaceAdminApi().unpublishWorkspace(namespace, id);
       }
       this.updateWorkspaceState({...workspace, published: publish});
     } catch (error) {

--- a/ui/src/testing/stubs/workspace-admin-api-stub.ts
+++ b/ui/src/testing/stubs/workspace-admin-api-stub.ts
@@ -1,6 +1,6 @@
-import { EmptyResponse, ResearchPurposeReviewRequest, WorkspaceAdminApi, WorkspaceListResponse } from "generated/fetch";
-import { stubNotImplementedError } from "./stub-utils";
-import { workspaceStubs } from "./workspaces";
+import { EmptyResponse, ResearchPurposeReviewRequest, WorkspaceAdminApi, WorkspaceListResponse } from 'generated/fetch';
+import { stubNotImplementedError } from './stub-utils';
+import { workspaceStubs } from './workspaces';
 
 
 export class WorkspaceAdminApiStub extends WorkspaceAdminApi {

--- a/ui/src/testing/stubs/workspace-admin-api-stub.ts
+++ b/ui/src/testing/stubs/workspace-admin-api-stub.ts
@@ -1,0 +1,28 @@
+import { EmptyResponse, ResearchPurposeReviewRequest, WorkspaceAdminApi, WorkspaceListResponse } from "generated/fetch";
+import { stubNotImplementedError } from "./stub-utils";
+import { workspaceStubs } from "./workspaces";
+
+
+export class WorkspaceAdminApiStub extends WorkspaceAdminApi {
+
+  constructor(public workspaces = workspaceStubs) {
+    super(undefined, undefined, (..._: any[]) => { throw stubNotImplementedError; });
+  }
+
+  getWorkspacesForReview(options?: any): Promise<WorkspaceListResponse> {
+    return new Promise<WorkspaceListResponse>(resolve => {
+      resolve({
+        items: this.workspaces
+      });
+    });
+  }
+
+  reviewWorkspace(workspaceNamespace: string, workspaceId: string,
+    review?: ResearchPurposeReviewRequest): Promise<EmptyResponse> {
+    return new Promise<EmptyResponse>(resolve => {
+      resolve({});
+    });
+  }
+
+
+}


### PR DESCRIPTION
Move the following endpoints from WorkspacesController -> WorkspaceAdminController:

- {un,}publishWorkspace
- reviewWorkspace
- getWorkspacesForReview

**No behavioral or API changes**, just moving existing methods.

The workspace review endpoints **may** be unnecessary. I'm checking on that: https://precisionmedicineinitiative.atlassian.net/browse/RW-7640