### PR TITLE
[RW-7835][risk=no] Add new genomic CDR env vars

### DIFF
--- a/api/config/cdr_config_local.json
+++ b/api/config/cdr_config_local.json
@@ -93,7 +93,10 @@
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "allSamplesWgsDataBucket": "5/wgs/vcf/merged/",
-      "singleSampleArrayDataBucket": "5/microarray/vcf/single_sample/"
+      "singleSampleArrayDataBucket": "5/microarray/vcf/single_sample/",
+      "storageBasePath": "5",
+      "wgsVcfMergedStoragePath": "wgs/vcf/merged",
+      "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample"
     },
     {
       "cdrVersionId": 6,

--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -120,7 +120,12 @@
       "hasCopeSurveyData": true,
       "accessTier": "controlled",
       "allSamplesWgsDataBucket": "5/wgs/vcf/merged/beta",
-      "singleSampleArrayDataBucket": "5/microarray/vcf/single_sample/beta"
+      "singleSampleArrayDataBucket": "5/microarray/vcf/single_sample/beta",
+      "storageBasePath": "5",
+      "wgsVcfMergedStoragePath": "wgs/vcf/merged/beta",
+      "wgsHailStoragePath": "wgs/hail.mt",
+      "microarrayHailStoragePath": "microarray/hail.mt",
+      "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample/beta"
     }
   ]
 }

--- a/api/config/cdr_config_test.json
+++ b/api/config/cdr_config_test.json
@@ -93,6 +93,9 @@
       "hasCopeSurveyData": true,
       "allSamplesWgsDataBucket": "5/wgs/vcf/merged/",
       "singleSampleArrayDataBucket": "5/microarray/vcf/single_sample/",
+      "storageBasePath": "5",
+      "wgsVcfMergedStoragePath": "wgs/vcf/merged",
+      "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample",
       "accessTier": "controlled"
     },
     {

--- a/api/db/changelog/db.changelog-188-cdr-bucket-paths.xml
+++ b/api/db/changelog/db.changelog-188-cdr-bucket-paths.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="calbach" id="changelog-188-cdr-bucket-paths">
+    <addColumn tableName="cdr_version">
+      <column name="storage_base_path" type="varchar(100)"></column>
+      <column name="wgs_vcf_merged_storage_path" type="varchar(100)"></column>
+      <column name="wgs_hail_storage_path" type="varchar(100)"></column>
+      <column name="microarray_hail_storage_path" type="varchar(100)"></column>
+      <column name="microarray_vcf_single_sample_storage_path" type="varchar(100)"></column>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-189-cdr-bucket-paths.xml
+++ b/api/db/changelog/db.changelog-189-cdr-bucket-paths.xml
@@ -4,7 +4,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
-  <changeSet author="calbach" id="changelog-188-cdr-bucket-paths">
+  <changeSet author="calbach" id="changelog-189-cdr-bucket-paths">
     <addColumn tableName="cdr_version">
       <column name="storage_base_path" type="varchar(100)"></column>
       <column name="wgs_vcf_merged_storage_path" type="varchar(100)"></column>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -198,6 +198,7 @@
   <include file="changelog/db.changelog-186-user-code-of-conduct-agreement-backfill.xml"/>
   <include file="changelog/db.changelog-187-user-code-of-conduct-agreement-backfill-v2.xml"/>
   <include file="changelog/db.changelog-188-controlled-tier-training-expirable.xml"/>
+  <include file="changelog/db.changelog-189-cdr-bucket-paths.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
@@ -30,9 +30,15 @@ public class DbCdrVersion {
   private String wgsBigqueryDataset;
   private Boolean hasFitbitData;
   private Boolean hasCopeSurveyData;
-  // TODO(calbach): Rename these columns.
+  // TODO(calbach): Remove these columns.
   private String allSamplesWgsDataBucket;
   private String singleSampleArrayDataBucket;
+
+  private String storageBasePath;
+  private String wgsVcfMergedStoragePath;
+  private String wgsHailStoragePath;
+  private String microarrayHailStoragePath;
+  private String microarrayVcfSingleSampleStoragePath;
 
   @Id
   @Column(name = "cdr_version_id")
@@ -198,6 +204,51 @@ public class DbCdrVersion {
     this.singleSampleArrayDataBucket = singleSampleArrayDataBucket;
   }
 
+  @Column(name = "storage_base_path")
+  public String getStorageBasePath() {
+    return storageBasePath;
+  }
+
+  public void setStorageBasePath(String storageBasePath) {
+    this.storageBasePath = storageBasePath;
+  }
+
+  @Column(name = "wgs_vcf_merged_storage_path")
+  public String getWgsVcfMergedStoragePath() {
+    return wgsVcfMergedStoragePath;
+  }
+
+  public void setWgsVcfMergedStoragePath(String wgsVcfMergedStoragePath) {
+    this.wgsVcfMergedStoragePath = wgsVcfMergedStoragePath;
+  }
+
+  @Column(name = "wgs_hail_storage_path")
+  public String getWgsHailStoragePath() {
+    return wgsHailStoragePath;
+  }
+
+  public void setWgsHailStoragePath(String wgsHailStoragePath) {
+    this.wgsHailStoragePath = wgsHailStoragePath;
+  }
+
+  @Column(name = "microarray_hail_storage_path")
+  public String getMicroarrayHailStoragePath() {
+    return microarrayHailStoragePath;
+  }
+
+  public void setMicroarrayHailStoragePath(String microarrayHailStoragePath) {
+    this.microarrayHailStoragePath = microarrayHailStoragePath;
+  }
+
+  @Column(name = "microarray_vcf_single_sample_storage_path")
+  public String getMicroarrayVcfSingleSampleStoragePath() {
+    return microarrayVcfSingleSampleStoragePath;
+  }
+
+  public void setMicroarrayVcfSingleSampleStoragePath(String microarrayVcfSingleSampleStoragePath) {
+    this.microarrayVcfSingleSampleStoragePath = microarrayVcfSingleSampleStoragePath;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -215,7 +266,12 @@ public class DbCdrVersion {
         wgsBigqueryDataset,
         hasFitbitData,
         hasCopeSurveyData,
-        allSamplesWgsDataBucket);
+        allSamplesWgsDataBucket,
+        storageBasePath,
+        wgsVcfMergedStoragePath,
+        wgsHailStoragePath,
+        microarrayHailStoragePath,
+        microarrayVcfSingleSampleStoragePath);
   }
 
   @Override
@@ -228,10 +284,10 @@ public class DbCdrVersion {
     }
     DbCdrVersion that = (DbCdrVersion) o;
     return cdrVersionId == that.cdrVersionId
-        && isDefault == that.isDefault
         && releaseNumber == that.releaseNumber
         && archivalStatus == that.archivalStatus
         && numParticipants == that.numParticipants
+        && Objects.equals(isDefault, that.isDefault)
         && Objects.equals(name, that.name)
         && Objects.equals(accessTier, that.accessTier)
         && Objects.equals(bigqueryProject, that.bigqueryProject)
@@ -241,6 +297,13 @@ public class DbCdrVersion {
         && Objects.equals(wgsBigqueryDataset, that.wgsBigqueryDataset)
         && Objects.equals(hasFitbitData, that.hasFitbitData)
         && Objects.equals(hasCopeSurveyData, that.hasCopeSurveyData)
-        && Objects.equals(allSamplesWgsDataBucket, that.allSamplesWgsDataBucket);
+        && Objects.equals(allSamplesWgsDataBucket, that.allSamplesWgsDataBucket)
+        && Objects.equals(singleSampleArrayDataBucket, that.singleSampleArrayDataBucket)
+        && Objects.equals(storageBasePath, that.storageBasePath)
+        && Objects.equals(wgsVcfMergedStoragePath, that.wgsVcfMergedStoragePath)
+        && Objects.equals(wgsHailStoragePath, that.wgsHailStoragePath)
+        && Objects.equals(microarrayHailStoragePath, that.microarrayHailStoragePath)
+        && Objects.equals(
+            microarrayVcfSingleSampleStoragePath, that.microarrayVcfSingleSampleStoragePath);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
@@ -30,6 +30,7 @@ public class DbCdrVersion {
   private String wgsBigqueryDataset;
   private Boolean hasFitbitData;
   private Boolean hasCopeSurveyData;
+  // TODO(calbach): Rename these columns.
   private String allSamplesWgsDataBucket;
   private String singleSampleArrayDataBucket;
 

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -245,17 +245,14 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     if (!Strings.isNullOrEmpty(datasetsBucket) && !Strings.isNullOrEmpty(bucketInfix)) {
       String basePath = joinStoragePaths(datasetsBucket, bucketInfix);
       customEnvironmentVariables.putAll(
-          ImmutableMap.<String, String>builder()
-              .put(CDR_STORAGE_PATH_KEY, "/")
+          ImmutableMap.<String, String>builder().put(CDR_STORAGE_PATH_KEY, "/")
               .put(WGS_VCF_MERGED_STORAGE_PATH_KEY, cdrVersion.getWgsVcfMergedStoragePath())
               .put(WGS_HAIL_STORAGE_PATH_KEY, cdrVersion.getWgsHailStoragePath())
               .put(MICROARRAY_HAIL_STORAGE_PATH_KEY, cdrVersion.getMicroarrayHailStoragePath())
               .put(
                   MICROARRAY_VCF_SINGLE_SAMPLE_STORAGE_PATH_KEY,
                   cdrVersion.getMicroarrayVcfSingleSampleStoragePath())
-              .build()
-              .entrySet()
-              .stream()
+              .build().entrySet().stream()
               .filter(entry -> !Strings.isNullOrEmpty(entry.getValue()))
               .collect(
                   Collectors.toMap(

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -1,4 +1,4 @@
-package org.pmiops.workbench.notebooks;
+ package org.pmiops.workbench.notebooks;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -56,8 +56,16 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
   private static final String WORKSPACE_NAMESPACE_KEY = "WORKSPACE_NAMESPACE";
   private static final String WORKSPACE_BUCKET_KEY = "WORKSPACE_BUCKET";
   private static final String JUPYTER_DEBUG_LOGGING_ENV_KEY = "JUPYTER_DEBUG_LOGGING";
+
+  // Deprecated env vars: remove once featured workspaces are updated.
   private static final String ALL_SAMPLES_WGS_KEY = "ALL_SAMPLES_WGS_BUCKET";
   private static final String SINGLE_SAMPLE_ARRAY_BUCKET_KEY = "SINGLE_SAMPLE_ARRAY_BUCKET";
+
+  private static final String CDR_STORAGE_PATH_KEY = "CDR_STORAGE_PATH";
+  private static final String WGS_VCF_MERGED_STORAGE_PATH_KEY = "WGS_VCF_MERGED_STORAGE_PATH";
+  private static final String WGS_HAIL_STORAGE_PATH_KEY = "WGS_HAIL_STORAGE_PATH";
+  private static final String MICROARRAY_HAIL_STORAGE_PATH_KEY = "MICROARRAY_HAIL_STORAGE_PATH";
+  private static final String MICROARRAY_VCF_SINGLE_SAMPLE_STORAGE_PATH_KEY = "MICROARRAY_VCF_SINGLE_SAMPLE_STORAGE_PATH";
 
   // Keep in sync with
   // https://github.com/DataBiosphere/leonardo/blob/develop/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala#L162

--- a/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/LeonardoNotebooksClientImpl.java
@@ -245,17 +245,15 @@ public class LeonardoNotebooksClientImpl implements LeonardoNotebooksClient {
     if (!Strings.isNullOrEmpty(datasetsBucket) && !Strings.isNullOrEmpty(bucketInfix)) {
       String basePath = joinStoragePaths(datasetsBucket, bucketInfix);
       customEnvironmentVariables.putAll(
-          ImmutableMap.of(
-                  CDR_STORAGE_PATH_KEY,
-                  "",
-                  WGS_VCF_MERGED_STORAGE_PATH_KEY,
-                  cdrVersion.getWgsVcfMergedStoragePath(),
-                  WGS_HAIL_STORAGE_PATH_KEY,
-                  cdrVersion.getWgsHailStoragePath(),
-                  MICROARRAY_HAIL_STORAGE_PATH_KEY,
-                  cdrVersion.getMicroarrayHailStoragePath(),
+          ImmutableMap.<String, String>builder()
+              .put(CDR_STORAGE_PATH_KEY, "/")
+              .put(WGS_VCF_MERGED_STORAGE_PATH_KEY, cdrVersion.getWgsVcfMergedStoragePath())
+              .put(WGS_HAIL_STORAGE_PATH_KEY, cdrVersion.getWgsHailStoragePath())
+              .put(MICROARRAY_HAIL_STORAGE_PATH_KEY, cdrVersion.getMicroarrayHailStoragePath())
+              .put(
                   MICROARRAY_VCF_SINGLE_SAMPLE_STORAGE_PATH_KEY,
                   cdrVersion.getMicroarrayVcfSingleSampleStoragePath())
+              .build()
               .entrySet()
               .stream()
               .filter(entry -> !Strings.isNullOrEmpty(entry.getValue()))

--- a/api/src/main/java/org/pmiops/workbench/tools/cdrconfig/CdrVersionVO.java
+++ b/api/src/main/java/org/pmiops/workbench/tools/cdrconfig/CdrVersionVO.java
@@ -24,4 +24,9 @@ public class CdrVersionVO {
   public Boolean hasCopeSurveyData;
   public String allSamplesWgsDataBucket;
   public String singleSampleArrayDataBucket;
+  public String storageBasePath;
+  public String wgsVcfMergedStoragePath;
+  public String wgsHailStoragePath;
+  public String microarrayHailStoragePath;
+  public String microarrayVcfSingleSampleStoragePath;
 }

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -44,6 +44,7 @@ import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.conceptset.mapper.ConceptSetMapperImpl;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
+import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.AdminActionHistoryDao;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.UserDao;
@@ -103,6 +104,7 @@ import org.pmiops.workbench.notebooks.model.LocalizationEntry;
 import org.pmiops.workbench.notebooks.model.Localize;
 import org.pmiops.workbench.test.FakeLongRandom;
 import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
+import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
@@ -228,6 +230,7 @@ public class RuntimeControllerTest {
   @Autowired CdrVersionDao cdrVersionDao;
   @MockBean WorkspaceDao workspaceDao;
   @Autowired UserDao userDao;
+  @Autowired AccessTierDao accessTierDao;
   @Autowired RuntimeController runtimeController;
   @Autowired LeonardoMapper leonardoMapper;
 
@@ -267,6 +270,7 @@ public class RuntimeControllerTest {
     // run in the workbench schema only.
     cdrVersion.setCdrDbName("");
     cdrVersion.setBigqueryDataset(BIGQUERY_DATASET);
+    cdrVersion.setAccessTier(TestMockFactory.createControlledTierForTests(accessTierDao));
 
     String createdDate = Date.fromYearMonthDay(1988, 12, 26).toString();
 

--- a/api/src/test/java/org/pmiops/workbench/tools/cdrconfig/CdrConfigVOMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/tools/cdrconfig/CdrConfigVOMapperTest.java
@@ -58,6 +58,8 @@ public class CdrConfigVOMapperTest {
     testVersionJson.hasCopeSurveyData = true;
     testVersionJson.allSamplesWgsDataBucket = "";
     testVersionJson.singleSampleArrayDataBucket = "gs://lol";
+    testVersionJson.storageBasePath = "20";
+    testVersionJson.microarrayHailStoragePath = "hail/mt";
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/tools/cdrconfig/CdrConfigVOMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/tools/cdrconfig/CdrConfigVOMapperTest.java
@@ -163,6 +163,8 @@ public class CdrConfigVOMapperTest {
     expected.setHasCopeSurveyData(testVersionJson.hasCopeSurveyData);
     expected.setAllSamplesWgsDataBucket(testVersionJson.allSamplesWgsDataBucket);
     expected.setSingleSampleArrayDataBucket(testVersionJson.singleSampleArrayDataBucket);
+    expected.setStorageBasePath(testVersionJson.storageBasePath);
+    expected.setMicroarrayHailStoragePath(testVersionJson.microarrayHailStoragePath);
 
     assertThat(mapper.toDbVersion(testVersionJson, accessTierDao)).isEqualTo(expected);
   }


### PR DESCRIPTION
- The old VCF vars are using incorrect terminology and will be removed (specifically, they are called BUCKET - but actually refer to storage paths); rename these
- Add new vars:
  - Base data path (can use this for non-standard data files)
  - Hail paths (wgs and microarray)

![image](https://user-images.githubusercontent.com/822298/153690855-ce5643e5-62a3-4b4e-8343-b456be611e0f.png)
