### PR TITLE
[RW-7541][risk=no] Fix navigation for participants in cohort review

### DIFF
--- a/ui/src/app/pages/data/cohort-review/detail-tab-table.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-tab-table.component.tsx
@@ -350,26 +350,24 @@ export const DetailTabTable = fp.flow(withCurrentCohortReview(), withCurrentWork
             await this.callCountApi(pageFilterRequest).then(async(count) => {
               totalCount = count;
               if (lazyLoad) {
-                if (start > totalCount) {
-                  // If the data was filtered to a smaller count than the previous start, reset to the last page of the new data
-                  start = Math.floor((totalCount - 1) / rowsPerPage) * rowsPerPage;
-                  page = start / rowsPerPage;
-                  pageFilterRequest.page = Math.floor(totalCount / lazyLoadSize);
-                }
+                // reset pagination
+                start = 0;
+                page = 0;
+                pageFilterRequest.page = 0;
+                range[0] = start;
               } else {
                 lazyLoad = totalCount > 1000;
                 if (lazyLoad) {
                   pageFilterRequest.filters = filters;
                   pageFilterRequest.pageSize = lazyLoadSize;
                   if (filters.items.length) {
-                    // if filters exist, call api for count a second time to get the filtered count
+                    // if filters exist, call api for count a second time to get the filtered count and reset pagination
                     await this.callCountApi(pageFilterRequest).then(filteredCount => {
                       totalCount = filteredCount;
-                      if (start > totalCount) {
-                        // If the data was filtered to a smaller count than the previous start, reset to the last page of the new data
-                        start = Math.floor(totalCount / rowsPerPage) * rowsPerPage;
-                        pageFilterRequest.page = Math.floor(totalCount / lazyLoadSize);
-                      }
+                      start = 0;
+                      page = 0;
+                      pageFilterRequest.page = 0;
+                      range[0] = start;
                     });
                   }
                 } else {
@@ -537,7 +535,7 @@ export const DetailTabTable = fp.flow(withCurrentCohortReview(), withCurrentWork
       }
     }
 
-    onPage = (event: any) => {
+    onPage(event: any) {
       const {lazyLoad, page, range, totalCount} = this.state;
       if (lazyLoad) {
         if (event.page < page && event.page > 1 && range[0] >= (event.first - rowsPerPage)) {
@@ -964,7 +962,7 @@ export const DetailTabTable = fp.flow(withCurrentCohortReview(), withCurrentWork
           paginator
           paginatorTemplate={!spinner && !!value ? paginatorTemplate : ''}
           currentPageReportTemplate={!spinner && !!value ? pageReportTemplate : ''}
-          onPage={this.onPage}
+          onPage={(e) => this.onPage(e)}
           alwaysShowPaginator={false}
           first={start}
           rows={rowsPerPage}


### PR DESCRIPTION
The PrimeReact Data table will reset its internal page count to `0` every time a checkbox is checked. This can cause a blank table if on one of the middle pages when the filter is changed. Fixed by resetting all pagination values (to `0`) whenever a filter is changed.:

Before:
<img width="1515" alt="Screen Shot 2021-12-13 at 11 06 03 PM" src="https://user-images.githubusercontent.com/40036095/145936972-edd3118b-12c3-4684-b910-c9a5b19e9747.png">

After:
<img width="1516" alt="Screen Shot 2021-12-13 at 11 06 25 PM" src="https://user-images.githubusercontent.com/40036095/145936997-04b0cc46-23c5-4401-96bf-2a8352c1ed4e.png">

---

**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
