### PR TITLE
[no ticket][risk=no] e2e test: Click Create a New Notebook button is not working

### DIFF
--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -184,7 +184,7 @@ export default class BaseElement {
       if (previousX === undefined || previousY === undefined) {
         throw new Error(`Failed to click element because the it is not visible. xpath: ${this.getXpath()}`);
       }
-      return element.click(options);
+      await element.click(options);
     });
   }
 

--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -182,7 +182,7 @@ export default class BaseElement {
       }
       // End the test if previousX or previousY is still undefined after waiting.
       if (previousX === undefined || previousY === undefined) {
-        throw new Error(`Failed to click element because the it is not visible. xpath: ${this.getXpath()}`);
+        throw new Error(`Failed to click element because it is not visible. xpath: ${this.getXpath()}`);
       }
       await element.click(options);
     });

--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -1,4 +1,12 @@
-import { BoxModel, ClickOptions, ElementHandle, NavigationOptions, Page, WaitForSelectorOptions } from 'puppeteer';
+import {
+  BoxModel,
+  ClickOptions,
+  ElementHandle,
+  JSHandle,
+  NavigationOptions,
+  Page,
+  WaitForSelectorOptions
+} from 'puppeteer';
 import { getAttrValue, getPropValue } from 'utils/element-utils';
 import { logger } from 'libs/logger';
 import { waitForFn } from 'utils/waits-utils';
@@ -115,8 +123,8 @@ export default class BaseElement {
    * </pre>
    */
   async isVisible(): Promise<boolean> {
-    const isDisplayed = async (element): Promise<boolean> => {
-      const elementHandle = await this.page
+    const isDisplayed = async (element: ElementHandle): Promise<boolean> => {
+      const jsHandle: JSHandle = await this.page
         .evaluateHandle((elem) => {
           const style = window.getComputedStyle(elem);
           return style && style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
@@ -124,51 +132,57 @@ export default class BaseElement {
         .catch(() => {
           return null;
         });
-      return (await elementHandle.jsonValue()) as boolean;
+      return (await jsHandle.jsonValue()) as boolean;
     };
 
-    const boxModel = async (element): Promise<BoxModel | null> => {
-      return element.boxModel();
+    const boxModel = async (element: ElementHandle): Promise<BoxModel | null> => {
+      const boxModel = await element.boxModel();
+      return boxModel;
     };
 
     return this.asElementHandle()
-      .then((element) => {
-        return isDisplayed(element) && !!boxModel(element);
+      .then(async (element) => {
+        return (await isDisplayed(element)) && (await boxModel(element)) !== null;
       })
       .catch(() => false);
   }
 
   async click(options?: ClickOptions): Promise<void> {
     await this.asElementHandle().then(async (element) => {
-      // Click workaround: Wait for x,y to stop changing within specified time
+      // Click workaround: Wait for (x,y) to stop changing within specified time
       const startTime = Date.now();
       let previousX: number;
       let previousY: number;
       while (Date.now() - startTime < 30 * 1000) {
-        const viewport = await element.isIntersectingViewport();
-        if (viewport) {
-          const boundingBox = await element.boundingBox();
-          const boxModel = await element.boxModel();
-          if (boundingBox && boxModel) {
-            const x = boundingBox.x + boundingBox.width / 2;
-            const y = boundingBox.y + boundingBox.height / 2;
-            if (previousX !== undefined && previousY !== undefined) {
-              if (
-                parseFloat(previousX.toFixed(7)) === parseFloat(x.toFixed(7)) &&
-                parseFloat(previousY.toFixed(7)) === parseFloat(y.toFixed(7))
-              ) {
-                break;
-              }
-            }
-            previousX = x;
-            previousY = y;
-          }
+        const visible = await this.isVisible();
+        if (!visible) {
+          // Scrolls element into viewport if needed.
+          await element.hover();
+          await element.focus();
+          await this.page.waitForTimeout(1000);
         }
-        await element.hover();
+        const boundingBox = await element.boundingBox();
+        const boxModel = await element.boxModel();
+        if (boundingBox !== null && boxModel !== null) {
+          const x = boundingBox.x + boundingBox.width / 2;
+          const y = boundingBox.y + boundingBox.height / 2;
+          if (previousX !== undefined && previousY !== undefined) {
+            if (
+              parseFloat(previousX.toFixed(7)) === parseFloat(x.toFixed(7)) &&
+              parseFloat(previousY.toFixed(7)) === parseFloat(y.toFixed(7))
+            ) {
+              break;
+            }
+          }
+          previousX = x;
+          previousY = y;
+        }
+        // Half second sleep before getting values of (x, y) again.
         await this.page.waitForTimeout(500);
       }
+      // End the test if previousX or previousY is still undefined after waiting.
       if (previousX === undefined || previousY === undefined) {
-        throw new Error(`Failed to click element because the it is not visible in the viewport. (${this.getXpath()})`);
+        throw new Error(`Failed to click element because the it is not visible. xpath: ${this.getXpath()}`);
       }
       return element.click(options);
     });
@@ -361,7 +375,7 @@ export default class BaseElement {
   async clickWithEval(): Promise<void> {
     const element = await this.asElementHandle();
     await element.focus();
-    await this.page.evaluate((elem) => elem.click(), element);
+    await this.page.evaluate((elem: ElementHandle) => elem.click(), element);
     await this.page.waitForTimeout(500);
   }
 
@@ -384,7 +398,7 @@ export default class BaseElement {
    * @param text
    */
   async paste(text: string): Promise<void> {
-    return this.asElementHandle().then((element) => {
+    return this.asElementHandle().then((element: ElementHandle) => {
       return this.page.evaluate(
         (elemt, textValue) => {
           // Refer to https://stackoverflow.com/a/46012210/440432

--- a/e2e/app/element/base-element.ts
+++ b/e2e/app/element/base-element.ts
@@ -139,7 +139,7 @@ export default class BaseElement {
   }
 
   async click(options?: ClickOptions): Promise<void> {
-    return this.asElementHandle().then(async (element) => {
+    await this.asElementHandle().then(async (element) => {
       // Click workaround: Wait for x,y to stop changing within specified time
       const startTime = Date.now();
       let previousX: number;
@@ -166,6 +166,9 @@ export default class BaseElement {
         }
         await element.hover();
         await this.page.waitForTimeout(500);
+      }
+      if (previousX === undefined || previousY === undefined) {
+        throw new Error(`Failed to click element because the it is not visible in the viewport. (${this.getXpath()})`);
       }
       return element.click(options);
     });

--- a/e2e/app/modal/new-notebook-modal.ts
+++ b/e2e/app/modal/new-notebook-modal.ts
@@ -17,6 +17,7 @@ export default class NewNotebookModal extends Modal {
 
   async isLoaded(): Promise<boolean> {
     await waitForText(this.page, modalTitle, { container: this });
+    await this.name().exists(30000);
     return true;
   }
 

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -37,20 +37,16 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
     const clickCreateButtonWithRetries = async (): Promise<void> => {
       const link = this.createNewNotebookLink();
       await link.click();
-      let succeeded = false;
       try {
         await modal.waitForLoad();
-        succeeded = true;
+        return;
       } catch (err) {
-        if (maxRetries === 0) {
-          throw new Error(err);
+        if (maxRetries < 1) {
+          throw new Error(`Click link "Create a New Notebook" failed after trying ${maxRetries} times.\n${err}`);
         }
       }
-      if (succeeded) {
-        return;
-      }
       if (maxRetries < 1) {
-        throw new Error(`Click link "Create a New Notebook" failed after trying ${maxRetries} times.`);
+        throw new Error('Investigate why waitForLoad() did not throw error. It should not happen.');
       }
       maxRetries--;
       await this.page.waitForTimeout(2000).then(() => clickCreateButtonWithRetries());

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -19,6 +19,12 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
 
   async isLoaded(): Promise<boolean> {
     await Promise.all([waitForDocumentTitle(this.page, PageTitle), this.createNewNotebookLink().waitUntilEnabled()]);
+    await this.page.waitForResponse(
+      (response) => {
+        return response.url().endsWith('/notebook-list') && response.request().method() === 'GET';
+      },
+      { timeout: 60000 }
+    );
     await waitWhileLoading(this.page);
     return true;
   }


### PR DESCRIPTION
This is a test code workaround to deal with puppeteer flaky `.click` function. I don't know why it doesn't work sometimes.

Example of failed CircleCI [job](https://app.circleci.com/pipelines/github/all-of-us/workbench/16886/workflows/e386dbd4-969b-45c0-9fab-3c7401546553/jobs/188705/tests).

```
failure: [
  'TimeoutError: waiting for XPath `//*[@id="popup-root"]//*[@role="dialog" and contains(@class, "after-open")]` failed: timeout 30000ms exceeded\n' +
    '    at new WaitTask (/home/circleci/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:505:34)\n' +
    '    at DOMWorld.waitForXPath (/home/circleci/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:441:26)\n' +
    '    at Frame.waitForXPath (/home/circleci/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/FrameManager.js:866:51)\n' +
    '    at Page.waitForXPath (/home/circleci/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:1288:33)\n' +
    '    at NewNotebookModal.waitUntilVisible (/home/circleci/workbench/e2e/app/container.ts:34:21)\n' +
    '    at NewNotebookModal.waitForLoad (/home/circleci/workbench/e2e/app/modal/base-modal.ts:27:16)\n' +
    '    at WorkspaceAnalysisPage.createNotebook (/home/circleci/workbench/e2e/app/page/workspace-analysis-page.ts:38:17)\n' +
    '    at Object.<anonymous> (/home/circleci/workbench/e2e/tests/notebook/notebook-create-python.spec.ts:52:22)'
]
```