### PR TITLE
[risk=no] Rename disksApi -> diskApi

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -13,7 +13,7 @@ import {
   RuntimePanelWrapper,
 } from 'app/pages/analysis/runtime-panel';
 import {
-  disksApi,
+  diskApi,
   profileApi,
   registerApiClient,
   runtimeApi,
@@ -1321,8 +1321,8 @@ describe('RuntimePanel', () => {
     ]: DetachableDiskCase,
     existingDiskName: string
   ) {
-    const updateDiskSpy = jest.spyOn(disksApi(), 'updateDisk');
-    const deleteDiskSpy = jest.spyOn(disksApi(), 'deleteDisk');
+    const updateDiskSpy = jest.spyOn(diskApi(), 'updateDisk');
+    const deleteDiskSpy = jest.spyOn(diskApi(), 'deleteDisk');
     const createRuntimeSpy = jest.spyOn(runtimeApi(), 'createRuntime');
     const updateRuntimeSpy = jest.spyOn(runtimeApi(), 'updateRuntime');
 

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -11,7 +11,7 @@ import { TooltipTrigger } from 'app/components/popups';
 import { Spinner } from 'app/components/spinners';
 import { TextColumn } from 'app/components/text-column';
 
-import { disksApi, workspacesApi } from 'app/services/swagger-fetch-clients';
+import { diskApi, workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { addOpacity, colorWithWhiteness } from 'app/styles/colors';
 import {
   cond,
@@ -2031,7 +2031,7 @@ const RuntimePanel = fp.flow(
             () => (
               <ConfirmDeleteUnattachedPD
                 onConfirm={async () => {
-                  await disksApi().deleteDisk(namespace, persistentDisk.name);
+                  await diskApi().deleteDisk(namespace, persistentDisk.name);
                   onClose();
                 }}
                 onCancel={() => setPanelContent(PanelContent.Customize)}
@@ -2044,7 +2044,7 @@ const RuntimePanel = fp.flow(
               <ConfirmDeleteUnattachedPD
                 showCreateMessaging
                 onConfirm={async () => {
-                  await disksApi().deleteDisk(namespace, persistentDisk.name);
+                  await diskApi().deleteDisk(namespace, persistentDisk.name);
                   setRequestedRuntime(fromRuntimeConfig(runtimeConfig));
                   onClose();
                 }}

--- a/ui/src/app/services/swagger-fetch-clients.ts
+++ b/ui/src/app/services/swagger-fetch-clients.ts
@@ -122,7 +122,7 @@ export const userApi = bindCtor(UserApi);
 export const userMetricsApi = bindCtor(UserMetricsApi);
 export const workspaceAdminApi = bindCtor(WorkspaceAdminApi);
 export const workspacesApi = bindCtor(WorkspacesApi);
-export const disksApi = bindCtor(DiskApi);
+export const diskApi = bindCtor(DiskApi);
 
 export const getApiBaseUrl = () => {
   if (cookiesEnabled()) {

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -1,5 +1,5 @@
 import { leoRuntimesApi } from 'app/services/notebooks-swagger-fetch-clients';
-import { disksApi, runtimeApi } from 'app/services/swagger-fetch-clients';
+import { diskApi, runtimeApi } from 'app/services/swagger-fetch-clients';
 import { switchCase, withAsyncErrorHandling } from 'app/utils';
 import {
   ExceededActionCountError,
@@ -844,7 +844,7 @@ export const useDisk = (currentWorkspaceNamespace: string) => {
       async () => {
         let persistentDisk: Disk = null;
         try {
-          persistentDisk = await disksApi().getDisk(currentWorkspaceNamespace);
+          persistentDisk = await diskApi().getDisk(currentWorkspaceNamespace);
         } catch (e) {
           if (!(e instanceof Response && e.status === 404)) {
             throw e;
@@ -946,7 +946,7 @@ export const useRuntimeStatus = (
       [
         RuntimeStatusRequest.DeletePD,
         () => {
-          return disksApi().deleteDisk(
+          return diskApi().deleteDisk(
             currentWorkspaceNamespace,
             diskStore.get().persistentDisk.name
           );
@@ -1019,7 +1019,7 @@ export const useCustomRuntime = (
 
         // A disk update may be need in combination with a runtime update.
         if (mostSevereDiskDiff === RuntimeDiffState.CAN_UPDATE_IN_PLACE) {
-          await disksApi().updateDisk(
+          await diskApi().updateDisk(
             currentWorkspaceNamespace,
             existingDisk.name,
             requestedDisk.size
@@ -1070,7 +1070,7 @@ export const useCustomRuntime = (
         if (runtimeExists) {
           await applyRuntimeUpdate();
         } else if (diskNeedsSizeIncrease(requestedDisk, existingDisk)) {
-          await disksApi().updateDisk(
+          await diskApi().updateDisk(
             currentWorkspaceNamespace,
             existingDisk.name,
             requestedDisk.size

--- a/ui/src/testing/stubs/runtime-api-stub.ts
+++ b/ui/src/testing/stubs/runtime-api-stub.ts
@@ -12,7 +12,7 @@ import {
   DATAPROC_WORKER_MIN_DISK_SIZE_GB,
   MIN_DISK_SIZE_GB,
 } from 'app/pages/analysis/runtime-panel';
-import { disksApi } from 'app/services/swagger-fetch-clients';
+import { diskApi } from 'app/services/swagger-fetch-clients';
 import { DiskApiStub, stubDisk } from './disk-api-stub';
 
 export const defaultGceConfig = (): GceConfig => ({
@@ -63,7 +63,7 @@ export class RuntimeApiStub extends RuntimeApi {
   ): Promise<{}> {
     const reqDisk = runtime?.gceWithPdConfig?.persistentDisk;
     if (reqDisk && !reqDisk.name) {
-      const dapi = disksApi();
+      const dapi = diskApi();
       if (dapi instanceof DiskApiStub) {
         dapi.disk = {
           ...stubDisk(),
@@ -82,7 +82,7 @@ export class RuntimeApiStub extends RuntimeApi {
     deleteDisk: boolean
   ): Promise<{}> {
     if (deleteDisk) {
-      await disksApi().deleteDisk(
+      await diskApi().deleteDisk(
         workspaceNamespace,
         this.runtime.gceWithPdConfig?.persistentDisk?.name
       );


### PR DESCRIPTION
Stacked on #6225 

The interface is named `DiskApi`, not `DisksApi`.