### PR TITLE
[RW-7725][risk=no] Prevent duplicate cohort and concept set calls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -624,7 +624,7 @@ jobs:
       - run:
           name: "Create a file contains test names"
           working_directory: ~/workbench/e2e
-          command: yarn jest --listTests | grep -o 'tests/.*.ts$' > e2e_tests.txt
+          command: yarn jest --listTests | grep -o 'tests/conceptsets/.*.ts$' > e2e_tests.txt
       - run:
           name: "Running Puppeteer e2e tests"
           working_directory: ~/workbench/e2e
@@ -681,11 +681,11 @@ workflows:
       - wait_until_previous_workflow_done
       # Always run basic test/lint/compilation (open PRs, main branch merge)
       # Note: by default tags are not picked up.
-      - api-local-test
-      - api-unit-test
-      - ui-unit-test
-      - api-bigquery-test
-      - api-integration-test
+#      - api-local-test
+#      - api-unit-test
+#      - ui-unit-test
+#      - api-bigquery-test
+#      - api-integration-test
       # Deploy to "test" on main branch merges
       - api-deploy-to-test:
           <<: *filter-main-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -624,7 +624,7 @@ jobs:
       - run:
           name: "Create a file contains test names"
           working_directory: ~/workbench/e2e
-          command: yarn jest --listTests | grep -o 'tests/conceptsets/.*.ts$' > e2e_tests.txt
+          command: yarn jest --listTests | grep -o 'tests/.*.ts$' > e2e_tests.txt
       - run:
           name: "Running Puppeteer e2e tests"
           working_directory: ~/workbench/e2e
@@ -681,22 +681,22 @@ workflows:
       - wait_until_previous_workflow_done
       # Always run basic test/lint/compilation (open PRs, main branch merge)
       # Note: by default tags are not picked up.
-#      - api-local-test
-#      - api-unit-test
-#      - ui-unit-test
-#      - api-bigquery-test
-#      - api-integration-test
+      - api-local-test
+      - api-unit-test
+      - ui-unit-test
+      - api-bigquery-test
+      - api-integration-test
       # Deploy to "test" on main branch merges
-#      - api-deploy-to-test:
-#          <<: *filter-main-branch
-#          requires:
-#            - api-unit-test
-#            - wait_until_previous_workflow_done
-#      - ui-deploy-to-test:
-#          <<: *filter-main-branch
-#          requires:
-#            - ui-unit-test
-#            - wait_until_previous_workflow_done
+      - api-deploy-to-test:
+          <<: *filter-main-branch
+          requires:
+            - api-unit-test
+            - wait_until_previous_workflow_done
+      - ui-deploy-to-test:
+          <<: *filter-main-branch
+          requires:
+            - ui-unit-test
+            - wait_until_previous_workflow_done
       # Deploy local UI server connected to "test" API server. Run Puppeteer tests for PR commits only
       - puppeteer-env-setup
       - puppeteer-generate-access-tokens:
@@ -713,18 +713,18 @@ workflows:
             # PR commits e2e tests waits for workflow triggered by main branch merge to finish.
             - wait_until_previous_workflow_done
       # On main branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully
-#      - puppeteer-test:
-#          parallel_num: 5
-#          env_name: "test"
-#          <<: *filter-main-branch
-#          requires:
-#            - puppeteer-env-setup
-#            - puppeteer-generate-access-tokens
-#            - api-deploy-to-test
-#            - ui-deploy-to-test
-#            - wait_until_previous_workflow_done
-#          post-steps:
-#            - gcs-load-test-results
+      - puppeteer-test:
+          parallel_num: 5
+          env_name: "test"
+          <<: *filter-main-branch
+          requires:
+            - puppeteer-env-setup
+            - puppeteer-generate-access-tokens
+            - api-deploy-to-test
+            - ui-deploy-to-test
+            - wait_until_previous_workflow_done
+          post-steps:
+            - gcs-load-test-results
 
   deploy-staging:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -687,16 +687,16 @@ workflows:
 #      - api-bigquery-test
 #      - api-integration-test
       # Deploy to "test" on main branch merges
-      - api-deploy-to-test:
-          <<: *filter-main-branch
-          requires:
-            - api-unit-test
-            - wait_until_previous_workflow_done
-      - ui-deploy-to-test:
-          <<: *filter-main-branch
-          requires:
-            - ui-unit-test
-            - wait_until_previous_workflow_done
+#      - api-deploy-to-test:
+#          <<: *filter-main-branch
+#          requires:
+#            - api-unit-test
+#            - wait_until_previous_workflow_done
+#      - ui-deploy-to-test:
+#          <<: *filter-main-branch
+#          requires:
+#            - ui-unit-test
+#            - wait_until_previous_workflow_done
       # Deploy local UI server connected to "test" API server. Run Puppeteer tests for PR commits only
       - puppeteer-env-setup
       - puppeteer-generate-access-tokens:
@@ -713,18 +713,18 @@ workflows:
             # PR commits e2e tests waits for workflow triggered by main branch merge to finish.
             - wait_until_previous_workflow_done
       # On main branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully
-      - puppeteer-test:
-          parallel_num: 5
-          env_name: "test"
-          <<: *filter-main-branch
-          requires:
-            - puppeteer-env-setup
-            - puppeteer-generate-access-tokens
-            - api-deploy-to-test
-            - ui-deploy-to-test
-            - wait_until_previous_workflow_done
-          post-steps:
-            - gcs-load-test-results
+#      - puppeteer-test:
+#          parallel_num: 5
+#          env_name: "test"
+#          <<: *filter-main-branch
+#          requires:
+#            - puppeteer-env-setup
+#            - puppeteer-generate-access-tokens
+#            - api-deploy-to-test
+#            - ui-deploy-to-test
+#            - wait_until_previous_workflow_done
+#          post-steps:
+#            - gcs-load-test-results
 
   deploy-staging:
     jobs:

--- a/ui/src/app/pages/data/cohort/cohort-actions.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-actions.tsx
@@ -12,7 +12,7 @@ import {
   withCurrentCohort,
   withCurrentWorkspace,
 } from 'app/utils';
-import { currentCohortStore, NavigationProps } from 'app/utils/navigation';
+import { NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
@@ -130,7 +130,6 @@ export const CohortActions = fp.flow(
           .getCohort(namespace, id, +this.props.match.params.cid)
           .then((c) => {
             if (c) {
-              currentCohortStore.next(c);
               this.setState({ cohort: c, cohortLoading: false });
             } else {
               this.props.navigate([

--- a/ui/src/app/pages/data/concept/concept-set-actions.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-actions.tsx
@@ -12,11 +12,7 @@ import {
   withCurrentConceptSet,
   withCurrentWorkspace,
 } from 'app/utils';
-import {
-  conceptSetUpdating,
-  currentConceptSetStore,
-  NavigationProps,
-} from 'app/utils/navigation';
+import { conceptSetUpdating, NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
@@ -132,7 +128,6 @@ export const ConceptSetActions = fp.flow(
           .getConceptSet(namespace, id, +csid)
           .then((cs) => {
             if (cs) {
-              currentConceptSetStore.next(cs);
               this.setState({ conceptSet: cs, conceptSetLoading: false });
             } else {
               this.props.navigate([

--- a/ui/src/app/pages/data/concept/concept-set-actions.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-actions.tsx
@@ -7,8 +7,16 @@ import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { conceptSetsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
-import { reactStyles, withCurrentWorkspace } from 'app/utils';
-import { conceptSetUpdating, NavigationProps } from 'app/utils/navigation';
+import {
+  reactStyles,
+  withCurrentConceptSet,
+  withCurrentWorkspace,
+} from 'app/utils';
+import {
+  conceptSetUpdating,
+  currentConceptSetStore,
+  NavigationProps,
+} from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
@@ -87,10 +95,12 @@ interface Props
   extends WithSpinnerOverlayProps,
     NavigationProps,
     RouteComponentProps<MatchParams> {
+  conceptSet: ConceptSet;
   workspace: WorkspaceData;
 }
 
 export const ConceptSetActions = fp.flow(
+  withCurrentConceptSet(),
   withCurrentWorkspace(),
   withNavigation,
   withRouter
@@ -107,17 +117,22 @@ export const ConceptSetActions = fp.flow(
     componentDidMount(): void {
       this.props.hideSpinner();
       conceptSetUpdating.next(false);
-      this.setState({ conceptSetLoading: true });
-    }
-
-    componentDidUpdate() {
-      const { csid } = this.props.match.params;
-      if (csid && this.state.conceptSetLoading) {
+      const {
+        conceptSet,
+        match: {
+          params: { csid },
+        },
+      } = this.props;
+      if (conceptSet && +csid === conceptSet.id) {
+        this.setState({ conceptSet });
+      } else {
+        this.setState({ conceptSetLoading: true });
         const { namespace, id } = this.props.workspace;
         conceptSetsApi()
           .getConceptSet(namespace, id, +csid)
           .then((cs) => {
             if (cs) {
+              currentConceptSetStore.next(cs);
               this.setState({ conceptSet: cs, conceptSetLoading: false });
             } else {
               this.props.navigate([


### PR DESCRIPTION
Prevents redundant calls to the api in these components:
- `cohort-actions` - prevents `getCohort` call if cohort is already loaded in `currentCohortStore`
- `concept-set-actions` - prevents `getConceptSet` call if concept set is already loaded in `currentConceptSetStore`
- `concept-search` - prevents multiple `getConceptSet` calls when loading an existing concept set

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
