### PR TITLE
[RW-7199][risk=no] Drop active billing enforcement on getRuntime

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -1419,25 +1419,6 @@ public class RuntimeControllerTest {
   }
 
   @Test
-  public void getRuntime_validateActiveBilling() {
-    doThrow(ForbiddenException.class)
-        .when(mockWorkspaceAuthService)
-        .validateActiveBilling(WORKSPACE_NS, WORKSPACE_ID);
-
-    assertThrows(ForbiddenException.class, () -> runtimeController.getRuntime(WORKSPACE_NS));
-  }
-
-  @Test
-  public void getRuntime_validateActiveBilling_checkAccessFirst() {
-    doThrow(ForbiddenException.class)
-        .when(mockWorkspaceAuthService)
-        .enforceWorkspaceAccessLevel(WORKSPACE_NS, WORKSPACE_ID, WorkspaceAccessLevel.WRITER);
-
-    assertThrows(ForbiddenException.class, () -> runtimeController.getRuntime(WORKSPACE_NS));
-    verify(mockWorkspaceAuthService, never()).validateActiveBilling(anyString(), anyString());
-  }
-
-  @Test
   public void localize_validateActiveBilling() {
     doThrow(ForbiddenException.class)
         .when(mockWorkspaceAuthService)


### PR DESCRIPTION
- `enforceWorkspaceAccessLevel()` is only called from these methods to guard the active billing check - otherwise it would expose information about the billing status to any caller
- Actual access checks on the method are implicitly made by Leo, as we forward end user credentials for these interactions
- Originally, it made sense to have this check on getRuntime, which would lazily initialize the user's notebook runtime; however, that behavior no longer exists, so calling this method cannot increase compute spend

Most of the remaining calls to check valid billing in the other methods still apply, since they could affect spending in the workspace.

As a side-effect, we'll no longer generate 403s when a user loads a read-only workspace. It may not be terrible to allow this interaction, as we have not clearly defined the behavior for what happens when a user has a runtime, and then is revoked access to a workspace.