### PR TITLE
[risk=no] Generate more egress in the nightly tests

### DIFF
--- a/e2e/resources/python-code/generate-egress.py
+++ b/e2e/resources/python-code/generate-egress.py
@@ -20,7 +20,8 @@ newfile.write(os.urandom(20000000))    # generate 20MB random content file
 newfile.close()
 # Upload to the internet.
 #
-# Upload the file 9 times and expect to upload 180MB data. 
+# Upload the file 9 times and expect to upload 180MB data. This stays under the 200MB limit, which could affect
+# tests up to an hour later via the larger egress window.
 for x in range(1, 10):
     print('Uploading to the internet at '+ timestamp() + ' , current count: ' + str(x))
     with open('data.txt', 'rb') as f:

--- a/e2e/resources/python-code/generate-egress.py
+++ b/e2e/resources/python-code/generate-egress.py
@@ -20,8 +20,8 @@ newfile.write(os.urandom(20000000))    # generate 20MB random content file
 newfile.close()
 # Upload to the internet.
 #
-# Upload the file for 8 times and expect to upload 160MB data. 
-for x in range(1, 9):
+# Upload the file for 16 times and expect to upload 320MB data. 
+for x in range(1, 17):
     print('Uploading to the internet at '+ timestamp() + ' , current count: ' + str(x))
     with open('data.txt', 'rb') as f:
         r = requests.post('http://speedtest.tele2.net/upload.php', files={'data.txt': f})

--- a/e2e/resources/python-code/generate-egress.py
+++ b/e2e/resources/python-code/generate-egress.py
@@ -20,8 +20,8 @@ newfile.write(os.urandom(20000000))    # generate 20MB random content file
 newfile.close()
 # Upload to the internet.
 #
-# Upload the file for 16 times and expect to upload 320MB data. 
-for x in range(1, 17):
+# Upload the file 9 times and expect to upload 180MB data. 
+for x in range(1, 10):
     print('Uploading to the internet at '+ timestamp() + ' , current count: ' + str(x))
     with open('data.txt', 'rb') as f:
         r = requests.post('http://speedtest.tele2.net/upload.php', files={'data.txt': f})


### PR DESCRIPTION
Slight mitigation for https://app.circleci.com/pipelines/github/all-of-us/workbench/17366/workflows/75365790-14ea-48e9-a65b-e538246321df/jobs/192896

Unfortunately we don't want to go too much higher, as we risk hitting the 1h egress window, which would get in the way a lot more when retrying a test run.