### PR TITLE
[risk=low] Fix formatting for updated Calhoun notebook previews

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -118,8 +118,7 @@ public class NotebooksServiceImpl implements NotebooksService {
   // NOTE: may be an undercount since we only retrieve the first Page of Storage List results
   @Override
   public List<FileDetail> getNotebooksAsService(String bucketName) {
-    return cloudStorageClient
-        .getBlobPageForPrefix(bucketName, NOTEBOOKS_WORKSPACE_DIRECTORY)
+    return cloudStorageClient.getBlobPageForPrefix(bucketName, NOTEBOOKS_WORKSPACE_DIRECTORY)
         .stream()
         .filter(this::isNotebookBlob)
         .map(blob -> cloudStorageClient.blobToFileDetail(blob, bucketName))

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -68,7 +68,7 @@ public class NotebooksServiceImpl implements NotebooksService {
                   .allowTextIn("style")
                   // <pre> is not included in the prebuilt sanitizers; it is used for monospace code
                   // block formatting
-                  .allowElements("style", "pre")
+                  .allowElements("head", "body", "style", "pre")
 
                   // Allow id/class in order to interact with the style tag.
                   .allowAttributes("id", "class")
@@ -118,7 +118,8 @@ public class NotebooksServiceImpl implements NotebooksService {
   // NOTE: may be an undercount since we only retrieve the first Page of Storage List results
   @Override
   public List<FileDetail> getNotebooksAsService(String bucketName) {
-    return cloudStorageClient.getBlobPageForPrefix(bucketName, NOTEBOOKS_WORKSPACE_DIRECTORY)
+    return cloudStorageClient
+        .getBlobPageForPrefix(bucketName, NOTEBOOKS_WORKSPACE_DIRECTORY)
         .stream()
         .filter(this::isNotebookBlob)
         .map(blob -> cloudStorageClient.blobToFileDetail(blob, bucketName))

--- a/e2e/app/modal/export-to-notebook-modal.ts
+++ b/e2e/app/modal/export-to-notebook-modal.ts
@@ -57,7 +57,6 @@ export default class ExportToNotebookModal extends Modal {
     return getFormattedPreviewCode(await previewFrame.contentFrame());
   }
 
-
   async clickExportButton(): Promise<NotebookPreviewPage> {
     await this.clickButton(LinkText.Export, { waitForClose: true });
     const notebookPreviewPage = new NotebookPreviewPage(this.page);

--- a/e2e/app/modal/export-to-notebook-modal.ts
+++ b/e2e/app/modal/export-to-notebook-modal.ts
@@ -5,6 +5,7 @@ import { AnalysisTool, Language, LinkText } from 'app/text-labels';
 import Modal from './modal';
 import { waitForText } from 'utils/waits-utils';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
+import { getFormattedPreviewCode } from 'utils/notebook-preview-utils';
 
 const title = 'Export Dataset';
 
@@ -48,6 +49,14 @@ export default class ExportToNotebookModal extends Modal {
     const radioButtonXpath = this.getRadioButtonXpath(analysisTool);
     return new RadioButton(this.page, radioButtonXpath);
   }
+
+  async showCodePreview(): Promise<string[]> {
+    await this.clickButton(LinkText.SeeCodePreview);
+
+    const previewFrame = await this.page.waitForSelector('#export-preview-frame');
+    return getFormattedPreviewCode(await previewFrame.contentFrame());
+  }
+
 
   async clickExportButton(): Promise<NotebookPreviewPage> {
     await this.clickButton(LinkText.Export, { waitForClose: true });

--- a/e2e/tests/datasets/export-to-notebook.spec.ts
+++ b/e2e/tests/datasets/export-to-notebook.spec.ts
@@ -116,6 +116,7 @@ describe('Export dataset to notebook tests', () => {
     const notebookName = makeRandomName('notebook', { includeHyphen: false });
     await exportModal.enterNotebookName(notebookName);
     await exportModal.pickLanguage(kernelLanguage.LANGUAGE);
+    await exportModal.showCodePreview();
     await exportModal.clickExportButton();
 
     // Verify Notebook preview. Not going to start the Jupyter notebook.

--- a/e2e/utils/notebook-preview-utils.ts
+++ b/e2e/utils/notebook-preview-utils.ts
@@ -5,8 +5,7 @@ import { waitForFn } from 'utils/waits-utils';
 export async function waitForPreviewCellsRendered(previewFrame: Frame): Promise<void> {
   await waitForFn(
     async () => {
-      return (await previewFrame.$$('.jp-CodeCell')).length ===
-        (await previewFrame.$$('.jp-CodeMirrorEditor')).length;
+      return (await previewFrame.$$('.jp-CodeCell')).length === (await previewFrame.$$('.jp-CodeMirrorEditor')).length;
     },
     1000,
     30000
@@ -18,5 +17,4 @@ export async function getFormattedPreviewCode(previewFrame: Frame): Promise<stri
   await previewFrame.waitForSelector(css, { visible: true });
   const elements = await previewFrame.$$(css);
   return Promise.all(elements.map(async (content) => await getPropValue<string>(content, 'textContent')));
-
 }

--- a/e2e/utils/notebook-preview-utils.ts
+++ b/e2e/utils/notebook-preview-utils.ts
@@ -1,0 +1,22 @@
+import { Frame } from 'puppeteer';
+import { getPropValue } from 'utils/element-utils';
+import { waitForFn } from 'utils/waits-utils';
+
+export async function waitForPreviewCellsRendered(previewFrame: Frame): Promise<void> {
+  await waitForFn(
+    async () => {
+      return (await previewFrame.$$('.jp-CodeCell')).length ===
+        (await previewFrame.$$('.jp-CodeMirrorEditor')).length;
+    },
+    1000,
+    30000
+  );
+}
+
+export async function getFormattedPreviewCode(previewFrame: Frame): Promise<string[]> {
+  const css = '.jp-CodeMirrorEditor';
+  await previewFrame.waitForSelector(css, { visible: true });
+  const elements = await previewFrame.$$(css);
+  return Promise.all(elements.map(async (content) => await getPropValue<string>(content, 'textContent')));
+
+}

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -111,14 +111,14 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(withCur
     function loadHtmlStringIntoIFrame(html) {
       const placeholder = document.createElement('html');
       placeholder.innerHTML = html;
-      // Some styling changes to the jupyter notebook to make it easier to view
-      placeholder.style.overflowY = 'scroll';
-      placeholder.getElementsByTagName('body')[0].style.overflowY = 'scroll';
-      placeholder.querySelector<HTMLElement>('#notebook').style.paddingTop = '0';
 
       // Remove input column from notebook cells. Also possible to strip this out in Calhoun but requires some API changes
-      placeholder.querySelectorAll('.input_prompt').forEach(e => e.remove());
-      return <iframe scrolling='no' style={{width: '100%', height: '100%', border: 'none'}} srcDoc={placeholder.outerHTML}/>;
+      placeholder.querySelectorAll('.jp-InputPrompt').forEach(e => e.remove());
+      return <iframe
+        id='export-preview-frame'
+        scrolling='yes'
+        style={{width: '100%', height: '100%', border: 'none'}}
+        srcDoc={placeholder.outerHTML}/>;
     }
 
     function loadCodePreview() {


### PR DESCRIPTION
Stacked on #6121 

Recent Calhoun changes resulted in different HTML and CSS. Specifically, there are styles which are now applied to the body tag; our previous sanitizer was stripping these out. On codegen preview, this would simply result in a rendering error - this is fixed. On both notebook and export preview, this would result in ugly formatting - this is also fixed.

Add test coverage to verify the export preview feature works.

Before:

![image](https://user-images.githubusercontent.com/822298/148621553-cae1568a-d74d-4d4d-8203-b867e935bb65.png)


After: 

![image](https://user-images.githubusercontent.com/822298/148621581-42c3458f-6dec-4936-a180-3a9862224740.png)
