### PR TITLE
[RW-7868][risk=no] promoting cdr in prod

### DIFF
--- a/api/config/cdr_config_prod.json
+++ b/api/config/cdr_config_prod.json
@@ -103,7 +103,7 @@
       "creationTime": "2021-08-10 00:00:00Z",
       "releaseNumber": 5,
       "numParticipants": 329070,
-      "cdrDbName": "r_2021q3_5",
+      "cdrDbName": "r_2021q3_8",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"


### PR DESCRIPTION
promoting cdr in prod.

@yonghaoy tagging you as reviewer on this PR since you are release engineer next week. This will require a cdr publish in prod before deploying release to prod. [Documented here](https://docs.google.com/document/d/17YVCqu4BhVV8ai3OutHx8u0m6V5NkdM5H9kLNxTPDdo/edit#bookmark=id.hfa4tzr0afy5)

Publish command:
`db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-prod --bq-dataset R2021Q3R5 --tier registered --table-prefixes cb_,ds_`