### PR TITLE
[RW-7652][risk=no] Mitigate egress suspension test timeouts

### DIFF
--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -69,34 +69,6 @@ export default class NotebookPage extends NotebookFrame {
     return true;
   }
 
-  async waitForSecuritySuspendedStatus(suspended: boolean, timeOut = 25 * 60 * 1000): Promise<void> {
-    const startTime = Date.now();
-    const pollPeriod = 20 * 1000;
-
-    while (true) {
-      await this.reloadPage();
-
-      if ((await this.isSecuritySuspended()) === suspended) {
-        // Success
-        break;
-      }
-
-      if (Date.now() - startTime > timeOut - pollPeriod) {
-        throw new Error('timed out waiting for security suspension status = ' + suspended);
-      }
-      await this.page.waitForTimeout(pollPeriod);
-    }
-  }
-
-  private async isSecuritySuspended(): Promise<boolean> {
-    try {
-      await this.page.waitForXPath('//*[@data-test-id="security-suspended-msg"]', { visible: true });
-    } catch (e) {
-      return false;
-    }
-    return true;
-  }
-
   /**
    * Click "Notebook" link, goto Workspace Analysis page.
    * This function does not handle Unsaved Changes confirmation.

--- a/e2e/tests/nightly/egress-suspension.spec.ts
+++ b/e2e/tests/nightly/egress-suspension.spec.ts
@@ -31,7 +31,8 @@ describe('egress suspension', () => {
     console.log('Generating egress via notebook');
     notebookPage.runCodeFile(1, egressFilename, 5 * 60 * 1000).catch((err) => {
       if (!page.isClosed()) {
-        console.log('egress notebook failed to run: this may be expected if the user was suspended during execution', err);
+        console.log(
+          'egress notebook failed to run: this may be expected if the user was suspended during execution', err);
       }
     });
 

--- a/e2e/tests/nightly/egress-suspension.spec.ts
+++ b/e2e/tests/nightly/egress-suspension.spec.ts
@@ -38,6 +38,6 @@ describe('egress suspension', () => {
     // error on reload once the user becomes suspended.
     await newPage.goto(page.url());
 
-    await waitForSecuritySuspendedStatus(newPage, true);
+    await waitForSecuritySuspendedStatus(newPage);
   });
 });

--- a/e2e/tests/nightly/egress-suspension.spec.ts
+++ b/e2e/tests/nightly/egress-suspension.spec.ts
@@ -3,6 +3,7 @@ import { config } from 'resources/workbench-config';
 import { makeRandomName } from 'utils/str-utils';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import path from 'path';
+import { waitForSecuritySuspendedStatus } from 'utils/runtime-utils';
 
 // 45 minutes. Test could take a long time.
 jest.setTimeout(45 * 60 * 1000);
@@ -22,13 +23,25 @@ describe('egress suspension', () => {
     const dataPage = new WorkspaceDataPage(page);
     const notebookPage = await dataPage.createNotebook(notebookName);
 
-    console.log('Generating egress via notebook');
     await notebookPage.uploadFile(egressFilename, egressFilePath);
-    await notebookPage.runCodeFile(1, egressFilename, 5 * 60 * 1000);
 
-    await notebookPage.save();
+    // Let the egress notebook run in the background; intentionally do not await here.
+    // It may not complete since our user may have their compute disabled while
+    // this is still running.
+    console.log('Generating egress via notebook');
+    notebookPage.runCodeFile(1, egressFilename, 5 * 60 * 1000).catch((err) => {
+      if (!page.isClosed()) {
+        console.log('egress notebook failed to run: this may be expected if the user was suspended during execution', err);
+      }
+    });
 
-    console.log('Awaiting security suspension');
-    await notebookPage.waitForSecuritySuspendedStatus(true);
+    console.log('Awaiting security suspension in a new page');
+    const newPage = await browser.newPage();
+    await signInWithAccessToken(newPage, config.EGRESS_TEST_USER);
+    // Open the current notebook URL again; this will instead show a suspended
+    // error on reload once the user becomes suspended.
+    await newPage.goto(page.url());
+
+    await waitForSecuritySuspendedStatus(newPage, true);
   });
 });

--- a/e2e/tests/nightly/egress-suspension.spec.ts
+++ b/e2e/tests/nightly/egress-suspension.spec.ts
@@ -25,16 +25,11 @@ describe('egress suspension', () => {
 
     await notebookPage.uploadFile(egressFilename, egressFilePath);
 
-    // Let the egress notebook run in the background; intentionally do not await here.
-    // It may not complete since our user may have their compute disabled while
-    // this is still running.
+    // Start the egress notebook and let it run in a tab. It may not complete
+    // since our user may have their compute disabled while this is still
+    // running. Intentionally do not wait for completion or check output.
     console.log('Generating egress via notebook');
-    notebookPage.runCodeFile(1, egressFilename, 5 * 60 * 1000).catch((err) => {
-      if (!page.isClosed()) {
-        console.log(
-          'egress notebook failed to run: this may be expected if the user was suspended during execution', err);
-      }
-    });
+    await notebookPage.startCodeFile(1, egressFilename, 5 * 60 * 1000);
 
     console.log('Awaiting security suspension in a new page');
     const newPage = await browser.newPage();

--- a/e2e/utils/runtime-utils.ts
+++ b/e2e/utils/runtime-utils.ts
@@ -29,7 +29,7 @@ async function isSecuritySuspended(page: Page): Promise<boolean> {
 
 export async function waitForSecuritySuspendedStatus(
   page: Page,
-  suspended: boolean,
+  suspended = true,
   timeOut = 25 * 60 * 1000
 ): Promise<void> {
   const startTime = Date.now();

--- a/e2e/utils/runtime-utils.ts
+++ b/e2e/utils/runtime-utils.ts
@@ -17,3 +17,35 @@ export async function initializeRuntimeIfModalPresented(page: Page): Promise<voi
 
   await initializeButton.clickAndWait();
 }
+
+async function isSecuritySuspended(page: Page): Promise<boolean> {
+  try {
+    await page.waitForXPath('//*[@data-test-id="security-suspended-msg"]', { visible: true });
+  } catch (e) {
+    return false;
+  }
+  return true;
+}
+
+export async function waitForSecuritySuspendedStatus(
+  page: Page,
+  suspended: boolean,
+  timeOut = 25 * 60 * 1000
+): Promise<void> {
+  const startTime = Date.now();
+  const pollPeriod = 20 * 1000;
+
+  while (true) {
+    await page.reload({ waitUntil: ['load', 'domcontentloaded'], timeout: 60 * 1000 });
+
+    if ((await isSecuritySuspended(page)) === suspended) {
+      // Success
+      break;
+    }
+
+    if (Date.now() - startTime > timeOut - pollPeriod) {
+      throw new Error('timed out waiting for security suspension status = ' + suspended);
+    }
+    await page.waitForTimeout(pollPeriod);
+  }
+}


### PR DESCRIPTION
Problem: running the egress notebook is problematic, as we may be suspended in the middle of the run (this pauses the notebook, and makes it unresponsive). Furthermore, we can get dialogs when trying to navigate away from the notebook page, since it may not be fully saved or completed running.

Solution: run the notebook in the "background", and then refresh/check for suspension in another tab. This avoids any dependency on the code running to completion.