### PR TITLE
[risk=no][no ticket] rm deprecated accessRenewal config

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -134,11 +134,6 @@
     "clientId": "e5c5d714-d597-48c8-b564-a249d729d0c9",
     "logoutUrl": "https:\/\/authtest.nih.gov\/siteminderagent\/smlogoutredirector.asp?TARGET="
   },
-  "accessRenewal": {
-    "expiryDays": 365,
-    "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
-    "lookbackPeriod": 330
-  },
   "offlineBatch": {
     "unsafeCloudTasksForwardingHost": "http:\/\/localhost:8081",
     "usersPerAuditTask": 20,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -134,11 +134,6 @@
     "clientId": "e5c5d714-d597-48c8-b564-a249d729d0c9",
     "logoutUrl": "https:\/\/authtest.nih.gov\/siteminderagent\/smlogoutredirector.asp?TARGET="
   },
-  "accessRenewal": {
-    "expiryDays": 3650,
-    "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
-    "lookbackPeriod": 330
-  },
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -129,11 +129,6 @@
     "clientId": "d139ec98-5c24-4076-a103-e020a558bea0",
     "logoutUrl": "https:\/\/auth.nih.gov\/siteminderagent\/smlogoutredirector.asp?TARGET="
   },
-  "accessRenewal": {
-    "expiryDays": 3650,
-    "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
-    "lookbackPeriod": 330
-  },
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -134,11 +134,6 @@
     "clientId": "d139ec98-5c24-4076-a103-e020a558bea0",
     "logoutUrl": "https:\/\/auth.nih.gov\/siteminderagent\/smlogoutredirector.asp?TARGET="
   },
-  "accessRenewal": {
-    "expiryDays": 365,
-    "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
-    "lookbackPeriod": 330
-  },
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -134,11 +134,6 @@
     "clientId": "d139ec98-5c24-4076-a103-e020a558bea0",
     "logoutUrl": "https:\/\/auth.nih.gov\/siteminderagent\/smlogoutredirector.asp?TARGET="
   },
-  "accessRenewal": {
-    "expiryDays": 365,
-    "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
-    "lookbackPeriod": 330
-  },
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -134,11 +134,6 @@
     "clientId": "d139ec98-5c24-4076-a103-e020a558bea0",
     "logoutUrl": "https:\/\/auth.nih.gov\/siteminderagent\/smlogoutredirector.asp?TARGET="
   },
-  "accessRenewal": {
-    "expiryDays": 365,
-    "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
-    "lookbackPeriod": 330
-  },
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -134,11 +134,6 @@
     "clientId": "e5c5d714-d597-48c8-b564-a249d729d0c9",
     "logoutUrl": "https:\/\/authtest.nih.gov\/siteminderagent\/smlogoutredirector.asp?TARGET="
   },
-  "accessRenewal": {
-    "expiryDays": 3650,
-    "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
-    "lookbackPeriod": 330
-  },
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -37,7 +37,7 @@ public class WorkbenchConfig {
     WorkbenchConfig config = new WorkbenchConfig();
     config.access = new AccessConfig();
     config.access.currentDuccVersions = new ArrayList<>();
-    config.access.renewal = new AccessConfig.AccessRenewalConfig();
+    config.access.renewal = new AccessConfig.Renewal();
     config.actionAudit = new ActionAuditConfig();
     config.admin = new AdminConfig();
     config.auth = new AuthConfig();
@@ -222,7 +222,7 @@ public class WorkbenchConfig {
     // Which Data User Code of Conduct (DUCC) Agreement version(s) are currently accepted as valid
     public List<Integer> currentDuccVersions;
 
-    public static class AccessRenewalConfig {
+    public static class Renewal {
       // Days a user's module completion is good for until it expires
       public Long expiryDays;
       // Lookback period - the point when we give users the option to update their compliance items
@@ -231,7 +231,7 @@ public class WorkbenchConfig {
       public List<Long> expiryDaysWarningThresholds;
     }
 
-    public AccessRenewalConfig renewal;
+    public Renewal renewal;
   }
 
   public static class FeatureFlagsConfig {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -29,8 +29,6 @@ public class WorkbenchConfig {
   public CaptchaConfig captcha;
   public ReportingConfig reporting;
   public RasConfig ras;
-  @Deprecated // moved inside AccessConfig.  will remove as part of RW-7828
-  public AccessRenewalConfig accessRenewal;
   public OfflineBatchConfig offlineBatch;
   public EgressAlertRemediationPolicy egressAlertRemediationPolicy;
 
@@ -39,8 +37,7 @@ public class WorkbenchConfig {
     WorkbenchConfig config = new WorkbenchConfig();
     config.access = new AccessConfig();
     config.access.currentDuccVersions = new ArrayList<>();
-    config.access.renewal = new AccessRenewalConfig();
-    config.accessRenewal = new AccessRenewalConfig();
+    config.access.renewal = new AccessConfig.AccessRenewalConfig();
     config.actionAudit = new ActionAuditConfig();
     config.admin = new AdminConfig();
     config.auth = new AuthConfig();
@@ -225,6 +222,15 @@ public class WorkbenchConfig {
     // Which Data User Code of Conduct (DUCC) Agreement version(s) are currently accepted as valid
     public List<Integer> currentDuccVersions;
 
+    public static class AccessRenewalConfig {
+      // Days a user's module completion is good for until it expires
+      public Long expiryDays;
+      // Lookback period - the point when we give users the option to update their compliance items
+      public Long lookbackPeriod;
+      // Thresholds for sending warning emails based on approaching module expiration, in days
+      public List<Long> expiryDaysWarningThresholds;
+    }
+
     public AccessRenewalConfig renewal;
   }
 
@@ -306,16 +312,6 @@ public class WorkbenchConfig {
     public String clientId;
     // The URL that can sign out RAS login session.
     public String logoutUrl;
-  }
-
-  // Note: migrating this to live inside AccessConfig soon as part of RW-7828
-  public static class AccessRenewalConfig {
-    // Days a user's module completion is good for until it expires
-    public Long expiryDays;
-    // Lookback period - the point when we give users the option to update their compliance items
-    public Long lookbackPeriod;
-    // Thresholds for sending warning emails based on approaching module expiration, in days
-    public List<Long> expiryDaysWarningThresholds;
   }
 
   public static class OfflineBatchConfig {


### PR DESCRIPTION
After the access renewal config migration in #6271 has been released, remove the old config.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
