### PR TITLE
[risk=no][no ticket] Guard against empty e2e user access tokens

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2708,7 +2708,7 @@ def list_runtimes(cmd_name, *args)
       "--format [format]",
       ->(opts, v) { opts.format = v },
       "JSON or TABULAR, defaults to TABULAR (summary)")
-  op.opts.runime_project = ""
+  op.opts.runtime_project = ""
   op.opts.include_deleted = false
   op.opts.format = "TABULAR"
 

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2107,6 +2107,9 @@ def can_skip_token_generation(token_filenames)
 
     age_minutes = (Time.now - File.ctime(f)) / 60
     return false unless age_minutes < staleness_limit_minutes
+
+    contents = File.readlines(f)
+    return false if contents.nil? || contents.empty?
   end
 
   return true

--- a/e2e/utils/str-utils.ts
+++ b/e2e/utils/str-utils.ts
@@ -76,7 +76,7 @@ export function numericalStringToNumber(value: string): number {
   return Number(value.replace(/,/g, ''));
 }
 
-export function isBlank(toTest: String): boolean {
+export function isBlank(toTest: string): boolean {
   if (toTest === null || toTest === undefined) {
     return true;
   } else {

--- a/e2e/utils/str-utils.ts
+++ b/e2e/utils/str-utils.ts
@@ -75,3 +75,12 @@ export function extractNamespace(url: URL): string {
 export function numericalStringToNumber(value: string): number {
   return Number(value.replace(/,/g, ''));
 }
+
+export function isBlank(toTest: String): boolean {
+  if (toTest === null || toTest === undefined) {
+    return true;
+  } else {
+    toTest = toTest.trim();
+    return toTest === '';
+  }
+}

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -11,7 +11,7 @@ import WorkspaceCard from 'app/component/workspace-card';
 import { PageUrl, WorkspaceAccessLevel } from 'app/text-labels';
 import WorkspacesPage from 'app/page/workspaces-page';
 import Navigation, { NavLink } from 'app/component/navigation';
-import {isBlank, makeWorkspaceName} from './str-utils';
+import { isBlank, makeWorkspaceName } from './str-utils';
 import { config } from 'resources/workbench-config';
 import { logger } from 'libs/logger';
 import { authenticator } from 'otplib';

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -42,7 +42,7 @@ export async function signInWithAccessToken(
   // Keep file naming convention synchronized with generate-impersonated-user-tokens
   const token = fs.readFileSync(tokenLocation, 'ascii');
   if (isBlank(token)) {
-    throw Error(`no token found at ${tokenLocation}`);
+    throw Error(`Token found at ${tokenLocation} is blank`);
   }
   logger.info('Sign in with access token to Workbench application');
   const homePage = new HomePage(page);

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -11,7 +11,7 @@ import WorkspaceCard from 'app/component/workspace-card';
 import { PageUrl, WorkspaceAccessLevel } from 'app/text-labels';
 import WorkspacesPage from 'app/page/workspaces-page';
 import Navigation, { NavLink } from 'app/component/navigation';
-import { makeWorkspaceName } from './str-utils';
+import {isBlank, makeWorkspaceName} from './str-utils';
 import { config } from 'resources/workbench-config';
 import { logger } from 'libs/logger';
 import { authenticator } from 'otplib';
@@ -38,8 +38,12 @@ export async function signInWithAccessToken(
   userEmail = config.USER_NAME,
   postSignInPage: AuthenticatedPage = new HomePage(page)
 ): Promise<void> {
+  const tokenLocation = `signin-tokens/${userEmail}.txt`;
   // Keep file naming convention synchronized with generate-impersonated-user-tokens
-  const token = fs.readFileSync(`signin-tokens/${userEmail}.txt`, 'ascii');
+  const token = fs.readFileSync(tokenLocation, 'ascii');
+  if (isBlank(token)) {
+    throw Error(`no token found at ${tokenLocation}`);
+  }
   logger.info('Sign in with access token to Workbench application');
   const homePage = new HomePage(page);
   await homePage.gotoUrl(PageUrl.Home);


### PR DESCRIPTION
Testing a hypothesis for today's nightly test failures

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
