### PR TITLE
[RW-7511][risk=no] Move user admin endpoints into new user admin controller

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.api;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.inject.Provider;
@@ -18,7 +17,6 @@ import org.pmiops.workbench.model.AdminUserListResponse;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.Profile;
-import org.pmiops.workbench.model.UserAccessExpiration;
 import org.pmiops.workbench.model.UserAuditLogQueryResponse;
 import org.pmiops.workbench.profile.ProfileService;
 import org.springframework.http.ResponseEntity;
@@ -82,28 +80,6 @@ public class UserAdminController implements UserAdminApiDelegate {
         Optional.ofNullable(beforeMillis).map(Instant::ofEpochMilli).orElse(Instant.now());
     return ResponseEntity.ok(
         actionAuditQueryService.queryEventsForUser(userDatabaseId, limit, after, before));
-  }
-
-  /**
-   * Gets a JSON list of users and their registered tier access expiration dates.
-   *
-   * <p>This endpoint is intended as a temporary manual measure to assist with user communication
-   * during the rollout of Annual Access Renewal (AAR).
-   *
-   * <p>Once fully rolled out, we will have an automated expiration email process and this can
-   * likely be removed. See RW-6689 and RW-6703.
-   */
-  @Override
-  @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
-  public ResponseEntity<List<UserAccessExpiration>> getRegisteredTierAccessExpirations() {
-    return ResponseEntity.ok(userService.getRegisteredTierExpirations());
-  }
-
-  @Override
-  @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
-  public ResponseEntity<Profile> getUser(Long userId) {
-    DbUser user = userDao.findUserByUserId(userId);
-    return ResponseEntity.ok(profileService.getProfile(user));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
@@ -7,7 +7,6 @@ import javax.inject.Provider;
 import org.pmiops.workbench.actionaudit.ActionAuditQueryService;
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.ForbiddenException;
@@ -28,7 +27,6 @@ public class UserAdminController implements UserAdminApiDelegate {
   private final UserService userService;
   private final ProfileService profileService;
   private final ActionAuditQueryService actionAuditQueryService;
-  private final UserDao userDao;
   private final Provider<DbUser> userProvider;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
 
@@ -36,13 +34,11 @@ public class UserAdminController implements UserAdminApiDelegate {
       UserService userService,
       ProfileService profileService,
       ActionAuditQueryService actionAuditQueryService,
-      UserDao userDao,
       Provider<DbUser> userProvider,
       Provider<WorkbenchConfig> workbenchConfigProvider) {
     this.userService = userService;
     this.profileService = profileService;
     this.actionAuditQueryService = actionAuditQueryService;
-    this.userDao = userDao;
     this.userProvider = userProvider;
     this.workbenchConfigProvider = workbenchConfigProvider;
   }
@@ -50,8 +46,8 @@ public class UserAdminController implements UserAdminApiDelegate {
   @Override
   @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
   public ResponseEntity<EmptyResponse> bypassAccessRequirement(
-      Long userId, AccessBypassRequest bypassed) {
-    userService.updateBypassTime(userId, bypassed);
+      Long userId, AccessBypassRequest request) {
+    userService.updateBypassTime(userId, request);
     return ResponseEntity.ok(new EmptyResponse());
   }
 
@@ -91,12 +87,12 @@ public class UserAdminController implements UserAdminApiDelegate {
 
   @Override
   public ResponseEntity<EmptyResponse> unsafeSelfBypassAccessRequirement(
-      AccessBypassRequest bypassed) {
+      AccessBypassRequest request) {
     if (!workbenchConfigProvider.get().access.unsafeAllowSelfBypass) {
       throw new ForbiddenException("Self bypass is disallowed in this environment.");
     }
     long userId = userProvider.get().getUserId();
-    userService.updateBypassTime(userId, bypassed);
+    userService.updateBypassTime(userId, request);
     return ResponseEntity.ok(new EmptyResponse());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
@@ -1,0 +1,132 @@
+package org.pmiops.workbench.api;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import javax.inject.Provider;
+import org.pmiops.workbench.actionaudit.ActionAuditQueryService;
+import org.pmiops.workbench.annotations.AuthorityRequired;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.UserService;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.exceptions.ForbiddenException;
+import org.pmiops.workbench.model.AccessBypassRequest;
+import org.pmiops.workbench.model.AccountPropertyUpdate;
+import org.pmiops.workbench.model.AdminUserListResponse;
+import org.pmiops.workbench.model.Authority;
+import org.pmiops.workbench.model.EmptyResponse;
+import org.pmiops.workbench.model.Profile;
+import org.pmiops.workbench.model.UserAccessExpiration;
+import org.pmiops.workbench.model.UserAuditLogQueryResponse;
+import org.pmiops.workbench.profile.ProfileService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserAdminController implements UserAdminApiDelegate {
+
+  private final UserService userService;
+  private final ProfileService profileService;
+  private final ActionAuditQueryService actionAuditQueryService;
+  private final UserDao userDao;
+  private final Provider<DbUser> userProvider;
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
+
+  public UserAdminController(
+      UserService userService,
+      ProfileService profileService,
+      ActionAuditQueryService actionAuditQueryService,
+      UserDao userDao,
+      Provider<DbUser> userProvider,
+      Provider<WorkbenchConfig> workbenchConfigProvider) {
+    this.userService = userService;
+    this.profileService = profileService;
+    this.actionAuditQueryService = actionAuditQueryService;
+    this.userDao = userDao;
+    this.userProvider = userProvider;
+    this.workbenchConfigProvider = workbenchConfigProvider;
+  }
+
+  @Override
+  @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
+  public ResponseEntity<EmptyResponse> bypassAccessRequirement(
+      Long userId, AccessBypassRequest bypassed) {
+    userService.updateBypassTime(userId, bypassed);
+    return ResponseEntity.ok(new EmptyResponse());
+  }
+
+  @Override
+  @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
+  public ResponseEntity<AdminUserListResponse> getAllUsers() {
+    return ResponseEntity.ok(
+        new AdminUserListResponse().users(profileService.getAdminTableUsers()));
+  }
+
+  @Override
+  @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
+  public ResponseEntity<UserAuditLogQueryResponse> getAuditLogEntries(
+      String usernameWithoutGsuiteDomain,
+      Integer limit,
+      Long afterMillis,
+      @Nullable Long beforeMillis) {
+    final String username =
+        String.format(
+            "%s@%s",
+            usernameWithoutGsuiteDomain,
+            workbenchConfigProvider.get().googleDirectoryService.gSuiteDomain);
+    final long userDatabaseId = userService.getByUsernameOrThrow(username).getUserId();
+    final Instant after = Instant.ofEpochMilli(afterMillis);
+    final Instant before =
+        Optional.ofNullable(beforeMillis).map(Instant::ofEpochMilli).orElse(Instant.now());
+    return ResponseEntity.ok(
+        actionAuditQueryService.queryEventsForUser(userDatabaseId, limit, after, before));
+  }
+
+  /**
+   * Gets a JSON list of users and their registered tier access expiration dates.
+   *
+   * <p>This endpoint is intended as a temporary manual measure to assist with user communication
+   * during the rollout of Annual Access Renewal (AAR).
+   *
+   * <p>Once fully rolled out, we will have an automated expiration email process and this can
+   * likely be removed. See RW-6689 and RW-6703.
+   */
+  @Override
+  @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
+  public ResponseEntity<List<UserAccessExpiration>> getRegisteredTierAccessExpirations() {
+    return ResponseEntity.ok(userService.getRegisteredTierExpirations());
+  }
+
+  @Override
+  @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
+  public ResponseEntity<Profile> getUser(Long userId) {
+    DbUser user = userDao.findUserByUserId(userId);
+    return ResponseEntity.ok(profileService.getProfile(user));
+  }
+
+  @Override
+  @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
+  public ResponseEntity<Profile> getUserByUsername(String username) {
+    DbUser user = userService.getByUsernameOrThrow(username);
+    return ResponseEntity.ok(profileService.getProfile(user));
+  }
+
+  @Override
+  public ResponseEntity<EmptyResponse> unsafeSelfBypassAccessRequirement(
+      AccessBypassRequest bypassed) {
+    if (!workbenchConfigProvider.get().access.unsafeAllowSelfBypass) {
+      throw new ForbiddenException("Self bypass is disallowed in this environment.");
+    }
+    long userId = userProvider.get().getUserId();
+    userService.updateBypassTime(userId, bypassed);
+    return ResponseEntity.ok(new EmptyResponse());
+  }
+
+  @Override
+  @AuthorityRequired({Authority.ACCESS_CONTROL_ADMIN})
+  public ResponseEntity<Profile> updateAccountProperties(AccountPropertyUpdate request) {
+    return ResponseEntity.ok(profileService.updateAccountProperties(request));
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -14,7 +14,6 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.model.AccessBypassRequest;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.Degree;
-import org.pmiops.workbench.model.UserAccessExpiration;
 import org.springframework.data.domain.Sort;
 
 public interface UserService {
@@ -148,10 +147,4 @@ public interface UserService {
 
   /** Send an Access Renewal Expiration or Warning email to the user, if appropriate */
   void maybeSendAccessExpirationEmail(DbUser user);
-
-  /**
-   * Return a mapping of users to their Annual Access Renewal expiration date for Registered Tier,
-   * for users who have them
-   */
-  List<UserAccessExpiration> getRegisteredTierExpirations();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.inject.Provider;
@@ -57,7 +56,6 @@ import org.pmiops.workbench.model.AccessModuleStatus;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.Institution;
-import org.pmiops.workbench.model.UserAccessExpiration;
 import org.pmiops.workbench.monitoring.GaugeDataCollector;
 import org.pmiops.workbench.monitoring.MeasurementBundle;
 import org.pmiops.workbench.monitoring.labels.MetricLabel;
@@ -900,34 +898,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
 
     final Optional<Timestamp> rtExpiration = getRegisteredTierExpirationForEmails(user);
     rtExpiration.ifPresent(expiration -> maybeSendRegisteredTierExpirationEmail(user, expiration));
-  }
-
-  /**
-   * Return a mapping of users to their Annual Access Renewal expiration date for Registered Tier,
-   * for users who have them
-   */
-  @Override
-  public List<UserAccessExpiration> getRegisteredTierExpirations() {
-    // restrict to current RT users
-    return accessTierService.getAllRegisteredTierUsers().stream()
-        .flatMap(this::maybeAccessExpiration)
-        .collect(Collectors.toList());
-  }
-
-  // streams a UserAccessExpiration object, if the user has an expiration
-  private Stream<UserAccessExpiration> maybeAccessExpiration(DbUser user) {
-    return getRegisteredTierExpirationForEmails(user)
-        .map(
-            exp ->
-                Stream.of(
-                    new UserAccessExpiration()
-                        .userName(user.getUsername())
-                        .contactEmail(user.getContactEmail())
-                        .givenName(user.getGivenName())
-                        .familyName(user.getFamilyName())
-                        // converts to UTC
-                        .expirationDate(exp.toInstant().toString())))
-        .orElse(Stream.empty());
   }
 
   /**

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1383,41 +1383,6 @@ paths:
           description: User associated with request could not be found
           schema:
             "$ref": "#/definitions/ErrorResponse"
-  "/v1/admin/accessExpirations":
-    get:
-      tags:
-        - userAdmin
-      description: 'Retrieves a mapping of users to access expiration times.  Requires ACCESS_CONTROL_ADMIN authority.'
-      operationId: getRegisteredTierAccessExpirations
-      responses:
-        200:
-          description: 'An array of users and their access expirations'
-          schema:
-            type: array
-            items:
-              "$ref": "#/definitions/UserAccessExpiration"
-        403:
-          description: User doesn't have the ACCESS_CONTROL_ADMIN authority
-          schema:
-            "$ref": "#/definitions/ErrorResponse"
-  "/v1/admin/users/{userId}":
-    get:
-      tags:
-      - userAdmin
-      description: 'Returns a user''s profile for review.  Requires ACCESS_CONTROL_ADMIN
-        authority.'
-      parameters:
-      - "$ref": "#/parameters/userId"
-      operationId: getUser
-      responses:
-        200:
-          description: A user's profile
-          schema:
-            "$ref": "#/definitions/Profile"
-        403:
-          description: User doesn't have the ACCESS_CONTROL_ADMIN authority
-          schema:
-            "$ref": "#/definitions/ErrorResponse"
   "/v1/admin/users/getUserByUsername":
     get:
       tags:
@@ -5785,25 +5750,6 @@ definitions:
         type: integer
         format: int64
         description: When this module is bypassed if applicable
-
-  UserAccessExpiration:
-    type: object
-    properties:
-      userName:
-        type: string
-        description: a full All of Us email userName
-      contactEmail:
-        type: string
-        description: the institutional contact email of the user
-      givenName:
-        type: string
-        description: the user's given name (first name)
-      familyName:
-        type: string
-        description: the user's family name (last name)
-      expirationDate:
-        type: string
-        description: the time a user's access will expire, in ISO-8601 format
 
   DemographicSurvey:
     type: object

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1254,7 +1254,7 @@ paths:
       description: 'Updates the given user to bypass the request access requirement'
       parameters:
       - in: body
-        name: bypassed
+        name: request
         schema:
           "$ref": "#/definitions/AccessBypassRequest"
         description: 'Whether the requirement should be bypassed or not. Defaults
@@ -1337,7 +1337,7 @@ paths:
       parameters:
       - "$ref": "#/parameters/userId"
       - in: body
-        name: bypassed
+        name: request
         schema:
           "$ref": "#/definitions/AccessBypassRequest"
         description: 'Whether the requirement should be bypassed or not. Defaults

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1248,7 +1248,7 @@ paths:
   "/v1/admin/unsafe-self-bypass-access-requirement":
     post:
       tags:
-      - profile
+      - userAdmin
       consumes:
       - application/json
       description: 'Updates the given user to bypass the request access requirement'
@@ -1276,7 +1276,7 @@ paths:
   "/v1/admin/users/{usernameWithoutGsuiteDomain}/audit":
     get:
       tags:
-        - profile
+        - userAdmin
       description: >
         Fetch audit logs involving this user as either a subject or object. Requires the
         RESEARCHER_DATA_VIEW authority.
@@ -1329,7 +1329,7 @@ paths:
   "/v1/admin/users/{userId}/bypass-access-requirement":
     post:
       tags:
-      - profile
+      - userAdmin
       consumes:
       - application/json
       description: 'Updates the given user to bypass the request access requirement,
@@ -1359,7 +1359,7 @@ paths:
   "/v1/admin/users/updateAccount":
     post:
       tags:
-        - profile
+        - userAdmin
       consumes:
         - application/json
       description: 'Updates a subset of a user''s account metadata, as defined by the AccountPropertyUpdate object.  Requires ACCESS_CONTROL_ADMIN authority.'
@@ -1386,7 +1386,7 @@ paths:
   "/v1/admin/accessExpirations":
     get:
       tags:
-        - profile
+        - userAdmin
       description: 'Retrieves a mapping of users to access expiration times.  Requires ACCESS_CONTROL_ADMIN authority.'
       operationId: getRegisteredTierAccessExpirations
       responses:
@@ -1403,7 +1403,7 @@ paths:
   "/v1/admin/users/{userId}":
     get:
       tags:
-      - profile
+      - userAdmin
       description: 'Returns a user''s profile for review.  Requires ACCESS_CONTROL_ADMIN
         authority.'
       parameters:
@@ -1421,7 +1421,7 @@ paths:
   "/v1/admin/users/getUserByUsername":
     get:
       tags:
-        - profile
+        - userAdmin
       description: 'Returns a user''s profile for review. Requires ACCESS_CONTROL_ADMIN authority.'
       parameters:
         - in: query
@@ -1441,7 +1441,7 @@ paths:
   "/v1/admin/users/list":
     get:
       tags:
-      - profile
+      - userAdmin
       description: 'Returns a list of profiles for users to be reviewed. Requires
         ACCESS_CONTROL_ADMIN authority.'
       operationId: getAllUsers

--- a/ui/src/app/pages/admin/admin-user-bypass.tsx
+++ b/ui/src/app/pages/admin/admin-user-bypass.tsx
@@ -7,7 +7,7 @@ import {Check, ClrIcon, Times} from 'app/components/icons';
 import {Toggle} from 'app/components/inputs';
 import {PopupTrigger} from 'app/components/popups';
 import {SpinnerOverlay} from 'app/components/spinners';
-import {profileApi} from 'app/services/swagger-fetch-clients';
+import { profileApi, userAdminApi} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {serverConfigStore} from 'app/utils/stores';
 import {AccessModule, AdminTableUser} from 'generated/fetch';
@@ -78,7 +78,7 @@ export class AdminUserBypass extends React.Component<Props, State> {
     this.setState({isSaving: true});
     try {
       for (const module of changedModules) {
-        await profileApi()
+        await userAdminApi()
           .bypassAccessRequirement(user.userId,
           {isBypassed: selectedModules.includes(module), moduleName: module});
       }

--- a/ui/src/app/pages/admin/admin-user.tsx
+++ b/ui/src/app/pages/admin/admin-user.tsx
@@ -11,7 +11,7 @@ import {SmallHeader} from 'app/components/headers';
 import {ClrIcon} from 'app/components/icons';
 import {TextInputWithLabel, Toggle} from 'app/components/inputs';
 import {SpinnerOverlay} from 'app/components/spinners';
-import {institutionApi, profileApi} from 'app/services/swagger-fetch-clients';
+import { institutionApi, userAdminApi} from 'app/services/swagger-fetch-clients';
 import colors, {colorWithWhiteness} from 'app/styles/colors';
 import {
   formatFreeCreditsUSD,
@@ -266,7 +266,7 @@ export const AdminUser = withRouter(class extends React.Component<Props, State> 
   async getUser() {
     const {gsuiteDomain} = serverConfigStore.get().config;
     try {
-      const profile = await profileApi().getUserByUsername(this.props.match.params.usernameWithoutGsuiteDomain + '@' + gsuiteDomain);
+      const profile = await userAdminApi().getUserByUsername(this.props.match.params.usernameWithoutGsuiteDomain + '@' + gsuiteDomain);
       this.setState({oldProfile: profile, updatedProfile: profile, profileLoadingError: ''});
     } catch (error) {
       this.setState({profileLoadingError: 'Could not find user - please check spelling of username and try again'});
@@ -380,7 +380,7 @@ export const AdminUser = withRouter(class extends React.Component<Props, State> 
     };
 
     this.setState({loading: true});
-    profileApi().updateAccountProperties(request).then((response) => {
+    userAdminApi().updateAccountProperties(request).then((response) => {
       this.setState({oldProfile: response, updatedProfile: response, loading: false});
     });
   }

--- a/ui/src/app/pages/admin/admin-users.spec.tsx
+++ b/ui/src/app/pages/admin/admin-users.spec.tsx
@@ -3,9 +3,10 @@ import * as React from 'react';
 import * as fp from 'lodash/fp';
 
 import {AdminUsers} from './admin-users';
-import {AuthDomainApi, Profile, ProfileApi} from 'generated/fetch';
+import { AuthDomainApi, Profile, UserAdminApi} from 'generated/fetch';
 import {serverConfigStore} from 'app/utils/stores';
-import {ProfileApiStub, ProfileStubVariables} from 'testing/stubs/profile-api-stub';
+import {ProfileStubVariables} from 'testing/stubs/profile-api-stub';
+import {UserAdminApiStub} from 'testing/stubs/user-admin-api-stub';
 import {registerApiClient} from 'app/services/swagger-fetch-clients';
 import {AuthDomainApiStub} from 'testing/stubs/auth-domain-api-stub';
 
@@ -30,7 +31,7 @@ describe('AdminUsers', () => {
       hideSpinner: () => fp.noop,
       showSpinner: () => fp.noop
     };
-    registerApiClient(ProfileApi, new ProfileApiStub());
+    registerApiClient(UserAdminApi, new UserAdminApiStub());
     registerApiClient(AuthDomainApi, new AuthDomainApiStub());
   });
 

--- a/ui/src/app/pages/admin/admin-users.tsx
+++ b/ui/src/app/pages/admin/admin-users.tsx
@@ -8,7 +8,7 @@ import {TooltipTrigger} from 'app/components/popups';
 import {Spinner, SpinnerOverlay} from 'app/components/spinners';
 import {WithSpinnerOverlayProps} from 'app/components/with-spinner-overlay';
 import {AdminUserBypass} from 'app/pages/admin/admin-user-bypass';
-import {authDomainApi, profileApi} from 'app/services/swagger-fetch-clients';
+import { authDomainApi, userAdminApi} from 'app/services/swagger-fetch-clients';
 import {reactStyles, withUserProfile} from 'app/utils';
 import {usernameWithoutDomain} from 'app/utils/audit-utils';
 import {serverConfigStore} from 'app/utils/stores';
@@ -81,7 +81,7 @@ export const AdminUsers = withUserProfile()(class extends React.Component<Props,
   }
 
   async loadProfiles() {
-    const userListResponse = await profileApi().getAllUsers();
+    const userListResponse = await userAdminApi().getAllUsers();
     this.setState({users: userListResponse.users});
   }
 

--- a/ui/src/app/pages/admin/user-audit.tsx
+++ b/ui/src/app/pages/admin/user-audit.tsx
@@ -1,13 +1,13 @@
 import {AuditPageComponent} from 'app/components/admin/audit-page-component';
 import {WithSpinnerOverlayProps} from 'app/components/with-spinner-overlay';
-import {profileApi} from 'app/services/swagger-fetch-clients';
+import { userAdminApi} from 'app/services/swagger-fetch-clients';
 import * as React from 'react';
 import {useEffect} from 'react';
 import {useParams} from 'react-router-dom';
 
 const getAuditLog = (subject: string) => {
   const bqRowLimit = 1000; // Workspaces take many rows because of the Research Purpose fields
-  return profileApi().getAuditLogEntries(subject, bqRowLimit);
+  return userAdminApi().getAuditLogEntries(subject, bqRowLimit);
 };
 
 const queryAuditLog = (subject: string) => {

--- a/ui/src/app/services/swagger-fetch-clients.ts
+++ b/ui/src/app/services/swagger-fetch-clients.ts
@@ -43,6 +43,7 @@ import {
   RuntimeApi,
   StatusAlertApi,
   StatusApi,
+  UserAdminApi,
   UserApi,
   UserMetricsApi,
   WorkspaceAdminApi,
@@ -105,6 +106,7 @@ export const profileApi = bindCtor(ProfileApi);
 export const runtimeApi = bindCtor(RuntimeApi);
 export const statusApi = bindCtor(StatusApi);
 export const statusAlertApi = bindCtor(StatusAlertApi);
+export const userAdminApi = bindCtor(UserAdminApi);
 export const userApi = bindCtor(UserApi);
 export const userMetricsApi = bindCtor(UserMetricsApi);
 export const workspaceAdminApi = bindCtor(WorkspaceAdminApi);

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -4,7 +4,7 @@ import {Redirect} from 'react-router-dom';
 
 import {Button} from 'app/components/buttons';
 import {AoU} from 'app/components/text-wrappers';
-import {profileApi} from 'app/services/swagger-fetch-clients';
+import { profileApi, userAdminApi} from 'app/services/swagger-fetch-clients';
 import {AnalyticsTracker} from 'app/utils/analytics';
 import {convertAPIError} from 'app/utils/errors';
 import {encodeURIComponentStrict} from 'app/utils/navigation';
@@ -247,7 +247,7 @@ export const getAccessModuleStatusByName = (profile: Profile, moduleName: Access
 
 export const bypassAll = async(accessModules: AccessModule[], isBypassed: boolean) => {
   for (const module of accessModules) {
-    await profileApi().unsafeSelfBypassAccessRequirement({
+    await userAdminApi().unsafeSelfBypassAccessRequirement({
       moduleName: module,
       isBypassed: isBypassed
     });

--- a/ui/src/testing/stubs/user-admin-api-stub.ts
+++ b/ui/src/testing/stubs/user-admin-api-stub.ts
@@ -1,6 +1,6 @@
-import { AccessBypassRequest, AdminUserListResponse, EmptyResponse, Profile, UserAdminApi } from "generated/fetch";
-import { ProfileStubVariables } from "./profile-api-stub";
-import { stubNotImplementedError } from "./stub-utils";
+import { AccessBypassRequest, AdminUserListResponse, EmptyResponse, Profile, UserAdminApi } from 'generated/fetch';
+import { ProfileStubVariables } from './profile-api-stub';
+import { stubNotImplementedError } from './stub-utils';
 
 export class UserAdminApiStub extends UserAdminApi {
   constructor(public profile = ProfileStubVariables.PROFILE_STUB) {

--- a/ui/src/testing/stubs/user-admin-api-stub.ts
+++ b/ui/src/testing/stubs/user-admin-api-stub.ts
@@ -1,0 +1,26 @@
+import { AccessBypassRequest, AdminUserListResponse, EmptyResponse, Profile, UserAdminApi } from "generated/fetch";
+import { ProfileStubVariables } from "./profile-api-stub";
+import { stubNotImplementedError } from "./stub-utils";
+
+export class UserAdminApiStub extends UserAdminApi {
+  constructor(public profile = ProfileStubVariables.PROFILE_STUB) {
+    super(undefined, undefined, (..._: any[]) => { throw stubNotImplementedError; });
+  }
+
+  public bypassAccessRequirement(
+    userId: number, bypassed?: AccessBypassRequest, options?: any): Promise<EmptyResponse> {
+    return new Promise<EmptyResponse>(() => {});
+  }
+
+
+  public getUser(userId: number): Promise<Profile> {
+    return Promise.resolve(this.profile);
+  }
+
+  public getAllUsers(): Promise<AdminUserListResponse> {
+    return Promise.resolve({users: [{
+      userId: 1,
+      username: ProfileStubVariables.PROFILE_STUB.username,
+    }]});
+  }
+}

--- a/ui/src/testing/stubs/user-admin-api-stub.ts
+++ b/ui/src/testing/stubs/user-admin-api-stub.ts
@@ -12,11 +12,6 @@ export class UserAdminApiStub extends UserAdminApi {
     return new Promise<EmptyResponse>(() => {});
   }
 
-
-  public getUser(userId: number): Promise<Profile> {
-    return Promise.resolve(this.profile);
-  }
-
   public getAllUsers(): Promise<AdminUserListResponse> {
     return Promise.resolve({users: [{
       userId: 1,


### PR DESCRIPTION
Stacked on #6015 

- Remove **getUser()**, **getRegisteredTierExpirations**, as they are unused
- Move the other admin methods to the new controller, with no functional / API changes

There were no controller tests to move in this case, as testing was only being applied at the service layer for these methods.