### PR TITLE
[risk=no] Revert eslint to warn; fail CircleCI if there are any warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,7 +477,7 @@ jobs:
           # Lint last; it's more important to surface test failures early.
           name: Lint typescript
           working_directory: ~/workbench/ui
-          command: yarn run lint
+          command: yarn run lint --max-warnings 0
       - persist_to_workspace:
           root: .
           paths:

--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -30,67 +30,67 @@ module.exports = {
 
   // The eslint rules can be found here: https://eslint.org/docs/rules/
   rules: {
-    // 'prettier/prettier': 'error', // Possibly use prettier to handle some formatting
+    // 'prettier/prettier': 'warn', // Possibly use prettier to handle some formatting
 
     /* Best Practices */
-    // 'no-multi-spaces': 'error',
+    // 'no-multi-spaces': 'warn',
 
     /* Typescript specific */
     '@typescript-eslint/explicit-member-accessibility': 'off',
-    // '@typescript-eslint/member-ordering': ['error', { 'classExpressions': ['method', 'field'] }],
-    '@typescript-eslint/no-empty-interface': 'error',
-    '@typescript-eslint/no-inferrable-types': ['error', {ignoreParameters: true}],
-    '@typescript-eslint/no-non-null-assertion': 'error',
-    // 'prefer-arrow/prefer-arrow-functions': ['error'], // Lots of 'newable' functions in the code base 
-    '@typescript-eslint/type-annotation-spacing': 'error',
-    '@typescript-eslint/unified-signatures': 'error',
+    // '@typescript-eslint/member-ordering': ['warn', { 'classExpressions': ['method', 'field'] }],
+    '@typescript-eslint/no-empty-interface': 'warn',
+    '@typescript-eslint/no-inferrable-types': ['warn', {ignoreParameters: true}],
+    '@typescript-eslint/no-non-null-assertion': 'warn',
+    // 'prefer-arrow/prefer-arrow-functions': ['warn'], // Lots of 'newable' functions in the code base 
+    '@typescript-eslint/type-annotation-spacing': 'warn',
+    '@typescript-eslint/unified-signatures': 'warn',
 
     /* Style */
-    '@typescript-eslint/prefer-function-type': 'error',
-    // 'spaced-comment': 'error',
-    '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
-    'no-trailing-spaces': 'error',
-    'no-undef-init': 'error',
-    // 'brace-style': ['error', '1tbs'],
-    // 'simple-import-sort/sort': 'error',
-    'quotes': ['error', 'single'],
-    // '@typescript-eslint/semi': 'error',
-    // 'space-before-function-paren': ['error', { 'anonymous': 'never', 'named': 'never', 'asyncArrow': 'always' }],
+    '@typescript-eslint/prefer-function-type': 'warn',
+    // 'spaced-comment': 'warn',
+    '@typescript-eslint/consistent-type-definitions': ['warn', 'interface'],
+    'no-trailing-spaces': 'warn',
+    'no-undef-init': 'warn',
+    // 'brace-style': ['warn', '1tbs'],
+    // 'simple-import-sort/sort': 'warn',
+    'quotes': ['warn', 'single'],
+    // '@typescript-eslint/semi': 'warn',
+    // 'space-before-function-paren': ['warn', { 'anonymous': 'never', 'named': 'never', 'asyncArrow': 'always' }],
 
     /* Functionality */
-    'curly': 'error',
-    'guard-for-in': 'error',
+    'curly': 'warn',
+    'guard-for-in': 'warn',
     'no-restricted-imports': ['error', {paths: ['rxjs'], patterns: ['../']}],
-    'no-caller': 'error',
-    'no-bitwise': 'error',
-    // 'no-console': 'error', 
-    'no-new-wrappers': 'error',
-    'no-debugger': 'error',
-    'constructor-super': 'error',
-    'no-empty': 'error',
-    'no-eval': 'error',
-    'no-irregular-whitespace': 'error',
-    '@typescript-eslint/no-misused-new': 'error',
-    // 'no-shadow': 'error',
-    // 'dot-notation': 'error',
-    'no-throw-literal': 'error', 
-    'no-fallthrough': 'error', // For switch statements
+    'no-caller': 'warn',
+    'no-bitwise': 'warn',
+    // 'no-console': 'warn', 
+    'no-new-wrappers': 'warn',
+    'no-debugger': 'warn',
+    'constructor-super': 'warn',
+    'no-empty': 'warn',
+    'no-eval': 'warn',
+    'no-irregular-whitespace': 'warn',
+    '@typescript-eslint/no-misused-new': 'warn',
+    // 'no-shadow': 'warn',
+    // 'dot-notation': 'warn',
+    'no-throw-literal': 'warn', 
+    'no-fallthrough': 'warn', // For switch statements
     'no-use-before-define': 'off', // Needed for TS
-    // '@typescript-eslint/no-use-before-define': 'error',
+    // '@typescript-eslint/no-use-before-define': 'warn',
     // 'no-unused-vars': 'off', // Needed for TS 
-    // '@typescript-eslint/no-unused-vars': 'error', 
+    // '@typescript-eslint/no-unused-vars': 'warn', 
     'react/jsx-curly-spacing': ["warn", {'when': 'never'}],
-    'react/jsx-uses-vars': 'error',
-    'no-var': 'error',
-    'radix': 'error', // Add radix on parseInt
-    'eqeqeq': ['error', 'always', {'null': 'ignore'}],
+    'react/jsx-uses-vars': 'warn',
+    'no-var': 'warn',
+    'radix': 'warn', // Add radix on parseInt
+    'eqeqeq': ['warn', 'always', {'null': 'ignore'}],
     
     /* Maintainability */
-    'eol-last': 'error',
-    'max-len': ['error', {code: 140, ignorePattern: '^import |^export\\{(.*?)\\}', ignoreComments: true}], 
-    // 'prefer-const': ['error', {'destructuring': 'all'}],
+    'eol-last': 'warn',
+    'max-len': ['warn', {code: 140, ignorePattern: '^import |^export\\{(.*?)\\}', ignoreComments: true}], 
+    // 'prefer-const': ['warn', {'destructuring': 'all'}],
 
     /* Jest */
-    'jest/no-focused-tests': 'error',
+    'jest/no-focused-tests': 'warn',
   }
 };

--- a/ui/src/app/pages/login/account-creation/account-creation.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.spec.tsx
@@ -65,7 +65,7 @@ it('should handle username validity ends with .', () => {
   expect(wrapper.exists('#usernameError')).toBeTruthy();
 });
 
-test.each(['user@name', '.user', 'user.', 'user..', "O'Riley", '50%', 'no+plus', 'ælfred', 'money$man'])
+test.each(['user@name', '.user', 'user.', 'user..', 'O\'Riley', '50%', 'no+plus', 'ælfred', 'money$man'])
 ('should mark username %s as invalid', (username) => {
   const wrapper = component();
   expect(wrapper.exists('#username')).toBeTruthy();

--- a/ui/src/app/pages/login/account-creation/account-creation.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.spec.tsx
@@ -65,7 +65,7 @@ it('should handle username validity ends with .', () => {
   expect(wrapper.exists('#usernameError')).toBeTruthy();
 });
 
-test.each(['user@name', '.user', 'user.', 'user..', 'O\'Riley', '50%', 'no+plus', 'ælfred', 'money$man'])
+test.each(['user@name', '.user', 'user.', 'user..', "O'Riley", '50%', 'no+plus', 'ælfred', 'money$man'])
 ('should mark username %s as invalid', (username) => {
   const wrapper = component();
   expect(wrapper.exists('#username')).toBeTruthy();


### PR DESCRIPTION
"error" has the very annoying side-effect of causing the local dev server compilation to fail; I missed this initially.

--max-warnings 0 yields a non-zero exit code if there are more than 0 warnings, which is what I was originally trying to achieve with this change.