### PR TITLE
[RW-7647][risk=no] Fix recreating runtimes with changes on error

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -337,6 +337,30 @@ describe('RuntimePanel', () => {
     expect(runtimeApiStub.runtime.status).toEqual('Deleting');
   });
 
+  it('should allow creation with update from error', async() => {
+    const runtime = {...runtimeApiStub.runtime,
+      status: RuntimeStatus.Error,
+      errors: [{errorMessage: 'I\'m sorry Dave, I\'m afraid I can\'t do that'}],
+      configurationType: RuntimeConfigurationType.GeneralAnalysis,
+      gceConfig: {
+        ...defaultGceConfig(),
+        machineType: 'n1-standard-16',
+        diskSize: 100
+      },
+      dataprocConfig: null
+    };
+    runtimeApiStub.runtime = runtime;
+    runtimeStoreStub.runtime = runtime;
+
+    const wrapper = await component();
+
+    await pickMainCpu(wrapper, 8);
+    await mustClickButton(wrapper, 'Try Again');
+
+    // Kicks off a deletion to first clear the error status runtime.
+    expect(runtimeApiStub.runtime.status).toEqual('Deleting');
+  });
+
   it('should disable controls when runtime has non-updateable status', async() => {
     runtimeApiStub.runtime.status = RuntimeStatus.Stopping;
     runtimeStoreStub.runtime = runtimeApiStub.runtime;

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -556,7 +556,7 @@ export const useRuntimeStatus = (currentWorkspaceNamespace, currentGoogleProject
 
 export const getRuntimeCtx = (runtime: Runtime, pendingRuntime: Runtime) => {
   const pdFeatureFlag = serverConfigStore.get().config.enablePersistentDisk;
-  const runtimeExists = (runtime.status && ![RuntimeStatus.Deleted, RuntimeStatus.Error].includes(runtime.status)) || !!pendingRuntime;
+  const runtimeExists = (runtime?.status && ![RuntimeStatus.Deleted, RuntimeStatus.Error].includes(runtime.status)) || !!pendingRuntime;
   const {dataprocConfig = null} = pendingRuntime || runtime || {} as Partial<Runtime>;
   const initialCompute = dataprocConfig ? ComputeType.Dataproc : ComputeType.Standard;
   const gceExists = runtimeExists &&  initialCompute === ComputeType.Standard;
@@ -634,7 +634,7 @@ export const useCustomRuntime = (currentWorkspaceNamespace, detachablePd):
                 requestedRuntime.gceWithPdConfig.persistentDisk.size);
             }
           }
-        } else if (runtime.status === RuntimeStatus.Error) {
+        } else if (runtime?.status === RuntimeStatus.Error) {
           await runtimeApi().deleteRuntime(currentWorkspaceNamespace, false, {
             signal: aborter.signal
           });


### PR DESCRIPTION
Bug occurred when clicking "try again" for error runtimes, after changing any of the runtime panel details. This can occur without the user having interacting with the runtime panel, e.g. if the defaults changed since they last created a runtime. Verified this regression test fails at HEAD.