### PR TITLE
[RW-7899][risk=no] Drop unnecessary deletion radio button interactions

### DIFF
--- a/e2e/app/sidebar/runtime-panel.ts
+++ b/e2e/app/sidebar/runtime-panel.ts
@@ -396,10 +396,6 @@ export default class RuntimePanel extends BaseSidebar {
 
   async clickDeleteEnvironmentButton(): Promise<void> {
     await this.clickButton(LinkText.DeleteEnvironment);
-    // Select "Delete gce runtime and pd" radiobutton when PD-disk is enabled.
-    if (config.ENABLED_PERSISTENT_DISK) {
-      await RadioButton.findByName(this.page, { dataTestId: 'delete-runtime' }).select();
-    }
     await this.clickButton(LinkText.Delete);
   }
 }


### PR DESCRIPTION
This is causing nightly failures, but the previous behavior actually did nothing anyways; the comment says "delete runtime and PD", but it was actually just selecting the default option "delete runtime only".

We want to avoid depending on radio buttons here in any case, because these options are only shown when a detachable PD is used, which is now optional (and non-default) behavior.