### PR TITLE
[RW-7613][risk=no] Include Datasets in "Recently Accessed Items" list

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -22,7 +22,6 @@ import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.dataset.DataSetService;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
-import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserRecentResource;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
@@ -250,47 +249,14 @@ public class UserMetricsController implements UserMetricsApiDelegate {
       Map<Long, DbWorkspace> idToDbWorkspace,
       Map<Long, FirecloudWorkspaceResponse> idToFcWorkspaceResponse,
       DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource) {
-
     final long workspaceId = dbUserRecentlyModifiedResource.getWorkspaceId();
-    FirecloudWorkspaceResponse firecloudWorkspaceResponse =
-        idToFcWorkspaceResponse.get(workspaceId);
-    DbWorkspace dbWorkspace = idToDbWorkspace.get(workspaceId);
-    switch (dbUserRecentlyModifiedResource.getResourceType()) {
-      case COHORT:
-        return workspaceResourceMapper.fromDbUserRecentlyModifiedResourceAndCohort(
-            dbUserRecentlyModifiedResource,
-            firecloudWorkspaceResponse,
-            dbWorkspace,
-            cohortService.findDbCohortByCohortId(
-                getResourceIdInLong(dbUserRecentlyModifiedResource)));
-      case CONCEPT_SET:
-        return workspaceResourceMapper.fromDbUserRecentlyModifiedResourceAndConceptSet(
-            dbUserRecentlyModifiedResource,
-            firecloudWorkspaceResponse,
-            dbWorkspace,
-            conceptSetService.getDbConceptSet(
-                workspaceId, getResourceIdInLong(dbUserRecentlyModifiedResource)));
-      case DATA_SET:
-        return workspaceResourceMapper.fromDbUserRecentlyModifiedResourceAndDataSet(
-            dbUserRecentlyModifiedResource,
-            firecloudWorkspaceResponse,
-            dbWorkspace,
-            dataSetService
-                .getDbDataSet(workspaceId, getResourceIdInLong(dbUserRecentlyModifiedResource))
-                .orElse(new DbDataset()));
-      case NOTEBOOK:
-        return workspaceResourceMapper.fromDbUserRecentlyModifiedResourceAndNotebookName(
-            dbUserRecentlyModifiedResource,
-            firecloudWorkspaceResponse,
-            dbWorkspace,
-            dbUserRecentlyModifiedResource.getResourceId());
-    }
-    return null;
-  }
-
-  private Long getResourceIdInLong(DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource) {
-    return Long.parseLong(
-        Optional.ofNullable(dbUserRecentlyModifiedResource.getResourceId()).orElse("0"));
+    return workspaceResourceMapper.fromDbUserRecentlyModifiedResource(
+        dbUserRecentlyModifiedResource,
+        idToFcWorkspaceResponse.get(workspaceId),
+        idToDbWorkspace.get(workspaceId),
+        cohortService,
+        conceptSetService,
+        dataSetService);
   }
 
   // Retrieves Database workspace ID

--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -195,15 +195,6 @@ public class UserMetricsController implements UserMetricsApiDelegate {
     return ResponseEntity.ok(recentResponse);
   }
 
-  @Deprecated
-  private Boolean foundBlobIdsContainsUserRecentResource(
-      Set<BlobId> foundNotebooks, DbUserRecentResource urr) {
-    return Optional.ofNullable(urr.getNotebookName())
-        .flatMap(this::uriToBlobId)
-        .map(foundNotebooks::contains)
-        .orElse(true);
-  }
-
   private Boolean foundBlobIdsContainsUserRecentlyModifiedResource(
       Set<BlobId> foundNotebooks, DbUserRecentlyModifiedResource urr) {
     return Optional.ofNullable(urr.getNotebookName())
@@ -213,30 +204,11 @@ public class UserMetricsController implements UserMetricsApiDelegate {
   }
 
   @VisibleForTesting
-  public boolean hasValidBlobIdIfNotebookNamePresent(DbUserRecentResource dbUserRecentResource) {
-    return Optional.ofNullable(dbUserRecentResource.getNotebookName())
-        .map(name -> uriToBlobId(name).isPresent())
-        .orElse(true);
-  }
-
-  @VisibleForTesting
   public boolean hasValidBlobIdIfNotebookNamePresent(
       DbUserRecentlyModifiedResource dbUserRecentResource) {
     return Optional.ofNullable(dbUserRecentResource.getNotebookName())
         .map(name -> uriToBlobId(name).isPresent())
         .orElse(true);
-  }
-
-  private WorkspaceResource buildRecentResource(
-      Map<Long, DbWorkspace> idToDbWorkspace,
-      Map<Long, FirecloudWorkspaceResponse> idToFcWorkspaceResponse,
-      DbUserRecentResource dbUserRecentResource) {
-
-    final long workspaceId = dbUserRecentResource.getWorkspaceId();
-    return workspaceResourceMapper.fromDbUserRecentResource(
-        dbUserRecentResource,
-        idToFcWorkspaceResponse.get(workspaceId),
-        idToDbWorkspace.get(workspaceId));
   }
 
   private WorkspaceResource buildRecentResource(

--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -6,6 +6,17 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
+import java.util.AbstractMap;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import javax.inject.Provider;
 import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.dataset.DataSetService;
@@ -30,18 +41,6 @@ import org.pmiops.workbench.workspaces.resources.WorkspaceResourceMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.inject.Provider;
-import java.util.AbstractMap;
-import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 @RestController
 public class UserMetricsController implements UserMetricsApiDelegate {

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortService.java
@@ -7,6 +7,7 @@ import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;
 import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.model.DbCohort;
+import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.model.Cohort;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -38,7 +39,12 @@ public class CohortService {
   }
 
   public DbCohort findDbCohortByCohortId(Long cohortId) {
-    return cohortDao.findById(cohortId).orElse(new DbCohort());
+    return cohortDao
+        .findById(cohortId)
+        .orElseThrow(
+            () ->
+                new NotFoundException(
+                    String.format("Cohort not found for cohortId: %d", cohortId)));
   }
 
   public List<Cohort> findByWorkspaceId(Long workspaceId) {

--- a/api/src/main/java/org/pmiops/workbench/cohorts/CohortService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohorts/CohortService.java
@@ -6,6 +6,7 @@ import java.util.stream.StreamSupport;
 import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;
 import org.pmiops.workbench.db.dao.CohortDao;
+import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.model.Cohort;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,10 @@ public class CohortService {
     return StreamSupport.stream(cohortDao.findAllById(cohortIds).spliterator(), false)
         .map(cohortMapper::dbModelToClient)
         .collect(Collectors.toList());
+  }
+
+  public DbCohort findDbCohortByCohortId(Long cohortId) {
+    return cohortDao.findById(cohortId).orElse(new DbCohort());
   }
 
   public List<Cohort> findByWorkspaceId(Long workspaceId) {

--- a/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
@@ -194,7 +194,7 @@ public class ConceptSetService {
     return conceptSetDao.findByWorkspaceId(workspace.getWorkspaceId());
   }
 
-  private DbConceptSet getDbConceptSet(Long workspaceId, Long conceptSetId) {
+  public DbConceptSet getDbConceptSet(Long workspaceId, Long conceptSetId) {
     return conceptSetDao
         .findByWorkspaceIdAndConceptSetId(workspaceId, conceptSetId)
         .orElseThrow(

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceDao.java
@@ -6,6 +6,7 @@ import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbUserRecentResource;
 import org.springframework.data.repository.CrudRepository;
 
+@Deprecated
 public interface UserRecentResourceDao extends CrudRepository<DbUserRecentResource, Long> {
 
   long countUserRecentResourceByUserId(long userId);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceDao.java
@@ -6,6 +6,7 @@ import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbUserRecentResource;
 import org.springframework.data.repository.CrudRepository;
 
+// This DAO will be replaced by UserRecentlyModifiedResourceDao
 @Deprecated
 public interface UserRecentResourceDao extends CrudRepository<DbUserRecentResource, Long> {
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceService.java
@@ -31,6 +31,7 @@ public interface UserRecentResourceService {
 
   void deleteCohortReviewEntry(long workspaceId, long userId, long cohortReviewId);
 
+  @Deprecated
   List<DbUserRecentResource> findAllResourcesByUser(long userId);
 
   List<DbUserRecentlyModifiedResource> findAllRecentlyModifiedResourcesByUser(long userId);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceService.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.db.dao;
 
 import java.util.List;
 import org.pmiops.workbench.db.model.DbUserRecentResource;
+import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -31,4 +32,6 @@ public interface UserRecentResourceService {
   void deleteCohortReviewEntry(long workspaceId, long userId, long cohortReviewId);
 
   List<DbUserRecentResource> findAllResourcesByUser(long userId);
+
+  List<DbUserRecentlyModifiedResource> findAllRecentlyModifiedResourcesByUser(long userId);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceServiceImpl.java
@@ -10,6 +10,7 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.DbRetryUtils;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbConceptSet;
+import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbUserRecentResource;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.pmiops.workbench.exceptions.ServerErrorException;
@@ -22,6 +23,7 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
   private Clock clock;
   private CohortDao cohortDao;
   private ConceptSetDao conceptSetDao;
+  private DataSetDao dataSetDao;
   private UserRecentResourceDao userRecentResourceDao;
   private UserRecentlyModifiedResourceDao userRecentlyModifiedResourceDao;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
@@ -31,12 +33,14 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
       Clock clock,
       CohortDao cohortDao,
       ConceptSetDao conceptSetDao,
+      DataSetDao dataSetDao,
       UserRecentlyModifiedResourceDao userRecentlyModifiedResourceDao,
       UserRecentResourceDao userRecentResourceDao,
       Provider<WorkbenchConfig> workbenchConfigProvider) {
     this.clock = clock;
     this.cohortDao = cohortDao;
     this.conceptSetDao = conceptSetDao;
+    this.dataSetDao = dataSetDao;
     this.userRecentlyModifiedResourceDao = userRecentlyModifiedResourceDao;
     this.userRecentResourceDao = userRecentResourceDao;
     this.workbenchConfigProvider = workbenchConfigProvider;
@@ -253,6 +257,69 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
     } catch (InterruptedException e) {
       throw new ServerErrorException("Unable to find Resources for user" + userId);
     }
+  }
+
+  @Override
+  public List<DbUserRecentlyModifiedResource> findAllRecentlyModifiedResourcesByUser(long userId) {
+    try {
+      System.out.println("in here");
+      return DbRetryUtils.executeAndRetry(
+          () -> populateRecentlyModifiedResources(userId), Duration.ofSeconds(1), 5);
+    } catch (InterruptedException e) {
+      throw new ServerErrorException(
+          "Unable to find Recently Modified Resources for user" + userId);
+    }
+  }
+
+  public List<DbUserRecentlyModifiedResource> populateRecentlyModifiedResources(long userId) {
+    List<DbUserRecentlyModifiedResource> userList =
+        userRecentlyModifiedResourceDao.findDbUserRecentResourcesByUserId(userId);
+    userList.stream()
+        .forEach(
+            userRecentResource -> {
+              switch (userRecentResource.getResourceType()) {
+                case COHORT:
+                  userRecentResource.setCohort(getCohort(userRecentResource));
+                  break;
+                case CONCEPT_SET:
+                  userRecentResource.setConceptSet(getConceptSet(userRecentResource));
+                  break;
+                case DATA_SET:
+                  userRecentResource.setDataSet(getDataSet(userRecentResource));
+                  break;
+                case NOTEBOOK:
+                  userRecentResource.setNotebookName(getNotebookName(userRecentResource));
+                  break;
+              }
+            });
+    return userList;
+  }
+
+  private DbCohort getCohort(DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource) {
+    return cohortDao.findCohortByWorkspaceIdAndCohortId(
+        dbUserRecentlyModifiedResource.getWorkspaceId(),
+        Long.parseLong(dbUserRecentlyModifiedResource.getResourceId()));
+  }
+
+  private DbConceptSet getConceptSet(
+      DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource) {
+    return conceptSetDao
+        .findByWorkspaceIdAndConceptSetId(
+            dbUserRecentlyModifiedResource.getWorkspaceId(),
+            Long.parseLong(dbUserRecentlyModifiedResource.getResourceId()))
+        .orElse(null);
+  }
+
+  private DbDataset getDataSet(DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource) {
+    return dataSetDao
+        .findByDataSetIdAndWorkspaceId(
+            Long.parseLong(dbUserRecentlyModifiedResource.getResourceId()),
+            dbUserRecentlyModifiedResource.getWorkspaceId())
+        .orElse(null);
+  }
+
+  private String getNotebookName(DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource) {
+    return dbUserRecentlyModifiedResource.getResourceId();
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceServiceImpl.java
@@ -270,7 +270,7 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
     }
   }
 
-  public List<DbUserRecentlyModifiedResource> populateRecentlyModifiedResources(long userId) {
+  private List<DbUserRecentlyModifiedResource> populateRecentlyModifiedResources(long userId) {
     List<DbUserRecentlyModifiedResource> userList =
         userRecentlyModifiedResourceDao.findDbUserRecentResourcesByUserId(userId);
     userList.stream()

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceServiceImpl.java
@@ -262,7 +262,6 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
   @Override
   public List<DbUserRecentlyModifiedResource> findAllRecentlyModifiedResourcesByUser(long userId) {
     try {
-      System.out.println("in here");
       return DbRetryUtils.executeAndRetry(
           () -> populateRecentlyModifiedResources(userId), Duration.ofSeconds(1), 5);
     } catch (InterruptedException e) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentlyModifiedResourceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentlyModifiedResourceDao.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
 import java.util.Collection;
+import java.util.List;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.springframework.data.repository.CrudRepository;
 
@@ -27,5 +28,12 @@ public interface UserRecentlyModifiedResourceDao
       String resourceId) {
     return this.findDbUserRecentResourcesIdByUserIdAndWorkspaceIdAndResourceTypeAndResourceId(
         userId, workspaceId, resourceType, resourceId);
+  }
+
+  List<DbUserRecentlyModifiedResource>
+      findDbUserRecentlyModifiedResourcesByUserIdOrderByLastAccessDateDesc(long userId);
+
+  default List<DbUserRecentlyModifiedResource> findDbUserRecentResourcesByUserId(long userId) {
+    return this.findDbUserRecentlyModifiedResourcesByUserIdOrderByLastAccessDateDesc(userId);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserRecentResource.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserRecentResource.java
@@ -10,6 +10,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+@Deprecated // Using user_recently_modified_resource table instead of this
 @Entity
 @Table(name = "user_recent_resource")
 public class DbUserRecentResource {

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserRecentResource.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserRecentResource.java
@@ -10,7 +10,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
-@Deprecated // Using user_recently_modified_resource table instead of this
+// This will be replaced by DbUserRecentlyModifiedResource
+@Deprecated
 @Entity
 @Table(name = "user_recent_resource")
 public class DbUserRecentResource {

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserRecentlyModifiedResource.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserRecentlyModifiedResource.java
@@ -9,6 +9,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 
 @Entity
 @Table(name = "user_recently_modified_resource")
@@ -27,6 +28,10 @@ public class DbUserRecentlyModifiedResource {
   private DbUserRecentlyModifiedResourceType resourceTypeEnum;
   private String resourceId;
   private Timestamp lastAccessDate;
+  private DbCohort cohort;
+  private DbConceptSet conceptSet;
+  private DbDataset dataSet;
+  private String notebookName;
 
   public DbUserRecentlyModifiedResource() {}
 
@@ -97,5 +102,41 @@ public class DbUserRecentlyModifiedResource {
 
   public void setLastAccessDate(Timestamp lastAccessDate) {
     this.lastAccessDate = lastAccessDate;
+  }
+
+  @Transient
+  public DbCohort getCohort() {
+    return cohort;
+  }
+
+  public void setCohort(DbCohort cohort) {
+    this.cohort = cohort;
+  }
+
+  @Transient
+  public DbConceptSet getConceptSet() {
+    return conceptSet;
+  }
+
+  public void setConceptSet(DbConceptSet conceptSet) {
+    this.conceptSet = conceptSet;
+  }
+
+  @Transient
+  public DbDataset getDataSet() {
+    return dataSet;
+  }
+
+  public void setDataSet(DbDataset dataSet) {
+    this.dataSet = dataSet;
+  }
+
+  @Transient
+  public String getNotebookName() {
+    return notebookName;
+  }
+
+  public void setNotebookName(String notebookName) {
+    this.notebookName = notebookName;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserRecentlyModifiedResource.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserRecentlyModifiedResource.java
@@ -9,7 +9,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import javax.persistence.Transient;
 
 @Entity
 @Table(name = "user_recently_modified_resource")
@@ -28,10 +27,6 @@ public class DbUserRecentlyModifiedResource {
   private DbUserRecentlyModifiedResourceType resourceTypeEnum;
   private String resourceId;
   private Timestamp lastAccessDate;
-  private DbCohort cohort;
-  private DbConceptSet conceptSet;
-  private DbDataset dataSet;
-  private String notebookName;
 
   public DbUserRecentlyModifiedResource() {}
 
@@ -102,41 +97,5 @@ public class DbUserRecentlyModifiedResource {
 
   public void setLastAccessDate(Timestamp lastAccessDate) {
     this.lastAccessDate = lastAccessDate;
-  }
-
-  @Transient
-  public DbCohort getCohort() {
-    return cohort;
-  }
-
-  public void setCohort(DbCohort cohort) {
-    this.cohort = cohort;
-  }
-
-  @Transient
-  public DbConceptSet getConceptSet() {
-    return conceptSet;
-  }
-
-  public void setConceptSet(DbConceptSet conceptSet) {
-    this.conceptSet = conceptSet;
-  }
-
-  @Transient
-  public DbDataset getDataSet() {
-    return dataSet;
-  }
-
-  public void setDataSet(DbDataset dataSet) {
-    this.dataSet = dataSet;
-  }
-
-  @Transient
-  public String getNotebookName() {
-    return notebookName;
-  }
-
-  public void setNotebookName(String notebookName) {
-    this.notebookName = notebookName;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
@@ -10,6 +10,7 @@ import org.pmiops.workbench.dataset.mapper.DataSetMapper;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbUserRecentResource;
+import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.model.CohortReview;
@@ -81,6 +82,14 @@ public interface WorkspaceResourceMapper {
   @Mapping(target = "lastModifiedEpochMillis", source = "dbUserRecentResource.lastAccessDate")
   ResourceFields fromDbUserRecentResource(DbUserRecentResource dbUserRecentResource);
 
+  @Mapping(target = "cohortReview", ignore = true)
+  @Mapping(target = "notebook", source = "notebookName")
+  @Mapping(
+      target = "lastModifiedEpochMillis",
+      source = "dbUserRecentlyModifiedResource.lastAccessDate")
+  ResourceFields fromDbUserRecentResource(
+      DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource);
+
   @Mapping(target = "permission", source = "accessLevel")
   WorkspaceResource mergeWorkspaceAndResourceFields(
       WorkspaceFields workspaceFields,
@@ -122,6 +131,14 @@ public interface WorkspaceResourceMapper {
 
   default WorkspaceResource fromDbUserRecentResource(
       DbUserRecentResource dbUserRecentResource,
+      FirecloudWorkspaceResponse fcWorkspace,
+      DbWorkspace dbWorkspace) {
+    return mergeWorkspaceAndResourceFields(
+        fromWorkspace(dbWorkspace), fcWorkspace, fromDbUserRecentResource(dbUserRecentResource));
+  }
+
+  default WorkspaceResource fromDbUserRecentlyModifiedResource(
+      DbUserRecentlyModifiedResource dbUserRecentResource,
       FirecloudWorkspaceResponse fcWorkspace,
       DbWorkspace dbWorkspace) {
     return mergeWorkspaceAndResourceFields(

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
@@ -17,6 +17,8 @@ import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbUserRecentResource;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.model.CohortReview;
 import org.pmiops.workbench.model.ConceptSet;
@@ -253,15 +255,21 @@ public interface WorkspaceResourceMapper {
             dbWorkspace,
             dataSetService
                 .getDbDataSet(workspaceId, getResourceIdInLong(dbUserRecentlyModifiedResource))
-                .orElse(new DbDataset()));
+                .orElseThrow(
+                    () ->
+                        new NotFoundException(
+                            String.format(
+                                "Data Set not found for dataSetId: %d",
+                                dbUserRecentlyModifiedResource.getResourceId()))));
       case NOTEBOOK:
         return fromDbUserRecentlyModifiedResourceAndNotebookName(
             dbUserRecentlyModifiedResource,
             fcWorkspace,
             dbWorkspace,
             dbUserRecentlyModifiedResource.getResourceId());
+      default:
+        throw new ServerErrorException("Recent resource: bad resource type ");
     }
-    return null;
   }
 
   default Long getResourceIdInLong(DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource) {

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.workspaces.resources;
 
-import java.util.Optional;
 import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -28,6 +27,8 @@ import org.pmiops.workbench.model.WorkspaceResource;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.FirecloudMapper;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
+
+import java.util.Optional;
 
 @Mapper(
     config = MapStructConfig.class,
@@ -259,7 +260,7 @@ public interface WorkspaceResourceMapper {
                     () ->
                         new NotFoundException(
                             String.format(
-                                "Data Set not found for dataSetId: %d",
+                                "Dataset not found for dataSetId: %s",
                                 dbUserRecentlyModifiedResource.getResourceId()))));
       case NOTEBOOK:
         return fromDbUserRecentlyModifiedResourceAndNotebookName(
@@ -272,7 +273,7 @@ public interface WorkspaceResourceMapper {
     }
   }
 
-  default Long getResourceIdInLong(DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource) {
+  default long getResourceIdInLong(DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource) {
     return Long.parseLong(
         Optional.ofNullable(dbUserRecentlyModifiedResource.getResourceId()).orElse("0"));
   }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
@@ -8,6 +8,7 @@ import org.pmiops.workbench.cohorts.CohortMapper;
 import org.pmiops.workbench.conceptset.mapper.ConceptSetMapper;
 import org.pmiops.workbench.dataset.mapper.DataSetMapper;
 import org.pmiops.workbench.db.model.DbCohort;
+import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbUserRecentResource;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
@@ -83,12 +84,47 @@ public interface WorkspaceResourceMapper {
   ResourceFields fromDbUserRecentResource(DbUserRecentResource dbUserRecentResource);
 
   @Mapping(target = "cohortReview", ignore = true)
-  @Mapping(target = "notebook", source = "notebookName")
+  @Mapping(target = "cohort", source = "dbCohort")
+  @Mapping(target = "conceptSet", ignore = true)
+  @Mapping(target = "notebook", ignore = true)
+  @Mapping(target = "dataSet", ignore = true)
   @Mapping(
       target = "lastModifiedEpochMillis",
       source = "dbUserRecentlyModifiedResource.lastAccessDate")
-  ResourceFields fromDbUserRecentResource(
-      DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource);
+  ResourceFields fromDbUserRecentlyModifiedResource(
+      DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource, DbCohort dbCohort);
+
+  @Mapping(target = "cohortReview", ignore = true)
+  @Mapping(target = "cohort", ignore = true)
+  @Mapping(target = "conceptSet", source = "dbConceptSet")
+  @Mapping(target = "notebook", ignore = true)
+  @Mapping(target = "dataSet", ignore = true)
+  @Mapping(
+      target = "lastModifiedEpochMillis",
+      source = "dbUserRecentlyModifiedResource.lastAccessDate")
+  ResourceFields fromDbUserRecentlyModifiedResource(
+      DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource, DbConceptSet dbConceptSet);
+
+  @Mapping(target = "cohortReview", ignore = true)
+  @Mapping(target = "cohort", ignore = true)
+  @Mapping(target = "conceptSet", ignore = true)
+  @Mapping(target = "notebook", ignore = true)
+  @Mapping(target = "dataSet", source = "dbDataset")
+  @Mapping(
+      target = "lastModifiedEpochMillis",
+      source = "dbUserRecentlyModifiedResource.lastAccessDate")
+  ResourceFields fromDbUserRecentlyModifiedResource(
+      DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource, DbDataset dbDataset);
+
+  @Mapping(target = "cohortReview", ignore = true)
+  @Mapping(target = "cohort", ignore = true)
+  @Mapping(target = "conceptSet", ignore = true)
+  @Mapping(target = "dataSet", ignore = true)
+  @Mapping(
+      target = "lastModifiedEpochMillis",
+      source = "dbUserRecentlyModifiedResource.lastAccessDate")
+  ResourceFields fromDbUserRecentlyModifiedResource(
+      DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource, String notebook);
 
   @Mapping(target = "permission", source = "accessLevel")
   WorkspaceResource mergeWorkspaceAndResourceFields(
@@ -129,6 +165,7 @@ public interface WorkspaceResourceMapper {
         fromWorkspace(dbWorkspace), accessLevel, fromDbDataset(dbDataset));
   }
 
+  @Deprecated
   default WorkspaceResource fromDbUserRecentResource(
       DbUserRecentResource dbUserRecentResource,
       FirecloudWorkspaceResponse fcWorkspace,
@@ -137,12 +174,48 @@ public interface WorkspaceResourceMapper {
         fromWorkspace(dbWorkspace), fcWorkspace, fromDbUserRecentResource(dbUserRecentResource));
   }
 
-  default WorkspaceResource fromDbUserRecentlyModifiedResource(
+  default WorkspaceResource fromDbUserRecentlyModifiedResourceAndCohort(
       DbUserRecentlyModifiedResource dbUserRecentResource,
       FirecloudWorkspaceResponse fcWorkspace,
-      DbWorkspace dbWorkspace) {
+      DbWorkspace dbWorkspace,
+      DbCohort dbCohort) {
     return mergeWorkspaceAndResourceFields(
-        fromWorkspace(dbWorkspace), fcWorkspace, fromDbUserRecentResource(dbUserRecentResource));
+        fromWorkspace(dbWorkspace),
+        fcWorkspace,
+        fromDbUserRecentlyModifiedResource(dbUserRecentResource, dbCohort));
+  }
+
+  default WorkspaceResource fromDbUserRecentlyModifiedResourceAndConceptSet(
+      DbUserRecentlyModifiedResource dbUserRecentResource,
+      FirecloudWorkspaceResponse fcWorkspace,
+      DbWorkspace dbWorkspace,
+      DbConceptSet dbConceptSet) {
+    return mergeWorkspaceAndResourceFields(
+        fromWorkspace(dbWorkspace),
+        fcWorkspace,
+        fromDbUserRecentlyModifiedResource(dbUserRecentResource, dbConceptSet));
+  }
+
+  default WorkspaceResource fromDbUserRecentlyModifiedResourceAndDataSet(
+      DbUserRecentlyModifiedResource dbUserRecentResource,
+      FirecloudWorkspaceResponse fcWorkspace,
+      DbWorkspace dbWorkspace,
+      DbDataset dbDataset) {
+    return mergeWorkspaceAndResourceFields(
+        fromWorkspace(dbWorkspace),
+        fcWorkspace,
+        fromDbUserRecentlyModifiedResource(dbUserRecentResource, dbDataset));
+  }
+
+  default WorkspaceResource fromDbUserRecentlyModifiedResourceAndNotebookName(
+      DbUserRecentlyModifiedResource dbUserRecentResource,
+      FirecloudWorkspaceResponse fcWorkspace,
+      DbWorkspace dbWorkspace,
+      String notebookName) {
+    return mergeWorkspaceAndResourceFields(
+        fromWorkspace(dbWorkspace),
+        fcWorkspace,
+        fromDbUserRecentlyModifiedResource(dbUserRecentResource, notebookName));
   }
 
   default FileDetail convertStringToFileDetail(String str) {

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.workspaces.resources;
 
+import java.util.Optional;
 import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -27,8 +28,6 @@ import org.pmiops.workbench.model.WorkspaceResource;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.FirecloudMapper;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
-
-import java.util.Optional;
 
 @Mapper(
     config = MapStructConfig.class,

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -24,6 +24,7 @@ import org.pmiops.workbench.cohorts.CohortMapperImpl;
 import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.conceptset.mapper.ConceptSetMapperImpl;
+import org.pmiops.workbench.dataset.DataSetService;
 import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
 import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
@@ -65,6 +66,9 @@ public class UserMetricsControllerTest {
 
   @Mock private CloudStorageClient mockCloudStorageClient;
   @Mock private UserRecentResourceService mockUserRecentResourceService;
+  @Mock private CohortService mockCohortService;
+  @Mock private ConceptSetService mockConceptSetService;
+  @Mock private DataSetService mockDataSetService;
   @Mock private Provider<DbUser> mockUserProvider;
   @Mock private FireCloudService mockFireCloudService;
   @Mock private WorkspaceDao workspaceDao;
@@ -204,6 +208,9 @@ public class UserMetricsControllerTest {
     userMetricsController =
         new UserMetricsController(
             mockCloudStorageClient,
+            mockCohortService,
+            mockConceptSetService,
+            mockDataSetService,
             mockFireCloudService,
             mockUserProvider,
             mockUserRecentResourceService,

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -80,13 +80,10 @@ public class UserMetricsControllerTest {
   private UserMetricsController userMetricsController;
 
   private DbUser dbUser;
-  //  private DbUserRecentResource dbUserRecentResource1;
-  //  private DbUserRecentResource dbUserRecentResource2;
-  //  private DbUserRecentResource dbUserRecentResource3;
 
-  private DbUserRecentlyModifiedResource dbUserRecentResource1;
-  private DbUserRecentlyModifiedResource dbUserRecentResource2;
-  private DbUserRecentlyModifiedResource dbUserRecentResource3;
+  private DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource1;
+  private DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource2;
+  private DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource3;
 
   private DbWorkspace dbWorkspace1;
   private DbWorkspace dbWorkspace2;
@@ -144,29 +141,29 @@ public class UserMetricsControllerTest {
     dbWorkspace2.setFirecloudName("firecloudName2");
     dbWorkspace2.setCdrVersion(dbCdrVersion);
 
-    dbUserRecentResource1 = new DbUserRecentlyModifiedResource();
-    dbUserRecentResource1.setResourceType(
+    dbUserRecentlyModifiedResource1 = new DbUserRecentlyModifiedResource();
+    dbUserRecentlyModifiedResource1.setResourceType(
         DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.NOTEBOOK);
-    dbUserRecentResource1.setNotebookName("gs://bucketFile/notebooks/notebook1.ipynb");
-    dbUserRecentResource1.setLastAccessDate(new Timestamp(fakeClock.millis()));
-    dbUserRecentResource1.setUserId(dbUser.getUserId());
-    dbUserRecentResource1.setWorkspaceId(dbWorkspace1.getWorkspaceId());
+    dbUserRecentlyModifiedResource1.setNotebookName("gs://bucketFile/notebooks/notebook1.ipynb");
+    dbUserRecentlyModifiedResource1.setLastAccessDate(new Timestamp(fakeClock.millis()));
+    dbUserRecentlyModifiedResource1.setUserId(dbUser.getUserId());
+    dbUserRecentlyModifiedResource1.setWorkspaceId(dbWorkspace1.getWorkspaceId());
 
-    dbUserRecentResource2 = new DbUserRecentlyModifiedResource();
-    dbUserRecentResource2.setResourceType(
+    dbUserRecentlyModifiedResource2 = new DbUserRecentlyModifiedResource();
+    dbUserRecentlyModifiedResource2.setResourceType(
         DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.COHORT);
-    dbUserRecentResource2.setCohort(dbCohort);
-    dbUserRecentResource2.setLastAccessDate(new Timestamp(fakeClock.millis() - 10000));
-    dbUserRecentResource2.setUserId(dbUser.getUserId());
-    dbUserRecentResource2.setWorkspaceId(dbWorkspace2.getWorkspaceId());
+    dbUserRecentlyModifiedResource2.setCohort(dbCohort);
+    dbUserRecentlyModifiedResource2.setLastAccessDate(new Timestamp(fakeClock.millis() - 10000));
+    dbUserRecentlyModifiedResource2.setUserId(dbUser.getUserId());
+    dbUserRecentlyModifiedResource2.setWorkspaceId(dbWorkspace2.getWorkspaceId());
 
-    dbUserRecentResource3 = new DbUserRecentlyModifiedResource();
-    dbUserRecentResource3.setResourceType(
+    dbUserRecentlyModifiedResource3 = new DbUserRecentlyModifiedResource();
+    dbUserRecentlyModifiedResource3.setResourceType(
         DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.CONCEPT_SET);
-    dbUserRecentResource3.setConceptSet(dbConceptSet);
-    dbUserRecentResource3.setLastAccessDate(new Timestamp(fakeClock.millis() - 10000));
-    dbUserRecentResource3.setUserId(dbUser.getUserId());
-    dbUserRecentResource3.setWorkspaceId(dbWorkspace2.getWorkspaceId());
+    dbUserRecentlyModifiedResource3.setConceptSet(dbConceptSet);
+    dbUserRecentlyModifiedResource3.setLastAccessDate(new Timestamp(fakeClock.millis() - 10000));
+    dbUserRecentlyModifiedResource3.setUserId(dbUser.getUserId());
+    dbUserRecentlyModifiedResource3.setWorkspaceId(dbWorkspace2.getWorkspaceId());
 
     final FirecloudWorkspaceDetails fcWorkspace1 = new FirecloudWorkspaceDetails();
     fcWorkspace1.setNamespace(dbWorkspace1.getFirecloudName());
@@ -189,7 +186,10 @@ public class UserMetricsControllerTest {
 
     when(mockUserRecentResourceService.findAllRecentlyModifiedResourcesByUser(dbUser.getUserId()))
         .thenReturn(
-            Arrays.asList(dbUserRecentResource1, dbUserRecentResource2, dbUserRecentResource3));
+            Arrays.asList(
+                dbUserRecentlyModifiedResource1,
+                dbUserRecentlyModifiedResource2,
+                dbUserRecentlyModifiedResource3));
 
     when(mockCloudStorageClient.getExistingBlobIdsIn(anyList()))
         .then(
@@ -232,9 +232,9 @@ public class UserMetricsControllerTest {
 
   @Test
   public void testGetUserRecentResourceFromRawBucket() {
-    dbUserRecentResource1.setNotebookName("gs://bucketFile/notebook.ipynb");
+    dbUserRecentlyModifiedResource1.setNotebookName("gs://bucketFile/notebook.ipynb");
     when(mockUserRecentResourceService.findAllRecentlyModifiedResourcesByUser(dbUser.getUserId()))
-        .thenReturn(Collections.singletonList(dbUserRecentResource1));
+        .thenReturn(Collections.singletonList(dbUserRecentlyModifiedResource1));
 
     WorkspaceResourceResponse recentResources =
         userMetricsController.getUserRecentResources().getBody();
@@ -245,9 +245,10 @@ public class UserMetricsControllerTest {
   // To do add test for recently resource
   @Test
   public void testGetUserRecentResourceWithDuplicatedNameInPath() {
-    dbUserRecentResource1.setNotebookName("gs://bucketFile/nb.ipynb/intermediate/nb.ipynb");
+    dbUserRecentlyModifiedResource1.setNotebookName(
+        "gs://bucketFile/nb.ipynb/intermediate/nb.ipynb");
     when(mockUserRecentResourceService.findAllRecentlyModifiedResourcesByUser(dbUser.getUserId()))
-        .thenReturn(Collections.singletonList(dbUserRecentResource1));
+        .thenReturn(Collections.singletonList(dbUserRecentlyModifiedResource1));
 
     WorkspaceResourceResponse recentResources =
         userMetricsController.getUserRecentResources().getBody();
@@ -259,9 +260,10 @@ public class UserMetricsControllerTest {
 
   @Test
   public void testGetUserRecentResourceWithSpacesInPath() {
-    dbUserRecentResource1.setNotebookName("gs://bucketFile/note books/My favorite notebook.ipynb");
+    dbUserRecentlyModifiedResource1.setNotebookName(
+        "gs://bucketFile/note books/My favorite notebook.ipynb");
     when(mockUserRecentResourceService.findAllRecentlyModifiedResourcesByUser(dbUser.getUserId()))
-        .thenReturn(Collections.singletonList(dbUserRecentResource1));
+        .thenReturn(Collections.singletonList(dbUserRecentlyModifiedResource1));
 
     WorkspaceResourceResponse recentResources =
         userMetricsController.getUserRecentResources().getBody();
@@ -274,9 +276,9 @@ public class UserMetricsControllerTest {
 
   @Test
   public void testGetUserRecentResourceInvalidURINotebookPath() {
-    dbUserRecentResource1.setNotebookName("my local notebook directory: notebook.ipynb");
+    dbUserRecentlyModifiedResource1.setNotebookName("my local notebook directory: notebook.ipynb");
     when(mockUserRecentResourceService.findAllRecentlyModifiedResourcesByUser(dbUser.getUserId()))
-        .thenReturn(Collections.singletonList(dbUserRecentResource1));
+        .thenReturn(Collections.singletonList(dbUserRecentlyModifiedResource1));
 
     WorkspaceResourceResponse recentResources =
         userMetricsController.getUserRecentResources().getBody();
@@ -286,9 +288,9 @@ public class UserMetricsControllerTest {
 
   @Test
   public void testGetUserRecentResourceNotebookPathEndsWithSlash() {
-    dbUserRecentResource1.setNotebookName("gs://bucketFile/notebooks/notebook.ipynb/");
+    dbUserRecentlyModifiedResource1.setNotebookName("gs://bucketFile/notebooks/notebook.ipynb/");
     when(mockUserRecentResourceService.findAllRecentlyModifiedResourcesByUser(dbUser.getUserId()))
-        .thenReturn(Collections.singletonList(dbUserRecentResource1));
+        .thenReturn(Collections.singletonList(dbUserRecentlyModifiedResource1));
 
     WorkspaceResourceResponse recentResources =
         userMetricsController.getUserRecentResources().getBody();
@@ -301,9 +303,9 @@ public class UserMetricsControllerTest {
   // RW-7498 regression test
   @Test
   public void testGetUserRecentResource_notebookNameWithParen() {
-    dbUserRecentResource1.setNotebookName("gs://bucketFile/notebooks/notebook :).ipynb");
+    dbUserRecentlyModifiedResource1.setNotebookName("gs://bucketFile/notebooks/notebook :).ipynb");
     when(mockUserRecentResourceService.findAllRecentlyModifiedResourcesByUser(dbUser.getUserId()))
-        .thenReturn(Collections.singletonList(dbUserRecentResource1));
+        .thenReturn(Collections.singletonList(dbUserRecentlyModifiedResource1));
 
     WorkspaceResourceResponse recentResources =
         userMetricsController.getUserRecentResources().getBody();
@@ -313,11 +315,12 @@ public class UserMetricsControllerTest {
 
   @Test
   public void testGetUserRecentResourceNonexistentNotebook() {
-    dbUserRecentResource1.setNotebookName("gs://bkt/notebooks/notebook.ipynb");
-    dbUserRecentResource2.setCohort(null);
-    dbUserRecentResource2.setNotebookName("gs://bkt/notebooks/not-found.ipynb");
+    dbUserRecentlyModifiedResource1.setNotebookName("gs://bkt/notebooks/notebook.ipynb");
+    dbUserRecentlyModifiedResource2.setCohort(null);
+    dbUserRecentlyModifiedResource2.setNotebookName("gs://bkt/notebooks/not-found.ipynb");
     when(mockUserRecentResourceService.findAllRecentlyModifiedResourcesByUser(dbUser.getUserId()))
-        .thenReturn(ImmutableList.of(dbUserRecentResource1, dbUserRecentResource2));
+        .thenReturn(
+            ImmutableList.of(dbUserRecentlyModifiedResource1, dbUserRecentlyModifiedResource2));
     when(mockCloudStorageClient.getExistingBlobIdsIn(anyList()))
         .thenReturn(ImmutableSet.of(BlobId.of("bkt", "notebooks/notebook.ipynb")));
 
@@ -346,18 +349,21 @@ public class UserMetricsControllerTest {
 
   @Test
   public void testGetUserRecentResources_missingWorkspace() {
-    dbUserRecentResource1.setWorkspaceId(9999); // missing workspace
+    dbUserRecentlyModifiedResource1.setWorkspaceId(9999); // missing workspace
     when(mockUserRecentResourceService.findAllRecentlyModifiedResourcesByUser(dbUser.getUserId()))
-        .thenReturn(ImmutableList.of(dbUserRecentResource1, dbUserRecentResource2));
+        .thenReturn(
+            ImmutableList.of(dbUserRecentlyModifiedResource1, dbUserRecentlyModifiedResource2));
     WorkspaceResourceResponse recentResources =
         userMetricsController.getUserRecentResources().getBody();
     assertThat(recentResources.size()).isEqualTo(1);
     WorkspaceResource foundResource = recentResources.get(0);
     final Cohort cohort1 = foundResource.getCohort();
-    final Cohort cohort2 = cohortMapper.dbModelToClient(dbUserRecentResource2.getCohort());
+    final Cohort cohort2 =
+        cohortMapper.dbModelToClient(dbUserRecentlyModifiedResource2.getCohort());
 
     assertThat(cohort1).isEqualTo(cohort2);
-    assertThat(foundResource.getWorkspaceId()).isEqualTo(dbUserRecentResource2.getWorkspaceId());
+    assertThat(foundResource.getWorkspaceId())
+        .isEqualTo(dbUserRecentlyModifiedResource2.getWorkspaceId());
   }
 
   @Test
@@ -376,14 +382,14 @@ public class UserMetricsControllerTest {
   @Test
   public void testDeleteResource() {
     RecentResourceRequest request = new RecentResourceRequest();
-    request.setNotebookName(dbUserRecentResource1.getNotebookName());
+    request.setNotebookName(dbUserRecentlyModifiedResource1.getNotebookName());
     userMetricsController.deleteRecentResource(
         dbWorkspace2.getWorkspaceNamespace(), dbWorkspace2.getFirecloudName(), request);
     verify(mockUserRecentResourceService)
         .deleteNotebookEntry(
             dbWorkspace2.getWorkspaceId(),
             dbUser.getUserId(),
-            dbUserRecentResource1.getNotebookName());
+            dbUserRecentlyModifiedResource1.getNotebookName());
   }
 
   @Test
@@ -420,21 +426,27 @@ public class UserMetricsControllerTest {
 
   @Test
   public void testHasValidBlobIdIfNotebookNamePresent_nullNotebookName_passes() {
-    dbUserRecentResource1.setNotebookName(null);
-    assertThat(userMetricsController.hasValidBlobIdIfNotebookNamePresent(dbUserRecentResource1))
+    dbUserRecentlyModifiedResource1.setNotebookName(null);
+    assertThat(
+            userMetricsController.hasValidBlobIdIfNotebookNamePresent(
+                dbUserRecentlyModifiedResource1))
         .isTrue();
   }
 
   @Test
   public void testHasValidBlobIdIfNotebookNamePresent_validNotebookName_passes() {
-    assertThat(userMetricsController.hasValidBlobIdIfNotebookNamePresent(dbUserRecentResource1))
+    assertThat(
+            userMetricsController.hasValidBlobIdIfNotebookNamePresent(
+                dbUserRecentlyModifiedResource1))
         .isTrue();
   }
 
   @Test
   public void testHasValidBlobIdIfNotebookNamePresent_invalidNotebookName_fails() {
-    dbUserRecentResource1.setNotebookName("invalid-notebook@name");
-    assertThat(userMetricsController.hasValidBlobIdIfNotebookNamePresent(dbUserRecentResource1))
+    dbUserRecentlyModifiedResource1.setNotebookName("invalid-notebook@name");
+    assertThat(
+            userMetricsController.hasValidBlobIdIfNotebookNamePresent(
+                dbUserRecentlyModifiedResource1))
         .isFalse();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -242,7 +242,7 @@ public class UserMetricsControllerTest {
     assertThat(recentResources.get(0).getNotebook().getPath()).isEqualTo("gs://bucketFile/");
     assertThat(recentResources.get(0).getNotebook().getName()).isEqualTo("notebook.ipynb");
   }
-  // To do add test for recently resource
+
   @Test
   public void testGetUserRecentResourceWithDuplicatedNameInPath() {
     dbUserRecentlyModifiedResource1.setNotebookName(

--- a/api/src/test/java/org/pmiops/workbench/db/service/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/service/UserRecentResourceServiceTest.java
@@ -21,6 +21,7 @@ import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbConceptSetConceptId;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserRecentResource;
+import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.test.FakeClock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -240,8 +241,8 @@ public class UserRecentResourceServiceTest {
     userRecentResourceService.updateConceptSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
 
-    List<DbUserRecentResource> resources =
-        userRecentResourceService.findAllResourcesByUser(user.getUserId());
+    List<DbUserRecentlyModifiedResource> resources =
+        userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
 
     assertThat(resources.size()).isEqualTo(4);
     assertThat(resources.get(0).getNotebookName())

--- a/api/src/test/java/org/pmiops/workbench/db/service/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/service/UserRecentResourceServiceTest.java
@@ -245,11 +245,12 @@ public class UserRecentResourceServiceTest {
         userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
 
     assertThat(resources.size()).isEqualTo(4);
-    assertThat(resources.get(0).getNotebookName())
+    assertThat(resources.get(0).getResourceId())
         .isEqualTo("gs://someDirectory1/notebooks/notebook2");
-    assertThat(resources.get(1).getConceptSet()).isEqualTo(conceptSet);
-    assertThat(resources.get(2).getCohort().getCohortId()).isEqualTo(cohort.getCohortId());
-    assertThat(resources.get(3).getNotebookName())
+    assertThat(Long.parseLong(resources.get(1).getResourceId()))
+        .isEqualTo(conceptSet.getConceptSetId());
+    assertThat(Long.parseLong(resources.get(2).getResourceId())).isEqualTo(cohort.getCohortId());
+    assertThat(resources.get(3).getResourceId())
         .isEqualTo("gs://someDirectory1/notebooks/notebook1");
   }
 }


### PR DESCRIPTION
This PR is to display recent resources using  the new table user_recently_modified_resource table
In case of TEST/LOCAL it will start displaying NOTEBOOK resources as well.

<img width="1595" alt="Screen Shot 2022-01-26 at 1 14 24 PM" src="https://user-images.githubusercontent.com/34481816/151222443-f054b755-677d-44b8-a026-e7a807429c51.png">

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
