### PR TITLE
[RW-5492][risk=no] rm deprecated billing migration status enum

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -27,7 +27,6 @@ import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserRecentWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspace;
-import org.pmiops.workbench.db.model.DbWorkspace.BillingMigrationStatus;
 import org.pmiops.workbench.db.model.DbWorkspace.FirecloudWorkspaceId;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
@@ -215,7 +214,6 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     dbWorkspace.setLastModifiedTime(now);
     dbWorkspace.setVersion(1);
     dbWorkspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    dbWorkspace.setBillingMigrationStatusEnum(BillingMigrationStatus.NEW);
     dbWorkspace.setCdrVersion(cdrVersion);
     dbWorkspace.setGoogleProject(fcWorkspace.getGoogleProject());
 

--- a/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
@@ -28,7 +28,6 @@ import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.dao.WorkspaceFreeTierUsageDao;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
-import org.pmiops.workbench.db.model.DbWorkspace.BillingMigrationStatus;
 import org.pmiops.workbench.db.model.DbWorkspaceFreeTierUsage;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.BillingStatus;
@@ -238,8 +237,7 @@ public class FreeTierBillingService {
   private Map<DbWorkspace, Double> getFreeTierWorkspaceCostsFromBQ() {
 
     final Map<String, DbWorkspace> workspacesIndexedByGoogleProject =
-        // don't record cost for OLD or MIGRATED workspaces - only NEW
-        workspaceDao.findAllByBillingMigrationStatus(BillingMigrationStatus.NEW).stream()
+        workspaceDao.findAllWithBillingMigrationNewStatus().stream()
             .collect(Collectors.toMap(DbWorkspace::getGoogleProject, Function.identity()));
 
     final QueryJobConfiguration queryConfig =

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -9,7 +9,6 @@ import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
-import org.pmiops.workbench.db.model.DbWorkspace.BillingMigrationStatus;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
@@ -113,8 +112,8 @@ public interface WorkspaceDao extends CrudRepository<DbWorkspace, Long>, Workspa
 
   List<DbWorkspace> findAllByNeedsResearchPurposeReviewPrompt(short researchPurposeReviewed);
 
-  default List<DbWorkspace> findAllByBillingMigrationStatus(BillingMigrationStatus status) {
-    return findAllByBillingMigrationStatus(DbStorageEnums.billingMigrationStatusToStorage(status));
+  default List<DbWorkspace> findAllWithBillingMigrationNewStatus() {
+    return findAllByBillingMigrationStatus(DbWorkspace.BILLING_MIGRATION_NEW_STATUS);
   }
 
   default void updateBillingStatus(long workspaceId, BillingStatus status) {

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -2,7 +2,6 @@ package org.pmiops.workbench.db.model;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
-import org.pmiops.workbench.db.model.DbWorkspace.BillingMigrationStatus;
 import org.pmiops.workbench.model.AnnotationType;
 import org.pmiops.workbench.model.ArchivalStatus;
 import org.pmiops.workbench.model.Authority;
@@ -102,23 +101,6 @@ public final class DbStorageEnums {
 
   public static Short authorityToStorage(Authority authority) {
     return CLIENT_TO_STORAGE_AUTHORITY.get(authority);
-  }
-
-  // BillingMigrationStatus
-  private static final BiMap<BillingMigrationStatus, Short>
-      CLIENT_TO_STORAGE_BILLING_MIGRATION_STATUS =
-          ImmutableBiMap.<BillingMigrationStatus, Short>builder()
-              .put(BillingMigrationStatus.OLD, (short) 0)
-              .put(BillingMigrationStatus.NEW, (short) 1)
-              .put(BillingMigrationStatus.MIGRATED, (short) 2)
-              .build();
-
-  public static BillingMigrationStatus billingMigrationStatusFromStorage(Short s) {
-    return CLIENT_TO_STORAGE_BILLING_MIGRATION_STATUS.inverse().get(s);
-  }
-
-  public static Short billingMigrationStatusToStorage(BillingMigrationStatus s) {
-    return CLIENT_TO_STORAGE_BILLING_MIGRATION_STATUS.get(s);
   }
 
   // BillingStatus

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
@@ -36,6 +36,7 @@ public class DbWorkspace {
    */
   public static final short BILLING_MIGRATION_NEW_STATUS = 2;
 
+  private short billingMigrationStatus = BILLING_MIGRATION_NEW_STATUS;
   private String firecloudUuid;
 
   public static class FirecloudWorkspaceId {
@@ -386,10 +387,12 @@ public class DbWorkspace {
 
   @Column(name = "billing_migration_status")
   private short getBillingMigrationStatus() {
-    return BILLING_MIGRATION_NEW_STATUS;
+    return billingMigrationStatus;
   }
 
-  private void setBillingMigrationStatus(Short status) {}
+  private void setBillingMigrationStatus(Short status) {
+    this.billingMigrationStatus = status;
+  }
 
   @Column(name = "google_project")
   public String getGoogleProject() {

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
@@ -30,6 +30,12 @@ import org.pmiops.workbench.model.WorkspaceActiveStatus;
 @Entity
 @Table(name = "workspace")
 public class DbWorkspace {
+  /**
+   * Deprecated database migration field. The column is preserved for historical reference, but
+   * forced to 2 (NEW) for all workspaces going forward.
+   */
+  public static final short BILLING_MIGRATION_NEW_STATUS = 2;
+
   private String firecloudUuid;
 
   public static class FirecloudWorkspaceId {
@@ -86,8 +92,6 @@ public class DbWorkspace {
   private Set<DbConceptSet> conceptSets = new HashSet<>();
   private Set<DbDataset> dataSets = new HashSet<>();
   private Short activeStatus;
-  private Short billingMigrationStatus =
-      DbStorageEnums.billingMigrationStatusToStorage(BillingMigrationStatus.OLD);
   private boolean published;
 
   private boolean diseaseFocusedResearch;
@@ -380,6 +384,13 @@ public class DbWorkspace {
     return this;
   }
 
+  @Column(name = "billing_migration_status")
+  private short getBillingMigrationStatus() {
+    return BILLING_MIGRATION_NEW_STATUS;
+  }
+
+  private void setBillingMigrationStatus(Short status) {}
+
   @Column(name = "google_project")
   public String getGoogleProject() {
     return googleProject;
@@ -669,25 +680,6 @@ public class DbWorkspace {
   @Transient
   public boolean isActive() {
     return WorkspaceActiveStatus.ACTIVE.equals(getWorkspaceActiveStatusEnum());
-  }
-
-  @Transient
-  public BillingMigrationStatus getBillingMigrationStatusEnum() {
-    return DbStorageEnums.billingMigrationStatusFromStorage(billingMigrationStatus);
-  }
-
-  public DbWorkspace setBillingMigrationStatusEnum(BillingMigrationStatus status) {
-    return setBillingMigrationStatus(DbStorageEnums.billingMigrationStatusToStorage(status));
-  }
-
-  @Column(name = "billing_migration_status")
-  private short getBillingMigrationStatus() {
-    return this.billingMigrationStatus;
-  }
-
-  private DbWorkspace setBillingMigrationStatus(short s) {
-    this.billingMigrationStatus = s;
-    return this;
   }
 
   @Column(name = "billing_status")

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -17,7 +17,6 @@ import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
-import org.pmiops.workbench.db.model.DbWorkspace.BillingMigrationStatus;
 import org.pmiops.workbench.exceptions.ExceptionUtils;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
@@ -215,12 +214,9 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
       customEnvironmentVariables.put(BIGQUERY_STORAGE_API_ENABLED_ENV_KEY, "true");
     }
 
-    // i.e. is NEW or MIGRATED
-    if (!workspace.getBillingMigrationStatusEnum().equals(BillingMigrationStatus.OLD)) {
-      customEnvironmentVariables.put(
-          WORKSPACE_CDR_ENV_KEY,
-          cdrVersion.getBigqueryProject() + "." + cdrVersion.getBigqueryDataset());
-    }
+    customEnvironmentVariables.put(
+        WORKSPACE_CDR_ENV_KEY,
+        cdrVersion.getBigqueryProject() + "." + cdrVersion.getBigqueryDataset());
 
     if (cdrVersion.getAllSamplesWgsDataBucket() != null) {
       customEnvironmentVariables.put(

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -65,7 +65,8 @@ public interface WorkspaceMapper {
     return toApiWorkspaceResponse(
         toApiWorkspace(dbWorkspace, firecloudWorkspaceResponse.getWorkspace()),
         firecloudWorkspaceResponse.getAccessLevel());
-  };
+  }
+  ;
 
   @Mapping(target = "timeReviewed", ignore = true)
   @Mapping(target = "populationDetails", source = "specificPopulationsEnum")
@@ -105,7 +106,6 @@ public interface WorkspaceMapper {
   @Mapping(target = "adminLockedReason", ignore = true)
   @Mapping(target = "approved", ignore = true)
   @Mapping(target = "billingAccountName", ignore = true)
-  @Mapping(target = "billingMigrationStatusEnum", ignore = true)
   @Mapping(target = "billingStatus", ignore = true)
   @Mapping(target = "cdrVersion", ignore = true)
   @Mapping(target = "cohorts", ignore = true)

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -65,8 +65,7 @@ public interface WorkspaceMapper {
     return toApiWorkspaceResponse(
         toApiWorkspace(dbWorkspace, firecloudWorkspaceResponse.getWorkspace()),
         firecloudWorkspaceResponse.getAccessLevel());
-  }
-  ;
+  };
 
   @Mapping(target = "timeReviewed", ignore = true)
   @Mapping(target = "populationDetails", source = "specificPopulationsEnum")

--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -43,7 +43,6 @@ import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
-import org.pmiops.workbench.db.model.DbWorkspace.BillingMigrationStatus;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.ForbiddenException;
@@ -743,7 +742,6 @@ public class NotebooksControllerTest {
         .setFirecloudName("fc-name")
         .setWorkspaceNamespace("namespace")
         .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE)
-        .setBillingMigrationStatusEnum(BillingMigrationStatus.NEW)
         .setCdrVersion(cdrVersion)
         .setGoogleProject("proj");
   }

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -23,7 +23,6 @@ import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
-import org.pmiops.workbench.db.model.DbWorkspace.BillingMigrationStatus;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceDetails;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.model.BillingStatus;
@@ -118,7 +117,6 @@ public class WorkspaceMapperTest {
     sourceDbWorkspace.setConceptSets(Collections.emptySet());
     sourceDbWorkspace.setDataSets(Collections.emptySet());
     sourceDbWorkspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    sourceDbWorkspace.setBillingMigrationStatusEnum(BillingMigrationStatus.MIGRATED);
     sourceDbWorkspace.setPublished(false);
     sourceDbWorkspace.setDiseaseFocusedResearch(true);
     sourceDbWorkspace.setDiseaseOfFocus("leukemia");


### PR DESCRIPTION
Proposing to leave the value population going forward, so that we can use the column for historical reference in the db. Otherwise, there are rows in the DB that simply look like deleted workspaces, and are otherwise indistinguishable. If we ever need some kind of historical batch project cleanup - it would be important to understand what their migration status was.

Also, the free tier billing cron wants to grab undeleted workspaces. We explicitly do not want this to include pre-migration projects, as the google project association will be incorrect.