### PR TITLE
[RW-7741][risk=no]  [P2] Show warning banner when user is on a browser not supported by Workbench

### DIFF
--- a/ui/src/app/routing/app-routing.tsx
+++ b/ui/src/app/routing/app-routing.tsx
@@ -239,6 +239,7 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> =
 
     return (
       <React.Fragment>
+        <div id='outdated' /> {/* for outdated-browser-rework */}
         {authLoaded && isUserDisabledInDb !== undefined && (
           <React.Fragment>
             {/* Once Angular is removed the app structure will change and we can put this in a more appropriate place */}
@@ -295,7 +296,6 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> =
                 </span>
               </div>
             )}
-            <div id='outdated' /> {/* for outdated-browser-rework */}
           </React.Fragment>
         )}
         {!firstPartyCookiesEnabled ||

--- a/ui/src/app/routing/app-routing.tsx
+++ b/ui/src/app/routing/app-routing.tsx
@@ -239,7 +239,9 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> =
 
     return (
       <React.Fragment>
-        <div id='outdated' /> {/* for outdated-browser-rework */}
+        {/* for outdated-browser-rework https://www.npmjs.com/package/outdated-browser-rework*/}
+        {/* The outdated browser banner should be shown on all pages not just for authenticated user*/}
+        <div id='outdated' />
         {authLoaded && isUserDisabledInDb !== undefined && (
           <React.Fragment>
             {/* Once Angular is removed the app structure will change and we can put this in a more appropriate place */}

--- a/ui/src/app/routing/app-routing.tsx
+++ b/ui/src/app/routing/app-routing.tsx
@@ -240,6 +240,7 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> =
     return (
       <React.Fragment>
         {/* for outdated-browser-rework https://www.npmjs.com/package/outdated-browser-rework*/}
+        {/* Check checkBrowserSupport() function defined in index.ts and implemented in setup.ts*/}
         {/* The outdated browser banner should be shown on all pages not just for authenticated user*/}
         <div id='outdated' />
         {authLoaded && isUserDisabledInDb !== undefined && (


### PR DESCRIPTION
This banner was displayed after the user is authenticated. I cannot verify that since there is a issue in login on safari. However its a good idea to show the banner always starting from the login page


<img width="1680" alt="Screen Shot 2022-02-14 at 1 20 00 PM" src="https://user-images.githubusercontent.com/34481816/153923587-786b21bc-dfec-4f9a-a9f4-16330e163244.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
