### PR TITLE
[no ticket][risk=no] e2e flaky test fixes

### DIFF
--- a/e2e/app/modal/annotation-field-modal.ts
+++ b/e2e/app/modal/annotation-field-modal.ts
@@ -17,8 +17,8 @@ export enum AnnotationType {
 }
 
 export default class AnnotationFieldModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/base-modal.ts
+++ b/e2e/app/modal/base-modal.ts
@@ -9,11 +9,12 @@ import Textarea from 'app/element/textarea';
 import Textbox from 'app/element/textbox';
 import { LinkText } from 'app/text-labels';
 
-const defaultXpath = '//*[@id="popup-root"]//*[@role="dialog" and contains(@class, "after-open")]';
+const modalRootXpath = '//*[@id="popup-root"]/*[@class="ReactModalPortal"]';
+const modalXpath = '//*[@role="dialog" and contains(@class, "after-open")]';
 
 export default abstract class BaseModal extends Container {
-  protected constructor(page: Page, xpath: string = defaultXpath, opts?: { modalIndex: number }) {
-    super(page, opts ? `${xpath}[${opts.modalIndex}]` : xpath);
+  protected constructor(page: Page, xpath?: string, opts?: { modalIndex: number }) {
+    super(page, xpath ? xpath : `${modalRootXpath}${opts ? [opts.modalIndex] : ''}${modalXpath}`);
   }
 
   /**

--- a/e2e/app/modal/base-modal.ts
+++ b/e2e/app/modal/base-modal.ts
@@ -10,11 +10,11 @@ import Textbox from 'app/element/textbox';
 import { LinkText } from 'app/text-labels';
 
 const modalRootXpath = '//*[@id="popup-root"]/*[@class="ReactModalPortal"]';
-const modalXpath = '//*[@role="dialog" and contains(@class, "after-open")]';
+const modalXpath = '//*[@role="dialog" and @aria-modal="true" and contains(@class, "after-open")]';
 
 export default abstract class BaseModal extends Container {
-  protected constructor(page: Page, xpath?: string, opts?: { modalIndex: number }) {
-    super(page, xpath ? xpath : `${modalRootXpath}${opts ? [opts.modalIndex] : ''}${modalXpath}`);
+  protected constructor(page: Page, opts: { xpath?: string; modalIndex?: number } = { modalIndex: 1 }) {
+    super(page, opts.xpath ? opts.xpath : `${modalRootXpath}[${opts.modalIndex}]${modalXpath}`);
   }
 
   /**

--- a/e2e/app/modal/cdr-version-upgrade-modal.ts
+++ b/e2e/app/modal/cdr-version-upgrade-modal.ts
@@ -10,6 +10,7 @@ export default class CdrVersionUpgradeModal extends Modal {
   }
 
   async isLoaded(): Promise<boolean> {
+    await super.isLoaded();
     const xpath = '//*[@data-test-id="cdr-version-upgrade-modal"]';
     await this.page.waitForXPath(xpath, { visible: true });
     return true;

--- a/e2e/app/modal/cdr-version-upgrade-modal.ts
+++ b/e2e/app/modal/cdr-version-upgrade-modal.ts
@@ -5,8 +5,8 @@ import ClrIcon from 'app/element/clr-icon-link';
 import Modal from './modal';
 
 export default class CdrVersionUpgradeModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/cohort-review-modal.ts
+++ b/e2e/app/modal/cohort-review-modal.ts
@@ -6,8 +6,8 @@ import Modal from './modal';
 const title = 'Create Review Set';
 
 export default class CohortReviewModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/cohort-save-as-modal.ts
+++ b/e2e/app/modal/cohort-save-as-modal.ts
@@ -6,8 +6,8 @@ import { LinkText } from 'app/text-labels';
 const title = 'Save Cohort as';
 
 export default class CohortSaveAsModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/conceptset-save-modal.ts
+++ b/e2e/app/modal/conceptset-save-modal.ts
@@ -18,8 +18,8 @@ export enum SaveOption {
 export default class ConceptSetSaveModal extends Modal {
   modalTitle: string;
 
-  constructor(page: Page) {
-    super(page);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/copy-to-workspace-modal.ts
+++ b/e2e/app/modal/copy-to-workspace-modal.ts
@@ -8,8 +8,8 @@ import ReactSelect from 'app/element/react-select';
 const modalTitle = 'Copy to Workspace';
 
 export default class CopyToWorkspaceModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/dataset-create-modal.ts
+++ b/e2e/app/modal/dataset-create-modal.ts
@@ -13,8 +13,8 @@ const modalTitleXpath =
   '//*[contains(normalize-space(),"Create Dataset") or contains(normalize-space(),"Update Dataset")]';
 
 export default class DatasetCreateModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/dataset-rename-modal.ts
+++ b/e2e/app/modal/dataset-rename-modal.ts
@@ -7,8 +7,8 @@ import Textarea from 'app/element/textarea';
 const title = 'Enter new name for ';
 
 export default class DatasetRenameModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/delete-confirmation-modal.ts
+++ b/e2e/app/modal/delete-confirmation-modal.ts
@@ -5,8 +5,8 @@ import { waitForText } from 'utils/waits-utils';
 const modalTitle = 'Are you sure you want to delete';
 
 export default class DeleteConfirmationModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/edit-delete-annotations-modal.ts
+++ b/e2e/app/modal/edit-delete-annotations-modal.ts
@@ -7,8 +7,8 @@ import BaseElement from 'app/element/base-element';
 const modalTitle = 'Edit or Delete Review-Wide Annotation Fields';
 
 export default class EditDeleteAnnotationsModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/export-to-notebook-modal.ts
+++ b/e2e/app/modal/export-to-notebook-modal.ts
@@ -10,8 +10,8 @@ import { getFormattedPreviewCode } from 'utils/notebook-preview-utils';
 const title = 'Export Dataset';
 
 export default class ExportToNotebookModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/genomic-extract-confirmation-modal.ts
+++ b/e2e/app/modal/genomic-extract-confirmation-modal.ts
@@ -7,8 +7,8 @@ import { LinkText } from 'app/text-labels';
 const modalTitle = 'Would you like to extract genomic variant data as VCF files?';
 
 export default class GenomicsVariantExtractConfirmationModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/institution-not-saved-modal.ts
+++ b/e2e/app/modal/institution-not-saved-modal.ts
@@ -6,8 +6,8 @@ import { waitForText } from 'utils/waits-utils';
 const modalTitle = 'Institution not saved';
 
 export default class InstitutionNotSavedModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/modal.ts
+++ b/e2e/app/modal/modal.ts
@@ -6,7 +6,8 @@ export default class Modal extends BaseModal {
     super(page, xpath, opts);
   }
 
-  isLoaded(): Promise<boolean> {
-    return Promise.resolve(true);
+  async isLoaded(): Promise<boolean> {
+    await this.page.waitForXPath(this.getXpath(), { visible: true });
+    return true;
   }
 }

--- a/e2e/app/modal/modal.ts
+++ b/e2e/app/modal/modal.ts
@@ -2,8 +2,8 @@ import { Page } from 'puppeteer';
 import BaseModal from './base-modal';
 
 export default class Modal extends BaseModal {
-  constructor(page: Page, xpath?: string, opts?: { modalIndex: 1 }) {
-    super(page, xpath, opts);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/new-notebook-modal.ts
+++ b/e2e/app/modal/new-notebook-modal.ts
@@ -11,8 +11,8 @@ import Modal from './modal';
 const modalTitle = 'New Notebook';
 
 export default class NewNotebookModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/new-workspace-modal.ts
+++ b/e2e/app/modal/new-workspace-modal.ts
@@ -5,8 +5,8 @@ import Modal from './modal';
 const modalTitle = '(Create|Update|Duplicate) Workspace'; // regex expression
 
 export default class NewWorkspaceModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/old-cdr-version-modal.ts
+++ b/e2e/app/modal/old-cdr-version-modal.ts
@@ -29,8 +29,8 @@ const FIELD = {
 };
 
 export default class OldCdrVersionModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/profile-confirmation-modal.ts
+++ b/e2e/app/modal/profile-confirmation-modal.ts
@@ -7,8 +7,8 @@ import { LinkText } from 'app/text-labels';
 const modalTitle = 'You have confirmed your profile is accurate';
 
 export default class ProfileConfirmationModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/replace-file-modal.ts
+++ b/e2e/app/modal/replace-file-modal.ts
@@ -10,8 +10,8 @@ export enum Xpath {
 }
 
 export default class ReplaceFileModal extends Modal {
-  constructor(page: Page, xpath = Xpath.modal) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async clickCancelButton(): Promise<void> {

--- a/e2e/app/modal/share-modal.ts
+++ b/e2e/app/modal/share-modal.ts
@@ -11,8 +11,8 @@ import { logger } from 'libs/logger';
 const modalText = 'share this workspace';
 
 export default class ShareModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/warning-discard-changes-modal.ts
+++ b/e2e/app/modal/warning-discard-changes-modal.ts
@@ -6,8 +6,8 @@ import { LinkText } from 'app/text-labels';
 const title = 'Warning|WARNING';
 
 export default class WarningDiscardChangesModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/modal/workspace-review-research-purpose-modal.ts
+++ b/e2e/app/modal/workspace-review-research-purpose-modal.ts
@@ -6,8 +6,8 @@ import { LinkText } from 'app/text-labels';
 const modalTitle = 'Please review Research Purpose for Workspace';
 
 export default class WorkspaceReviewResearchPurposeModal extends Modal {
-  constructor(page: Page, xpath?: string) {
-    super(page, xpath);
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
   }
 
   async isLoaded(): Promise<boolean> {

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -282,13 +282,12 @@ export default class WorkspaceEditPage extends WorkspaceBase {
   }
 
   async isLoaded(): Promise<boolean> {
-    await Promise.all([waitForDocumentTitle(this.page, PageTitle), waitWhileLoading(this.page)]);
-    const selectXpath = buildXPath(FIELD.billingAccountSelect.textOption);
-    const select = new Select(this.page, selectXpath);
+    await waitForDocumentTitle(this.page, PageTitle);
     // Wait for Workspace name text-field, Billing Account Select.
+    const select = new Select(this.page, buildXPath(FIELD.billingAccountSelect.textOption));
     await Promise.all([this.getWorkspaceNameTextbox().waitForXPath(), select.waitForXPath()]);
-    // Build Workspace page is used for Duplicate and Create. Wait for Create or Duplicate button.
-    await this.getCancelButton().waitForXPath();
+    await this.getCancelButton().waitUntilEnabled();
+    await waitWhileLoading(this.page);
     return true;
   }
 
@@ -465,7 +464,7 @@ export default class WorkspaceEditPage extends WorkspaceBase {
    * @param selected: True means select "Yes, Request Review" radiobutton. False means select "No, Request Review" radiobutton.
    */
   async requestForReviewRadiobutton(selected: boolean): Promise<void> {
-    let radioComponent;
+    let radioComponent: WebComponent;
     if (selected) {
       radioComponent = new WebComponent(this.page, FIELD.REQUEST_FOR_REVIEW.yesRequestReviewRadiobutton.textOption);
     } else {


### PR DESCRIPTION
Fix flakiness seen in two tests failed [here](https://app.circleci.com/pipelines/github/all-of-us/workbench/17144/workflows/9d4fd2a4-89ec-47bd-a878-d6cadaf146cf/jobs/190965/tests).

- `cdr-version-upgrade.spec.ts`: Click the `CANCEL` button in Workspace Edit page fails to work intermittently due to the button is not ready when clicking (not enabled). Caused by intermittent slow network that slows down page loading.
- `workspace-create.spec.ts`: Create workspace failed after click CONFIRM button in modal but test did not fail immediately. Fix modal xpath so test will fail immediately next time if an error modal appears on top of Create Workspace modal.