### PR TITLE
[risk=low][RW-5275] rm last instances of joda.time

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -10,7 +10,6 @@ buildscript {
         GAE_VERSION = '1.9.92'
         GSON_VERSION = '2.8.9'
         JACKSON_VERSION = '2.13.0'
-        JODA_VERSION = '2.10'
         KOTLIN_VERSION = '1.5.32'
         MAPSTRUCT_VERSION = '1.4.2.Final'
         MOCKITO_KOTLIN_VERSION = '2.2.0'
@@ -406,7 +405,6 @@ dependencies {
     compile "io.opencensus:opencensus-impl:$project.ext.OPENCENSUS_VERSION"
     compile "io.swagger:swagger-annotations:1.5.16"
     compile "javax.inject:javax.inject:1"
-    compile "joda-time:joda-time:$project.ext.JODA_VERSION"
     compile "org.liquibase:liquibase-core:3.10.3"
     compile "mysql:mysql-connector-java:8.0.27"
     compile "org.apache.commons:commons-collections4:4.4"
@@ -459,8 +457,6 @@ dependencies {
     generatedCompile "com.squareup.okhttp:okhttp:$project.ext.OKHTTP_VERSION"
     generatedCompile "com.squareup.okhttp:logging-interceptor:$project.ext.OKHTTP_VERSION"
     generatedCompile "com.google.code.gson:gson:$project.ext.GSON_VERSION"
-    generatedCompile "joda-time:joda-time:$project.ext.JODA_VERSION"
-    generatedCompile "com.fasterxml.jackson.datatype:jackson-datatype-joda:$project.ext.JACKSON_VERSION"
     // OpenCensus is an AoU-specific addition to the default Swagger API dependencies. See the
     // template file api.mustache for more details.
     generatedCompile "io.opencensus:opencensus-api:$project.ext.OPENCENSUS_VERSION"

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -8,12 +8,12 @@ import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTierFor
 
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.common.collect.ImmutableList;
+import java.time.LocalDate;
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.inject.Provider;
-import org.joda.time.DateTime;
-import org.joda.time.Period;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -2138,9 +2138,8 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   }
 
   private Period getTestPeriod() {
-    DateTime birthDate = new DateTime(1980, 8, 1, 0, 0, 0, 0);
-    DateTime now = new DateTime();
-    return new Period(birthDate, now);
+    LocalDate birthDate = LocalDate.of(1980, 8, 1);
+    return Period.between(birthDate, LocalDate.now());
   }
 
   private SearchRequest createSearchRequests(

--- a/api/src/main/java/org/pmiops/workbench/api/BigQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/api/BigQueryService.java
@@ -15,7 +15,7 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
@@ -148,7 +148,7 @@ public class BigQueryService {
       return null;
     }
     DateTimeFormatter df =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss zzz").withZone(ZoneOffset.UTC);
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss zzz").withZone(ZoneId.of("UTC"));
     return df.format(FieldValues.getInstant(row.get(index)));
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/BigQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/api/BigQueryService.java
@@ -15,6 +15,8 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -24,8 +26,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
 import javax.servlet.http.HttpServletResponse;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.pmiops.workbench.cdr.CdrVersionContext;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.dataset.BigQueryDataSetTableInfo;
@@ -147,8 +147,9 @@ public class BigQueryService {
     if (row.get(index).isNull()) {
       return null;
     }
-    DateTimeFormatter df = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss zzz").withZoneUTC();
-    return df.print(FieldValues.getInstant(row.get(index)).toEpochMilli());
+    DateTimeFormatter df =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss zzz").withZone(ZoneOffset.UTC);
+    return df.format(FieldValues.getInstant(row.get(index)));
   }
 
   public String getDate(List<FieldValue> row, int index) {

--- a/api/src/main/java/org/pmiops/workbench/api/DiskController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DiskController.java
@@ -1,11 +1,11 @@
 package org.pmiops.workbench.api;
 
+import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
-import org.joda.time.Instant;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
@@ -1,10 +1,10 @@
 package org.pmiops.workbench.api;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeComparator;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbWorkspace;
@@ -37,8 +37,10 @@ public class OfflineWorkspaceController implements OfflineWorkspaceApiDelegate {
           workspaceList.stream()
               .filter(
                   workspace -> {
-                    DateTime workspaceCreationDate = new DateTime(workspace.getCreationTime());
-                    DateTime workspaceModifiedDate = new DateTime(workspace.getLastModifiedTime());
+                    LocalDateTime workspaceCreationDate =
+                        workspace.getCreationTime().toLocalDateTime();
+                    LocalDateTime workspaceModifiedDate =
+                        workspace.getLastModifiedTime().toLocalDateTime();
                     return checkReviewDate(workspaceCreationDate, workspaceModifiedDate);
                   })
               .map(
@@ -52,9 +54,10 @@ public class OfflineWorkspaceController implements OfflineWorkspaceApiDelegate {
     return ResponseEntity.noContent().build();
   }
 
-  private boolean checkReviewDate(DateTime workspaceCreationDate, DateTime workspaceModifiedDate) {
-    DateTime creationDatePlus15 = workspaceCreationDate.plusDays(15);
-    DateTime creationDatePlus1Year = workspaceCreationDate.plusYears(1);
+  private boolean checkReviewDate(
+      LocalDateTime workspaceCreationDate, LocalDateTime workspaceModifiedDate) {
+    LocalDateTime creationDatePlus15 = workspaceCreationDate.plusDays(15);
+    LocalDateTime creationDatePlus1Year = workspaceCreationDate.plusYears(1);
 
     // True if
     // 1. Current date is creation Date + 1 year or
@@ -63,9 +66,9 @@ public class OfflineWorkspaceController implements OfflineWorkspaceApiDelegate {
     // picking the workspace) and the Workspace has
     // not been modified after 1 year of creation date.
     int compareCreationDatePlus1Year =
-        DateTimeComparator.getDateOnlyInstance().compare(creationDatePlus1Year, null);
+        creationDatePlus1Year.toLocalDate().compareTo(LocalDate.now());
     return compareCreationDatePlus1Year == 0
-        || DateTimeComparator.getDateOnlyInstance().compare(creationDatePlus15, null) == 0
+        || creationDatePlus15.toLocalDate().compareTo(LocalDate.now()) == 0
         || (compareCreationDatePlus1Year < 0
             && workspaceModifiedDate.isBefore(creationDatePlus1Year));
   }

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
@@ -13,7 +13,7 @@ import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -54,7 +54,7 @@ public class FieldSetQueryBuilder {
 
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat(DATE_FORMAT_PATTERN);
   private static final DateTimeFormatter DATE_TIME_FORMAT =
-      DateTimeFormatter.ofPattern(DATE_TIME_FORMAT_PATTERN).withZone(ZoneOffset.UTC);
+      DateTimeFormatter.ofPattern(DATE_TIME_FORMAT_PATTERN).withZone(ZoneId.of("UTC"));
 
   private final CohortQueryBuilder cohortQueryBuilder;
   private final BigQueryService bigQueryService;

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/FieldSetQueryBuilder.java
@@ -12,6 +12,9 @@ import com.google.common.collect.Iterables;
 import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -20,8 +23,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.cohortbuilder.QueryConfiguration.ColumnInfo;
 import org.pmiops.workbench.config.CdrBigQuerySchemaConfig;
@@ -53,7 +54,7 @@ public class FieldSetQueryBuilder {
 
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat(DATE_FORMAT_PATTERN);
   private static final DateTimeFormatter DATE_TIME_FORMAT =
-      DateTimeFormat.forPattern(DATE_TIME_FORMAT_PATTERN).withZoneUTC();
+      DateTimeFormatter.ofPattern(DATE_TIME_FORMAT_PATTERN).withZone(ZoneOffset.UTC);
 
   private final CohortQueryBuilder cohortQueryBuilder;
   private final BigQueryService bigQueryService;
@@ -317,7 +318,7 @@ public class FieldSetQueryBuilder {
         try {
           long timestamp =
               FieldValues.toTimestampMicroseconds(
-                  DATE_TIME_FORMAT.parseDateTime(columnFilter.getValueDate()));
+                  Instant.from(DATE_TIME_FORMAT.parse(columnFilter.getValueDate())));
           queryState.paramMap.put(paramName, QueryParameterValue.timestamp(timestamp));
         } catch (IllegalArgumentException e) {
           throw new BadRequestException(
@@ -752,7 +753,7 @@ public class FieldSetQueryBuilder {
             value = fieldValue.getStringValue();
             break;
           case TIMESTAMP:
-            value = DATE_TIME_FORMAT.print(FieldValues.getInstant(fieldValue).toEpochMilli());
+            value = DATE_TIME_FORMAT.format(FieldValues.getInstant(fieldValue));
             break;
           default:
             throw new IllegalStateException("Unrecognized column type: " + columnConfig.type);

--- a/api/src/main/java/org/pmiops/workbench/utils/FieldValues.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/FieldValues.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import org.joda.time.DateTime;
 
 /** Utility class for working with FieldValueLists, FieldValues, and Fields */
 public final class FieldValues {
@@ -127,10 +126,6 @@ public final class FieldValues {
 
   public static long toTimestampMicroseconds(Instant instant) {
     return millisecondsToMicros(instant.toEpochMilli());
-  }
-
-  public static long toTimestampMicroseconds(DateTime dateTime) {
-    return millisecondsToMicros(dateTime.getMillis());
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Joda-Time was the de-facto Java standard package for good date/time handling ... before Java 8.  The [Joda team now says](https://www.joda.org/joda-time/) to use the built-in java.time package.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
