### PR TITLE
[risk=low][no ticket] make updateUserAccessTiers() public to avoid excessive user saves

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskUserController.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -139,7 +138,7 @@ public class CloudTaskUserController implements CloudTaskUserApiDelegate {
         // should result in access expiration changes here, but this is also a backstop for ensuring
         // the database is consistent with our access tier groups, e.g. due to partial system
         // failures or bugs.
-        userService.updateUserWithRetries(Function.identity(), user, Agent.asSystem());
+        userService.updateUserAccessTiers(user, Agent.asSystem());
       } catch (WorkbenchException e) {
         log.log(Level.SEVERE, "failed to synchronize access for user " + user.getUsername(), e);
         errorCount++;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -18,7 +18,18 @@ import org.pmiops.workbench.model.UserAccessExpiration;
 import org.springframework.data.domain.Sort;
 
 public interface UserService {
+  /**
+   * Updates a user record with a modifier function.
+   *
+   * <p>Ensures that the data access tiers for the user reflect the state of other fields on the
+   * user; handles conflicts with concurrent updates by retrying.
+   */
   DbUser updateUserWithRetries(Function<DbUser, DbUser> userModifier, DbUser dbUser, Agent agent);
+
+  /**
+   * Ensures that the data access tiers for the user reflect the state of other fields on the user
+   */
+  void updateUserAccessTiers(DbUser dbUser, Agent agent);
 
   DbUser createServiceAccountUser(String email);
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -29,7 +29,7 @@ public interface UserService {
   /**
    * Ensures that the data access tiers for the user reflect the state of other fields on the user
    */
-  void updateUserAccessTiers(DbUser dbUser, Agent agent);
+  DbUser updateUserAccessTiers(DbUser dbUser, Agent agent);
 
   DbUser createServiceAccountUser(String email);
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -880,7 +880,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
         dbUser, AccessModuleName.PROFILE_CONFIRMATION, timestamp);
 
     return updateUserAccessTiers(dbUser, Agent.asUser(dbUser));
-    ;
   }
 
   /** Confirm that a user has either reported any AoU-related publications, or has none. */

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -253,10 +253,9 @@ public class ProfileService {
 
     // update institution and synchronize access tiers
     final DbUser updatedUser =
-        userService.updateUserWithRetries(
-            u -> upsertAffiliation(u, updatedProfile.getVerifiedInstitutionalAffiliation()),
-            user,
-            agent);
+        upsertAffiliation(user, updatedProfile.getVerifiedInstitutionalAffiliation());
+    userService.updateUserAccessTiers(updatedUser, agent);
+
     final Profile appliedUpdatedProfile = getProfile(updatedUser);
     profileAuditor.fireUpdateAction(previousProfile, appliedUpdatedProfile, agent);
     return updatedUser;

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -252,9 +252,9 @@ public class ProfileService {
     user.setDemographicSurvey(dbDemographicSurvey);
 
     // update institution and synchronize access tiers
-    final DbUser updatedUser =
+    DbUser updatedUser =
         upsertAffiliation(user, updatedProfile.getVerifiedInstitutionalAffiliation());
-    userService.updateUserAccessTiers(updatedUser, agent);
+    updatedUser = userService.updateUserAccessTiers(updatedUser, agent);
 
     final Profile appliedUpdatedProfile = getProfile(updatedUser);
     profileAuditor.fireUpdateAction(previousProfile, appliedUpdatedProfile, agent);

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -1293,8 +1293,8 @@ public class UserServiceAccessTest {
     return userService.updateUserWithRetries(userModifier, dbUser, Agent.asUser(dbUser));
   }
 
-  private void updateUserAccessTiers() {
-    userService.updateUserAccessTiers(dbUser, Agent.asUser(dbUser));
+  private DbUser updateUserAccessTiers() {
+    return userService.updateUserAccessTiers(dbUser, Agent.asUser(dbUser));
   }
 
   private void updateInstitutionTier(InstitutionTierConfig updatedTierConfig) {

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -69,8 +69,10 @@ import org.springframework.test.annotation.DirtiesContext;
 /**
  * Tests to cover access change determinations by executing {@link
  * UserService#updateUserWithRetries(java.util.function.Function,
- * org.pmiops.workbench.db.model.DbUser, org.pmiops.workbench.actionaudit.Agent)} with different
- * configurations, which ultimately executes the private method {
+ * org.pmiops.workbench.db.model.DbUser, org.pmiops.workbench.actionaudit.Agent)} or {@link
+ * UserService#updateUserAccessTiers(org.pmiops.workbench.db.model.DbUser,
+ * org.pmiops.workbench.actionaudit.Agent)} with different configurations, which ultimately executes
+ * the private method {
  * UserServiceImpl#shouldGrantUserTierAccess(org.pmiops.workbench.db.model.DbUser, List, String)} to
  * make this determination.
  */
@@ -202,7 +204,7 @@ public class UserServiceAccessTest {
   public void test_updateUserWithRetries_never_registered() {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
-    dbUser = updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
 
     // the user has never been registered so they have no DbUserAccessTier entry
 
@@ -240,20 +242,13 @@ public class UserServiceAccessTest {
 
     // Simulate time passing, user is no longer compliant
     advanceClockDays(2);
-    dbUser = updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
 
     // Simulate user filling out DUA, becoming compliant again
-    dbUser =
-        updateUserWithRetries(
-            user -> {
-              accessModuleService.updateCompletionTime(
-                  dbUser,
-                  AccessModuleName.DATA_USER_CODE_OF_CONDUCT,
-                  new Timestamp(PROVIDED_CLOCK.millis()));
-              return user;
-            });
-
+    accessModuleService.updateCompletionTime(
+        dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, new Timestamp(PROVIDED_CLOCK.millis()));
+    updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
 
@@ -951,14 +946,14 @@ public class UserServiceAccessTest {
     // Now make user eRA not complete, expect user removed from Registered tier;
     accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
     accessModuleService.updateCompletionTime(dbUser, AccessModuleName.ERA_COMMONS, null);
-    updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
 
     // Make eRA is optional for that institution, verify user become registered
     institutionService.updateInstitution(
         institution.getShortName(),
         institution.tierConfigs(ImmutableList.of(rtTierConfig.eraRequired(false))));
-    updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
 
@@ -974,12 +969,12 @@ public class UserServiceAccessTest {
         institution.tierConfigs(ImmutableList.of(rtTierConfig.eraRequired(false))));
     accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
     accessModuleService.updateCompletionTime(dbUser, AccessModuleName.ERA_COMMONS, null);
-    updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
 
     // Now login.gov flag disabled, eRA is always required.
     providedWorkbenchConfig.access.enableRasLoginGovLinking = false;
-    updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
   }
 
@@ -995,7 +990,7 @@ public class UserServiceAccessTest {
         institution.tierConfigs(ImmutableList.of(rtTierConfig.eraRequired(true))));
     accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
     accessModuleService.updateCompletionTime(dbUser, AccessModuleName.ERA_COMMONS, null);
-    updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
 
@@ -1009,13 +1004,13 @@ public class UserServiceAccessTest {
     // Incomplete RAS module, expect user removed from Registered tier;
     accessModuleService.updateBypassTime(
         dbUser.getUserId(), AccessModule.RAS_LINK_LOGIN_GOV, false);
-    updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
 
     // Complete RAS Linking, verify user become registered
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.RAS_LOGIN_GOV, new Timestamp(PROVIDED_CLOCK.millis()));
-    updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
 
@@ -1030,7 +1025,7 @@ public class UserServiceAccessTest {
     // Incomplete RAS module, expect user is still Registered;
     accessModuleService.updateBypassTime(
         dbUser.getUserId(), AccessModule.RAS_LINK_LOGIN_GOV, false);
-    updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
 
@@ -1047,13 +1042,13 @@ public class UserServiceAccessTest {
     // Incomplete RAS module, expect user removed from Registered tier;
     accessModuleService.updateBypassTime(
         dbUser.getUserId(), AccessModule.RAS_LINK_LOGIN_GOV, false);
-    updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
 
     // Complete RAS Linking, verify user become registered
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.RAS_LOGIN_GOV, new Timestamp(PROVIDED_CLOCK.millis()));
-    updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
 
@@ -1081,13 +1076,9 @@ public class UserServiceAccessTest {
 
     dbUser = completeRTAndCTRequirements(dbUser);
 
-    dbUser =
-        updateUserWithRetries(
-            user -> {
-              accessModuleService.updateBypassTime(
-                  dbUser.getUserId(), AccessModule.CT_COMPLIANCE_TRAINING, false);
-              return userDao.save(user);
-            });
+    accessModuleService.updateBypassTime(
+        dbUser.getUserId(), AccessModule.CT_COMPLIANCE_TRAINING, false);
+    updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertUserNotInAccessTier(dbUser, controlledTier);
@@ -1107,13 +1098,8 @@ public class UserServiceAccessTest {
     ctTierConfig.setEraRequired(true);
     updateInstitutionTier(ctTierConfig);
 
-    dbUser =
-        updateUserWithRetries(
-            user -> {
-              accessModuleService.updateBypassTime(
-                  user.getUserId(), AccessModule.ERA_COMMONS, false);
-              return userDao.save(user);
-            });
+    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
+    updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertUserNotInAccessTier(dbUser, controlledTier);
@@ -1129,13 +1115,8 @@ public class UserServiceAccessTest {
     ctTierConfig.setEraRequired(false);
     updateInstitutionTier(ctTierConfig);
 
-    dbUser =
-        updateUserWithRetries(
-            user -> {
-              accessModuleService.updateBypassTime(
-                  user.getUserId(), AccessModule.ERA_COMMONS, false);
-              return userDao.save(user);
-            });
+    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
+    updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
@@ -1150,14 +1131,14 @@ public class UserServiceAccessTest {
     dbUser = completeRTAndCTRequirements(dbUser);
     ctTierConfig.setEraRequired(true);
     updateInstitutionTier(ctTierConfig);
-    dbUser = updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
 
     ctTierConfig.setEraRequired(false);
     updateInstitutionTier(ctTierConfig);
-    dbUser = updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
@@ -1171,7 +1152,7 @@ public class UserServiceAccessTest {
     ctTierConfig.setEmailDomains(Arrays.asList("fakeDomain.com"));
     updateInstitutionTier(ctTierConfig);
 
-    dbUser = updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertUserNotInAccessTier(dbUser, controlledTier);
@@ -1184,7 +1165,7 @@ public class UserServiceAccessTest {
     ctTierConfig.setEmailDomains(Arrays.asList("domain.com"));
     updateInstitutionTier(ctTierConfig);
 
-    dbUser = updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
@@ -1202,7 +1183,7 @@ public class UserServiceAccessTest {
                 tier.getAccessTierShortName().equals(AccessTierService.CONTROLLED_TIER_SHORT_NAME));
     institutionService.updateInstitution(institution.getShortName(), institution);
 
-    dbUser = updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertUserNotInAccessTier(dbUser, controlledTier);
@@ -1218,18 +1199,13 @@ public class UserServiceAccessTest {
     ctTierConfig.setEraRequired(true);
     updateInstitutionTier(ctTierConfig);
 
-    dbUser = updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
 
-    dbUser =
-        updateUserWithRetries(
-            user -> {
-              accessModuleService.updateBypassTime(
-                  user.getUserId(), AccessModule.ERA_COMMONS, false);
-              return userDao.save(user);
-            });
+    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
+    updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
@@ -1241,18 +1217,14 @@ public class UserServiceAccessTest {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
     dbUser = completeRTAndCTRequirements(dbUser);
-    dbUser = updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
 
-    dbUser =
-        updateUserWithRetries(
-            user -> {
-              accessModuleService.updateBypassTime(
-                  user.getUserId(), AccessModule.CT_COMPLIANCE_TRAINING, false);
-              return userDao.save(user);
-            });
+    accessModuleService.updateBypassTime(
+        dbUser.getUserId(), AccessModule.CT_COMPLIANCE_TRAINING, false);
+    updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
@@ -1267,7 +1239,7 @@ public class UserServiceAccessTest {
     TestMockFactory.removeControlledTierForTests(accessTierDao);
     removeCTConfigFromInstitution();
 
-    dbUser = updateUserWithRetries(Function.identity());
+    updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertUserNotInAccessTier(dbUser, controlledTier);
@@ -1315,9 +1287,14 @@ public class UserServiceAccessTest {
     assertRegisteredTierDisabled(dbUser);
   }
 
-  // we can trim the signature since we always call this in the same way
+  // we can trim the signatures since we always call these in the same way
+
   private DbUser updateUserWithRetries(Function<DbUser, DbUser> userModifier) {
     return userService.updateUserWithRetries(userModifier, dbUser, Agent.asUser(dbUser));
+  }
+
+  private void updateUserAccessTiers() {
+    userService.updateUserAccessTiers(dbUser, Agent.asUser(dbUser));
   }
 
   private void updateInstitutionTier(InstitutionTierConfig updatedTierConfig) {

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -204,7 +204,7 @@ public class UserServiceAccessTest {
   public void test_updateUserWithRetries_never_registered() {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     // the user has never been registered so they have no DbUserAccessTier entry
 
@@ -242,13 +242,13 @@ public class UserServiceAccessTest {
 
     // Simulate time passing, user is no longer compliant
     advanceClockDays(2);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
 
     // Simulate user filling out DUA, becoming compliant again
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, new Timestamp(PROVIDED_CLOCK.millis()));
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
 
@@ -946,14 +946,14 @@ public class UserServiceAccessTest {
     // Now make user eRA not complete, expect user removed from Registered tier;
     accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
     accessModuleService.updateCompletionTime(dbUser, AccessModuleName.ERA_COMMONS, null);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
 
     // Make eRA is optional for that institution, verify user become registered
     institutionService.updateInstitution(
         institution.getShortName(),
         institution.tierConfigs(ImmutableList.of(rtTierConfig.eraRequired(false))));
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
 
@@ -969,12 +969,12 @@ public class UserServiceAccessTest {
         institution.tierConfigs(ImmutableList.of(rtTierConfig.eraRequired(false))));
     accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
     accessModuleService.updateCompletionTime(dbUser, AccessModuleName.ERA_COMMONS, null);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
 
     // Now login.gov flag disabled, eRA is always required.
     providedWorkbenchConfig.access.enableRasLoginGovLinking = false;
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
   }
 
@@ -990,7 +990,7 @@ public class UserServiceAccessTest {
         institution.tierConfigs(ImmutableList.of(rtTierConfig.eraRequired(true))));
     accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
     accessModuleService.updateCompletionTime(dbUser, AccessModuleName.ERA_COMMONS, null);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
 
@@ -1004,13 +1004,13 @@ public class UserServiceAccessTest {
     // Incomplete RAS module, expect user removed from Registered tier;
     accessModuleService.updateBypassTime(
         dbUser.getUserId(), AccessModule.RAS_LINK_LOGIN_GOV, false);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
 
     // Complete RAS Linking, verify user become registered
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.RAS_LOGIN_GOV, new Timestamp(PROVIDED_CLOCK.millis()));
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
 
@@ -1025,7 +1025,7 @@ public class UserServiceAccessTest {
     // Incomplete RAS module, expect user is still Registered;
     accessModuleService.updateBypassTime(
         dbUser.getUserId(), AccessModule.RAS_LINK_LOGIN_GOV, false);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
 
@@ -1042,13 +1042,13 @@ public class UserServiceAccessTest {
     // Incomplete RAS module, expect user removed from Registered tier;
     accessModuleService.updateBypassTime(
         dbUser.getUserId(), AccessModule.RAS_LINK_LOGIN_GOV, false);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
 
     // Complete RAS Linking, verify user become registered
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.RAS_LOGIN_GOV, new Timestamp(PROVIDED_CLOCK.millis()));
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
 
@@ -1078,7 +1078,7 @@ public class UserServiceAccessTest {
 
     accessModuleService.updateBypassTime(
         dbUser.getUserId(), AccessModule.CT_COMPLIANCE_TRAINING, false);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertUserNotInAccessTier(dbUser, controlledTier);
@@ -1099,7 +1099,7 @@ public class UserServiceAccessTest {
     updateInstitutionTier(ctTierConfig);
 
     accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertUserNotInAccessTier(dbUser, controlledTier);
@@ -1116,7 +1116,7 @@ public class UserServiceAccessTest {
     updateInstitutionTier(ctTierConfig);
 
     accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
@@ -1131,14 +1131,14 @@ public class UserServiceAccessTest {
     dbUser = completeRTAndCTRequirements(dbUser);
     ctTierConfig.setEraRequired(true);
     updateInstitutionTier(ctTierConfig);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
 
     ctTierConfig.setEraRequired(false);
     updateInstitutionTier(ctTierConfig);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
@@ -1152,7 +1152,7 @@ public class UserServiceAccessTest {
     ctTierConfig.setEmailDomains(Arrays.asList("fakeDomain.com"));
     updateInstitutionTier(ctTierConfig);
 
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertUserNotInAccessTier(dbUser, controlledTier);
@@ -1165,7 +1165,7 @@ public class UserServiceAccessTest {
     ctTierConfig.setEmailDomains(Arrays.asList("domain.com"));
     updateInstitutionTier(ctTierConfig);
 
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
@@ -1183,7 +1183,7 @@ public class UserServiceAccessTest {
                 tier.getAccessTierShortName().equals(AccessTierService.CONTROLLED_TIER_SHORT_NAME));
     institutionService.updateInstitution(institution.getShortName(), institution);
 
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertUserNotInAccessTier(dbUser, controlledTier);
@@ -1199,13 +1199,13 @@ public class UserServiceAccessTest {
     ctTierConfig.setEraRequired(true);
     updateInstitutionTier(ctTierConfig);
 
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
 
     accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
@@ -1217,14 +1217,14 @@ public class UserServiceAccessTest {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
     dbUser = completeRTAndCTRequirements(dbUser);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
 
     accessModuleService.updateBypassTime(
         dbUser.getUserId(), AccessModule.CT_COMPLIANCE_TRAINING, false);
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
@@ -1239,7 +1239,7 @@ public class UserServiceAccessTest {
     TestMockFactory.removeControlledTierForTests(accessTierDao);
     removeCTConfigFromInstitution();
 
-    updateUserAccessTiers();
+    dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
     assertUserNotInAccessTier(dbUser, controlledTier);

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskUserControllerTest.java
@@ -110,7 +110,7 @@ public class CloudTaskUserControllerTest {
 
     // normally we would expect the userService sync methods to add to this count, but userService
     // is mocked so we only see the direct calls from synchronizeUserAccess(), one per user
-    verify(mockUserService, times(2)).updateUserWithRetries(any(), any(), any());
+    verify(mockUserService, times(2)).updateUserAccessTiers(any(), any());
     verifyNoMoreInteractions(mockUserService);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
@@ -370,7 +370,7 @@ public class ProfileServiceTest {
             newAffiliation, mockInstitutionService))
         .thenReturn(dbVerifiedInstitutionalAffiliation);
 
-    when(mockUserService.updateUserWithRetries(any(), any(), any())).thenReturn(user);
+    when(mockUserService.updateUserAccessTiers(any(), any())).thenReturn(user);
 
     profileService.updateProfile(
         user, Agent.asAdmin(loggedInUser), updatedProfile, previousProfile);
@@ -428,7 +428,7 @@ public class ProfileServiceTest {
     targetUser.setGivenName("John");
     targetUser.setFamilyName("Doe");
 
-    when(mockUserService.updateUserWithRetries(any(), any(), any())).thenReturn(targetUser);
+    when(mockUserService.updateUserAccessTiers(any(), any())).thenReturn(targetUser);
 
     profileService.updateProfile(
         targetUser, Agent.asAdmin(loggedInUser), updatedProfile, previousProfile);


### PR DESCRIPTION
`UserService.updateUserWithRetries()` is often called simply to trigger an access tier recalculation.  This leads to a lot of unnecessary `userDao.save()` calls, which we can avoid by exposing a standalone access tier recalc method.

This PR removes roughly half of these calls from our codebase.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
