### PR TITLE
[RW-7652][risk=no] Add logs to egress test case

### DIFF
--- a/e2e/tests/nightly/egress-suspension.spec.ts
+++ b/e2e/tests/nightly/egress-suspension.spec.ts
@@ -22,12 +22,13 @@ describe('egress suspension', () => {
     const dataPage = new WorkspaceDataPage(page);
     const notebookPage = await dataPage.createNotebook(notebookName);
 
+    console.log('Generating egress via notebook');
     await notebookPage.uploadFile(egressFilename, egressFilePath);
     await notebookPage.runCodeFile(1, egressFilename, 5 * 60 * 1000);
 
     await notebookPage.save();
 
-    // Wait until we become suspended.
+    console.log('Awaiting security suspension');
     await notebookPage.waitForSecuritySuspendedStatus(true);
   });
 });


### PR DESCRIPTION
I can't determine the source of the timeout, due to poor puppeteer logs. Add some additional logging to the test case; though I'll also investigate a more general solution.