### PR TITLE
[RW-7582][risk=no] Add persistent disk e2e coverage

### DIFF
--- a/e2e/resources/python-code/disk-reattach-after.py
+++ b/e2e/resources/python-code/disk-reattach-after.py
@@ -1,0 +1,1 @@
+print 'after!'

--- a/e2e/resources/python-code/disk-reattach-after.py
+++ b/e2e/resources/python-code/disk-reattach-after.py
@@ -1,1 +1,23 @@
-print 'after!'
+import os
+import re
+
+disk_file = os.environ.get('HOME') + '/disk_size.txt'
+assert os.path.exists(disk_file), f"expected file to persist on disk @ {disk_file}"
+
+def parse_gb(str_gb):
+    m = re.search('(\d+)G', str_gb)
+    assert m, f"Input value is misformatted: '{str_gb}'"
+    return int(m.group(1))
+
+with open(disk_file, 'r') as f:
+    txt = f.read()
+    old_gb = parse_gb(txt)
+
+new_gb_str = ! df -h --output=size $HOME | sed 1d
+new_gb = parse_gb(new_gb_str[0])
+
+# The test increases the disk size by 10GB. Use a more conservative value here
+# to account for rounding and unavailable space.
+assert new_gb - old_gb > 7, f"expected disk size to increase by at least 7GB, got {old_gb} -> {new_gb} GB"
+
+print('success')

--- a/e2e/resources/python-code/disk-reattach-before.py
+++ b/e2e/resources/python-code/disk-reattach-before.py
@@ -1,1 +1,1 @@
-print 'before!'
+! df -h --output=size $HOME | sed 1d | tee $HOME/disk_size.txt && echo 'success'

--- a/e2e/resources/python-code/disk-reattach-before.py
+++ b/e2e/resources/python-code/disk-reattach-before.py
@@ -1,0 +1,1 @@
+print 'before!'

--- a/e2e/tests/nightly/detachable-disk.spec.ts
+++ b/e2e/tests/nightly/detachable-disk.spec.ts
@@ -35,7 +35,7 @@ describe('Updating runtime status', () => {
     await runtimePanel.pickDetachableDisk();
 
     // TODO(calbach): Investigate why 110GB -> 120GB causes issues.
-    await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 50);
+    await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 10);
     await runtimePanel.createRuntime({ waitForComplete: false });
 
     // Run notebook to write a file to disk.
@@ -50,7 +50,7 @@ describe('Updating runtime status', () => {
 
     // Select increase detachable disk, enable GPU to force a recreate.
     await runtimePanel.open();
-    await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 10);
+    await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 50);
     await runtimePanel.pickEnableGpu();
     await runtimePanel.applyChanges();
 

--- a/e2e/tests/nightly/detachable-disk.spec.ts
+++ b/e2e/tests/nightly/detachable-disk.spec.ts
@@ -1,34 +1,27 @@
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import RuntimePanel from 'app/sidebar/runtime-panel';
-import path from 'path';
-import { config } from 'resources/workbench-config';
 import { makeRandomName } from 'utils/str-utils';
 import { createWorkspace, signInWithAccessToken } from 'utils/test-utils';
+import path from 'path';
 
-// 30 minutes. Test could take a long time.
 jest.setTimeout(30 * 60 * 1000);
 
 describe('Updating runtime status', () => {
+  // Notebooks to run before/after reattaching a PD.
+  const diskBeforeNotebookName = 'disk-reattach-before.py';
+  const diskBeforeNotebookFilePath = path.relative(
+    process.cwd(),
+    __dirname + `../../../resources/python-code/${diskBeforeNotebookName}`
+  );
+
+  const diskAfterNotebookName = 'disk-reattach-after.py';
+  const diskAfterNotebookFilePath = path.relative(
+    process.cwd(),
+    __dirname + `../../../resources/python-code/${diskAfterNotebookName}`
+  );
+
   beforeEach(async () => {
     await signInWithAccessToken(page);
-  });
-
-  test('Create, pause, resume, delete', async () => {
-    await createWorkspace(page, { cdrVersionName: config.OLD_CDR_VERSION_NAME });
-
-    const runtimePanel = new RuntimePanel(page);
-
-    // Create runtime
-    await runtimePanel.createRuntime();
-
-    // Pause runtime
-    await runtimePanel.pauseRuntime();
-
-    // Restart runtime
-    await runtimePanel.resumeRuntime();
-
-    // Delete runtime
-    await runtimePanel.deleteRuntime();
   });
 
   test('Create with detachable disk, re-attach, delete', async () => {
@@ -42,7 +35,7 @@ describe('Updating runtime status', () => {
     await runtimePanel.pickDetachableDisk();
 
     // TODO(calbach): Investigate why 110GB -> 120GB causes issues.
-    await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 10);
+    await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 50);
     await runtimePanel.createRuntime({ waitForComplete: false });
 
     // Run notebook to write a file to disk.

--- a/e2e/tests/nightly/detachable-disk.spec.ts
+++ b/e2e/tests/nightly/detachable-disk.spec.ts
@@ -48,11 +48,15 @@ describe('Updating runtime status', () => {
     await notebookPage.save();
     dataPage = await notebookPage.goDataPage();
 
-    // Select increase detachable disk, enable GPU to force a recreate.
+    // Delete the environment, but not the PD.
     await runtimePanel.open();
+    await runtimePanel.deleteRuntime();
+
+    // Create a new runtime, reattaching the PD and increasing the size.
+    await runtimePanel.open();
+    await runtimePanel.pickDetachableDisk();
     await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 50);
-    await runtimePanel.pickEnableGpu();
-    await runtimePanel.applyChanges();
+    await runtimePanel.createRuntime({ waitForComplete: false });
 
     // Run notebook to verify file is still on disk; check new disk size.
     notebookPage = await dataPage.createNotebook(makeRandomName('disk-after'));

--- a/e2e/tests/nightly/detachable-disk.spec.ts
+++ b/e2e/tests/nightly/detachable-disk.spec.ts
@@ -33,9 +33,6 @@ describe('Updating runtime status', () => {
 
     // Select detachable disk, start.
     await runtimePanel.pickDetachableDisk();
-
-    // TODO(calbach): Investigate why 110GB -> 120GB causes issues.
-    await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 10);
     await runtimePanel.createRuntime({ waitForComplete: false });
 
     // Run notebook to write a file to disk.
@@ -55,7 +52,7 @@ describe('Updating runtime status', () => {
     // Create a new runtime, reattaching the PD and increasing the size.
     await runtimePanel.open();
     await runtimePanel.pickDetachableDisk();
-    await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 50);
+    await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 10);
     await runtimePanel.createRuntime({ waitForComplete: false });
 
     // Run notebook to verify file is still on disk; check new disk size.

--- a/e2e/tests/nightly/detachable-disk.spec.ts
+++ b/e2e/tests/nightly/detachable-disk.spec.ts
@@ -42,6 +42,11 @@ describe('Updating runtime status', () => {
     let codeOutput = await notebookPage.runCodeFile(1, diskBeforeNotebookName);
     expect(codeOutput).toMatch(/success$/);
 
+    // TODO(IA-3258): Remove this sleep once the ticket is resolved.
+    // Due to IA-3258, files written within ~30s of runtime deletion are likely to
+    // be truncated. Wait 90s to allow a wide margin for this bug.
+    await page.waitForTimeout(90 * 1000);
+
     await notebookPage.save();
     dataPage = await notebookPage.goDataPage();
 

--- a/e2e/tests/nightly/runtime.spec.ts
+++ b/e2e/tests/nightly/runtime.spec.ts
@@ -9,13 +9,18 @@ import { createWorkspace, signInWithAccessToken } from 'utils/test-utils';
 jest.setTimeout(30 * 60 * 1000);
 
 describe('Updating runtime status', () => {
-
   // Notebooks to run before/after reattaching a PD.
   const diskBeforeNotebookName = 'disk-reattach-before.py';
-  const diskBeforeNotebookFilePath = path.relative(process.cwd(), __dirname + `../../../resources/python-code/${diskBeforeNotebookName}`);
+  const diskBeforeNotebookFilePath = path.relative(
+    process.cwd(),
+    __dirname + `../../../resources/python-code/${diskBeforeNotebookName}`
+  );
 
   const diskAfterNotebookName = 'disk-reattach-after.py';
-  const diskAfterNotebookFilePath = path.relative(process.cwd(), __dirname + `../../../resources/python-code/${diskAfterNotebookName}`);
+  const diskAfterNotebookFilePath = path.relative(
+    process.cwd(),
+    __dirname + `../../../resources/python-code/${diskAfterNotebookName}`
+  );
 
   beforeEach(async () => {
     await signInWithAccessToken(page);
@@ -48,7 +53,10 @@ describe('Updating runtime status', () => {
 
     // Select detachable disk, start.
     await runtimePanel.pickDetachableDisk();
-    await runtimePanel.createRuntime({waitForComplete: false});
+
+    // TODO(calbach): Investigate why 110GB -> 120GB causes issues.
+    await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 10);
+    await runtimePanel.createRuntime({ waitForComplete: false });
 
     // Run notebook to write a file to disk.
     let dataPage = new WorkspaceDataPage(page);
@@ -62,7 +70,7 @@ describe('Updating runtime status', () => {
 
     // Select increase detachable disk, enable GPU to force a recreate.
     await runtimePanel.open();
-    await runtimePanel.pickDetachableDiskGbs(await runtimePanel.getDetachableDiskGbs() + 10);
+    await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 10);
     await runtimePanel.pickEnableGpu();
     await runtimePanel.applyChanges();
 

--- a/e2e/tests/nightly/runtime.spec.ts
+++ b/e2e/tests/nightly/runtime.spec.ts
@@ -1,11 +1,22 @@
+import WorkspaceDataPage from 'app/page/workspace-data-page';
 import RuntimePanel from 'app/sidebar/runtime-panel';
+import path from 'path';
 import { config } from 'resources/workbench-config';
+import { makeRandomName } from 'utils/str-utils';
 import { createWorkspace, signInWithAccessToken } from 'utils/test-utils';
 
 // 30 minutes. Test could take a long time.
 jest.setTimeout(30 * 60 * 1000);
 
 describe('Updating runtime status', () => {
+
+  // Notebooks to run before/after reattaching a PD.
+  const diskBeforeNotebookName = 'disk-reattach-before.py';
+  const diskBeforeNotebookFilePath = path.relative(process.cwd(), __dirname + `../../../resources/python-code/${diskBeforeNotebookName}`);
+
+  const diskAfterNotebookName = 'disk-reattach-after.py';
+  const diskAfterNotebookFilePath = path.relative(process.cwd(), __dirname + `../../../resources/python-code/${diskAfterNotebookName}`);
+
   beforeEach(async () => {
     await signInWithAccessToken(page);
   });
@@ -26,5 +37,37 @@ describe('Updating runtime status', () => {
 
     // Delete runtime
     await runtimePanel.deleteRuntime();
+  });
+
+  test.only('Create with detachable disk, re-attach, delete', async () => {
+    await createWorkspace(page, { cdrVersionName: config.DEFAULT_CDR_VERSION_NAME });
+
+    const runtimePanel = new RuntimePanel(page);
+
+    // Select detachable disk, start.
+    await runtimePanel.pickDetachableDisk();
+    await runtimePanel.createRuntime({waitForComplete: false});
+
+    // Run notebook to write a file to disk.
+    let dataPage = new WorkspaceDataPage(page);
+    let notebookPage = await dataPage.createNotebook(makeRandomName('disk-before'));
+    await notebookPage.uploadFile(diskBeforeNotebookName, diskBeforeNotebookFilePath);
+    await notebookPage.runCodeFile(1, diskBeforeNotebookName);
+
+    // Select increase detachable disk, enable GPU to force a recreate.
+    await runtimePanel.open();
+    await runtimePanel.pickDetachableDiskGbs(await runtimePanel.getDetachableDiskGbs() + 10);
+    await runtimePanel.pickEnableGpu();
+    await runtimePanel.applyChanges();
+
+    // Run notebook to verify file is still on disk; check new disk size.
+    dataPage = new WorkspaceDataPage(page);
+    notebookPage = await dataPage.createNotebook(makeRandomName('disk-after'));
+    await notebookPage.uploadFile(diskAfterNotebookName, diskAfterNotebookFilePath);
+    await notebookPage.runCodeFile(1, diskAfterNotebookName);
+
+    // Delete runtime, then delete disk
+    await runtimePanel.deleteRuntime();
+    await runtimePanel.deleteUnattachedPd();
   });
 });


### PR DESCRIPTION
Previously reviewed as https://github.com/all-of-us/workbench/pull/6293. Now working after fixes from the Leo team.

- Create a runtime with a detachable PD
- Write some files to disk, including the disk size
- Recreate with GPU enabled (this forces a recreate) and increased disk size
- Verify the file is still there
- Compare the disk size, and verify increase