### PR TITLE
[no ticket][risk=no] circleci restore-cache fallback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,11 +552,14 @@ jobs:
           key: v6-gradle-wrapper-{{ .Branch }}-{{ checksum "~/workbench/api/gradle/wrapper/gradle-wrapper.properties" }}
       - restore_cache:
           name: "Restore api gradle cache"
-          key: v6-gradle-cache-{{ .Branch }}-{{ checksum "~/workbench/api/build.gradle" }}
+          keys:
+            - v6-gradle-cache-{{ .Branch }}-{{ checksum "~/workbench/api/build.gradle" }}
+            - v6-gradle-cache-
       - restore_cache:
           name: "Restore e2e yarn cache"
           keys:
             - v5-e2e-yarn-{{ .Branch }}-{{ arch }}-{{ checksum "~/workbench/e2e/yarn.lock" }}
+            - v5-e2e-yarn-
       - run:
           name: "Set environment variables for e2e test users"
           working_directory: ~/workbench/e2e


### PR DESCRIPTION
Fix an error thrown by the CircleCI `puppeteer-generate-access-tokens` job. 
The error is caused by a race condition: When `puppeteer-generate-access-tokens` job ran before `puppeteer-env-setup` can finish. `yarn install` is called in `puppeteer-env-setup` job only. The error only happens when CircleCI is running a new PR for the first time.

```
#!/bin/bash -eo pipefail
yarn _impersonate-test-users
yarn run v1.22.5
$ yarn _create-signin-token-dir && env-cmd -x ../api/project.rb generate-impersonated-user-tokens --impersonated-usernames \$USER_NAME,\$READER_USER,\$WRITER_USER,\$COLLABORATOR_USER,\$ACCESS_TEST_USER,\$ADMIN_TEST_USER,\$EGRESS_TEST_USER --output-token-dir ../e2e/signin-tokens
$ mkdir -p ../e2e/signin-tokens
/bin/sh: 1: env-cmd: not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

Exited with code exit status 127
```
