### PR TITLE
[risk=low][no ticket] new API entity AccessModuleName

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleNameMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleNameMapper.java
@@ -7,17 +7,24 @@ import org.pmiops.workbench.actionaudit.targetproperties.BypassTimeTargetPropert
 import org.pmiops.workbench.compliance.ComplianceService.BadgeName;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.model.AccessModule;
+import org.pmiops.workbench.model.AccessModuleName;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
 @Mapper(config = MapStructConfig.class)
 public interface AccessModuleNameMapper {
+  @Deprecated // use the AccessModuleName mappers
   @ValueMapping(source = "COMPLIANCE_TRAINING", target = "RT_COMPLIANCE_TRAINING")
   @ValueMapping(source = "RAS_LINK_LOGIN_GOV", target = "RAS_LOGIN_GOV")
-  DbAccessModuleName clientAccessModuleToStorage(AccessModule source);
+  DbAccessModuleName deprecatedClientAccessModuleToStorage(AccessModule source);
 
+  @Deprecated // use the AccessModuleName mappers
   @ValueMapping(source = "RT_COMPLIANCE_TRAINING", target = "COMPLIANCE_TRAINING")
   @ValueMapping(source = "RAS_LOGIN_GOV", target = "RAS_LINK_LOGIN_GOV")
-  AccessModule storageAccessModuleToClient(DbAccessModuleName source);
+  AccessModule deprecatedStorageAccessModuleToClient(DbAccessModuleName source);
+
+  DbAccessModuleName clientAccessModuleToStorage(AccessModuleName source);
+
+  AccessModuleName storageAccessModuleToClient(DbAccessModuleName source);
 
   // these modules cannot be bypassed
   @ValueMapping(source = "PROFILE_CONFIRMATION", target = MappingConstants.NULL)

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.AccessBypassRequest;
-import org.pmiops.workbench.model.AccessModule;
+import org.pmiops.workbench.model.AccessModuleName;
 import org.pmiops.workbench.model.AccessModuleStatus;
 
 public interface AccessModuleService {
@@ -14,7 +14,7 @@ public interface AccessModuleService {
   void updateBypassTime(long userId, AccessBypassRequest accessBypassRequest);
 
   /** Updates bypass time for a module. */
-  void updateBypassTime(long userId, AccessModule accessModuleName, boolean isBypassed);
+  void updateBypassTime(long userId, AccessModuleName accessModuleName, boolean isBypassed);
 
   /** Update module status to complete for a user. */
   void updateCompletionTime(

--- a/api/src/main/java/org/pmiops/workbench/access/UserAccessModuleMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/access/UserAccessModuleMapper.java
@@ -18,6 +18,7 @@ import org.pmiops.workbench.utils.mappers.MapStructConfig;
     uses = {CommonMappers.class, AccessModuleNameMapper.class},
     nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
 public interface UserAccessModuleMapper {
+  @Mapping(target = "moduleNameTemp", source = "accessModule.name")
   @Mapping(target = "moduleName", source = "accessModule.name")
   @Mapping(target = "completionEpochMillis", source = "completionTime")
   @Mapping(target = "bypassEpochMillis", source = "bypassTime")

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -36,6 +36,7 @@ public interface WorkbenchConfigMapper {
             .collect(Collectors.toList()));
   }
 
+  @Mapping(target = "moduleNameTemp", source = "accessModule.name")
   AccessModuleConfig mapAccessModule(DbAccessModule accessModule);
 
   // handled by mapRuntimeImages()

--- a/api/src/main/java/org/pmiops/workbench/ras/RasLinkService.java
+++ b/api/src/main/java/org/pmiops/workbench/ras/RasLinkService.java
@@ -28,7 +28,7 @@ import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
-import org.pmiops.workbench.model.AccessModule;
+import org.pmiops.workbench.model.AccessModuleName;
 import org.pmiops.workbench.model.AccessModuleStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -154,7 +154,7 @@ public class RasLinkService {
     DbUser user = userService.updateRasLinkLoginGovStatus(getLoginGovUsername(userInfoResponse));
     Optional<AccessModuleStatus> eRAModuleStatus =
         accessModuleService.getAccessModuleStatus(user).stream()
-            .filter(a -> a.getModuleName() == AccessModule.ERA_COMMONS)
+            .filter(a -> a.getModuleNameTemp() == AccessModuleName.ERA_COMMONS)
             .findFirst();
     if (eRAModuleStatus.isPresent()
         && (eRAModuleStatus.get().getCompletionEpochMillis() != null

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4504,14 +4504,17 @@ definitions:
   AccessModuleConfig:
     type: object
     required:
-      - name
+      - moduleNameTemp
       - expirable
       - bypassable
       - requiredForRTAccess
       - requiredForCTAccess
     properties:
       name:
+        description: DEPRECATED. Use moduleNameTemp.
         "$ref": "#/definitions/AccessModule"
+      moduleNameTemp:
+        "$ref": "#/definitions/AccessModuleName"
       expirable:
         type: boolean
       bypassable:
@@ -5072,6 +5075,7 @@ definitions:
         type: boolean
         default: false
   AccessModule:
+    description: DEPRECATED.  use AccessModuleName.
     type: string
     enum:
     - DATA_USER_CODE_OF_CONDUCT
@@ -5082,13 +5086,27 @@ definitions:
     - RAS_LINK_LOGIN_GOV
     - PROFILE_CONFIRMATION
     - PUBLICATION_CONFIRMATION
+  AccessModuleName:
+    type: string
+    enum:
+      - DATA_USER_CODE_OF_CONDUCT
+      - RT_COMPLIANCE_TRAINING
+      - CT_COMPLIANCE_TRAINING
+      - ERA_COMMONS
+      - TWO_FACTOR_AUTH
+      - RAS_LOGIN_GOV
+      - PROFILE_CONFIRMATION
+      - PUBLICATION_CONFIRMATION
   AccessBypassRequest:
     type: object
     required:
-    - moduleName
+    - moduleNameTemp
     - isBypassed
     properties:
+      moduleNameTemp:
+        "$ref": "#/definitions/AccessModuleName"
       moduleName:
+        description: DEPRECATED. Use moduleNameTemp.
         "$ref": "#/definitions/AccessModule"
       isBypassed:
         type: boolean
@@ -6005,9 +6023,12 @@ definitions:
   AccessModuleStatus:
     type: object
     required:
-      - moduleName
+      - moduleNameTemp
     properties:
+      moduleNameTemp:
+        "$ref": "#/definitions/AccessModuleName"
       moduleName:
+        description: DEPRECATED. Use moduleNameTemp.
         "$ref": "#/definitions/AccessModule"
       completionEpochMillis:
         type: integer

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4511,7 +4511,7 @@ definitions:
       - requiredForCTAccess
     properties:
       name:
-        description: DEPRECATED. Use moduleNameTemp.
+        description: DEPRECATED. We're in the process of transitioning to a new structure.  Use moduleNameTemp for now.
         "$ref": "#/definitions/AccessModule"
       moduleNameTemp:
         "$ref": "#/definitions/AccessModuleName"
@@ -5103,11 +5103,11 @@ definitions:
     - moduleNameTemp
     - isBypassed
     properties:
+      moduleName:
+        description: DEPRECATED. We're in the process of transitioning to a new structure.  Use moduleNameTemp for now.
+        "$ref": "#/definitions/AccessModule"
       moduleNameTemp:
         "$ref": "#/definitions/AccessModuleName"
-      moduleName:
-        description: DEPRECATED. Use moduleNameTemp.
-        "$ref": "#/definitions/AccessModule"
       isBypassed:
         type: boolean
         default: false
@@ -6025,11 +6025,11 @@ definitions:
     required:
       - moduleNameTemp
     properties:
+      moduleName:
+        description: DEPRECATED. We're in the process of transitioning to a new structure.  Use moduleNameTemp for now.
+        "$ref": "#/definitions/AccessModule"
       moduleNameTemp:
         "$ref": "#/definitions/AccessModuleName"
-      moduleName:
-        description: DEPRECATED. Use moduleNameTemp.
-        "$ref": "#/definitions/AccessModule"
       completionEpochMillis:
         type: integer
         format: int64

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleNameMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleNameMapperTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.compliance.ComplianceService.BadgeName;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.model.AccessModule;
+import org.pmiops.workbench.model.AccessModuleName;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -19,9 +20,27 @@ public class AccessModuleNameMapperTest {
   @Autowired private AccessModuleNameMapper mapper;
 
   @Test
+  public void testDeprecatedStorageToClientMapping() {
+    for (DbAccessModuleName name : DbAccessModuleName.values()) {
+      AccessModule clientName = mapper.deprecatedStorageAccessModuleToClient(name);
+      assertThat(clientName).isNotNull();
+      assertThat(mapper.deprecatedClientAccessModuleToStorage(clientName)).isEqualTo(name);
+    }
+  }
+
+  @Test
+  public void testDeprecatedClientToStorageMapping() {
+    for (AccessModule name : AccessModule.values()) {
+      DbAccessModuleName dbName = mapper.deprecatedClientAccessModuleToStorage(name);
+      assertThat(dbName).isNotNull();
+      assertThat(mapper.deprecatedStorageAccessModuleToClient(dbName)).isEqualTo(name);
+    }
+  }
+
+  @Test
   public void testStorageToClientMapping() {
     for (DbAccessModuleName name : DbAccessModuleName.values()) {
-      AccessModule clientName = mapper.storageAccessModuleToClient(name);
+      AccessModuleName clientName = mapper.storageAccessModuleToClient(name);
       assertThat(clientName).isNotNull();
       assertThat(mapper.clientAccessModuleToStorage(clientName)).isEqualTo(name);
     }
@@ -29,7 +48,7 @@ public class AccessModuleNameMapperTest {
 
   @Test
   public void testClientToStorageMapping() {
-    for (AccessModule name : AccessModule.values()) {
+    for (AccessModuleName name : AccessModuleName.values()) {
       DbAccessModuleName dbName = mapper.clientAccessModuleToStorage(name);
       assertThat(dbName).isNotNull();
       assertThat(mapper.storageAccessModuleToClient(dbName)).isEqualTo(name);

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
@@ -26,7 +26,7 @@ import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.exceptions.ForbiddenException;
-import org.pmiops.workbench.model.AccessModule;
+import org.pmiops.workbench.model.AccessModuleName;
 import org.pmiops.workbench.model.AccessModuleStatus;
 import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
@@ -92,7 +92,7 @@ public class AccessModuleServiceTest {
   @Test
   public void testBypassSuccess_insertNewEntity() {
     assertThat(userAccessModuleDao.getAllByUser(user)).isEmpty();
-    accessModuleService.updateBypassTime(user.getUserId(), AccessModule.TWO_FACTOR_AUTH, true);
+    accessModuleService.updateBypassTime(user.getUserId(), AccessModuleName.TWO_FACTOR_AUTH, true);
     List<DbUserAccessModule> userAccessModule = userAccessModuleDao.getAllByUser(user);
     assertThat(userAccessModule.size()).isEqualTo(1);
     assertThat(userAccessModule.get(0).getAccessModule().getName())
@@ -120,7 +120,7 @@ public class AccessModuleServiceTest {
             .setBypassTime(existingBypasstime);
     userAccessModuleDao.save(existingDbUserAccessModule);
     assertThat(userAccessModuleDao.getAllByUser(user).size()).isEqualTo(1);
-    accessModuleService.updateBypassTime(user.getUserId(), AccessModule.TWO_FACTOR_AUTH, true);
+    accessModuleService.updateBypassTime(user.getUserId(), AccessModuleName.TWO_FACTOR_AUTH, true);
 
     List<DbUserAccessModule> userAccessModule = userAccessModuleDao.getAllByUser(user);
     assertThat(userAccessModule.size()).isEqualTo(1);
@@ -138,7 +138,7 @@ public class AccessModuleServiceTest {
   @Test
   public void testUnBypassSuccess_insertNewEntity() {
     assertThat(userAccessModuleDao.getAllByUser(user)).isEmpty();
-    accessModuleService.updateBypassTime(user.getUserId(), AccessModule.TWO_FACTOR_AUTH, false);
+    accessModuleService.updateBypassTime(user.getUserId(), AccessModuleName.TWO_FACTOR_AUTH, false);
 
     List<DbUserAccessModule> userAccessModule = userAccessModuleDao.getAllByUser(user);
     assertThat(userAccessModule.size()).isEqualTo(1);
@@ -166,7 +166,7 @@ public class AccessModuleServiceTest {
             .setBypassTime(existingBypasstime);
     userAccessModuleDao.save(existingDbUserAccessModule);
     assertThat(userAccessModuleDao.getAllByUser(user).size()).isEqualTo(1);
-    accessModuleService.updateBypassTime(user.getUserId(), AccessModule.TWO_FACTOR_AUTH, false);
+    accessModuleService.updateBypassTime(user.getUserId(), AccessModuleName.TWO_FACTOR_AUTH, false);
 
     List<DbUserAccessModule> userAccessModule = userAccessModuleDao.getAllByUser(user);
     assertThat(userAccessModule.size()).isEqualTo(1);
@@ -187,7 +187,7 @@ public class AccessModuleServiceTest {
         ForbiddenException.class,
         () ->
             accessModuleService.updateBypassTime(
-                user.getUserId(), AccessModule.PROFILE_CONFIRMATION, true));
+                user.getUserId(), AccessModuleName.PROFILE_CONFIRMATION, true));
   }
 
   @Test
@@ -215,7 +215,7 @@ public class AccessModuleServiceTest {
             .setCompletionTime(twoFactorCompletionTime);
     AccessModuleStatus expected2FAModuleStatus =
         new AccessModuleStatus()
-            .moduleName(AccessModule.TWO_FACTOR_AUTH)
+            .moduleNameTemp(AccessModuleName.TWO_FACTOR_AUTH)
             .completionEpochMillis(twoFactorCompletionTime.getTime());
 
     // RT Training module: Completion time + expiryDays is 10 days ahead current time, but the
@@ -231,7 +231,7 @@ public class AccessModuleServiceTest {
             .setCompletionTime(rtTrainingCompletionTime);
     AccessModuleStatus expectedRtTrainingModuleStatus =
         new AccessModuleStatus()
-            .moduleName(AccessModule.COMPLIANCE_TRAINING)
+            .moduleNameTemp(AccessModuleName.RT_COMPLIANCE_TRAINING)
             .completionEpochMillis(rtTrainingCompletionTime.getTime())
             .bypassEpochMillis(rtTrainingBypassTime.getTime());
 
@@ -249,7 +249,7 @@ public class AccessModuleServiceTest {
             .setCompletionTime(profileCompletionTime);
     AccessModuleStatus expectedProfileModuleStatus =
         new AccessModuleStatus()
-            .moduleName(AccessModule.PROFILE_CONFIRMATION)
+            .moduleNameTemp(AccessModuleName.PROFILE_CONFIRMATION)
             .completionEpochMillis(profileCompletionTime.getTime())
             .expirationEpochMillis(expectedProfileExpirationTime.getTime());
 
@@ -266,7 +266,7 @@ public class AccessModuleServiceTest {
             .setCompletionTime(publicationCompletionTime);
     AccessModuleStatus expectedPublicationModuleStatus =
         new AccessModuleStatus()
-            .moduleName(AccessModule.PUBLICATION_CONFIRMATION)
+            .moduleNameTemp(AccessModuleName.PUBLICATION_CONFIRMATION)
             .completionEpochMillis(publicationCompletionTime.getTime())
             .expirationEpochMillis(expectedPublicationExpirationTime.getTime());
 
@@ -274,7 +274,7 @@ public class AccessModuleServiceTest {
     DbUserAccessModule duccAccessModule =
         new DbUserAccessModule().setAccessModule(ducc).setUser(user);
     AccessModuleStatus expectedDuccModuleStatus =
-        new AccessModuleStatus().moduleName(AccessModule.DATA_USER_CODE_OF_CONDUCT);
+        new AccessModuleStatus().moduleNameTemp(AccessModuleName.DATA_USER_CODE_OF_CONDUCT);
 
     userAccessModuleDao.saveAll(
         ImmutableList.of(
@@ -317,7 +317,7 @@ public class AccessModuleServiceTest {
             .setCompletionTime(twoFactorCompletionTime);
     AccessModuleStatus expected2FAModuleStatus =
         new AccessModuleStatus()
-            .moduleName(AccessModule.TWO_FACTOR_AUTH)
+            .moduleNameTemp(AccessModuleName.TWO_FACTOR_AUTH)
             .completionEpochMillis(twoFactorCompletionTime.getTime());
 
     Timestamp rtTrainingCompletionTime =

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
@@ -26,6 +26,7 @@ import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.exceptions.ForbiddenException;
+import org.pmiops.workbench.model.AccessModule;
 import org.pmiops.workbench.model.AccessModuleName;
 import org.pmiops.workbench.model.AccessModuleStatus;
 import org.pmiops.workbench.utils.TestMockFactory;
@@ -215,6 +216,7 @@ public class AccessModuleServiceTest {
             .setCompletionTime(twoFactorCompletionTime);
     AccessModuleStatus expected2FAModuleStatus =
         new AccessModuleStatus()
+            .moduleName(AccessModule.TWO_FACTOR_AUTH)
             .moduleNameTemp(AccessModuleName.TWO_FACTOR_AUTH)
             .completionEpochMillis(twoFactorCompletionTime.getTime());
 
@@ -231,6 +233,7 @@ public class AccessModuleServiceTest {
             .setCompletionTime(rtTrainingCompletionTime);
     AccessModuleStatus expectedRtTrainingModuleStatus =
         new AccessModuleStatus()
+            .moduleName(AccessModule.COMPLIANCE_TRAINING)
             .moduleNameTemp(AccessModuleName.RT_COMPLIANCE_TRAINING)
             .completionEpochMillis(rtTrainingCompletionTime.getTime())
             .bypassEpochMillis(rtTrainingBypassTime.getTime());
@@ -249,6 +252,7 @@ public class AccessModuleServiceTest {
             .setCompletionTime(profileCompletionTime);
     AccessModuleStatus expectedProfileModuleStatus =
         new AccessModuleStatus()
+            .moduleName(AccessModule.PROFILE_CONFIRMATION)
             .moduleNameTemp(AccessModuleName.PROFILE_CONFIRMATION)
             .completionEpochMillis(profileCompletionTime.getTime())
             .expirationEpochMillis(expectedProfileExpirationTime.getTime());
@@ -266,6 +270,7 @@ public class AccessModuleServiceTest {
             .setCompletionTime(publicationCompletionTime);
     AccessModuleStatus expectedPublicationModuleStatus =
         new AccessModuleStatus()
+            .moduleName(AccessModule.PUBLICATION_CONFIRMATION)
             .moduleNameTemp(AccessModuleName.PUBLICATION_CONFIRMATION)
             .completionEpochMillis(publicationCompletionTime.getTime())
             .expirationEpochMillis(expectedPublicationExpirationTime.getTime());
@@ -274,7 +279,9 @@ public class AccessModuleServiceTest {
     DbUserAccessModule duccAccessModule =
         new DbUserAccessModule().setAccessModule(ducc).setUser(user);
     AccessModuleStatus expectedDuccModuleStatus =
-        new AccessModuleStatus().moduleNameTemp(AccessModuleName.DATA_USER_CODE_OF_CONDUCT);
+        new AccessModuleStatus()
+            .moduleName(AccessModule.DATA_USER_CODE_OF_CONDUCT)
+            .moduleNameTemp(AccessModuleName.DATA_USER_CODE_OF_CONDUCT);
 
     userAccessModuleDao.saveAll(
         ImmutableList.of(
@@ -317,6 +324,7 @@ public class AccessModuleServiceTest {
             .setCompletionTime(twoFactorCompletionTime);
     AccessModuleStatus expected2FAModuleStatus =
         new AccessModuleStatus()
+            .moduleName(AccessModule.TWO_FACTOR_AUTH)
             .moduleNameTemp(AccessModuleName.TWO_FACTOR_AUTH)
             .completionEpochMillis(twoFactorCompletionTime.getTime());
 

--- a/api/src/test/java/org/pmiops/workbench/access/UserAccessModuleMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserAccessModuleMapperTest.java
@@ -9,7 +9,7 @@ import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUserAccessModule;
-import org.pmiops.workbench.model.AccessModule;
+import org.pmiops.workbench.model.AccessModuleName;
 import org.pmiops.workbench.model.AccessModuleStatus;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,7 +42,7 @@ public class UserAccessModuleMapperTest {
     assertThat(mapper.dbToModule(dbUserAccessModule, expirationTime))
         .isEqualTo(
             new AccessModuleStatus()
-                .moduleName(AccessModule.ERA_COMMONS)
+                .moduleNameTemp(AccessModuleName.ERA_COMMONS)
                 .bypassEpochMillis(bypassTime.getTime())
                 .expirationEpochMillis(expirationTime.getTime())
                 .completionEpochMillis(completionTime.getTime()));
@@ -62,7 +62,7 @@ public class UserAccessModuleMapperTest {
     assertThat(mapper.dbToModule(dbUserAccessModule, expirationTime))
         .isEqualTo(
             new AccessModuleStatus()
-                .moduleName(AccessModule.ERA_COMMONS)
+                .moduleNameTemp(AccessModuleName.ERA_COMMONS)
                 .completionEpochMillis(completionTime.getTime()));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/access/UserAccessModuleMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserAccessModuleMapperTest.java
@@ -9,6 +9,7 @@ import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUserAccessModule;
+import org.pmiops.workbench.model.AccessModule;
 import org.pmiops.workbench.model.AccessModuleName;
 import org.pmiops.workbench.model.AccessModuleStatus;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
@@ -42,6 +43,7 @@ public class UserAccessModuleMapperTest {
     assertThat(mapper.dbToModule(dbUserAccessModule, expirationTime))
         .isEqualTo(
             new AccessModuleStatus()
+                .moduleName(AccessModule.ERA_COMMONS)
                 .moduleNameTemp(AccessModuleName.ERA_COMMONS)
                 .bypassEpochMillis(bypassTime.getTime())
                 .expirationEpochMillis(expirationTime.getTime())
@@ -62,6 +64,7 @@ public class UserAccessModuleMapperTest {
     assertThat(mapper.dbToModule(dbUserAccessModule, expirationTime))
         .isEqualTo(
             new AccessModuleStatus()
+                .moduleName(AccessModule.ERA_COMMONS)
                 .moduleNameTemp(AccessModuleName.ERA_COMMONS)
                 .completionEpochMillis(completionTime.getTime()));
   }

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -45,7 +45,7 @@ import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.institution.InstitutionServiceImpl;
 import org.pmiops.workbench.mail.MailService;
-import org.pmiops.workbench.model.AccessModule;
+import org.pmiops.workbench.model.AccessModuleName;
 import org.pmiops.workbench.model.Institution;
 import org.pmiops.workbench.model.InstitutionMembershipRequirement;
 import org.pmiops.workbench.model.InstitutionTierConfig;
@@ -256,7 +256,7 @@ public class UserServiceAccessTest {
 
   private DbUser removeDuccBypass(DbUser user) {
     accessModuleService.updateBypassTime(
-        user.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
+        user.getUserId(), AccessModuleName.DATA_USER_CODE_OF_CONDUCT, false);
     return userDao.save(user);
   }
 
@@ -282,7 +282,8 @@ public class UserServiceAccessTest {
   public void test_updateUserWithRetries_era_unbypassed_noncompliant() {
     testUnregistration(
         user -> {
-          accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
+          accessModuleService.updateBypassTime(
+              dbUser.getUserId(), AccessModuleName.ERA_COMMONS, false);
           return userDao.save(user);
         });
   }
@@ -294,7 +295,7 @@ public class UserServiceAccessTest {
     testUnregistration(
         user -> {
           accessModuleService.updateBypassTime(
-              dbUser.getUserId(), AccessModule.TWO_FACTOR_AUTH, false);
+              dbUser.getUserId(), AccessModuleName.TWO_FACTOR_AUTH, false);
           return userDao.save(user);
         });
   }
@@ -306,7 +307,7 @@ public class UserServiceAccessTest {
     testUnregistration(
         user -> {
           accessModuleService.updateBypassTime(
-              dbUser.getUserId(), AccessModule.COMPLIANCE_TRAINING, false);
+              dbUser.getUserId(), AccessModuleName.RT_COMPLIANCE_TRAINING, false);
           return userDao.save(user);
         });
   }
@@ -317,7 +318,7 @@ public class UserServiceAccessTest {
         user -> {
           final Timestamp willExpire = Timestamp.from(START_INSTANT);
           accessModuleService.updateBypassTime(
-              dbUser.getUserId(), AccessModule.COMPLIANCE_TRAINING, false);
+              dbUser.getUserId(), AccessModuleName.RT_COMPLIANCE_TRAINING, false);
           accessModuleService.updateCompletionTime(
               dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, willExpire);
 
@@ -335,7 +336,7 @@ public class UserServiceAccessTest {
     testUnregistration(
         user -> {
           accessModuleService.updateBypassTime(
-              dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
+              dbUser.getUserId(), AccessModuleName.DATA_USER_CODE_OF_CONDUCT, false);
           return userDao.save(user);
         });
   }
@@ -345,7 +346,7 @@ public class UserServiceAccessTest {
     testUnregistration(
         user -> {
           accessModuleService.updateBypassTime(
-              dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
+              dbUser.getUserId(), AccessModuleName.DATA_USER_CODE_OF_CONDUCT, false);
           accessModuleService.updateCompletionTime(
               dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, Timestamp.from(START_INSTANT));
           return userDao.save(user);
@@ -359,7 +360,7 @@ public class UserServiceAccessTest {
     testUnregistration(
         user -> {
           accessModuleService.updateBypassTime(
-              dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
+              dbUser.getUserId(), AccessModuleName.DATA_USER_CODE_OF_CONDUCT, false);
           accessModuleService.updateCompletionTime(
               dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, Timestamp.from(START_INSTANT));
           user.setDuccAgreement(signDucc(user, 3));
@@ -373,7 +374,7 @@ public class UserServiceAccessTest {
         user -> {
           final Timestamp willExpire = Timestamp.from(START_INSTANT);
           accessModuleService.updateBypassTime(
-              dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
+              dbUser.getUserId(), AccessModuleName.DATA_USER_CODE_OF_CONDUCT, false);
           accessModuleService.updateCompletionTime(
               dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpire);
 
@@ -461,9 +462,9 @@ public class UserServiceAccessTest {
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
 
     accessModuleService.updateBypassTime(
-        dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, true);
+        dbUser.getUserId(), AccessModuleName.DATA_USER_CODE_OF_CONDUCT, true);
     accessModuleService.updateBypassTime(
-        dbUser.getUserId(), AccessModule.COMPLIANCE_TRAINING, true);
+        dbUser.getUserId(), AccessModuleName.RT_COMPLIANCE_TRAINING, true);
 
     // these 2 are not bypassable
     accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
@@ -521,7 +522,7 @@ public class UserServiceAccessTest {
     accessModuleService.updateCompletionTime(
         dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, null);
     accessModuleService.updateBypassTime(
-        dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
+        dbUser.getUserId(), AccessModuleName.DATA_USER_CODE_OF_CONDUCT, false);
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -542,7 +543,7 @@ public class UserServiceAccessTest {
 
     // this is bypassed
     accessModuleService.updateBypassTime(
-        dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, true);
+        dbUser.getUserId(), AccessModuleName.DATA_USER_CODE_OF_CONDUCT, true);
 
     // expiring in 1 day (plus some) will trigger the 1-day warning
 
@@ -576,7 +577,7 @@ public class UserServiceAccessTest {
 
     // a bypass which would "expire" in 30 days does NOT trigger a 30-day warning
     accessModuleService.updateBypassTime(
-        dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, true);
+        dbUser.getUserId(), AccessModuleName.DATA_USER_CODE_OF_CONDUCT, true);
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -868,7 +869,7 @@ public class UserServiceAccessTest {
     assertRegisteredTierEnabled(dbUser);
 
     // Now make user eRA not complete, expect user removed from Registered tier;
-    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
+    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModuleName.ERA_COMMONS, false);
     accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.ERA_COMMONS, null);
     dbUser = updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
@@ -891,7 +892,7 @@ public class UserServiceAccessTest {
     institutionService.updateInstitution(
         institution.getShortName(),
         institution.tierConfigs(ImmutableList.of(rtTierConfig.eraRequired(false))));
-    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
+    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModuleName.ERA_COMMONS, false);
     accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.ERA_COMMONS, null);
     dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
@@ -912,7 +913,7 @@ public class UserServiceAccessTest {
     institutionService.updateInstitution(
         institution.getShortName(),
         institution.tierConfigs(ImmutableList.of(rtTierConfig.eraRequired(true))));
-    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
+    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModuleName.ERA_COMMONS, false);
     accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.ERA_COMMONS, null);
     dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
@@ -926,8 +927,7 @@ public class UserServiceAccessTest {
     assertRegisteredTierEnabled(dbUser);
 
     // Incomplete RAS module, expect user removed from Registered tier;
-    accessModuleService.updateBypassTime(
-        dbUser.getUserId(), AccessModule.RAS_LINK_LOGIN_GOV, false);
+    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModuleName.RAS_LOGIN_GOV, false);
     dbUser = updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
 
@@ -947,8 +947,7 @@ public class UserServiceAccessTest {
     assertRegisteredTierEnabled(dbUser);
 
     // Incomplete RAS module, expect user is still Registered;
-    accessModuleService.updateBypassTime(
-        dbUser.getUserId(), AccessModule.RAS_LINK_LOGIN_GOV, false);
+    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModuleName.RAS_LOGIN_GOV, false);
     dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
@@ -964,8 +963,7 @@ public class UserServiceAccessTest {
     assertRegisteredTierEnabled(dbUser);
 
     // Incomplete RAS module, expect user removed from Registered tier;
-    accessModuleService.updateBypassTime(
-        dbUser.getUserId(), AccessModule.RAS_LINK_LOGIN_GOV, false);
+    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModuleName.RAS_LOGIN_GOV, false);
     dbUser = updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
 
@@ -1001,7 +999,7 @@ public class UserServiceAccessTest {
     dbUser = completeRTAndCTRequirements(dbUser);
 
     accessModuleService.updateBypassTime(
-        dbUser.getUserId(), AccessModule.CT_COMPLIANCE_TRAINING, false);
+        dbUser.getUserId(), AccessModuleName.CT_COMPLIANCE_TRAINING, false);
     dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
@@ -1022,7 +1020,7 @@ public class UserServiceAccessTest {
     ctTierConfig.setEraRequired(true);
     updateInstitutionTier(ctTierConfig);
 
-    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
+    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModuleName.ERA_COMMONS, false);
     dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
@@ -1039,7 +1037,7 @@ public class UserServiceAccessTest {
     ctTierConfig.setEraRequired(false);
     updateInstitutionTier(ctTierConfig);
 
-    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
+    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModuleName.ERA_COMMONS, false);
     dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
@@ -1128,7 +1126,7 @@ public class UserServiceAccessTest {
     assertRegisteredTierEnabled(dbUser);
     assertControlledTierEnabled(dbUser);
 
-    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
+    accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModuleName.ERA_COMMONS, false);
     dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
@@ -1147,7 +1145,7 @@ public class UserServiceAccessTest {
     assertControlledTierEnabled(dbUser);
 
     accessModuleService.updateBypassTime(
-        dbUser.getUserId(), AccessModule.CT_COMPLIANCE_TRAINING, false);
+        dbUser.getUserId(), AccessModuleName.CT_COMPLIANCE_TRAINING, false);
     dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);
@@ -1292,12 +1290,13 @@ public class UserServiceAccessTest {
     //        && isPublicationsCompliant
     //        && isProfileCompliant
     //        && institutionEmailValid
-    accessModuleService.updateBypassTime(user.getUserId(), AccessModule.COMPLIANCE_TRAINING, true);
-    accessModuleService.updateBypassTime(user.getUserId(), AccessModule.ERA_COMMONS, true);
-    accessModuleService.updateBypassTime(user.getUserId(), AccessModule.TWO_FACTOR_AUTH, true);
     accessModuleService.updateBypassTime(
-        user.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, true);
-    accessModuleService.updateBypassTime(user.getUserId(), AccessModule.RAS_LINK_LOGIN_GOV, true);
+        user.getUserId(), AccessModuleName.RT_COMPLIANCE_TRAINING, true);
+    accessModuleService.updateBypassTime(user.getUserId(), AccessModuleName.ERA_COMMONS, true);
+    accessModuleService.updateBypassTime(user.getUserId(), AccessModuleName.TWO_FACTOR_AUTH, true);
+    accessModuleService.updateBypassTime(
+        user.getUserId(), AccessModuleName.DATA_USER_CODE_OF_CONDUCT, true);
+    accessModuleService.updateBypassTime(user.getUserId(), AccessModuleName.RAS_LOGIN_GOV, true);
 
     accessModuleService.updateCompletionTime(
         user, DbAccessModuleName.PUBLICATION_CONFIRMATION, timestamp);
@@ -1329,9 +1328,9 @@ public class UserServiceAccessTest {
 
   private DbUser completeCTRequirements(DbUser user) {
     addCTConfigToInstitution(institutionService.getByUser(user).get());
-    accessModuleService.updateBypassTime(user.getUserId(), AccessModule.ERA_COMMONS, true);
+    accessModuleService.updateBypassTime(user.getUserId(), AccessModuleName.ERA_COMMONS, true);
     accessModuleService.updateBypassTime(
-        user.getUserId(), AccessModule.CT_COMPLIANCE_TRAINING, true);
+        user.getUserId(), AccessModuleName.CT_COMPLIANCE_TRAINING, true);
     return user;
   }
 

--- a/ui/src/app/pages/access/access-renewal.spec.tsx
+++ b/ui/src/app/pages/access/access-renewal.spec.tsx
@@ -3,7 +3,7 @@ import * as fp from 'lodash/fp';
 import { mount, ReactWrapper } from 'enzyme';
 
 import {
-  AccessModule,
+  AccessModuleName,
   AccessModuleStatus,
   InstitutionApi,
   Profile,
@@ -53,7 +53,7 @@ describe('Access Renewal Page', () => {
         modules: accessRenewalModules.map(
           (m) =>
             ({
-              moduleName: m,
+              moduleNameTemp: m,
               completionEpochMillis: expiredTime - 1,
               expirationEpochMillis: expiredTime,
             } as AccessModuleStatus)
@@ -64,10 +64,10 @@ describe('Access Renewal Page', () => {
     profileStore.set({ profile: newProfile, load, reload, updateCache });
   }
 
-  function removeOneModule(toBeRemoved: AccessModule) {
+  function removeOneModule(toBeRemoved: AccessModuleName) {
     const oldProfile = profileStore.get().profile;
     const newModules = oldProfile.accessModules.modules.filter(
-      (m) => m.moduleName !== toBeRemoved
+      (m) => m.moduleNameTemp !== toBeRemoved
     );
     const newProfile = fp.set(
       ['accessModules', 'modules'],
@@ -78,17 +78,17 @@ describe('Access Renewal Page', () => {
   }
 
   function updateOneModuleExpirationTime(
-    updateModuleName: AccessModule,
+    updateModuleName: AccessModuleName,
     time: number
   ) {
     const oldProfile = profileStore.get().profile;
     const newModules = [
       ...oldProfile.accessModules.modules.filter(
-        (m) => m.moduleName !== updateModuleName
+        (m) => m.moduleNameTemp !== updateModuleName
       ),
       {
         ...oldProfile.accessModules.modules.find(
-          (m) => m.moduleName === updateModuleName
+          (m) => m.moduleNameTemp === updateModuleName
         ),
         completionEpochMillis: time - 1,
         expirationEpochMillis: time,
@@ -126,8 +126,10 @@ describe('Access Renewal Page', () => {
         ...moduleStatus,
         bypassEpochMillis:
           // profile and publication are not bypassable.
-          moduleStatus.moduleName === AccessModule.PROFILECONFIRMATION ||
-          moduleStatus.moduleName === AccessModule.PUBLICATIONCONFIRMATION
+          moduleStatus.moduleNameTemp ===
+            AccessModuleName.PROFILECONFIRMATION ||
+          moduleStatus.moduleNameTemp ===
+            AccessModuleName.PUBLICATIONCONFIRMATION
             ? null
             : bypassFn(),
       }),
@@ -198,19 +200,19 @@ describe('Access Renewal Page', () => {
     const wrapper = component();
 
     updateOneModuleExpirationTime(
-      AccessModule.PROFILECONFIRMATION,
+      AccessModuleName.PROFILECONFIRMATION,
       oneYearFromNow()
     );
     updateOneModuleExpirationTime(
-      AccessModule.PUBLICATIONCONFIRMATION,
+      AccessModuleName.PUBLICATIONCONFIRMATION,
       oneYearFromNow()
     );
     updateOneModuleExpirationTime(
-      AccessModule.COMPLIANCETRAINING,
+      AccessModuleName.RTCOMPLIANCETRAINING,
       oneYearFromNow()
     );
     updateOneModuleExpirationTime(
-      AccessModule.DATAUSERCODEOFCONDUCT,
+      AccessModuleName.DATAUSERCODEOFCONDUCT,
       oneYearFromNow()
     );
 
@@ -265,7 +267,7 @@ describe('Access Renewal Page', () => {
     const wrapper = component();
 
     updateOneModuleExpirationTime(
-      AccessModule.PROFILECONFIRMATION,
+      AccessModuleName.PROFILECONFIRMATION,
       oneYearFromNow()
     );
     await waitOneTickAndUpdate(wrapper);
@@ -288,11 +290,11 @@ describe('Access Renewal Page', () => {
     const wrapper = component();
 
     updateOneModuleExpirationTime(
-      AccessModule.PROFILECONFIRMATION,
+      AccessModuleName.PROFILECONFIRMATION,
       oneYearFromNow()
     );
     updateOneModuleExpirationTime(
-      AccessModule.PUBLICATIONCONFIRMATION,
+      AccessModuleName.PUBLICATIONCONFIRMATION,
       oneYearFromNow()
     );
     await waitOneTickAndUpdate(wrapper);
@@ -314,15 +316,15 @@ describe('Access Renewal Page', () => {
     const wrapper = component();
 
     updateOneModuleExpirationTime(
-      AccessModule.PROFILECONFIRMATION,
+      AccessModuleName.PROFILECONFIRMATION,
       oneYearFromNow()
     );
     updateOneModuleExpirationTime(
-      AccessModule.PUBLICATIONCONFIRMATION,
+      AccessModuleName.PUBLICATIONCONFIRMATION,
       oneYearFromNow()
     );
     updateOneModuleExpirationTime(
-      AccessModule.COMPLIANCETRAINING,
+      AccessModuleName.RTCOMPLIANCETRAINING,
       oneYearFromNow()
     );
     await waitOneTickAndUpdate(wrapper);
@@ -343,7 +345,7 @@ describe('Access Renewal Page', () => {
     const newModules = [
       ...profileStore.get().profile.accessModules.modules,
       {
-        moduleName: AccessModule.TWOFACTORAUTH, // not expirable
+        moduleNameTemp: AccessModuleName.TWOFACTORAUTH, // not expirable
         completionEpochMillis: null,
         bypassEpochMillis: null,
         expirationEpochMillis: oneYearAgo(),
@@ -360,19 +362,19 @@ describe('Access Renewal Page', () => {
     const wrapper = component();
 
     updateOneModuleExpirationTime(
-      AccessModule.PROFILECONFIRMATION,
+      AccessModuleName.PROFILECONFIRMATION,
       oneYearFromNow()
     );
     updateOneModuleExpirationTime(
-      AccessModule.PUBLICATIONCONFIRMATION,
+      AccessModuleName.PUBLICATIONCONFIRMATION,
       oneYearFromNow()
     );
     updateOneModuleExpirationTime(
-      AccessModule.COMPLIANCETRAINING,
+      AccessModuleName.RTCOMPLIANCETRAINING,
       oneYearFromNow()
     );
     updateOneModuleExpirationTime(
-      AccessModule.DATAUSERCODEOFCONDUCT,
+      AccessModuleName.DATAUSERCODEOFCONDUCT,
       oneYearFromNow()
     );
 
@@ -425,11 +427,11 @@ describe('Access Renewal Page', () => {
     setBypassTimes(() => Date.now());
 
     updateOneModuleExpirationTime(
-      AccessModule.PROFILECONFIRMATION,
+      AccessModuleName.PROFILECONFIRMATION,
       oneYearFromNow()
     );
     updateOneModuleExpirationTime(
-      AccessModule.PUBLICATIONCONFIRMATION,
+      AccessModuleName.PUBLICATIONCONFIRMATION,
       oneYearFromNow()
     );
 
@@ -461,20 +463,20 @@ describe('Access Renewal Page', () => {
     setCompletionTimes(() => Date.now());
 
     updateOneModuleExpirationTime(
-      AccessModule.PROFILECONFIRMATION,
+      AccessModuleName.PROFILECONFIRMATION,
       oneYearFromNow()
     );
     updateOneModuleExpirationTime(
-      AccessModule.PUBLICATIONCONFIRMATION,
+      AccessModuleName.PUBLICATIONCONFIRMATION,
       oneYearFromNow()
     );
     updateOneModuleExpirationTime(
-      AccessModule.DATAUSERCODEOFCONDUCT,
+      AccessModuleName.DATAUSERCODEOFCONDUCT,
       oneYearFromNow()
     );
 
     // this module will not be returned in AccessModules because it is disabled
-    removeOneModule(AccessModule.COMPLIANCETRAINING);
+    removeOneModule(AccessModuleName.RTCOMPLIANCETRAINING);
 
     await waitOneTickAndUpdate(wrapper);
 
@@ -506,7 +508,7 @@ describe('Access Renewal Page', () => {
       const spy = jest.spyOn(profileApi(), 'syncComplianceTrainingStatus');
 
       updateOneModuleExpirationTime(
-        AccessModule.COMPLIANCETRAINING,
+        AccessModuleName.RTCOMPLIANCETRAINING,
         expirationTime
       );
 
@@ -518,8 +520,8 @@ describe('Access Renewal Page', () => {
 
   // RW-7961
   it('should allow completion of profile and publication confirmations when incomplete', async () => {
-    removeOneModule(AccessModule.PROFILECONFIRMATION);
-    removeOneModule(AccessModule.PUBLICATIONCONFIRMATION);
+    removeOneModule(AccessModuleName.PROFILECONFIRMATION);
+    removeOneModule(AccessModuleName.PUBLICATIONCONFIRMATION);
 
     const wrapper = component();
 

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as fp from 'lodash/fp';
 
-import { AccessModule, AccessModuleStatus } from 'generated/fetch';
+import { AccessModuleName, AccessModuleStatus } from 'generated/fetch';
 
 import { Button, Clickable } from 'app/components/buttons';
 import { FadeBox } from 'app/components/containers';
@@ -227,7 +227,7 @@ interface CardProps {
 const RenewalCard = withStyle(renewalStyle.card)(
   ({ step, moduleStatus, style, children }: CardProps) => {
     const { AARTitleComponent } = getAccessModuleConfig(
-      moduleStatus.moduleName
+      moduleStatus.moduleNameTemp
     );
     const { lastConfirmedDate, nextReviewDate } =
       computeRenewalDisplayDates(moduleStatus);
@@ -278,7 +278,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
     const [, navigateByUrl] = useNavigation();
 
     const expirableModules = modules.filter((moduleStatus) =>
-      accessRenewalModules.includes(moduleStatus.moduleName)
+      accessRenewalModules.includes(moduleStatus.moduleNameTemp)
     );
     const accessRenewalCompleted = expirableModules.every(
       isRenewalCompleteForModule
@@ -286,9 +286,9 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
 
     // onMount - as we move between pages, let's make sure we have the latest profile and external module information
     useEffect(() => {
-      const expiringModuleNames: AccessModule[] = expirableModules
+      const expiringModuleNames: AccessModuleName[] = expirableModules
         .filter((status) => isExpiringOrExpired(status.expirationEpochMillis))
-        .map((status) => status.moduleName);
+        .map((status) => status.moduleNameTemp);
 
       const onMount = async () => {
         setLoading(true);
@@ -387,7 +387,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
             step={1}
             moduleStatus={getAccessModuleStatusByNameOrEmpty(
               modules,
-              AccessModule.PROFILECONFIRMATION
+              AccessModuleName.PROFILECONFIRMATION
             )}
           >
             <div style={{ marginBottom: '0.5rem' }}>
@@ -403,7 +403,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
               completedButtonText='Confirmed'
               moduleStatus={getAccessModuleStatusByNameOrEmpty(
                 modules,
-                AccessModule.PROFILECONFIRMATION
+                AccessModuleName.PROFILECONFIRMATION
               )}
               onClick={() =>
                 navigateByUrl('profile', { queryParams: { renewal: 1 } })
@@ -415,7 +415,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
             step={2}
             moduleStatus={getAccessModuleStatusByNameOrEmpty(
               modules,
-              AccessModule.PUBLICATIONCONFIRMATION
+              AccessModuleName.PUBLICATIONCONFIRMATION
             )}
           >
             <div>
@@ -439,7 +439,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
                 completedButtonText='Confirmed'
                 moduleStatus={getAccessModuleStatusByNameOrEmpty(
                   modules,
-                  AccessModule.PUBLICATIONCONFIRMATION
+                  AccessModuleName.PUBLICATIONCONFIRMATION
                 )}
                 onClick={async () => {
                   setLoading(true);
@@ -455,7 +455,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
                 disabled={isRenewalCompleteForModule(
                   getAccessModuleStatusByNameOrEmpty(
                     modules,
-                    AccessModule.PUBLICATIONCONFIRMATION
+                    AccessModuleName.PUBLICATIONCONFIRMATION
                   )
                 )}
                 style={{ justifySelf: 'end' }}
@@ -471,7 +471,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
                 disabled={isRenewalCompleteForModule(
                   getAccessModuleStatusByNameOrEmpty(
                     modules,
-                    AccessModule.PUBLICATIONCONFIRMATION
+                    AccessModuleName.PUBLICATIONCONFIRMATION
                   )
                 )}
                 style={{ justifySelf: 'end' }}
@@ -487,7 +487,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
               step={3}
               moduleStatus={getAccessModuleStatusByNameOrEmpty(
                 modules,
-                AccessModule.COMPLIANCETRAINING
+                AccessModuleName.RTCOMPLIANCETRAINING
               )}
             >
               <div>
@@ -499,7 +499,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
               {!isRenewalCompleteForModule(
                 getAccessModuleStatusByNameOrEmpty(
                   modules,
-                  AccessModule.COMPLIANCETRAINING
+                  AccessModuleName.RTCOMPLIANCETRAINING
                 )
               ) && (
                 <div style={renewalStyle.complianceTrainingExpiring}>
@@ -513,7 +513,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
                   completedButtonText='Completed'
                   moduleStatus={getAccessModuleStatusByNameOrEmpty(
                     modules,
-                    AccessModule.COMPLIANCETRAINING
+                    AccessModuleName.RTCOMPLIANCETRAINING
                   )}
                   onClick={() => {
                     setRefreshButtonDisabled(false);
@@ -523,7 +523,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
                 {!isRenewalCompleteForModule(
                   getAccessModuleStatusByNameOrEmpty(
                     modules,
-                    AccessModule.COMPLIANCETRAINING
+                    AccessModuleName.RTCOMPLIANCETRAINING
                   )
                 ) && (
                   <Button
@@ -550,7 +550,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
             step={enableComplianceTraining ? 4 : 3}
             moduleStatus={getAccessModuleStatusByNameOrEmpty(
               modules,
-              AccessModule.DATAUSERCODEOFCONDUCT
+              AccessModuleName.DATAUSERCODEOFCONDUCT
             )}
           >
             <div>
@@ -562,7 +562,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
               completedButtonText='Completed'
               moduleStatus={getAccessModuleStatusByNameOrEmpty(
                 modules,
-                AccessModule.DATAUSERCODEOFCONDUCT
+                AccessModuleName.DATAUSERCODEOFCONDUCT
               )}
               onClick={() =>
                 navigateByUrl('data-code-of-conduct', {

--- a/ui/src/app/pages/admin/admin-user-bypass.tsx
+++ b/ui/src/app/pages/admin/admin-user-bypass.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as fp from 'lodash/fp';
 
-import { AccessModule, AdminTableUser } from 'generated/fetch';
+import { AccessModuleName, AdminTableUser } from 'generated/fetch';
 
 import { Button, IconButton } from 'app/components/buttons';
 import { FlexColumn } from 'app/components/flex';
@@ -30,23 +30,23 @@ interface State {
   // a spinner should be shown.
   isSaving: boolean;
   // The current set of bypassed access modules in the widget.
-  selectedModules: AccessModule[];
+  selectedModules: AccessModuleName[];
 }
 
-const getBypassedModules = (user: AdminTableUser): Array<AccessModule> => {
+const getBypassedModules = (user: AdminTableUser): Array<AccessModuleName> => {
   return [
     ...(user.complianceTrainingBypassTime
-      ? [AccessModule.COMPLIANCETRAINING]
+      ? [AccessModuleName.RTCOMPLIANCETRAINING]
       : []),
     ...(user.ctComplianceTrainingBypassTime
-      ? [AccessModule.CTCOMPLIANCETRAINING]
+      ? [AccessModuleName.CTCOMPLIANCETRAINING]
       : []),
     ...(user.dataUseAgreementBypassTime
-      ? [AccessModule.DATAUSERCODEOFCONDUCT]
+      ? [AccessModuleName.DATAUSERCODEOFCONDUCT]
       : []),
-    ...(user.eraCommonsBypassTime ? [AccessModule.ERACOMMONS] : []),
-    ...(user.twoFactorAuthBypassTime ? [AccessModule.TWOFACTORAUTH] : []),
-    ...(user.rasLinkLoginGovBypassTime ? [AccessModule.RASLINKLOGINGOV] : []),
+    ...(user.eraCommonsBypassTime ? [AccessModuleName.ERACOMMONS] : []),
+    ...(user.twoFactorAuthBypassTime ? [AccessModuleName.TWOFACTORAUTH] : []),
+    ...(user.rasLinkLoginGovBypassTime ? [AccessModuleName.RASLOGINGOV] : []),
   ];
 };
 
@@ -84,10 +84,10 @@ export class AdminUserBypass extends React.Component<Props, State> {
     const changedModules = fp.xor(getBypassedModules(user), selectedModules);
     this.setState({ isSaving: true });
     try {
-      for (const module of changedModules) {
+      for (const moduleName of changedModules) {
         await userAdminApi().bypassAccessRequirement(user.userId, {
-          isBypassed: selectedModules.includes(module),
-          moduleName: module,
+          isBypassed: selectedModules.includes(moduleName),
+          moduleNameTemp: moduleName,
         });
       }
       this.setState({ isSaving: false });
@@ -149,13 +149,13 @@ export class AdminUserBypass extends React.Component<Props, State> {
               <Toggle
                 name='RT Compliance Training'
                 checked={selectedModules.includes(
-                  AccessModule.COMPLIANCETRAINING
+                  AccessModuleName.RTCOMPLIANCETRAINING
                 )}
                 data-test-id='rt-compliance-training-toggle'
                 onToggle={() => {
                   this.setState({
                     selectedModules: fp.xor(selectedModules, [
-                      AccessModule.COMPLIANCETRAINING,
+                      AccessModuleName.RTCOMPLIANCETRAINING,
                     ]),
                   });
                 }}
@@ -165,13 +165,13 @@ export class AdminUserBypass extends React.Component<Props, State> {
               <Toggle
                 name='CT Compliance Training'
                 checked={selectedModules.includes(
-                  AccessModule.CTCOMPLIANCETRAINING
+                  AccessModuleName.CTCOMPLIANCETRAINING
                 )}
                 data-test-id='ct-compliance-training-toggle'
                 onToggle={() => {
                   this.setState({
                     selectedModules: fp.xor(selectedModules, [
-                      AccessModule.CTCOMPLIANCETRAINING,
+                      AccessModuleName.CTCOMPLIANCETRAINING,
                     ]),
                   });
                 }}
@@ -180,12 +180,12 @@ export class AdminUserBypass extends React.Component<Props, State> {
             {enableEraCommons && (
               <Toggle
                 name='eRA Commons Linking'
-                checked={selectedModules.includes(AccessModule.ERACOMMONS)}
+                checked={selectedModules.includes(AccessModuleName.ERACOMMONS)}
                 data-test-id='era-commons-toggle'
                 onToggle={() => {
                   this.setState({
                     selectedModules: fp.xor(selectedModules, [
-                      AccessModule.ERACOMMONS,
+                      AccessModuleName.ERACOMMONS,
                     ]),
                   });
                 }}
@@ -193,12 +193,12 @@ export class AdminUserBypass extends React.Component<Props, State> {
             )}
             <Toggle
               name='Two Factor Auth'
-              checked={selectedModules.includes(AccessModule.TWOFACTORAUTH)}
+              checked={selectedModules.includes(AccessModuleName.TWOFACTORAUTH)}
               data-test-id='two-factor-auth-toggle'
               onToggle={() => {
                 this.setState({
                   selectedModules: fp.xor(selectedModules, [
-                    AccessModule.TWOFACTORAUTH,
+                    AccessModuleName.TWOFACTORAUTH,
                   ]),
                 });
               }}
@@ -206,13 +206,13 @@ export class AdminUserBypass extends React.Component<Props, State> {
             <Toggle
               name='Data User Code of Conduct'
               checked={selectedModules.includes(
-                AccessModule.DATAUSERCODEOFCONDUCT
+                AccessModuleName.DATAUSERCODEOFCONDUCT
               )}
               data-test-id='ducc-toggle'
               onToggle={() => {
                 this.setState({
                   selectedModules: fp.xor(selectedModules, [
-                    AccessModule.DATAUSERCODEOFCONDUCT,
+                    AccessModuleName.DATAUSERCODEOFCONDUCT,
                   ]),
                 });
               }}
@@ -220,12 +220,12 @@ export class AdminUserBypass extends React.Component<Props, State> {
             {(enableRasLoginGovLinking || enforceRasLoginGovLinking) && (
               <Toggle
                 name='RAS Login.gov Link'
-                checked={selectedModules.includes(AccessModule.RASLINKLOGINGOV)}
+                checked={selectedModules.includes(AccessModuleName.RASLOGINGOV)}
                 data-test-id='ras-link-login-gov-toggle'
                 onToggle={() => {
                   this.setState({
                     selectedModules: fp.xor(selectedModules, [
-                      AccessModule.RASLINKLOGINGOV,
+                      AccessModuleName.RASLOGINGOV,
                     ]),
                   });
                 }}

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -9,7 +9,7 @@ import { Dropdown } from 'primereact/dropdown';
 
 import {
   AccessBypassRequest,
-  AccessModule,
+  AccessModuleName,
   AccountDisabledStatus,
   AccountPropertyUpdate,
   InstitutionalRole,
@@ -175,7 +175,7 @@ export const getUpdatedProfileValue = (
 
 const getModuleStatus = (
   profile: Profile,
-  moduleName: AccessModule
+  moduleName: AccessModuleName
 ): AccessRenewalStatus =>
   computeRenewalDisplayDates(getAccessModuleStatusByName(profile, moduleName))
     .moduleStatus;
@@ -196,7 +196,7 @@ const moduleStatusStyle = (moduleStatus) =>
 
 const displayModuleStatusAndDate = (
   profile: Profile,
-  moduleName: AccessModule,
+  moduleName: AccessModuleName,
   child: string
 ): JSX.Element => {
   return (
@@ -208,19 +208,19 @@ const displayModuleStatusAndDate = (
 
 export const isBypassed = (
   profile: Profile,
-  moduleName: AccessModule
+  moduleName: AccessModuleName
 ): boolean =>
   !!getAccessModuleStatusByName(profile, moduleName)?.bypassEpochMillis;
 
 // Some modules may never expire (eg GOOGLE TWO STEP NOTIFICATION, ERA COMMONS etc),
 // in such cases set the expiry date as NEVER
 // For other modules display the expiry date if known, else display '-' (say in case of bypass)
-const getNullStringForExpirationDate = (moduleName: AccessModule): string =>
+const getNullStringForExpirationDate = (moduleName: AccessModuleName): string =>
   getAccessModuleConfig(moduleName).expirable ? '-' : 'Never';
 
 export const displayModuleStatus = (
   profile: Profile,
-  moduleName: AccessModule
+  moduleName: AccessModuleName
 ): JSX.Element =>
   displayModuleStatusAndDate(
     profile,
@@ -230,7 +230,7 @@ export const displayModuleStatus = (
 
 export const displayModuleCompletionDate = (
   profile: Profile,
-  moduleName: AccessModule
+  moduleName: AccessModuleName
 ): JSX.Element =>
   displayModuleStatusAndDate(
     profile,
@@ -243,7 +243,7 @@ export const displayModuleCompletionDate = (
 
 export const displayModuleExpirationDate = (
   profile: Profile,
-  moduleName: AccessModule
+  moduleName: AccessModuleName
 ): JSX.Element =>
   displayModuleStatusAndDate(
     profile,
@@ -262,24 +262,24 @@ const isEraRequiredForTier = (
     (tier) => tier.accessTierShortName === accessTierShortName
   );
   return (
-    getAccessModuleConfig(AccessModule.ERACOMMONS).isEnabledInEnvironment &&
+    getAccessModuleConfig(AccessModuleName.ERACOMMONS).isEnabledInEnvironment &&
     tierEligibility?.eraRequired
   );
 };
 
 export const TierBadgesMaybe = (props: {
   profile: Profile;
-  moduleName: AccessModule;
+  moduleName: AccessModuleName;
 }) => {
   const { profile, moduleName } = props;
 
   const rtRequired =
-    moduleName === AccessModule.ERACOMMONS
+    moduleName === AccessModuleName.ERACOMMONS
       ? isEraRequiredForTier(profile, AccessTierShortNames.Registered)
       : getAccessModuleConfig(moduleName)?.requiredForRTAccess;
 
   const ctRequired =
-    moduleName === AccessModule.ERACOMMONS
+    moduleName === AccessModuleName.ERACOMMONS
       ? isEraRequiredForTier(profile, AccessTierShortNames.Controlled)
       : getAccessModuleConfig(moduleName)?.requiredForCTAccess;
 
@@ -323,7 +323,8 @@ export const getEraNote = (profile: Profile): string => {
 export const wouldUpdateBypassState = (
   oldProfile: Profile,
   request: AccessBypassRequest
-): boolean => isBypassed(oldProfile, request.moduleName) !== request.isBypassed;
+): boolean =>
+  isBypassed(oldProfile, request.moduleNameTemp) !== request.isBypassed;
 
 export const profileNeedsUpdate = (
   oldProfile: Profile,
@@ -655,7 +656,7 @@ export const AccessModuleExpirations = ({ profile }: ExpirationProps) => {
   const moduleNames = enableComplianceTraining
     ? accessRenewalModules
     : accessRenewalModules.filter(
-        (moduleName) => moduleName !== AccessModule.COMPLIANCETRAINING
+        (moduleName) => moduleName !== AccessModuleName.RTCOMPLIANCETRAINING
       );
 
   const accessStatus = hasRegisteredTierAccess(profile) ? (

--- a/ui/src/app/pages/admin/admin-user-profile.spec.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.spec.tsx
@@ -532,7 +532,7 @@ describe('AdminUserProfile', () => {
       AccessRenewalStatus.EXPIRED,
       AccessModuleName.RTCOMPLIANCETRAINING,
       {
-        moduleName: AccessModuleName.RTCOMPLIANCETRAINING,
+        moduleNameTemp: AccessModuleName.RTCOMPLIANCETRAINING,
         completionEpochMillis: nowPlusDays(-1000),
         expirationEpochMillis: nowPlusDays(-1),
       },
@@ -541,7 +541,7 @@ describe('AdminUserProfile', () => {
       AccessRenewalStatus.NEVER_EXPIRES,
       AccessModuleName.TWOFACTORAUTH,
       {
-        moduleName: AccessModuleName.TWOFACTORAUTH,
+        moduleNameTemp: AccessModuleName.TWOFACTORAUTH,
         completionEpochMillis: nowPlusDays(-1000),
       },
     ],
@@ -549,14 +549,14 @@ describe('AdminUserProfile', () => {
       AccessRenewalStatus.INCOMPLETE,
       AccessModuleName.RASLOGINGOV,
       {
-        moduleName: AccessModuleName.RASLOGINGOV,
+        moduleNameTemp: AccessModuleName.RASLOGINGOV,
       },
     ],
     [
       AccessRenewalStatus.CURRENT,
       AccessModuleName.CTCOMPLIANCETRAINING,
       {
-        moduleName: AccessModuleName.CTCOMPLIANCETRAINING,
+        moduleNameTemp: AccessModuleName.CTCOMPLIANCETRAINING,
         completionEpochMillis: nowPlusDays(-1000),
         expirationEpochMillis: nowPlusDays(400),
       },
@@ -565,7 +565,7 @@ describe('AdminUserProfile', () => {
       AccessRenewalStatus.BYPASSED,
       AccessModuleName.ERACOMMONS,
       {
-        moduleName: AccessModuleName.ERACOMMONS,
+        moduleNameTemp: AccessModuleName.ERACOMMONS,
         bypassEpochMillis: 1,
       },
     ],
@@ -573,7 +573,7 @@ describe('AdminUserProfile', () => {
       AccessRenewalStatus.EXPIRING_SOON,
       AccessModuleName.PROFILECONFIRMATION,
       {
-        moduleName: AccessModuleName.PROFILECONFIRMATION,
+        moduleNameTemp: AccessModuleName.PROFILECONFIRMATION,
         completionEpochMillis: nowPlusDays(-1000),
         expirationEpochMillis: nowPlusDays(5),
       },

--- a/ui/src/app/pages/admin/admin-user-profile.spec.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.spec.tsx
@@ -4,7 +4,7 @@ import { mount, ReactWrapper } from 'enzyme';
 import { Dropdown } from 'primereact/dropdown';
 
 import {
-  AccessModule,
+  AccessModuleName,
   AccessModuleStatus,
   Authority,
   EgressEventsAdminApi,
@@ -500,7 +500,7 @@ describe('AdminUserProfile', () => {
   });
 
   function expectModuleTitlesInOrder(
-    accessModules: AccessModule[],
+    accessModules: AccessModuleName[],
     tableRows: ReactWrapper
   ) {
     accessModules.forEach((moduleName, index) => {
@@ -530,50 +530,50 @@ describe('AdminUserProfile', () => {
   test.each([
     [
       AccessRenewalStatus.EXPIRED,
-      AccessModule.COMPLIANCETRAINING,
+      AccessModuleName.RTCOMPLIANCETRAINING,
       {
-        moduleName: AccessModule.COMPLIANCETRAINING,
+        moduleName: AccessModuleName.RTCOMPLIANCETRAINING,
         completionEpochMillis: nowPlusDays(-1000),
         expirationEpochMillis: nowPlusDays(-1),
       },
     ],
     [
       AccessRenewalStatus.NEVER_EXPIRES,
-      AccessModule.TWOFACTORAUTH,
+      AccessModuleName.TWOFACTORAUTH,
       {
-        moduleName: AccessModule.TWOFACTORAUTH,
+        moduleName: AccessModuleName.TWOFACTORAUTH,
         completionEpochMillis: nowPlusDays(-1000),
       },
     ],
     [
       AccessRenewalStatus.INCOMPLETE,
-      AccessModule.RASLINKLOGINGOV,
+      AccessModuleName.RASLOGINGOV,
       {
-        moduleName: AccessModule.RASLINKLOGINGOV,
+        moduleName: AccessModuleName.RASLOGINGOV,
       },
     ],
     [
       AccessRenewalStatus.CURRENT,
-      AccessModule.CTCOMPLIANCETRAINING,
+      AccessModuleName.CTCOMPLIANCETRAINING,
       {
-        moduleName: AccessModule.CTCOMPLIANCETRAINING,
+        moduleName: AccessModuleName.CTCOMPLIANCETRAINING,
         completionEpochMillis: nowPlusDays(-1000),
         expirationEpochMillis: nowPlusDays(400),
       },
     ],
     [
       AccessRenewalStatus.BYPASSED,
-      AccessModule.ERACOMMONS,
+      AccessModuleName.ERACOMMONS,
       {
-        moduleName: AccessModule.ERACOMMONS,
+        moduleName: AccessModuleName.ERACOMMONS,
         bypassEpochMillis: 1,
       },
     ],
     [
       AccessRenewalStatus.EXPIRING_SOON,
-      AccessModule.PROFILECONFIRMATION,
+      AccessModuleName.PROFILECONFIRMATION,
       {
-        moduleName: AccessModule.PROFILECONFIRMATION,
+        moduleName: AccessModuleName.PROFILECONFIRMATION,
         completionEpochMillis: nowPlusDays(-1000),
         expirationEpochMillis: nowPlusDays(5),
       },
@@ -582,12 +582,12 @@ describe('AdminUserProfile', () => {
     "should render a(n) '%s' completion status for access module %s",
     async (
       expectedStatus: AccessRenewalStatus,
-      moduleName: AccessModule,
+      moduleName: AccessModuleName,
       moduleStatus: AccessModuleStatus
     ) => {
       const statusesExceptThisOne =
         TARGET_USER_PROFILE.accessModules.modules.filter(
-          (s) => s.moduleName !== moduleName
+          (s) => s.moduleNameTemp !== moduleName
         );
       updateTargetProfile({
         accessModules: {
@@ -631,10 +631,10 @@ describe('AdminUserProfile', () => {
     });
 
     const excludedModules = [
-      AccessModule.RASLINKLOGINGOV,
-      AccessModule.ERACOMMONS,
-      AccessModule.COMPLIANCETRAINING,
-      AccessModule.CTCOMPLIANCETRAINING,
+      AccessModuleName.RASLOGINGOV,
+      AccessModuleName.ERACOMMONS,
+      AccessModuleName.RTCOMPLIANCETRAINING,
+      AccessModuleName.CTCOMPLIANCETRAINING,
     ];
     const expectedModules = accessModulesForTable.filter(
       (moduleName) => !excludedModules.includes(moduleName)
@@ -729,7 +729,7 @@ describe('AdminUserProfile', () => {
       // a previous test confirmed that the accessModulesForTable are in the expected order, so we can ref by index
 
       const eraRow = tableRows.at(
-        accessModulesForTable.indexOf(AccessModule.ERACOMMONS)
+        accessModulesForTable.indexOf(AccessModuleName.ERACOMMONS)
       );
       const eraBadges = eraRow.find('[data-test-id="tier-badges"]');
 

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -9,7 +9,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import {
   AccessBypassRequest,
-  AccessModule,
+  AccessModuleName,
   InstitutionalRole,
   Profile,
   PublicInstitutionDetails,
@@ -299,14 +299,14 @@ const EditableFields = ({
 // list the access modules in the desired order
 // exported for testing
 export const accessModulesForTable = [
-  AccessModule.TWOFACTORAUTH,
-  AccessModule.ERACOMMONS,
-  AccessModule.COMPLIANCETRAINING,
-  AccessModule.CTCOMPLIANCETRAINING,
-  AccessModule.DATAUSERCODEOFCONDUCT,
-  AccessModule.RASLINKLOGINGOV,
-  AccessModule.PROFILECONFIRMATION,
-  AccessModule.PUBLICATIONCONFIRMATION,
+  AccessModuleName.TWOFACTORAUTH,
+  AccessModuleName.ERACOMMONS,
+  AccessModuleName.RTCOMPLIANCETRAINING,
+  AccessModuleName.CTCOMPLIANCETRAINING,
+  AccessModuleName.DATAUSERCODEOFCONDUCT,
+  AccessModuleName.RASLOGINGOV,
+  AccessModuleName.PROFILECONFIRMATION,
+  AccessModuleName.PUBLICATIONCONFIRMATION,
 ];
 
 interface CommonToggleProps {
@@ -340,7 +340,7 @@ interface AccessModuleTableProps {
 }
 
 interface ToggleProps extends AccessModuleTableProps {
-  moduleName: AccessModule;
+  moduleName: AccessModuleName;
 }
 
 const ToggleForModule = (props: ToggleProps) => {
@@ -354,7 +354,7 @@ const ToggleForModule = (props: ToggleProps) => {
 
   const previouslyBypassed = isBypassed(oldProfile, moduleName);
   const pendingBypassState = pendingBypassRequests.find(
-    (r) => r.moduleName === moduleName
+    (r) => r.moduleNameTemp === moduleName
   );
   const isModuleBypassed = pendingBypassState
     ? pendingBypassState.isBypassed
@@ -376,7 +376,10 @@ const ToggleForModule = (props: ToggleProps) => {
         checked={isModuleBypassed}
         dataTestId={`${moduleName}-toggle`}
         onToggle={() =>
-          bypassUpdate({ moduleName, isBypassed: !isModuleBypassed })
+          bypassUpdate({
+            moduleNameTemp: moduleName,
+            isBypassed: !isModuleBypassed,
+          })
         }
       />
     </FlexRow>
@@ -432,7 +435,7 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
       style={{ paddingTop: '1em' }}
       value={tableData}
       footer={
-        getAccessModuleConfig(AccessModule.ERACOMMONS)
+        getAccessModuleConfig(AccessModuleName.ERACOMMONS)
           .isEnabledInEnvironment && (
           <div style={{ textAlign: 'left', fontWeight: 'normal' }}>
             {getEraNote(updatedProfile)}
@@ -622,7 +625,7 @@ export const AdminUserProfile = (spinnerProps: WithSpinnerOverlayProps) => {
     accessBypassRequest: AccessBypassRequest
   ) => {
     const otherModuleRequests = bypassChangeRequests.filter(
-      (r) => r.moduleName !== accessBypassRequest.moduleName
+      (r) => r.moduleNameTemp !== accessBypassRequest.moduleNameTemp
     );
     setBypassChangeRequests([...otherModuleRequests, accessBypassRequest]);
   };

--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -214,7 +214,7 @@ describe('DataAccessRequirements', () => {
       accessModules: {
         modules: [
           {
-            moduleName: AccessModuleName.TWOFACTORAUTH,
+            moduleNameTemp: AccessModuleName.TWOFACTORAUTH,
             completionEpochMillis: 1,
           },
         ],
@@ -236,7 +236,10 @@ describe('DataAccessRequirements', () => {
       ...profile,
       accessModules: {
         modules: [
-          { moduleName: AccessModuleName.TWOFACTORAUTH, bypassEpochMillis: 1 },
+          {
+            moduleNameTemp: AccessModuleName.TWOFACTORAUTH,
+            bypassEpochMillis: 1,
+          },
         ],
       },
     };
@@ -268,7 +271,7 @@ describe('DataAccessRequirements', () => {
         accessModules: {
           modules: [
             {
-              moduleName: AccessModuleName.TWOFACTORAUTH,
+              moduleNameTemp: AccessModuleName.TWOFACTORAUTH,
               completionEpochMillis: 1,
             },
           ],
@@ -295,12 +298,15 @@ describe('DataAccessRequirements', () => {
       accessModules: {
         modules: [
           {
-            moduleName: AccessModuleName.TWOFACTORAUTH,
+            moduleNameTemp: AccessModuleName.TWOFACTORAUTH,
             completionEpochMillis: 1,
           },
-          { moduleName: AccessModuleName.ERACOMMONS, completionEpochMillis: 1 },
           {
-            moduleName: AccessModuleName.RASLOGINGOV,
+            moduleNameTemp: AccessModuleName.ERACOMMONS,
+            completionEpochMillis: 1,
+          },
+          {
+            moduleNameTemp: AccessModuleName.RASLOGINGOV,
             completionEpochMillis: 1,
           },
         ],
@@ -322,7 +328,7 @@ describe('DataAccessRequirements', () => {
       ...profile,
       accessModules: {
         modules: requiredModules.map((module) => ({
-          moduleName: module,
+          moduleNameTemp: module,
           completionEpochMillis: 1,
         })),
       },
@@ -341,16 +347,19 @@ describe('DataAccessRequirements', () => {
       accessModules: {
         modules: [
           {
-            moduleName: AccessModuleName.TWOFACTORAUTH,
-            completionEpochMillis: 1,
-          },
-          { moduleName: AccessModuleName.ERACOMMONS, completionEpochMillis: 1 },
-          {
-            moduleName: AccessModuleName.RTCOMPLIANCETRAINING,
+            moduleNameTemp: AccessModuleName.TWOFACTORAUTH,
             completionEpochMillis: 1,
           },
           {
-            moduleName: AccessModuleName.DATAUSERCODEOFCONDUCT,
+            moduleNameTemp: AccessModuleName.ERACOMMONS,
+            completionEpochMillis: 1,
+          },
+          {
+            moduleNameTemp: AccessModuleName.RTCOMPLIANCETRAINING,
+            completionEpochMillis: 1,
+          },
+          {
+            moduleNameTemp: AccessModuleName.DATAUSERCODEOFCONDUCT,
             completionEpochMillis: 1,
           },
         ],
@@ -370,7 +379,7 @@ describe('DataAccessRequirements', () => {
         modules: [
           ...testProfile.accessModules.modules,
           {
-            moduleName: AccessModuleName.RASLOGINGOV,
+            moduleNameTemp: AccessModuleName.RASLOGINGOV,
             completionEpochMillis: 1,
           },
         ],

--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { mount, ReactWrapper } from 'enzyme';
 
 import {
-  AccessModule,
+  AccessModuleName,
   InstitutionApi,
   Profile,
   ProfileApi,
@@ -57,16 +57,16 @@ describe('DataAccessRequirements', () => {
     );
   };
 
-  const findModule = (wrapper, module: AccessModule) =>
+  const findModule = (wrapper, module: AccessModuleName) =>
     wrapper.find(`[data-test-id="module-${module}"]`);
-  const findIneligibleModule = (wrapper, module: AccessModule) =>
+  const findIneligibleModule = (wrapper, module: AccessModuleName) =>
     wrapper.find(`[data-test-id="module-${module}-ineligible"]`);
-  const findCompleteModule = (wrapper, module: AccessModule) =>
+  const findCompleteModule = (wrapper, module: AccessModuleName) =>
     wrapper.find(`[data-test-id="module-${module}-complete"]`);
-  const findIncompleteModule = (wrapper, module: AccessModule) =>
+  const findIncompleteModule = (wrapper, module: AccessModuleName) =>
     wrapper.find(`[data-test-id="module-${module}-incomplete"]`);
 
-  const findNextCtaForModule = (wrapper, module: AccessModule) =>
+  const findNextCtaForModule = (wrapper, module: AccessModuleName) =>
     findModule(wrapper, module).find('[data-test-id="next-module-cta"]');
 
   const findCompletionBanner = (wrapper) =>
@@ -96,7 +96,7 @@ describe('DataAccessRequirements', () => {
     wrapper.find('[data-test-id="eligible-text"]');
   const findIneligibleText = (wrapper) =>
     wrapper.find('[data-test-id="ineligible-text"]');
-  const findClickableModuleText = (wrapper, module: AccessModule) =>
+  const findClickableModuleText = (wrapper, module: AccessModuleName) =>
     wrapper.find(`[data-test-id="module-${module}-clickable-text"]`);
 
   const findContactUs = (wrapper) =>
@@ -158,7 +158,7 @@ describe('DataAccessRequirements', () => {
       },
     });
     const enabledModules = getEligibleModules(allModules, profile);
-    expect(enabledModules.includes(AccessModule.RASLINKLOGINGOV)).toBeFalsy();
+    expect(enabledModules.includes(AccessModuleName.RASLOGINGOV)).toBeFalsy();
   });
 
   it(
@@ -174,7 +174,7 @@ describe('DataAccessRequirements', () => {
       });
       const enabledModules = getEligibleModules(allModules, profile);
       expect(
-        enabledModules.includes(AccessModule.RASLINKLOGINGOV)
+        enabledModules.includes(AccessModuleName.RASLOGINGOV)
       ).toBeTruthy();
     }
   );
@@ -184,7 +184,7 @@ describe('DataAccessRequirements', () => {
       config: { ...defaultServerConfig, enableEraCommons: false },
     });
     const enabledModules = getEligibleModules(allModules, profile);
-    expect(enabledModules.includes(AccessModule.ERACOMMONS)).toBeFalsy();
+    expect(enabledModules.includes(AccessModuleName.ERACOMMONS)).toBeFalsy();
   });
 
   it('should not return the Compliance module from getEligibleModules when its feature flag is disabled', () => {
@@ -193,7 +193,7 @@ describe('DataAccessRequirements', () => {
     });
     const enabledModules = getEligibleModules(allModules, profile);
     expect(
-      enabledModules.includes(AccessModule.COMPLIANCETRAINING)
+      enabledModules.includes(AccessModuleName.RTCOMPLIANCETRAINING)
     ).toBeFalsy();
   });
 
@@ -205,7 +205,7 @@ describe('DataAccessRequirements', () => {
     expect(activeModule).toEqual(enabledModules[0]);
 
     // update this if the order changes
-    expect(activeModule).toEqual(AccessModule.TWOFACTORAUTH);
+    expect(activeModule).toEqual(AccessModuleName.TWOFACTORAUTH);
   });
 
   it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been completed', () => {
@@ -213,7 +213,10 @@ describe('DataAccessRequirements', () => {
       ...profile,
       accessModules: {
         modules: [
-          { moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1 },
+          {
+            moduleName: AccessModuleName.TWOFACTORAUTH,
+            completionEpochMillis: 1,
+          },
         ],
       },
     };
@@ -225,7 +228,7 @@ describe('DataAccessRequirements', () => {
     expect(activeModule).toEqual(enabledModules[1]);
 
     // update this if the order changes
-    expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
+    expect(activeModule).toEqual(AccessModuleName.RASLOGINGOV);
   });
 
   it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been bypassed', () => {
@@ -233,7 +236,7 @@ describe('DataAccessRequirements', () => {
       ...profile,
       accessModules: {
         modules: [
-          { moduleName: AccessModule.TWOFACTORAUTH, bypassEpochMillis: 1 },
+          { moduleName: AccessModuleName.TWOFACTORAUTH, bypassEpochMillis: 1 },
         ],
       },
     };
@@ -245,7 +248,7 @@ describe('DataAccessRequirements', () => {
     expect(activeModule).toEqual(enabledModules[1]);
 
     // update this if the order changes
-    expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
+    expect(activeModule).toEqual(AccessModuleName.RASLOGINGOV);
   });
 
   it(
@@ -265,7 +268,7 @@ describe('DataAccessRequirements', () => {
         accessModules: {
           modules: [
             {
-              moduleName: AccessModule.TWOFACTORAUTH,
+              moduleName: AccessModuleName.TWOFACTORAUTH,
               completionEpochMillis: 1,
             },
           ],
@@ -276,7 +279,7 @@ describe('DataAccessRequirements', () => {
       const activeModule = getActiveModule(enabledModules, testProfile);
 
       // update this if the order changes
-      expect(activeModule).toEqual(AccessModule.ERACOMMONS);
+      expect(activeModule).toEqual(AccessModuleName.ERACOMMONS);
 
       // 2FA (module 0) is complete, so enabled #1 is active
       expect(activeModule).toEqual(enabledModules[1]);
@@ -291,10 +294,13 @@ describe('DataAccessRequirements', () => {
       ...profile,
       accessModules: {
         modules: [
-          { moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1 },
-          { moduleName: AccessModule.ERACOMMONS, completionEpochMillis: 1 },
           {
-            moduleName: AccessModule.RASLINKLOGINGOV,
+            moduleName: AccessModuleName.TWOFACTORAUTH,
+            completionEpochMillis: 1,
+          },
+          { moduleName: AccessModuleName.ERACOMMONS, completionEpochMillis: 1 },
+          {
+            moduleName: AccessModuleName.RASLOGINGOV,
             completionEpochMillis: 1,
           },
         ],
@@ -308,7 +314,7 @@ describe('DataAccessRequirements', () => {
     expect(activeModule).toEqual(enabledModules[3]);
 
     // update this if the order changes
-    expect(activeModule).toEqual(AccessModule.COMPLIANCETRAINING);
+    expect(activeModule).toEqual(AccessModuleName.RTCOMPLIANCETRAINING);
   });
 
   it('should return undefined from getActiveModule when all modules have been completed', () => {
@@ -334,14 +340,17 @@ describe('DataAccessRequirements', () => {
       ...profile,
       accessModules: {
         modules: [
-          { moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1 },
-          { moduleName: AccessModule.ERACOMMONS, completionEpochMillis: 1 },
           {
-            moduleName: AccessModule.COMPLIANCETRAINING,
+            moduleName: AccessModuleName.TWOFACTORAUTH,
+            completionEpochMillis: 1,
+          },
+          { moduleName: AccessModuleName.ERACOMMONS, completionEpochMillis: 1 },
+          {
+            moduleName: AccessModuleName.RTCOMPLIANCETRAINING,
             completionEpochMillis: 1,
           },
           {
-            moduleName: AccessModule.DATAUSERCODEOFCONDUCT,
+            moduleName: AccessModuleName.DATAUSERCODEOFCONDUCT,
             completionEpochMillis: 1,
           },
         ],
@@ -351,7 +360,7 @@ describe('DataAccessRequirements', () => {
     const enabledModules = getEligibleModules(requiredModules, profile);
 
     let activeModule = getActiveModule(enabledModules, testProfile);
-    expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
+    expect(activeModule).toEqual(AccessModuleName.RASLOGINGOV);
 
     // simulate handleRasCallback() by updating the profile
 
@@ -361,7 +370,7 @@ describe('DataAccessRequirements', () => {
         modules: [
           ...testProfile.accessModules.modules,
           {
-            moduleName: AccessModule.RASLINKLOGINGOV,
+            moduleName: AccessModuleName.RASLOGINGOV,
             completionEpochMillis: 1,
           },
         ],
@@ -384,7 +393,9 @@ describe('DataAccessRequirements', () => {
       config: { ...defaultServerConfig, enableEraCommons: false },
     });
     const wrapper = component();
-    expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeFalsy();
+    expect(
+      findModule(wrapper, AccessModuleName.ERACOMMONS).exists()
+    ).toBeFalsy();
   });
 
   it('should not render the Compliance module when its feature flag is disabled', () => {
@@ -393,7 +404,7 @@ describe('DataAccessRequirements', () => {
     });
     const wrapper = component();
     expect(
-      findModule(wrapper, AccessModule.COMPLIANCETRAINING).exists()
+      findModule(wrapper, AccessModuleName.RTCOMPLIANCETRAINING).exists()
     ).toBeFalsy();
   });
 
@@ -410,17 +421,17 @@ describe('DataAccessRequirements', () => {
     });
     const wrapper = component();
     expect(
-      findModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      findModule(wrapper, AccessModuleName.RASLOGINGOV).exists()
     ).toBeTruthy();
     expect(
-      findIneligibleModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      findIneligibleModule(wrapper, AccessModuleName.RASLOGINGOV).exists()
     ).toBeTruthy();
 
     expect(
-      findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      findCompleteModule(wrapper, AccessModuleName.RASLOGINGOV).exists()
     ).toBeFalsy();
     expect(
-      findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      findIncompleteModule(wrapper, AccessModuleName.RASLOGINGOV).exists()
     ).toBeFalsy();
   });
 
@@ -440,8 +451,8 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: requiredModules.map((module) => ({
-            moduleName: module,
+          modules: requiredModules.map((moduleName) => ({
+            moduleNameTemp: moduleName,
             completionEpochMillis: 1,
           })),
         },
@@ -469,14 +480,14 @@ describe('DataAccessRequirements', () => {
     // initially, the user has completed all required modules except RAS (the standard case at RAS launch time)
 
     const allExceptRas = requiredModules.filter(
-      (m) => m !== AccessModule.RASLINKLOGINGOV
+      (m) => m !== AccessModuleName.RASLOGINGOV
     );
     profileStore.set({
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: allExceptRas.map((module) => ({
-            moduleName: module,
+          modules: allExceptRas.map((moduleName) => ({
+            moduleNameTemp: moduleName,
             completionEpochMillis: 1,
           })),
         },
@@ -496,14 +507,14 @@ describe('DataAccessRequirements', () => {
 
     // RAS is not complete
     expect(
-      findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      findIncompleteModule(wrapper, AccessModuleName.RASLOGINGOV).exists()
     ).toBeTruthy();
 
     expect(
-      findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      findCompleteModule(wrapper, AccessModuleName.RASLOGINGOV).exists()
     ).toBeFalsy();
     expect(
-      findIneligibleModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      findIneligibleModule(wrapper, AccessModuleName.RASLOGINGOV).exists()
     ).toBeFalsy();
 
     expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
@@ -514,8 +525,8 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: requiredModules.map((module) => ({
-            moduleName: module,
+          modules: requiredModules.map((moduleName) => ({
+            moduleNameTemp: moduleName,
             completionEpochMillis: 1,
           })),
         },
@@ -542,8 +553,8 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: requiredModules.map((module) => {
-            return { moduleName: module, bypassEpochMillis: 1 };
+          modules: requiredModules.map((moduleName) => {
+            return { moduleNameTemp: moduleName, bypassEpochMillis: 1 };
           }),
         },
       },
@@ -564,9 +575,9 @@ describe('DataAccessRequirements', () => {
 
   it('should render a mix of complete and incomplete modules, as appropriate', () => {
     const requiredModulesSize = requiredModules.length;
-    const incompleteModules = [AccessModule.RASLINKLOGINGOV];
+    const incompleteModules = [AccessModuleName.RASLOGINGOV];
     const completeModules = requiredModules.filter(
-      (module) => module !== AccessModule.RASLINKLOGINGOV
+      (module) => module !== AccessModuleName.RASLOGINGOV
     );
     const completeModulesSize = requiredModulesSize - incompleteModules.length;
 
@@ -578,8 +589,8 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: completeModules.map((module) => {
-            return { moduleName: module, completionEpochMillis: 1 };
+          modules: completeModules.map((moduleName) => {
+            return { moduleNameTemp: moduleName, completionEpochMillis: 1 };
           }),
         },
       },
@@ -637,8 +648,8 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: requiredModules.map((module) => {
-            return { moduleName: module, completionEpochMillis: 1 };
+          modules: requiredModules.map((moduleName) => {
+            return { moduleNameTemp: moduleName, completionEpochMillis: 1 };
           }),
         },
       },
@@ -662,8 +673,8 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: requiredModules.map((module) => {
-            return { moduleName: module, completionEpochMillis: 1 };
+          modules: requiredModules.map((moduleName) => {
+            return { moduleNameTemp: moduleName, completionEpochMillis: 1 };
           }),
         },
         tierEligibilities: [
@@ -712,8 +723,8 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: requiredModules.map((module) => ({
-            moduleName: module,
+          modules: requiredModules.map((moduleName) => ({
+            moduleNameTemp: moduleName,
             completionEpochMillis: 1,
           })),
         },
@@ -741,7 +752,9 @@ describe('DataAccessRequirements', () => {
   it('Should not show Era Commons Module for Registered Tier if the institution does not require eRa', async () => {
     let wrapper = component();
     await waitOneTickAndUpdate(wrapper);
-    expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeTruthy();
+    expect(
+      findModule(wrapper, AccessModuleName.ERACOMMONS).exists()
+    ).toBeTruthy();
 
     profileStore.set({
       profile: {
@@ -759,7 +772,9 @@ describe('DataAccessRequirements', () => {
     });
     wrapper = component();
     await waitOneTickAndUpdate(wrapper);
-    expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeFalsy();
+    expect(
+      findModule(wrapper, AccessModuleName.ERACOMMONS).exists()
+    ).toBeFalsy();
 
     // Ignore eraRequired if the accessTier is Controlled
     profileStore.set({
@@ -782,7 +797,9 @@ describe('DataAccessRequirements', () => {
     });
     wrapper = component();
     await waitOneTickAndUpdate(wrapper);
-    expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeTruthy();
+    expect(
+      findModule(wrapper, AccessModuleName.ERACOMMONS).exists()
+    ).toBeTruthy();
   });
 
   it('Should display Institution has signed agreement when the user has a Tier Eligibility object for CT', async () => {
@@ -1001,7 +1018,7 @@ describe('DataAccessRequirements', () => {
       expect(
         findModule(
           findControlledTierCard(wrapper),
-          AccessModule.ERACOMMONS
+          AccessModuleName.ERACOMMONS
         ).exists()
       ).toBeTruthy();
     }
@@ -1039,7 +1056,7 @@ describe('DataAccessRequirements', () => {
       expect(
         findModule(
           findControlledTierCard(wrapper),
-          AccessModule.ERACOMMONS
+          AccessModuleName.ERACOMMONS
         ).exists()
       ).toBeFalsy();
     }
@@ -1073,7 +1090,7 @@ describe('DataAccessRequirements', () => {
       expect(
         findModule(
           findControlledTierCard(wrapper),
-          AccessModule.ERACOMMONS
+          AccessModuleName.ERACOMMONS
         ).exists()
       ).toBeFalsy();
     }
@@ -1107,7 +1124,7 @@ describe('DataAccessRequirements', () => {
       expect(
         findIneligibleModule(
           findControlledTierCard(wrapper),
-          AccessModule.CTCOMPLIANCETRAINING
+          AccessModuleName.CTCOMPLIANCETRAINING
         ).exists()
       ).toBeTruthy();
     }
@@ -1147,7 +1164,7 @@ describe('DataAccessRequirements', () => {
       expect(
         findIneligibleModule(
           findControlledTierCard(wrapper),
-          AccessModule.CTCOMPLIANCETRAINING
+          AccessModuleName.CTCOMPLIANCETRAINING
         ).exists()
       ).toBeTruthy();
     }
@@ -1189,7 +1206,7 @@ describe('DataAccessRequirements', () => {
       expect(
         findModule(
           findControlledTierCard(wrapper),
-          AccessModule.ERACOMMONS
+          AccessModuleName.ERACOMMONS
         ).exists()
       ).toBeFalsy();
     }
@@ -1200,10 +1217,10 @@ describe('DataAccessRequirements', () => {
     await waitOneTickAndUpdate(wrapper);
 
     expect(
-      findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      findCompleteModule(wrapper, AccessModuleName.RASLOGINGOV).exists()
     ).toBeFalsy();
     expect(
-      findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      findIncompleteModule(wrapper, AccessModuleName.RASLOGINGOV).exists()
     ).toBeTruthy();
 
     expect(findContactUs(wrapper).exists()).toBeTruthy();
@@ -1216,7 +1233,7 @@ describe('DataAccessRequirements', () => {
         accessModules: {
           modules: [
             {
-              moduleName: AccessModule.RASLINKLOGINGOV,
+              moduleNameTemp: AccessModuleName.RASLOGINGOV,
               completionEpochMillis: 1,
             },
           ],
@@ -1231,10 +1248,10 @@ describe('DataAccessRequirements', () => {
     await waitOneTickAndUpdate(wrapper);
 
     expect(
-      findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      findCompleteModule(wrapper, AccessModuleName.RASLOGINGOV).exists()
     ).toBeTruthy();
     expect(
-      findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      findIncompleteModule(wrapper, AccessModuleName.RASLOGINGOV).exists()
     ).toBeFalsy();
 
     expect(findContactUs(wrapper).exists()).toBeFalsy();
@@ -1276,7 +1293,7 @@ describe('DataAccessRequirements', () => {
       expect(
         findModule(
           findControlledTierCard(wrapper),
-          AccessModule.CTCOMPLIANCETRAINING
+          AccessModuleName.CTCOMPLIANCETRAINING
         ).exists()
       ).toBeFalsy();
     }
@@ -1309,7 +1326,10 @@ describe('DataAccessRequirements', () => {
     wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(
-      findIneligibleModule(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()
+      findIneligibleModule(
+        wrapper,
+        AccessModuleName.CTCOMPLIANCETRAINING
+      ).exists()
     ).toBeTruthy();
   });
 
@@ -1335,7 +1355,10 @@ describe('DataAccessRequirements', () => {
     wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(
-      findIneligibleModule(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()
+      findIneligibleModule(
+        wrapper,
+        AccessModuleName.CTCOMPLIANCETRAINING
+      ).exists()
     ).toBeTruthy();
   });
 
@@ -1366,7 +1389,10 @@ describe('DataAccessRequirements', () => {
     wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(
-      findIncompleteModule(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()
+      findIncompleteModule(
+        wrapper,
+        AccessModuleName.CTCOMPLIANCETRAINING
+      ).exists()
     ).toBeTruthy();
   });
 
@@ -1381,13 +1407,13 @@ describe('DataAccessRequirements', () => {
           modules: allModules.map((moduleName) => {
             if (
               [
-                AccessModule.CTCOMPLIANCETRAINING,
-                AccessModule.DATAUSERCODEOFCONDUCT,
+                AccessModuleName.CTCOMPLIANCETRAINING,
+                AccessModuleName.DATAUSERCODEOFCONDUCT,
               ].includes(moduleName)
             ) {
-              return { moduleName };
+              return { moduleNameTemp: moduleName };
             }
-            return { moduleName, completionEpochMillis: 1 };
+            return { moduleNameTemp: moduleName, completionEpochMillis: 1 };
           }),
         },
         tierEligibilities: [
@@ -1414,22 +1440,28 @@ describe('DataAccessRequirements', () => {
     expect(
       findClickableModuleText(
         wrapper,
-        AccessModule.CTCOMPLIANCETRAINING
+        AccessModuleName.CTCOMPLIANCETRAINING
       ).exists()
     ).toBeTruthy();
     expect(
       findClickableModuleText(
         wrapper,
-        AccessModule.DATAUSERCODEOFCONDUCT
+        AccessModuleName.DATAUSERCODEOFCONDUCT
       ).exists()
     ).toBeTruthy();
 
     // Only the first module is active.
     expect(
-      findNextCtaForModule(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()
+      findNextCtaForModule(
+        wrapper,
+        AccessModuleName.CTCOMPLIANCETRAINING
+      ).exists()
     ).toBeTruthy();
     expect(
-      findNextCtaForModule(wrapper, AccessModule.DATAUSERCODEOFCONDUCT).exists()
+      findNextCtaForModule(
+        wrapper,
+        AccessModuleName.DATAUSERCODEOFCONDUCT
+      ).exists()
     ).toBeFalsy();
   });
 

--- a/ui/src/app/pages/profile/profile-component.tsx
+++ b/ui/src/app/pages/profile/profile-component.tsx
@@ -4,7 +4,7 @@ import * as fp from 'lodash/fp';
 import { Dropdown } from 'primereact/dropdown';
 import validate from 'validate.js';
 
-import { AccessModule, InstitutionalRole, Profile } from 'generated/fetch';
+import { AccessModuleName, InstitutionalRole, Profile } from 'generated/fetch';
 import { PublicInstitutionDetails } from 'generated/fetch';
 
 import { Button } from 'app/components/buttons';
@@ -242,7 +242,7 @@ export const ProfileComponent = fp.flow(
       } = currentProfile;
 
       const profileExpiration = fp.flow(
-        fp.find({ moduleName: AccessModule.PROFILECONFIRMATION }),
+        fp.find({ moduleName: AccessModuleName.PROFILECONFIRMATION }),
         fp.get('expirationEpochMillis')
       )(profile.accessModules.modules);
       const hasExpired = profileExpiration && profileExpiration < Date.now();

--- a/ui/src/app/utils/access-utils.spec.tsx
+++ b/ui/src/app/utils/access-utils.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 
 import {
-  AccessModule,
+  AccessModuleName,
   AccessModuleStatus,
   ErrorCode,
   ProfileApi,
@@ -56,7 +56,7 @@ describe('maybeDaysRemaining', () => {
       accessModules: {
         modules: [
           {
-            moduleName: AccessModule.RASLINKLOGINGOV,
+            moduleNameTemp: AccessModuleName.RASLOGINGOV,
             expirationEpochMillis: undefined,
           },
         ],
@@ -72,7 +72,7 @@ describe('maybeDaysRemaining', () => {
       accessModules: {
         modules: [
           {
-            moduleName: AccessModule.COMPLIANCETRAINING,
+            moduleNameTemp: AccessModuleName.RTCOMPLIANCETRAINING,
             expirationEpochMillis: undefined,
           },
         ],
@@ -88,7 +88,7 @@ describe('maybeDaysRemaining', () => {
       accessModules: {
         modules: [
           {
-            moduleName: AccessModule.COMPLIANCETRAINING,
+            moduleNameTemp: AccessModuleName.RTCOMPLIANCETRAINING,
             expirationEpochMillis:
               nowPlusDays(NOTIFICATION_THRESHOLD_DAYS + 1) +
               ONE_MINUTE_IN_MILLIS,
@@ -109,11 +109,11 @@ describe('maybeDaysRemaining', () => {
       accessModules: {
         modules: [
           {
-            moduleName: AccessModule.COMPLIANCETRAINING,
+            moduleNameTemp: AccessModuleName.RTCOMPLIANCETRAINING,
             expirationEpochMillis: nowPlusDays(soonDays) + ONE_MINUTE_IN_MILLIS,
           },
           {
-            moduleName: AccessModule.DATAUSERCODEOFCONDUCT,
+            moduleNameTemp: AccessModuleName.DATAUSERCODEOFCONDUCT,
             expirationEpochMillis:
               nowPlusDays(aBitLater) + ONE_MINUTE_IN_MILLIS,
           },
@@ -131,11 +131,11 @@ describe('maybeDaysRemaining', () => {
       accessModules: {
         modules: [
           {
-            moduleName: AccessModule.COMPLIANCETRAINING,
+            moduleNameTemp: AccessModuleName.RTCOMPLIANCETRAINING,
             expirationEpochMillis: nowPlusDays(30) + ONE_MINUTE_IN_MILLIS,
           },
           {
-            moduleName: AccessModule.DATAUSERCODEOFCONDUCT,
+            moduleNameTemp: AccessModuleName.DATAUSERCODEOFCONDUCT,
             expirationEpochMillis: nowPlusDays(31) + ONE_MINUTE_IN_MILLIS,
           },
         ],

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -1,6 +1,6 @@
 import {
-  AccessModule,
   AccessModuleConfig,
+  AccessModuleName,
   ConfigResponse,
 } from 'generated/fetch/api';
 
@@ -8,56 +8,56 @@ import { AccessTierShortNames } from 'app/utils/access-tiers';
 
 const defaultAccessModuleConfig: AccessModuleConfig[] = [
   {
-    name: AccessModule.TWOFACTORAUTH,
+    moduleNameTemp: AccessModuleName.TWOFACTORAUTH,
     bypassable: true,
     expirable: false,
     requiredForRTAccess: true,
     requiredForCTAccess: true,
   },
   {
-    name: AccessModule.RASLINKLOGINGOV,
+    moduleNameTemp: AccessModuleName.RASLOGINGOV,
     bypassable: true,
     expirable: false,
     requiredForRTAccess: true,
     requiredForCTAccess: true,
   },
   {
-    name: AccessModule.ERACOMMONS,
+    moduleNameTemp: AccessModuleName.ERACOMMONS,
     bypassable: true,
     expirable: false,
     requiredForRTAccess: false,
     requiredForCTAccess: false,
   },
   {
-    name: AccessModule.COMPLIANCETRAINING,
+    moduleNameTemp: AccessModuleName.RTCOMPLIANCETRAINING,
     bypassable: true,
     expirable: true,
     requiredForRTAccess: true,
     requiredForCTAccess: true,
   },
   {
-    name: AccessModule.CTCOMPLIANCETRAINING,
+    moduleNameTemp: AccessModuleName.CTCOMPLIANCETRAINING,
     bypassable: true,
     expirable: false,
     requiredForRTAccess: false,
     requiredForCTAccess: true,
   },
   {
-    name: AccessModule.DATAUSERCODEOFCONDUCT,
+    moduleNameTemp: AccessModuleName.DATAUSERCODEOFCONDUCT,
     bypassable: true,
     expirable: true,
     requiredForRTAccess: true,
     requiredForCTAccess: true,
   },
   {
-    name: AccessModule.PROFILECONFIRMATION,
+    moduleNameTemp: AccessModuleName.PROFILECONFIRMATION,
     bypassable: false,
     expirable: true,
     requiredForRTAccess: true,
     requiredForCTAccess: true,
   },
   {
-    name: AccessModule.PUBLICATIONCONFIRMATION,
+    moduleNameTemp: AccessModuleName.PUBLICATIONCONFIRMATION,
     bypassable: false,
     expirable: true,
     requiredForRTAccess: true,

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -1,5 +1,5 @@
 import {
-  AccessModule,
+  AccessModuleName,
   AdminTableUser,
   InstitutionalRole,
   Profile,
@@ -46,19 +46,19 @@ export class ProfileStubVariables {
     accessModules: {
       modules: [
         {
-          moduleName: AccessModule.COMPLIANCETRAINING,
+          moduleNameTemp: AccessModuleName.RTCOMPLIANCETRAINING,
           expirationEpochMillis: undefined,
         },
         {
-          moduleName: AccessModule.DATAUSERCODEOFCONDUCT,
+          moduleNameTemp: AccessModuleName.DATAUSERCODEOFCONDUCT,
           expirationEpochMillis: undefined,
         },
         {
-          moduleName: AccessModule.PROFILECONFIRMATION,
+          moduleNameTemp: AccessModuleName.PROFILECONFIRMATION,
           expirationEpochMillis: undefined,
         },
         {
-          moduleName: AccessModule.PUBLICATIONCONFIRMATION,
+          moduleNameTemp: AccessModuleName.PUBLICATIONCONFIRMATION,
           expirationEpochMillis: undefined,
         },
       ],


### PR DESCRIPTION
Rename `AccessModule` to `AccessModuleName` and rename values to match `DbAccessModuleName`
Deprecate uses of the old `AccessModule`

This is Part 1 of a deployment-safe process.
1. Add the new API enum `AccessModuleName` and add a temp field `*` using that enum to `AccessModuleConfig`,`AccessBypassRequest`, and `AccessModuleStatus`.  Update all UI code to use the new temp field.
2. Remove the old `AccessModule` enum and add a new permanent field to the API entities.  Update all UI code to use the new permanent field.
3. Remove the temporary fields

`*` using a temp field because I want to use `moduleName` as the field name, which is currently in use in 2 of 3 entities

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
