### PR TITLE
[risk=low][RW-7866] Update initial CT config behavior for Institutions

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionTierRequirement.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionTierRequirement.java
@@ -19,6 +19,7 @@ public class DbInstitutionTierRequirement {
     DOMAINS,
     ADDRESSES,
     NO_ACCESS,
+    UNINITIALIZED
   }
 
   private long institutionTierRequirementId;

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6772,12 +6772,15 @@ definitions:
 
   InstitutionMembershipRequirement:
     type: string
-    description: 'Type of Institution requirement for member to access a tier.
-      It can be matching email address, email domains or no access'
+    description: 'Institution email matching requirements for tier access.
+      We can match on email DOMAINS or individual email ADDRESSES.  NO_ACCESS indicates that the
+      institution does not provide access to the tier at all, and UNINITIALIZED is for unsaved
+      institutions in the admin UI.'
     enum:
       - DOMAINS
       - ADDRESSES
       - NO_ACCESS
+      - UNINITIALIZED
 
   InstitutionalRole:
     type: string

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -153,6 +153,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     expect(findCTDetails(wrapper).exists()).toBeTruthy();
 
     await simulateComponentChange(wrapper, findCTEnabled(wrapper), false);
+    expect(findCTEnabled(wrapper).props.checked).toBeFalsy();
     expect(findCTDetails(wrapper).exists()).toBeFalsy();
 
     await simulateComponentChange(wrapper, findCTEnabled(wrapper), true);
@@ -307,11 +308,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
-    await simulateComponentChange(
-      wrapper,
-      findRTDropdown(wrapper),
-      InstitutionMembershipRequirement.DOMAINS
-    );
+    // VERILY inst starts with RT = DOMAINS
 
     expect(findRTAddress(wrapper).exists()).toBeFalsy();
     expect(findRTDomain(wrapper).exists()).toBeTruthy();
@@ -339,36 +336,36 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
-    await simulateComponentChange(wrapper, findCTEnabled(wrapper), true);
+    // VERILY inst starts with RT DOMAINS and CT ADDRS
 
     await simulateComponentChange(
       wrapper,
       findRTDropdown(wrapper),
-      InstitutionMembershipRequirement.DOMAINS
+      InstitutionMembershipRequirement.ADDRESSES
     );
     await simulateComponentChange(
       wrapper,
       findCTDropdown(wrapper),
-      InstitutionMembershipRequirement.ADDRESSES
+      InstitutionMembershipRequirement.DOMAINS
+    );
+
+    findRTAddressInput(wrapper)
+      .first()
+      .simulate('change', { target: { value: 'correctEmail@domain.com' } });
+    findRTAddressInput(wrapper).first().simulate('blur');
+    expect(textInputValue(findRTAddressInput(wrapper))).toBe(
+      'correctEmail@domain.com'
     );
 
     // one entry has an incorrect Email Domain format (whitespace)
-    findRTDomainInput(wrapper)
+    findCTDomainInput(wrapper)
       .first()
       .simulate('change', {
         target: { value: 'someDomain.com,\njustSomeRandom.domain,\n,' },
       });
-    findRTDomainInput(wrapper).first().simulate('blur');
-    expect(textInputValue(findRTDomainInput(wrapper))).toBe(
+    findCTDomainInput(wrapper).first().simulate('blur');
+    expect(textInputValue(findCTDomainInput(wrapper))).toBe(
       'someDomain.com,\njustSomeRandom.domain'
-    );
-
-    findCTAddressInput(wrapper)
-      .first()
-      .simulate('change', { target: { value: 'correctEmail@domain.com' } });
-    findCTAddressInput(wrapper).first().simulate('blur');
-    expect(textInputValue(findCTAddressInput(wrapper))).toBe(
-      'correctEmail@domain.com'
     );
   });
 
@@ -377,7 +374,8 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
-    await simulateComponentChange(wrapper, findCTEnabled(wrapper), true);
+    // VERILY inst starts with CT ADDRS
+
     await simulateComponentChange(
       wrapper,
       findCTDropdown(wrapper),
@@ -409,6 +407,8 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
+
+    // VERILY inst starts with RT DOMAINS
 
     await simulateComponentChange(
       wrapper,
@@ -466,13 +466,9 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
-    expect(findCTDetails(wrapper).exists()).toBeTruthy();
+    // VERILY inst starts with CT ADDRS
 
-    await simulateComponentChange(
-      wrapper,
-      findCTDropdown(wrapper),
-      InstitutionMembershipRequirement.ADDRESSES
-    );
+    expect(findCTDetails(wrapper).exists()).toBeTruthy();
 
     // In case of a single entry which is not in the correct format
     findCTAddressInput(wrapper)
@@ -517,11 +513,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
-    await simulateComponentChange(
-      wrapper,
-      findRTDropdown(wrapper),
-      InstitutionMembershipRequirement.DOMAINS
-    );
+    // VERILY inst starts with RT DOMAINS
 
     expect(findRTDomainError(wrapper)).toBeFalsy();
 
@@ -565,7 +557,8 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
-    await simulateComponentChange(wrapper, findCTEnabled(wrapper), true);
+    // VERILY inst starts with CT ADDRS
+
     await simulateComponentChange(
       wrapper,
       findCTDropdown(wrapper),
@@ -612,11 +605,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
-    await simulateComponentChange(
-      wrapper,
-      findRTDropdown(wrapper),
-      InstitutionMembershipRequirement.DOMAINS
-    );
+    // VERILY inst starts with RT DOMAINS
 
     // one entry has an incorrect Email Domain format (whitespace)
     findRTDomainInput(wrapper)
@@ -637,8 +626,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
-    await simulateComponentChange(wrapper, findCTEnabled(wrapper), true);
-    await waitOneTickAndUpdate(wrapper);
+    // VERILY inst starts with CT ADDRS
 
     await simulateComponentChange(
       wrapper,
@@ -665,11 +653,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
-    await simulateComponentChange(
-      wrapper,
-      findRTDropdown(wrapper),
-      InstitutionMembershipRequirement.DOMAINS
-    );
+    // VERILY inst starts with RT DOMAINS
 
     // one entry has an incorrect Email Domain format (whitespace)
     findRTDomainInput(wrapper)
@@ -690,7 +674,8 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
-    await simulateComponentChange(wrapper, findCTEnabled(wrapper), true);
+    // VERILY inst starts with CT ADDRS
+
     await simulateComponentChange(
       wrapper,
       findCTDropdown(wrapper),
@@ -783,6 +768,7 @@ describe('AdminInstitutionEditSpec - add mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
+    // uninitialized
     expect(findRTDomainInput(wrapper).exists()).toBeFalsy();
     expect(findRTAddressInput(wrapper).exists()).toBeFalsy();
     expect(findCTAddressInput(wrapper).exists()).toBeFalsy();

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -766,6 +766,12 @@ describe('AdminInstitutionEditSpec - add mode', () => {
     await simulateComponentChange(wrapper, findCTEnabled(wrapper), false);
     expect(findCTEnabled(wrapper).props.checked).toBeFalsy();
     expect(findCTDetails(wrapper).exists()).toBeFalsy();
+
+    // both RT and CT are uninitialized
+    expect(findRTDomainInput(wrapper).exists()).toBeFalsy();
+    expect(findRTAddressInput(wrapper).exists()).toBeFalsy();
+    expect(findCTAddressInput(wrapper).exists()).toBeFalsy();
+    expect(findCTDomainInput(wrapper).exists()).toBeFalsy();
   });
 
   it('should update institution tier requirement', async () => {

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -73,6 +73,8 @@ const findCTAddressInput = (wrapper) =>
 const findCTDomainInput = (wrapper) =>
   wrapper.find('[data-test-id="controlled-email-domain-input"]');
 
+const textInputValue = (wrapper) => wrapper.first().prop('value');
+
 const findSaveButton = (wrapper) =>
   wrapper.find('[data-test-id="save-institution-button"]');
 const findSaveButtonDisabled = (wrapper) =>
@@ -158,6 +160,53 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     expect(findCTDetails(wrapper).exists()).toBeTruthy();
   });
 
+  it('should populate CT requirements from RT when enabling CT if RT matches on DOMAIN', async () => {});
+
+  it('should not populate CT requirements from RT when enabling CT if RT matches on ADDRESS', async () => {
+    const wrapper = component(VERILY_WITHOUT_CT.shortName);
+    await waitOneTickAndUpdate(wrapper);
+    expect(wrapper).toBeTruthy();
+    expect(findCTDetails(wrapper).exists()).toBeFalsy();
+
+    expect(findRTERARequired(wrapper).props.checked).toBeTruthy();
+
+    // change Registered from DOMAIN to ADDRESS
+
+    expect(findRTDomain(wrapper).exists()).toBeTruthy();
+    expect(findRTAddress(wrapper).exists()).toBeFalsy();
+
+    await simulateComponentChange(
+      wrapper,
+      findRTDropdown(wrapper),
+      InstitutionMembershipRequirement.ADDRESSES
+    );
+
+    expect(findRTAddress(wrapper).exists()).toBeTruthy();
+    expect(findRTDomain(wrapper).exists()).toBeFalsy();
+
+    // update RT addresses
+
+    findRTAddressInput(wrapper)
+      .first()
+      .simulate('change', {
+        target: {
+          value:
+            'test1@domain.com,\n' + 'test2@domain.com,\n' + 'test3@domain.com',
+        },
+      });
+
+    await simulateComponentChange(wrapper, findCTEnabled(wrapper), true);
+    expect(findCTEnabled(wrapper).props.checked).toBeTruthy();
+    expect(findCTDetails(wrapper).exists()).toBeTruthy();
+
+    // CT has the default requirement: domain and empty
+
+    expect(findCTDomain(wrapper).exists()).toBeTruthy();
+    expect(findCTAddress(wrapper).exists()).toBeFalsy();
+
+    expect(textInputValue(findCTDomainInput(wrapper))).toBeUndefined();
+  });
+
   it('should not change eRA Required and tier enabled switches when changing tier requirement', async () => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
@@ -192,12 +241,10 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     expect(wrapper).toBeTruthy();
 
     // Value before test.
-    expect(findRTDomainInput(wrapper).first().prop('value')).toBe(
+    expect(textInputValue(findRTDomainInput(wrapper))).toBe(
       'verily.com,\ngoogle.com'
     );
-    expect(findCTAddressInput(wrapper).first().prop('value')).toBe(
-      'foo@verily.com'
-    );
+    expect(textInputValue(findCTAddressInput(wrapper))).toBe('foo@verily.com');
 
     await simulateComponentChange(
       wrapper,
@@ -214,11 +261,11 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
       .first()
       .simulate('click');
     // RT no change
-    expect(findRTDomainInput(wrapper).first().prop('value')).toBe(
+    expect(textInputValue(findRTDomainInput(wrapper))).toBe(
       'verily.com,\n' + 'google.com'
     );
     // CT changed to email domains
-    expect(findCTDomainInput(wrapper).first().prop('value')).toBe('domain.com');
+    expect(textInputValue(findCTDomainInput(wrapper))).toBe('domain.com');
     // CT email addresses become empty
     expect(findCTAddressInput(wrapper).exists()).toBeFalsy();
   });
@@ -280,7 +327,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
         target: { value: 'someDomain.com,\njustSomeRandom.domain,\n,' },
       });
     findRTDomainInput(wrapper).first().simulate('blur');
-    expect(findRTDomainInput(wrapper).first().prop('value')).toBe(
+    expect(textInputValue(findRTDomainInput(wrapper))).toBe(
       'someDomain.com,\njustSomeRandom.domain'
     );
 
@@ -288,7 +335,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
       .first()
       .simulate('change', { target: { value: 'correctEmail@domain.com' } });
     findCTAddressInput(wrapper).first().simulate('blur');
-    expect(findCTAddressInput(wrapper).first().prop('value')).toBe(
+    expect(textInputValue(findCTAddressInput(wrapper))).toBe(
       'correctEmail@domain.com'
     );
   });
@@ -552,7 +599,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
         target: { value: 'validEmail.com,\n     ,\njustSomeRandom.domain,\n,' },
       });
     findRTDomainInput(wrapper).first().simulate('blur');
-    expect(findRTDomainInput(wrapper).first().prop('value')).toBe(
+    expect(textInputValue(findRTDomainInput(wrapper))).toBe(
       'validEmail.com,\njustSomeRandom.domain'
     );
 
@@ -580,7 +627,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
         target: { value: 'validEmail.com,\n     ,\njustSomeRandom.domain,\n,' },
       });
     findCTDomainInput(wrapper).first().simulate('blur');
-    expect(findCTDomainInput(wrapper).first().prop('value')).toBe(
+    expect(textInputValue(findCTDomainInput(wrapper))).toBe(
       'validEmail.com,\njustSomeRandom.domain'
     );
 
@@ -605,7 +652,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
         target: { value: '  someDomain.com,\njustSomeRandom.domain   ,\n,' },
       });
     findRTDomainInput(wrapper).first().simulate('blur');
-    expect(findRTDomainInput(wrapper).first().prop('value')).toBe(
+    expect(textInputValue(findRTDomainInput(wrapper))).toBe(
       'someDomain.com,\njustSomeRandom.domain'
     );
 
@@ -631,7 +678,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
         target: { value: '  someDomain.com,\njustSomeRandom.domain   ,\n,' },
       });
     findCTDomainInput(wrapper).first().simulate('blur');
-    expect(findCTDomainInput(wrapper).first().prop('value')).toBe(
+    expect(textInputValue(findCTDomainInput(wrapper))).toBe(
       'someDomain.com,\njustSomeRandom.domain'
     );
 
@@ -722,7 +769,7 @@ describe('AdminInstitutionEditSpec - add mode', () => {
     );
 
     expect(findRTAddressInput(wrapper).exists()).toBeTruthy();
-    expect(findRTAddressInput(wrapper).first().prop('value')).toBe('');
+    expect(textInputValue(findRTAddressInput(wrapper))).toBe('');
 
     expect(findRTDomainInput(wrapper).exists()).toBeFalsy();
     expect(findCTAddressInput(wrapper).exists()).toBeFalsy();
@@ -734,9 +781,7 @@ describe('AdminInstitutionEditSpec - add mode', () => {
     findRTAddressInput(wrapper).first().simulate('blur');
 
     // RT no change
-    expect(findRTAddressInput(wrapper).first().prop('value')).toBe(
-      'user@domain.com'
-    );
+    expect(textInputValue(findRTAddressInput(wrapper))).toBe('user@domain.com');
   });
 
   it('should not change eRA Required and tier enabled switches when changing tier requirement', async () => {
@@ -840,7 +885,7 @@ describe('AdminInstitutionEditSpec - add mode', () => {
         target: { value: 'validEmail.com,\n     ,\njustSomeRandom.domain,\n,' },
       });
     findCTDomainInput(wrapper).first().simulate('blur');
-    expect(findCTDomainInput(wrapper).first().prop('value')).toBe(
+    expect(textInputValue(findCTDomainInput(wrapper))).toBe(
       'validEmail.com,\njustSomeRandom.domain'
     );
 

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -6,10 +6,8 @@ import { Dropdown } from 'primereact/dropdown';
 import { InputSwitch } from 'primereact/inputswitch';
 
 import {
-  Institution,
   InstitutionApi,
   InstitutionMembershipRequirement,
-  OrganizationType,
 } from 'generated/fetch';
 
 import { registerApiClient } from 'app/services/swagger-fetch-clients';

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -170,11 +170,12 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
 
     // update RT domains
 
+    const testDomains = 'domain1.com,\n' + 'domain2.com,\n' + 'domain3.com';
     findRTDomainInput(wrapper)
       .first()
       .simulate('change', {
         target: {
-          value: 'domain1.com,\n' + 'domain2.com,\n' + 'domain3.com',
+          value: testDomains,
         },
       });
 
@@ -182,13 +183,13 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     expect(findCTEnabled(wrapper).props.checked).toBeTruthy();
     expect(findCTDetails(wrapper).exists()).toBeTruthy();
 
-    // CT has the default requirement: domain, empty, ERA = false
+    // CT copies RT's requirements: domain, same domains, ERA = true
 
     expect(findCTDomain(wrapper).exists()).toBeTruthy();
     expect(findCTAddress(wrapper).exists()).toBeFalsy();
-    expect(findRTERARequired(wrapper).props.checked).toBeFalsy();
+    expect(findCTERARequired(wrapper).props.checked).toBeTruthy();
 
-    expect(textInputValue(findCTDomainInput(wrapper))).toBeUndefined();
+    expect(textInputValue(findCTDomainInput(wrapper))).toBe(testDomains);
   });
 
   it('should not populate CT requirements from RT when enabling CT if RT matches on ADDRESS', async () => {
@@ -232,9 +233,9 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
 
     expect(findCTDomain(wrapper).exists()).toBeTruthy();
     expect(findCTAddress(wrapper).exists()).toBeFalsy();
-    expect(findRTERARequired(wrapper).props.checked).toBeFalsy();
+    expect(findCTERARequired(wrapper).props.checked).toBeFalsy();
 
-    expect(textInputValue(findCTDomainInput(wrapper))).toBeUndefined();
+    expect(textInputValue(findCTDomainInput(wrapper))).toBe('');
   });
 
   it('should not change eRA Required and tier enabled switches when changing tier requirement', async () => {

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -183,7 +183,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     expect(findCTEnabled(wrapper).props.checked).toBeTruthy();
     expect(findCTDetails(wrapper).exists()).toBeTruthy();
 
-    // CT copies RT's requirements: domain, same domains, ERA = true
+    // CT copies RT's requirements: domain, ERA = true, domain list is equal
 
     expect(findCTDomain(wrapper).exists()).toBeTruthy();
     expect(findCTAddress(wrapper).exists()).toBeFalsy();
@@ -192,7 +192,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     expect(textInputValue(findCTDomainInput(wrapper))).toBe(testDomains);
   });
 
-  it('should not populate CT requirements from RT when enabling CT if RT matches on ADDRESS', async () => {
+  it('should populate CT requirements from RT when enabling CT if RT matches on ADDRESS', async () => {
     const wrapper = component(VERILY_WITHOUT_CT.shortName);
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
@@ -229,13 +229,14 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     expect(findCTEnabled(wrapper).props.checked).toBeTruthy();
     expect(findCTDetails(wrapper).exists()).toBeTruthy();
 
-    // CT has the default requirement: domain, empty, ERA = false
+    // CT copies RT's requirements: address, ERA = true
+    // but the CT address list is empty
 
-    expect(findCTDomain(wrapper).exists()).toBeTruthy();
-    expect(findCTAddress(wrapper).exists()).toBeFalsy();
-    expect(findCTERARequired(wrapper).props.checked).toBeFalsy();
+    expect(findCTAddress(wrapper).exists()).toBeTruthy();
+    expect(findCTDomain(wrapper).exists()).toBeFalsy();
+    expect(findCTERARequired(wrapper).props.checked).toBeTruthy();
 
-    expect(textInputValue(findCTDomainInput(wrapper))).toBe('');
+    expect(textInputValue(findCTAddressInput(wrapper))).toBe('');
   });
 
   it('should not change eRA Required and tier enabled switches when changing tier requirement', async () => {

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -160,7 +160,36 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     expect(findCTDetails(wrapper).exists()).toBeTruthy();
   });
 
-  it('should populate CT requirements from RT when enabling CT if RT matches on DOMAIN', async () => {});
+  it('should populate CT requirements from RT when enabling CT if RT matches on DOMAIN', async () => {
+    const wrapper = component(VERILY_WITHOUT_CT.shortName);
+    await waitOneTickAndUpdate(wrapper);
+    expect(wrapper).toBeTruthy();
+    expect(findCTDetails(wrapper).exists()).toBeFalsy();
+
+    expect(findRTERARequired(wrapper).props.checked).toBeTruthy();
+
+    // update RT domains
+
+    findRTDomainInput(wrapper)
+      .first()
+      .simulate('change', {
+        target: {
+          value: 'domain1.com,\n' + 'domain2.com,\n' + 'domain3.com',
+        },
+      });
+
+    await simulateComponentChange(wrapper, findCTEnabled(wrapper), true);
+    expect(findCTEnabled(wrapper).props.checked).toBeTruthy();
+    expect(findCTDetails(wrapper).exists()).toBeTruthy();
+
+    // CT has the default requirement: domain, empty, ERA = false
+
+    expect(findCTDomain(wrapper).exists()).toBeTruthy();
+    expect(findCTAddress(wrapper).exists()).toBeFalsy();
+    expect(findRTERARequired(wrapper).props.checked).toBeFalsy();
+
+    expect(textInputValue(findCTDomainInput(wrapper))).toBeUndefined();
+  });
 
   it('should not populate CT requirements from RT when enabling CT if RT matches on ADDRESS', async () => {
     const wrapper = component(VERILY_WITHOUT_CT.shortName);
@@ -199,10 +228,11 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     expect(findCTEnabled(wrapper).props.checked).toBeTruthy();
     expect(findCTDetails(wrapper).exists()).toBeTruthy();
 
-    // CT has the default requirement: domain and empty
+    // CT has the default requirement: domain, empty, ERA = false
 
     expect(findCTDomain(wrapper).exists()).toBeTruthy();
     expect(findCTAddress(wrapper).exists()).toBeFalsy();
+    expect(findRTERARequired(wrapper).props.checked).toBeFalsy();
 
     expect(textInputValue(findCTDomainInput(wrapper))).toBeUndefined();
   });

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -565,6 +565,11 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
       InstitutionMembershipRequirement.DOMAINS
     );
 
+    expect(findCTDomainError(wrapper)).toBeTruthy();
+    expect(findCTDomainError(wrapper)[0]).toBe(
+      'Controlled tier email domains should not be empty'
+    );
+
     // Single Entry with incorrect Email Domain format
     findCTDomainInput(wrapper)
       .first()

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -465,14 +465,13 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
 
-    await simulateComponentChange(wrapper, findCTEnabled(wrapper), true);
+    expect(findCTDetails(wrapper).exists()).toBeTruthy();
+
     await simulateComponentChange(
       wrapper,
       findCTDropdown(wrapper),
       InstitutionMembershipRequirement.ADDRESSES
     );
-
-    expect(findCTAddressError(wrapper)).toBeFalsy();
 
     // In case of a single entry which is not in the correct format
     findCTAddressInput(wrapper)
@@ -570,11 +569,6 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
       wrapper,
       findCTDropdown(wrapper),
       InstitutionMembershipRequirement.DOMAINS
-    );
-
-    expect(findCTDomainError(wrapper)).toBeTruthy();
-    expect(findCTDomainError(wrapper)[0]).toBe(
-      'Controlled tier email domains should not be empty'
     );
 
     // Single Entry with incorrect Email Domain format

--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -6,8 +6,10 @@ import { Dropdown } from 'primereact/dropdown';
 import { InputSwitch } from 'primereact/inputswitch';
 
 import {
+  Institution,
   InstitutionApi,
   InstitutionMembershipRequirement,
+  OrganizationType,
 } from 'generated/fetch';
 
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
@@ -151,14 +153,17 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     expect(wrapper).toBeTruthy();
 
     expect(findCTDetails(wrapper).exists()).toBeTruthy();
+    expect(textInputValue(findCTAddressInput(wrapper))).toBe('foo@verily.com');
 
     await simulateComponentChange(wrapper, findCTEnabled(wrapper), false);
     expect(findCTEnabled(wrapper).props.checked).toBeFalsy();
     expect(findCTDetails(wrapper).exists()).toBeFalsy();
+    expect(findCTAddressInput(wrapper).exists()).toBeFalsy();
 
     await simulateComponentChange(wrapper, findCTEnabled(wrapper), true);
     expect(findCTEnabled(wrapper).props.checked).toBeTruthy();
     expect(findCTDetails(wrapper).exists()).toBeTruthy();
+    expect(textInputValue(findCTAddressInput(wrapper))).toBe('foo@verily.com');
   });
 
   it('should populate CT requirements from RT when enabling CT if RT matches on DOMAIN', async () => {

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -449,7 +449,8 @@ export const AdminInstitutionEdit = fp.flow(
           tierConfigs: [
             {
               ...defaultTierConfig(AccessTierShortNames.Registered),
-              membershipRequirement: null, // the default is NOACCESS which also means "don't render the card"
+              membershipRequirement:
+                InstitutionMembershipRequirement.UNINITIALIZED,
             },
           ],
         },

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -524,17 +524,10 @@ export const AdminInstitutionEdit = fp.flow(
       );
     }
 
-    private setEnableControlledTier(
-      accessTierShortName: string,
-      enableControlled: boolean
-    ) {
+    private setEnableControlledTier(enableControlled: boolean) {
       const { tierConfigs } = this.state.institution;
       this.setTierConfigs(
-        updateEnableControlledTier(
-          tierConfigs,
-          accessTierShortName,
-          enableControlled
-        )
+        updateEnableControlledTier(tierConfigs, enableControlled)
       );
     }
 
@@ -899,7 +892,7 @@ export const AdminInstitutionEdit = fp.flow(
                   accessTierShortName={accessTierShortName}
                   institution={institution}
                   setEnableControlledTier={(value) =>
-                    this.setEnableControlledTier(accessTierShortName, value)
+                    this.setEnableControlledTier(value)
                   }
                   setEraRequired={(value) =>
                     this.setRequireEra(accessTierShortName, value)

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -526,9 +526,13 @@ export const AdminInstitutionEdit = fp.flow(
     }
 
     private setEnableControlledTier(enableControlled: boolean) {
-      const { tierConfigs } = this.state.institution;
+      const { institution, institutionBeforeEdits } = this.state;
       this.setTierConfigs(
-        updateEnableControlledTier(tierConfigs, enableControlled)
+        updateEnableControlledTier(
+          institution.tierConfigs,
+          institutionBeforeEdits?.tierConfigs,
+          enableControlled
+        )
       );
     }
 

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -212,9 +212,10 @@ export function updateRequireEra(
   });
 }
 
-// if RT has InstitutionMembershipRequirement.DOMAINS,
-// copy the RT config and domains to CT.
-// otherwise initialize to the defaultTierConfig with empty DOMAINS
+// initialize the CT config depending on the RT config:
+// RT = DOMAINS -> copy the DOMAINS list to CT
+// RT = ADDRESSES -> use ADDRESSES in CT but do not copy the list
+// RT = UNINITIALIZED (add mode) -> CT is also UNINITIALIZED
 export function updateEnableControlledTier(
   tierConfigs: Array<InstitutionTierConfig>,
   enableCtAccess: boolean

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -225,7 +225,7 @@ export function updateEnableControlledTier(
   );
 
   const ctConfig = !enableCtAccess
-    ? // if we are disabling CT access, choose the default (empty) config
+    ? // if we are disabling CT access, choose the default (no-render) config
       defaultTierConfig(AccessTierShortNames.Controlled)
     : switchCase(
         rtConfig.membershipRequirement,
@@ -247,7 +247,7 @@ export function updateEnableControlledTier(
           }),
         ],
         [
-          // if RT is UNINITIALIZED, choose the default (empty) config but set to UNINITIALIZED
+          // if RT is UNINITIALIZED, choose the default config but set to UNINITIALIZED
           InstitutionMembershipRequirement.UNINITIALIZED,
           () => ({
             ...defaultTierConfig(AccessTierShortNames.Controlled),

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -214,11 +214,10 @@ export function updateRequireEra(
 
 export function updateEnableControlledTier(
   tierConfigs: Array<InstitutionTierConfig>,
-  accessTierShortName: string,
   enableCtAccess: boolean
 ): Array<InstitutionTierConfig> {
   return mergeTierConfigs(tierConfigs, {
-    ...getTierConfigOrDefault(tierConfigs, accessTierShortName),
+    ...getTierConfigOrDefault(tierConfigs, AccessTierShortNames.Controlled),
     membershipRequirement:
       enableCtAccess === true
         ? InstitutionMembershipRequirement.DOMAINS

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -222,7 +222,6 @@ export function updateEnableControlledTier(
   const rtConfig = tierConfigs.find(
     (tier) => tier.accessTierShortName === AccessTierShortNames.Registered
   );
-
   const rtReq = rtConfig.membershipRequirement;
 
   const ctConfig = cond(
@@ -240,11 +239,11 @@ export function updateEnableControlledTier(
       }),
     ],
     [
-      // if we are enabling CT access and RT is ADDRESSES, init CT with DOMAINS and leave empty
-      enableCtAccess && rtReq === InstitutionMembershipRequirement.ADDRESSES,
+      // otherwise, init CT with RT's requirement (UNINITIALIZED or ADDRESSES) and leave empty
+      enableCtAccess,
       () => ({
         ...defaultTierConfig(AccessTierShortNames.Controlled),
-        membershipRequirement: InstitutionMembershipRequirement.DOMAINS,
+        membershipRequirement: rtReq,
       }),
     ]
   );

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -247,12 +247,11 @@ export function updateEnableControlledTier(
           }),
         ],
         [
-          // if RT is UNINITIALIZED, choose the default config but set to UNINITIALIZED
+          // if RT is UNINITIALIZED, copy UNINITIALIZED RT to CT
           InstitutionMembershipRequirement.UNINITIALIZED,
           () => ({
-            ...defaultTierConfig(AccessTierShortNames.Controlled),
-            membershipRequirement:
-              InstitutionMembershipRequirement.UNINITIALIZED,
+            ...rtConfig,
+            accessTierShortName: AccessTierShortNames.Controlled,
           }),
         ]
       );

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -17,7 +17,7 @@ import colors from 'app/styles/colors';
 import { AccessTierShortNames } from 'app/utils/access-tiers';
 
 import { isAbortError } from './errors';
-import { isBlank, switchCase } from './index';
+import { cond, isBlank, switchCase } from './index';
 
 /**
  * Checks that the entered email address is a valid member of the chosen institution.
@@ -212,51 +212,71 @@ export function updateRequireEra(
   });
 }
 
-// initialize the CT config depending on the RT config:
+// initialize a new CT config depending on the RT config:
 // RT = DOMAINS -> copy the DOMAINS list to CT
 // RT = ADDRESSES -> use ADDRESSES in CT but do not copy the list
 // RT = UNINITIALIZED (add mode) -> CT is also UNINITIALIZED
-export function updateEnableControlledTier(
-  tierConfigs: Array<InstitutionTierConfig>,
-  enableCtAccess: boolean
-): Array<InstitutionTierConfig> {
+const initControlledTierConfig = (
+  tierConfigs: InstitutionTierConfig[]
+): InstitutionTierConfig => {
   const rtConfig = tierConfigs.find(
     (tier) => tier.accessTierShortName === AccessTierShortNames.Registered
   );
 
-  const ctConfig = !enableCtAccess
-    ? // if we are disabling CT access, choose the default (no-render) config
-      defaultTierConfig(AccessTierShortNames.Controlled)
-    : switchCase(
-        rtConfig.membershipRequirement,
-        [
-          // if RT is DOMAINS, copy RT to CT
-          InstitutionMembershipRequirement.DOMAINS,
-          () => ({
-            ...rtConfig,
-            accessTierShortName: AccessTierShortNames.Controlled,
-          }),
-        ],
-        [
-          // if RT is ADDRESSES, copy RT to CT but clear the address list
-          InstitutionMembershipRequirement.ADDRESSES,
-          () => ({
-            ...rtConfig,
-            accessTierShortName: AccessTierShortNames.Controlled,
-            emailAddresses: [],
-          }),
-        ],
-        [
-          // if RT is UNINITIALIZED, copy UNINITIALIZED RT to CT
-          InstitutionMembershipRequirement.UNINITIALIZED,
-          () => ({
-            ...rtConfig,
-            accessTierShortName: AccessTierShortNames.Controlled,
-          }),
-        ]
-      );
+  return switchCase(
+    rtConfig.membershipRequirement,
+    [
+      // if RT is DOMAINS, copy RT to CT
+      InstitutionMembershipRequirement.DOMAINS,
+      () => ({
+        ...rtConfig,
+        accessTierShortName: AccessTierShortNames.Controlled,
+      }),
+    ],
+    [
+      // if RT is ADDRESSES, copy RT to CT but clear the address list
+      InstitutionMembershipRequirement.ADDRESSES,
+      () => ({
+        ...rtConfig,
+        accessTierShortName: AccessTierShortNames.Controlled,
+        emailAddresses: [],
+      }),
+    ],
+    [
+      // if RT is UNINITIALIZED, copy UNINITIALIZED RT to CT
+      InstitutionMembershipRequirement.UNINITIALIZED,
+      () => ({
+        ...rtConfig,
+        accessTierShortName: AccessTierShortNames.Controlled,
+      }),
+    ]
+  );
+};
 
-  return mergeTierConfigs(tierConfigs, ctConfig);
+// 3 scenarios here:
+// disable CT -> use the default no-render tier config for CT
+// enable CT for the first time -> initControlledTierConfig() from RT
+// re-enable CT after disabling without saving -> use the pre-changes CT
+export function updateEnableControlledTier(
+  tierConfigs: InstitutionTierConfig[],
+  tierConfigsBeforeEditing: InstitutionTierConfig[],
+  enableCtAccess: boolean
+): InstitutionTierConfig[] {
+  // if the before-editing institution had a CT and we are restoring it, use the before-editing CT
+  const previousCtConfig = tierConfigsBeforeEditing?.find(
+    (tier) => tier.accessTierShortName === AccessTierShortNames.Controlled
+  );
+
+  const newCtConfig = cond(
+    [!enableCtAccess, () => defaultTierConfig(AccessTierShortNames.Controlled)],
+    [enableCtAccess && !!previousCtConfig, () => previousCtConfig],
+    [
+      enableCtAccess && !previousCtConfig,
+      () => initControlledTierConfig(tierConfigs),
+    ]
+  );
+
+  return mergeTierConfigs(tierConfigs, newCtConfig);
 }
 
 export function getTierBadge(accessTierShortName: string): () => JSX.Element {

--- a/ui/src/testing/stubs/institution-api-stub.ts
+++ b/ui/src/testing/stubs/institution-api-stub.ts
@@ -78,10 +78,6 @@ export const VERILY_WITHOUT_CT: Institution = {
       eraRequired: true,
       emailDomains: ['verily.com', 'google.com'],
     },
-    {
-      accessTierShortName: 'controlled',
-      membershipRequirement: InstitutionMembershipRequirement.NOACCESS,
-    },
   ],
   userInstructions: 'Verily User Instruction',
 };


### PR DESCRIPTION
Edit Institution - copies domain list but not address when enabling Controlled Tier
![Edit_Mode](https://user-images.githubusercontent.com/2701406/153949023-2050a9d4-83ce-4657-a09a-ba672397bab3.gif)


Add Institution - same
![Add_Mode](https://user-images.githubusercontent.com/2701406/153949038-da4c6633-4283-4eea-aac4-0d4247fb1982.gif)


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
