### PR TITLE
[RW-7582][risk=no] rename RuntimeConfig -> AnalysisConfig

### DIFF
--- a/ui/src/app/components/runtime-cost-estimator.tsx
+++ b/ui/src/app/components/runtime-cost-estimator.tsx
@@ -11,11 +11,11 @@ import {
   machineStorageCostBreakdown,
 } from 'app/utils/machines';
 import { formatUsd } from 'app/utils/numbers';
-import { RuntimeConfig } from 'app/utils/runtime-utils';
+import { AnalysisConfig } from 'app/utils/runtime-utils';
 import { CSSProperties } from 'react';
 
 interface Props {
-  runtimeConfig: RuntimeConfig;
+  analysisConfig: AnalysisConfig;
   costTextColor?: string;
   style?: CSSProperties;
 }
@@ -33,15 +33,15 @@ const styles = reactStyles({
 });
 
 export const RuntimeCostEstimator = ({
-  runtimeConfig,
+  analysisConfig,
   costTextColor = colors.accent,
   style = {},
 }: Props) => {
-  const { computeType, diskConfig } = runtimeConfig;
-  const runningCost = machineRunningCost(runtimeConfig);
-  const runningCostBreakdown = machineRunningCostBreakdown(runtimeConfig);
-  const storageCost = machineStorageCost(runtimeConfig);
-  const storageCostBreakdown = machineStorageCostBreakdown(runtimeConfig);
+  const { computeType, diskConfig } = analysisConfig;
+  const runningCost = machineRunningCost(analysisConfig);
+  const runningCostBreakdown = machineRunningCostBreakdown(analysisConfig);
+  const storageCost = machineStorageCost(analysisConfig);
+  const storageCostBreakdown = machineStorageCostBreakdown(analysisConfig);
   const costStyle = {
     ...styles.cost,
     fontSize: diskConfig.detachable ? '12px' : '15px',

--- a/ui/src/app/components/runtime-initializer-modal.tsx
+++ b/ui/src/app/components/runtime-initializer-modal.tsx
@@ -5,7 +5,7 @@ import { Runtime, RuntimeConfigurationType } from 'generated/fetch';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { RuntimeCostEstimator } from './runtime-cost-estimator';
 import { RuntimeSummary } from './runtime-summary';
-import { toRuntimeConfig } from 'app/utils/runtime-utils';
+import { toAnalysisConfig } from 'app/utils/runtime-utils';
 
 import { useState } from 'react';
 import { ClrIcon } from './icons';
@@ -40,7 +40,10 @@ export const RuntimeInitializerModal = ({
   const [showDetails, setShowDetails] = useState(false);
   const { persistentDisk } = useStore(diskStore);
 
-  const defaultRuntimeConfig = toRuntimeConfig(defaultRuntime, persistentDisk);
+  const defaultAnalysisConfig = toAnalysisConfig(
+    defaultRuntime,
+    persistentDisk
+  );
   return (
     <Modal width={600}>
       <ModalTitle>Create an Analysis Environment</ModalTitle>
@@ -54,7 +57,7 @@ export const RuntimeInitializerModal = ({
             : 'Would you like to continue with your most recently used environment settings in this workspace?'}
         </WarningMessage>
         <RuntimeCostEstimator
-          runtimeConfig={defaultRuntimeConfig}
+          analysisConfig={defaultAnalysisConfig}
           style={{ ...styles.bodyElement, justifyContent: 'space-evenly' }}
         />
         <Clickable
@@ -71,7 +74,7 @@ export const RuntimeInitializerModal = ({
         </Clickable>
         {showDetails && (
           <div style={styles.runtimeDetails}>
-            <RuntimeSummary runtimeConfig={defaultRuntimeConfig} />
+            <RuntimeSummary analysisConfig={defaultAnalysisConfig} />
             <div style={{ marginTop: '10px' }}>
               To change this configuration, click 'Configure' below.
             </div>

--- a/ui/src/app/components/runtime-summary.tsx
+++ b/ui/src/app/components/runtime-summary.tsx
@@ -1,6 +1,6 @@
 import { reactStyles } from 'app/utils';
 import { ComputeType, findMachineByName } from 'app/utils/machines';
-import { RuntimeConfig } from 'app/utils/runtime-utils';
+import { AnalysisConfig } from 'app/utils/runtime-utils';
 
 const styles = reactStyles({
   bold: {
@@ -9,9 +9,9 @@ const styles = reactStyles({
 });
 
 export const RuntimeSummary = ({
-  runtimeConfig,
+  analysisConfig,
 }: {
-  runtimeConfig: RuntimeConfig;
+  analysisConfig: AnalysisConfig;
 }) => {
   return (
     <>
@@ -23,11 +23,11 @@ export const RuntimeSummary = ({
       </label>
       <div id='compute-resources'>
         - Compute size of
-        <b> {runtimeConfig.machine.cpu} CPUs</b>,
-        <b> {runtimeConfig.machine.memory} GB memory</b>, and a
-        <b> {runtimeConfig.diskConfig.size} GB disk</b>
+        <b> {analysisConfig.machine.cpu} CPUs</b>,
+        <b> {analysisConfig.machine.memory} GB memory</b>, and a
+        <b> {analysisConfig.diskConfig.size} GB disk</b>
       </div>
-      {runtimeConfig.computeType === ComputeType.Dataproc && (
+      {analysisConfig.computeType === ComputeType.Dataproc && (
         <>
           <label
             htmlFor='worker-configuration'
@@ -36,10 +36,10 @@ export const RuntimeSummary = ({
             Worker Configuration
           </label>
           <div id='worker-configuration'>
-            -<b> {runtimeConfig.dataprocConfig.numberOfWorkers} worker(s) </b>
-            {runtimeConfig.dataprocConfig.numberOfPreemptibleWorkers > 0 && (
+            -<b> {analysisConfig.dataprocConfig.numberOfWorkers} worker(s) </b>
+            {analysisConfig.dataprocConfig.numberOfPreemptibleWorkers > 0 && (
               <b>
-                and {runtimeConfig.dataprocConfig.numberOfPreemptibleWorkers}{' '}
+                and {analysisConfig.dataprocConfig.numberOfPreemptibleWorkers}{' '}
                 preemptible worker(s){' '}
               </b>
             )}
@@ -47,7 +47,7 @@ export const RuntimeSummary = ({
             <b>
               {
                 findMachineByName(
-                  runtimeConfig.dataprocConfig.workerMachineType
+                  analysisConfig.dataprocConfig.workerMachineType
                 ).cpu
               }{' '}
               CPUs
@@ -57,12 +57,13 @@ export const RuntimeSummary = ({
               {' '}
               {
                 findMachineByName(
-                  runtimeConfig.dataprocConfig.workerMachineType
+                  analysisConfig.dataprocConfig.workerMachineType
                 ).memory
               }{' '}
               GB memory
             </b>
-            , and a<b> {runtimeConfig.dataprocConfig.workerDiskSize} GB disk</b>
+            , and a
+            <b> {analysisConfig.dataprocConfig.workerDiskSize} GB disk</b>
           </div>
         </>
       )}

--- a/ui/src/app/utils/machines.ts
+++ b/ui/src/app/utils/machines.ts
@@ -2,7 +2,7 @@ import { DiskType } from 'generated/fetch';
 import * as fp from 'lodash/fp';
 import { DEFAULT, switchCase } from './index';
 import { formatUsd } from './numbers';
-import { DiskConfig, RuntimeConfig } from './runtime-utils';
+import { DiskConfig, AnalysisConfig } from './runtime-utils';
 
 // Copied from https://github.com/DataBiosphere/terra-ui/blob/219b063b07d56499ccc38013fd88f4f0b88f8cd6/src/data/machines.js
 
@@ -416,7 +416,7 @@ export const diskConfigPrice = ({ size, detachableType }: DiskConfig) => {
 export const machineStorageCost = ({
   diskConfig,
   dataprocConfig,
-}: RuntimeConfig) => {
+}: AnalysisConfig) => {
   const { numberOfWorkers, numberOfPreemptibleWorkers, workerDiskSize } =
     dataprocConfig ?? {};
   return fp.sum([
@@ -431,7 +431,7 @@ export const machineStorageCost = ({
 export const machineStorageCostBreakdown = ({
   diskConfig,
   dataprocConfig,
-}: RuntimeConfig) => {
+}: AnalysisConfig) => {
   const { numberOfWorkers, numberOfPreemptibleWorkers, workerDiskSize } =
     dataprocConfig ?? {};
   const costs = [];
@@ -457,10 +457,10 @@ export const machineStorageCostBreakdown = ({
   return costs;
 };
 
-export const machineRunningCost = (runtimeConfig: RuntimeConfig) => {
-  const { computeType, machine, gpuConfig } = runtimeConfig;
+export const machineRunningCost = (analysisConfig: AnalysisConfig) => {
+  const { computeType, machine, gpuConfig } = analysisConfig;
   const { workerMachineType, numberOfWorkers, numberOfPreemptibleWorkers } =
-    runtimeConfig.dataprocConfig ?? {};
+    analysisConfig.dataprocConfig ?? {};
 
   const workerMachine =
     workerMachineType && findMachineByName(workerMachineType);
@@ -486,14 +486,14 @@ export const machineRunningCost = (runtimeConfig: RuntimeConfig) => {
     dataprocPrice,
     machine.price,
     gpu ? gpu.price : 0,
-    machineStorageCost(runtimeConfig),
+    machineStorageCost(analysisConfig),
   ]);
 };
 
-export const machineRunningCostBreakdown = (runtimeConfig: RuntimeConfig) => {
-  const { computeType, machine, gpuConfig } = runtimeConfig;
+export const machineRunningCostBreakdown = (analysisConfig: AnalysisConfig) => {
+  const { computeType, machine, gpuConfig } = analysisConfig;
   const { workerMachineType, numberOfWorkers, numberOfPreemptibleWorkers } =
-    runtimeConfig.dataprocConfig ?? {};
+    analysisConfig.dataprocConfig ?? {};
 
   const workerMachine =
     workerMachineType && findMachineByName(workerMachineType);
@@ -532,6 +532,6 @@ export const machineRunningCostBreakdown = (runtimeConfig: RuntimeConfig) => {
       costs.push(`${formatUsd(gpu.price)}/hr GPU`);
     }
   }
-  costs.push(...machineStorageCostBreakdown(runtimeConfig));
+  costs.push(...machineStorageCostBreakdown(analysisConfig));
   return costs;
 };

--- a/ui/src/app/utils/runtime-utils.spec.tsx
+++ b/ui/src/app/utils/runtime-utils.spec.tsx
@@ -2,7 +2,7 @@ import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import {
   useCustomRuntime,
-  RuntimeDiffState,
+  AnalysisDiffState,
   findMostSevereDiffState,
 } from 'app/utils/runtime-utils';
 import { runtimeStore, diskStore, serverConfigStore } from 'app/utils/stores';
@@ -108,36 +108,39 @@ describe('runtime-utils', () => {
 
   test.each([
     [[], undefined],
-    [[RuntimeDiffState.NEEDS_DELETE], RuntimeDiffState.NEEDS_DELETE],
-    [[RuntimeDiffState.NEEDS_DELETE, undefined], RuntimeDiffState.NEEDS_DELETE],
+    [[AnalysisDiffState.NEEDS_DELETE], AnalysisDiffState.NEEDS_DELETE],
     [
-      [
-        RuntimeDiffState.CAN_UPDATE_IN_PLACE,
-        RuntimeDiffState.NEEDS_DELETE,
-        RuntimeDiffState.NO_CHANGE,
-        RuntimeDiffState.CAN_UPDATE_WITH_REBOOT,
-        RuntimeDiffState.NO_CHANGE,
-      ],
-      RuntimeDiffState.NEEDS_DELETE,
+      [AnalysisDiffState.NEEDS_DELETE, undefined],
+      AnalysisDiffState.NEEDS_DELETE,
     ],
     [
       [
-        RuntimeDiffState.CAN_UPDATE_IN_PLACE,
-        RuntimeDiffState.NO_CHANGE,
-        RuntimeDiffState.CAN_UPDATE_WITH_REBOOT,
-        RuntimeDiffState.CAN_UPDATE_IN_PLACE,
+        AnalysisDiffState.CAN_UPDATE_IN_PLACE,
+        AnalysisDiffState.NEEDS_DELETE,
+        AnalysisDiffState.NO_CHANGE,
+        AnalysisDiffState.CAN_UPDATE_WITH_REBOOT,
+        AnalysisDiffState.NO_CHANGE,
       ],
-      RuntimeDiffState.CAN_UPDATE_WITH_REBOOT,
+      AnalysisDiffState.NEEDS_DELETE,
     ],
     [
       [
-        RuntimeDiffState.NO_CHANGE,
-        RuntimeDiffState.CAN_UPDATE_IN_PLACE,
-        RuntimeDiffState.NO_CHANGE,
+        AnalysisDiffState.CAN_UPDATE_IN_PLACE,
+        AnalysisDiffState.NO_CHANGE,
+        AnalysisDiffState.CAN_UPDATE_WITH_REBOOT,
+        AnalysisDiffState.CAN_UPDATE_IN_PLACE,
       ],
-      RuntimeDiffState.CAN_UPDATE_IN_PLACE,
+      AnalysisDiffState.CAN_UPDATE_WITH_REBOOT,
     ],
-    [[RuntimeDiffState.NO_CHANGE], RuntimeDiffState.NO_CHANGE],
+    [
+      [
+        AnalysisDiffState.NO_CHANGE,
+        AnalysisDiffState.CAN_UPDATE_IN_PLACE,
+        AnalysisDiffState.NO_CHANGE,
+      ],
+      AnalysisDiffState.CAN_UPDATE_IN_PLACE,
+    ],
+    [[AnalysisDiffState.NO_CHANGE], AnalysisDiffState.NO_CHANGE],
   ])('findMostSevereDiffState(%s) = %s', (diffStates, want) => {
     expect(findMostSevereDiffState(diffStates)).toEqual(want);
   });


### PR DESCRIPTION
Detachable PD part 4/??

This change should be a functional no-op; renames only.

**Context**: in working out some of the reattachable PD flows, I found that it will likely be cleaner to combine the state representation of the Runtime, and the detached disk (if any). The has the following benefits:

1. We can provide a unified view of an update being made, including whether a disk delete is requested
2. We can provide an accurate cost estimate; which **should** include the detached disk cost when the analysis environment is either deleted, or the active runtime does not have the disk attached.

Renaming `RuntimeConfig` -> `AnalysisConfig` will allow me to add a `detachedDisk` property in the next PR. This now represents the overall analysis environment, rather than just the active runtime.