### PR TITLE
[risk=low][no ticket] Actually update the user DB object when calling updateProfile()

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -470,7 +470,7 @@ public class ProfileController implements ProfileApiDelegate {
       throw new BadRequestException("Cannot update Verified Institutional Affiliation");
     }
 
-    DbUser updatedUser =
+    final DbUser updatedUser =
         profileService.updateProfile(user, Agent.asUser(user), updatedProfile, previousProfile);
     userService.confirmProfile(updatedUser);
 

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -251,10 +251,12 @@ public class ProfileService {
     }
     user.setDemographicSurvey(dbDemographicSurvey);
 
-    // update institution and synchronize access tiers
+    // save user, update institution, and synchronize access tiers
     DbUser updatedUser =
-        upsertAffiliation(user, updatedProfile.getVerifiedInstitutionalAffiliation());
-    updatedUser = userService.updateUserAccessTiers(updatedUser, agent);
+        userService.updateUserWithRetries(
+            u -> upsertAffiliation(u, updatedProfile.getVerifiedInstitutionalAffiliation()),
+            user,
+            agent);
 
     final Profile appliedUpdatedProfile = getProfile(updatedUser);
     profileAuditor.fireUpdateAction(previousProfile, appliedUpdatedProfile, agent);

--- a/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
@@ -370,7 +370,7 @@ public class ProfileServiceTest {
             newAffiliation, mockInstitutionService))
         .thenReturn(dbVerifiedInstitutionalAffiliation);
 
-    when(mockUserService.updateUserAccessTiers(any(), any())).thenReturn(user);
+    when(mockUserService.updateUserWithRetries(any(), any(), any())).thenReturn(user);
 
     profileService.updateProfile(
         user, Agent.asAdmin(loggedInUser), updatedProfile, previousProfile);
@@ -428,7 +428,7 @@ public class ProfileServiceTest {
     targetUser.setGivenName("John");
     targetUser.setFamilyName("Doe");
 
-    when(mockUserService.updateUserAccessTiers(any(), any())).thenReturn(targetUser);
+    when(mockUserService.updateUserWithRetries(any(), any(), any())).thenReturn(targetUser);
 
     profileService.updateProfile(
         targetUser, Agent.asAdmin(loggedInUser), updatedProfile, previousProfile);


### PR DESCRIPTION
This was broken by #6018

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
