### PR TITLE
[risk=low][RW-7907] Add a Feature Flag to control tier visibility to users

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -97,7 +97,8 @@
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
       "lookbackPeriod": 330
-    }
+    },
+    "tiersVisibleToUsers": ["registered", "controlled"]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -97,7 +97,8 @@
       "expiryDays": 3650,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
       "lookbackPeriod": 330
-    }
+    },
+    "tiersVisibleToUsers": ["registered", "controlled"]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -97,7 +97,8 @@
       "expiryDays": 3650,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
       "lookbackPeriod": 330
-    }
+    },
+    "tiersVisibleToUsers": ["registered", "controlled"]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -97,7 +97,8 @@
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
       "lookbackPeriod": 330
-    }
+    },
+    "tiersVisibleToUsers": ["registered"]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -97,7 +97,8 @@
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
       "lookbackPeriod": 330
-    }
+    },
+    "tiersVisibleToUsers": ["registered"]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -97,7 +97,8 @@
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
       "lookbackPeriod": 330
-    }
+    },
+    "tiersVisibleToUsers": ["registered", "controlled"]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": false,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -97,7 +97,8 @@
       "expiryDays": 3650,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],
       "lookbackPeriod": 330
-    }
+    },
+    "tiersVisibleToUsers": ["registered", "controlled"]
   },
   "featureFlags": {
     "unsafeAllowDeleteUser": true,

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
@@ -12,8 +12,8 @@ public interface AccessTierService {
   String CONTROLLED_TIER_SHORT_NAME = "controlled";
 
   /**
-   * Return all access tiers in the database, in alphabetical order by shortName. To return only
-   * the tiers which are visible to users, use getAllTiersVisibleToUsers().
+   * Return all access tiers in the database, in alphabetical order by shortName. To return only the
+   * tiers which are visible to users, use getAllTiersVisibleToUsers().
    *
    * @return the List of all DbAccessTiers in the database
    */
@@ -23,16 +23,16 @@ public interface AccessTierService {
    * Return all access tiers in the database which are visible to users, in alphabetical order by
    * shortName. To return all tiers, use getAllTiers().
    *
-   * @return the List of all DbAccessTiers in the database
+   * @return the List of all DbAccessTiers in the database which are visible to users
    */
   List<DbAccessTier> getAllTiersVisibleToUsers();
 
-    /**
-     * Add memberships to all tiers for a user if they don't exist by inserting DB row(s) set to
-     * ENABLED. For any memberships which exist and are DISABLED, set them to ENABLED.
-     *
-     * @param user the DbUser in the user-accessTier mappings we're updating
-     */
+  /**
+   * Add memberships to all tiers for a user if they don't exist by inserting DB row(s) set to
+   * ENABLED. For any memberships which exist and are DISABLED, set them to ENABLED.
+   *
+   * @param user the DbUser in the user-accessTier mappings we're updating
+   */
   void addUserToAllTiers(DbUser user);
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierService.java
@@ -12,18 +12,27 @@ public interface AccessTierService {
   String CONTROLLED_TIER_SHORT_NAME = "controlled";
 
   /**
-   * Return all access tiers in the database, in alphabetical order by shortName
+   * Return all access tiers in the database, in alphabetical order by shortName. To return only
+   * the tiers which are visible to users, use getAllTiersVisibleToUsers().
    *
    * @return the List of all DbAccessTiers in the database
    */
   List<DbAccessTier> getAllTiers();
 
   /**
-   * Add memberships to all tiers for a user if they don't exist by inserting DB row(s) set to
-   * ENABLED. For any memberships which exist and are DISABLED, set them to ENABLED.
+   * Return all access tiers in the database which are visible to users, in alphabetical order by
+   * shortName. To return all tiers, use getAllTiers().
    *
-   * @param user the DbUser in the user-accessTier mappings we're updating
+   * @return the List of all DbAccessTiers in the database
    */
+  List<DbAccessTier> getAllTiersVisibleToUsers();
+
+    /**
+     * Add memberships to all tiers for a user if they don't exist by inserting DB row(s) set to
+     * ENABLED. For any memberships which exist and are DISABLED, set them to ENABLED.
+     *
+     * @param user the DbUser in the user-accessTier mappings we're updating
+     */
   void addUserToAllTiers(DbUser user);
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
@@ -47,8 +47,8 @@ public class AccessTierServiceImpl implements AccessTierService {
   }
 
   /**
-   * Return all access tiers in the database, in alphabetical order by shortName. To return only
-   * the tiers which are visible to users, use getAllTiersVisibleToUsers().
+   * Return all access tiers in the database, in alphabetical order by shortName. To return only the
+   * tiers which are visible to users, use getAllTiersVisibleToUsers().
    *
    * @return the List of all DbAccessTiers in the database
    */
@@ -63,7 +63,7 @@ public class AccessTierServiceImpl implements AccessTierService {
    * Return all access tiers in the database which are visible to users, in alphabetical order by
    * shortName. To return all tiers, use getAllTiers().
    *
-   * @return the List of all DbAccessTiers in the database
+   * @return the List of all DbAccessTiers in the database which are visible to users
    */
   @Override
   public List<DbAccessTier> getAllTiersVisibleToUsers() {

--- a/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessTierServiceImpl.java
@@ -47,13 +47,29 @@ public class AccessTierServiceImpl implements AccessTierService {
   }
 
   /**
-   * Return all access tiers in the database, in alphabetical order by shortName
+   * Return all access tiers in the database, in alphabetical order by shortName. To return only
+   * the tiers which are visible to users, use getAllTiersVisibleToUsers().
    *
    * @return the List of all DbAccessTiers in the database
    */
   @Override
   public List<DbAccessTier> getAllTiers() {
     return accessTierDao.findAll().stream()
+        .sorted(Comparator.comparing(DbAccessTier::getShortName))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Return all access tiers in the database which are visible to users, in alphabetical order by
+   * shortName. To return all tiers, use getAllTiers().
+   *
+   * @return the List of all DbAccessTiers in the database
+   */
+  @Override
+  public List<DbAccessTier> getAllTiersVisibleToUsers() {
+    return accessTierDao.findAll().stream()
+        .filter(
+            tier -> configProvider.get().access.tiersVisibleToUsers.contains(tier.getShortName()))
         .sorted(Comparator.comparing(DbAccessTier::getShortName))
         .collect(Collectors.toList());
   }

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionService.java
@@ -89,7 +89,7 @@ public class CdrVersionService {
 
     return new CdrVersionTiersResponse()
         .tiers(
-            accessTierService.getAllTiers().stream()
+            accessTierService.getAllTiersVisibleToUsers().stream()
                 .map(this::getVersionsForTier)
                 .collect(Collectors.toList()));
   }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -232,6 +232,10 @@ public class WorkbenchConfig {
     }
 
     public Renewal renewal;
+
+    // which Access Tiers are visible to users?  This is intended to allow Institution Admins to
+    // configure CT institutions before CT launch, and can likely be removed after that time.
+    public List<String> tiersVisibleToUsers;
   }
 
   public static class FeatureFlagsConfig {

--- a/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
@@ -103,7 +103,7 @@ public class AccessTierServiceTest {
   @Test
   public void test_getAllTiersVisibleToUsers_RTnotCT() {
     final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
-    final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    TestMockFactory.createControlledTierForTests(accessTierDao);
 
     config.access.tiersVisibleToUsers = Collections.singletonList(registeredTier.getShortName());
 

--- a/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
@@ -3,10 +3,12 @@ package org.pmiops.workbench.access;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -89,6 +91,34 @@ public class AccessTierServiceTest {
     final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
 
     assertThat(accessTierService.getAllTiers())
+        .containsExactly(controlledTier, registeredTier)
+        .inOrder(); // enforce a consistent ordering: alphabetical by shortName
+  }
+
+  @Test
+  public void test_getAllTiersVisibleToUsers_empty() {
+    assertThat(accessTierService.getAllTiersVisibleToUsers()).isEmpty();
+  }
+
+  @Test
+  public void test_getAllTiersVisibleToUsers_RTnotCT() {
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+
+    config.access.tiersVisibleToUsers = Collections.singletonList(registeredTier.getShortName());
+
+    assertThat(accessTierService.getAllTiersVisibleToUsers()).containsExactly(registeredTier);
+  }
+
+  @Test
+  public void test_getAllTiersVisibleToUsers_RTandCT() {
+    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+
+    config.access.tiersVisibleToUsers =
+        ImmutableList.of(registeredTier.getShortName(), controlledTier.getShortName());
+
+    assertThat(accessTierService.getAllTiersVisibleToUsers())
         .containsExactly(controlledTier, registeredTier)
         .inOrder(); // enforce a consistent ordering: alphabetical by shortName
   }


### PR DESCRIPTION
This is one of a series of PRs to help with Controlled Tier rollout.

Adding CT configurations to Institutions requires a CT DB entity. We can't currently construct one in Prod (and Stable) because (a) we do not have a CDR to populate, and UpdateCDRConfig requires one to add a tier DB entity and (b) there may be a risk of users becoming aware of the CT before we are ready to launch. **This PR partially addresses (b)**.  (a) is covered by #6355 and (b) is completed by https://github.com/all-of-us/workbench/pull/6354

Add a Feature Flag to restrict `getCdrVersionsByTier()` to only those tiers which we choose to show the users, instead of all tiers.  This also prevents errors related to tiers without CDRs (see #6355)

Local testing:
* add a new tier and observe that it does not appear in `getCdrVersionsByTier()`
* add a new tier without CDRs (using #6355) and observe that the UI is fully functional

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
