### PR TITLE
[RW-7717][risk=no] Add required-for-tier badges to access module table in AdminUserProfile

### DIFF
--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -196,6 +196,7 @@ const isModuleRequiredByAccessTier = (
   const tierEligibility = profile.tierEligibilities.find(
     (tier) => tier.accessTierShortName === accessTierShortName
   );
+  // Handling only ERACommon module.
   return switchCase(moduleName, [
     AccessModule.ERACOMMONS,
     () =>

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -12,7 +12,7 @@ import {
   RegisteredTierBadge,
 } from 'app/components/icons';
 
-import { formatInitialCreditsUSD, reactStyles, switchCase } from 'app/utils';
+import { formatInitialCreditsUSD, reactStyles } from 'app/utils';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import {
   AccessBypassRequest,
@@ -188,21 +188,17 @@ export const displayModuleExpirationDate = (
     getNullStringForExpirationDate(moduleName)
   );
 
-const isModuleRequiredByAccessTier = (
+const isEraRequiredForTier = (
   profile: Profile,
-  moduleName: AccessModule,
   accessTierShortName: AccessTierShortNames
 ): boolean => {
   const tierEligibility = profile.tierEligibilities.find(
     (tier) => tier.accessTierShortName === accessTierShortName
   );
-  // Handling only ERACommon module.
-  return switchCase(moduleName, [
-    AccessModule.ERACOMMONS,
-    () =>
-      getAccessModuleConfig(moduleName).isEnabledInEnvironment &&
-      tierEligibility?.eraRequired,
-  ]);
+  return (
+    getAccessModuleConfig(AccessModule.ERACOMMONS).isEnabledInEnvironment &&
+    tierEligibility?.eraRequired
+  );
 };
 
 export const displayTierBadgeByRequiredModule = (
@@ -211,18 +207,16 @@ export const displayTierBadgeByRequiredModule = (
 ) => {
   return (
     <div>
-      {(getAccessModuleConfig(moduleName)?.isRequiredByRT ||
-        isModuleRequiredByAccessTier(
-          profile,
-          moduleName,
-          AccessTierShortNames.Registered
-        )) && <RegisteredTierBadge style={{ gridArea: 'badge' }} />}
-      {(getAccessModuleConfig(moduleName)?.isRequiredByCT ||
-        isModuleRequiredByAccessTier(
-          profile,
-          moduleName,
-          AccessTierShortNames.Controlled
-        )) && <ControlledTierBadge style={{ gridArea: 'badge' }} />}
+      {(moduleName === AccessModule.ERACOMMONS
+        ? isEraRequiredForTier(profile, AccessTierShortNames.Registered)
+        : getAccessModuleConfig(moduleName)?.isRequiredByRT) && (
+        <RegisteredTierBadge style={{ gridArea: 'badge' }} />
+      )}
+      {(moduleName === AccessModule.ERACOMMONS
+        ? isEraRequiredForTier(profile, AccessTierShortNames.Controlled)
+        : getAccessModuleConfig(moduleName)?.isRequiredByCT) && (
+        <ControlledTierBadge style={{ gridArea: 'badge' }} />
+      )}
     </div>
   );
 };

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -305,6 +305,10 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
       moduleName: adminPageTitle,
       completionDate: displayModuleCompletionDate(updatedProfile, moduleName),
       expirationDate: displayModuleExpirationDate(updatedProfile, moduleName),
+      accessTierBadge: displayTierBadgeByRequiredModule(
+        props.updatedProfile,
+        moduleName
+      ),
       bypassToggle: adminBypassable && (
         <ToggleForModule moduleName={moduleName} {...props} />
       ),
@@ -316,6 +320,7 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
       <Column field='moduleName' header='Access Module' />
       <Column field='completionDate' header='Last completed on' />
       <Column field='expirationDate' header='Expires on' />
+      <Column field='accessTierBadge' header='Required for tier access' />
       <Column field='bypassToggle' header='Bypass' />
     </DataTable>
   );

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -23,6 +23,7 @@ import {
   profileNeedsUpdate,
   displayModuleCompletionDate,
   displayModuleExpirationDate,
+  displayTierBadgeByRequiredModule,
 } from './admin-user-common';
 import { FadeBox } from 'app/components/containers';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -113,6 +113,8 @@ export const redirectToRas = (openInNewTab: boolean = true): void => {
 interface AccessModuleConfig {
   moduleName: AccessModule;
   isEnabledInEnvironment: boolean; // either true or dependent on a feature flag
+  isRequiredByRT: boolean;
+  isRequiredByCT: boolean;
   AARTitleComponent: () => JSX.Element;
   DARTitleComponent: () => JSX.Element;
   adminPageTitle: string;
@@ -154,6 +156,8 @@ export const getAccessModuleConfig = (
         externalSyncAction: async () =>
           await profileApi().syncTwoFactorAuthStatus(),
         refreshAction: async () => await profileApi().syncTwoFactorAuthStatus(),
+        isRequiredByRT: true,
+        isRequiredByCT: true,
       }),
     ],
 
@@ -179,6 +183,8 @@ export const getAccessModuleConfig = (
         canExpire: false,
         adminBypassable: true,
         refreshAction: () => redirectToRas(false),
+        isRequiredByRT: enforceRasLoginGovLinking,
+        isRequiredByCT: enforceRasLoginGovLinking,
       }),
     ],
 
@@ -219,6 +225,8 @@ export const getAccessModuleConfig = (
           await profileApi().syncComplianceTrainingStatus(),
         refreshAction: async () =>
           await profileApi().syncComplianceTrainingStatus(),
+        isRequiredByRT: true,
+        isRequiredByCT: true,
       }),
     ],
 
@@ -239,6 +247,8 @@ export const getAccessModuleConfig = (
           await profileApi().syncComplianceTrainingStatus(),
         refreshAction: async () =>
           await profileApi().syncComplianceTrainingStatus(),
+        isRequiredByRT: false,
+        isRequiredByCT: true,
       }),
     ],
 
@@ -251,6 +261,8 @@ export const getAccessModuleConfig = (
         DARTitleComponent: () => <div>Sign Data User Code of Conduct</div>,
         adminPageTitle: 'Sign Data User Code of Conduct',
         adminBypassable: true,
+        isRequiredByRT: true,
+        isRequiredByCT: true,
         canExpire: true,
       }),
     ],
@@ -263,6 +275,8 @@ export const getAccessModuleConfig = (
         AARTitleComponent: () => 'Update your profile',
         adminPageTitle: 'Update your profile',
         adminBypassable: false,
+        isRequiredByRT: true,
+        isRequiredByCT: true,
         canExpire: true,
       }),
     ],
@@ -276,6 +290,8 @@ export const getAccessModuleConfig = (
           'Report any publications or presentations based on your research using the Researcher Workbench',
         adminPageTitle: 'Report any publications',
         adminBypassable: false,
+        isRequiredByRT: true,
+        isRequiredByCT: true,
         canExpire: true,
       }),
     ]


### PR DESCRIPTION
[RW-7717](https://precisionmedicineinitiative.atlassian.net/browse/RW-7717)
When a module is required for RT or CT tier or both, display tier badge icons in AdminUser table.

EraCommon required for CT and RT:

<img width="1558" alt="Screen Shot 2022-01-28 at 2 51 36 PM" src="https://user-images.githubusercontent.com/35533885/151612614-412e9f86-95e7-4068-918d-8e9fc38bfee3.png">

EraCommon required for CT, not required for RT:

<img width="1538" alt="Screen Shot 2022-01-28 at 2 52 15 PM" src="https://user-images.githubusercontent.com/35533885/151612742-21ebbcc3-2356-4d18-b3ac-53f09d25cfeb.png">

EraCommon required for RT, not required for CT:

<img width="1525" alt="Screen Shot 2022-01-28 at 2 52 37 PM" src="https://user-images.githubusercontent.com/35533885/151612874-c863b27b-0954-4f32-99ef-c0ffdb46f20f.png">

EraCommon not required for RT and CT:

<img width="1522" alt="Screen Shot 2022-01-28 at 2 52 58 PM" src="https://user-images.githubusercontent.com/35533885/151612924-9b3512df-ce56-4cc8-909b-ae25e0014108.png">


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
