### PR TITLE
[RW-7810][risk-no] Add cohort review as user recent resource

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -367,6 +367,9 @@ public class CohortReviewController implements CohortReviewApiDelegate {
 
     cohortReview.participantCohortStatuses(participantCohortStatuses);
 
+    // Pushing the following logic behind the feature flag so that in test/local opening/creating
+    // cohort review will create an entry in user recent resource with resource type cohortReview
+    // rather than cohort, while the rest of the environments remains as is
     if (!workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
       userRecentResourceService.updateCohortEntry(
           cohort.getWorkspaceId(), userProvider.get().getUserId(), cohortId);

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -367,17 +367,18 @@ public class CohortReviewController implements CohortReviewApiDelegate {
 
     cohortReview.participantCohortStatuses(participantCohortStatuses);
 
-    // Pushing the following logic behind the feature flag so that in test/local opening/creating
-    // cohort review will create an entry in user recent resource with resource type cohortReview
-    // rather than cohort, while the rest of the environments remains as is
+    // Wrapping the following logic behind the feature flag so that only in test/local
+    // opening/creating cohort review will create an entry in user recent resource with
+    // resource type cohortReview rather than cohort,
+    // while the rest of the environments remains as is
     if (!workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
       userRecentResourceService.updateCohortEntry(
           cohort.getWorkspaceId(), userProvider.get().getUserId(), cohortId);
     }
 
     // Cohort review id will be null if the user is creating a new Cohort Review
-    // In such cases createCohort will update the userrecentresource
-    // This scenario covers viewing an existing cohort review
+    // In such cases createCohort will update the entry in userrecentresource
+    // Cohort review id will be populated, if  user is viewing an existing cohort review
     if (cohortReview.getCohortReviewId() != null) {
       userRecentResourceService.updateCohortReviewEntry(
           cohort.getWorkspaceId(),

--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -17,6 +17,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
+import org.pmiops.workbench.cohortreview.CohortReviewService;
 import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.dataset.DataSetService;
@@ -58,6 +59,7 @@ public class UserMetricsController implements UserMetricsApiDelegate {
   private final ConceptSetService conceptSetService;
   private final DataSetService dataSetService;
   private final CohortService cohortService;
+  private final CohortReviewService cohortReviewService;
 
   private int distinctWorkspaceLimit = 5;
 
@@ -65,6 +67,7 @@ public class UserMetricsController implements UserMetricsApiDelegate {
   UserMetricsController(
       CloudStorageClient cloudStorageClient,
       CohortService cohortService,
+      CohortReviewService cohortReviewService,
       ConceptSetService conceptSetService,
       DataSetService dataSetService,
       FireCloudService fireCloudService,
@@ -75,6 +78,7 @@ public class UserMetricsController implements UserMetricsApiDelegate {
       WorkspaceResourceMapper workspaceResourceMapper) {
     this.cloudStorageClient = cloudStorageClient;
     this.cohortService = cohortService;
+    this.cohortReviewService = cohortReviewService;
     this.conceptSetService = conceptSetService;
     this.dataSetService = dataSetService;
     this.fireCloudService = fireCloudService;
@@ -255,6 +259,7 @@ public class UserMetricsController implements UserMetricsApiDelegate {
         idToFcWorkspaceResponse.get(workspaceId),
         idToDbWorkspace.get(workspaceId),
         cohortService,
+        cohortReviewService,
         conceptSetService,
         dataSetService);
   }

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import javax.inject.Provider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,7 @@ import org.pmiops.workbench.cohortreview.ReviewQueryBuilder;
 import org.pmiops.workbench.cohortreview.mapper.CohortReviewMapperImpl;
 import org.pmiops.workbench.cohortreview.mapper.ParticipantCohortAnnotationMapperImpl;
 import org.pmiops.workbench.cohortreview.mapper.ParticipantCohortStatusMapperImpl;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.CohortAnnotationDefinitionDao;
 import org.pmiops.workbench.db.dao.CohortDao;
@@ -153,6 +155,8 @@ public class CohortReviewControllerTest {
 
   @Autowired private UserDao userDao;
 
+  @Autowired private Provider<WorkbenchConfig> workbenchConfigProvider;
+
   private enum TestConcepts {
     ASIAN("Asian", 8515),
     WHITE("White", 8527),
@@ -203,7 +207,7 @@ public class CohortReviewControllerTest {
     ParticipantCohortStatusMapperImpl.class,
     CohortReviewMapperImpl.class,
     ParticipantCohortAnnotationMapperImpl.class,
-    CommonMappers.class,
+    CommonMappers.class
   })
   @MockBean({
     BigQueryService.class,
@@ -214,7 +218,7 @@ public class CohortReviewControllerTest {
     WorkspaceAuthService.class,
     AccessTierService.class,
     AccessModuleService.class,
-    CdrVersionService.class,
+    CdrVersionService.class
   })
   static class Configuration {
     @Bean
@@ -226,6 +230,12 @@ public class CohortReviewControllerTest {
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     DbUser user() {
       return user;
+    }
+
+    @Bean
+    WorkbenchConfig workbenchConfig() {
+      WorkbenchConfig workbenchConfig = WorkbenchConfig.createEmptyConfig();
+      return workbenchConfig;
     }
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.pmiops.workbench.FakeClockConfiguration;
+import org.pmiops.workbench.cohortreview.CohortReviewService;
 import org.pmiops.workbench.cohortreview.mapper.CohortReviewMapperImpl;
 import org.pmiops.workbench.cohorts.CohortMapper;
 import org.pmiops.workbench.cohorts.CohortMapperImpl;
@@ -67,6 +68,7 @@ public class UserMetricsControllerTest {
   @Mock private CloudStorageClient mockCloudStorageClient;
   @Mock private UserRecentResourceService mockUserRecentResourceService;
   @Mock private CohortService mockCohortService;
+  @Mock private CohortReviewService mockCohortReviewService;
   @Mock private ConceptSetService mockConceptSetService;
   @Mock private DataSetService mockDataSetService;
   @Mock private Provider<DbUser> mockUserProvider;
@@ -211,6 +213,7 @@ public class UserMetricsControllerTest {
         new UserMetricsController(
             mockCloudStorageClient,
             mockCohortService,
+            mockCohortReviewService,
             mockConceptSetService,
             mockDataSetService,
             mockFireCloudService,


### PR DESCRIPTION
Update the existing functionality to update the entry in user recent resource on opening or creating a cohort review with resource type COHORT to cohort_review
<img width="1593" alt="Screen Shot 2022-02-10 at 11 29 40 AM" src="https://user-images.githubusercontent.com/34481816/153452474-42381c30-5140-48bd-985e-16aeacc8f641.png">
---


**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
