### PR TITLE
[risk=low][RW-7472] Simplify set-access-module-timestamps for future expansion

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/SetAccessModuleTimestamps.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/SetAccessModuleTimestamps.java
@@ -11,7 +11,6 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessModuleServiceImpl;
-import org.pmiops.workbench.access.AccessUtils;
 import org.pmiops.workbench.access.UserAccessModuleMapperImpl;
 import org.pmiops.workbench.actionaudit.ActionAuditServiceImpl;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditorImpl;
@@ -58,24 +57,15 @@ public class SetAccessModuleTimestamps {
 
   private static DbUser dbUser;
 
-  void applyTimestampUpdateToUser(
+  void updateCompletionTime(
       AccessModuleService accessModuleService,
       String username,
       AccessModuleName moduleName,
-      @Nullable Timestamp timestamp,
-      boolean isBypass) {
+      @Nullable Timestamp timestamp) {
     accessModuleService.updateCompletionTime(dbUser, moduleName, timestamp);
 
-    if (moduleName != AccessModuleName.PROFILE_CONFIRMATION) {
-      accessModuleService.updateBypassTime(
-          dbUser.getUserId(), AccessUtils.storageAccessModuleToClient(moduleName), isBypass);
-    }
-
     final String time = Optional.ofNullable(timestamp).map(Timestamp::toString).orElse("NULL");
-    LOG.info(
-        String.format(
-            "Updating %s bypass and/or completion time for user %s to %s; bypass mode is %s",
-            moduleName, username, time, isBypass));
+    LOG.info(String.format("Updating %s completion time for user %s to %s", moduleName, username, time));
   }
 
   @Bean
@@ -88,12 +78,12 @@ public class SetAccessModuleTimestamps {
         throw new IllegalArgumentException(String.format("User %s not found!", username));
       }
 
-      applyTimestampUpdateToUser(
+      updateCompletionTime(
           accessModuleService,
           username,
           AccessModuleName.PROFILE_CONFIRMATION,
-          PROFILE_CONFIRMATION_TIMESTAMP,
-          false);
+          PROFILE_CONFIRMATION_TIMESTAMP
+      );
     };
   }
 

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/SetAccessModuleTimestamps.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/SetAccessModuleTimestamps.java
@@ -65,7 +65,8 @@ public class SetAccessModuleTimestamps {
     accessModuleService.updateCompletionTime(dbUser, moduleName, timestamp);
 
     final String time = Optional.ofNullable(timestamp).map(Timestamp::toString).orElse("NULL");
-    LOG.info(String.format("Updating %s completion time for user %s to %s", moduleName, username, time));
+    LOG.info(
+        String.format("Updating %s completion time for user %s to %s", moduleName, username, time));
   }
 
   @Bean
@@ -82,8 +83,7 @@ public class SetAccessModuleTimestamps {
           accessModuleService,
           username,
           AccessModuleName.PROFILE_CONFIRMATION,
-          PROFILE_CONFIRMATION_TIMESTAMP
-      );
+          PROFILE_CONFIRMATION_TIMESTAMP);
     };
   }
 


### PR DESCRIPTION
We're planning to expand this tool for RW-7472 and other stories like RAS testing.  To make that easier, let's simplify the logic a bit by removing the unused bypass functionality.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
