### PR TITLE
[RW-7617][risk=no] Roll forward 2.0.4 again

### DIFF
--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -8,7 +8,7 @@
     "leoBaseUrl": "https:\/\/leonardo.dsde-dev.broadinstitute.org",
     "xAppIdValue": "test-AoU-RW",
     "timeoutInSeconds": 60,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.1",
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.4",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev",
     "workspaceLogsProject": "fc-aou-logs-test",


### PR DESCRIPTION
After further investigation on https://precisionmedicineinitiative.atlassian.net/browse/RW-7617, I believe the image upgrade is unrelated to this class of errors. It may still be related to 500/503 issues, but I haven't been able to reproduce these yet. Roll this forward for further observation, after https://github.com/all-of-us/workbench/pull/6041