### PR TITLE
[RW-7687][risk=no] Fix e2e notebook preview selectors

### DIFF
--- a/e2e/app/page/notebook-cell.ts
+++ b/e2e/app/page/notebook-cell.ts
@@ -160,6 +160,14 @@ export default class NotebookCell extends NotebookFrame {
     return iframe.waitForSelector(selector, { visible: true, timeout: timeOut });
   }
 
+  async findRenderedHtmlElementHandle(timeOut?: number): Promise<ElementHandle> {
+    const selector = `${this.outputSelector(this.getCellIndex())}.rendered_html`;
+    const iframe = await this.getIFrame();
+    await iframe.waitForSelector(selector, { visible: true, timeout: timeOut });
+    const elements = await iframe.$$(selector);
+    return elements[elements.length - 1];
+  }
+
   private async findAllCells(): Promise<ElementHandle[]> {
     const frame = await this.getIFrame();
     const selector = `${this.cellSelector()} .CodeMirror-code`;

--- a/e2e/app/page/notebook-preview-page.ts
+++ b/e2e/app/page/notebook-preview-page.ts
@@ -51,7 +51,7 @@ export default class NotebookPreviewPage extends AuthenticatedPage {
     const iframe = await this.findNotebookIframe();
     await waitForFn(
       async () => {
-        return (await iframe.$$('.code_cell')).length === (await iframe.$$('.code_cell.rendered')).length;
+        return (await iframe.$$('.jp-CodeCell')).length === (await iframe.$$('.jp-CodeMirrorEditor')).length;
       },
       1000,
       30000
@@ -59,7 +59,7 @@ export default class NotebookPreviewPage extends AuthenticatedPage {
   }
 
   async getFormattedCode(): Promise<string[]> {
-    const css = '#notebook .code_cell.rendered pre';
+    const css = '.jp-CodeMirrorEditor';
     const iframe = await this.findNotebookIframe();
     await iframe.waitForSelector(css, { visible: true });
     const elements = await iframe.$$(css);

--- a/e2e/tests/datasets/export-to-notebook.spec.ts
+++ b/e2e/tests/datasets/export-to-notebook.spec.ts
@@ -131,6 +131,7 @@ describe('Export dataset to notebook tests', () => {
         expect(code.some((item) => item.includes('import os'))).toBe(true);
         break;
       case Language.R:
+        expect(code.some((item) => item.includes('library(tidyverse)'))).toBe(true);
         expect(code.some((item) => item.includes('library(bigrquery)'))).toBe(true);
         break;
     }
@@ -138,15 +139,14 @@ describe('Export dataset to notebook tests', () => {
     // Open notebook in Edit mode.
     const notebookPage = await notebookPreviewPage.openEditMode(notebookName);
 
-    // Run notebook code cell #1.
-    await notebookPage.runCodeCell(1);
+    // Run all cells.
+    await notebookPage.runAllCells();
 
-    const cell1 = notebookPage.findCell(1);
-    const cell1Output = await cell1.findOutputElementHandle();
+    // In both Python / R, the last cell contains a preview of the dataframe.
+    const lastCell = await notebookPage.findLastCell();
 
     // Verify run output: Cell output format should be html table.
-    const outputClassName = await getPropValue<string>(cell1Output, 'className');
-    expect(outputClassName).toContain('rendered_html');
+    await lastCell.findRenderedHtmlElementHandle();
 
     // Verify workspace name is in notebook page.
     const workspaceLink = await notebookPage.getWorkspaceLink().asElementHandle();


### PR DESCRIPTION
The Calhoun export code was recently updated, which modified some of the HTML / CSS. Update to the new selectors.

Notebooks tests pass locally with these changes.