### PR TITLE
[RW-7151][risk=no] Add Spark console links to runtime panel

### DIFF
--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -912,11 +912,6 @@ export const HelpSidebar = fp.flow(
                 >
                   Cloud analysis environment
                 </h3>
-                <div style={{ padding: '0.5rem 1rem' }}>
-                  Your analysis environment consists of an application and
-                  compute resources. Your cloud environment is unique to this
-                  workspace and not shared with other users.
-                </div>
               </div>
             ),
             bodyWidthRem: '30',

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -355,8 +355,7 @@ export const LeonardoAppLauncher = fp.flow(
   withCurrentWorkspace(),
   withRuntimeStore(),
   withNavigation,
-  withRouter,
-  withParamsKey('sparkConsolePath')
+  withRouter
 )(
   class extends React.Component<Props, State> {
     private redirectTimer: NodeJS.Timeout;

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -4,7 +4,7 @@ import Iframe from 'react-iframe';
 
 import { NavigationProps } from 'app/utils/navigation';
 import { fetchAbortableRetry } from 'app/utils/retry';
-import { MatchParams, RuntimeStore } from 'app/utils/stores';
+import { MatchParams, RuntimeStore, withParamsKey } from 'app/utils/stores';
 
 import { Button } from 'app/components/buttons';
 import { FlexRow } from 'app/components/flex';
@@ -355,7 +355,8 @@ export const LeonardoAppLauncher = fp.flow(
   withCurrentWorkspace(),
   withRuntimeStore(),
   withNavigation,
-  withRouter
+  withRouter,
+  withParamsKey('sparkConsolePath')
 )(
   class extends React.Component<Props, State> {
     private redirectTimer: NodeJS.Timeout;

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -29,7 +29,10 @@ import {
 } from 'generated/fetch';
 import { RuntimeApi } from 'generated/fetch/api';
 import defaultServerConfig from 'testing/default-server-config';
-import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
+import {
+  mountWithRouter,
+  waitOneTickAndUpdate,
+} from 'testing/react-test-helpers';
 import {
   cdrVersionTiersResponse,
   CdrVersionsStubVariables,
@@ -63,7 +66,7 @@ describe('RuntimePanel', () => {
 
   const component = async (propOverrides?: object) => {
     const allProps = { ...props, ...propOverrides };
-    const c = mount(<RuntimePanelWrapper {...allProps} />);
+    const c = mountWithRouter(<RuntimePanelWrapper {...allProps} />);
     await waitOneTickAndUpdate(c);
     return c;
   };

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -187,14 +187,28 @@ export const WorkspaceRoutes = () => {
           routeData={{
             breadcrumb: BreadcrumbType.Workspace,
             pageKey: LEONARDO_APP_PAGE_KEY,
-            // The iframe we use to display the Jupyter notebook does something strange
-            // to the height calculation of the container, which is normally set to auto.
-            // Setting this flag sets the container to 100% so that no content is clipped.
             contentFullHeightOverride: true,
-            workspaceNavBarTab: 'terminals',
+            workspaceNavBarTab: 'notebooks',
             minimizeChrome: true,
           }}
           leoAppType={LeoApplicationType.Terminal}
+        />
+      </AppRoute>
+      <AppRoute
+        exact
+        path={`${path}/spark/:sparkConsolePath`}
+        guards={[adminLockedGuard(ns, wsid)]}
+      >
+        <LeonardoAppRedirectPage
+          key='spark'
+          routeData={{
+            breadcrumb: BreadcrumbType.Workspace,
+            pageKey: LEONARDO_APP_PAGE_KEY,
+            contentFullHeightOverride: true,
+            workspaceNavBarTab: 'notebooks',
+            minimizeChrome: true,
+          }}
+          leoAppType={LeoApplicationType.SparkConsole}
         />
       </AppRoute>
       <AppRoute

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -26,7 +26,7 @@ import {
 } from 'app/pages/workspace/workspace-edit';
 import { LeoApplicationType } from 'app/pages/analysis/leonardo-app-launcher';
 import { adminLockedGuard } from 'app/routing/guards';
-import { MatchParams } from 'app/utils/stores';
+import { MatchParams, withParamsKey } from 'app/utils/stores';
 import { BreadcrumbType } from 'app/components/breadcrumb-type';
 
 const CohortPagePage = fp.flow(withRouteData, withRoutingSpinner)(CohortPage);
@@ -199,17 +199,20 @@ export const WorkspaceRoutes = () => {
         path={`${path}/spark/:sparkConsolePath`}
         guards={[adminLockedGuard(ns, wsid)]}
       >
-        <LeonardoAppRedirectPage
-          key='spark'
-          routeData={{
-            breadcrumb: BreadcrumbType.Workspace,
-            pageKey: LEONARDO_APP_PAGE_KEY,
-            contentFullHeightOverride: true,
-            workspaceNavBarTab: 'notebooks',
-            minimizeChrome: true,
-          }}
-          leoAppType={LeoApplicationType.SparkConsole}
-        />
+        {/* Force remounting on parameter change. */}
+        {withParamsKey('sparkConsolePath')(
+          <LeonardoAppRedirectPage
+            key='spark'
+            routeData={{
+              breadcrumb: BreadcrumbType.Workspace,
+              pageKey: LEONARDO_APP_PAGE_KEY,
+              contentFullHeightOverride: true,
+              workspaceNavBarTab: 'notebooks',
+              minimizeChrome: true,
+            }}
+            leoAppType={LeoApplicationType.SparkConsole}
+          />
+        )}
       </AppRoute>
       <AppRoute
         exact

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -71,6 +71,12 @@ const LeonardoAppRedirectPage = fp.flow(
   withRouteData,
   withRoutingSpinner
 )(LeonardoAppLauncher);
+const LeonardoSparkConsoleRedirectPage = fp.flow(
+  withRouteData,
+  withRoutingSpinner,
+  // Force remounting on parameter change.
+  withParamsKey('sparkConsolePath')
+)(LeonardoAppLauncher);
 const ParticipantsTablePage = fp.flow(
   withRouteData,
   withRoutingSpinner
@@ -199,20 +205,16 @@ export const WorkspaceRoutes = () => {
         path={`${path}/spark/:sparkConsolePath`}
         guards={[adminLockedGuard(ns, wsid)]}
       >
-        {/* Force remounting on parameter change. */}
-        {withParamsKey('sparkConsolePath')(
-          <LeonardoAppRedirectPage
-            key='spark'
-            routeData={{
-              breadcrumb: BreadcrumbType.Workspace,
-              pageKey: LEONARDO_APP_PAGE_KEY,
-              contentFullHeightOverride: true,
-              workspaceNavBarTab: 'notebooks',
-              minimizeChrome: true,
-            }}
-            leoAppType={LeoApplicationType.SparkConsole}
-          />
-        )}
+        <LeonardoSparkConsoleRedirectPage
+          routeData={{
+            breadcrumb: BreadcrumbType.Workspace,
+            pageKey: LEONARDO_APP_PAGE_KEY,
+            contentFullHeightOverride: true,
+            workspaceNavBarTab: 'notebooks',
+            minimizeChrome: true,
+          }}
+          leoAppType={LeoApplicationType.SparkConsole}
+        />
       </AppRoute>
       <AppRoute
         exact

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -11,6 +11,7 @@ import {
 import * as React from 'react';
 import { StackdriverErrorReporter } from 'stackdriver-errors-js';
 import { BreadcrumbType } from 'app/components/breadcrumb-type';
+import { useParams } from 'react-router';
 
 const { useEffect, useState } = React;
 
@@ -194,6 +195,24 @@ export interface MatchParams {
   username?: string;
   usernameWithoutGsuiteDomain?: string;
   wsid?: string;
+}
+
+/**
+ * HOC which invalidates a component when the specified params change, by way
+ * of changing the React key value. This can be used to force a remount / render
+ * when a route param changes.
+ */
+export function withParamsKey(...paramNames: (keyof MatchParams)[]) {
+  return (WrappedComponent) =>
+    ({ ...props }) => {
+      const params = useParams<MatchParams>();
+      return (
+        <WrappedComponent
+          key={paramNames.map((k) => params[k] || '').join('/')}
+          {...props}
+        />
+      );
+    };
 }
 
 /**

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -190,6 +190,7 @@ export interface MatchParams {
   nbName?: string;
   ns?: string;
   pid?: string;
+  sparkConsolePath?: string;
   username?: string;
   usernameWithoutGsuiteDomain?: string;
   wsid?: string;


### PR DESCRIPTION
* Generalize the LeonardoAppRedirect component to support Spark console pages
* Add a pattern for forcing remount of a component based on parameter change; otherwise navigation from spark console -> spark console via the panel fails. `withParamsKey()`

Sample usage:

https://user-images.githubusercontent.com/822298/149268710-6da9e483-947a-495d-875c-f0ac9e3b2c2b.mp4


