### PR TITLE
[RW-7709][risk=no] Fix duplicate params in cohort description

### DIFF
--- a/ui/src/app/pages/data/cohort-review/cohort-definition.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-definition.component.tsx
@@ -109,10 +109,7 @@ export class CohortDefinition extends React.Component<
   }
 
   mapParams(params: Array<any>, mod) {
-    const groupedData =
-      params[0].domain === Domain[Domain.DRUG]
-        ? this.getGroupedData(params, 'group')
-        : this.getGroupedData(params, 'domain');
+    const groupedData = this.getGroupedData(params, 'type');
     let paramList;
     if (mod.length) {
       paramList = this.getModifierFormattedData(groupedData, params, mod);
@@ -123,15 +120,8 @@ export class CohortDefinition extends React.Component<
   }
 
   getModifierFormattedData(groupedData, params, modifiers) {
-    let typeMatched;
-    const modArray = params.map(({ domain, group, type }) => {
-      if (domain === Domain.DRUG) {
-        typeMatched = groupedData.find(
-          (matched) => matched.group === group.toString()
-        );
-      } else {
-        typeMatched = groupedData.find((matched) => matched.group === domain);
-      }
+    const modArray = params.map(({ domain, type }) => {
+      const typeMatched = groupedData.find((matched) => matched.group === type);
       const modifierName = modifiers.reduce((acc, m) => {
         const concatOperand = m.operands.reduce((final, o) => {
           return final !== '' ? `${final} & ${o}` : `${final} ${o}`;
@@ -163,15 +153,8 @@ export class CohortDefinition extends React.Component<
   }
 
   getOtherTreeFormattedData(groupedData, params) {
-    let typeMatched;
-    const noModArray = params.map(({ domain, group, name, type }) => {
-      if (domain === Domain.DRUG) {
-        typeMatched = groupedData.find(
-          (matched) => matched.group === group.toString()
-        );
-      } else {
-        typeMatched = groupedData.find((matched) => matched.group === domain);
-      }
+    const noModArray = params.map(({ domain, name, type }) => {
+      const typeMatched = groupedData.find((matched) => matched.group === type);
       if (domain === Domain.PERSON) {
         return {
           items:


### PR DESCRIPTION
Fixes issue where search items with parameters of multiple criteria types duplicate all params for each criteria type on the cohort description page.

Before (Each condition type should only have 2 parameters):
![Screen Shot 2022-02-03 at 10 32 32 AM](https://user-images.githubusercontent.com/40036095/152390531-f0a7e439-96c0-449f-b0da-645b4f0a0280.png)

After:
![Screen Shot 2022-02-03 at 10 32 43 AM](https://user-images.githubusercontent.com/40036095/152390580-1c0ea3d9-9045-4d5d-a95a-38087686964a.png)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
