### PR TITLE
[RW-7832][risk=no] fix for gsutil problem

### DIFF
--- a/api/db-cdr/generate-cdr/init-new-cdr-db.sh
+++ b/api/db-cdr/generate-cdr/init-new-cdr-db.sh
@@ -68,7 +68,7 @@ then
     rm -rf "$(dirname "${BASH_SOURCE}")/../csv"
     mkdir "$(dirname "${BASH_SOURCE}")/../csv"
     # copy down csv files from bucket
-    gsutil -m cp gs://all-of-us-cb-test-csv/*.csv "$(dirname "${BASH_SOURCE}")/../csv"
+    gsutil -m -o "GSUtil:parallel_process_count=1" cp gs://all-of-us-cb-test-csv/*.csv "$(dirname "${BASH_SOURCE}")/../csv"
 fi
 
 # Use liquibase to generate the schema and data


### PR DESCRIPTION
@dolbeew please checkout branch and run ./project.rb run-local-data-migrations, if it inserts data correctly, then this can be approved.

Hangs for Chenchal when copying files :
...
Copying gs://all-of-us-cb-test-csv/cb_survey_attribute.csv...                  
/ [16/26 files][  2.6 MiB/  2.7 MiB]  93% Done

Stacktrace suggestions:

If you experience problems with multiprocessing on MacOS, they might be related to https://bugs.python.org/issue33725. You can disable multiprocessing by editing your .boto config or by adding the following flag to your command: `-o "GSUtil:parallel_process_count=1"`. Note that multithreading is still available even if you disable multiprocessing.

Machine configuration:
MacOS Monterey Version 12.1

Google Cloud SDK 370.0.0
alpha 2022.01.21
app-engine-java 1.9.93
app-engine-python 1.9.98
bq 2.0.73
cloud-datastore-emulator 2.1.0
core 2022.01.21
gsutil 5.6

Python 3.9.4