### PR TITLE
[RW-7694][risk=no] Fix CB total count when previous call not returned

### DIFF
--- a/ui/src/app/cohort-search/cohort-page/cohort-page.component.tsx
+++ b/ui/src/app/cohort-search/cohort-page/cohort-page.component.tsx
@@ -243,10 +243,7 @@ export const CohortPage = fp.flow(
     }
 
     updateRequest = () => {
-      // timeout prevents Angular 'Expression changed after checked' error
-      setTimeout(() =>
-        this.setState({ updateCount: this.state.updateCount + 1 })
-      );
+      this.setState({ updateCount: this.state.updateCount + 1 });
     };
 
     setSearchContext(context: any) {

--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -196,7 +196,7 @@ export const ListOverview = fp.flow(
       if (!this.definitionErrors) {
         this.getTotalCount();
         // Prevents multiple count calls on initial cohort load
-        setTimeout(() => this.setState({ initializing: false}), 100);
+        setTimeout(() => this.setState({ initializing: false }), 100);
       }
     }
 

--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -195,6 +195,8 @@ export const ListOverview = fp.flow(
     componentDidMount(): void {
       if (!this.definitionErrors) {
         this.getTotalCount();
+        // Prevents multiple count calls on initial cohort load
+        setTimeout(() => this.setState({ initializing: false}), 100);
       }
     }
 
@@ -225,7 +227,6 @@ export const ListOverview = fp.flow(
           .then((response) => {
             this.setState({
               chartData: response.items,
-              initializing: false,
               loading: false,
               total: response.items.reduce((sum, data) => sum + data.count, 0),
             });
@@ -237,7 +238,7 @@ export const ListOverview = fp.flow(
             }
           });
       } else {
-        this.setState({ chartData: [], total: 0, initializing: false });
+        this.setState({ chartData: [], total: 0 });
       }
     }
 


### PR DESCRIPTION
Fixes issue if the total count call for the first item added to a cohort has not returned before the second item is added, the second item won't be reflected in the total count.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
