### PR TITLE
[no ticket][risk=no] e2e test: Fix modal getText xpath

### DIFF
--- a/e2e/app/modal/base-modal.ts
+++ b/e2e/app/modal/base-modal.ts
@@ -33,7 +33,7 @@ export default abstract class BaseModal extends Container {
 
   async getTextContent(): Promise<string[]> {
     // xpath that excludes button labels and spans
-    const selector = `${this.getXpath()}//div[normalize-space(text()) and not(@role="button")]`;
+    const selector = `${this.getXpath()}//div[normalize-space() and not(@role="button")]`;
     await this.page.waitForXPath(selector, { visible: true });
     const elements: ElementHandle[] = await this.page.$x(selector);
     return fp.flow(


### PR DESCRIPTION
e2e nightly test `owner-copy-to-workspace.spec` is failing caused by [pull/6107](https://github.com/all-of-us/workbench/pull/6107).

<img width="573" alt="Screen Shot 2022-01-14 at 10 49 15 AM" src="https://user-images.githubusercontent.com/35533885/149544312-42a7593e-5a50-41aa-90d8-433194024531.png">

