### PR TITLE
[no ticket][risk=no] no ticket src to target db fix for data set mapper

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/dataset/mapper/DataSetMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/mapper/DataSetMapper.java
@@ -57,7 +57,7 @@ public interface DataSetMapper {
   @Mapping(target = "values", source = "domainValuePairs")
   @Mapping(target = "prePackagedConceptSetEnum", ignore = true)
   DbDataset dataSetRequestToDb(
-      DataSetRequest dataSetRequest, @Context DbDataset dbDataSet, @Context Clock clock);
+      DataSetRequest dataSetRequest, @Context DbDataset srcDbDataset, @Context Clock clock);
 
   @Mapping(target = "id", source = "dataSetId")
   @Mapping(target = "conceptSets", source = "conceptSetIds")
@@ -68,26 +68,26 @@ public interface DataSetMapper {
 
   @AfterMapping
   default void populateFromSourceDbObject(
-      @MappingTarget DbDataset targetDb, @Context DbDataset dbDataSet, @Context Clock clock) {
-    targetDb.setInvalid(dbDataSet == null ? false : dbDataSet.getInvalid());
+      @MappingTarget DbDataset targetDb, @Context DbDataset srcDbDataset, @Context Clock clock) {
+    targetDb.setInvalid(srcDbDataset == null ? false : srcDbDataset.getInvalid());
     Timestamp now = new Timestamp(clock.instant().toEpochMilli());
-    if (dbDataSet == null) {
+    if (srcDbDataset == null) {
       targetDb.setInvalid(false);
       targetDb.setCreationTime(now);
       targetDb.setLastModifiedTime(now);
     } else {
-      targetDb.setCreationTime(dbDataSet.getCreationTime());
-      targetDb.setDataSetId(dbDataSet.getDataSetId());
-      targetDb.setCreatorId(dbDataSet.getCreatorId());
+      targetDb.setCreationTime(srcDbDataset.getCreationTime());
+      targetDb.setDataSetId(srcDbDataset.getDataSetId());
+      targetDb.setCreatorId(srcDbDataset.getCreatorId());
       targetDb.setLastModifiedTime(now);
-    }
-    if (targetDb.getValues().isEmpty()) {
-      // In case of rename, dataSetRequest does not have cohort/Concept ID information
-      targetDb.setConceptSetIds(dbDataSet.getConceptSetIds());
-      targetDb.setCohortIds(dbDataSet.getCohortIds());
-      targetDb.setValues(dbDataSet.getValues());
-      targetDb.setIncludesAllParticipants(dbDataSet.getIncludesAllParticipants());
-      targetDb.setPrePackagedConceptSet(dbDataSet.getPrePackagedConceptSet());
+      if (targetDb.getValues().isEmpty()) {
+        // In case of rename, dataSetRequest does not have cohort/Concept ID information
+        targetDb.setConceptSetIds(srcDbDataset.getConceptSetIds());
+        targetDb.setCohortIds(srcDbDataset.getCohortIds());
+        targetDb.setValues(srcDbDataset.getValues());
+        targetDb.setIncludesAllParticipants(srcDbDataset.getIncludesAllParticipants());
+        targetDb.setPrePackagedConceptSet(srcDbDataset.getPrePackagedConceptSet());
+      }
     }
   }
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5085,6 +5085,7 @@ definitions:
     type: object
     required:
     - name
+    - criteriums
     properties:
       id:
         type: integer
@@ -5176,6 +5177,7 @@ definitions:
     type: object
     required:
     - name
+    - domainValuePairs
     properties:
       dataSetId:
         type: integer

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -1260,7 +1260,9 @@ public class DataSetControllerTest {
         dataSetController
             .createDataSet(workspace.getNamespace(), workspace.getId(), dataSetRequest)
             .getBody();
-    System.out.println(dataset);
+    // criteriums must be empty and not null, since
+    // conceptSetDao *will* return an empty hashSet for dbConceptEtConceptIds
+    // fix workbench-api.yml#ConceptSet#criteriums array to be required
     assertThat(dataset.getConceptSets()).contains(conceptSet1);
     assertThat(dataset.getCohorts()).contains(cohort);
     assertThat(dataset.getDomainValuePairs())

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -32,6 +32,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -1246,6 +1247,19 @@ public class DataSetControllerTest {
                 .markDirty(workspace.getNamespace(), workspace.getId(), markDataSetRequest)
                 .getBody())
         .isTrue();
+  }
+
+  @Test
+  public void testCreateMinimalDataset(){
+    DataSetRequest dataSetRequest = buildEmptyDataSetRequest();
+    dataSetRequest.setConceptSetIds(Arrays.asList(conceptSet1.getId()));
+    dataSetRequest.setCohortIds(Arrays.asList(cohort.getId()));
+    dataSetRequest.setDomainValuePairs(Arrays.asList(new DomainValuePair().domain(Domain.CONDITION).value("some condition1")));
+    DataSet dataset = dataSetController.createDataSet(workspace.getNamespace(),workspace.getId(),dataSetRequest).getBody();
+    System.out.println(dataset);
+    assertThat(dataset.getConceptSets()).contains(conceptSet1);
+    assertThat(dataset.getCohorts()).contains(cohort);
+    assertThat(dataset.getDomainValuePairs()).contains(new DomainValuePair().domain(Domain.CONDITION).value("some condition1"));
   }
 
   @Disabled(

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -1250,16 +1250,21 @@ public class DataSetControllerTest {
   }
 
   @Test
-  public void testCreateMinimalDataset(){
+  public void testCreateMinimalDataset() {
     DataSetRequest dataSetRequest = buildEmptyDataSetRequest();
     dataSetRequest.setConceptSetIds(Arrays.asList(conceptSet1.getId()));
     dataSetRequest.setCohortIds(Arrays.asList(cohort.getId()));
-    dataSetRequest.setDomainValuePairs(Arrays.asList(new DomainValuePair().domain(Domain.CONDITION).value("some condition1")));
-    DataSet dataset = dataSetController.createDataSet(workspace.getNamespace(),workspace.getId(),dataSetRequest).getBody();
+    dataSetRequest.setDomainValuePairs(
+        Arrays.asList(new DomainValuePair().domain(Domain.CONDITION).value("some condition1")));
+    DataSet dataset =
+        dataSetController
+            .createDataSet(workspace.getNamespace(), workspace.getId(), dataSetRequest)
+            .getBody();
     System.out.println(dataset);
     assertThat(dataset.getConceptSets()).contains(conceptSet1);
     assertThat(dataset.getCohorts()).contains(cohort);
-    assertThat(dataset.getDomainValuePairs()).contains(new DomainValuePair().domain(Domain.CONDITION).value("some condition1"));
+    assertThat(dataset.getDomainValuePairs())
+        .contains(new DomainValuePair().domain(Domain.CONDITION).value("some condition1"));
   }
 
   @Disabled(

--- a/api/src/test/java/org/pmiops/workbench/conceptset/mapper/ConceptSetMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/conceptset/mapper/ConceptSetMapperTest.java
@@ -70,7 +70,10 @@ public class ConceptSetMapperTest {
     assertThat(clientConceptSet.getLastModifiedTime())
         .isEqualTo(dbConceptSet.getLastModifiedTime().getTime());
     assertThat(clientConceptSet.getCreator()).isEqualTo(dbConceptSet.getCreator().getUsername());
-    assertThat(clientConceptSet.getCriteriums()).isNull();
+    // DbConceptSet initializes the dbConceptSetConceptIds to empty HashSet
+    // conceptSetDao *will return an empty dbConceptSetConceptIds* hence an empty ConceptSet
+    // *must* initialize criteriums to empty and not a null object
+    assertThat(clientConceptSet.getCriteriums()).isEmpty();
   }
 
   @Test
@@ -101,6 +104,6 @@ public class ConceptSetMapperTest {
     assertThat(clientConceptSet.getLastModifiedTime())
         .isEqualTo(dbConceptSet.getLastModifiedTime().getTime());
     assertThat(clientConceptSet.getCreator()).isEqualTo(dbConceptSet.getCreator().getUsername());
-    assertThat(clientConceptSet.getCriteriums()).isNull();
+    assertThat(clientConceptSet.getCriteriums()).isEmpty();
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/ConceptSetDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/ConceptSetDaoTest.java
@@ -93,4 +93,11 @@ public class ConceptSetDaoTest {
                 .get(0))
         .isEqualTo(dbConceptSet);
   }
+
+  @Test
+  public void saveEmptyDbConceptSetReturnsNonNullConceptSetConceptIds() {
+    DbConceptSet dbConceptSet1 = new DbConceptSet();
+    DbConceptSet saved = conceptSetDao.save(dbConceptSet1);
+    assertThat(saved.getConceptSetConceptIds()).isEmpty();
+  }
 }


### PR DESCRIPTION
Description:
- Updated ConceptSet to initialize criteriums to empty list to align with conceptSetDao returning empoty hashset of DbConceptSetConceptSetIds. Updated test to reflect the same
- DataSetControllerTest: Added test to create a minimal DataSet
- DataSetMapper: Changed argument name to avoid confusion with local variable name and moved if-block to logically correct location and avoid possible NPE
- workbench-api.yml: made `domainValuePairs` for DataSetRequest and  `criteriums` for ConceptSet *required* -  swagger will initialize these to empty instead of null



---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
