### PR TITLE
[no ticket][risk=no] Remove redundant e2e createWorkspace test

### DIFF
--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -13,32 +13,6 @@ describe('Creating new workspaces', () => {
     await signInWithAccessToken(page);
   });
 
-  test('Create workspace using minimum required fields', async () => {
-    const newWorkspaceName = makeWorkspaceName();
-    const workspacesPage = new WorkspacesPage(page);
-    await workspacesPage.load();
-
-    // create workspace with "No Review Requested" radiobutton selected
-    const modalTextContent = await workspacesPage.createWorkspace(newWorkspaceName);
-
-    // Pick out few sentences to verify
-    expect(modalTextContent).toContain('Create Workspace');
-    expect(modalTextContent).toContain(
-      'Will be displayed publicly to inform All of Us research participants. ' +
-        'Therefore, please verify that you have provided sufficiently detailed responses in plain language.'
-    );
-    expect(modalTextContent).toContain('You can also make changes to your answers after you create your workspace.');
-
-    const dataPage = new WorkspaceDataPage(page);
-    await dataPage.verifyWorkspaceNameOnDataPage(newWorkspaceName);
-
-    // Verify the CDR version displays in the workspace navigation bar
-    expect(await dataPage.getCdrVersion()).toBe(config.DEFAULT_CDR_VERSION_NAME);
-
-    // cleanup
-    await dataPage.deleteWorkspace();
-  });
-
   test('Create workspace using all fields', async () => {
     const workspacesPage = new WorkspacesPage(page);
     await workspacesPage.load();
@@ -116,15 +90,4 @@ describe('Creating new workspaces', () => {
     // cleanup
     await dataPage.deleteWorkspace();
   });
-
-  // // helper function to check visible workspace link on Data page
-  // async function verifyWorkspaceLinkOnDataPage(workspaceName: string): Promise<WorkspaceDataPage> {
-  //   const dataPage = new WorkspaceDataPage(page);
-  //   await dataPage.waitForLoad();
-
-  //   const workspaceLink = new Link(page, `//a[text()='${workspaceName}']`);
-  //   await workspaceLink.waitForXPath({visible: true});
-  //   expect(await workspaceLink.isVisible()).toBe(true);
-  //   return dataPage;
-  // }
 });


### PR DESCRIPTION
Create new workspace with minimum fields required are already tested in many other tests. Test coverage is unchanged after removal of test.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
