### PR TITLE
[RW-7659][risk=no] Fix hidden content in participant detail table

### DIFF
--- a/ui/src/app/pages/data/cohort-review/detail-tab-table.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-tab-table.component.tsx
@@ -669,6 +669,16 @@ export const DetailTabTable = fp.flow(
       }
     }
 
+    // Scrolls to the bottom of the table content if an overlay or chart is expanded on the last row
+    scrollToBottom(rowIndex, numberOfRows) {
+      if (rowIndex === numberOfRows - 1) {
+        const tableBody = document.getElementsByClassName(
+          'p-datatable-scrollable-body'
+        );
+        tableBody[0].scrollTop = tableBody[0].scrollHeight;
+      }
+    }
+
     overlayTemplate = (rowData: any, column: any) => {
       let vl: any;
       const {
@@ -688,7 +698,10 @@ export const DetailTabTable = fp.flow(
               <i
                 className='pi pi-caret-down'
                 style={styles.caretIcon}
-                onClick={(e) => vl.toggle(e)}
+                onClick={(e) => {
+                  vl.toggle(e);
+                  this.scrollToBottom(column.rowIndex, column.value.length);
+                }}
               />
             )}
             <OverlayPanel
@@ -1236,7 +1249,12 @@ export const DetailTabTable = fp.flow(
           <style>{datatableStyles}</style>
           <DataTable
             expandedRows={expandedRows}
-            onRowToggle={(e) => this.setState({ expandedRows: e.data })}
+            onRowToggle={({ data }) => this.setState({ expandedRows: data })}
+            onRowExpand={({ data }) =>
+              setTimeout(() =>
+                this.scrollToBottom(value.indexOf(data), value.length)
+              )
+            }
             rowExpansionTemplate={this.rowExpansionTemplate}
             rowClassName={this.hideGraphIcon}
             style={styles.table}


### PR DESCRIPTION
Fixes issue where expanding content is hidden on the last row of the participant detail table in cohort review. Now it will automatically scroll to show the hidden content.

Before:

https://user-images.githubusercontent.com/40036095/150019809-f65a40f0-532c-48ad-af29-4ba53567a3f9.mov

After:

https://user-images.githubusercontent.com/40036095/150019846-11d1946b-5666-4b22-97d8-0bdfa2031b76.mov

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
