### PR TITLE
[risk=low][no ticket] bump perf gatling so Snyk stops complaining

### DIFF
--- a/performance/build.gradle
+++ b/performance/build.gradle
@@ -9,12 +9,14 @@ repositories {
 apply plugin: 'com.github.lkishalmi.gatling'
 apply plugin: 'scala'
 
-// Latest Gatling scala defaults to '2.12.3'
+// [TODO outdated?] Latest Gatling scala defaults to '2.12.3'
 def projectScalaVersion = '2.12.3'
 
+def gatlingVersion = '3.3.0'
+
 dependencies {
-    compile group: 'io.gatling', name: 'gatling-core', version: '3.0.2'
-    compile group: 'io.gatling', name: 'gatling-http', version: '3.0.2'
+    compile group: 'io.gatling', name: 'gatling-core', version: gatlingVersion
+    compile group: 'io.gatling', name: 'gatling-http', version: gatlingVersion
     compile group: 'org.scala-lang', name: 'scala-library', version: projectScalaVersion
 }
 


### PR DESCRIPTION
Not sure if this will actually do anything (since I don't think we use it) but it should quiet a lot of noise here: https://app.snyk.io/org/all-of-us-researcher-workbench/project/31ce5c7a-17c1-49cd-a69b-cdc0a44a6772

Alt: remove this entirely.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
