### PR TITLE
[RW-7688][risk=low] Improve e2e token invalidation by embedding creation time

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/GenerateImpersonatedUserTokens.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/GenerateImpersonatedUserTokens.java
@@ -3,8 +3,11 @@ package org.pmiops.workbench.tools;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.logging.Logger;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -40,7 +43,7 @@ public class GenerateImpersonatedUserTokens {
   private static Option outputTokenFilename =
       Option.builder()
           .longOpt("output-token-filename")
-          .desc("Path to an output file for the generated impersonated token")
+          .desc("Path to an output JSON file for the generated impersonated token")
           .required()
           .hasArg()
           .build();
@@ -63,6 +66,7 @@ public class GenerateImpersonatedUserTokens {
     final IamCredentialsClient credsClient = IamCredentialsClient.create();
     final HttpTransport transport = new ApacheHttpTransport();
 
+    final Gson gson = new Gson();
     for (int i = 0; i < usernames.length; i++) {
       final String username = usernames[i];
       final String filename = filenames[i];
@@ -77,7 +81,10 @@ public class GenerateImpersonatedUserTokens {
       final String token = creds.getAccessToken().getTokenValue();
 
       try (FileWriter w = new FileWriter(filename)) {
-        w.write(token);
+        w.write(
+            gson.toJson(
+                ImmutableMap.of(
+                    "created_at_epoch_seconds", Instant.now().getEpochSecond(), "token", token)));
       }
     }
   }

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -38,12 +38,14 @@ export async function signInWithAccessToken(
   userEmail = config.USER_NAME,
   postSignInPage: AuthenticatedPage = new HomePage(page)
 ): Promise<void> {
-  const tokenLocation = `signin-tokens/${userEmail}.txt`;
+  const tokenLocation = `signin-tokens/${userEmail}.json`;
   // Keep file naming convention synchronized with generate-impersonated-user-tokens
-  const token = fs.readFileSync(tokenLocation, 'ascii');
-  if (isBlank(token)) {
+  const tokenJson = fs.readFileSync(tokenLocation, 'ascii');
+  if (isBlank(tokenJson)) {
     throw Error(`Token found at ${tokenLocation} is blank`);
   }
+  const {token} = JSON.parse(tokenJson);
+
   logger.info('Sign in with access token to Workbench application');
   const homePage = new HomePage(page);
   await homePage.gotoUrl(PageUrl.Home);

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -44,7 +44,7 @@ export async function signInWithAccessToken(
   if (isBlank(tokenJson)) {
     throw Error(`Token found at ${tokenLocation} is blank`);
   }
-  const {token} = JSON.parse(tokenJson);
+  const { token } = JSON.parse(tokenJson);
 
   logger.info('Sign in with access token to Workbench application');
   const homePage = new HomePage(page);


### PR DESCRIPTION
Previously we used unix file ctime. This is problematic on CircleCI, as ctime will always be recent when we copy in tokens using the CircleCI workspace feature. Embedding the token creation time allows us to invalidate cached tokens without any dependency on file operations.

Format for these token files is:

```
{
  "created_at_epoch_seconds": 123,
  "token": "asdf"
}
```