### PR TITLE
[RW-7727][risk=no] Updating cdr in preprod for RT and CT

### DIFF
--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -100,7 +100,7 @@
       "creationTime": "2021-08-10 00:00:00Z",
       "releaseNumber": 7,
       "numParticipants": 329070,
-      "cdrDbName": "r_2021q3_5",
+      "cdrDbName": "r_2021q3_6",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"
@@ -115,7 +115,7 @@
       "creationTime": "2021-10-06 00:00:00Z",
       "releaseNumber": 8,
       "numParticipants": 331382,
-      "cdrDbName": "c_2021q3_5",
+      "cdrDbName": "c_2021q3_6",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "controlled",


### PR DESCRIPTION
Updating cdr in preprod for RT and CT. 

@calbach You're scheduled as the release eng next week... this will require a publish of cb_ and ds_ tables in preprod RT(R2021Q3R5) and CT(C2021Q3R5).