### PR TITLE
[RW-7814][risk=no] Fix UI calls for cross domain tree nodes

### DIFF
--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -501,18 +501,19 @@ export const CriteriaSearch = fp.flow(
             />
             {hierarchyNode && (
               <CriteriaTree
-                source={source}
-                selectedSurvey={selectedSurvey}
                 autocompleteSelection={autocompleteSelection}
                 back={this.back}
+                domain={domain}
                 groupSelections={groupSelections}
                 node={hierarchyNode}
                 scrollToMatch={this.setScroll}
                 searchTerms={treeSearchTerms}
                 select={this.addSelection}
                 selectedIds={this.getListSearchSelectedIds()}
+                selectedSurvey={selectedSurvey}
                 selectOption={this.setAutocompleteSelection}
                 setSearchTerms={this.setTreeSearchTerms}
+                source={source}
               />
             )}
             {/*List View (using duplicated version of ListSearch) */}


### PR DESCRIPTION
Use the domain selected from the criteria menu instead of the domain from the tree node for any calls to load criteria for trees