### PR TITLE
[risk=no] Fix edge case on worker count update disable

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -1222,4 +1222,27 @@ describe('RuntimePanel', () => {
     expect(preemptibleCountInput.prop('disabled')).toBeTruthy();
     expect(preemptibleCountInput.prop('tooltip')).toBeTruthy();
   });
+
+  it('should allow worker configuration for stopped GCE runtime', async() => {
+    const runtime = {
+      ...runtimeApiStub.runtime,
+      status: RuntimeStatus.Stopped,
+      configurationType: RuntimeConfigurationType.GeneralAnalysis,
+      gceConfig: defaultGceConfig(),
+      dataprocConfig: null
+    };
+    runtimeApiStub.runtime = runtime;
+    runtimeStoreStub.runtime = runtime;
+
+    const wrapper = await component();
+    await pickComputeType(wrapper, ComputeType.Dataproc);
+
+    const workerCountInput = wrapper.find('#num-workers').first();
+    expect(workerCountInput.prop('disabled')).toBeFalsy();
+    expect(workerCountInput.prop('tooltip')).toBeFalsy();
+
+    const preemptibleCountInput = wrapper.find('#num-preemptible').first();
+    expect(preemptibleCountInput.prop('disabled')).toBeFalsy();
+    expect(preemptibleCountInput.prop('tooltip')).toBeFalsy();
+  });
 });

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -584,7 +584,7 @@ const PersistentDiskSizeSelector = ({onChange, disabled, selectedDiskSize, diskS
   </div>;
 };
 
-const DataProcConfigSelector = ({onChange, disabled, runtimeStatus, dataprocConfig})  => {
+const DataProcConfigSelector = ({onChange, disabled, runtimeStatus, dataprocExists, dataprocConfig})  => {
   const {
     workerMachineType = defaultMachineName,
     workerDiskSize = DATAPROC_WORKER_MIN_DISK_SIZE_GB,
@@ -619,7 +619,7 @@ const DataProcConfigSelector = ({onChange, disabled, runtimeStatus, dataprocConf
   // a running cluster but not on a stopped cluster. Rather than building a
   // one-off resume->update workflow into Workbench, just disable the control
   // and let the user resume themselves.
-  const workerCountDisabledByStopped = runtimeStatus === RuntimeStatus.Stopped;
+  const workerCountDisabledByStopped = dataprocExists && runtimeStatus === RuntimeStatus.Stopped;
   const workerCountTooltip = workerCountDisabledByStopped ?
       'Cannot update worker counts on a stopped Dataproc environment, please start your environment first.' : undefined;
 
@@ -1487,6 +1487,7 @@ const RuntimePanel = fp.flow(
                <DataProcConfigSelector
                    disabled={disableControls}
                    runtimeStatus={status}
+                   dataprocExists={runtimeCtx.dataprocExists}
                    onChange={config => setSelectedDataprocConfig(config)}
                    dataprocConfig={selectedDataprocConfig} />
              }


### PR DESCRIPTION
If the current runtime is GCE, we **do not** want to disable the worker controls, since this is not an update, but rather a full recreate.

Confirmed regression test fails at HEAD.