### PR TITLE
[risk=low][RW-7863] Only show enabled modules in table for AdminUserProfile

### DIFF
--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import validate from 'validate.js';
 import { Column } from 'primereact/column';
 import { DataTable } from 'primereact/datatable';
+import * as fp from 'lodash/fp';
 
 import {
   adminGetProfile,
@@ -299,23 +300,34 @@ interface TableRow {
 const AccessModuleTable = (props: AccessModuleTableProps) => {
   const { updatedProfile } = props;
 
-  const tableData: TableRow[] = accessModulesForTable.map((moduleName) => {
-    const { adminPageTitle, bypassable } = getAccessModuleConfig(moduleName);
+  const tableData: TableRow[] = fp.flatMap((moduleName) => {
+    const { adminPageTitle, bypassable, isEnabledInEnvironment } =
+      getAccessModuleConfig(moduleName);
 
-    return {
-      moduleName: adminPageTitle,
-      moduleStatus: displayModuleStatus(props.updatedProfile, moduleName),
-      completionDate: displayModuleCompletionDate(updatedProfile, moduleName),
-      expirationDate: displayModuleExpirationDate(updatedProfile, moduleName),
-      accessTierBadge: displayTierBadgeByRequiredModule(
-        props.updatedProfile,
-        moduleName
-      ),
-      bypassToggle: bypassable && (
-        <ToggleForModule moduleName={moduleName} {...props} />
-      ),
-    };
-  });
+    return isEnabledInEnvironment
+      ? [
+          {
+            moduleName: adminPageTitle,
+            moduleStatus: displayModuleStatus(props.updatedProfile, moduleName),
+            completionDate: displayModuleCompletionDate(
+              updatedProfile,
+              moduleName
+            ),
+            expirationDate: displayModuleExpirationDate(
+              updatedProfile,
+              moduleName
+            ),
+            accessTierBadge: displayTierBadgeByRequiredModule(
+              props.updatedProfile,
+              moduleName
+            ),
+            bypassToggle: bypassable && (
+              <ToggleForModule moduleName={moduleName} {...props} />
+            ),
+          },
+        ]
+      : [];
+  }, accessModulesForTable);
 
   return (
     <DataTable

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -6,16 +6,9 @@ import { DataTable } from 'primereact/datatable';
 import * as fp from 'lodash/fp';
 
 import {
+  AccessModuleExpirations,
   adminGetProfile,
-  UserAdminTableLink,
-  UserAuditLink,
   commonStyles,
-  getInitalCreditsUsage,
-  InitialCreditsDropdown,
-  InstitutionDropdown,
-  InstitutionalRoleDropdown,
-  InstitutionalRoleOtherTextInput,
-  getPublicInstitutionDetails,
   ContactEmailTextInput,
   updateAccountProperties,
   ErrorsTooltip,
@@ -25,7 +18,19 @@ import {
   displayModuleExpirationDate,
   displayModuleStatus,
   displayTierBadgeByRequiredModule,
+  ErrorsTooltip,
   getEraNote,
+  getInitalCreditsUsage,
+  getPublicInstitutionDetails,
+  InitialCreditsDropdown,
+  InstitutionalRoleDropdown,
+  InstitutionalRoleOtherTextInput,
+  InstitutionDropdown,
+  isBypassed,
+  profileNeedsUpdate,
+  updateAccountProperties,
+  UserAdminTableLink,
+  UserAuditLink,
 } from './admin-user-common';
 import { FadeBox } from 'app/components/containers';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
@@ -335,9 +340,12 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
       style={{ paddingTop: '1em' }}
       value={tableData}
       footer={
-        <div style={{ textAlign: 'left', fontWeight: 'normal' }}>
-          {getEraNote(updatedProfile)}
-        </div>
+        getAccessModuleConfig(AccessModule.ERACOMMONS)
+          .isEnabledInEnvironment && (
+          <div style={{ textAlign: 'left', fontWeight: 'normal' }}>
+            {getEraNote(updatedProfile)}
+          </div>
+        )
       }
     >
       <Column field='moduleName' header='Access Module' />

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -6,14 +6,9 @@ import { DataTable } from 'primereact/datatable';
 import * as fp from 'lodash/fp';
 
 import {
-  AccessModuleExpirations,
   adminGetProfile,
   commonStyles,
   ContactEmailTextInput,
-  updateAccountProperties,
-  ErrorsTooltip,
-  isBypassed,
-  profileNeedsUpdate,
   displayModuleCompletionDate,
   displayModuleExpirationDate,
   displayModuleStatus,


### PR DESCRIPTION
Also fixes a crash bug when modules are not present
Also don't display the ERA Commons note when ERA is not enabled

Tested by disabling some modules in config_local.json and running Local API+UI

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
