### PR TITLE
[no ticket][risk=no] removing repo url https://plugins.gradle.org/m2/

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -24,7 +24,6 @@ buildscript {
     project.ext['hibernate.version'] = '5.4.31.Final'
 
     repositories {
-        // Bintray's repository - a fast Maven Central mirror & more
         mavenCentral()
     }
 }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -26,9 +26,6 @@ buildscript {
     repositories {
         // Bintray's repository - a fast Maven Central mirror & more
         mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
     }
 }
 

--- a/api/settings.gradle
+++ b/api/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        gradlePluginPortal()
         mavenCentral()
         // add mavenLocal() if you are using a locally built version of the plugin
     }

--- a/api/settings.gradle
+++ b/api/settings.gradle
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+        gradlePluginPortal()
         mavenCentral()
         // add mavenLocal() if you are using a locally built version of the plugin
     }


### PR DESCRIPTION
According to [Gradle Blog](https://blog.gradle.org/jcenter-shutdown#troubleshooting)

The Gradle Plugin Portal implicitly mirrors JCenter currently. If you’re using the Plugin Portal (via gradlePluginPortal() or the URL plugins.gradle.org/m2) to resolve your application’s dependencies, you may be relying on JCenter. You should avoid using the Plugin Portal as a repository, except for Gradle plugin projects.