### PR TITLE
[RW-7715][risk=no]Add module completion/expiration status to table

### DIFF
--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -37,7 +37,7 @@ import {
   getAccessModuleStatusByName,
 } from 'app/utils/access-utils';
 import { hasRegisteredTierAccess } from 'app/utils/access-tiers';
-import { formatDates } from 'app/utils/dates';
+import { formatDate } from 'app/utils/dates';
 
 export const commonStyles = reactStyles({
   semiBold: {
@@ -156,20 +156,20 @@ export const isBypassed = (
 ): boolean =>
   !!getAccessModuleStatusByName(profile, moduleName)?.bypassEpochMillis;
 
-export const displayModuleCompletionTime = (
+export const displayModuleCompletionDate = (
   profile: Profile,
   moduleName: AccessModule
 ): string =>
-  formatDates(
+  formatDate(
     getAccessModuleStatusByName(profile, moduleName)?.completionEpochMillis,
     '-'
   );
 
-export const displayModuleExpirationTime = (
+export const displayModuleExpirationDate = (
   profile: Profile,
   moduleName: AccessModule
 ): string =>
-  formatDates(
+  formatDate(
     getAccessModuleStatusByName(profile, moduleName)?.expirationEpochMillis,
     '-'
   );

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -37,6 +37,7 @@ import {
   getAccessModuleStatusByName,
 } from 'app/utils/access-utils';
 import { hasRegisteredTierAccess } from 'app/utils/access-tiers';
+import { formatDates } from 'app/utils/dates';
 
 export const commonStyles = reactStyles({
   semiBold: {
@@ -154,6 +155,24 @@ export const isBypassed = (
   moduleName: AccessModule
 ): boolean =>
   !!getAccessModuleStatusByName(profile, moduleName)?.bypassEpochMillis;
+
+export const moduleCompletionTime = (
+  profile: Profile,
+  moduleName: AccessModule
+): string =>
+  formatDates(
+    getAccessModuleStatusByName(profile, moduleName)?.completionEpochMillis,
+    '-'
+  );
+
+export const moduleExpirationTime = (
+  profile: Profile,
+  moduleName: AccessModule
+): string =>
+  formatDates(
+    getAccessModuleStatusByName(profile, moduleName)?.expirationEpochMillis,
+    '-'
+  );
 
 // would this AccessBypassRequest actually change the profile state?
 // allows un-toggling of bypass for a module

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -156,7 +156,7 @@ export const isBypassed = (
 ): boolean =>
   !!getAccessModuleStatusByName(profile, moduleName)?.bypassEpochMillis;
 
-export const moduleCompletionTime = (
+export const displayModuleCompletionTime = (
   profile: Profile,
   moduleName: AccessModule
 ): string =>
@@ -165,7 +165,7 @@ export const moduleCompletionTime = (
     '-'
   );
 
-export const moduleExpirationTime = (
+export const displayModuleExpirationTime = (
   profile: Profile,
   moduleName: AccessModule
 ): string =>

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -21,6 +21,8 @@ import {
   AccessModuleExpirations,
   isBypassed,
   profileNeedsUpdate,
+  moduleCompletionTime,
+  moduleExpirationTime,
 } from './admin-user-common';
 import { FadeBox } from 'app/components/containers';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
@@ -282,6 +284,8 @@ const ToggleForModule = (props: ToggleProps) => {
 
 interface TableRow {
   moduleName: string;
+  completionTime: string;
+  expirationTime: string;
   bypassToggle: JSX.Element;
 }
 
@@ -292,6 +296,8 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
 
     return {
       moduleName: adminPageTitle,
+      completionTime: moduleCompletionTime(props.updatedProfile, moduleName),
+      expirationTime: moduleExpirationTime(props.updatedProfile, moduleName),
       bypassToggle: adminBypassable && (
         <ToggleForModule moduleName={moduleName} {...props} />
       ),
@@ -303,6 +309,8 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
       <div style={styles.tableHeader}>Access status</div>
       <DataTable style={{ paddingTop: '1em' }} value={tableData}>
         <Column field='moduleName' header='Access Module' />
+        <Column field='completionTime' header='Last completed on' />
+        <Column field='expirationTime' header='Expires on' />
         <Column field='bypassToggle' header='Bypass' />
       </DataTable>
     </FlexColumn>

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -21,8 +21,8 @@ import {
   AccessModuleExpirations,
   isBypassed,
   profileNeedsUpdate,
-  moduleCompletionTime,
-  moduleExpirationTime,
+  displayModuleCompletionTime,
+  displayModuleExpirationTime,
 } from './admin-user-common';
 import { FadeBox } from 'app/components/containers';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
@@ -296,8 +296,14 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
 
     return {
       moduleName: adminPageTitle,
-      completionTime: moduleCompletionTime(props.updatedProfile, moduleName),
-      expirationTime: moduleExpirationTime(props.updatedProfile, moduleName),
+      completionTime: displayModuleCompletionTime(
+        props.updatedProfile,
+        moduleName
+      ),
+      expirationTime: displayModuleExpirationTime(
+        props.updatedProfile,
+        moduleName
+      ),
       bypassToggle: adminBypassable && (
         <ToggleForModule moduleName={moduleName} {...props} />
       ),

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -21,8 +21,8 @@ import {
   AccessModuleExpirations,
   isBypassed,
   profileNeedsUpdate,
-  displayModuleCompletionTime,
-  displayModuleExpirationTime,
+  displayModuleCompletionDate,
+  displayModuleExpirationDate,
 } from './admin-user-common';
 import { FadeBox } from 'app/components/containers';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
@@ -284,8 +284,8 @@ const ToggleForModule = (props: ToggleProps) => {
 
 interface TableRow {
   moduleName: string;
-  completionTime: string;
-  expirationTime: string;
+  completionDate: string;
+  expirationDate: string;
   bypassToggle: JSX.Element;
 }
 
@@ -296,11 +296,11 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
 
     return {
       moduleName: adminPageTitle,
-      completionTime: displayModuleCompletionTime(
+      completionDate: displayModuleCompletionDate(
         props.updatedProfile,
         moduleName
       ),
-      expirationTime: displayModuleExpirationTime(
+      expirationDate: displayModuleExpirationDate(
         props.updatedProfile,
         moduleName
       ),
@@ -315,8 +315,8 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
       <div style={styles.tableHeader}>Access status</div>
       <DataTable style={{ paddingTop: '1em' }} value={tableData}>
         <Column field='moduleName' header='Access Module' />
-        <Column field='completionTime' header='Last completed on' />
-        <Column field='expirationTime' header='Expires on' />
+        <Column field='completionDate' header='Last completed on' />
+        <Column field='expirationDate' header='Expires on' />
         <Column field='bypassToggle' header='Bypass' />
       </DataTable>
     </FlexColumn>

--- a/ui/src/app/utils/dates.tsx
+++ b/ui/src/app/utils/dates.tsx
@@ -34,7 +34,7 @@ export function displayDateWithoutHours(time: number): string {
   });
 }
 
-// If the time passed is null, return the nullDateStringRep else format it into dates without hours
+// If the time passed is null, return the nullDateStringRep else format it into date without hours
 export function formatDates(time: number, nullDateStringRep: string): string {
   return displayDateWithoutHours(time) || nullDateStringRep;
 }

--- a/ui/src/app/utils/dates.tsx
+++ b/ui/src/app/utils/dates.tsx
@@ -22,6 +22,9 @@ export function displayDate(time: number): string {
 }
 
 export function displayDateWithoutHours(time: number): string {
+  if (!time) {
+    return null;
+  }
   const date = new Date(time);
   // datetime formatting to slice off weekday and exact time
   return date.toLocaleString('en-us', {
@@ -29,6 +32,11 @@ export function displayDateWithoutHours(time: number): string {
     day: 'numeric',
     year: 'numeric',
   });
+}
+
+// If the time passed is null, return the nullDateStringRep else format it into dates without hours
+export function formatDates(time: number, nullDateStringRep: string): string {
+  return displayDateWithoutHours(time) || nullDateStringRep;
 }
 
 export function isDateValid(date: Date): boolean {

--- a/ui/src/app/utils/dates.tsx
+++ b/ui/src/app/utils/dates.tsx
@@ -35,8 +35,11 @@ export function displayDateWithoutHours(time: number): string {
 }
 
 // If the time passed is null, return the nullDateStringRep else format it into date without hours
-export function formatDates(time: number, nullDateStringRep: string): string {
-  return displayDateWithoutHours(time) || nullDateStringRep;
+export function formatDate(
+  timeInEpochMillis: number | undefined,
+  nullDateStringRep?: string
+): string {
+  return displayDateWithoutHours(timeInEpochMillis) || nullDateStringRep;
 }
 
 export function isDateValid(date: Date): boolean {


### PR DESCRIPTION
Updates the Module table on admin page for the user to include each module's Completion/Expiration time. 
If the Date is null (say if the module has been bypassed) it will show '-' instead

<img width="1652" alt="Screen Shot 2022-01-19 at 11 09 49 AM" src="https://user-images.githubusercontent.com/34481816/150170482-5f5a4cd9-42d5-42bc-b0a4-e161dace0160.png">


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
