### PR TITLE
[RW-7717][risk=no] Set footer in Admin User table

### DIFF
--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -221,6 +221,30 @@ export const displayTierBadgeByRequiredModule = (
   );
 };
 
+export const getEraNote = (profile: Profile): string => {
+  const requiredForRT = isEraRequiredForTier(
+    profile,
+    AccessTierShortNames.Registered
+  );
+  const requiredForCT = isEraRequiredForTier(
+    profile,
+    AccessTierShortNames.Controlled
+  );
+  let note = `*eRA Commons requirements vary by institution. This user's institution 
+  (${profile.verifiedInstitutionalAffiliation.institutionDisplayName}) `;
+
+  if (!requiredForRT && !requiredForCT) {
+    note += 'does not require eRA Commons.';
+  } else if (requiredForRT && !requiredForCT) {
+    note += 'requires eRA Commons for RT access.';
+  } else if (!requiredForRT && requiredForCT) {
+    note += 'requires eRA Commons for CT access.';
+  } else if (requiredForRT && requiredForCT) {
+    note += 'requires eRA Commons for RT and CT access.';
+  }
+  return note;
+};
+
 // would this AccessBypassRequest actually change the profile state?
 // allows un-toggling of bypass for a module
 export const wouldUpdateBypassState = (

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -223,23 +223,29 @@ export const displayTierBadgeByRequiredModule = (
 };
 
 export const getEraNote = (profile: Profile): string => {
-  const tierDisplayNames: AccessTierDisplayNames[] = Object.keys(
-    AccessTierDisplayNames
-  ).map((key) => {
-    return AccessTierDisplayNames[key];
-  });
+  // Boolean array that indicates whether eRA is required for Registered Tier and Controlled Tier
   const tiersRequired: boolean[] = Object.keys(AccessTierShortNames).map(
     (key) => {
       return isEraRequiredForTier(profile, AccessTierShortNames[key]);
     }
   );
-  const requiredForTierNames: AccessTierDisplayNames[] =
+
+  // Turn values of enum AccessTierDisplayNames to an array
+  const tierDisplayNames: AccessTierDisplayNames[] = Object.keys(
+    AccessTierDisplayNames
+  ).map((key) => {
+    return AccessTierDisplayNames[key];
+  });
+
+  // Tiers that require eRA
+  const requiredTierDisplayNames: AccessTierDisplayNames[] =
     tierDisplayNames.filter((name, index) => tiersRequired[index]);
+
   const accessText =
-    requiredForTierNames.length === 0
+    requiredTierDisplayNames.length === 0
       ? 'does not require eRA Commons'
       : 'requires eRA Commons for ' +
-        (requiredForTierNames.join(' and ') + ' access');
+        (requiredTierDisplayNames.join(' and ') + ' access');
   const institutionName =
     profile.verifiedInstitutionalAffiliation?.institutionDisplayName;
   const note = '* eRA Commons requirements vary by institution.';

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -42,9 +42,10 @@ import {
   getAccessModuleStatusByName,
 } from 'app/utils/access-utils';
 import {
-  AccessTierDisplayNames,
   AccessTierShortNames,
   hasRegisteredTierAccess,
+  orderedAccessTierShortNames,
+  displayNameForTier,
 } from 'app/utils/access-tiers';
 import { formatDate } from 'app/utils/dates';
 
@@ -223,29 +224,15 @@ export const displayTierBadgeByRequiredModule = (
 };
 
 export const getEraNote = (profile: Profile): string => {
-  // Boolean array that indicates whether eRA is required for Registered Tier and Controlled Tier
-  const tiersRequired: boolean[] = Object.keys(AccessTierShortNames).map(
-    (key) => {
-      return isEraRequiredForTier(profile, AccessTierShortNames[key]);
-    }
-  );
-
-  // Turn values of enum AccessTierDisplayNames to an array
-  const tierDisplayNames: AccessTierDisplayNames[] = Object.keys(
-    AccessTierDisplayNames
-  ).map((key) => {
-    return AccessTierDisplayNames[key];
-  });
-
-  // Tiers that require eRA
-  const requiredTierDisplayNames: AccessTierDisplayNames[] =
-    tierDisplayNames.filter((name, index) => tiersRequired[index]);
+  const requiredTierNames = orderedAccessTierShortNames
+    .filter((name) => isEraRequiredForTier(profile, name))
+    .map(displayNameForTier);
 
   const accessText =
-    requiredTierDisplayNames.length === 0
+    requiredTierNames.length === 0
       ? 'does not require eRA Commons'
       : 'requires eRA Commons for ' +
-        (requiredTierDisplayNames.join(' and ') + ' access');
+        (requiredTierNames.join(' and ') + ' access');
   const institutionName =
     profile.verifiedInstitutionalAffiliation?.institutionDisplayName;
   const note = '* eRA Commons requirements vary by institution.';

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -42,10 +42,9 @@ import {
   getAccessModuleStatusByName,
 } from 'app/utils/access-utils';
 import {
+  AccessTierDisplayNames,
   AccessTierShortNames,
   hasRegisteredTierAccess,
-  orderedAccessTierDisplayNames,
-  orderedAccessTierShortNames,
 } from 'app/utils/access-tiers';
 import { formatDate } from 'app/utils/dates';
 
@@ -224,10 +223,14 @@ export const displayTierBadgeByRequiredModule = (
 };
 
 export const getEraNote = (profile: Profile): string => {
-  const tiersRequired = orderedAccessTierShortNames.map((t) =>
-    isEraRequiredForTier(profile, t)
-  );
-  const requiredForTierNames = orderedAccessTierDisplayNames.filter(
+  // prettier-ignore
+  const tierDisplayNames = Object.keys(AccessTierDisplayNames).map(function (key) {
+    return AccessTierDisplayNames[key];
+  });
+  const tiersRequired = Object.keys(AccessTierShortNames).map(function (key) {
+    return isEraRequiredForTier(profile, AccessTierShortNames[key]);
+  });
+  const requiredForTierNames = tierDisplayNames.filter(
     (n, i) => tiersRequired[i]
   );
   const accessText =

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -223,16 +223,18 @@ export const displayTierBadgeByRequiredModule = (
 };
 
 export const getEraNote = (profile: Profile): string => {
-  // prettier-ignore
-  const tierDisplayNames = Object.keys(AccessTierDisplayNames).map(function (key) {
+  const tierDisplayNames: AccessTierDisplayNames[] = Object.keys(
+    AccessTierDisplayNames
+  ).map((key) => {
     return AccessTierDisplayNames[key];
   });
-  const tiersRequired = Object.keys(AccessTierShortNames).map(function (key) {
-    return isEraRequiredForTier(profile, AccessTierShortNames[key]);
-  });
-  const requiredForTierNames = tierDisplayNames.filter(
-    (n, i) => tiersRequired[i]
+  const tiersRequired: boolean[] = Object.keys(AccessTierShortNames).map(
+    (key) => {
+      return isEraRequiredForTier(profile, AccessTierShortNames[key]);
+    }
   );
+  const requiredForTierNames: AccessTierDisplayNames[] =
+    tierDisplayNames.filter((name, index) => tiersRequired[index]);
   const accessText =
     requiredForTierNames.length === 0
       ? 'does not require eRA Commons'

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -44,6 +44,8 @@ import {
 import {
   AccessTierShortNames,
   hasRegisteredTierAccess,
+  orderedAccessTierDisplayNames,
+  orderedAccessTierShortNames,
 } from 'app/utils/access-tiers';
 import { formatDate } from 'app/utils/dates';
 
@@ -222,33 +224,26 @@ export const displayTierBadgeByRequiredModule = (
 };
 
 export const getEraNote = (profile: Profile): string => {
-  const requiredForRT = isEraRequiredForTier(
-    profile,
-    AccessTierShortNames.Registered
+  const tiersRequired = orderedAccessTierShortNames.map((t) =>
+    isEraRequiredForTier(profile, t)
   );
-  const requiredForCT = isEraRequiredForTier(
-    profile,
-    AccessTierShortNames.Controlled
+  const requiredForTierNames = orderedAccessTierDisplayNames.filter(
+    (n, i) => tiersRequired[i]
   );
+  const accessText =
+    requiredForTierNames.length === 0
+      ? 'does not require eRA Commons'
+      : 'requires eRA Commons for ' +
+        (requiredForTierNames.join(' and ') + ' access');
   const institutionName =
     profile.verifiedInstitutionalAffiliation?.institutionDisplayName;
-  let note = '* eRA Commons requirements vary by institution.';
-  if (isBlank(institutionName)) {
-    return (note +=
-      " We don't have any institutional information for this user.");
-  }
-  note += ` This user's institution (${institutionName}) `;
-  if (!requiredForRT && !requiredForCT) {
-    note += 'does not require eRA Commons.';
-  } else if (requiredForRT && !requiredForCT) {
-    note += 'requires eRA Commons for Registered Tier access.';
-  } else if (!requiredForRT && requiredForCT) {
-    note += 'requires eRA Commons for Controlled Tier access.';
-  } else if (requiredForRT && requiredForCT) {
-    note +=
-      'requires eRA Commons for Registered Tier and Controlled Tier access.';
-  }
-  return note;
+  const note = '* eRA Commons requirements vary by institution.';
+  return (
+    note +
+    (isBlank(institutionName)
+      ? ` We don't have any institutional information for this user.`
+      : ` This user's institution (${institutionName}) ${accessText}.`)
+  );
 };
 
 // would this AccessBypassRequest actually change the profile state?

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -232,9 +232,12 @@ export const getEraNote = (profile: Profile): string => {
   );
   const institutionName =
     profile.verifiedInstitutionalAffiliation?.institutionDisplayName;
-  let note = `* eRA Commons requirements vary by institution. This user's institution 
-  (${isBlank(institutionName) ? 'N/A' : institutionName}) `;
-
+  let note = '* eRA Commons requirements vary by institution.';
+  if (isBlank(institutionName)) {
+    return (note +=
+      " We don't have any institutional information for this user.");
+  }
+  note += ` This user's institution (${institutionName}) `;
   if (!requiredForRT && !requiredForCT) {
     note += 'does not require eRA Commons.';
   } else if (requiredForRT && !requiredForCT) {
@@ -245,7 +248,7 @@ export const getEraNote = (profile: Profile): string => {
     note +=
       'requires eRA Commons for Registered Tier and Controlled Tier access.';
   }
-  return (note += ' *');
+  return note;
 };
 
 // would this AccessBypassRequest actually change the profile state?

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -12,7 +12,7 @@ import {
   RegisteredTierBadge,
 } from 'app/components/icons';
 
-import { formatInitialCreditsUSD, reactStyles } from 'app/utils';
+import { formatInitialCreditsUSD, isBlank, reactStyles } from 'app/utils';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import {
   AccessBypassRequest,
@@ -230,19 +230,22 @@ export const getEraNote = (profile: Profile): string => {
     profile,
     AccessTierShortNames.Controlled
   );
-  let note = `*eRA Commons requirements vary by institution. This user's institution 
-  (${profile.verifiedInstitutionalAffiliation.institutionDisplayName}) `;
+  const institutionName =
+    profile.verifiedInstitutionalAffiliation?.institutionDisplayName;
+  let note = `* eRA Commons requirements vary by institution. This user's institution 
+  (${isBlank(institutionName) ? 'N/A' : institutionName}) `;
 
   if (!requiredForRT && !requiredForCT) {
     note += 'does not require eRA Commons.';
   } else if (requiredForRT && !requiredForCT) {
-    note += 'requires eRA Commons for RT access.';
+    note += 'requires eRA Commons for Registered Tier access.';
   } else if (!requiredForRT && requiredForCT) {
-    note += 'requires eRA Commons for CT access.';
+    note += 'requires eRA Commons for Controlled Tier access.';
   } else if (requiredForRT && requiredForCT) {
-    note += 'requires eRA Commons for RT and CT access.';
+    note +=
+      'requires eRA Commons for Registered Tier and Controlled Tier access.';
   }
-  return note;
+  return (note += ' *');
 };
 
 // would this AccessBypassRequest actually change the profile state?

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -24,6 +24,7 @@ import {
   displayModuleCompletionDate,
   displayModuleExpirationDate,
   displayTierBadgeByRequiredModule,
+  getEraNote,
 } from './admin-user-common';
 import { FadeBox } from 'app/components/containers';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
@@ -316,7 +317,16 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
   });
 
   return (
-    <DataTable style={{ paddingTop: '1em' }} value={tableData}>
+    <DataTable
+      rowHover
+      style={{ paddingTop: '1em' }}
+      value={tableData}
+      footer={
+        <div style={{ textAlign: 'left', fontWeight: 'normal' }}>
+          {getEraNote(updatedProfile)}
+        </div>
+      }
+    >
       <Column field='moduleName' header='Access Module' />
       <Column field='completionDate' header='Last completed on' />
       <Column field='expirationDate' header='Expires on' />

--- a/ui/src/app/utils/access-tiers.tsx
+++ b/ui/src/app/utils/access-tiers.tsx
@@ -6,6 +6,11 @@ export enum AccessTierShortNames {
   Controlled = 'controlled',
 }
 
+export const orderedAccessTierShortNames = [
+  AccessTierShortNames.Registered,
+  AccessTierShortNames.Controlled,
+];
+
 export enum AccessTierDisplayNames {
   Registered = 'Registered Tier',
   Controlled = 'Controlled Tier',

--- a/ui/src/app/utils/access-tiers.tsx
+++ b/ui/src/app/utils/access-tiers.tsx
@@ -6,20 +6,10 @@ export enum AccessTierShortNames {
   Controlled = 'controlled',
 }
 
-export const orderedAccessTierShortNames = [
-  AccessTierShortNames.Registered,
-  AccessTierShortNames.Controlled,
-];
-
 export enum AccessTierDisplayNames {
   Registered = 'Registered Tier',
   Controlled = 'Controlled Tier',
 }
-
-export const orderedAccessTierDisplayNames = [
-  AccessTierDisplayNames.Registered,
-  AccessTierDisplayNames.Controlled,
-];
 
 export function hasTierAccess(profile: Profile, shortName): boolean {
   return profile.accessTierShortNames.includes(shortName);

--- a/ui/src/app/utils/access-tiers.tsx
+++ b/ui/src/app/utils/access-tiers.tsx
@@ -6,10 +6,20 @@ export enum AccessTierShortNames {
   Controlled = 'controlled',
 }
 
+export const orderedAccessTierShortNames = [
+  AccessTierShortNames.Registered,
+  AccessTierShortNames.Controlled,
+];
+
 export enum AccessTierDisplayNames {
   Registered = 'Registered Tier',
   Controlled = 'Controlled Tier',
 }
+
+export const orderedAccessTierDisplayNames = [
+  AccessTierDisplayNames.Registered,
+  AccessTierDisplayNames.Controlled,
+];
 
 export function hasTierAccess(profile: Profile, shortName): boolean {
   return profile.accessTierShortNames.includes(shortName);

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -194,7 +194,7 @@ export const getAccessModuleConfig = (
         moduleName,
         isEnabledInEnvironment: enableEraCommons,
         DARTitleComponent: () => <div>Connect your eRA Commons account</div>,
-        adminPageTitle: 'Connect your eRA Commons account',
+        adminPageTitle: 'Connect your eRA Commons* account',
         adminBypassable: true,
         canExpire: false,
         externalSyncAction: async () =>


### PR DESCRIPTION
Populate ERA Commons as appropriate for the user’s institution and add a note at the bottom of the table accordingly.

RT required only:
<img width="1568" alt="Screen Shot 2022-02-02 at 3 36 19 PM" src="https://user-images.githubusercontent.com/35533885/152234518-f04fc1dd-d19d-4a82-b4fa-31cb9620b077.png">

RT and CT not required with institution name:
<img width="1543" alt="Screen Shot 2022-02-02 at 3 36 43 PM" src="https://user-images.githubusercontent.com/35533885/152234520-5f9e9ef9-b18f-49d0-93e9-7363a2b17855.png">

RT and CT required:
<img width="1551" alt="Screen Shot 2022-02-02 at 3 37 00 PM" src="https://user-images.githubusercontent.com/35533885/152234536-b3140692-765c-4d78-84cc-3ab4e6949152.png">

RT and CT not required without institution name:
<img width="1545" alt="Screen Shot 2022-02-02 at 3 38 11 PM" src="https://user-images.githubusercontent.com/35533885/152234543-81bbbe0b-1b14-4eb3-8b24-fe9fb209a112.png">


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
