### PR TITLE
[risk=no] Fix Egress event timestamp plumbing and display

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
@@ -70,6 +70,14 @@ public class CommonMappers {
     return null;
   }
 
+  @Named("timestampToIso8601String")
+  public String timestampToIso8601String(Timestamp timestamp) {
+    if (timestamp == null) {
+      return null;
+    }
+    return timestamp.toInstant().toString();
+  }
+
   @Named("dateToString")
   public String dateToString(Date date) {
     // We are using this method because mapstruct defaults to gregorian conversion. The difference

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/EgressEventMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/EgressEventMapper.java
@@ -13,6 +13,7 @@ public interface EgressEventMapper {
   @Mapping(target = "sourceUserEmail", source = "user.username")
   @Mapping(target = "sourceWorkspaceNamespace", source = "workspace.workspaceNamespace")
   @Mapping(target = "sourceGoogleProject", source = "workspace.googleProject")
+  @Mapping(target = "creationTime", qualifiedByName = "timestampToIso8601String")
   EgressEvent toApiEvent(DbEgressEvent event);
 
   EgressEventStatus toApiStatus(DbEgressEventStatus status);

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/EgressEventMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/EgressEventMapperTest.java
@@ -65,7 +65,7 @@ public class EgressEventMapperTest {
                 .sourceUserEmail(user.getUsername())
                 .sourceWorkspaceNamespace("ns")
                 .sourceGoogleProject("proj")
-                .creationTime(Timestamp.from(created).toString())
+                .creationTime("2000-01-01T00:00:00Z")
                 .status(EgressEventStatus.PENDING)
                 .egressMegabytes(201.0)
                 .egressWindowSeconds(BigDecimal.valueOf(3600L)));
@@ -85,7 +85,7 @@ public class EgressEventMapperTest {
         .isEqualTo(
             new EgressEvent()
                 .egressEventId("7")
-                .creationTime(Timestamp.from(created).toString())
+                .creationTime("2000-01-01T00:00:00Z")
                 .status(EgressEventStatus.PENDING));
   }
 }

--- a/ui/src/app/pages/admin/admin-egress-audit.tsx
+++ b/ui/src/app/pages/admin/admin-egress-audit.tsx
@@ -88,7 +88,7 @@ export const AdminEgressAudit = (props: WithSpinnerOverlayProps) => {
     <h2>Egress event {event.egressEventId}</h2>
     <div style={{display: 'table', marginBottom: '15px'}}>
       <DetailRow label="Detection time">
-        {(new Date(event.creationTime)).toString()}
+        {(new Date(event.creationTime)).toLocaleString()}
       </DetailRow>
       <DetailRow label="Source user">
         <StyledRouterLink path={`/admin/users/${username}`}>

--- a/ui/src/app/pages/admin/egress-events-table.tsx
+++ b/ui/src/app/pages/admin/egress-events-table.tsx
@@ -123,6 +123,7 @@ export const EgressEventsTable = ({sourceUserEmail, sourceWorkspaceNamespace, di
     <Column field='creationTime'
             header='Time'
             headerStyle={{width: '150px'}}
+            body={({creationTime}) => new Date(creationTime).toLocaleString()}
     />
     <Column field='sourceUserEmail'
             body={({sourceUserEmail}) => {


### PR DESCRIPTION
Bug on the backend due to timestamp conversion.

Egress table:
![image](https://user-images.githubusercontent.com/822298/146106053-8eb6458e-ff1a-457a-8e87-853c53d83870.png)

Egress audit page:
![image](https://user-images.githubusercontent.com/822298/146106025-a75cc4fc-35cb-44cc-ad85-4a7b371ff134.png)
