### PR TITLE
[risk=low][RW-7613] Delete dependent resources from user_recently_modified_resource if COHORT/CONCEPT Set is deleted

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -444,15 +444,6 @@ public class CohortReviewController implements CohortReviewApiDelegate {
 
     cohortReview.participantCohortStatuses(participantCohortStatuses);
 
-    // Wrapping the following logic behind the feature flag so that only in test/local
-    // opening/creating cohort review will create an entry in user recent resource with
-    // resource type cohortReview rather than cohort,
-    // while the rest of the environments remains as is
-    if (!workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
-      userRecentResourceService.updateCohortEntry(
-          cohort.getWorkspaceId(), userProvider.get().getUserId(), cohortId);
-    }
-
     // Cohort review id will be null if the user is creating a new Cohort Review
     // In such cases createCohort will update the entry in userrecentresource
     // Cohort review id will be populated, if  user is viewing an existing cohort review

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
@@ -78,9 +78,9 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
     // conceptSetId and workspaceId
     ConceptSet conceptSet =
         conceptSetService.getConceptSet(dbWorkspace.getWorkspaceId(), conceptSetId);
-    conceptSetService.delete(conceptSet.getId());
     userRecentResourceService.deleteConceptSetEntry(
         dbWorkspace.getWorkspaceId(), userProvider.get().getUserId(), conceptSetId);
+    conceptSetService.delete(conceptSet.getId());
     return ResponseEntity.ok(new EmptyResponse());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetDao.java
@@ -1,12 +1,13 @@
 package org.pmiops.workbench.db.dao;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.pmiops.workbench.db.model.DbDataset;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public interface DataSetDao extends CrudRepository<DbDataset, Long> {
   List<DbDataset> findByWorkspaceIdAndInvalid(long workspaceId, boolean invalid);
@@ -14,9 +15,9 @@ public interface DataSetDao extends CrudRepository<DbDataset, Long> {
   List<DbDataset> findDataSetsByCohortIdsAndWorkspaceIdAndInvalid(
       long cohortId, long workspaceId, boolean dirty);
 
-  List<DbDataset> findDbDataSetsByCohortIdsAndWorkspaceId(long cohortId, long workspaceId);
+  List<DbDataset> findDbDataSetsByCohortIdAndWorkspaceId(long cohortId, long workspaceId);
 
-  List<DbDataset> findDbDatasetsByConceptSetIdsAndWorkspaceId(long conceptId, long workspaceId);
+  List<DbDataset> findDbDatasetsByConceptSetIdAndWorkspaceId(long conceptId, long workspaceId);
 
   List<DbDataset> findDataSetsByConceptSetIdsAndWorkspaceIdAndInvalid(
       long conceptId, long workspaceId, boolean dirty);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetDao.java
@@ -1,13 +1,12 @@
 package org.pmiops.workbench.db.dao;
 
 import com.google.common.collect.ImmutableMap;
-import org.pmiops.workbench.db.model.DbDataset;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.pmiops.workbench.db.model.DbDataset;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
 
 public interface DataSetDao extends CrudRepository<DbDataset, Long> {
   List<DbDataset> findByWorkspaceIdAndInvalid(long workspaceId, boolean invalid);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetDao.java
@@ -14,6 +14,10 @@ public interface DataSetDao extends CrudRepository<DbDataset, Long> {
   List<DbDataset> findDataSetsByCohortIdsAndWorkspaceIdAndInvalid(
       long cohortId, long workspaceId, boolean dirty);
 
+  List<DbDataset> findDbDataSetsByCohortIdsAndWorkspaceId(long cohortId, long workspaceId);
+
+  List<DbDataset> findDbDatasetsByConceptSetIdsAndWorkspaceId(long conceptId, long workspaceId);
+
   List<DbDataset> findDataSetsByConceptSetIdsAndWorkspaceIdAndInvalid(
       long conceptId, long workspaceId, boolean dirty);
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/DataSetDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/DataSetDao.java
@@ -14,9 +14,9 @@ public interface DataSetDao extends CrudRepository<DbDataset, Long> {
   List<DbDataset> findDataSetsByCohortIdsAndWorkspaceIdAndInvalid(
       long cohortId, long workspaceId, boolean dirty);
 
-  List<DbDataset> findDbDataSetsByCohortIdAndWorkspaceId(long cohortId, long workspaceId);
+  List<DbDataset> findDbDataSetsByCohortIdsAndWorkspaceId(long cohortId, long workspaceId);
 
-  List<DbDataset> findDbDatasetsByConceptSetIdAndWorkspaceId(long conceptId, long workspaceId);
+  List<DbDataset> findDbDatasetsByConceptSetIdsAndWorkspaceId(long conceptId, long workspaceId);
 
   List<DbDataset> findDataSetsByConceptSetIdsAndWorkspaceIdAndInvalid(
       long conceptId, long workspaceId, boolean dirty);

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
@@ -142,10 +142,10 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
       cohortReviewIds.forEach(id -> deleteCohortReviewEntry(workspaceId, userId, id));
     }
 
-      List<Long> datasetIds =
-          datasetDao.findDbDataSetsByCohortIdsAndWorkspaceId(cohortId, workspaceId).stream()
-              .map(DbDataset::getDataSetId)
-              .collect(Collectors.toList());
+    List<Long> datasetIds =
+        datasetDao.findDbDataSetsByCohortIdsAndWorkspaceId(cohortId, workspaceId).stream()
+            .map(DbDataset::getDataSetId)
+            .collect(Collectors.toList());
 
     if (datasetIds.size() > 0) {
       datasetIds.forEach(id -> deleteDataSetEntry(workspaceId, userId, id));

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
@@ -153,7 +153,7 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
       }
 
       List<Long> datasetIds =
-          datasetDao.findDbDataSetsByCohortIdAndWorkspaceId(cohortId, workspaceId).stream()
+          datasetDao.findDbDataSetsByCohortIdsAndWorkspaceId(cohortId, workspaceId).stream()
               .map(DbDataset::getDataSetId)
               .collect(Collectors.toList());
 
@@ -180,7 +180,7 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
     // execute it only if the feature flag enableDSCREntryInRecentModified is set to TRUE
     if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
       List<Long> datasetIds =
-          datasetDao.findDbDatasetsByConceptSetIdAndWorkspaceId(conceptSetId, workspaceId).stream()
+          datasetDao.findDbDatasetsByConceptSetIdsAndWorkspaceId(conceptSetId, workspaceId).stream()
               .map(DbDataset::getDataSetId)
               .collect(Collectors.toList());
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
@@ -131,13 +131,11 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
         notebookPath);
   }
 
-  /** Deletes cohort entry from user_recently_modified_resource */
   /**
    * Deleting Cohort resource in workbench, deletes all the cohort reviews that is using the cohort
-   * as well mark the DataSet using the deleted cohort as INVALID. Therefore, as part of
-   * deleteCohortEntry method, delete not just the Cohort entry from
-   * user_recently_modified_resource, but also all the cohort review/dataSet that references the
-   * deleted cohort
+   * as well mark the DataSet using the deleted cohort as INVALID. As part of deleteCohortEntry
+   * method : 1) Delete Cohort entry from user_recently_modified_resource, 2) Also all the cohort
+   * review/dataSet that references the deleted cohort
    */
   @Override
   public void deleteCohortEntry(long workspaceId, long userId, long cohortId) {
@@ -172,12 +170,11 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
   }
 
   /**
-   * Deletes concept set entry from user_recently_modified_resource
-   *
-   * <p>Deleting ConceptSet from database will mark the dataSet, using the concept Set, as invalid
-   * which removes the dataset from the user resources list So as part of deleteConceptSetEntry,
-   * apart from deleting the concept set entry check all the dataSet using the concept set and
-   * delete them as well so they do not appear in user recent resource list
+   * Deleting ConceptSet from database will mark the dataSet, using the concept Set, as invalid
+   * which removes the dataset from the user resources list. For deleteConceptSetEntry: 1) Deleting
+   * the concept set entry from userRecentResource table 2) Delete all the dataSet using the concept
+   * Set from userRecentResource table as well so they do not appear in user recent resource list in
+   * UI
    */
   @Override
   public void deleteConceptSetEntry(long workspaceId, long userId, long conceptSetId) {

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
@@ -127,8 +127,8 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
   }
 
   /**
-   * When a Cohort recent-resource is deleted, delete all Cohort Reviews and Datasets which
-   * reference the Cohort as well
+   * When a Cohort recent-resource is deleted, delete all the entries of Cohort Reviews and Datasets
+   * which reference the Cohort as well from recent_resource
    */
   @Override
   public void deleteCohortEntry(long workspaceId, long userId, long cohortId) {
@@ -148,8 +148,8 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
   }
 
   /**
-   * When a Concept Set recent-resource is deleted, delete all Datasets which reference the Cohort
-   * as well
+   * When a Concept Set recent-resource is deleted, delete all the entries of Datasets which
+   * reference the Cohort as well from recent_resource
    */
   @Override
   public void deleteConceptSetEntry(long workspaceId, long userId, long conceptSetId) {

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
@@ -132,17 +132,14 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
   }
 
   /**
-   * Deleting Cohort resource in workbench, deletes all the cohort reviews that is using the cohort
-   * as well mark the DataSet using the deleted cohort as INVALID. As part of deleteCohortEntry
-   * method : 1) Delete Cohort entry from user_recently_modified_resource, 2) Also all the cohort
-   * review/dataSet that references the deleted cohort
+   * When a Cohort recent-resource is deleted, we also delete those of all Cohort Reviews and
+   * Datasets which reference the Cohort
    */
   @Override
   public void deleteCohortEntry(long workspaceId, long userId, long cohortId) {
-    // The logic to delete Cohort Review/DataSet used by deleted conceptSet is to be done
-    // for the new table (user_recently_modified_resource) only, hence execute it only if the
-    // feature flag enableDSCREntryInRecentModified is set to TRUE
-
+    // The logic to delete dependent recent-resources only applies to the new table
+    // (user_recently_modified_resource), so it's gated on the feature flag
+    // enableDSCREntryInRecentModified
     if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
       List<Long> cohortReviewIds =
           cohortReviewDao.findAllByCohortId(cohortId).stream()
@@ -150,7 +147,7 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
               .collect(Collectors.toList());
 
       if (cohortReviewIds.size() > 0) {
-        cohortReviewIds.stream().forEach(id -> deleteCohortReviewEntry(workspaceId, userId, id));
+        cohortReviewIds.forEach(id -> deleteCohortReviewEntry(workspaceId, userId, id));
       }
 
       List<Long> datasetIds =
@@ -159,7 +156,7 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
               .collect(Collectors.toList());
 
       if (datasetIds.size() > 0) {
-        datasetIds.stream().forEach(id -> deleteDataSetEntry(workspaceId, userId, id));
+        datasetIds.forEach(id -> deleteDataSetEntry(workspaceId, userId, id));
       }
     }
     deleteUserRecentlyModifiedResourceEntry(
@@ -170,17 +167,14 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
   }
 
   /**
-   * Deleting ConceptSet from database will mark the dataSet, using the concept Set, as invalid
-   * which removes the dataset from the user resources list. For deleteConceptSetEntry: 1) Deleting
-   * the concept set entry from userRecentResource table 2) Delete all the dataSet using the concept
-   * Set from userRecentResource table as well so they do not appear in user recent resource list in
-   * UI
+   * When a Concept Set recent-resource is deleted, we also delete those of all Datasets which
+   * reference the Cohort
    */
   @Override
   public void deleteConceptSetEntry(long workspaceId, long userId, long conceptSetId) {
-    // The logic to delete dataSet used by deleted conceptSet is to be done for the new table
-    // (user_recently_modified_resource)
-    // execute it only if the feature flag enableDSCREntryInRecentModified is set to TRUE
+    // The logic to delete dependent recent-resources only applies to the new table
+    // (user_recently_modified_resource), so it's gated on the feature flag
+    // enableDSCREntryInRecentModified
     if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
       List<Long> datasetIds =
           datasetDao.findDbDatasetsByConceptSetIdsAndWorkspaceId(conceptSetId, workspaceId).stream()
@@ -188,7 +182,7 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
               .collect(Collectors.toList());
 
       if (datasetIds.size() > 0) {
-        datasetIds.stream().forEach(id -> deleteDataSetEntry(workspaceId, userId, id));
+        datasetIds.forEach(id -> deleteDataSetEntry(workspaceId, userId, id));
       }
     }
     deleteUserRecentlyModifiedResourceEntry(

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
@@ -133,8 +133,11 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
 
   /** Deletes cohort entry from user_recently_modified_resource */
   /**
-   * Since user_recently_modified_resource does not hold FK constraints, hence we have to explicitly
-   * delete COHORT REVIEWS and DATA SETs that are using the deleted cohort id
+   * Deleting Cohort resource in workbench, deletes all the cohort reviews that is using the cohort
+   * as well mark the DataSet using the deleted cohort as INVALID. Therefore, as part of
+   * deleteCohortEntry method, delete not just the Cohort entry from
+   * user_recently_modified_resource, but also all the cohort review/dataSet that references the
+   * deleted cohort
    */
   @Override
   public void deleteCohortEntry(long workspaceId, long userId, long cohortId) {
@@ -168,10 +171,13 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
         String.valueOf(cohortId));
   }
 
-  /** Deletes concept set entry from user_recently_modified_resource */
   /**
-   * Since user_recently_modified_resource does not hold FK hence we have to explicitly delete
-   * DATA_SET using the deleted concept set id
+   * Deletes concept set entry from user_recently_modified_resource
+   *
+   * <p>Deleting ConceptSet from database will mark the dataSet, using the concept Set, as invalid
+   * which removes the dataset from the user resources list So as part of deleteConceptSetEntry,
+   * apart from deleting the concept set entry check all the dataSet using the concept set and
+   * delete them as well so they do not appear in user recent resource list
    */
   @Override
   public void deleteConceptSetEntry(long workspaceId, long userId, long conceptSetId) {

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
@@ -83,24 +83,20 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
 
   @Override
   public void updateDataSetEntry(long workspaceId, long userId, long dataSetId) {
-    if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
-      updateUserRecentlyModifiedResourceEntry(
-          workspaceId,
-          userId,
-          DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.DATA_SET,
-          String.valueOf(dataSetId));
-    }
+    updateUserRecentlyModifiedResourceEntry(
+        workspaceId,
+        userId,
+        DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.DATA_SET,
+        String.valueOf(dataSetId));
   }
 
   @Override
   public void updateCohortReviewEntry(long workspaceId, long userId, long cohortReviewId) {
-    if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
-      updateUserRecentlyModifiedResourceEntry(
-          workspaceId,
-          userId,
-          DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.COHORT_REVIEW,
-          String.valueOf(cohortReviewId));
-    }
+    updateUserRecentlyModifiedResourceEntry(
+        workspaceId,
+        userId,
+        DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.COHORT_REVIEW,
+        String.valueOf(cohortReviewId));
   }
 
   private DbUserRecentlyModifiedResource updateUserRecentlyModifiedResourceEntry(
@@ -137,28 +133,24 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
    */
   @Override
   public void deleteCohortEntry(long workspaceId, long userId, long cohortId) {
-    // The logic to delete dependent recent-resources only applies to the new table
-    // (user_recently_modified_resource), so it's gated on the feature flag
-    // enableDSCREntryInRecentModified
-    if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
-      List<Long> cohortReviewIds =
-          cohortReviewDao.findAllByCohortId(cohortId).stream()
-              .map(DbCohortReview::getCohortReviewId)
-              .collect(Collectors.toList());
+    List<Long> cohortReviewIds =
+        cohortReviewDao.findAllByCohortId(cohortId).stream()
+            .map(DbCohortReview::getCohortReviewId)
+            .collect(Collectors.toList());
 
-      if (cohortReviewIds.size() > 0) {
-        cohortReviewIds.forEach(id -> deleteCohortReviewEntry(workspaceId, userId, id));
-      }
+    if (cohortReviewIds.size() > 0) {
+      cohortReviewIds.forEach(id -> deleteCohortReviewEntry(workspaceId, userId, id));
+    }
 
       List<Long> datasetIds =
           datasetDao.findDbDataSetsByCohortIdsAndWorkspaceId(cohortId, workspaceId).stream()
               .map(DbDataset::getDataSetId)
               .collect(Collectors.toList());
 
-      if (datasetIds.size() > 0) {
-        datasetIds.forEach(id -> deleteDataSetEntry(workspaceId, userId, id));
-      }
+    if (datasetIds.size() > 0) {
+      datasetIds.forEach(id -> deleteDataSetEntry(workspaceId, userId, id));
     }
+
     deleteUserRecentlyModifiedResourceEntry(
         userId,
         workspaceId,
@@ -172,19 +164,15 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
    */
   @Override
   public void deleteConceptSetEntry(long workspaceId, long userId, long conceptSetId) {
-    // The logic to delete dependent recent-resources only applies to the new table
-    // (user_recently_modified_resource), so it's gated on the feature flag
-    // enableDSCREntryInRecentModified
-    if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
-      List<Long> datasetIds =
-          datasetDao.findDbDatasetsByConceptSetIdsAndWorkspaceId(conceptSetId, workspaceId).stream()
-              .map(DbDataset::getDataSetId)
-              .collect(Collectors.toList());
+    List<Long> datasetIds =
+        datasetDao.findDbDatasetsByConceptSetIdsAndWorkspaceId(conceptSetId, workspaceId).stream()
+            .map(DbDataset::getDataSetId)
+            .collect(Collectors.toList());
 
-      if (datasetIds.size() > 0) {
-        datasetIds.forEach(id -> deleteDataSetEntry(workspaceId, userId, id));
-      }
+    if (datasetIds.size() > 0) {
+      datasetIds.forEach(id -> deleteDataSetEntry(workspaceId, userId, id));
     }
+
     deleteUserRecentlyModifiedResourceEntry(
         userId,
         workspaceId,
@@ -194,24 +182,20 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
 
   @Override
   public void deleteDataSetEntry(long workspaceId, long userId, long dataSetId) {
-    if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
-      deleteUserRecentlyModifiedResourceEntry(
-          userId,
-          workspaceId,
-          DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.DATA_SET,
-          String.valueOf(dataSetId));
-    }
+    deleteUserRecentlyModifiedResourceEntry(
+        userId,
+        workspaceId,
+        DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.DATA_SET,
+        String.valueOf(dataSetId));
   }
 
   @Override
   public void deleteCohortReviewEntry(long workspaceId, long userId, long cohortReviewId) {
-    if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
-      deleteUserRecentlyModifiedResourceEntry(
-          userId,
-          workspaceId,
-          DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.COHORT_REVIEW,
-          String.valueOf(cohortReviewId));
-    }
+    deleteUserRecentlyModifiedResourceEntry(
+        userId,
+        workspaceId,
+        DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType.COHORT_REVIEW,
+        String.valueOf(cohortReviewId));
   }
 
   private void deleteUserRecentlyModifiedResourceEntry(

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
@@ -134,10 +134,14 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
   /** Deletes cohort entry from user_recently_modified_resource */
   /**
    * Since user_recently_modified_resource does not hold FK constraints, hence we have to explicitly
-   * delete COHORT REVIEWs and DATA SETs that are using the deleted cohort id
+   * delete COHORT REVIEWS and DATA SETs that are using the deleted cohort id
    */
   @Override
   public void deleteCohortEntry(long workspaceId, long userId, long cohortId) {
+    // The logic to delete Cohort Review/DataSet used by deleted conceptSet is to be done
+    // for the new table (user_recently_modified_resource) only, hence execute it only if the
+    // feature flag enableDSCREntryInRecentModified is set to TRUE
+
     if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
       List<Long> cohortReviewIds =
           cohortReviewDao.findAllByCohortId(cohortId).stream()
@@ -149,7 +153,7 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
       }
 
       List<Long> datasetIds =
-          datasetDao.findDbDataSetsByCohortIdsAndWorkspaceId(cohortId, workspaceId).stream()
+          datasetDao.findDbDataSetsByCohortIdAndWorkspaceId(cohortId, workspaceId).stream()
               .map(DbDataset::getDataSetId)
               .collect(Collectors.toList());
 
@@ -167,14 +171,16 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
   /** Deletes concept set entry from user_recently_modified_resource */
   /**
    * Since user_recently_modified_resource does not hold FK hence we have to explicitly delete
-   * DATA_SET using the deleted concept set id Since this is the case only for the new table, the
-   * logic will be behind the feature flag
+   * DATA_SET using the deleted concept set id
    */
   @Override
   public void deleteConceptSetEntry(long workspaceId, long userId, long conceptSetId) {
+    // The logic to delete dataSet used by deleted conceptSet is to be done for the new table
+    // (user_recently_modified_resource)
+    // execute it only if the feature flag enableDSCREntryInRecentModified is set to TRUE
     if (workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
       List<Long> datasetIds =
-          datasetDao.findDbDatasetsByConceptSetIdsAndWorkspaceId(conceptSetId, workspaceId).stream()
+          datasetDao.findDbDatasetsByConceptSetIdAndWorkspaceId(conceptSetId, workspaceId).stream()
               .map(DbDataset::getDataSetId)
               .collect(Collectors.toList());
 

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -1945,7 +1945,7 @@ public class CohortReviewControllerTest {
             .getCohortReview();
 
     verify(userRecentResourceService, atLeastOnce())
-        .updateCohortEntry(anyLong(), anyLong(), anyLong());
+        .updateCohortReviewEntry(anyLong(), anyLong(), anyLong());
     assertCohortReviewParticipantCohortStatuses(
         actualReview, expectedReview, filterColumns, sortOrder);
   }
@@ -1975,7 +1975,7 @@ public class CohortReviewControllerTest {
             .getCohortReview();
 
     verify(userRecentResourceService, atLeastOnce())
-        .updateCohortEntry(anyLong(), anyLong(), anyLong());
+        .updateCohortReviewEntry(anyLong(), anyLong(), anyLong());
     // PageFilterRequest defaults to participantId, ascending (if not given)
     assertCohortReviewParticipantCohortStatuses(
         actualReview, expectedReview, FilterColumns.PARTICIPANTID, SortOrder.ASC);
@@ -2072,7 +2072,7 @@ public class CohortReviewControllerTest {
             .getCohortReview();
 
     verify(userRecentResourceService, atLeastOnce())
-        .updateCohortEntry(anyLong(), anyLong(), anyLong());
+        .updateCohortReviewEntry(anyLong(), anyLong(), anyLong());
     assertCohortReviewParticipantCohortStatuses(
         actualReview, expectedReview, filterColumns, sortOrder);
   }
@@ -2103,7 +2103,7 @@ public class CohortReviewControllerTest {
             .getCohortReview();
 
     verify(userRecentResourceService, atLeastOnce())
-        .updateCohortEntry(anyLong(), anyLong(), anyLong());
+        .updateCohortReviewEntry(anyLong(), anyLong(), anyLong());
     // PageFilterRequest defaults to participantId, ascending (if not given)
     assertCohortReviewParticipantCohortStatuses(
         actualReview, expectedReview, FilterColumns.PARTICIPANTID, SortOrder.ASC);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableSet;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,10 +23,12 @@ import org.pmiops.workbench.db.model.DbCohortReview;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbConceptSetConceptId;
 import org.pmiops.workbench.db.model.DbDataset;
+import org.pmiops.workbench.db.model.DbDatasetValue;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.test.FakeClock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -97,9 +100,17 @@ public class UserRecentResourceServiceTest {
     conceptSet.setConceptSetConceptIds(ImmutableSet.of(dbConceptSetConceptId));
     conceptSet = conceptSetDao.save(conceptSet);
 
+    DbDatasetValue dbDatasetValue = new DbDatasetValue();
+    dbDatasetValue.setDomainId(Domain.OBSERVATION.toString());
+    dbDatasetValue.setValue("Mock Value");
+
     dataset = new DbDataset();
+    dataset.setName("Mock Data Set");
+    dataset.setCohortIds(Arrays.asList(cohort.getCohortId()));
+    dataset.setConceptSetIds(Arrays.asList(conceptSet.getConceptSetId()));
+    dataset.setValues(Arrays.asList(dbDatasetValue));
     dataset.setWorkspaceId(workspace.getWorkspaceId());
-    dataset = datasetDao.save(dataset);
+    datasetDao.save(dataset);
   }
 
   @Test
@@ -439,5 +450,64 @@ public class UserRecentResourceServiceTest {
     assertThat(Long.parseLong(resources.get(2).getResourceId())).isEqualTo(cohort.getCohortId());
     assertThat(resources.get(3).getResourceId())
         .isEqualTo("gs://someDirectory1/notebooks/notebook1");
+  }
+
+  @Test
+  public void testDeleteDependentCohortReviewOnDeletingCohort() {
+    userRecentResourceService.updateCohortEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
+    userRecentResourceService.updateCohortReviewEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohortReview.getCohortReviewId());
+
+    List<DbUserRecentlyModifiedResource> resources =
+        userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
+
+    assertThat(resources.size()).isEqualTo(2);
+
+    userRecentResourceService.deleteCohortEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
+
+    resources = userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
+
+    assertThat(resources.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void testDeleteDependentDataSetOnDeletingCohort() {
+    userRecentResourceService.updateCohortEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
+
+    userRecentResourceService.updateDataSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), dataset.getDataSetId());
+
+    List<DbUserRecentlyModifiedResource> resources =
+        userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
+    assertThat(resources.size()).isEqualTo(2);
+
+    userRecentResourceService.deleteCohortEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
+
+    resources = userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
+    assertThat(resources.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void testDeleteDependentDataSetOnDeletingConceptSet() {
+    userRecentResourceService.updateConceptSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
+
+    userRecentResourceService.updateDataSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), dataset.getDataSetId());
+
+    List<DbUserRecentlyModifiedResource> resources =
+        userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
+    assertThat(resources.size()).isEqualTo(2);
+
+    userRecentResourceService.deleteConceptSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
+
+    resources = userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
+    // Deleting Concept Set should delete the dataSet using it
+    assertThat(resources.size()).isEqualTo(0);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
@@ -454,6 +454,9 @@ public class UserRecentResourceServiceTest {
 
   @Test
   public void testDeleteDependentCohortReviewOnDeletingCohort() {
+    // Add the following entry in user_recently_modified_resource:
+    // 1) Cohort
+    // 2) Cohort Review that is using the Cohort
     userRecentResourceService.updateCohortEntry(
         workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
     userRecentResourceService.updateCohortReviewEntry(
@@ -461,12 +464,11 @@ public class UserRecentResourceServiceTest {
 
     List<DbUserRecentlyModifiedResource> resources =
         userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
-
     assertThat(resources.size()).isEqualTo(2);
 
+    // Deleting Cohort should delete the Cohort Review using it
     userRecentResourceService.deleteCohortEntry(
         workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
-
     resources = userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
 
     assertThat(resources.size()).isEqualTo(0);
@@ -474,6 +476,9 @@ public class UserRecentResourceServiceTest {
 
   @Test
   public void testDeleteDependentDataSetOnDeletingCohort() {
+    // Add the following entry in user_recently_modified_resource:
+    // 1) Cohort
+    // 2) Data Set that is using the Cohort
     userRecentResourceService.updateCohortEntry(
         workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
 
@@ -487,12 +492,16 @@ public class UserRecentResourceServiceTest {
     userRecentResourceService.deleteCohortEntry(
         workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
 
+    // Deleting Cohort should delete the dataSet using it
     resources = userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
     assertThat(resources.size()).isEqualTo(0);
   }
 
   @Test
   public void testDeleteDependentDataSetOnDeletingConceptSet() {
+    // Add the following entry in user_recently_modified_resource:
+    // 1) Concept Set
+    // 2) Data Set that is using the Concept Set
     userRecentResourceService.updateConceptSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
 
@@ -506,8 +515,8 @@ public class UserRecentResourceServiceTest {
     userRecentResourceService.deleteConceptSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
 
+    // Deleting Concept Set should also delete the data Set entry that is using the Concept Set
     resources = userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
-    // Deleting Concept Set should delete the dataSet using it
     assertThat(resources.size()).isEqualTo(0);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
@@ -454,6 +454,12 @@ public class UserRecentResourceServiceTest {
 
   @Test
   public void testDeleteDependentCohortReviewOnDeletingCohort() {
+    // Confirm the table has no recent modified resources
+    List<DbUserRecentlyModifiedResource> resources =
+        userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
+
+    assertThat(resources.size()).isEqualTo(0);
+
     // Add the following entry in user_recently_modified_resource:
     // 1) Cohort
     // 2) Cohort Review that is using the Cohort
@@ -462,11 +468,10 @@ public class UserRecentResourceServiceTest {
     userRecentResourceService.updateCohortReviewEntry(
         workspace.getWorkspaceId(), user.getUserId(), cohortReview.getCohortReviewId());
 
-    List<DbUserRecentlyModifiedResource> resources =
-        userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
+    // Deleting Cohort should delete the Cohort Review using it
+    resources = userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
     assertThat(resources.size()).isEqualTo(2);
 
-    // Deleting Cohort should delete the Cohort Review using it
     userRecentResourceService.deleteCohortEntry(
         workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
     resources = userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());

--- a/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
@@ -6,7 +6,7 @@ import com.google.common.collect.ImmutableSet;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -106,11 +106,11 @@ public class UserRecentResourceServiceTest {
 
     dataset = new DbDataset();
     dataset.setName("Mock Data Set");
-    dataset.setCohortIds(Arrays.asList(cohort.getCohortId()));
-    dataset.setConceptSetIds(Arrays.asList(conceptSet.getConceptSetId()));
-    dataset.setValues(Arrays.asList(dbDatasetValue));
+    dataset.setCohortIds(Collections.singletonList(cohort.getCohortId()));
+    dataset.setConceptSetIds(Collections.singletonList(conceptSet.getConceptSetId()));
+    dataset.setValues(Collections.singletonList(dbDatasetValue));
     dataset.setWorkspaceId(workspace.getWorkspaceId());
-    datasetDao.save(dataset);
+    dataset = datasetDao.save(dataset);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
@@ -476,6 +476,12 @@ public class UserRecentResourceServiceTest {
 
   @Test
   public void testDeleteDependentDataSetOnDeletingCohort() {
+    // Confirm the table has no recent modified resources
+    List<DbUserRecentlyModifiedResource> resources =
+        userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
+
+    assertThat(resources.size()).isEqualTo(0);
+
     // Add the following entry in user_recently_modified_resource:
     // 1) Cohort
     // 2) Data Set that is using the Cohort
@@ -485,20 +491,24 @@ public class UserRecentResourceServiceTest {
     userRecentResourceService.updateDataSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), dataset.getDataSetId());
 
-    List<DbUserRecentlyModifiedResource> resources =
-        userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
+    resources = userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
     assertThat(resources.size()).isEqualTo(2);
 
+    // Deleting Cohort should delete the dataSet using it
     userRecentResourceService.deleteCohortEntry(
         workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
 
-    // Deleting Cohort should delete the dataSet using it
     resources = userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
     assertThat(resources.size()).isEqualTo(0);
   }
 
   @Test
   public void testDeleteDependentDataSetOnDeletingConceptSet() {
+    List<DbUserRecentlyModifiedResource> resources =
+        userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
+
+    assertThat(resources.size()).isEqualTo(0);
+
     // Add the following entry in user_recently_modified_resource:
     // 1) Concept Set
     // 2) Data Set that is using the Concept Set
@@ -508,14 +518,13 @@ public class UserRecentResourceServiceTest {
     userRecentResourceService.updateDataSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), dataset.getDataSetId());
 
-    List<DbUserRecentlyModifiedResource> resources =
-        userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
+    resources = userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
     assertThat(resources.size()).isEqualTo(2);
 
+    // Deleting Concept Set should also delete the data Set entry that is using the Concept Set
     userRecentResourceService.deleteConceptSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
 
-    // Deleting Concept Set should also delete the data Set entry that is using the Concept Set
     resources = userRecentResourceService.findAllRecentlyModifiedResourcesByUser(user.getUserId());
     assertThat(resources.size()).isEqualTo(0);
   }


### PR DESCRIPTION



https://user-images.githubusercontent.com/34481816/154352153-fa6adee7-2469-4f48-b0ca-c69ad1e99b41.mov


---
**PR checklist**


- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
