### PR TITLE
[RW-7863][risk=low] User should not be able to modify own's access status

### DIFF
--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -402,7 +402,7 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
   );
 };
 
-const isCurrentUser = (userProfile: Profile): boolean => {
+const isLoggedInUser = (userProfile: Profile): boolean => {
   const { profile } = profileStore.get();
   return userProfile?.username === profile?.username;
 };
@@ -428,7 +428,7 @@ const DisabledToggle = (props: {
           checked={!currentlyDisabled}
           dataTestId='user-disabled-toggle'
           onToggle={() => toggleDisabled()}
-          disabled={isCurrentUser(profile)}
+          disabled={isLoggedInUser(profile)}
         />
       </div>
     </div>
@@ -665,7 +665,7 @@ export const AdminUserProfile = (spinnerProps: WithSpinnerOverlayProps) => {
               <FlexRow>
                 <div style={styles.tableHeader}>Access status</div>
                 <TooltipTrigger
-                  disabled={!isCurrentUser(updatedProfile)}
+                  disabled={!isLoggedInUser(updatedProfile)}
                   content={'Cannot change your own Access Status'}
                 >
                   <div>

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -434,7 +434,6 @@ export const AdminUserProfile = (spinnerProps: WithSpinnerOverlayProps) => {
   const {
     config: { gsuiteDomain },
   } = useStore(serverConfigStore);
-  const { profile } = profileStore.get();
   const { usernameWithoutGsuiteDomain } = useParams<MatchParams>();
   const [oldProfile, setOldProfile] = useState<Profile>(null);
   const [updatedProfile, setUpdatedProfile] = useState<Profile>(null);
@@ -576,6 +575,7 @@ export const AdminUserProfile = (spinnerProps: WithSpinnerOverlayProps) => {
   };
 
   const isCurrentUser = (userProfile: Profile): boolean => {
+    const { profile } = profileStore.get();
     return userProfile?.userId === profile?.userId;
   };
 

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -20,6 +20,7 @@ import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow, FlexSpacer } from 'app/components/flex';
 import { CaretRight, ClrIcon } from 'app/components/icons';
 import { Toggle } from 'app/components/inputs';
+import { TooltipTrigger } from 'app/components/popups';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { isBlank, reactStyles } from 'app/utils';
@@ -29,7 +30,12 @@ import {
   checkInstitutionalEmail,
   getEmailValidationErrorMessage,
 } from 'app/utils/institutions';
-import { MatchParams, serverConfigStore, useStore } from 'app/utils/stores';
+import {
+  MatchParams,
+  profileStore,
+  serverConfigStore,
+  useStore,
+} from 'app/utils/stores';
 
 import {
   adminGetProfile,
@@ -261,9 +267,10 @@ interface CommonToggleProps {
   checked: boolean;
   dataTestId: string;
   onToggle: () => void;
+  disabled?: boolean;
 }
 const CommonToggle = (props: CommonToggleProps) => {
-  const { name, checked, dataTestId, onToggle } = props;
+  const { name, checked, dataTestId, disabled, onToggle } = props;
   return (
     <Toggle
       name={name}
@@ -273,6 +280,7 @@ const CommonToggle = (props: CommonToggleProps) => {
       style={{ paddingBottom: 0, flexGrow: 0 }}
       height={24}
       width={50}
+      disabled={disabled}
     />
   );
 };
@@ -398,8 +406,10 @@ const DisabledToggle = (props: {
   currentlyDisabled: boolean;
   previouslyDisabled: boolean;
   toggleDisabled: () => void;
+  disabled?: boolean;
 }) => {
-  const { currentlyDisabled, previouslyDisabled, toggleDisabled } = props;
+  const { currentlyDisabled, previouslyDisabled, toggleDisabled, disabled } =
+    props;
   const highlightStyle =
     currentlyDisabled !== previouslyDisabled
       ? { background: colors.highlight }
@@ -413,6 +423,7 @@ const DisabledToggle = (props: {
           checked={!currentlyDisabled}
           dataTestId='user-disabled-toggle'
           onToggle={() => toggleDisabled()}
+          disabled={disabled}
         />
       </div>
     </div>
@@ -423,6 +434,7 @@ export const AdminUserProfile = (spinnerProps: WithSpinnerOverlayProps) => {
   const {
     config: { gsuiteDomain },
   } = useStore(serverConfigStore);
+  const { profile } = profileStore.get();
   const { usernameWithoutGsuiteDomain } = useParams<MatchParams>();
   const [oldProfile, setOldProfile] = useState<Profile>(null);
   const [updatedProfile, setUpdatedProfile] = useState<Profile>(null);
@@ -563,6 +575,10 @@ export const AdminUserProfile = (spinnerProps: WithSpinnerOverlayProps) => {
     setBypassChangeRequests([...otherModuleRequests, accessBypassRequest]);
   };
 
+  const isCurrentUser = (userProfile: Profile): boolean => {
+    return userProfile?.userId === profile?.userId;
+  };
+
   const errors = validate(
     {
       contactEmail: !isBlank(updatedProfile?.contactEmail),
@@ -648,13 +664,21 @@ export const AdminUserProfile = (spinnerProps: WithSpinnerOverlayProps) => {
             <FlexColumn>
               <FlexRow>
                 <div style={styles.tableHeader}>Access status</div>
-                <DisabledToggle
-                  currentlyDisabled={updatedProfile.disabled}
-                  previouslyDisabled={oldProfile.disabled}
-                  toggleDisabled={() =>
-                    updateProfile({ disabled: !updatedProfile.disabled })
-                  }
-                />
+                <TooltipTrigger
+                  disabled={!isCurrentUser(updatedProfile)}
+                  content={'Cannot change your own Access Status'}
+                >
+                  <div>
+                    <DisabledToggle
+                      currentlyDisabled={updatedProfile.disabled}
+                      previouslyDisabled={oldProfile.disabled}
+                      toggleDisabled={() =>
+                        updateProfile({ disabled: !updatedProfile.disabled })
+                      }
+                      disabled={isCurrentUser(updatedProfile)}
+                    />
+                  </div>
+                </TooltipTrigger>
               </FlexRow>
               <AccessModuleTable
                 oldProfile={oldProfile}

--- a/ui/src/app/pages/admin/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/admin-user-profile.tsx
@@ -402,13 +402,18 @@ const AccessModuleTable = (props: AccessModuleTableProps) => {
   );
 };
 
+const isCurrentUser = (userProfile: Profile): boolean => {
+  const { profile } = profileStore.get();
+  return userProfile?.username === profile?.username;
+};
+
 const DisabledToggle = (props: {
   currentlyDisabled: boolean;
   previouslyDisabled: boolean;
+  profile: Profile;
   toggleDisabled: () => void;
-  disabled?: boolean;
 }) => {
-  const { currentlyDisabled, previouslyDisabled, toggleDisabled, disabled } =
+  const { currentlyDisabled, previouslyDisabled, profile, toggleDisabled } =
     props;
   const highlightStyle =
     currentlyDisabled !== previouslyDisabled
@@ -423,7 +428,7 @@ const DisabledToggle = (props: {
           checked={!currentlyDisabled}
           dataTestId='user-disabled-toggle'
           onToggle={() => toggleDisabled()}
-          disabled={disabled}
+          disabled={isCurrentUser(profile)}
         />
       </div>
     </div>
@@ -574,11 +579,6 @@ export const AdminUserProfile = (spinnerProps: WithSpinnerOverlayProps) => {
     setBypassChangeRequests([...otherModuleRequests, accessBypassRequest]);
   };
 
-  const isCurrentUser = (userProfile: Profile): boolean => {
-    const { profile } = profileStore.get();
-    return userProfile?.userId === profile?.userId;
-  };
-
   const errors = validate(
     {
       contactEmail: !isBlank(updatedProfile?.contactEmail),
@@ -675,7 +675,7 @@ export const AdminUserProfile = (spinnerProps: WithSpinnerOverlayProps) => {
                       toggleDisabled={() =>
                         updateProfile({ disabled: !updatedProfile.disabled })
                       }
-                      disabled={isCurrentUser(updatedProfile)}
+                      profile={updatedProfile}
                     />
                   </div>
                 </TooltipTrigger>


### PR DESCRIPTION
One option: We can just disable the access status, if admin is viewing their own user detail page.

<img width="1639" alt="Screen Shot 2022-02-18 at 1 20 56 PM" src="https://user-images.githubusercontent.com/34481816/154741050-50f5e406-9ba9-48fb-ad8d-15f5cae5b0e2.png">


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
