### PR TITLE
[RW-7571][risk=no] Disallow worker count updates while stopped

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -1201,4 +1201,25 @@ describe('RuntimePanel', () => {
     }
   });
 
+  fit('should disable worker count updates for stopped dataproc cluster', async() => {
+    const runtime = {
+      ...runtimeApiStub.runtime,
+      status: RuntimeStatus.Stopped,
+      configurationType: RuntimeConfigurationType.HailGenomicAnalysis,
+      gceConfig: null,
+      dataprocConfig: defaultDataprocConfig()
+    };
+    runtimeApiStub.runtime = runtime;
+    runtimeStoreStub.runtime = runtime;
+
+    const wrapper = await component();
+
+    const workerCountInput = wrapper.find('#num-workers').first();
+    expect(workerCountInput.prop('disabled')).toBeTruthy();
+    expect(workerCountInput.prop('tooltip')).toBeTruthy();
+
+    const preemptibleCountInput = wrapper.find('#num-preemptible').first();
+    expect(preemptibleCountInput.prop('disabled')).toBeTruthy();
+    expect(preemptibleCountInput.prop('tooltip')).toBeTruthy();
+  });
 });

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -1201,7 +1201,7 @@ describe('RuntimePanel', () => {
     }
   });
 
-  fit('should disable worker count updates for stopped dataproc cluster', async() => {
+  it('should disable worker count updates for stopped dataproc cluster', async() => {
     const runtime = {
       ...runtimeApiStub.runtime,
       status: RuntimeStatus.Stopped,


### PR DESCRIPTION
Dataproc worker count updates are only possible while the runtime is running.