### PR TITLE
[RW-7310][risk=no] Avoid excessive profile URL validation

### DIFF
--- a/e2e/tests/profile/profile-page.spec.ts
+++ b/e2e/tests/profile/profile-page.spec.ts
@@ -174,7 +174,7 @@ describe('Profile', () => {
   test('Typing an invalid URL disables the save button', async () => {
     const url = profilePage.getProfessionalUrlInput();
     const validUrl = makeUrl(10);
-    const invalidUrls = ['hello', 'hello.com', 'http://', 'https://broad    institute.org', '*http://google.com/'];
+    const invalidUrls = ['hello', 'http://', 'https://broad    institute.org', '*http://google.com/'];
 
     await url.type(validUrl);
 

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -291,7 +291,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
     // validatejs requires a scheme, which we don't necessarily need in the profile; rather than
     // forking their website regex, just ensure a scheme ahead of validation.
     const urlError = validationData.professionalUrl
-      ? validate({website: validationData.professionalUrl}, {
+      ? validate({website: canonicalizeUrl(validationData.professionalUrl)}, {
         website: { url: { message: '^Professional URL %{value} is not a valid URL' } }
       })
       : undefined;
@@ -534,7 +534,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
               value={professionalUrl}
               labelText={<div>Paste Professional URL here</div>}
               containerStyle={{width: '26rem', marginTop: '.25rem'}}
-              onChange={value => this.updateProfileObject('professionalUrl', canonicalizeUrl(value))}
+              onChange={value => this.updateProfileObject('professionalUrl', value)}
             />
           </Section>
           <FormSection style={{marginTop: '4rem', paddingBottom: '1rem'}}>

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -178,6 +178,13 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
     this.setState(fp.set(['profile', 'address', attribute], value));
   }
 
+  private ensureScheme(url: string): string {
+    if (/^https?:\/\//.test(url)) {
+      return url;
+    }
+    return `http://${url}`;
+  }
+
   validate(): {[key: string]: string} {
     const {gsuiteDomain} = serverConfigStore.get().config;
 
@@ -287,8 +294,10 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
       };
     }
 
+    // validatejs requires a scheme, which we don't necessarily need in the profile; rather than
+    // forking their website regex, just ensure a scheme ahead of validation.
     const urlError = validationData.professionalUrl
-      ? validate({website: validationData.professionalUrl}, {
+      ? validate({website: this.ensureScheme(validationData.professionalUrl)}, {
         website: { url: { message: '^Professional URL %{value} is not a valid URL' } }
       })
       : undefined;

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -290,9 +290,10 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
 
     // validatejs requires a scheme, which we don't necessarily need in the profile; rather than
     // forking their website regex, just ensure a scheme ahead of validation.
-    const urlError = validationData.professionalUrl
-      ? validate({website: canonicalizeUrl(validationData.professionalUrl)}, {
-        website: { url: { message: '^Professional URL %{value} is not a valid URL' } }
+    const {professionalUrl} = validationData;
+    const urlError = professionalUrl
+      ? validate({website: canonicalizeUrl(professionalUrl)}, {
+        website: { url: { message: `^Professional URL ${professionalUrl} is not a valid URL` } }
       })
       : undefined;
 

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -31,6 +31,7 @@ import {AnalyticsTracker} from 'app/utils/analytics';
 import {serverConfigStore} from 'app/utils/stores';
 import {NOT_ENOUGH_CHARACTERS_RESEARCH_DESCRIPTION} from 'app/utils/strings';
 import {Profile} from 'generated/fetch';
+import { canonicalizeUrl } from 'app/utils/urls';
 
 const styles = reactStyles({
   ...commonStyles,
@@ -178,13 +179,6 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
     this.setState(fp.set(['profile', 'address', attribute], value));
   }
 
-  private ensureScheme(url: string): string {
-    if (/^https?:\/\//.test(url)) {
-      return url;
-    }
-    return `http://${url}`;
-  }
-
   validate(): {[key: string]: string} {
     const {gsuiteDomain} = serverConfigStore.get().config;
 
@@ -297,7 +291,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
     // validatejs requires a scheme, which we don't necessarily need in the profile; rather than
     // forking their website regex, just ensure a scheme ahead of validation.
     const urlError = validationData.professionalUrl
-      ? validate({website: this.ensureScheme(validationData.professionalUrl)}, {
+      ? validate({website: validationData.professionalUrl}, {
         website: { url: { message: '^Professional URL %{value} is not a valid URL' } }
       })
       : undefined;
@@ -540,7 +534,7 @@ export class AccountCreation extends React.Component<AccountCreationProps, Accou
               value={professionalUrl}
               labelText={<div>Paste Professional URL here</div>}
               containerStyle={{width: '26rem', marginTop: '.25rem'}}
-              onChange={value => this.updateProfileObject('professionalUrl', value)}
+              onChange={value => this.updateProfileObject('professionalUrl', canonicalizeUrl(value))}
             />
           </Section>
           <FormSection style={{marginTop: '4rem', paddingBottom: '1rem'}}>

--- a/ui/src/app/pages/login/account-creation/account-creation.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation.tsx
@@ -31,7 +31,7 @@ import {AnalyticsTracker} from 'app/utils/analytics';
 import {serverConfigStore} from 'app/utils/stores';
 import {NOT_ENOUGH_CHARACTERS_RESEARCH_DESCRIPTION} from 'app/utils/strings';
 import {Profile} from 'generated/fetch';
-import { canonicalizeUrl } from 'app/utils/urls';
+import {canonicalizeUrl} from 'app/utils/urls';
 
 const styles = reactStyles({
   ...commonStyles,

--- a/ui/src/app/pages/profile/profile-component.tsx
+++ b/ui/src/app/pages/profile/profile-component.tsx
@@ -34,6 +34,7 @@ import {AccessModule, InstitutionalRole, Profile} from 'generated/fetch';
 import {PublicInstitutionDetails} from 'generated/fetch';
 import {DataAccessPanel} from './data-access-panel';
 import {displayDateWithoutHours} from 'app/utils/dates';
+import {canonicalizeUrl} from 'app/utils/urls';
 
 
 // validators for validate.js
@@ -251,7 +252,7 @@ export const ProfileComponent = fp.flow(
       };
       const errors = fp.isEmpty(errorMessages) ? undefined : errorMessages;
 
-      const makeProfileInput = ({title, valueKey, isLong = false, ...props}) => {
+      const makeProfileInput = ({title, valueKey, isLong = false, sanitize = (v: any) => v, ...props}) => {
         let errorText = profile && errors && errors[valueKey];
         if (valueKey && !Array.isArray(valueKey)) {
           valueKey = [valueKey];
@@ -261,7 +262,7 @@ export const ProfileComponent = fp.flow(
         }
         const inputProps = {
           value: fp.get(valueKey, currentProfile) || '',
-          onChange: v => this.setState(fp.set(['currentProfile', ...valueKey], v)),
+          onChange: v => this.setState(fp.set(['currentProfile', ...valueKey], sanitize(v))),
           invalid: !!errorText,
           style: props.style,
           maxCharacters: props.maxCharacters,
@@ -352,9 +353,10 @@ export const ProfileComponent = fp.flow(
 
             <FlexRow style={{width: '100%'}}>
               {makeProfileInput({
-                title: 'Professional URL',
-                valueKey: 'professionalUrl',
-                style: {width: '26rem'}
+                 title: 'Professional URL',
+                 valueKey: 'professionalUrl',
+                 sanitize: (v) => canonicalizeUrl(v),
+                 style: {width: '26rem'}
               })}
             </FlexRow>
             <FlexRow>

--- a/ui/src/app/pages/profile/profile-component.tsx
+++ b/ui/src/app/pages/profile/profile-component.tsx
@@ -227,11 +227,13 @@ export const ProfileComponent = fp.flow(
       )(profile.accessModules.modules);
       const hasExpired = profileExpiration && profileExpiration < Date.now();
 
+      // validatejs requires a scheme, which we don't necessarily need in the profile; rather than
+      // forking their website regex, just ensure a scheme ahead of validation.
       const urlError =
         professionalUrl ?
         validate(
           {website: canonicalizeUrl(professionalUrl)},
-          {website: {url: {message: '^Professional URL %{value} is not a valid URL'}}})
+          {website: {url: {message: `^Professional URL ${professionalUrl} is not a valid URL`}}})
         : undefined;
       const errorMessages = {
         ...urlError,

--- a/ui/src/app/pages/profile/profile-component.tsx
+++ b/ui/src/app/pages/profile/profile-component.tsx
@@ -227,9 +227,12 @@ export const ProfileComponent = fp.flow(
       )(profile.accessModules.modules);
       const hasExpired = profileExpiration && profileExpiration < Date.now();
 
-      const urlError = professionalUrl
-      ? validate({website: professionalUrl}, {website: {url: {message: '^Professional URL %{value} is not a valid URL'}}})
-      : undefined;
+      const urlError =
+        professionalUrl ?
+        validate(
+          {website: canonicalizeUrl(professionalUrl)},
+          {website: {url: {message: '^Professional URL %{value} is not a valid URL'}}})
+        : undefined;
       const errorMessages = {
         ...urlError,
         ...validate({
@@ -252,7 +255,7 @@ export const ProfileComponent = fp.flow(
       };
       const errors = fp.isEmpty(errorMessages) ? undefined : errorMessages;
 
-      const makeProfileInput = ({title, valueKey, isLong = false, sanitize = (v: any) => v, ...props}) => {
+      const makeProfileInput = ({title, valueKey, isLong = false, ...props}) => {
         let errorText = profile && errors && errors[valueKey];
         if (valueKey && !Array.isArray(valueKey)) {
           valueKey = [valueKey];
@@ -262,7 +265,7 @@ export const ProfileComponent = fp.flow(
         }
         const inputProps = {
           value: fp.get(valueKey, currentProfile) || '',
-          onChange: v => this.setState(fp.set(['currentProfile', ...valueKey], sanitize(v))),
+          onChange: v => this.setState(fp.set(['currentProfile', ...valueKey], v)),
           invalid: !!errorText,
           style: props.style,
           maxCharacters: props.maxCharacters,
@@ -355,7 +358,6 @@ export const ProfileComponent = fp.flow(
               {makeProfileInput({
                  title: 'Professional URL',
                  valueKey: 'professionalUrl',
-                 sanitize: (v) => canonicalizeUrl(v),
                  style: {width: '26rem'}
               })}
             </FlexRow>

--- a/ui/src/app/utils/urls.ts
+++ b/ui/src/app/utils/urls.ts
@@ -1,0 +1,12 @@
+
+// Canonicalizes a string as a URL. Suitable for use on user inputs. This does
+// not have any implications around trusting the URL.
+export function canonicalizeUrl(url: string): string {
+  url = url.toLowerCase().trim();
+  if (/^https?:\/\//.test(url)) {
+    return url;
+  }
+  // Default to http://, as many sites will upgrade to https:// automatically
+  // and https:// may yield a bad certificate if not configured.
+  return `http://${url}`;
+}


### PR DESCRIPTION
Initially I considered improving the error message to require a scheme, however - this seemed a bit too strict for an optional user profile field. I think we should just assume a scheme if not provided.