### PR TITLE
[RW-7754][risk=no] Enable dataset puppeteer tests

### DIFF
--- a/e2e/tests/conceptsets/conceptset-create.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-create.spec.ts
@@ -77,8 +77,7 @@ describe('Create Concept Sets from Domains', () => {
    * - Create new Dataset using above two Concept Sets.
    * - Delete Dataset, Concept Set.
    */
-  // TODO temporarily disabled, filed RW-7754 to investigate and re-enable
-  xtest('Create Concept Sets from Drug Exposures and Measurements domains', async () => {
+  test('Create Concept Sets from Drug Exposures and Measurements domains', async () => {
     await findOrCreateWorkspace(page, { workspaceName: workspace });
 
     // Click Add Datasets button.

--- a/e2e/tests/datasets/dataset-create.spec.ts
+++ b/e2e/tests/datasets/dataset-create.spec.ts
@@ -15,8 +15,7 @@ describe('Create Dataset', () => {
   const workspace = makeWorkspaceName();
   let datasetName;
 
-  // TODO temporarily disabled, filed RW-7754 to investigate and re-enable
-  xtest('Create dataset with all available inputs', async () => {
+  test('Create dataset with all available inputs', async () => {
     await signInWithAccessToken(page);
     await findOrCreateWorkspace(page, { workspaceName: workspace });
 

--- a/e2e/tests/datasets/dataset-export-notebook.spec.ts
+++ b/e2e/tests/datasets/dataset-export-notebook.spec.ts
@@ -29,8 +29,7 @@ describe('Export Notebook Test', () => {
    * - Export dataset to a notebook. Run the notebook code and verify run results.
    * (Cohort and Dataset are saved and reused)
    */
-  // TODO temporarily disabled, filed RW-7754 to investigate and re-enable
-  xtest.each(KernelLanguages)('Export to %s kernel notebook', async (kernelLanguage) => {
+  test.each(KernelLanguages)('Export to %s kernel notebook', async (kernelLanguage) => {
     await findOrCreateWorkspace(page, { workspaceName: workspaceName });
     await findOrCreateCohort(page, cohortName);
     const datasetBuildPage = await findOrCreateDataset(page, datasetName);

--- a/e2e/tests/datasets/dataset-snowman-menu-actions.spec.ts
+++ b/e2e/tests/datasets/dataset-snowman-menu-actions.spec.ts
@@ -20,8 +20,7 @@ describe('Datasets card snowman menu actions', () => {
 
   const workspace = makeWorkspaceName();
 
-  // TODO temporarily disabled, filed RW-7754 to investigate and re-enable
-  xtest('Edit dataset', async () => {
+  test('Edit dataset', async () => {
     await findOrCreateWorkspace(page, { workspaceName: workspace });
 
     const datasetName = await createDataSet();
@@ -67,8 +66,7 @@ describe('Datasets card snowman menu actions', () => {
     await dataPage.deleteResource(datasetName, ResourceCard.Dataset);
   });
 
-  // TODO temporarily disabled, filed RW-7754 to investigate and re-enable
-  xtest('Rename dataset', async () => {
+  test('Rename dataset', async () => {
     await findOrCreateWorkspace(page, { workspaceName: workspace });
 
     const datasetName = await createDataSet();
@@ -116,8 +114,7 @@ describe('Datasets card snowman menu actions', () => {
    * - Create dataset.
    * - Export dataset to notebook thru snowman menu (the notebook is not created).
    */
-  // TODO temporarily disabled, filed RW-7754 to investigate and re-enable
-  xtest.each(KernelLanguages)('Export to %s kernel Jupyter notebook', async (kernelLanguage) => {
+  test.each(KernelLanguages)('Export to %s kernel Jupyter notebook', async (kernelLanguage) => {
     await findOrCreateWorkspace(page, { workspaceName: workspace });
 
     const datasetName = await createDataSet();

--- a/e2e/tests/ui/dataset-ui.spec.ts
+++ b/e2e/tests/ui/dataset-ui.spec.ts
@@ -11,8 +11,7 @@ describe('Dataset UI Test', () => {
   });
 
   // Test reuse workspace that is older than 10 min. Test does not create new workspace.
-  // TODO temporarily disabled, filed RW-7754 to investigate and re-enable
-  xtest('Cannot Create Dataset if Required Fields are Empty', async () => {
+  test('Cannot Create Dataset if Required Fields are Empty', async () => {
     // Find all workspaces that are older than 10 min.
     const allWorkspaceCards = await findAllCards(page, 1000 * 60 * 10);
     if (allWorkspaceCards.length === 0) {


### PR DESCRIPTION
These tests were disabled in #6200 since the changes to the `getValuesFromDomain` call didn't exist in the test env yet.