### PR TITLE
[RW-7582][risk=low] Fix PD runtime API interactions

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -238,9 +238,9 @@ public class RuntimeController implements RuntimeApiDelegate {
       throw new BadRequestException("Runtime cannot be empty for an update request");
     }
 
-    if (runtimeRequest.getRuntime().getGceConfig() != null
+    if (!(runtimeRequest.getRuntime().getGceConfig() != null
         ^ runtimeRequest.getRuntime().getGceWithPdConfig() != null
-        ^ runtimeRequest.getRuntime().getDataprocConfig() != null) {
+        ^ runtimeRequest.getRuntime().getDataprocConfig() != null)) {
       throw new BadRequestException(
           "Exactly one of GceConfig, GceWithPdConfig, or DataprocConfig must be provided");
     }

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -238,14 +238,11 @@ public class RuntimeController implements RuntimeApiDelegate {
       throw new BadRequestException("Runtime cannot be empty for an update request");
     }
 
-    if (runtimeRequest.getRuntime().getGceConfig() == null
-        && runtimeRequest.getRuntime().getDataprocConfig() == null) {
-      throw new BadRequestException("Either a GceConfig or DataprocConfig must be provided");
-    }
-
     if (runtimeRequest.getRuntime().getGceConfig() != null
-        && runtimeRequest.getRuntime().getDataprocConfig() != null) {
-      throw new BadRequestException("Only one of GceConfig or DataprocConfig must be provided");
+        ^ runtimeRequest.getRuntime().getGceWithPdConfig() != null
+        ^ runtimeRequest.getRuntime().getDataprocConfig() != null) {
+      throw new BadRequestException(
+          "Exactly one of GceConfig, GceWithPdConfig, or DataprocConfig must be provided");
     }
 
     DbUser user = userProvider.get();

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5932,9 +5932,6 @@ definitions:
       dataprocConfig:
         description: oneOf gceConfig, dataprocConfig, gceWithPdConfig will be provided
         "$ref": "#/definitions/DataprocConfig"
-      diskConfig:
-        description: The configuration of a persistent disk
-        "$ref": "#/definitions/DiskConfig"
       errors:
         type: array
         description: The list of errors that were encountered on runtime create, if any.
@@ -6035,9 +6032,6 @@ definitions:
     properties:
       persistentDisk:
         $ref: "#/definitions/PersistentDiskRequest"
-      bootDiskSize:
-        type: integer
-        description: size for boot disk
       machineType:
         type: string
         description: >

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -278,7 +278,7 @@ public class RuntimeControllerTest {
     dataprocConfigObj.put("masterMachineType", "n1-standard-4");
     dataprocConfigObj.put("masterDiskSize", 50.0);
 
-    leonardoMapper.mapRuntimeConfig(tmpRuntime, dataprocConfigObj);
+    leonardoMapper.mapRuntimeConfig(tmpRuntime, dataprocConfigObj, null);
     dataprocConfig = tmpRuntime.getDataprocConfig();
 
     gceConfigObj = new LinkedTreeMap<>();
@@ -287,7 +287,7 @@ public class RuntimeControllerTest {
     gceConfigObj.put("diskSize", 100.0);
     gceConfigObj.put("machineType", "n1-standard-2");
 
-    leonardoMapper.mapRuntimeConfig(tmpRuntime, gceConfigObj);
+    leonardoMapper.mapRuntimeConfig(tmpRuntime, gceConfigObj, null);
     gceConfig = tmpRuntime.getGceConfig();
 
     testLeoRuntime =
@@ -785,14 +785,12 @@ public class RuntimeControllerTest {
                         .diskType(LeonardoDiskType.SSD)
                         .name("pd")
                         .blockSize(100)
-                        .size(100)));
+                        .size(200)));
 
     Runtime runtime = runtimeController.getRuntime(WORKSPACE_NS).getBody();
 
-    assertThat(runtime.getDiskConfig().getDiskType()).isEqualTo(DiskType.SSD);
-    assertThat(runtime.getDiskConfig().getName()).isEqualTo("pd");
-    assertThat(runtime.getDiskConfig().getSize()).isEqualTo(100);
-    assertThat(runtime.getDiskConfig().getBlockSize()).isEqualTo(100);
+    assertThat(runtime.getGceWithPdConfig().getPersistentDisk())
+        .isEqualTo(new PersistentDiskRequest().diskType(DiskType.SSD).name("pd").size(200));
   }
 
   @Test
@@ -915,7 +913,7 @@ public class RuntimeControllerTest {
   }
 
   @Test
-  public void testCreateRuntime_gceWihPD() throws ApiException {
+  public void testCreateRuntime_gceWithPD() throws ApiException {
     when(userRuntimesApi.getRuntime(GOOGLE_PROJECT_ID, getRuntimeName()))
         .thenThrow(new NotFoundException());
     stubGetWorkspace(WORKSPACE_NS, GOOGLE_PROJECT_ID, WORKSPACE_ID, "test");
@@ -925,7 +923,6 @@ public class RuntimeControllerTest {
         new Runtime()
             .gceWithPdConfig(
                 new GceWithPdConfig()
-                    .bootDiskSize(50)
                     .machineType("standard")
                     .persistentDisk(
                         new PersistentDiskRequest()
@@ -951,7 +948,6 @@ public class RuntimeControllerTest {
                 .getCloudService())
         .isEqualTo(LeonardoRuntimeConfig.CloudServiceEnum.GCE);
 
-    assertThat(createLeonardoGceWithPdConfig.getBootDiskSize()).isEqualTo(50);
     assertThat(createLeonardoGceWithPdConfig.getMachineType()).isEqualTo("standard");
     assertThat(createLeonardoGceWithPdConfig.getPersistentDisk().getDiskType())
         .isEqualTo(LeonardoDiskType.SSD);
@@ -1100,7 +1096,6 @@ public class RuntimeControllerTest {
         new Runtime()
             .gceWithPdConfig(
                 new GceWithPdConfig()
-                    .bootDiskSize(50)
                     .machineType("standard")
                     .persistentDisk(
                         new PersistentDiskRequest()


### PR DESCRIPTION
Part 2/??

- Return `GceWithPdConfig` when a PD is configured
- Allow updating via `GceWithPdConfig`
- Remove unused / redundant values from the workbench API
