### PR TITLE
[RW-7906][risk=low] Fix incorrect billing migration enum value and backfill

### DIFF
--- a/api/db/changelog/db.changelog-190-billing-migration-bug-backfill.xml
+++ b/api/db/changelog/db.changelog-190-billing-migration-bug-backfill.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="calbach" id="changelog-190-billing-migration-bug-backfill">
+    <!--
+     Fix incorrect billing migration status enum value, initialized for all projects going forward:
+     https://github.com/all-of-us/workbench/pull/6162.
+
+     The change was released in Jan 2022, and the incorrectly specified MIGRATED (2) status was not used
+     for a long time prior; so overwrite any such status we see for workspaces created after this time.
+     -->
+    <sql>
+      UPDATE workspace
+        SET billing_migration_status = 1
+        WHERE billing_migration_status = 2 AND creation_time > "2022-01-01 00:00:00";
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -199,6 +199,7 @@
   <include file="changelog/db.changelog-187-user-code-of-conduct-agreement-backfill-v2.xml"/>
   <include file="changelog/db.changelog-188-controlled-tier-training-expirable.xml"/>
   <include file="changelog/db.changelog-189-cdr-bucket-paths.xml"/>
+  <include file="changelog/db.changelog-190-billing-migration-bug-backfill.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
@@ -32,9 +32,9 @@ import org.pmiops.workbench.model.WorkspaceActiveStatus;
 public class DbWorkspace {
   /**
    * Deprecated database migration field. The column is preserved for historical reference, but
-   * forced to 2 (NEW) for all workspaces going forward.
+   * forced to 1 (NEW) for all workspaces going forward.
    */
-  public static final short BILLING_MIGRATION_NEW_STATUS = 2;
+  public static final short BILLING_MIGRATION_NEW_STATUS = 1;
 
   private short billingMigrationStatus = BILLING_MIGRATION_NEW_STATUS;
   private String firecloudUuid;


### PR DESCRIPTION
This was a very dumb typo of an enum value, introduced here: https://github.com/all-of-us/workbench/pull/6162/files#diff-10c390a509b150d607054d8ec2023fd71fb59bf9ba364376272d24275e994cdeR37

Backfill and fix the data which was created this way.

The only code path that considers this enum value is the free tier billing cron, so this was the only part of the system affected.