### PR TITLE
[RW-7701][risk=no] e2e test failure workaround: Provide alternative xpath to find domain cards

### DIFF
--- a/e2e/app/component/concept-domain-card.ts
+++ b/e2e/app/component/concept-domain-card.ts
@@ -18,8 +18,7 @@ const domainCardSelector = {
 
 export default class ConceptDomainCard extends Container {
   static findDomainCard(page: Page, domain: Domain): ConceptDomainCard {
-    const selector =
-      `${domainCardSelector.cardXpath}` + `[child::*[@tabindex="0" and @role="button" and text()="${domain}"]]`;
+    const selector = `${domainCardSelector.cardXpath}[.//*[@role="button" and text()="${domain}"]]`;
     return new ConceptDomainCard(page, selector);
   }
 
@@ -40,7 +39,7 @@ export default class ConceptDomainCard extends Container {
    * Find displayed number of Participants in this domain.
    */
   async getParticipantsCount(): Promise<string> {
-    const selector = `${this.getXpath()}//*[contains(normalize-space(text()), "participants in domain")]`;
+    const selector = `${this.getXpath()}//*[contains(normalize-space(), "participants in domain")]/div`;
     const num = await this.extractConceptsCount(selector);
     console.log(`Participants in this domain: ${num}`);
     return num;
@@ -50,14 +49,15 @@ export default class ConceptDomainCard extends Container {
    * Find displayed number of Concepts in this domain.
    */
   async getConceptsCount(): Promise<string> {
-    const selector = `${this.getXpath()}//*[contains(normalize-space(text()), "concepts in this domain")]`;
+    const selector = `${this.getXpath()}//*[contains(normalize-space(), "concepts in this domain")]/span`;
     const num = await this.extractConceptsCount(selector);
     console.log(`Concepts in this domain: ${num}`);
     return num;
   }
 
   private async extractConceptsCount(selector: string): Promise<string> {
-    const elemt = await this.page.waitForXPath(selector, { visible: true });
+    await this.page.waitForXPath(this.getXpath(), { visible: true });
+    const elemt = await this.page.waitForXPath(selector);
     const textContent = await getPropValue<string>(elemt, 'textContent');
     const regex = new RegExp(/\d{1,3}(,?\d{3})*/); // Match numbers with comma
     return regex.exec(textContent)[0];

--- a/e2e/app/page/conceptset-search-page.ts
+++ b/e2e/app/page/conceptset-search-page.ts
@@ -17,9 +17,10 @@ export default class ConceptSetSearchPage extends AuthenticatedPage {
   }
 
   async isLoaded(): Promise<boolean> {
-    await Promise.all([waitForDocumentTitle(this.page, PageTitle), waitWhileLoading(this.page)]);
+    await waitForDocumentTitle(this.page, PageTitle);
     const searchTextbox = this.getSearchTextbox();
     await searchTextbox.waitForXPath();
+    await waitWhileLoading(this.page);
     return true;
   }
 


### PR DESCRIPTION
CircleCI example [job](https://app.circleci.com/pipelines/github/all-of-us/workbench/17275/workflows/849e1389-6821-40e0-b4bf-091be013d60d/jobs/192080).

e2e test `conceptset-create.spec` is failing due to [pull/6107](https://github.com/all-of-us/workbench/pull/6107)

Slack discussion [here](https://pmi-engteam.slack.com/archives/C7JUTPQLE/p1642106532043400?thread_ts=1642090598.039300&cid=C7JUTPQLE).