### PR TITLE
[risk=no][no ticket] Use Boolean.TRUE.equals() for nulllable Boolean interactions

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskRdrExportController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskRdrExportController.java
@@ -3,6 +3,8 @@ package org.pmiops.workbench.api;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.logging.Logger;
+
+import org.apache.commons.lang3.BooleanUtils;
 import org.pmiops.workbench.model.ArrayOfLong;
 import org.pmiops.workbench.rdr.RdrExportService;
 import org.springframework.http.ResponseEntity;
@@ -46,11 +48,11 @@ public class CloudTaskRdrExportController implements CloudTaskRdrExportApiDelega
    */
   @Override
   public ResponseEntity<Void> exportWorkspaceData(ArrayOfLong workspaceIds, Boolean backfill) {
-    if (workspaceIds == null || ((ArrayList) workspaceIds).isEmpty()) {
+    if (workspaceIds == null || workspaceIds.isEmpty()) {
       log.severe(" call to export Workspace Data had no Ids");
       return ResponseEntity.noContent().build();
     }
-    rdrExportService.exportWorkspaces(workspaceIds, Optional.ofNullable(backfill).orElse(false));
+    rdrExportService.exportWorkspaces(workspaceIds, BooleanUtils.isTrue(backfill));
     return ResponseEntity.noContent().build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskRdrExportController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskRdrExportController.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.api;
 
 import java.util.logging.Logger;
-import org.apache.commons.lang3.BooleanUtils;
 import org.pmiops.workbench.model.ArrayOfLong;
 import org.pmiops.workbench.rdr.RdrExportService;
 import org.springframework.http.ResponseEntity;
@@ -49,7 +48,7 @@ public class CloudTaskRdrExportController implements CloudTaskRdrExportApiDelega
       log.severe(" call to export Workspace Data had no Ids");
       return ResponseEntity.noContent().build();
     }
-    rdrExportService.exportWorkspaces(workspaceIds, BooleanUtils.isTrue(backfill));
+    rdrExportService.exportWorkspaces(workspaceIds, Boolean.TRUE.equals(backfill));
     return ResponseEntity.noContent().build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskRdrExportController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskRdrExportController.java
@@ -1,9 +1,6 @@
 package org.pmiops.workbench.api;
 
-import java.util.ArrayList;
-import java.util.Optional;
 import java.util.logging.Logger;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.pmiops.workbench.model.ArrayOfLong;
 import org.pmiops.workbench.rdr.RdrExportService;

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -21,7 +21,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.inject.Provider;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -21,6 +21,8 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.inject.Provider;
+
+import org.apache.commons.lang3.BooleanUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.pmiops.workbench.cdr.CdrVersionContext;
@@ -123,7 +125,7 @@ public class DataSetController implements DataSetApiDelegate {
 
   private void validateDataSetCreateRequest(DataSetRequest dataSetRequest) {
     boolean includesAllParticipants =
-        Optional.ofNullable(dataSetRequest.getIncludesAllParticipants()).orElse(false);
+        BooleanUtils.isTrue(dataSetRequest.getIncludesAllParticipants());
     if (Strings.isNullOrEmpty(dataSetRequest.getName())) {
       throw new BadRequestException("Missing name");
     } else if (CollectionUtils.isEmpty(dataSetRequest.getConceptSetIds())

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -21,7 +21,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.inject.Provider;
-import org.apache.commons.lang3.BooleanUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.pmiops.workbench.cdr.CdrVersionContext;
@@ -124,7 +123,7 @@ public class DataSetController implements DataSetApiDelegate {
 
   private void validateDataSetCreateRequest(DataSetRequest dataSetRequest) {
     boolean includesAllParticipants =
-        BooleanUtils.isTrue(dataSetRequest.getIncludesAllParticipants());
+        Boolean.TRUE.equals(dataSetRequest.getIncludesAllParticipants());
     if (Strings.isNullOrEmpty(dataSetRequest.getName())) {
       throw new BadRequestException("Missing name");
     } else if (CollectionUtils.isEmpty(dataSetRequest.getConceptSetIds())

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -17,7 +17,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.inject.Provider;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.json.JSONObject;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -275,9 +274,7 @@ public class RuntimeController implements RuntimeApiDelegate {
     DbWorkspace dbWorkspace = lookupWorkspace(workspaceNamespace);
 
     leonardoNotebooksClient.deleteRuntime(
-        dbWorkspace.getGoogleProject(),
-        user.getRuntimeName(),
-            BooleanUtils.isTrue(deleteDisk));
+        dbWorkspace.getGoogleProject(), user.getRuntimeName(), BooleanUtils.isTrue(deleteDisk));
     return ResponseEntity.ok(new EmptyResponse());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -17,7 +17,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.inject.Provider;
-import org.apache.commons.lang3.BooleanUtils;
 import org.json.JSONObject;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
@@ -274,7 +273,7 @@ public class RuntimeController implements RuntimeApiDelegate {
     DbWorkspace dbWorkspace = lookupWorkspace(workspaceNamespace);
 
     leonardoNotebooksClient.deleteRuntime(
-        dbWorkspace.getGoogleProject(), user.getRuntimeName(), BooleanUtils.isTrue(deleteDisk));
+        dbWorkspace.getGoogleProject(), user.getRuntimeName(), Boolean.TRUE.equals(deleteDisk));
     return ResponseEntity.ok(new EmptyResponse());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -17,6 +17,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.inject.Provider;
+
+import org.apache.commons.lang3.BooleanUtils;
 import org.json.JSONObject;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserRecentResourceService;
@@ -275,7 +277,7 @@ public class RuntimeController implements RuntimeApiDelegate {
     leonardoNotebooksClient.deleteRuntime(
         dbWorkspace.getGoogleProject(),
         user.getRuntimeName(),
-        Optional.ofNullable(deleteDisk).orElse(false));
+            BooleanUtils.isTrue(deleteDisk));
     return ResponseEntity.ok(new EmptyResponse());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.inject.Provider;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.billing.FreeTierBillingService;

--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -16,6 +16,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.inject.Provider;
+
+import org.apache.commons.lang3.BooleanUtils;
 import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -247,7 +249,7 @@ public class UserController implements UserApiDelegate {
                     .isFreeTier(false)
                     .displayName(googleBillingAccount.getDisplayName())
                     .name(googleBillingAccount.getName())
-                    .isOpen(Optional.ofNullable(googleBillingAccount.getOpen()).orElse(false)));
+                    .isOpen(BooleanUtils.isTrue(googleBillingAccount.getOpen())));
   }
 
   private PaginationToken getPaginationTokenFromPageToken(String pageToken) {

--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.inject.Provider;
-import org.apache.commons.lang3.BooleanUtils;
 import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -248,7 +247,7 @@ public class UserController implements UserApiDelegate {
                     .isFreeTier(false)
                     .displayName(googleBillingAccount.getDisplayName())
                     .name(googleBillingAccount.getName())
-                    .isOpen(BooleanUtils.isTrue(googleBillingAccount.getOpen())));
+                    .isOpen(Boolean.TRUE.equals(googleBillingAccount.getOpen())));
   }
 
   private PaginationToken getPaginationTokenFromPageToken(String pageToken) {

--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -216,7 +216,7 @@ public class UserMetricsController implements UserMetricsApiDelegate {
     return ResponseEntity.ok(recentResponse);
   }
 
-  private Boolean foundBlobIdsContainsUserRecentlyModifiedResource(
+  private boolean foundBlobIdsContainsUserRecentlyModifiedResource(
       Set<BlobId> foundNotebooks, DbUserRecentlyModifiedResource urr) {
     if (urr.getResourceType()
         == DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.NOTEBOOK) {

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -13,7 +13,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
-import org.apache.commons.lang3.BooleanUtils;
 import org.pmiops.workbench.actionaudit.auditors.WorkspaceAuditor;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.cdr.CdrVersionContext;
@@ -420,7 +419,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     // a 500 to the user if this block of code fails since the workspace is already
     // committed to the database in an earlier call
     Map<String, WorkspaceAccessLevel> clonedRoles = new HashMap<>();
-    if (BooleanUtils.isTrue(body.getIncludeUserRoles())) {
+    if (Boolean.TRUE.equals(body.getIncludeUserRoles())) {
       Map<String, FirecloudWorkspaceAccessEntry> fromAclsMap =
           workspaceAuthService.getFirecloudWorkspaceAcls(
               fromWorkspace.getWorkspaceNamespace(), fromWorkspace.getFirecloudName());

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -8,13 +8,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.pmiops.workbench.actionaudit.auditors.WorkspaceAuditor;
 import org.pmiops.workbench.billing.FreeTierBillingService;

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -14,6 +14,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
+
+import org.apache.commons.lang3.BooleanUtils;
 import org.pmiops.workbench.actionaudit.auditors.WorkspaceAuditor;
 import org.pmiops.workbench.billing.FreeTierBillingService;
 import org.pmiops.workbench.cdr.CdrVersionContext;
@@ -420,7 +422,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     // a 500 to the user if this block of code fails since the workspace is already
     // committed to the database in an earlier call
     Map<String, WorkspaceAccessLevel> clonedRoles = new HashMap<>();
-    if (Optional.ofNullable(body.getIncludeUserRoles()).orElse(false)) {
+    if (BooleanUtils.isTrue(body.getIncludeUserRoles())) {
       Map<String, FirecloudWorkspaceAccessEntry> fromAclsMap =
           workspaceAuthService.getFirecloudWorkspaceAcls(
               fromWorkspace.getWorkspaceNamespace(), fromWorkspace.getFirecloudName());

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -34,7 +34,6 @@ import javax.annotation.Nullable;
 import javax.inject.Provider;
 import javax.persistence.OptimisticLockException;
 import javax.transaction.Transactional;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.engine.jdbc.internal.BasicFormatterImpl;
 import org.jetbrains.annotations.NotNull;
@@ -460,7 +459,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
 
   private Map<String, QueryJobConfiguration> buildQueriesByDomain(DbDataset dbDataset) {
     final boolean includesAllParticipants =
-        BooleanUtils.isTrue(dbDataset.getIncludesAllParticipants());
+        Boolean.TRUE.equals(dbDataset.getIncludesAllParticipants());
     final ImmutableList<DbCohort> cohortsSelected =
         ImmutableList.copyOf(this.cohortDao.findAllByCohortIdIn(dbDataset.getCohortIds()));
     final ImmutableList<DomainValuePair> domainValuePairs =

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -34,6 +34,8 @@ import javax.annotation.Nullable;
 import javax.inject.Provider;
 import javax.persistence.OptimisticLockException;
 import javax.transaction.Transactional;
+
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.engine.jdbc.internal.BasicFormatterImpl;
 import org.jetbrains.annotations.NotNull;
@@ -458,8 +460,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
   }
 
   private Map<String, QueryJobConfiguration> buildQueriesByDomain(DbDataset dbDataset) {
-    final boolean includesAllParticipants =
-        getBuiltinBooleanFromNullable(dbDataset.getIncludesAllParticipants());
+    final boolean includesAllParticipants = BooleanUtils.isTrue(dbDataset.getIncludesAllParticipants());
     final ImmutableList<DbCohort> cohortsSelected =
         ImmutableList.copyOf(this.cohortDao.findAllByCohortIdIn(dbDataset.getCohortIds()));
     final ImmutableList<DomainValuePair> domainValuePairs =
@@ -1518,10 +1519,6 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
 
   private static <T> List<T> nullableListToEmpty(List<T> nullableList) {
     return Optional.ofNullable(nullableList).orElse(new ArrayList<>());
-  }
-
-  private static boolean getBuiltinBooleanFromNullable(Boolean boo) {
-    return Optional.ofNullable(boo).orElse(false);
   }
 
   private DbConceptSet buildPrePackagedSurveyConceptSet() {

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -34,7 +34,6 @@ import javax.annotation.Nullable;
 import javax.inject.Provider;
 import javax.persistence.OptimisticLockException;
 import javax.transaction.Transactional;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.engine.jdbc.internal.BasicFormatterImpl;
@@ -460,7 +459,8 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
   }
 
   private Map<String, QueryJobConfiguration> buildQueriesByDomain(DbDataset dbDataset) {
-    final boolean includesAllParticipants = BooleanUtils.isTrue(dbDataset.getIncludesAllParticipants());
+    final boolean includesAllParticipants =
+        BooleanUtils.isTrue(dbDataset.getIncludesAllParticipants());
     final ImmutableList<DbCohort> cohortsSelected =
         ImmutableList.copyOf(this.cohortDao.findAllByCohortIdIn(dbDataset.getCohortIds()));
     final ImmutableList<DomainValuePair> domainValuePairs =

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
@@ -11,6 +11,8 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
+
+import org.apache.commons.lang3.BooleanUtils;
 import org.pmiops.workbench.model.ArchivalStatus;
 
 @Entity
@@ -58,7 +60,7 @@ public class DbCdrVersion {
   @Transient
   @NotNull
   public boolean getIsDefaultNotNull() {
-    return Optional.ofNullable(isDefault).orElse(false);
+    return BooleanUtils.isTrue(isDefault);
   }
 
   @Column(name = "name")

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
@@ -2,7 +2,6 @@ package org.pmiops.workbench.db.model;
 
 import java.sql.Timestamp;
 import java.util.Objects;
-import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -11,7 +10,6 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.pmiops.workbench.model.ArchivalStatus;
 

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
@@ -57,7 +57,7 @@ public class DbCdrVersion {
   @Transient
   @NotNull
   public boolean getIsDefaultNotNull() {
-    return Boolean.TRUE.equals(isDefault);
+    return Boolean.TRUE.equals(getIsDefault());
   }
 
   @Column(name = "name")

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
@@ -10,7 +10,6 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
-import org.apache.commons.lang3.BooleanUtils;
 import org.pmiops.workbench.model.ArchivalStatus;
 
 @Entity
@@ -58,7 +57,7 @@ public class DbCdrVersion {
   @Transient
   @NotNull
   public boolean getIsDefaultNotNull() {
-    return BooleanUtils.isTrue(isDefault);
+    return Boolean.TRUE.equals(isDefault);
   }
 
   @Column(name = "name")

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
-import org.apache.commons.lang3.BooleanUtils;
 import org.jetbrains.annotations.Nullable;
 import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.InstitutionDao;
@@ -227,7 +226,7 @@ public class InstitutionServiceImpl implements InstitutionService {
   public boolean eRaRequiredForTier(Institution institution, String accessTierShortName) {
     Optional<InstitutionTierConfig> tierConfig =
         getTierConfigByTier(institution, accessTierShortName);
-    return tierConfig.isPresent() && BooleanUtils.isTrue(tierConfig.get().getEraRequired());
+    return tierConfig.isPresent() && Boolean.TRUE.equals(tierConfig.get().getEraRequired());
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -23,7 +23,6 @@ import javax.inject.Provider;
 import javax.mail.MessagingException;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.text.StringSubstitutor;
@@ -396,7 +395,7 @@ public class MailServiceImpl implements MailService {
         .put(EmailSubstitutionField.USER_CONTACT_EMAIL, user.getContactEmail())
         .put(
             EmailSubstitutionField.NIH_FUNDED,
-            BooleanUtils.isTrue(request.getIsNihFunded()) ? "Yes" : "No")
+            Boolean.TRUE.equals(request.getIsNihFunded()) ? "Yes" : "No")
         .build();
   }
 


### PR DESCRIPTION
Ideally we'd have no nullable `Boolean`s, but sometimes it's necessary to work with them.  (Some examples are Swagger/OpenAPI and nullable DB fields)

One null-safe pattern to transform them into primitive `boolean`s is `Optional.ofNullable(value).orElse(false)` but there's a simpler and more readable way: ~`BooleanUtils.isTrue()`~  **[UPDATE]** `Boolean.TRUE.equals()`

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
