### PR TITLE
[RW-7734][risk=low] Bump gatk jar override version

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
     "extractionTempTablesDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-357-gc79075c-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": false
   },
   "cdr": {

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -55,6 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
     "extractionTempTablesDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_temp_tables",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": false
   },
   "cdr": {

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
     "extractionTempTablesDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": false
   },
   "cdr": {

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
     "extractionTempTablesDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": false
   },
   "cdr": {

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-perf-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-perf-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-perf-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-perf-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-perf-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-perf-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-357-gc79075c-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -55,6 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-perf-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-perf-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-perf-ct.wgs_extraction_temp_tables",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-perf-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-perf-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-perf-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-357-gc79075c-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -55,6 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_temp_tables",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -54,7 +54,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-prod-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-prod-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-prod-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -54,7 +54,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-prod-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-prod-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-prod-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-357-gc79075c-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -54,7 +54,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-prod-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-prod-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-prod-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -54,6 +54,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-prod-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-prod-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-prod-ct.wgs_extraction_temp_tables",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -54,6 +54,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-stable-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-stable-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-stable-ct.wgs_extraction_temp_tables",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -54,7 +54,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-stable-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-stable-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-stable-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -54,7 +54,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-stable-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-stable-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-stable-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -54,7 +54,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-stable-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-stable-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-stable-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-357-gc79075c-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-staging-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-staging-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-staging-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-357-gc79075c-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-staging-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-staging-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-staging-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -55,6 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-staging-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-staging-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-staging-ct.wgs_extraction_temp_tables",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-staging-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-staging-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-staging-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -55,6 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
     "extractionTempTablesDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_temp_tables",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
     "extractionTempTablesDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
     "extractionTempTablesDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-456-g3aa74a5-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-357-gc79075c-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -55,7 +55,7 @@
     "extractionCohortsDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
     "extractionTempTablesDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-131-g2c1fc16-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-149-gc6c21df-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -174,6 +174,7 @@ public class WorkbenchConfig {
     public String extractionCohortsDataset;
     public String extractionDestinationDataset;
     public String extractionTempTablesDataset;
+    public String gatkJarUri;
     public boolean enableJiraTicketingOnFailure;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -409,7 +409,7 @@ public class GenomicExtractionService {
                             .put(EXTRACT_WORKFLOW_NAME + ".output_gcs_dir", "\"" + outputDir + "\"")
                             .put(
                                 EXTRACT_WORKFLOW_NAME + ".gatk_override",
-                                "\"gs://all-of-us-workbench-test-genomics/wgs/gatk-package-4.2.0.0-359-gb3f0558-SNAPSHOT-local.jar\"")
+                                "\"" + cohortExtractionConfig.gatkJarUri + "\"")
                             .build())
                     .methodConfigVersion(
                         cohortExtractionConfig.extractionMethodConfigurationVersion)


### PR DESCRIPTION
Cherry-picked log4j upgrade onto the prior gatk jar version.

Currently testing this locally.