### PR TITLE
[no ticket][risk=no] Upgrade CircleCI puppeteer-executor resource_class to medium+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ executors:
 
   # Environment with browsers that is used to run Puppeteer end-to-end tests
   puppeteer-executor:
+    resource_class: medium+
     docker:
       - image: << pipeline.parameters.workbench-image >>
         environment:


### PR DESCRIPTION
Local UI server launched in CircleCI VM killed at random. I don't now why. Increase CircleCI VM class to prevent failures as a temporary solution.

```
The build failed because the process exited too early. This probably means the system ran out of memory or someone called `kill -9` on the process.
error Command failed with exit code 1.
```

Failed CircleCI [job](https://app.circleci.com/pipelines/github/all-of-us/workbench/17148/workflows/348a3866-dc1a-404f-a464-a212876f9a35/jobs/191006/steps).