### PR TITLE
[RW-7582][risk=no] More disk API fixes

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.api;
 
+import com.google.common.base.Strings;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.sql.Timestamp;
@@ -202,7 +203,7 @@ public class RuntimeController implements RuntimeApiDelegate {
     GceWithPdConfig gceWithPdConfig = runtime.getGceWithPdConfig();
     if (gceWithPdConfig != null) {
       PersistentDiskRequest persistentDiskRequest = gceWithPdConfig.getPersistentDisk();
-      if (persistentDiskRequest != null && persistentDiskRequest.getName().isEmpty()) {
+      if (persistentDiskRequest != null && Strings.isNullOrEmpty(persistentDiskRequest.getName())) {
         persistentDiskRequest.setName(userProvider.get().generatePDName());
       }
     }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5994,8 +5994,6 @@ definitions:
   PersistentDiskRequest:
     description: configuration to create a disk
     type: object
-    required:
-      - name
     properties:
       name:
         type: string


### PR DESCRIPTION
Don't require the field `disk.name` when it's expected for it to be `""`.