### PR TITLE
[risk=no][no ticket] Make TestMockFactory fully static

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -173,7 +173,6 @@ public class CohortsControllerTest {
   SearchRequest searchRequest;
   String cohortCriteria;
   String badCohortCriteria;
-  private TestMockFactory testMockFactory;
 
   @Autowired CdrVersionService cdrVersionService;
   @Autowired CloudStorageClient cloudStorageClient;
@@ -282,9 +281,8 @@ public class CohortsControllerTest {
 
   @BeforeEach
   public void setUp() {
-    testMockFactory = new TestMockFactory();
-    testMockFactory.stubCreateBillingProject(fireCloudService);
-    testMockFactory.stubCreateFcWorkspace(fireCloudService);
+    TestMockFactory.stubCreateBillingProject(fireCloudService);
+    TestMockFactory.stubCreateFcWorkspace(fireCloudService);
     DbUser user = new DbUser();
     user.setUsername(CREATOR_EMAIL);
     user.setUserId(123L);

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -263,9 +263,7 @@ public class ConceptSetsControllerTest {
 
   @BeforeEach
   public void setUp() {
-    TestMockFactory testMockFactory = new TestMockFactory();
-
-    testMockFactory.stubCreateBillingProject(fireCloudService);
+    TestMockFactory.stubCreateBillingProject(fireCloudService);
     TestMockFactory.stubCreateFcWorkspace(fireCloudService);
 
     DbUser user = new DbUser();

--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -99,7 +99,6 @@ public class NotebooksControllerTest {
 
   private static DbUser currentUser;
 
-  private TestMockFactory testMockFactory;
   private FirecloudWorkspaceACL fcWorkspaceAcl;
   private DbCdrVersion cdrVersion;
 
@@ -115,8 +114,6 @@ public class NotebooksControllerTest {
 
   @BeforeEach
   public void setUp() {
-    testMockFactory = new TestMockFactory();
-
     currentUser = createUser(LOGGED_IN_USER_EMAIL);
     fcWorkspaceAcl = createWorkspaceACL();
 
@@ -628,7 +625,7 @@ public class NotebooksControllerTest {
     final String testNotebook = NotebooksService.withNotebookExtension("test-notebook");
 
     FirecloudWorkspaceDetails fcWorkspace =
-        testMockFactory.createFirecloudWorkspace(
+        TestMockFactory.createFirecloudWorkspace(
             testWorkspaceNamespace, testWorkspaceName, LOGGED_IN_USER_EMAIL);
     fcWorkspace.setBucketName(TestMockFactory.WORKSPACE_BUCKET_NAME);
     stubGetWorkspace(fcWorkspace, WorkspaceAccessLevel.OWNER);

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspaceAdminControllerTest.java
@@ -120,13 +120,11 @@ public class WorkspaceAdminControllerTest {
 
   @BeforeEach
   public void setUp() {
-    final TestMockFactory testMockFactory = new TestMockFactory();
-
     when(mockWorkspaceAdminService.getFirstWorkspaceByNamespace(anyString()))
         .thenReturn(Optional.empty());
 
     final Workspace workspace =
-        testMockFactory.createWorkspace(WORKSPACE_NAMESPACE, WORKSPACE_NAME);
+        TestMockFactory.createWorkspace(WORKSPACE_NAMESPACE, WORKSPACE_NAME);
     final DbWorkspace dbWorkspace =
         TestMockFactory.createDbWorkspaceStub(workspace, DB_WORKSPACE_ID);
     when(mockWorkspaceAdminService.getFirstWorkspaceByNamespace(WORKSPACE_NAMESPACE))
@@ -154,7 +152,7 @@ public class WorkspaceAdminControllerTest {
         .thenReturn(cloudStorageCounts);
 
     LeonardoListRuntimeResponse leonardoListRuntimeResponse =
-        testMockFactory.createLeonardoListRuntimesResponse();
+        TestMockFactory.createLeonardoListRuntimesResponse();
     List<LeonardoListRuntimeResponse> runtimes = ImmutableList.of(leonardoListRuntimeResponse);
     when(mockLeonardoNotebooksClient.listRuntimesByProjectAsService(WORKSPACE_NAMESPACE))
         .thenReturn(runtimes);

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -341,8 +341,6 @@ public class WorkspacesControllerTest {
   private String cdrVersionId;
   private String archivedCdrVersionId;
 
-  private TestMockFactory testMockFactory;
-
   @BeforeEach
   public void setUp() throws Exception {
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
@@ -350,7 +348,6 @@ public class WorkspacesControllerTest {
     workbenchConfig.billing.accountId = "free-tier";
     workbenchConfig.billing.projectNamePrefix = "aou-local";
 
-    testMockFactory = new TestMockFactory();
     currentUser = createUser(LOGGED_IN_USER_EMAIL);
     accessTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
@@ -371,8 +368,8 @@ public class WorkspacesControllerTest {
     archivedCdrVersion = cdrVersionDao.save(archivedCdrVersion);
     archivedCdrVersionId = Long.toString(archivedCdrVersion.getCdrVersionId());
 
-    testMockFactory.stubCreateBillingProject(fireCloudService);
-    testMockFactory.stubCreateFcWorkspace(fireCloudService);
+    TestMockFactory.stubCreateBillingProject(fireCloudService);
+    TestMockFactory.stubCreateFcWorkspace(fireCloudService);
 
     when(mockCloudBillingClient.pollUntilBillingAccountLinked(any(), any()))
         .thenReturn(new ProjectBillingInfo().setBillingEnabled(true));
@@ -425,7 +422,7 @@ public class WorkspacesControllerTest {
 
   private void stubGetWorkspace(
       String ns, String name, String creator, WorkspaceAccessLevel access) {
-    stubGetWorkspace(testMockFactory.createFirecloudWorkspace(ns, name, creator), access);
+    stubGetWorkspace(TestMockFactory.createFirecloudWorkspace(ns, name, creator), access);
   }
 
   private void stubGetWorkspace(
@@ -497,7 +494,7 @@ public class WorkspacesControllerTest {
   }
 
   private Workspace createWorkspace() {
-    return testMockFactory.createWorkspace("namespace", "name");
+    return TestMockFactory.createWorkspace("namespace", "name");
   }
 
   public Cohort createDefaultCohort(String name) {
@@ -527,7 +524,7 @@ public class WorkspacesControllerTest {
 
     FirecloudWorkspaceResponse fcResponse = new FirecloudWorkspaceResponse();
     fcResponse.setWorkspace(
-        testMockFactory.createFirecloudWorkspace(
+        TestMockFactory.createFirecloudWorkspace(
             workspace.getNamespace(), workspace.getName(), null));
     fcResponse.setAccessLevel(WorkspaceAccessLevel.OWNER.toString());
     doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces();
@@ -597,7 +594,7 @@ public class WorkspacesControllerTest {
   public void testCreateWorkspace_resetBillingAccountOnFailedSave() throws Exception {
     doThrow(RuntimeException.class).when(workspaceDao).save(any(DbWorkspace.class));
     Workspace workspace = createWorkspace();
-    testMockFactory.stubCreateBillingProject(fireCloudService, workspace.getNamespace());
+    TestMockFactory.stubCreateBillingProject(fireCloudService, workspace.getNamespace());
 
     try {
       workspacesController.createWorkspace(workspace).getBody();
@@ -2499,7 +2496,7 @@ public class WorkspacesControllerTest {
 
     FirecloudWorkspaceResponse fcResponse = new FirecloudWorkspaceResponse();
     fcResponse.setWorkspace(
-        testMockFactory.createFirecloudWorkspace(
+        TestMockFactory.createFirecloudWorkspace(
             workspace.getNamespace(), workspace.getName(), null));
     fcResponse.setAccessLevel(WorkspaceAccessLevel.OWNER.toString());
     doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces();
@@ -2519,7 +2516,7 @@ public class WorkspacesControllerTest {
 
     FirecloudWorkspaceResponse fcResponse = new FirecloudWorkspaceResponse();
     fcResponse.setWorkspace(
-        testMockFactory.createFirecloudWorkspace(
+        TestMockFactory.createFirecloudWorkspace(
             workspace.getNamespace(), workspace.getName(), null));
     fcResponse.setAccessLevel(WorkspaceAccessLevel.OWNER.toString());
     doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces();
@@ -2538,7 +2535,7 @@ public class WorkspacesControllerTest {
 
     FirecloudWorkspaceResponse fcResponse = new FirecloudWorkspaceResponse();
     fcResponse.setWorkspace(
-        testMockFactory.createFirecloudWorkspace(
+        TestMockFactory.createFirecloudWorkspace(
             workspace.getNamespace(), workspace.getName(), null));
     fcResponse.setAccessLevel(WorkspaceAccessLevel.WRITER.toString());
     doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces();
@@ -2557,7 +2554,7 @@ public class WorkspacesControllerTest {
 
     FirecloudWorkspaceResponse fcResponse = new FirecloudWorkspaceResponse();
     fcResponse.setWorkspace(
-        testMockFactory.createFirecloudWorkspace(
+        TestMockFactory.createFirecloudWorkspace(
             workspace.getNamespace(), workspace.getName(), null));
     fcResponse.setAccessLevel(WorkspaceAccessLevel.READER.toString());
     doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces();

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -100,7 +100,7 @@ public class TestMockFactory {
   // TODO there's something off about how "workspaceName" here works.  Investigate.
   // For best results, use a lowercase-only workspaceName.
   // To me, this hints at a firecloudName/aouName discrepancy somewhere in here.
-  public Workspace createWorkspace(String workspaceNameSpace, String workspaceName) {
+  public static Workspace createWorkspace(String workspaceNameSpace, String workspaceName) {
     List<DisseminateResearchEnum> disseminateResearchEnumsList = new ArrayList<>();
     disseminateResearchEnumsList.add(DisseminateResearchEnum.PRESENATATION_SCIENTIFIC_CONFERENCES);
     disseminateResearchEnumsList.add(DisseminateResearchEnum.PRESENTATION_ADVISORY_GROUPS);
@@ -160,7 +160,7 @@ public class TestMockFactory {
         .googleProject(DEFAULT_GOOGLE_PROJECT);
   }
 
-  public LeonardoListRuntimeResponse createLeonardoListRuntimesResponse() {
+  public static LeonardoListRuntimeResponse createLeonardoListRuntimesResponse() {
     return new LeonardoListRuntimeResponse()
         .runtimeName("runtime")
         .googleProject("google-project")

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -148,8 +148,6 @@ public class WorkspaceAdminServiceTest {
 
   @BeforeEach
   public void setUp() {
-    final TestMockFactory testMockFactory = new TestMockFactory();
-
     when(mockFirecloudService.getWorkspaceAsService(any(), any()))
         .thenReturn(
             new FirecloudWorkspaceResponse()
@@ -159,7 +157,7 @@ public class WorkspaceAdminServiceTest {
                         .namespace(WORKSPACE_NAMESPACE)));
 
     final Workspace workspace =
-        testMockFactory.createWorkspace(WORKSPACE_NAMESPACE, WORKSPACE_NAME);
+        TestMockFactory.createWorkspace(WORKSPACE_NAMESPACE, WORKSPACE_NAME);
     final DbWorkspace dbWorkspace =
         TestMockFactory.createDbWorkspaceStub(workspace, DB_WORKSPACE_ID);
     doReturn(Optional.of(dbWorkspace))


### PR DESCRIPTION
There's no need to instantiate this class.  Updated all references to static ones.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/master/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
