### PR TITLE
[risk=no][no ticket] Add spinner when saving institution changes

### DIFF
--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -973,7 +973,11 @@ export const AdminInstitutionEdit = fp.flow(
                     data-test-id='save-institution-button'
                     style={styles.saveButton}
                     disabled={this.disableSave(errors)}
-                    onClick={() => this.saveInstitution()}
+                    onClick={async () => {
+                      this.props.showSpinner();
+                      await this.saveInstitution();
+                      this.props.hideSpinner();
+                    }}
                   >
                     {this.buttonText}
                   </Button>


### PR DESCRIPTION
Adding a loading spinner in UI to show waiting.


https://user-images.githubusercontent.com/35533885/152575280-f38c6cc4-517e-455f-8d8b-ab8f08705832.mov


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
