### PR TITLE
[risk=low][RW-7634] updateInstitution() syncs tiers for affiliated users

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -112,6 +112,8 @@ public interface InstitutionService {
 
   Optional<Institution> getByUser(DbUser user);
 
+  List<DbUser> getAffiliatedUsers(String shortName);
+
   /**
    * Retrieve list of the {@link InstitutionTierConfig} which specifies how members can access each
    * tier and the requirement for each tier.

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -198,7 +198,7 @@ public class InstitutionServiceImpl implements InstitutionService {
             .setInstitutionId(dbInstitution.getInstitutionId());
 
     try {
-      institutionDao.save(dbObjectToUpdate);
+      dbObjectToUpdate = institutionDao.save(dbObjectToUpdate);
       populateAuxTables(updatedInstitution, dbObjectToUpdate);
     } catch (DataIntegrityViolationException ex) {
       throw new ConflictException(
@@ -360,6 +360,14 @@ public class InstitutionServiceImpl implements InstitutionService {
         .findFirstByUser(user)
         .map(DbVerifiedInstitutionalAffiliation::getInstitution)
         .map(dbi -> institutionMapper.dbToModel(dbi, this));
+  }
+
+  @Override
+  public List<DbUser> getAffiliatedUsers(String shortName) {
+    return verifiedInstitutionalAffiliationDao
+        .findAllByInstitution(getDbInstitutionOrThrow(shortName)).stream()
+        .map(DbVerifiedInstitutionalAffiliation::getUser)
+        .collect(Collectors.toList());
   }
 
   @Override


### PR DESCRIPTION
When an Institution changes its tier requirements, sync the access tiers of all of its affiliated users.  (Currently this happens at nightly cron time)

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
