### PR TITLE
[risk=low][RW-7863] UX-requested improvements for AdminUserProfile

### DIFF
--- a/ui/src/app/components/inputs.tsx
+++ b/ui/src/app/components/inputs.tsx
@@ -556,7 +556,6 @@ interface ToggleProps {
   style?: React.CSSProperties;
   height?: number;
   width?: number;
-  handleDiameter?: number;
 }
 
 export class Toggle extends React.Component<ToggleProps> {
@@ -565,16 +564,13 @@ export class Toggle extends React.Component<ToggleProps> {
   }
 
   render() {
-    const {
-      name,
-      checked,
-      disabled,
-      onToggle,
-      style,
-      height,
-      width,
-      handleDiameter,
-    } = this.props;
+    const { name, checked, disabled, onToggle, style, height, width } =
+      this.props;
+
+    // the minimum of height and width to ensure the handle is inside the toggle
+    // minus a 1-pixel gap on both sides
+    const handleDiameter = height && width && Math.min(height, width) - 2;
+
     return (
       <label
         style={{

--- a/ui/src/app/components/inputs.tsx
+++ b/ui/src/app/components/inputs.tsx
@@ -556,6 +556,7 @@ interface ToggleProps {
   style?: React.CSSProperties;
   height?: number;
   width?: number;
+  handleDiameter?: number;
 }
 
 export class Toggle extends React.Component<ToggleProps> {
@@ -564,8 +565,16 @@ export class Toggle extends React.Component<ToggleProps> {
   }
 
   render() {
-    const { name, checked, disabled, onToggle, style, height, width } =
-      this.props;
+    const {
+      name,
+      checked,
+      disabled,
+      onToggle,
+      style,
+      height,
+      width,
+      handleDiameter,
+    } = this.props;
     return (
       <label
         style={{
@@ -583,6 +592,7 @@ export class Toggle extends React.Component<ToggleProps> {
           disabled={disabled}
           height={height}
           width={width}
+          handleDiameter={handleDiameter}
         />
         <span style={{ marginLeft: '.5rem' }}>{name}</span>
       </label>

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -268,12 +268,13 @@ const isEraRequiredForTier = (
   );
 };
 
-export const displayTierBadgeByRequiredModule = (
-  profile: Profile,
-  moduleName: AccessModule
-) => {
+export const TierBadgesMaybe = (props: {
+  profile: Profile;
+  moduleName: AccessModule;
+}) => {
+  const { profile, moduleName } = props;
   return (
-    <div>
+    <FlexRow style={{ justifyContent: 'center' }}>
       {(moduleName === AccessModule.ERACOMMONS
         ? isEraRequiredForTier(profile, AccessTierShortNames.Registered)
         : getAccessModuleConfig(moduleName)?.requiredForRTAccess) && (
@@ -284,7 +285,7 @@ export const displayTierBadgeByRequiredModule = (
         : getAccessModuleConfig(moduleName)?.requiredForCTAccess) && (
         <ControlledTierBadge style={{ gridArea: 'badge' }} />
       )}
-    </div>
+    </FlexRow>
   );
 };
 

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -19,7 +19,7 @@ import {
   VerifiedInstitutionalAffiliation,
 } from 'generated/fetch';
 
-import { FlexColumn, FlexRow, FlexSpacer } from 'app/components/flex';
+import { FlexColumn, FlexRow } from 'app/components/flex';
 import {
   ClrIcon,
   ControlledTierBadge,
@@ -87,14 +87,11 @@ export const commonStyles = reactStyles({
     borderRadius: '18px',
     transform: 'rotate(270deg)',
   },
-  incompleteModule: {
-    color: colorWithWhiteness(colors.highlight, -0.2),
+  incompleteOrExpiringModule: {
+    color: colors.warning,
   },
   expiredModule: {
     color: colors.danger,
-  },
-  expiringSoonModule: {
-    color: colorWithWhiteness(colors.warning, -0.3),
   },
   completeModule: {
     color: colors.black,
@@ -181,16 +178,13 @@ const getModuleStatus = (profile, moduleName) =>
 const moduleStatusStyle = (moduleStatus) =>
   cond(
     [
-      moduleStatus === AccessModulesStatus.INCOMPLETE,
-      () => commonStyles.incompleteModule,
+      moduleStatus === AccessModulesStatus.INCOMPLETE ||
+        moduleStatus === AccessModulesStatus.EXPIRING_SOON,
+      () => commonStyles.incompleteOrExpiringModule,
     ],
     [
       moduleStatus === AccessModulesStatus.EXPIRED,
       () => commonStyles.expiredModule,
-    ],
-    [
-      moduleStatus === AccessModulesStatus.EXPIRING_SOON,
-      () => commonStyles.expiringSoonModule,
     ],
     () => commonStyles.completeModule
   );

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -281,7 +281,7 @@ export const TierBadgesMaybe = (props: {
   );
 
   // give the badges a little space
-  const spacer = <div style={{ width: '20%' }} />;
+  const spacer = <div style={{ width: '5%' }} />;
 
   return (
     <FlexRow style={{ justifyContent: 'center' }}>

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -19,7 +19,7 @@ import {
   VerifiedInstitutionalAffiliation,
 } from 'generated/fetch';
 
-import { FlexColumn, FlexRow } from 'app/components/flex';
+import { FlexColumn, FlexRow, FlexSpacer } from 'app/components/flex';
 import {
   ClrIcon,
   ControlledTierBadge,
@@ -273,18 +273,27 @@ export const TierBadgesMaybe = (props: {
   moduleName: AccessModule;
 }) => {
   const { profile, moduleName } = props;
+
+  const rtMaybe = (moduleName === AccessModule.ERACOMMONS
+    ? isEraRequiredForTier(profile, AccessTierShortNames.Registered)
+    : getAccessModuleConfig(moduleName)?.requiredForRTAccess) && (
+    <RegisteredTierBadge style={{ gridArea: 'badge' }} />
+  );
+
+  const ctMaybe = (moduleName === AccessModule.ERACOMMONS
+    ? isEraRequiredForTier(profile, AccessTierShortNames.Controlled)
+    : getAccessModuleConfig(moduleName)?.requiredForCTAccess) && (
+    <ControlledTierBadge style={{ gridArea: 'badge' }} />
+  );
+
+  // give the badges a little space
+  const spacer = <div style={{ width: '20%' }} />;
+
   return (
     <FlexRow style={{ justifyContent: 'center' }}>
-      {(moduleName === AccessModule.ERACOMMONS
-        ? isEraRequiredForTier(profile, AccessTierShortNames.Registered)
-        : getAccessModuleConfig(moduleName)?.requiredForRTAccess) && (
-        <RegisteredTierBadge style={{ gridArea: 'badge' }} />
-      )}
-      {(moduleName === AccessModule.ERACOMMONS
-        ? isEraRequiredForTier(profile, AccessTierShortNames.Controlled)
-        : getAccessModuleConfig(moduleName)?.requiredForCTAccess) && (
-        <ControlledTierBadge style={{ gridArea: 'badge' }} />
-      )}
+      {rtMaybe}
+      {rtMaybe && ctMaybe && spacer}
+      {ctMaybe}
     </FlexRow>
   );
 };

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -67,7 +67,7 @@ const styles = reactStyles({
     color: colors.primary,
     fontSize: '16px',
     fontWeight: 'bold',
-    paddingLeft: '1em',
+    paddingLeft: '0.85em',
   },
   tableHeader: {
     color: colors.primary,

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -38,7 +38,6 @@ import {
   displayModuleCompletionDate,
   displayModuleExpirationDate,
   displayModuleStatus,
-  displayTierBadgeByRequiredModule,
   ErrorsTooltip,
   getEraNote,
   getInitalCreditsUsage,
@@ -49,6 +48,7 @@ import {
   InstitutionDropdown,
   isBypassed,
   profileNeedsUpdate,
+  TierBadgesMaybe,
   updateAccountProperties,
   UserAdminTableLink,
   UserAuditLink,
@@ -308,7 +308,12 @@ const ToggleForModule = (props: ToggleProps) => {
       : {};
 
   return (
-    <div style={highlightStyle}>
+    <FlexRow
+      style={{
+        ...highlightStyle,
+        justifyContent: 'center',
+      }}
+    >
       <CommonToggle
         name=' '
         checked={isModuleBypassed}
@@ -317,7 +322,7 @@ const ToggleForModule = (props: ToggleProps) => {
           bypassUpdate({ moduleName, isBypassed: !isModuleBypassed })
         }
       />
-    </div>
+    </FlexRow>
   );
 };
 
@@ -349,9 +354,11 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
               updatedProfile,
               moduleName
             ),
-            accessTierBadge: displayTierBadgeByRequiredModule(
-              props.updatedProfile,
-              moduleName
+            accessTierBadge: (
+              <TierBadgesMaybe
+                profile={props.updatedProfile}
+                moduleName={moduleName}
+              />
             ),
             bypassToggle: bypassable && (
               <ToggleForModule moduleName={moduleName} {...props} />

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -95,6 +95,7 @@ const styles = reactStyles({
     borderRadius: '9px',
     backgroundColor: colorWithWhiteness(colors.light, 0.23),
     paddingTop: '1em',
+    marginRight: '20px',
   },
   editableFields: {
     width: '601px',

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -253,6 +253,28 @@ const accessModulesForTable = [
   AccessModule.PUBLICATIONCONFIRMATION,
 ];
 
+interface CommonToggleProps {
+  name: string;
+  checked: boolean;
+  dataTestId: string;
+  onToggle: () => void;
+}
+const CommonToggle = (props: CommonToggleProps) => {
+  const { name, checked, dataTestId, onToggle } = props;
+  return (
+    <Toggle
+      name={name}
+      checked={checked}
+      data-test-id={dataTestId}
+      onToggle={() => onToggle()}
+      style={{ paddingBottom: 0, flexGrow: 0 }}
+      height={24}
+      width={50}
+      handleDiameter={22}
+    />
+  );
+};
+
 interface AccessModuleTableProps {
   oldProfile: Profile;
   updatedProfile: Profile;
@@ -287,11 +309,10 @@ const ToggleForModule = (props: ToggleProps) => {
 
   return (
     <div style={highlightStyle}>
-      <Toggle
+      <CommonToggle
         name=' '
-        style={{ paddingBottom: 0, flexGrow: 0 }}
         checked={isModuleBypassed}
-        data-test-id={`${moduleName}-toggle`}
+        dataTestId={`${moduleName}-toggle`}
         onToggle={() =>
           bypassUpdate({ moduleName, isBypassed: !isModuleBypassed })
         }
@@ -376,11 +397,11 @@ const DisabledToggle = (props: {
       : {};
 
   return (
-    <div style={highlightStyle}>
-      <Toggle
-        style={{ paddingTop: '2em', paddingLeft: '2em', flexGrow: 0 }}
+    <div style={{ ...highlightStyle, paddingTop: '2.5em', paddingLeft: '2em' }}>
+      <CommonToggle
         name={currentlyDisabled ? 'Account disabled' : 'Account enabled'}
         checked={!currentlyDisabled}
+        dataTestId='user-disabled-toggle'
         onToggle={() => toggleDisabled()}
       />
     </div>

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -270,7 +270,6 @@ const CommonToggle = (props: CommonToggleProps) => {
       style={{ paddingBottom: 0, flexGrow: 0 }}
       height={24}
       width={50}
-      handleDiameter={22}
     />
   );
 };

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -354,7 +354,7 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
               updatedProfile,
               moduleName
             ),
-            accessTierBadge: (
+            accessTierBadges: (
               <TierBadgesMaybe
                 profile={props.updatedProfile}
                 moduleName={moduleName}
@@ -386,7 +386,7 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
       <Column field='moduleStatus' header='Status' />
       <Column field='completionDate' header='Last completed on' />
       <Column field='expirationDate' header='Expires on' />
-      <Column field='accessTierBadge' header='Required for tier access' />
+      <Column field='accessTierBadges' header='Required for tier access' />
       <Column field='bypassToggle' header='Bypass' />
     </DataTable>
   );

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -397,13 +397,15 @@ const DisabledToggle = (props: {
       : {};
 
   return (
-    <div style={{ ...highlightStyle, paddingTop: '2.5em', paddingLeft: '2em' }}>
-      <CommonToggle
-        name={currentlyDisabled ? 'Account disabled' : 'Account enabled'}
-        checked={!currentlyDisabled}
-        dataTestId='user-disabled-toggle'
-        onToggle={() => toggleDisabled()}
-      />
+    <div style={{ paddingTop: '2.5em', paddingLeft: '2em' }}>
+      <div style={highlightStyle}>
+        <CommonToggle
+          name={currentlyDisabled ? 'Account disabled' : 'Account enabled'}
+          checked={!currentlyDisabled}
+          dataTestId='user-disabled-toggle'
+          onToggle={() => toggleDisabled()}
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
As requested by Joy in this feedback mockup: https://projects.invisionapp.com/share/C5121MQVD2ZB#/screens/464159071_feedback

Now looks like:

<img width="1558" alt="AdminUserProfile improved" src="https://user-images.githubusercontent.com/2701406/154158051-f307fc51-1b65-461a-b7f4-fc0ae679f680.png">



<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
