### PR TITLE
[risk=low][RW-7907] Use API accessTiersVisibleToUsers in UI

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -72,5 +72,6 @@ public interface WorkbenchConfigMapper {
   @Mapping(target = "rasClientId", source = "config.ras.clientId")
   @Mapping(target = "rasLogoutUrl", source = "config.ras.logoutUrl")
   @Mapping(target = "freeTierBillingAccountId", source = "config.billing.accountId")
+  @Mapping(target = "accessTiersVisibleToUsers", source = "config.access.tiersVisibleToUsers")
   ConfigResponse toModel(WorkbenchConfig config, List<DbAccessModule> accessModules);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4344,6 +4344,11 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/AccessModuleConfig"
+      accessTiersVisibleToUsers:
+        type: array
+        description: The shortnames of the access tiers which are visible to users in this environment.
+        items:
+          type: string
   RuntimeImage:
     type: object
     properties:

--- a/ui/src/app/components/ct-available-banner-maybe.spec.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.spec.tsx
@@ -4,7 +4,6 @@ import { mount } from 'enzyme';
 
 import { CdrVersionTier, Profile, UserTierEligibility } from 'generated/fetch';
 
-import { environment } from 'environments/environment';
 import { AccessTierShortNames } from 'app/utils/access-tiers';
 import { DATA_ACCESS_REQUIREMENTS_PATH } from 'app/utils/access-utils';
 import { cdrVersionStore, profileStore } from 'app/utils/stores';
@@ -12,6 +11,7 @@ import { cdrVersionStore, profileStore } from 'app/utils/stores';
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { cdrVersionTiersResponse } from 'testing/stubs/cdr-versions-api-stub';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
+import { updateVisibleTiers } from 'testing/test-utils';
 
 import { CTAvailableBannerMaybe } from './ct-available-banner-maybe';
 
@@ -63,10 +63,10 @@ describe('CTAvailableBannerMaybe', () => {
 
   const fulfillAllBannerRequirements = () => {
     // the environment allows users to see the CT (in the UI)
-    environment.accessTiersVisibleToUsers = [
+    updateVisibleTiers([
       AccessTierShortNames.Registered,
       AccessTierShortNames.Controlled,
-    ];
+    ]);
 
     // the user is eligible for the CT
     const newTierEligibilities: UserTierEligibility[] = [
@@ -121,7 +121,7 @@ describe('CTAvailableBannerMaybe', () => {
   });
 
   const ctNotVisible = () => {
-    environment.accessTiersVisibleToUsers = [AccessTierShortNames.Registered];
+    updateVisibleTiers([AccessTierShortNames.Registered]);
   };
   const userIneligible = () => {
     const newTierEligibilities: UserTierEligibility[] = [

--- a/ui/src/app/components/ct-available-banner-maybe.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.tsx
@@ -38,7 +38,7 @@ const shouldShowBanner = (
   const shouldShow =
     profile &&
     ctCdrVersions &&
-    // the environment allows users to see the CT (in the UI)
+    // the environment allows users to see the CT
     accessTiersVisibleToUsers.includes(AccessTierShortNames.Controlled) &&
     // the user is eligible for the CT
     eligibleForTier(profile, AccessTierShortNames.Controlled) &&

--- a/ui/src/app/components/ct-available-banner-maybe.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.tsx
@@ -30,14 +30,14 @@ const shouldShowBanner = (
   cdrVersionTiers: CdrVersionTier[],
   accessTiersVisibleToUsers: string[]
 ) => {
-  const ct = cdrVersionTiers?.find(
+  const ctCdrVersions = cdrVersionTiers?.find(
     (v) => v.accessTierShortName === AccessTierShortNames.Controlled
   );
 
   // all of the following must be true
   const shouldShow =
     profile &&
-    ct &&
+    ctCdrVersions &&
     // the environment allows users to see the CT (in the UI)
     accessTiersVisibleToUsers.includes(AccessTierShortNames.Controlled) &&
     // the user is eligible for the CT
@@ -45,7 +45,7 @@ const shouldShowBanner = (
     // the user does not currently have CT access
     !profile.accessTierShortNames.includes(AccessTierShortNames.Controlled) &&
     // the user's first sign-in time was before the release of the default CT CDR Version
-    profile.firstSignInTime < ct.defaultCdrVersionCreationTime &&
+    profile.firstSignInTime < ctCdrVersions.defaultCdrVersionCreationTime &&
     // the user is not currently visiting the DAR page
     window.location.pathname !== DATA_ACCESS_REQUIREMENTS_PATH;
 

--- a/ui/src/app/components/ct-available-banner-maybe.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 
 import { CdrVersionTier, Profile } from 'generated/fetch';
 
-import { environment } from 'environments/environment';
 import {
   AccessTierDisplayNames,
   AccessTierShortNames,
@@ -13,7 +12,12 @@ import {
   eligibleForTier,
 } from 'app/utils/access-utils';
 import { cookiesEnabled } from 'app/utils/cookies';
-import { cdrVersionStore, profileStore, useStore } from 'app/utils/stores';
+import {
+  cdrVersionStore,
+  profileStore,
+  serverConfigStore,
+  useStore,
+} from 'app/utils/stores';
 
 import { StyledRouterLink } from './buttons';
 import { AoU } from './text-wrappers';
@@ -23,7 +27,8 @@ const CT_COOKIE_KEY = 'controlled-tier-available';
 
 const shouldShowBanner = (
   profile: Profile,
-  cdrVersionTiers: CdrVersionTier[]
+  cdrVersionTiers: CdrVersionTier[],
+  accessTiersVisibleToUsers: string[]
 ) => {
   const ct = cdrVersionTiers?.find(
     (v) => v.accessTierShortName === AccessTierShortNames.Controlled
@@ -34,9 +39,7 @@ const shouldShowBanner = (
     profile &&
     ct &&
     // the environment allows users to see the CT (in the UI)
-    environment.accessTiersVisibleToUsers.includes(
-      AccessTierShortNames.Controlled
-    ) &&
+    accessTiersVisibleToUsers.includes(AccessTierShortNames.Controlled) &&
     // the user is eligible for the CT
     eligibleForTier(profile, AccessTierShortNames.Controlled) &&
     // the user does not currently have CT access
@@ -58,9 +61,15 @@ export const CTAvailableBannerMaybe = () => {
   const [showBanner, setShowBanner] = useState(false);
   const { profile } = useStore(profileStore);
   const { tiers } = useStore(cdrVersionStore);
+  const {
+    config: { accessTiersVisibleToUsers },
+  } = useStore(serverConfigStore);
 
   useEffect(
-    () => setShowBanner(shouldShowBanner(profile, tiers)),
+    () =>
+      setShowBanner(
+        shouldShowBanner(profile, tiers, accessTiersVisibleToUsers)
+      ),
     [profile, tiers]
   );
 

--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -9,7 +9,6 @@ import {
   ProfileApi,
 } from 'generated/fetch';
 
-import { environment } from 'environments/environment';
 import {
   profileApi,
   registerApiClient,
@@ -27,6 +26,7 @@ import {
   ProfileApiStub,
   ProfileStubVariables,
 } from 'testing/stubs/profile-api-stub';
+import { updateVisibleTiers } from 'testing/test-utils';
 
 import {
   allModules,
@@ -915,10 +915,10 @@ describe('DataAccessRequirements', () => {
   });
 
   it('Should display the CT card when the environment has a Controlled Tier', async () => {
-    environment.accessTiersVisibleToUsers = [
+    updateVisibleTiers([
       AccessTierShortNames.Registered,
       AccessTierShortNames.Controlled,
-    ];
+    ]);
 
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
@@ -926,7 +926,7 @@ describe('DataAccessRequirements', () => {
   });
 
   it('Should not display the CT card when the environment does not have a Controlled Tier', async () => {
-    environment.accessTiersVisibleToUsers = [AccessTierShortNames.Registered];
+    updateVisibleTiers([AccessTierShortNames.Registered]);
 
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
@@ -937,10 +937,10 @@ describe('DataAccessRequirements', () => {
     'Should display eraCommons module in CT card ' +
       'when the user institution has signed agreement and CT requires eraCommons and RT does not',
     async () => {
-      environment.accessTiersVisibleToUsers = [
+      updateVisibleTiers([
         AccessTierShortNames.Registered,
         AccessTierShortNames.Controlled,
-      ];
+      ]);
       let wrapper = component();
       await waitOneTickAndUpdate(wrapper);
 

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -4,7 +4,6 @@ import * as fp from 'lodash/fp';
 
 import { AccessModule, AccessModuleStatus, Profile } from 'generated/fetch';
 
-import { environment } from 'environments/environment';
 import { useQuery } from 'app/components/app-router';
 import { Button, Clickable } from 'app/components/buttons';
 import { FadeBox } from 'app/components/containers';
@@ -1024,7 +1023,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
   (spinnerProps: WithSpinnerOverlayProps) => {
     const { profile, reload } = useStore(profileStore);
     const {
-      config: { unsafeAllowSelfBypass },
+      config: { unsafeAllowSelfBypass, accessTiersVisibleToUsers },
     } = useStore(serverConfigStore);
 
     useEffect(() => {
@@ -1078,7 +1077,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
       );
     }, [nextActive, nextRequired]);
 
-    const showCtCard = environment.accessTiersVisibleToUsers.includes(
+    const showCtCard = accessTiersVisibleToUsers.includes(
       AccessTierShortNames.Controlled
     );
 

--- a/ui/src/app/pages/profile/data-access-panel.spec.tsx
+++ b/ui/src/app/pages/profile/data-access-panel.spec.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { mount } from 'enzyme';
 
-import { environment } from 'environments/environment';
 import {
   DataAccessPanel,
   DataAccessPanelProps,
@@ -11,6 +10,7 @@ import { AccessTierShortNames } from 'app/utils/access-tiers';
 import { cdrVersionStore } from 'app/utils/stores';
 
 import { cdrVersionTiersResponse } from 'testing/stubs/cdr-versions-api-stub';
+import { updateVisibleTiers } from 'testing/test-utils';
 
 const findRTGranted = (wrapper) =>
   wrapper.find('[data-test-id="registered-tier-access-granted"]');
@@ -48,10 +48,10 @@ describe('Data Access Panel', () => {
 
   beforeEach(() => {
     cdrVersionStore.set(cdrVersionTiersResponse);
-    environment.accessTiersVisibleToUsers = [
+    updateVisibleTiers([
       AccessTierShortNames.Registered,
       AccessTierShortNames.Controlled,
-    ];
+    ]);
   });
 
   it('Should show success status for registered tier when the user has access', async () => {
@@ -77,14 +77,14 @@ describe('Data Access Panel', () => {
   });
 
   it('Should only show the registered tier in environments without a controlled tier (user has access)', async () => {
-    environment.accessTiersVisibleToUsers = [AccessTierShortNames.Registered];
+    updateVisibleTiers([AccessTierShortNames.Registered]);
 
     const wrapper = component({ userAccessTiers: ['registered'] });
     expectAccessStatusRtOnly(wrapper, true);
   });
 
   it('Should only show the registered tier in environments without a controlled tier (user does not have access)', async () => {
-    environment.accessTiersVisibleToUsers = [AccessTierShortNames.Registered];
+    updateVisibleTiers([AccessTierShortNames.Registered]);
 
     const wrapper = component({ userAccessTiers: [] });
     expectAccessStatusRtOnly(wrapper, false);

--- a/ui/src/app/pages/profile/data-access-panel.tsx
+++ b/ui/src/app/pages/profile/data-access-panel.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 
-import { environment } from 'environments/environment';
 import { FlexRow } from 'app/components/flex';
 import {
   CheckCircle,
@@ -17,16 +16,20 @@ import {
   orderedAccessTierShortNames,
 } from 'app/utils/access-tiers';
 import { DATA_ACCESS_REQUIREMENTS_PATH } from 'app/utils/access-utils';
+import { serverConfigStore, useStore } from 'app/utils/stores';
 
 interface TierProps {
   shortName: string;
   userHasAccess: boolean;
 }
 const Tier = (props: TierProps) => {
+  const {
+    config: { accessTiersVisibleToUsers },
+  } = useStore(serverConfigStore);
   const { shortName, userHasAccess } = props;
   const displayName = displayNameForTier(shortName);
 
-  return environment.accessTiersVisibleToUsers.includes(shortName) ? (
+  return accessTiersVisibleToUsers.includes(shortName) ? (
     <div style={styles.dataAccessTier}>
       {shortName === AccessTierShortNames.Registered ? (
         <RegisteredTierBadge style={{ gridArea: 'badge' }} />

--- a/ui/src/app/pages/profile/profile-component.spec.tsx
+++ b/ui/src/app/pages/profile/profile-component.spec.tsx
@@ -9,6 +9,7 @@ import { ProfileComponent } from 'app/pages/profile/profile-component';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { profileStore, serverConfigStore } from 'app/utils/stores';
 
+import defaultServerConfig from 'testing/default-server-config';
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { InstitutionApiStub } from 'testing/stubs/institution-api-stub';
 import { ProfileApiStub } from 'testing/stubs/profile-api-stub';
@@ -57,6 +58,7 @@ describe('ProfilePageComponent', () => {
 
     serverConfigStore.set({
       config: {
+        ...defaultServerConfig,
         gsuiteDomain: 'fake-research-aou.org',
         projectId: 'aaa',
         publicApiKeyForErrorReports: 'aaa',

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -15,7 +15,6 @@ import {
   WorkspacesApi,
 } from 'generated/fetch';
 
-import { environment } from 'environments/environment';
 import {
   WorkspaceEdit,
   WorkspaceEditMode,
@@ -32,6 +31,7 @@ import {
 } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
+import defaultServerConfig from 'testing/default-server-config';
 import {
   simulateSelection,
   waitOneTickAndUpdate,
@@ -50,6 +50,7 @@ import {
 import { UserApiStub } from 'testing/stubs/user-api-stub';
 import { workspaceStubs } from 'testing/stubs/workspaces';
 import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
+import { updateVisibleTiers } from 'testing/test-utils';
 
 type AnyWrapper = ShallowWrapper | ReactWrapper;
 
@@ -144,6 +145,7 @@ describe('WorkspaceEdit', () => {
     cdrVersionStore.set(cdrVersionTiersResponse);
     serverConfigStore.set({
       config: {
+        ...defaultServerConfig,
         freeTierBillingAccountId: 'freetier',
         defaultFreeCreditsDollarLimit: 100.0,
         gsuiteDomain: '',
@@ -467,7 +469,7 @@ describe('WorkspaceEdit', () => {
   });
 
   it('does not display the access tier dropdown when multiple tiers are not available', async () => {
-    environment.accessTiersVisibleToUsers = [AccessTierShortNames.Registered];
+    updateVisibleTiers([AccessTierShortNames.Registered]);
 
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
@@ -485,7 +487,7 @@ describe('WorkspaceEdit', () => {
         AccessTierShortNames.Registered,
         AccessTierShortNames.Controlled,
       ];
-      environment.accessTiersVisibleToUsers = twoTiers;
+      updateVisibleTiers(twoTiers);
       workspaceEditMode = WorkspaceEditMode.Create;
       profileStore.set({
         ...profileStore.get(),
@@ -546,10 +548,10 @@ describe('WorkspaceEdit', () => {
     'enables the access tier selection dropdown on creation when multiple tiers are present' +
       ' but prevents selection when the user does not have access',
     async () => {
-      environment.accessTiersVisibleToUsers = [
+      updateVisibleTiers([
         AccessTierShortNames.Registered,
         AccessTierShortNames.Controlled,
-      ];
+      ]);
       workspaceEditMode = WorkspaceEditMode.Create;
       profileStore.set({
         ...profileStore.get(),

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -17,7 +17,6 @@ import {
   WorkspaceAccessLevel,
 } from 'generated/fetch';
 
-import { environment } from 'environments/environment';
 import { Button, LinkButton, StyledExternalLink } from 'app/components/buttons';
 import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow } from 'app/components/flex';
@@ -1319,7 +1318,9 @@ export const WorkspaceEdit = fp.flow(
 
     // show the Access Tiers selection dropdown only when there are multiple tiers to choose from
     enableAccessTierSelection(): boolean {
-      return environment.accessTiersVisibleToUsers.length > 1;
+      return (
+        serverConfigStore.get().config.accessTiersVisibleToUsers.length > 1
+      );
     }
 
     onAccessTierChange(
@@ -1482,13 +1483,15 @@ export const WorkspaceEdit = fp.flow(
                           }
                           disabled={!this.isMode(WorkspaceEditMode.Create)}
                         >
-                          {environment.accessTiersVisibleToUsers.map(
-                            (shortName) => (
-                              <option key={shortName} value={shortName}>
-                                {displayNameForTier(shortName)}
-                              </option>
-                            )
-                          )}
+                          {serverConfigStore
+                            .get()
+                            .config.accessTiersVisibleToUsers.map(
+                              (shortName) => (
+                                <option key={shortName} value={shortName}>
+                                  {displayNameForTier(shortName)}
+                                </option>
+                              )
+                            )}
                         </select>
                       </div>
                     </TooltipTrigger>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1318,9 +1318,11 @@ export const WorkspaceEdit = fp.flow(
 
     // show the Access Tiers selection dropdown only when there are multiple tiers to choose from
     enableAccessTierSelection(): boolean {
-      return (
-        serverConfigStore.get().config.accessTiersVisibleToUsers.length > 1
-      );
+      const {
+        config: { accessTiersVisibleToUsers },
+      } = serverConfigStore.get();
+
+      return accessTiersVisibleToUsers.length > 1;
     }
 
     onAccessTierChange(
@@ -1349,6 +1351,9 @@ export const WorkspaceEdit = fp.flow(
     }
 
     render() {
+      const {
+        config: { accessTiersVisibleToUsers },
+      } = serverConfigStore.get();
       const {
         workspace: {
           name,
@@ -1483,15 +1488,11 @@ export const WorkspaceEdit = fp.flow(
                           }
                           disabled={!this.isMode(WorkspaceEditMode.Create)}
                         >
-                          {serverConfigStore
-                            .get()
-                            .config.accessTiersVisibleToUsers.map(
-                              (shortName) => (
-                                <option key={shortName} value={shortName}>
-                                  {displayNameForTier(shortName)}
-                                </option>
-                              )
-                            )}
+                          {accessTiersVisibleToUsers.map((shortName) => (
+                            <option key={shortName} value={shortName}>
+                              {displayNameForTier(shortName)}
+                            </option>
+                          ))}
                         </select>
                       </div>
                     </TooltipTrigger>

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -6,13 +6,6 @@ export enum ZendeskEnv {
   Sandbox = 'sandbox',
 }
 
-// A copy of utils/access-tiers.tsx AccessTierShortNames, so there's no circular dependency.
-// TODO: remove this after accessTiersVisibleToUsers is removed
-export enum EnvAccessTierShortNames {
-  Registered = 'registered',
-  Controlled = 'controlled',
-}
-
 export interface EnvironmentBase {
   // Permanent environment variables.
   //
@@ -72,9 +65,6 @@ export interface EnvironmentBase {
   //
   // The UI environment config should be restricted to truly UI-specific environment variables, such
   // as server API endpoints and client IDs.
-
-  // which access tiers do we expose to the users via the UI?  likely temporary - until CT is fully rolled out
-  accessTiersVisibleToUsers: string[];
 }
 
 export interface Environment extends EnvironmentBase {

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -1,8 +1,4 @@
-import {
-  EnvAccessTierShortNames,
-  Environment,
-  ZendeskEnv,
-} from 'environments/environment-type';
+import { Environment, ZendeskEnv } from 'environments/environment-type';
 import { testEnvironmentBase } from 'environments/test-env-base';
 
 // This file is used for a local UI server pointed at a local API server
@@ -26,8 +22,4 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  accessTiersVisibleToUsers: [
-    EnvAccessTierShortNames.Registered,
-    EnvAccessTierShortNames.Controlled,
-  ],
 };

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -1,8 +1,4 @@
-import {
-  EnvAccessTierShortNames,
-  Environment,
-  ZendeskEnv,
-} from 'environments/environment-type';
+import { Environment, ZendeskEnv } from 'environments/environment-type';
 
 export const environment: Environment = {
   displayTag: 'Perf',
@@ -26,8 +22,4 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  accessTiersVisibleToUsers: [
-    EnvAccessTierShortNames.Registered,
-    EnvAccessTierShortNames.Controlled,
-  ],
 };

--- a/ui/src/environments/environment.preprod.ts
+++ b/ui/src/environments/environment.preprod.ts
@@ -1,8 +1,4 @@
-import {
-  EnvAccessTierShortNames,
-  Environment,
-  ZendeskEnv,
-} from 'environments/environment-type';
+import { Environment, ZendeskEnv } from 'environments/environment-type';
 
 export const environment: Environment = {
   displayTag: 'preprod',
@@ -25,8 +21,4 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  accessTiersVisibleToUsers: [
-    EnvAccessTierShortNames.Registered,
-    EnvAccessTierShortNames.Controlled,
-  ],
 };

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,8 +1,4 @@
-import {
-  EnvAccessTierShortNames,
-  Environment,
-  ZendeskEnv,
-} from 'environments/environment-type';
+import { Environment, ZendeskEnv } from 'environments/environment-type';
 
 export const environment: Environment = {
   displayTag: '',
@@ -25,5 +21,4 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  accessTiersVisibleToUsers: [EnvAccessTierShortNames.Registered],
 };

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -1,8 +1,4 @@
-import {
-  EnvAccessTierShortNames,
-  Environment,
-  ZendeskEnv,
-} from 'environments/environment-type';
+import { Environment, ZendeskEnv } from 'environments/environment-type';
 
 export const environment: Environment = {
   displayTag: 'Stable',
@@ -25,5 +21,4 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  accessTiersVisibleToUsers: [EnvAccessTierShortNames.Registered],
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -1,8 +1,4 @@
-import {
-  EnvAccessTierShortNames,
-  Environment,
-  ZendeskEnv,
-} from 'environments/environment-type';
+import { Environment, ZendeskEnv } from 'environments/environment-type';
 
 export const environment: Environment = {
   displayTag: 'Staging',
@@ -25,8 +21,4 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  accessTiersVisibleToUsers: [
-    EnvAccessTierShortNames.Registered,
-    EnvAccessTierShortNames.Controlled,
-  ],
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -1,4 +1,3 @@
-import { EnvAccessTierShortNames } from 'environments/environment-type';
 import { EnvironmentBase, ZendeskEnv } from 'environments/environment-type';
 
 // The values are shared across the deployed test env as well as the local dev
@@ -26,8 +25,4 @@ export const testEnvironmentBase: EnvironmentBase = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  accessTiersVisibleToUsers: [
-    EnvAccessTierShortNames.Registered,
-    EnvAccessTierShortNames.Controlled,
-  ],
 };

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -4,6 +4,8 @@ import {
   ConfigResponse,
 } from 'generated/fetch/api';
 
+import { AccessTierShortNames } from 'app/utils/access-tiers';
+
 const defaultAccessModuleConfig: AccessModuleConfig[] = [
   {
     name: AccessModule.TWOFACTORAUTH,
@@ -81,6 +83,10 @@ const defaultServerConfig: ConfigResponse = {
   accessRenewalLookback: 330,
   freeTierBillingAccountId: 'freetier',
   accessModules: defaultAccessModuleConfig,
+  accessTiersVisibleToUsers: [
+    AccessTierShortNames.Registered,
+    AccessTierShortNames.Controlled,
+  ],
 };
 
 export default defaultServerConfig;

--- a/ui/src/testing/test-utils.ts
+++ b/ui/src/testing/test-utils.ts
@@ -1,0 +1,10 @@
+import { serverConfigStore } from 'app/utils/stores';
+
+export const updateVisibleTiers = (tiers: string[]) => {
+  serverConfigStore.set({
+    config: {
+      ...serverConfigStore.get().config,
+      accessTiersVisibleToUsers: tiers,
+    },
+  });
+};


### PR DESCRIPTION
This is one of a series of PRs to help with Controlled Tier rollout.

Adding CT configurations to Institutions requires a CT DB entity. We can't currently construct one in Prod (and Stable) because (a) we do not have a CDR to populate, and UpdateCDRConfig requires one to add a tier DB entity and (b) there may be a risk of users becoming aware of the CT before we are ready to launch. (a) is covered by https://github.com/all-of-us/workbench/pull/6355 and **(b) is covered by this PR** and https://github.com/all-of-us/workbench/pull/6353

Tested locally in combination with #6355 - in an env where CT exists but is not visible to users, users cannot see it:
* Profile
* DAR
* Annual Renewal
* Create Workspace
* Get CDR Versions (API call)


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
