### PR TITLE
[RW-7613][risk=no] Include Datasets and Cohort Reviews in "Recently Accessed Items" list - insert data set entries

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -108,7 +108,8 @@
     "enableGpu": true,
     "enablePersistentDisk": true,
     "enablePrivateDataprocWorker": true,
-    "ccSupportWhenAdminLocking": false
+    "ccSupportWhenAdminLocking": false,
+    "enableDSCREntryInRecentModified": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-local",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -108,7 +108,8 @@
     "enableGpu": false,
     "enablePersistentDisk": false,
     "enablePrivateDataprocWorker": true,
-    "ccSupportWhenAdminLocking": false
+    "ccSupportWhenAdminLocking": false,
+    "enableDSCREntryInRecentModified": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-perf",

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -108,7 +108,8 @@
     "enableGpu": false,
     "enablePersistentDisk": false,
     "enablePrivateDataprocWorker": true,
-    "ccSupportWhenAdminLocking": true
+    "ccSupportWhenAdminLocking": true,
+    "enableDSCREntryInRecentModified": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-preprod",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -107,7 +107,8 @@
     "enableGpu": false,
     "enablePersistentDisk": false,
     "enablePrivateDataprocWorker": false,
-    "ccSupportWhenAdminLocking": true
+    "ccSupportWhenAdminLocking": true,
+    "enableDSCREntryInRecentModified": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-prod",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -107,7 +107,8 @@
     "enableGpu": false,
     "enablePersistentDisk": false,
     "enablePrivateDataprocWorker": true,
-    "ccSupportWhenAdminLocking": false
+    "ccSupportWhenAdminLocking": false,
+    "enableDSCREntryInRecentModified": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-stable",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -108,7 +108,8 @@
     "enableGpu": false,
     "enablePersistentDisk": false,
     "enablePrivateDataprocWorker": true,
-    "ccSupportWhenAdminLocking": false
+    "ccSupportWhenAdminLocking": false,
+    "enableDSCREntryInRecentModified": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-staging",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -108,7 +108,8 @@
     "enableGpu": true,
     "enablePersistentDisk": true,
     "enablePrivateDataprocWorker": true,
-    "ccSupportWhenAdminLocking": false
+    "ccSupportWhenAdminLocking": false,
+    "enableDSCREntryInRecentModified": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -46,6 +46,7 @@ import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.dao.ConceptSetDao;
 import org.pmiops.workbench.db.dao.DataSetDao;
+import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.dao.WgsExtractCromwellSubmissionDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
@@ -117,6 +118,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
   @Autowired private Provider<DbUser> userProvider;
   @Autowired private TestWorkbenchConfig testWorkbenchConfig;
   @Autowired private Provider<WorkbenchConfig> workbenchConfigProvider;
+  @Autowired private UserRecentResourceService userRecentResourceService;
   @Autowired private WgsExtractCromwellSubmissionDao submissionDao;
   @Autowired private WorkspaceDao workspaceDao;
   @Autowired private WorkspaceAuthService workspaceAuthService;
@@ -171,7 +173,8 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
     WorkspaceMapperImpl.class,
     AccessTierService.class,
     CdrVersionService.class,
-    GenomicExtractionService.class
+    GenomicExtractionService.class,
+    UserRecentResourceService.class
   })
   static class Configuration {
     @Bean
@@ -227,6 +230,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
             dataSetMapper,
             submissionDao,
             prefixProvider,
+            userRecentResourceService,
             workbenchConfigProvider,
             CLOCK);
     controller =

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -269,6 +269,8 @@ public class WorkbenchConfig {
     public boolean enablePrivateDataprocWorker;
     // If true, copy the support staff when sending Admin Locking emails.
     public boolean ccSupportWhenAdminLocking;
+    // If true, insert entries for DataSet and Cohort Review in user_recent_modified_resource table
+    public boolean enableDSCREntryInRecentModified;
   }
 
   public static class ActionAuditConfig {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -270,6 +270,11 @@ public class WorkbenchConfig {
     // If true, copy the support staff when sending Admin Locking emails.
     public boolean ccSupportWhenAdminLocking;
     // If true, insert entries for DataSet and Cohort Review in user_recent_modified_resource table
+    // We are using the feature flag because displaying dataSet as recent resource is done as part
+    // of multiple PR
+    // and we want to ensure that when it is ready the new table user_recently_modified table is
+    // still same as
+    // previously used table user_Recent_resource
     public boolean enableDSCREntryInRecentModified;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -271,10 +271,8 @@ public class WorkbenchConfig {
     public boolean ccSupportWhenAdminLocking;
     // If true, insert entries for DataSet and Cohort Review in user_recent_modified_resource table
     // We are using the feature flag because displaying dataSet as recent resource is done as part
-    // of multiple PR
-    // and we want to ensure that when it is ready the new table user_recently_modified table is
-    // still same as
-    // previously used table user_Recent_resource
+    // of multiple PR and we want to ensure that when then functionality is ready, the new table
+    // user_recently_modified table is still same as previously used table user_Recent_resource
     public boolean enableDSCREntryInRecentModified;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -273,12 +273,10 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
   @Override
   public DataSet saveDataSet(DbDataset dataset) {
     try {
-      DbDataset savedDbDataSet = dataSetDao.save(dataset);
+      dataset = dataSetDao.save(dataset);
       userRecentResourceService.updateDataSetEntry(
-          savedDbDataSet.getWorkspaceId(),
-          savedDbDataSet.getCreatorId(),
-          savedDbDataSet.getDataSetId());
-      return dataSetMapper.dbModelToClient(savedDbDataSet);
+          dataset.getWorkspaceId(), dataset.getCreatorId(), dataset.getDataSetId());
+      return dataSetMapper.dbModelToClient(dataset);
     } catch (OptimisticLockException e) {
       throw new ConflictException("Failed due to concurrent concept set modification");
     } catch (DataIntegrityViolationException ex) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceService.java
@@ -1,9 +1,8 @@
 package org.pmiops.workbench.db.dao;
 
+import java.util.List;
 import org.pmiops.workbench.db.model.DbUserRecentResource;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 public interface UserRecentResourceService {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceService.java
@@ -1,8 +1,9 @@
 package org.pmiops.workbench.db.dao;
 
-import java.util.List;
 import org.pmiops.workbench.db.model.DbUserRecentResource;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public interface UserRecentResourceService {
@@ -16,11 +17,19 @@ public interface UserRecentResourceService {
 
   void updateConceptSetEntry(long workspaceId, long userId, long conceptSetId);
 
+  void updateDataSetEntry(long workspaceId, long userId, long dataSetId);
+
+  void updateCohortReviewEntry(long workspaceId, long userId, long cohortReviewId);
+
   void deleteNotebookEntry(long workspaceId, long userId, String notebookName);
 
   void deleteCohortEntry(long workspaceId, long userId, long cohortId);
 
   void deleteConceptSetEntry(long workspaceId, long userId, long conceptSetId);
+
+  void deleteDataSetEntry(long workspaceId, long userId, long dataSetId);
+
+  void deleteCohortReviewEntry(long workspaceId, long userId, long cohortReviewId);
 
   List<DbUserRecentResource> findAllResourcesByUser(long userId);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceServiceImpl.java
@@ -111,10 +111,6 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
 
   @Override
   public void updateDataSetEntry(long workspaceId, long userId, long dataSetId) {
-    // Save entry for data set in the new user_recently_modified table only when the feature flag is
-    // on
-    // this is because workbench doesnt store dataset information in the existing table
-    // user_recent_resources,
     if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
       updateUserRecentlyModifiedResourceEntry(
           workspaceId,

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceServiceImpl.java
@@ -1,5 +1,10 @@
 package org.pmiops.workbench.db.dao;
 
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import javax.inject.Provider;
 import org.jetbrains.annotations.NotNull;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.DbRetryUtils;
@@ -10,12 +15,6 @@ import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import javax.inject.Provider;
-import java.sql.Timestamp;
-import java.time.Clock;
-import java.time.Duration;
-import java.util.List;
 
 @Service
 public class UserRecentResourceServiceImpl implements UserRecentResourceService {
@@ -112,8 +111,10 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
 
   @Override
   public void updateDataSetEntry(long workspaceId, long userId, long dataSetId) {
-    // Save entry for data set in the new user_recently_modified table only when the feature flag is on
-    // this is because workbench doesnt store dataset information in the existing table user_recent_resources,
+    // Save entry for data set in the new user_recently_modified table only when the feature flag is
+    // on
+    // this is because workbench doesnt store dataset information in the existing table
+    // user_recent_resources,
     if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
       updateUserRecentlyModifiedResourceEntry(
           workspaceId,
@@ -125,11 +126,13 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
 
   @Override
   public void updateCohortReviewEntry(long workspaceId, long userId, long cohortReviewId) {
-    updateUserRecentlyModifiedResourceEntry(
-        workspaceId,
-        userId,
-        DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.COHORT_REVIEW,
-        String.valueOf(cohortReviewId));
+    if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
+      updateUserRecentlyModifiedResourceEntry(
+          workspaceId,
+          userId,
+          DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.COHORT_REVIEW,
+          String.valueOf(cohortReviewId));
+    }
   }
 
   @NotNull
@@ -203,20 +206,24 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
 
   @Override
   public void deleteDataSetEntry(long workspaceId, long userId, long dataSetId) {
-    deleteUserRecentlyModifiedResourceEntry(
-        userId,
-        workspaceId,
-        DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.DATA_SET,
-        String.valueOf(dataSetId));
+    if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
+      deleteUserRecentlyModifiedResourceEntry(
+          userId,
+          workspaceId,
+          DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.DATA_SET,
+          String.valueOf(dataSetId));
+    }
   }
 
   @Override
   public void deleteCohortReviewEntry(long workspaceId, long userId, long cohortReviewId) {
-    deleteUserRecentlyModifiedResourceEntry(
-        userId,
-        workspaceId,
-        DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.COHORT_REVIEW,
-        String.valueOf(cohortReviewId));
+    if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
+      deleteUserRecentlyModifiedResourceEntry(
+          userId,
+          workspaceId,
+          DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.COHORT_REVIEW,
+          String.valueOf(cohortReviewId));
+    }
   }
 
   private void deleteUserRecentlyModifiedResourceEntry(

--- a/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
@@ -22,6 +22,7 @@ import org.pmiops.workbench.dataset.DataSetServiceImpl;
 import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
 import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
+import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
@@ -75,7 +76,8 @@ public class DataDictionaryTest {
     WorkspaceAuthService.class,
     AccessTierService.class,
     CdrVersionMapper.class,
-    GenomicExtractionService.class
+    GenomicExtractionService.class,
+    UserRecentResourceService.class
   })
   static class Configuration {}
 

--- a/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
@@ -123,6 +123,7 @@ public class DataSetServiceTest {
 
   private DbWorkspace workspace;
   private DbCohort cohort;
+  private DbDataset dbDataset;
 
   @TestConfiguration
   @Import({FakeClockConfiguration.class, DataSetMapperImpl.class, DataSetServiceImpl.class})
@@ -153,6 +154,7 @@ public class DataSetServiceTest {
     cohort = cohortDao.save(buildSimpleCohort(workspace));
     when(mockCohortQueryBuilder.buildParticipantIdQuery(any()))
         .thenReturn(QUERY_JOB_CONFIGURATION_1);
+    dbDataset = createDbDataSetEntry();
   }
 
   private DbCohort buildSimpleCohort(DbWorkspace workspace) {
@@ -745,7 +747,6 @@ public class DataSetServiceTest {
 
   @Test
   public void test_userRecentModifiedEntry_saveDataSet() {
-    DbDataset dbDataset = createDbDataSetEntry();
     DataSet dataset = dataSetServiceImpl.saveDataSet(dbDataset);
     verify(userRecentResourceService)
         .updateDataSetEntry(
@@ -753,20 +754,12 @@ public class DataSetServiceTest {
   }
 
   @Test
-  public void test_userRecentModifiedEntry_updateDataSet() {
-    DbDataset dbDataset = createDbDataSetEntry();
-    DataSet dataset = dataSetServiceImpl.saveDataSet(dbDataset);
-    dbDataset.setName("Update DataSet Name");
-    DataSetRequest req = new DataSetRequest();
-    req.dataSetId(dataset.getId());
-    req.setName("Update DataSet Name");
-    req.setDomainValuePairs(dataset.getDomainValuePairs());
-    req.setCohortIds(dbDataset.getCohortIds());
-    req.setConceptSetIds(dbDataset.getConceptSetIds());
-    dataSetServiceImpl.updateDataSet(dataset.getWorkspaceId(), dataset.getId(), req);
+  public void test_userRecentModifiedEntry_deleteDataSet() {
+    dbDataset = dataSetDao.save(dbDataset);
+    long dataSetId = dbDataset.getDataSetId();
+    dataSetServiceImpl.deleteDataSet(dbDataset.getWorkspaceId(), dbDataset.getDataSetId());
     verify(userRecentResourceService)
-        .updateDataSetEntry(
-            cohort.getWorkspaceId(), cohort.getCreator().getUserId(), dataset.getId());
+        .deleteDataSetEntry(cohort.getWorkspaceId(), cohort.getCreator().getUserId(), dataSetId);
   }
 
   private void mockDomainTableFields() {

--- a/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
@@ -756,9 +756,9 @@ public class DataSetServiceTest {
   public void test_userRecentModifiedEntry_deleteDataSet() {
     dbDataset = dataSetDao.save(dbDataset);
     long dataSetId = dbDataset.getDataSetId();
-    dataSetServiceImpl.deleteDataSet(dbDataset.getWorkspaceId(), dbDataset.getDataSetId());
+    dataSetServiceImpl.deleteDataSet(dbDataset.getWorkspaceId(), dataSetId);
     verify(userRecentResourceService)
-        .deleteDataSetEntry(cohort.getWorkspaceId(), cohort.getCreator().getUserId(), dataSetId);
+        .deleteDataSetEntry(dbDataset.getWorkspaceId(), dbDataset.getCreatorId(), dataSetId);
   }
 
   private void mockDomainTableFields() {

--- a/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
@@ -1,5 +1,15 @@
 package org.pmiops.workbench.dataset;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.db.model.DbStorageEnums.domainToStorage;
+
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.FieldValue;
@@ -13,6 +23,18 @@ import com.google.cloud.bigquery.TableResult;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -66,29 +88,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 
-import java.sql.Timestamp;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.pmiops.workbench.db.model.DbStorageEnums.domainToStorage;
-
 @DataJpaTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class DataSetServiceTest {
@@ -97,7 +96,7 @@ public class DataSetServiceTest {
       QueryJobConfiguration.newBuilder(
               "SELECT person_id FROM `${projectId}.${dataSetId}.person` person")
           .addNamedParameter(
-               "foo",
+              "foo",
               QueryParameterValue.newBuilder()
                   .setType(StandardSQLTypeName.INT64)
                   .setValue(Long.toString(101L))
@@ -748,8 +747,9 @@ public class DataSetServiceTest {
   public void test_userRecentModifiedEntry_saveDataSet() {
     DbDataset dbDataset = createDbDataSetEntry();
     DataSet dataset = dataSetServiceImpl.saveDataSet(dbDataset);
-    verify(userRecentResourceService).updateDataSetEntry(cohort.getWorkspaceId(),
-        cohort.getCreator().getUserId(), dataset.getId());
+    verify(userRecentResourceService)
+        .updateDataSetEntry(
+            cohort.getWorkspaceId(), cohort.getCreator().getUserId(), dataset.getId());
   }
 
   @Test
@@ -763,8 +763,10 @@ public class DataSetServiceTest {
     req.setDomainValuePairs(dataset.getDomainValuePairs());
     req.setCohortIds(dbDataset.getCohortIds());
     req.setConceptSetIds(dbDataset.getConceptSetIds());
-    dataSetServiceImpl.updateDataSet(dataset.getWorkspaceId(), dataset.getId(),req);
-    verify(userRecentResourceService).updateDataSetEntry(cohort.getWorkspaceId(), cohort.getCreator().getUserId(), dataset.getId());
+    dataSetServiceImpl.updateDataSet(dataset.getWorkspaceId(), dataset.getId(), req);
+    verify(userRecentResourceService)
+        .updateDataSetEntry(
+            cohort.getWorkspaceId(), cohort.getCreator().getUserId(), dataset.getId());
   }
 
   private void mockDomainTableFields() {

--- a/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
@@ -749,8 +749,7 @@ public class DataSetServiceTest {
   public void test_userRecentModifiedEntry_saveDataSet() {
     DataSet dataset = dataSetServiceImpl.saveDataSet(dbDataset);
     verify(userRecentResourceService)
-        .updateDataSetEntry(
-            cohort.getWorkspaceId(), cohort.getCreator().getUserId(), dataset.getId());
+        .updateDataSetEntry(dbDataset.getWorkspaceId(), dbDataset.getCreatorId(), dataset.getId());
   }
 
   @Test


### PR DESCRIPTION
- Introduce a feature flag to be turned on only in test and local
- If the feature flag is on : 
Insert entries for dataset in user_recently_modified when
1) Data Set is created
2) Data set is updated 
and delete entries from user_recently_modified table when the data set is deleted.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
