### PR TITLE
[RW-7743] [risk=low] Retry on get user call. 

### DIFF
--- a/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
@@ -38,7 +38,8 @@ public class DirectoryServiceImplIntegrationTest extends BaseIntegrationTest {
     String userPrefix = String.format("integration.test.%d", Clock.systemUTC().millis());
     String username = userPrefix + "@" + config.googleDirectoryService.gSuiteDomain;
     service.createUser("Integration", "Test", username, "notasecret@gmail.com");
-    assertThat(service.isUsernameTaken(userPrefix)).isTrue();
+    boolean userNameTaken = retryTemplate().execute(c -> service.isUsernameTaken(userPrefix));
+    assertThat(userNameTaken).isTrue();
 
     // As of ~6/25/19, customSchemas are sometimes unavailable on the initial call to Gsuite. This
     // data is likely not written with strong consistency. Retry until it is available.


### PR DESCRIPTION
Description:
Details see: https://precisionmedicineinitiative.atlassian.net/browse/RW-7743

Also, it is wired that from the log, I just saw 3 attempts. That means our RetryConfig is not correct. 
From the RetryConfig, we should start from 100ms, until 20s. But actually we just do 100ms, 200ms. 400ms. Then stop! 
https://196686-95247186-gh.circle-artifacts.com/0/JunitTestResult/tests/integrationTest/classes/org.pmiops.workbench.google.DirectoryServiceImplIntegrationTest.html#testCreateAndDeleteTestUser()

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
