### PR TITLE
[risk=low][RW-4838] rm DbUser.dataUseAgreementSignedVersion and rename more DUA to DUCC

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
@@ -41,4 +41,6 @@ public interface AccessModuleService {
   boolean isModuleBypassed(DbUser dbUser, AccessModuleName accessModuleName);
 
   int getCurrentDuccVersion();
+
+  boolean hasUserSignedTheCurrentDucc(DbUser targetUser);
 }

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
@@ -27,17 +27,16 @@ public interface AccessModuleService {
    *
    * @return
    */
-  Optional<AccessModuleStatus> getAccessModuleStatus(
-      DbUser user, AccessModuleName accessModuleName);
+  Optional<AccessModuleStatus> getAccessModuleStatus(DbUser user, AccessModuleName accessModuleName);
 
   /**
-   * Returns true is the access module compliant.
+   * Returns true if the access module is compliant.
    *
    * <p>The module can be bypassed OR (completed but not expired).
    */
   boolean isModuleCompliant(DbUser dbUser, AccessModuleName accessModuleName);
 
-  /** Returns true is the access module is bypassable and bypassed */
+  /** Returns true if the access module is bypassable and bypassed */
   boolean isModuleBypassed(DbUser dbUser, AccessModuleName accessModuleName);
 
   int getCurrentDuccVersion();

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
@@ -27,7 +27,8 @@ public interface AccessModuleService {
    *
    * @return
    */
-  Optional<AccessModuleStatus> getAccessModuleStatus(DbUser user, AccessModuleName accessModuleName);
+  Optional<AccessModuleStatus> getAccessModuleStatus(
+      DbUser user, AccessModuleName accessModuleName);
 
   /**
    * Returns true if the access module is compliant.

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
@@ -155,8 +155,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
     // we have an additional check before considering DUCC "complete"
     if (isCompleted && accessModuleName == AccessModuleName.DATA_USER_CODE_OF_CONDUCT) {
       // protect against NPE when unboxing for comparison
-      final int signedVersion =
-          Optional.ofNullable(dbUser.getDuccSignedVersion()).orElse(-1);
+      final int signedVersion = Optional.ofNullable(dbUser.getDuccSignedVersion()).orElse(-1);
       isCompleted = (getCurrentDuccVersion() == signedVersion);
     }
 

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
@@ -143,15 +143,12 @@ public class AccessModuleServiceImpl implements AccessModuleService {
 
   @Override
   public boolean hasUserSignedTheCurrentDucc(DbUser targetUser) {
-    // TODO simplify
+    final DbUserCodeOfConductAgreement duccAgreement = targetUser.getDuccAgreement();
+    if (duccAgreement == null) {
+      return false;
+    }
 
-    final int signedVersionForComparison =
-        Optional.ofNullable(targetUser.getDuccAgreement())
-            .map(DbUserCodeOfConductAgreement::getSignedVersion)
-            // if missing, convert to a known-invalid int
-            .orElse(getCurrentDuccVersion() - 1);
-
-    return signedVersionForComparison == getCurrentDuccVersion();
+    return duccAgreement.getSignedVersion() == getCurrentDuccVersion();
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
@@ -156,7 +156,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
     if (isCompleted && accessModuleName == AccessModuleName.DATA_USER_CODE_OF_CONDUCT) {
       // protect against NPE when unboxing for comparison
       final int signedVersion =
-          Optional.ofNullable(dbUser.getDataUseAgreementSignedVersion()).orElse(-1);
+          Optional.ofNullable(dbUser.getDuccSignedVersion()).orElse(-1);
       isCompleted = (getCurrentDuccVersion() == signedVersion);
     }
 

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
@@ -120,8 +120,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
   }
 
   @Override
-  public Optional<AccessModuleStatus> getAccessModuleStatus(
-      DbUser user, AccessModuleName accessModuleName) {
+  public Optional<AccessModuleStatus> getAccessModuleStatus(DbUser user, AccessModuleName accessModuleName) {
     DbAccessModule dbAccessModule =
         getDbAccessModuleOrThrow(dbAccessModulesProvider.get(), accessModuleName);
     DbUserAccessModule userAccessModule = retrieveUserAccessModuleOrCreate(user, dbAccessModule);
@@ -151,7 +150,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
             // if missing, convert to a known-invalid int
             .orElse(getCurrentDuccVersion() - 1);
 
-    return signedVersionForComparison != getCurrentDuccVersion();
+    return signedVersionForComparison == getCurrentDuccVersion();
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
@@ -120,7 +120,8 @@ public class AccessModuleServiceImpl implements AccessModuleService {
   }
 
   @Override
-  public Optional<AccessModuleStatus> getAccessModuleStatus(DbUser user, AccessModuleName accessModuleName) {
+  public Optional<AccessModuleStatus> getAccessModuleStatus(
+      DbUser user, AccessModuleName accessModuleName) {
     DbAccessModule dbAccessModule =
         getDbAccessModuleOrThrow(dbAccessModulesProvider.get(), accessModuleName);
     DbUserAccessModule userAccessModule = retrieveUserAccessModuleOrCreate(user, dbAccessModule);

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskUserController.java
@@ -117,8 +117,7 @@ public class CloudTaskUserController implements CloudTaskUserApiDelegate {
       DbUser user = userDao.findUserByUserId(userId);
 
       try {
-        user =
-            userService.syncDuccVersionStatus(user, Agent.asSystem(), user.getDuccSignedVersion());
+        user = userService.syncDuccVersionStatus(user, Agent.asSystem());
 
         // 2FA synchronization requires an outgoing call to gsuite. For this reason, we
         // optimize to only verify that users who have 2FA enabled, still have it enabled.

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskUserController.java
@@ -118,8 +118,7 @@ public class CloudTaskUserController implements CloudTaskUserApiDelegate {
 
       try {
         user =
-            userService.syncDuccVersionStatus(
-                user, Agent.asSystem(), user.getDuccSignedVersion());
+            userService.syncDuccVersionStatus(user, Agent.asSystem(), user.getDuccSignedVersion());
 
         // 2FA synchronization requires an outgoing call to gsuite. For this reason, we
         // optimize to only verify that users who have 2FA enabled, still have it enabled.

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskUserController.java
@@ -119,7 +119,7 @@ public class CloudTaskUserController implements CloudTaskUserApiDelegate {
       try {
         user =
             userService.syncDuccVersionStatus(
-                user, Agent.asSystem(), user.getDataUseAgreementSignedVersion());
+                user, Agent.asSystem(), user.getDuccSignedVersion());
 
         // 2FA synchronization requires an outgoing call to gsuite. For this reason, we
         // optimize to only verify that users who have 2FA enabled, still have it enabled.

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserCodeOfConductAgreementDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserCodeOfConductAgreementDao.java
@@ -1,10 +1,11 @@
 package org.pmiops.workbench.db.dao;
 
 import java.util.List;
+import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.springframework.data.repository.CrudRepository;
 
 public interface UserCodeOfConductAgreementDao
     extends CrudRepository<DbUserCodeOfConductAgreement, Long> {
-  List<DbUserCodeOfConductAgreement> findByUserIdOrderByCompletionTimeDesc(long userId);
+  List<DbUserCodeOfConductAgreement> findByUserOrderByCompletionTimeDesc(DbUser user);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -4,7 +4,6 @@ import com.google.api.services.oauth2.model.Userinfoplus;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
@@ -117,7 +116,7 @@ public interface UserService {
    */
   DbUser syncTwoFactorAuthStatus(DbUser targetUser, Agent agent, boolean isEnrolledIn2FA);
 
-  DbUser syncDuccVersionStatus(DbUser targetUser, Agent agent, @Nullable Integer signedDuccVersion);
+  DbUser syncDuccVersionStatus(DbUser targetUser, Agent agent);
 
   Optional<DbUser> getByUsername(String username);
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -444,7 +444,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     return updateUserWithRetries(
         (user) -> {
           // TODO: Teardown/reconcile duplicated state between the user profile and DUA.
-          user.setDataUseAgreementSignedVersion(duccSignedVersion);
+          user.setDuccSignedVersion(duccSignedVersion);
           accessModuleService.updateCompletionTime(
               user, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, timestamp);
           return user;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -438,12 +438,12 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     // RW-4838: dual-write the legacy DUA table and the new DUCC table for rollback safety
     // then delete the legacy DUA table after a release
     saveLegacyDUA(dbUser, duccSignedVersion, initials, timestamp);
-    saveDuccAgreement(dbUser, duccSignedVersion, initials, timestamp);
 
     return updateUserWithRetries(
         (user) -> {
           accessModuleService.updateCompletionTime(
               user, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, timestamp);
+          user.setDuccAgreement(createDuccAgreement(user, duccSignedVersion, initials, timestamp));
           return user;
         },
         dbUser,
@@ -463,7 +463,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     userDataUseAgreementDao.save(dataUseAgreement);
   }
 
-  private void saveDuccAgreement(
+  private DbUserCodeOfConductAgreement createDuccAgreement(
       DbUser dbUser, Integer duccSignedVersion, String initials, Timestamp timestamp) {
     DbUserCodeOfConductAgreement ducc = new DbUserCodeOfConductAgreement();
     ducc.setUser(dbUser);
@@ -472,7 +472,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     ducc.setUserGivenName(dbUser.getGivenName());
     ducc.setUserInitials(initials);
     ducc.setCompletionTime(timestamp);
-    userCodeOfConductAgreementDao.save(ducc);
+    return ducc;
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -443,7 +443,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
 
     return updateUserWithRetries(
         (user) -> {
-          // TODO: Teardown/reconcile duplicated state between the user profile and DUA.
+          // TODO: Teardown/reconcile duplicated state between the user profile and DUCC.
           user.setDuccSignedVersion(duccSignedVersion);
           accessModuleService.updateCompletionTime(
               user, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, timestamp);

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -190,7 +190,7 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "  u.creation_time,\n"
                 + "  uamd.data_use_agreement_bypass_time,\n"
                 + "  uamd.data_use_agreement_completion_time,\n"
-                + "  u.data_use_agreement_signed_version,\n"
+                + "  ducc.signed_version AS ducc_signed_version,\n"
                 + "  u.demographic_survey_completion_time,\n"
                 + "  u.disabled,\n"
                 + "  uame.era_commons_bypass_time,\n"
@@ -229,6 +229,7 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "FROM user u"
                 + "  LEFT OUTER JOIN address AS a ON u.user_id = a.user_id\n"
                 + "  LEFT OUTER JOIN user_verified_institutional_affiliation AS via on u.user_id = via.user_id\n"
+                + "  LEFT OUTER JOIN user_code_of_conduct_agreement AS ducc on u.user_id = ducc.user_id\n"
                 + "  LEFT OUTER JOIN "
                 + "  ( "
                 + "       SELECT \n"
@@ -319,7 +320,7 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                     offsetDateTimeUtc(rs.getTimestamp("data_use_agreement_bypass_time")))
                 .dataUseAgreementCompletionTime(
                     offsetDateTimeUtc(rs.getTimestamp("data_use_agreement_completion_time")))
-                .dataUseAgreementSignedVersion(rs.getInt("data_use_agreement_signed_version"))
+                .dataUseAgreementSignedVersion(rs.getInt("ducc_signed_version"))
                 .demographicSurveyCompletionTime(
                     offsetDateTimeUtc(rs.getTimestamp("demographic_survey_completion_time")))
                 .disabled(rs.getBoolean("disabled"))

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -77,7 +77,7 @@ public class DbUser {
   private String eraCommonsLinkedNihUsername;
   private Timestamp eraCommonsLinkExpireTime;
   private String rasLinkLoginGovUsername;
-  private Integer duccSignedVersion;
+  private DbUserCodeOfConductAgreement duccAgreement;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -297,13 +297,17 @@ public class DbUser {
     this.rasLinkLoginGovUsername = rasLinkLoginGovUsername;
   }
 
-  @Column(name = "data_use_agreement_signed_version")
-  public Integer getDuccSignedVersion() {
-    return duccSignedVersion;
+  @OneToOne(
+      cascade = CascadeType.ALL,
+      orphanRemoval = true,
+      fetch = FetchType.LAZY,
+      mappedBy = "user")
+  public DbUserCodeOfConductAgreement getDuccAgreement() {
+    return duccAgreement;
   }
 
-  public void setDuccSignedVersion(Integer duccSignedVersion) {
-    this.duccSignedVersion = duccSignedVersion;
+  public void setDuccAgreement(DbUserCodeOfConductAgreement duccAgreement) {
+    this.duccAgreement = duccAgreement;
   }
 
   @OneToOne(

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -77,8 +77,7 @@ public class DbUser {
   private String eraCommonsLinkedNihUsername;
   private Timestamp eraCommonsLinkExpireTime;
   private String rasLinkLoginGovUsername;
-  private Integer dataUseAgreementSignedVersion;
-  private Timestamp complianceTrainingExpirationTime;
+  private Integer duccSignedVersion;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -299,12 +298,12 @@ public class DbUser {
   }
 
   @Column(name = "data_use_agreement_signed_version")
-  public Integer getDataUseAgreementSignedVersion() {
-    return dataUseAgreementSignedVersion;
+  public Integer getDuccSignedVersion() {
+    return duccSignedVersion;
   }
 
-  public void setDataUseAgreementSignedVersion(Integer dataUseAgreementSignedVersion) {
-    this.dataUseAgreementSignedVersion = dataUseAgreementSignedVersion;
+  public void setDuccSignedVersion(Integer duccSignedVersion) {
+    this.duccSignedVersion = duccSignedVersion;
   }
 
   @OneToOne(

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserCodeOfConductAgreement.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserCodeOfConductAgreement.java
@@ -7,13 +7,15 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 @Entity
 @Table(name = "user_code_of_conduct_agreement")
 public class DbUserCodeOfConductAgreement {
   private long userDuccAgreementId;
-  private long userId;
+  private DbUser user;
   private String userGivenName;
   private String userFamilyName;
   private String userInitials;
@@ -32,13 +34,14 @@ public class DbUserCodeOfConductAgreement {
     this.userDuccAgreementId = userDuccAgreementId;
   }
 
-  @Column(name = "user_id")
-  public long getUserId() {
-    return userId;
+  @OneToOne
+  @JoinColumn(name = "user_id")
+  public DbUser getUser() {
+    return user;
   }
 
-  public void setUserId(long userId) {
-    this.userId = userId;
+  public void setUser(DbUser dbUser) {
+    this.user = dbUser;
   }
 
   @Column(name = "user_given_name")
@@ -107,7 +110,7 @@ public class DbUserCodeOfConductAgreement {
     }
     DbUserCodeOfConductAgreement that = (DbUserCodeOfConductAgreement) o;
     return userDuccAgreementId == that.userDuccAgreementId
-        && userId == that.userId
+        && user.equals(that.user)
         && userNameOutOfDate == that.userNameOutOfDate
         && signedVersion == that.signedVersion
         && userGivenName.equals(that.userGivenName)
@@ -120,7 +123,7 @@ public class DbUserCodeOfConductAgreement {
   public int hashCode() {
     return Objects.hash(
         userDuccAgreementId,
-        userId,
+        user,
         userGivenName,
         userFamilyName,
         userInitials,

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
@@ -35,6 +35,7 @@ public interface ProfileMapper {
   @Mapping(source = "latestTermsOfService.tosVersion", target = "latestTermsOfServiceVersion")
   @Mapping(source = "latestTermsOfService.agreementTime", target = "latestTermsOfServiceTime")
   @Mapping(source = "dbUser.userId", target = "userId")
+  @Mapping(source = "dbUser.duccAgreement.signedVersion", target = "duccSignedVersion")
   Profile toModel(
       DbUser dbUser,
       VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation,

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5717,10 +5717,10 @@ definitions:
         description: The FireCloud-calculated expiration time
         format: int64
         default: 0
-      dataUseAgreementSignedVersion:
+      duccSignedVersion:
         type: integer
         format: int32
-        description: Version of the data use agreement that the user last signed.
+        description: Version of the data user code of conduct agreement that the user last signed.
       address:
         "$ref": "#/definitions/Address"
       freeTierUsage:

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
@@ -76,7 +76,9 @@ public class AccessModuleServiceTest {
   public void setup() {
     user = new DbUser();
     user.setUsername("user");
-    user.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
+    user.setDuccAgreement(
+        TestMockFactory.createDuccAgreement(
+            user, accessModuleService.getCurrentDuccVersion(), FakeClockConfiguration.NOW));
     user = userDao.save(user);
 
     config = WorkbenchConfig.createEmptyConfig();
@@ -399,9 +401,6 @@ public class AccessModuleServiceTest {
     Instant now = Instant.ofEpochMilli(FakeClockConfiguration.NOW_TIME);
     long expiryDays = 365L;
     config.accessRenewal.expiryDays = expiryDays;
-
-    user.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
-    user = userDao.save(user);
 
     DbAccessModule duccModule =
         accessModuleDao.findOneByName(AccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
@@ -76,7 +76,7 @@ public class AccessModuleServiceTest {
   public void setup() {
     user = new DbUser();
     user.setUsername("user");
-    user.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion());
+    user.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
     user = userDao.save(user);
 
     config = WorkbenchConfig.createEmptyConfig();
@@ -400,7 +400,7 @@ public class AccessModuleServiceTest {
     long expiryDays = 365L;
     config.accessRenewal.expiryDays = expiryDays;
 
-    user.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion());
+    user.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
     user = userDao.save(user);
 
     DbAccessModule duccModule =

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -231,7 +231,7 @@ public class UserServiceAccessTest {
 
     // add a proper DUA completion which will expire soon, but remove DUA bypass
 
-    dbUser.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpireAfter(Duration.ofDays(1)));
     dbUser = updateUserWithRetries(this::removeDuaBypass);
@@ -357,7 +357,7 @@ public class UserServiceAccessTest {
               dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
           accessModuleService.updateCompletionTime(
               dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, Timestamp.from(START_INSTANT));
-          user.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion() - 1);
+          user.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion() - 1);
           return userDao.save(user);
         });
   }
@@ -372,7 +372,7 @@ public class UserServiceAccessTest {
           accessModuleService.updateCompletionTime(
               dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpire);
 
-          user.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion());
+          user.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
           advanceClockDays(EXPIRATION_DAYS + 1);
 
@@ -441,7 +441,7 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, now);
 
     // a completion requirement for DUCC (formerly "DUA" - TODO rename)
-    dbUser.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -479,7 +479,7 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
     // a completion requirement for DUCC (formerly "DUA" - TODO rename)
-    dbUser.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // expiring in 1 day (plus some) will trigger the 1-day warning
 
@@ -590,7 +590,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC (formerly "DUA" - TODO rename)
-    dbUser.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // expiring in .5 days will not trigger an email
 
@@ -614,7 +614,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC (formerly "DUA" - TODO rename)
-    dbUser.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // expiring in 30 days (plus) will trigger the 30-day warning
 
@@ -639,7 +639,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC (formerly "DUA" - TODO rename)
-    dbUser.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // expiring in 31 days (plus) will not trigger a warning
     accessModuleService.updateCompletionTime(
@@ -661,7 +661,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
 
     // a completion requirement for DUCC (formerly "DUA" - TODO rename)
-    dbUser.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // expiring in 30 days (plus) would trigger the 30-day warning...
     final Duration thirtyPlus = daysPlusSome(30);
@@ -694,7 +694,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
 
     // a completion requirement for DUCC (formerly "DUA" - TODO rename)
-    dbUser.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // expiring in 15 days (plus) would trigger the 15-day warning...
     accessModuleService.updateCompletionTime(
@@ -720,7 +720,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC (formerly "DUA" - TODO rename)
-    dbUser.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // but this is expired
     final Duration oneHour = Duration.ofHours(1);
@@ -747,7 +747,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC (formerly "DUA" - TODO rename)
-    dbUser.setDataUseAgreementSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // but this expired yesterday
 
@@ -1271,7 +1271,7 @@ public class UserServiceAccessTest {
     //        && complianceTrainingCompliant
     //        && eraCommonsCompliant
     //        && twoFactorAuthComplete
-    //        && dataUseAgreementCompliant
+    //        && duccCompliant
     //        && isPublicationsCompliant
     //        && isProfileCompliant
     //        && institutionEmailValid

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -38,6 +38,7 @@ import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserAccessTier;
+import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.DirectoryService;
@@ -231,11 +232,7 @@ public class UserServiceAccessTest {
 
     // add a proper DUCC completion which will expire soon, but remove DUCC bypass
 
-    dbUser.setDuccAgreement(
-        TestMockFactory.createDuccAgreement(
-            dbUser,
-            accessModuleService.getCurrentDuccVersion(),
-            new Timestamp(PROVIDED_CLOCK.millis())));
+    dbUser.setDuccAgreement(signCurrentDucc(dbUser));
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpireAfter(Duration.ofDays(1)));
     dbUser = updateUserWithRetries(this::removeDuccBypass);
@@ -361,11 +358,7 @@ public class UserServiceAccessTest {
               dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
           accessModuleService.updateCompletionTime(
               dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, Timestamp.from(START_INSTANT));
-          user.setDuccAgreement(
-              TestMockFactory.createDuccAgreement(
-                  user,
-                  accessModuleService.getCurrentDuccVersion() - 1,
-                  new Timestamp(PROVIDED_CLOCK.millis())));
+          user.setDuccAgreement(signDucc(user, accessModuleService.getCurrentDuccVersion() - 1));
           return userDao.save(user);
         });
   }
@@ -380,11 +373,7 @@ public class UserServiceAccessTest {
           accessModuleService.updateCompletionTime(
               dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpire);
 
-          user.setDuccAgreement(
-              TestMockFactory.createDuccAgreement(
-                  user,
-                  accessModuleService.getCurrentDuccVersion(),
-                  new Timestamp(PROVIDED_CLOCK.millis())));
+          user.setDuccAgreement(signCurrentDucc(user));
 
           advanceClockDays(EXPIRATION_DAYS + 1);
 
@@ -453,11 +442,7 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccAgreement(
-        TestMockFactory.createDuccAgreement(
-            dbUser,
-            accessModuleService.getCurrentDuccVersion(),
-            new Timestamp(PROVIDED_CLOCK.millis())));
+    dbUser.setDuccAgreement(signCurrentDucc(dbUser));
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -495,11 +480,7 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
     // a completion requirement for DUCC
-    dbUser.setDuccAgreement(
-        TestMockFactory.createDuccAgreement(
-            dbUser,
-            accessModuleService.getCurrentDuccVersion(),
-            new Timestamp(PROVIDED_CLOCK.millis())));
+    dbUser.setDuccAgreement(signCurrentDucc(dbUser));
 
     // expiring in 1 day (plus some) will trigger the 1-day warning
 
@@ -610,11 +591,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccAgreement(
-        TestMockFactory.createDuccAgreement(
-            dbUser,
-            accessModuleService.getCurrentDuccVersion(),
-            new Timestamp(PROVIDED_CLOCK.millis())));
+    dbUser.setDuccAgreement(signCurrentDucc(dbUser));
 
     // expiring in .5 days will not trigger an email
 
@@ -638,11 +615,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccAgreement(
-        TestMockFactory.createDuccAgreement(
-            dbUser,
-            accessModuleService.getCurrentDuccVersion(),
-            new Timestamp(PROVIDED_CLOCK.millis())));
+    dbUser.setDuccAgreement(signCurrentDucc(dbUser));
 
     // expiring in 30 days (plus) will trigger the 30-day warning
 
@@ -667,11 +640,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccAgreement(
-        TestMockFactory.createDuccAgreement(
-            dbUser,
-            accessModuleService.getCurrentDuccVersion(),
-            new Timestamp(PROVIDED_CLOCK.millis())));
+    dbUser.setDuccAgreement(signCurrentDucc(dbUser));
 
     // expiring in 31 days (plus) will not trigger a warning
     accessModuleService.updateCompletionTime(
@@ -693,11 +662,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccAgreement(
-        TestMockFactory.createDuccAgreement(
-            dbUser,
-            accessModuleService.getCurrentDuccVersion(),
-            new Timestamp(PROVIDED_CLOCK.millis())));
+    dbUser.setDuccAgreement(signCurrentDucc(dbUser));
 
     // expiring in 30 days (plus) would trigger the 30-day warning...
     final Duration thirtyPlus = daysPlusSome(30);
@@ -730,11 +695,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccAgreement(
-        TestMockFactory.createDuccAgreement(
-            dbUser,
-            accessModuleService.getCurrentDuccVersion(),
-            new Timestamp(PROVIDED_CLOCK.millis())));
+    dbUser.setDuccAgreement(signCurrentDucc(dbUser));
 
     // expiring in 15 days (plus) would trigger the 15-day warning...
     accessModuleService.updateCompletionTime(
@@ -760,11 +721,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccAgreement(
-        TestMockFactory.createDuccAgreement(
-            dbUser,
-            accessModuleService.getCurrentDuccVersion(),
-            new Timestamp(PROVIDED_CLOCK.millis())));
+    dbUser.setDuccAgreement(signCurrentDucc(dbUser));
 
     // but this is expired
     final Duration oneHour = Duration.ofHours(1);
@@ -791,11 +748,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccAgreement(
-        TestMockFactory.createDuccAgreement(
-            dbUser,
-            accessModuleService.getCurrentDuccVersion(),
-            new Timestamp(PROVIDED_CLOCK.millis())));
+    dbUser.setDuccAgreement(signCurrentDucc(dbUser));
 
     // but this expired yesterday
 
@@ -1233,6 +1186,15 @@ public class UserServiceAccessTest {
 
   private void advanceClockDays(long days) {
     PROVIDED_CLOCK.increment(daysPlusSome(days).toMillis());
+  }
+
+  private DbUserCodeOfConductAgreement signDucc(DbUser dbUser, int version) {
+    return TestMockFactory.createDuccAgreement(
+        dbUser, version, new Timestamp(PROVIDED_CLOCK.millis()));
+  }
+
+  private DbUserCodeOfConductAgreement signCurrentDucc(DbUser dbUser) {
+    return signDucc(dbUser, accessModuleService.getCurrentDuccVersion());
   }
 
   // checks which power most of these tests - confirm that the unregisteringFunction does that

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -224,17 +224,17 @@ public class UserServiceAccessTest {
 
   @Test
   public void testSimulateUserFlowThroughRenewal() {
-    // initialize user as registered with generic values including bypassed DUA
+    // initialize user as registered with generic values including bypassed DUCC
 
     dbUser = updateUserWithRetries(registerUserNow);
     assertRegisteredTierEnabled(dbUser);
 
-    // add a proper DUA completion which will expire soon, but remove DUA bypass
+    // add a proper DUCC completion which will expire soon, but remove DUCC bypass
 
     dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpireAfter(Duration.ofDays(1)));
-    dbUser = updateUserWithRetries(this::removeDuaBypass);
+    dbUser = updateUserWithRetries(this::removeDuccBypass);
 
     // User is compliant
     assertRegisteredTierEnabled(dbUser);
@@ -244,14 +244,14 @@ public class UserServiceAccessTest {
     dbUser = updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
 
-    // Simulate user filling out DUA, becoming compliant again
+    // Simulate user filling out DUCC, becoming compliant again
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, new Timestamp(PROVIDED_CLOCK.millis()));
     dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
 
-  private DbUser removeDuaBypass(DbUser user) {
+  private DbUser removeDuccBypass(DbUser user) {
     accessModuleService.updateBypassTime(
         user.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
     return userDao.save(user);
@@ -324,11 +324,11 @@ public class UserServiceAccessTest {
         });
   }
 
-  // DUA can be bypassed, and is subject to annual renewal.
-  // A missing DUA version or a version other than the latest is also noncompliant.
+  // DUCC can be bypassed, and is subject to annual renewal.
+  // A missing DUCC version or a version other than the latest is also noncompliant.
 
   @Test
-  public void test_updateUserWithRetries_dua_unbypassed_aar_noncompliant() {
+  public void test_updateUserWithRetries_ducc_unbypassed_aar_noncompliant() {
     testUnregistration(
         user -> {
           accessModuleService.updateBypassTime(
@@ -338,7 +338,7 @@ public class UserServiceAccessTest {
   }
 
   @Test
-  public void test_updateUserWithRetries_dua_unbypassed_aar_missing_version_noncompliant() {
+  public void test_updateUserWithRetries_ducc_unbypassed_aar_missing_version_noncompliant() {
     testUnregistration(
         user -> {
           accessModuleService.updateBypassTime(
@@ -350,7 +350,7 @@ public class UserServiceAccessTest {
   }
 
   @Test
-  public void test_updateUserWithRetries_dua_unbypassed_aar_wrong_version_noncompliant() {
+  public void test_updateUserWithRetries_ducc_unbypassed_aar_wrong_version_noncompliant() {
     testUnregistration(
         user -> {
           accessModuleService.updateBypassTime(
@@ -363,7 +363,7 @@ public class UserServiceAccessTest {
   }
 
   @Test
-  public void test_updateUserWithRetries_dua_unbypassed_aar_expired_noncompliant() {
+  public void test_updateUserWithRetries_ducc_unbypassed_aar_expired_noncompliant() {
     testUnregistration(
         user -> {
           final Timestamp willExpire = Timestamp.from(START_INSTANT);
@@ -440,7 +440,7 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
     accessModuleService.updateCompletionTime(dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, now);
 
-    // a completion requirement for DUCC (formerly "DUA" - TODO rename)
+    // a completion requirement for DUCC
     dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     userService.maybeSendAccessExpirationEmail(dbUser);
@@ -478,7 +478,7 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
-    // a completion requirement for DUCC (formerly "DUA" - TODO rename)
+    // a completion requirement for DUCC
     dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // expiring in 1 day (plus some) will trigger the 1-day warning
@@ -589,7 +589,7 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
-    // a completion requirement for DUCC (formerly "DUA" - TODO rename)
+    // a completion requirement for DUCC
     dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // expiring in .5 days will not trigger an email
@@ -613,7 +613,7 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
-    // a completion requirement for DUCC (formerly "DUA" - TODO rename)
+    // a completion requirement for DUCC
     dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // expiring in 30 days (plus) will trigger the 30-day warning
@@ -638,7 +638,7 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
-    // a completion requirement for DUCC (formerly "DUA" - TODO rename)
+    // a completion requirement for DUCC
     dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // expiring in 31 days (plus) will not trigger a warning
@@ -660,7 +660,7 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
 
-    // a completion requirement for DUCC (formerly "DUA" - TODO rename)
+    // a completion requirement for DUCC
     dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // expiring in 30 days (plus) would trigger the 30-day warning...
@@ -693,7 +693,7 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
 
-    // a completion requirement for DUCC (formerly "DUA" - TODO rename)
+    // a completion requirement for DUCC
     dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // expiring in 15 days (plus) would trigger the 15-day warning...
@@ -719,7 +719,7 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
-    // a completion requirement for DUCC (formerly "DUA" - TODO rename)
+    // a completion requirement for DUCC
     dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // but this is expired
@@ -746,7 +746,7 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
-    // a completion requirement for DUCC (formerly "DUA" - TODO rename)
+    // a completion requirement for DUCC
     dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
 
     // but this expired yesterday

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -231,7 +231,11 @@ public class UserServiceAccessTest {
 
     // add a proper DUCC completion which will expire soon, but remove DUCC bypass
 
-    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccAgreement(
+        TestMockFactory.createDuccAgreement(
+            dbUser,
+            accessModuleService.getCurrentDuccVersion(),
+            new Timestamp(PROVIDED_CLOCK.millis())));
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpireAfter(Duration.ofDays(1)));
     dbUser = updateUserWithRetries(this::removeDuccBypass);
@@ -357,7 +361,11 @@ public class UserServiceAccessTest {
               dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
           accessModuleService.updateCompletionTime(
               dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, Timestamp.from(START_INSTANT));
-          user.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion() - 1);
+          user.setDuccAgreement(
+              TestMockFactory.createDuccAgreement(
+                  user,
+                  accessModuleService.getCurrentDuccVersion() - 1,
+                  new Timestamp(PROVIDED_CLOCK.millis())));
           return userDao.save(user);
         });
   }
@@ -372,7 +380,11 @@ public class UserServiceAccessTest {
           accessModuleService.updateCompletionTime(
               dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpire);
 
-          user.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
+          user.setDuccAgreement(
+              TestMockFactory.createDuccAgreement(
+                  user,
+                  accessModuleService.getCurrentDuccVersion(),
+                  new Timestamp(PROVIDED_CLOCK.millis())));
 
           advanceClockDays(EXPIRATION_DAYS + 1);
 
@@ -441,7 +453,11 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccAgreement(
+        TestMockFactory.createDuccAgreement(
+            dbUser,
+            accessModuleService.getCurrentDuccVersion(),
+            new Timestamp(PROVIDED_CLOCK.millis())));
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -479,7 +495,11 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
     // a completion requirement for DUCC
-    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccAgreement(
+        TestMockFactory.createDuccAgreement(
+            dbUser,
+            accessModuleService.getCurrentDuccVersion(),
+            new Timestamp(PROVIDED_CLOCK.millis())));
 
     // expiring in 1 day (plus some) will trigger the 1-day warning
 
@@ -590,7 +610,11 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccAgreement(
+        TestMockFactory.createDuccAgreement(
+            dbUser,
+            accessModuleService.getCurrentDuccVersion(),
+            new Timestamp(PROVIDED_CLOCK.millis())));
 
     // expiring in .5 days will not trigger an email
 
@@ -614,7 +638,11 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccAgreement(
+        TestMockFactory.createDuccAgreement(
+            dbUser,
+            accessModuleService.getCurrentDuccVersion(),
+            new Timestamp(PROVIDED_CLOCK.millis())));
 
     // expiring in 30 days (plus) will trigger the 30-day warning
 
@@ -639,7 +667,11 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccAgreement(
+        TestMockFactory.createDuccAgreement(
+            dbUser,
+            accessModuleService.getCurrentDuccVersion(),
+            new Timestamp(PROVIDED_CLOCK.millis())));
 
     // expiring in 31 days (plus) will not trigger a warning
     accessModuleService.updateCompletionTime(
@@ -661,7 +693,11 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccAgreement(
+        TestMockFactory.createDuccAgreement(
+            dbUser,
+            accessModuleService.getCurrentDuccVersion(),
+            new Timestamp(PROVIDED_CLOCK.millis())));
 
     // expiring in 30 days (plus) would trigger the 30-day warning...
     final Duration thirtyPlus = daysPlusSome(30);
@@ -694,7 +730,11 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccAgreement(
+        TestMockFactory.createDuccAgreement(
+            dbUser,
+            accessModuleService.getCurrentDuccVersion(),
+            new Timestamp(PROVIDED_CLOCK.millis())));
 
     // expiring in 15 days (plus) would trigger the 15-day warning...
     accessModuleService.updateCompletionTime(
@@ -720,7 +760,11 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccAgreement(
+        TestMockFactory.createDuccAgreement(
+            dbUser,
+            accessModuleService.getCurrentDuccVersion(),
+            new Timestamp(PROVIDED_CLOCK.millis())));
 
     // but this is expired
     final Duration oneHour = Duration.ofHours(1);
@@ -747,7 +791,11 @@ public class UserServiceAccessTest {
         dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
-    dbUser.setDuccSignedVersion(accessModuleService.getCurrentDuccVersion());
+    dbUser.setDuccAgreement(
+        TestMockFactory.createDuccAgreement(
+            dbUser,
+            accessModuleService.getCurrentDuccVersion(),
+            new Timestamp(PROVIDED_CLOCK.millis())));
 
     // but this expired yesterday
 

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskUserControllerTest.java
@@ -90,8 +90,8 @@ public class CloudTaskUserControllerTest {
         .thenReturn(Optional.of(new AccessModuleStatus()));
 
     // kluge to prevent test NPEs on the return value of syncDuccVersionStatus()
-    when(mockUserService.syncDuccVersionStatus(userA, Agent.asSystem(), null)).thenReturn(userA);
-    when(mockUserService.syncDuccVersionStatus(userB, Agent.asSystem(), null)).thenReturn(userB);
+    when(mockUserService.syncDuccVersionStatus(userA, Agent.asSystem())).thenReturn(userA);
+    when(mockUserService.syncDuccVersionStatus(userB, Agent.asSystem())).thenReturn(userB);
 
     controller.synchronizeUserAccess(
         new SynchronizeUserAccessRequest()
@@ -102,8 +102,8 @@ public class CloudTaskUserControllerTest {
     // unfortunately UserService is too sprawling to replicate in a unit test.
 
     // we sync DUCC for all users
-    verify(mockUserService).syncDuccVersionStatus(userA, Agent.asSystem(), null);
-    verify(mockUserService).syncDuccVersionStatus(userB, Agent.asSystem(), null);
+    verify(mockUserService).syncDuccVersionStatus(userA, Agent.asSystem());
+    verify(mockUserService).syncDuccVersionStatus(userB, Agent.asSystem());
 
     // we only sync 2FA users with completed 2FA
     verify(mockUserService).syncTwoFactorAuthStatus(userA, Agent.asSystem());

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -51,6 +51,7 @@ import org.pmiops.workbench.config.CommonConfig;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.AccessModuleDao;
 import org.pmiops.workbench.db.dao.AccessTierDao;
+import org.pmiops.workbench.db.dao.UserCodeOfConductAgreementDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserDataUseAgreementDao;
 import org.pmiops.workbench.db.dao.UserServiceImpl;
@@ -59,7 +60,7 @@ import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.db.model.DbUserDataUseAgreement;
+import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
@@ -147,6 +148,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   @Autowired private ProfileController profileController;
   @Autowired private ProfileService profileService;
   @Autowired private UserDao userDao;
+  @Autowired private UserCodeOfConductAgreementDao userCodeOfConductAgreementDao;
   @Autowired private UserDataUseAgreementDao userDataUseAgreementDao;
   @Autowired private UserTermsOfServiceDao userTermsOfServiceDao;
   @Autowired private FakeClock fakeClock;
@@ -465,14 +467,14 @@ public class ProfileControllerTest extends BaseControllerTest {
     String initials = "NIH";
     assertThat(profileController.submitDUCC(DUCC_VERSION, initials).getStatusCode())
         .isEqualTo(HttpStatus.OK);
-    List<DbUserDataUseAgreement> dbUserDataUseAgreementList =
-        userDataUseAgreementDao.findByUserIdOrderByCompletionTimeDesc(dbUser.getUserId());
-    assertThat(dbUserDataUseAgreementList.size()).isEqualTo(1);
-    DbUserDataUseAgreement dbUserDataUseAgreement = dbUserDataUseAgreementList.get(0);
-    assertThat(dbUserDataUseAgreement.getUserFamilyName()).isEqualTo(dbUser.getFamilyName());
-    assertThat(dbUserDataUseAgreement.getUserGivenName()).isEqualTo(dbUser.getGivenName());
-    assertThat(dbUserDataUseAgreement.getUserInitials()).isEqualTo(initials);
-    assertThat(dbUserDataUseAgreement.getDataUseAgreementSignedVersion()).isEqualTo(DUCC_VERSION);
+    List<DbUserCodeOfConductAgreement> duccAgreementList =
+        userCodeOfConductAgreementDao.findByUserOrderByCompletionTimeDesc(dbUser);
+    assertThat(duccAgreementList.size()).isEqualTo(1);
+    DbUserCodeOfConductAgreement duccAgreement = duccAgreementList.get(0);
+    assertThat(duccAgreement.getUserFamilyName()).isEqualTo(dbUser.getFamilyName());
+    assertThat(duccAgreement.getUserGivenName()).isEqualTo(dbUser.getGivenName());
+    assertThat(duccAgreement.getUserInitials()).isEqualTo(initials);
+    assertThat(duccAgreement.getSignedVersion()).isEqualTo(DUCC_VERSION);
   }
 
   @Test
@@ -699,7 +701,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   }
 
   @Test
-  public void updateName_alsoUpdatesDua() {
+  public void updateName_alsoUpdatesDucc() {
     createAccountAndDbUserWithAffiliation();
     Profile profile = profileController.getMe().getBody();
     profile.setGivenName("OldGivenName");
@@ -709,9 +711,9 @@ public class ProfileControllerTest extends BaseControllerTest {
     profile.setGivenName("NewGivenName");
     profile.setFamilyName("NewFamilyName");
     profileController.updateProfile(profile);
-    List<DbUserDataUseAgreement> duas =
-        userDataUseAgreementDao.findByUserIdOrderByCompletionTimeDesc(profile.getUserId());
-    assertThat(duas.get(0).isUserNameOutOfDate()).isTrue();
+    List<DbUserCodeOfConductAgreement> duccAgreementList =
+        userCodeOfConductAgreementDao.findByUserOrderByCompletionTimeDesc(dbUser);
+    assertThat(duccAgreementList.get(0).isUserNameOutOfDate()).isTrue();
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -40,6 +40,7 @@ import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
@@ -443,6 +444,8 @@ public class UserServiceTest {
   @Test
   public void testSyncDuccVersionStatus_correctVersion() {
     final DbUser user = userDao.findUserByUsername(USERNAME);
+    user.setDuccAgreement(signDucc(user, accessModuleService.getCurrentDuccVersion()));
+    userDao.save(user);
 
     userService.syncDuccVersionStatus(user, Agent.asSystem());
 
@@ -452,6 +455,8 @@ public class UserServiceTest {
   @Test
   public void testSyncDuccVersionStatus_incorrectVersion() {
     final DbUser user = userDao.findUserByUsername(USERNAME);
+    user.setDuccAgreement(signDucc(user, accessModuleService.getCurrentDuccVersion() - 1));
+    userDao.save(user);
 
     userService.syncDuccVersionStatus(user, Agent.asSystem());
 
@@ -547,5 +552,9 @@ public class UserServiceTest {
     userAccessModuleDao
         .getByUserAndAccessModule(user, accessModuleDao.findOneByName(moduleName).get())
         .ifPresent(module -> assertThat(module.getCompletionTime()).isNull());
+  }
+
+  private DbUserCodeOfConductAgreement signDucc(DbUser dbUser, int version) {
+    return TestMockFactory.createDuccAgreement(dbUser, version, FakeClockConfiguration.NOW);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -444,8 +444,7 @@ public class UserServiceTest {
   public void testSyncDuccVersionStatus_correctVersion() {
     final DbUser user = userDao.findUserByUsername(USERNAME);
 
-    userService.syncDuccVersionStatus(
-        user, Agent.asSystem(), accessModuleService.getCurrentDuccVersion());
+    userService.syncDuccVersionStatus(user, Agent.asSystem());
 
     verify(accessModuleService, never()).updateCompletionTime(any(), any(), any());
   }
@@ -454,8 +453,7 @@ public class UserServiceTest {
   public void testSyncDuccVersionStatus_incorrectVersion() {
     final DbUser user = userDao.findUserByUsername(USERNAME);
 
-    userService.syncDuccVersionStatus(
-        user, Agent.asSystem(), accessModuleService.getCurrentDuccVersion() - 1);
+    userService.syncDuccVersionStatus(user, Agent.asSystem());
 
     verify(accessModuleService)
         .updateCompletionTime(user, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, null);
@@ -465,7 +463,7 @@ public class UserServiceTest {
   public void testSyncDuccVersionStatus_missing() {
     final DbUser user = userDao.findUserByUsername(USERNAME);
 
-    userService.syncDuccVersionStatus(user, Agent.asSystem(), null);
+    userService.syncDuccVersionStatus(user, Agent.asSystem());
 
     verify(accessModuleService)
         .updateCompletionTime(user, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, null);

--- a/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
@@ -59,7 +59,7 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
       Timestamp.from(Instant.parse("2015-05-14T00:00:00.00Z"));
   public static final Timestamp USER__DATA_USE_AGREEMENT_COMPLETION_TIME =
       Timestamp.from(Instant.parse("2015-05-15T00:00:00.00Z"));
-  public static final Integer USER__DATA_USE_AGREEMENT_SIGNED_VERSION = 11;
+  public static final Integer USER__DATA_USER_CODE_OF_CONDUCT_SIGNED_VERSION = 11;
   public static final Timestamp USER__DEMOGRAPHIC_SURVEY_COMPLETION_TIME =
       Timestamp.from(Instant.parse("2015-05-17T00:00:00.00Z"));
   public static final Boolean USER__DISABLED = false;
@@ -117,7 +117,7 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
     assertTimeApprox(
         user.getDataUseAgreementCompletionTime(), USER__DATA_USE_AGREEMENT_COMPLETION_TIME);
     assertThat(user.getDataUseAgreementSignedVersion())
-        .isEqualTo(USER__DATA_USE_AGREEMENT_SIGNED_VERSION);
+        .isEqualTo(USER__DATA_USER_CODE_OF_CONDUCT_SIGNED_VERSION);
     assertTimeApprox(
         user.getDemographicSurveyCompletionTime(), USER__DEMOGRAPHIC_SURVEY_COMPLETION_TIME);
     assertThat(user.getDisabled()).isEqualTo(USER__DISABLED);
@@ -159,7 +159,7 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
     user.setAreaOfResearch(USER__AREA_OF_RESEARCH);
     user.setContactEmail(USER__CONTACT_EMAIL);
     user.setCreationTime(USER__CREATION_TIME);
-    user.setDataUseAgreementSignedVersion(USER__DATA_USE_AGREEMENT_SIGNED_VERSION);
+    user.setDuccSignedVersion(USER__DATA_USER_CODE_OF_CONDUCT_SIGNED_VERSION);
     user.setDemographicSurveyCompletionTime(USER__DEMOGRAPHIC_SURVEY_COMPLETION_TIME);
     user.setDisabled(USER__DISABLED);
     user.setFamilyName(USER__FAMILY_NAME);
@@ -187,7 +187,7 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
         .creationTime(offsetDateTimeUtc(USER__CREATION_TIME))
         .dataUseAgreementBypassTime(offsetDateTimeUtc(USER__DATA_USE_AGREEMENT_BYPASS_TIME))
         .dataUseAgreementCompletionTime(offsetDateTimeUtc(USER__DATA_USE_AGREEMENT_COMPLETION_TIME))
-        .dataUseAgreementSignedVersion(USER__DATA_USE_AGREEMENT_SIGNED_VERSION)
+        .dataUseAgreementSignedVersion(USER__DATA_USER_CODE_OF_CONDUCT_SIGNED_VERSION)
         .demographicSurveyCompletionTime(
             offsetDateTimeUtc(USER__DEMOGRAPHIC_SURVEY_COMPLETION_TIME))
         .disabled(USER__DISABLED)

--- a/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
@@ -13,6 +13,7 @@ import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.Disability;
 import org.pmiops.workbench.model.Education;
@@ -104,6 +105,9 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
   public static String USER__LGBTQ_IDENTITY = "foo_28";
   public static boolean USER__IDENTIFIES_AS_LGBTQ = false;
   public static ImmutableList<Degree> USER__DEGREES = ImmutableList.of(Degree.BA, Degree.ME);
+  public static String USER__INITIALS = "foo_29";
+  public static final Timestamp DATA_USER_CODE_OF_CONDUCT_COMPLETION_TIME =
+      Timestamp.from(Instant.parse("2015-05-31T00:00:00.00Z"));
 
   @Override
   public void assertDTOFieldsMatchConstants(ReportingUser user) {
@@ -159,7 +163,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
     user.setAreaOfResearch(USER__AREA_OF_RESEARCH);
     user.setContactEmail(USER__CONTACT_EMAIL);
     user.setCreationTime(USER__CREATION_TIME);
-    user.setDuccSignedVersion(USER__DATA_USER_CODE_OF_CONDUCT_SIGNED_VERSION);
     user.setDemographicSurveyCompletionTime(USER__DEMOGRAPHIC_SURVEY_COMPLETION_TIME);
     user.setDisabled(USER__DISABLED);
     user.setFamilyName(USER__FAMILY_NAME);
@@ -170,9 +173,15 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
     user.setProfessionalUrl(USER__PROFESSIONAL_URL);
     user.setUsername(USER__USERNAME);
     user.setDegreesEnum(USER__DEGREES);
+
     DbDemographicSurvey dbDemographicSurvey = createDbDemographicSurvey();
     dbDemographicSurvey.setUser(user);
     user.setDemographicSurvey(dbDemographicSurvey);
+
+    DbUserCodeOfConductAgreement duccAgreement = createDbUserCodeOfConductAgreement();
+    duccAgreement.setUser(user);
+    user.setDuccAgreement(duccAgreement);
+
     return user;
   }
 
@@ -239,5 +248,15 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
     demographicSurvey.setIdentifiesAsLgbtq(USER__IDENTIFIES_AS_LGBTQ);
     demographicSurvey.setLgbtqIdentity(USER__LGBTQ_IDENTITY);
     return demographicSurvey;
+  }
+
+  public DbUserCodeOfConductAgreement createDbUserCodeOfConductAgreement() {
+    DbUserCodeOfConductAgreement duccAgreement = new DbUserCodeOfConductAgreement();
+    duccAgreement.setSignedVersion(USER__DATA_USER_CODE_OF_CONDUCT_SIGNED_VERSION);
+    duccAgreement.setUserFamilyName(USER__FAMILY_NAME);
+    duccAgreement.setUserGivenName(USER__GIVEN_NAME);
+    duccAgreement.setUserInitials(USER__INITIALS);
+    duccAgreement.setCompletionTime(DATA_USER_CODE_OF_CONDUCT_COMPLETION_TIME);
+    return duccAgreement;
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -11,6 +11,7 @@ import com.google.api.services.cloudbilling.model.ListBillingAccountsResponse;
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,6 +26,8 @@ import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbCdrVersion;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceDetails;
@@ -320,5 +323,17 @@ public class TestMockFactory {
     DbCdrVersion cdrVersion = createDefaultCdrVersion(cdrVersionDao, accessTierDao, id);
     cdrVersion.setAccessTier(createControlledTierForTests(accessTierDao));
     return cdrVersionDao.save(cdrVersion);
+  }
+
+  public static DbUserCodeOfConductAgreement createDuccAgreement(
+      DbUser dbUser, int signedVersion, Timestamp completionTime) {
+    DbUserCodeOfConductAgreement ducc = new DbUserCodeOfConductAgreement();
+    ducc.setUser(dbUser);
+    ducc.setSignedVersion(signedVersion);
+    ducc.setUserFamilyName(dbUser.getFamilyName());
+    ducc.setUserGivenName(dbUser.getGivenName());
+    ducc.setUserInitials("XYZ");
+    ducc.setCompletionTime(completionTime);
+    return ducc;
   }
 }

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.spec.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.spec.tsx
@@ -141,6 +141,6 @@ describe('DataUserCodeOfConduct', () => {
       wrapper.find('[data-test-id="submit-ducc-button"]').prop('disabled')
     ).toBeFalsy();
     wrapper.find('[data-test-id="submit-ducc-button"]').simulate('click');
-    expect(spy).toHaveBeenCalledWith(3, 'XX');  // duccSignedVersion
+    expect(spy).toHaveBeenCalledWith(3, 'XX'); // duccSignedVersion
   });
 });

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.spec.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.spec.tsx
@@ -141,6 +141,6 @@ describe('DataUserCodeOfConduct', () => {
       wrapper.find('[data-test-id="submit-ducc-button"]').prop('disabled')
     ).toBeFalsy();
     wrapper.find('[data-test-id="submit-ducc-button"]').simulate('click');
-    expect(spy).toHaveBeenCalledWith(3, 'XX'); // dataUseAgreementVersion
+    expect(spy).toHaveBeenCalledWith(3, 'XX');  // duccSignedVersion
   });
 });

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -134,7 +134,7 @@ export class ProfileApiStub extends ProfileApi {
   }
 
   public submitDUCC(duccVersion: number) {
-    this.profile.dataUseAgreementSignedVersion = duccVersion;
+    this.profile.duccSignedVersion = duccVersion;
     return Promise.resolve(this.profile);
   }
 


### PR DESCRIPTION
Remove DbUser.dataUseAgreementSignedVersion (use a Join instead) and rename many instances of DUA to DUCC.

Wait for the 24 Jan release before merging.

Does not complete RW-4838.  Still remaining:
* ReportingUser
* AdminTableUser and user admin UI

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
