### PR TITLE
[risk=low][RW-7616] Add the current DUCC version(s) to config and allow multiple

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -98,7 +98,8 @@
     "unsafeAllowSelfBypass": true,
     "unsafeAllowUserCreationFromGSuiteData": true,
     "enableRasLoginGovLinking": true,
-    "enforceRasLoginGovLinking": true
+    "enforceRasLoginGovLinking": true,
+    "currentDuccVersions": [3]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -98,7 +98,8 @@
     "unsafeAllowSelfBypass": true,
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasLoginGovLinking": true,
-    "enforceRasLoginGovLinking": true
+    "enforceRasLoginGovLinking": true,
+    "currentDuccVersions": [3]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -98,7 +98,8 @@
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasLoginGovLinking": false,
-    "enforceRasLoginGovLinking": false
+    "enforceRasLoginGovLinking": false,
+    "currentDuccVersions": [3]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -97,7 +97,8 @@
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasLoginGovLinking": true,
-    "enforceRasLoginGovLinking": true
+    "enforceRasLoginGovLinking": true,
+    "currentDuccVersions": [3]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -97,7 +97,8 @@
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasLoginGovLinking": true,
-    "enforceRasLoginGovLinking": true
+    "enforceRasLoginGovLinking": true,
+    "currentDuccVersions": [3]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -98,7 +98,8 @@
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasLoginGovLinking": true,
-    "enforceRasLoginGovLinking": true
+    "enforceRasLoginGovLinking": true,
+    "currentDuccVersions": [3]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -98,7 +98,8 @@
     "unsafeAllowSelfBypass": true,
     "unsafeAllowUserCreationFromGSuiteData": true,
     "enableRasLoginGovLinking": true,
-    "enforceRasLoginGovLinking": true
+    "enforceRasLoginGovLinking": true,
+    "currentDuccVersions": [3]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
@@ -40,7 +40,7 @@ public interface AccessModuleService {
   /** Returns true if the access module is bypassable and bypassed */
   boolean isModuleBypassed(DbUser dbUser, AccessModuleName accessModuleName);
 
-  int getCurrentDuccVersion();
+  boolean isSignedDuccVersionCurrent(Integer signedVersion);
 
-  boolean hasUserSignedTheCurrentDucc(DbUser targetUser);
+  boolean hasUserSignedACurrentDucc(DbUser targetUser);
 }

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
@@ -46,8 +46,6 @@ public class AccessModuleServiceImpl implements AccessModuleService {
   private final Provider<WorkbenchConfig> configProvider;
   private final UserAccessModuleMapper userAccessModuleMapper;
 
-  private static final int CURRENT_DATA_USER_CODE_OF_CONDUCT_VERSION = 3;
-
   @Autowired
   public AccessModuleServiceImpl(
       Provider<List<DbAccessModule>> dbAccessModulesProvider,
@@ -137,18 +135,18 @@ public class AccessModuleServiceImpl implements AccessModuleService {
 
   @VisibleForTesting
   @Override
-  public int getCurrentDuccVersion() {
-    return CURRENT_DATA_USER_CODE_OF_CONDUCT_VERSION;
+  public boolean isSignedDuccVersionCurrent(Integer signedVersion) {
+    return configProvider.get().access.currentDuccVersions.contains(signedVersion);
   }
 
   @Override
-  public boolean hasUserSignedTheCurrentDucc(DbUser targetUser) {
+  public boolean hasUserSignedACurrentDucc(DbUser targetUser) {
     final DbUserCodeOfConductAgreement duccAgreement = targetUser.getDuccAgreement();
     if (duccAgreement == null) {
       return false;
     }
 
-    return duccAgreement.getSignedVersion() == getCurrentDuccVersion();
+    return isSignedDuccVersionCurrent(duccAgreement.getSignedVersion());
   }
 
   @Override
@@ -165,7 +163,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
 
     // we have an additional check before considering DUCC "complete"
     if (isCompleted && accessModuleName == AccessModuleName.DATA_USER_CODE_OF_CONDUCT) {
-      isCompleted = hasUserSignedTheCurrentDucc(dbUser);
+      isCompleted = hasUserSignedACurrentDucc(dbUser);
     }
 
     boolean isExpired =

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -245,7 +245,7 @@ public class WorkbenchConfig {
     public boolean enableRasLoginGovLinking;
     // If true, all users are required to finish identity verification using RAS/login.gov
     public boolean enforceRasLoginGovLinking;
-    // Which Data User Code of Conduct (DUCC) Agreement versions are currently accepted as valid
+    // Which Data User Code of Conduct (DUCC) Agreement version(s) are currently accepted as valid
     public List<Integer> currentDuccVersions;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -245,6 +245,8 @@ public class WorkbenchConfig {
     public boolean enableRasLoginGovLinking;
     // If true, all users are required to finish identity verification using RAS/login.gov
     public boolean enforceRasLoginGovLinking;
+    // Which Data User Code of Conduct (DUCC) Agreement versions are currently accepted as valid
+    public List<Integer> currentDuccVersions;
   }
 
   public static class FeatureFlagsConfig {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -429,8 +429,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
 
   @Override
   public DbUser submitDUCC(DbUser dbUser, Integer duccSignedVersion, String initials) {
-    // FIXME: this should not be hardcoded
-    if (duccSignedVersion != accessModuleService.getCurrentDuccVersion()) {
+    if (!accessModuleService.isSignedDuccVersionCurrent(duccSignedVersion)) {
       throw new BadRequestException("Data User Code of Conduct Version is not up to date");
     }
     final Timestamp timestamp = new Timestamp(clock.instant().toEpochMilli());
@@ -819,7 +818,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       return targetUser;
     }
 
-    if (!accessModuleService.hasUserSignedTheCurrentDucc(targetUser)) {
+    if (!accessModuleService.hasUserSignedACurrentDucc(targetUser)) {
       accessModuleService.updateCompletionTime(
           targetUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, null);
     }

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
@@ -74,18 +74,18 @@ public class AccessModuleServiceTest {
 
   @BeforeEach
   public void setup() {
-    user = new DbUser();
-    user.setUsername("user");
-    user.setDuccAgreement(
-        TestMockFactory.createDuccAgreement(
-            user, accessModuleService.getCurrentDuccVersion(), FakeClockConfiguration.NOW));
-    user = userDao.save(user);
-
     config = WorkbenchConfig.createEmptyConfig();
     config.access.enableComplianceTraining = true;
     config.access.enableEraCommons = true;
+    config.access.currentDuccVersions = ImmutableList.of(10, 11);
 
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
+
+    user = new DbUser();
+    user.setUsername("user");
+    user.setDuccAgreement(
+        TestMockFactory.createDuccAgreement(user, 10, FakeClockConfiguration.NOW));
+    user = userDao.save(user);
   }
 
   @Test
@@ -342,7 +342,7 @@ public class AccessModuleServiceTest {
   }
 
   @Test
-  public void testModuleCompliant_byPassedAndExpired() {
+  public void testModuleCompliant_bypassedAndExpired() {
     Instant now = Instant.ofEpochMilli(FakeClockConfiguration.NOW_TIME);
     long expiryDays = 365L;
     config.accessRenewal.expiryDays = expiryDays;

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
@@ -77,7 +77,7 @@ public class AccessModuleServiceTest {
     config = WorkbenchConfig.createEmptyConfig();
     config.access.enableComplianceTraining = true;
     config.access.enableEraCommons = true;
-    config.access.currentDuccVersions = ImmutableList.of(10, 11);
+    config.access.currentDuccVersions = ImmutableList.of(10, 11); // arbitrary for test
 
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
 

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -53,7 +53,6 @@ import org.pmiops.workbench.db.dao.AccessModuleDao;
 import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.UserCodeOfConductAgreementDao;
 import org.pmiops.workbench.db.dao.UserDao;
-import org.pmiops.workbench.db.dao.UserDataUseAgreementDao;
 import org.pmiops.workbench.db.dao.UserServiceImpl;
 import org.pmiops.workbench.db.dao.UserTermsOfServiceDao;
 import org.pmiops.workbench.db.model.DbAccessModule;
@@ -118,7 +117,6 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
@@ -142,6 +140,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   @MockBean private RasLinkService mockRasLinkService;
 
   @Autowired private AccessModuleDao accessModuleDao;
+  @Autowired private AccessModuleService accessModuleService;
   @Autowired private AccessTierDao accessTierDao;
   @Autowired private AccessTierService accessTierService;
   @Autowired private InstitutionService institutionService;
@@ -149,12 +148,8 @@ public class ProfileControllerTest extends BaseControllerTest {
   @Autowired private ProfileService profileService;
   @Autowired private UserDao userDao;
   @Autowired private UserCodeOfConductAgreementDao userCodeOfConductAgreementDao;
-  @Autowired private UserDataUseAgreementDao userDataUseAgreementDao;
   @Autowired private UserTermsOfServiceDao userTermsOfServiceDao;
   @Autowired private FakeClock fakeClock;
-
-  // allows us to mock out only specific methods
-  @SpyBean private AccessModuleService accessModuleService;
 
   private static final long NONCE_LONG = 12345;
   private static final String CAPTCHA_TOKEN = "captchaToken";
@@ -175,7 +170,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   private static final Timestamp TIMESTAMP = FakeClockConfiguration.NOW;
   private static final double TIME_TOLERANCE_MILLIS = 100.0;
   private static final int CURRENT_TERMS_OF_SERVICE_VERSION = 1;
-  private static final int CURRENT_DUCC_VERSION = 27; // arbitrary
+  private static final int CURRENT_DUCC_VERSION = 27; // arbitrary for test
   private CreateAccountRequest createAccountRequest;
   private User googleUser;
   private static DbUser dbUser;

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -448,9 +448,9 @@ public class UserServiceTest {
 
     providedWorkbenchConfig.access.currentDuccVersions.forEach(
         version -> {
-          final DbUser user = userDao.findUserByUsername(USERNAME);
+          DbUser user = userDao.findUserByUsername(USERNAME);
           user.setDuccAgreement(signDucc(user, version));
-          userDao.save(user);
+          user = userDao.save(user);
           userService.syncDuccVersionStatus(user, Agent.asSystem());
           verify(accessModuleService, never()).updateCompletionTime(any(), any(), any());
         });

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -460,9 +460,9 @@ public class UserServiceTest {
   public void testSyncDuccVersionStatus_incorrectVersion() {
     providedWorkbenchConfig.access.currentDuccVersions = ImmutableList.of(3, 4, 5);
 
-    final DbUser user = userDao.findUserByUsername(USERNAME);
+    DbUser user = userDao.findUserByUsername(USERNAME);
     user.setDuccAgreement(signDucc(user, 2));
-    userDao.save(user);
+    user = userDao.save(user);
 
     userService.syncDuccVersionStatus(user, Agent.asSystem());
 


### PR DESCRIPTION
Add the current DUCC version to config instead of hardcoding.

We will need to support multiple "current" DUCC versions for RW-7616.  This PR doesn't change our requirement, but it sets us up to do so.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
