### PR TITLE
[risk=low][RW-7907]Modify UpdateCDRConfig to allow empty access tiers, with a flag

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2368,10 +2368,11 @@ def update_cdr_config_options(cmd_name, args)
       "--dry_run",
       ->(opts, _) { opts.dry_run = "true"},
       "Make no changes.")
+  # RW-7931 consider removing this option after Controlled Tier is fully rolled out
   op.opts.allow_empty_tiers = false
   op.add_option(
       "--allow_empty_tiers",
-      ->(opts, _) { opts.allow_empty_tiers = "true"},
+      ->(opts, _) { opts.allow_empty_tiers = "false"},
       "Allow access tiers to be empty (no CDR versions).")
   return op
 end
@@ -2406,7 +2407,10 @@ def update_cdr_config_local(cmd_name, *args)
   op = update_cdr_config_options(cmd_name, args)
   op.parse.validate
   cdr_config_file = 'config/cdr_config_local.json'
-  app_args = ["-PappArgs=['" + cdr_config_file + "',false,true]"]
+  dry_run = false
+  # RW-7931 consider switching to false or removal of this option after CT rollout is complete
+  allow_empty_tiers = true
+  app_args = ["-PappArgs=['#{cdr_config_file}',#{dry_run},#{allow_empty_tiers}]"]
   common = Common.new
   common.run_inline %W{./gradlew updateCdrConfig} + app_args
 end
@@ -2764,6 +2768,11 @@ def deploy(cmd_name, args)
     ->(opts, _) { opts.promote = false},
     "Deploy, but do not yet serve traffic from this version - DB migrations are still applied"
   )
+  op.opts.allow_empty_tiers = false
+    op.add_option(
+        "--allow_empty_tiers",
+        ->(opts, _) { opts.allow_empty_tiers = "false"},
+        "Allow access tiers to be empty (no CDR versions).")
   op.add_validator ->(opts) { raise ArgumentError if opts.promote.nil?}
 
   gcc = GcloudContextV2.new(op)
@@ -2776,7 +2785,7 @@ def deploy(cmd_name, args)
     migrate_database(op.opts.dry_run)
     load_config(ctx.project, op.opts.dry_run)
     cdr_config_file = must_get_env_value(gcc.project, :cdr_config_json)
-    update_cdr_config_for_project("config/#{cdr_config_file}", op.opts.dry_run, false)
+    update_cdr_config_for_project("config/#{cdr_config_file}", op.opts.dry_run, op.opts.allow_empty_tiers)
 
     # Keep the cloud proxy context open for the service account credentials.
     dry_flag = op.opts.dry_run ? %W{--dry-run} : []

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2372,7 +2372,7 @@ def update_cdr_config_options(cmd_name, args)
   op.opts.allow_empty_tiers = false
   op.add_option(
       "--allow_empty_tiers",
-      ->(opts, _) { opts.allow_empty_tiers = "false"},
+      ->(opts, _) { opts.allow_empty_tiers = "true"},
       "Allow access tiers to be empty (no CDR versions).")
   return op
 end
@@ -2771,7 +2771,7 @@ def deploy(cmd_name, args)
   op.opts.allow_empty_tiers = false
     op.add_option(
         "--allow_empty_tiers",
-        ->(opts, _) { opts.allow_empty_tiers = "false"},
+        ->(opts, _) { opts.allow_empty_tiers = "true"},
         "Allow access tiers to be empty (no CDR versions).")
   op.add_validator ->(opts) { raise ArgumentError if opts.promote.nil?}
 

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2368,14 +2368,19 @@ def update_cdr_config_options(cmd_name, args)
       "--dry_run",
       ->(opts, _) { opts.dry_run = "true"},
       "Make no changes.")
+  op.opts.allow_empty_tiers = false
+  op.add_option(
+      "--allow_empty_tiers",
+      ->(opts, _) { opts.allow_empty_tiers = "true"},
+      "Allow access tiers to be empty (no CDR versions).")
   return op
 end
 
-def update_cdr_config_for_project(cdr_config_file, dry_run)
+def update_cdr_config_for_project(cdr_config_file, dry_run, allow_empty_tiers)
   common = Common.new
   common.run_inline %W{
     ./gradlew updateCdrConfig
-   -PappArgs=['#{cdr_config_file}',#{dry_run}]}
+   -PappArgs=['#{cdr_config_file}',#{dry_run},#{allow_empty_tiers}]}
 end
 
 def update_cdr_config(cmd_name, *args)
@@ -2386,7 +2391,7 @@ def update_cdr_config(cmd_name, *args)
 
   with_cloud_proxy_and_db(gcc) do
     cdr_config_file = must_get_env_value(gcc.project, :cdr_config_json)
-    update_cdr_config_for_project("config/#{cdr_config_file}", op.opts.dry_run)
+    update_cdr_config_for_project("config/#{cdr_config_file}", op.opts.dry_run, op.opts.allow_empty_tiers)
   end
 end
 
@@ -2401,7 +2406,7 @@ def update_cdr_config_local(cmd_name, *args)
   op = update_cdr_config_options(cmd_name, args)
   op.parse.validate
   cdr_config_file = 'config/cdr_config_local.json'
-  app_args = ["-PappArgs=['" + cdr_config_file + "',false]"]
+  app_args = ["-PappArgs=['" + cdr_config_file + "',false,true]"]
   common = Common.new
   common.run_inline %W{./gradlew updateCdrConfig} + app_args
 end
@@ -2771,7 +2776,7 @@ def deploy(cmd_name, args)
     migrate_database(op.opts.dry_run)
     load_config(ctx.project, op.opts.dry_run)
     cdr_config_file = must_get_env_value(gcc.project, :cdr_config_json)
-    update_cdr_config_for_project("config/#{cdr_config_file}", op.opts.dry_run)
+    update_cdr_config_for_project("config/#{cdr_config_file}", op.opts.dry_run, false)
 
     # Keep the cloud proxy context open for the service account credentials.
     dry_flag = op.opts.dry_run ? %W{--dry-run} : []

--- a/api/libproject/load_local_data_and_configs.sh
+++ b/api/libproject/load_local_data_and_configs.sh
@@ -11,7 +11,7 @@ set -e
 # These commands should be kept in sync with the associated deployment commands, which can be
 # found under the "deploy" command in api/libproject/devstart.rb .
 
-./gradlew --daemon updateCdrConfig -PappArgs="['config/cdr_config_local.json',false]"
+./gradlew --daemon updateCdrConfig -PappArgs="['config/cdr_config_local.json',false,true]"
 ./gradlew --daemon loadConfig -Pconfig_key=main -Pconfig_file=config/config_local.json
 ./gradlew --daemon loadConfig -Pconfig_key=cdrBigQuerySchema -Pconfig_file=config/cdm/cdm_5_2.json
 ./gradlew --daemon loadConfig -Pconfig_key=featuredWorkspaces -Pconfig_file=config/featured_workspaces_local.json

--- a/api/libproject/load_local_data_and_configs.sh
+++ b/api/libproject/load_local_data_and_configs.sh
@@ -11,7 +11,11 @@ set -e
 # These commands should be kept in sync with the associated deployment commands, which can be
 # found under the "deploy" command in api/libproject/devstart.rb .
 
-./gradlew --daemon updateCdrConfig -PappArgs="['config/cdr_config_local.json',false,true]"
+DRY_RUN=false
+# RW-7931 consider switching to false or removal of this option after CT rollout is complete
+ALLOW_EMPTY_TIER=true
+./gradlew --daemon updateCdrConfig -PappArgs="['config/cdr_config_local.json',${DRY_RUN},${ALLOW_EMPTY_TIER}]"
+
 ./gradlew --daemon loadConfig -Pconfig_key=main -Pconfig_file=config/config_local.json
 ./gradlew --daemon loadConfig -Pconfig_key=cdrBigQuerySchema -Pconfig_file=config/cdm/cdm_5_2.json
 ./gradlew --daemon loadConfig -Pconfig_key=featuredWorkspaces -Pconfig_file=config/featured_workspaces_local.json

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
@@ -45,9 +45,10 @@ public class UpdateCdrConfig {
       AccessTierDao accessTierDao, CdrVersionDao cdrVersionDao, CdrConfigVOMapper cdrConfigMapper)
       throws IOException {
     return (args) -> {
-      if (args.length != 3) {
+      if (args.length != 2 && args.length != 3) {
         throw new IllegalArgumentException(
-            "Expected 3 args (file, dry_run, allow_empty_tiers). Got " + Arrays.asList(args));
+            "Expected 2-3 args (file, dry_run, allow_empty_tiers=false). Got "
+                + Arrays.asList(args));
       }
 
       final Gson gson =
@@ -59,7 +60,8 @@ public class UpdateCdrConfig {
         cdrConfig = gson.fromJson(cdrConfigReader, CdrConfigVO.class);
       }
       boolean dryRun = Boolean.parseBoolean(args[1]);
-      boolean allowEmptyTiers = Boolean.parseBoolean(args[2]);
+      // RW-7931 consider removal of this option after CT rollout is complete
+      boolean allowEmptyTiers = args.length > 2 && Boolean.parseBoolean(args[2]);
 
       preCheck(cdrConfig, allowEmptyTiers);
 

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
@@ -1,12 +1,14 @@
 package org.pmiops.workbench.tools.cdrconfig;
 
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.io.FileReader;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -43,9 +45,9 @@ public class UpdateCdrConfig {
       AccessTierDao accessTierDao, CdrVersionDao cdrVersionDao, CdrConfigVOMapper cdrConfigMapper)
       throws IOException {
     return (args) -> {
-      if (args.length != 2) {
+      if (args.length != 3) {
         throw new IllegalArgumentException(
-            "Expected 2 args (file, dry_run). Got " + Arrays.asList(args));
+            "Expected 3 args (file, dry_run, allow_empty_tiers). Got " + Arrays.asList(args));
       }
 
       final Gson gson =
@@ -57,8 +59,9 @@ public class UpdateCdrConfig {
         cdrConfig = gson.fromJson(cdrConfigReader, CdrConfigVO.class);
       }
       boolean dryRun = Boolean.parseBoolean(args[1]);
+      boolean allowEmptyTiers = Boolean.parseBoolean(args[2]);
 
-      preCheck(cdrConfig);
+      preCheck(cdrConfig, allowEmptyTiers);
 
       updateDB(dryRun, cdrConfig, gson, accessTierDao, cdrVersionDao, cdrConfigMapper);
     };
@@ -81,10 +84,17 @@ public class UpdateCdrConfig {
    *   <li>duplicate IDs (or lack one)
    *   <li>have an archived default version
    *   <li>belong to a tier which is not also present in this file
-   *   <li>have more or less than one default version per tier
+   *   <li>have more than one default version per tier
+   * </ul>
+   *
+   * <p>Unless allowEmptyTiers is set, CDR Versions must:
+   *
+   * <ul>
+   *   <li>have at least one version per tier
+   *   <li>have exactly one default version per tier
    * </ul>
    */
-  private void preCheck(CdrConfigVO cdrConfig) {
+  private void preCheck(CdrConfigVO cdrConfig, boolean allowEmptyTiers) {
     Set<Long> accessTierIds = new HashSet<>();
     Set<String> accessTierShortNames = new HashSet<>();
     Set<String> accessTierDisplayNames = new HashSet<>();
@@ -119,6 +129,7 @@ public class UpdateCdrConfig {
     }
 
     Set<Long> cdrVersionIds = new HashSet<>();
+    Map<String, Set<Long>> cdrVersionsPerTier = new HashMap<>();
     Map<String, Long> cdrDefaultVersionPerTier = new HashMap<>();
     for (CdrVersionVO v : cdrConfig.cdrVersions) {
       long id = v.cdrVersionId;
@@ -144,6 +155,7 @@ public class UpdateCdrConfig {
                 id, accessTier));
       }
 
+      cdrVersionsPerTier.merge(v.accessTier, Collections.singleton(v.cdrVersionId), Sets::union);
       if (v.isDefault != null && v.isDefault) {
         if (v.archivalStatus != DbStorageEnums.archivalStatusToStorage(ArchivalStatus.LIVE)) {
           throw new IllegalArgumentException(
@@ -161,13 +173,19 @@ public class UpdateCdrConfig {
       }
     }
 
-    accessTierShortNames.forEach(
-        t -> {
-          if (!cdrDefaultVersionPerTier.containsKey(t)) {
-            throw new IllegalArgumentException(
-                String.format("Missing default CDR version for Access Tier '%s'.", t));
-          }
-        });
+    if (!allowEmptyTiers) {
+      accessTierShortNames.forEach(
+          t -> {
+            if (!cdrVersionsPerTier.containsKey(t)) {
+              throw new IllegalArgumentException(
+                  String.format("No CDR versions are present for Access Tier '%s'.", t));
+            }
+            if (!cdrDefaultVersionPerTier.containsKey(t)) {
+              throw new IllegalArgumentException(
+                  String.format("Missing default CDR version for Access Tier '%s'.", t));
+            }
+          });
+    }
   }
 
   /**

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
@@ -175,19 +175,20 @@ public class UpdateCdrConfig {
       }
     }
 
-    if (!allowEmptyTiers) {
-      accessTierShortNames.forEach(
-          t -> {
-            if (!cdrVersionsPerTier.containsKey(t)) {
-              throw new IllegalArgumentException(
-                  String.format("No CDR versions are present for Access Tier '%s'.", t));
-            }
-            if (!cdrDefaultVersionPerTier.containsKey(t)) {
-              throw new IllegalArgumentException(
-                  String.format("Missing default CDR version for Access Tier '%s'.", t));
-            }
-          });
-    }
+    accessTierShortNames.forEach(
+        t -> {
+          if (!allowEmptyTiers && !cdrVersionsPerTier.containsKey(t)) {
+            throw new IllegalArgumentException(
+                String.format("No CDR versions are present for Access Tier '%s'.", t));
+          }
+
+          // check if a tier has CDR Versions but no default
+          // (empty is OK if it passed the previous check)
+          if (cdrVersionsPerTier.containsKey(t) && !cdrDefaultVersionPerTier.containsKey(t)) {
+            throw new IllegalArgumentException(
+                String.format("Missing default CDR version for Access Tier '%s'.", t));
+          }
+        });
   }
 
   /**

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
@@ -87,14 +87,11 @@ public class UpdateCdrConfig {
    *   <li>have an archived default version
    *   <li>belong to a tier which is not also present in this file
    *   <li>have more than one default version per tier
+   *   <li>have fewer than one default version per tier (unless allowEmptyTiers is set and the tier
+   *       is empty)
    * </ul>
    *
-   * <p>Unless allowEmptyTiers is set, CDR Versions must:
-   *
-   * <ul>
-   *   <li>have at least one version per tier
-   *   <li>have exactly one default version per tier
-   * </ul>
+   * <p>Unless allowEmptyTiers is set, CDR Versions must also have at least one version per tier
    */
   private void preCheck(CdrConfigVO cdrConfig, boolean allowEmptyTiers) {
     Set<Long> accessTierIds = new HashSet<>();


### PR DESCRIPTION
This is one of a series of PRs to help with Controlled Tier rollout.

Adding CT configurations to Institutions requires a CT DB entity.  We can't currently construct one in Prod (and Stable) because (a) we do not have a CDR to populate, and UpdateCDRConfig requires one to add a tier DB entity and (b) there may be a risk of users becoming aware of the CT before we are ready to launch.  **This PR addresses (a)**.  (b) is covered by #6353 and #6354 

Local testing for this tool update:
* attempt to add a new empty third tier with flag = false -> failure 
* attempt to add a new third tier with no default version and flag = false -> failure 
* attempt to add a new empty third tier with flag = true -> success 
* attempt to add a new third tier with no default version and flag = false -> success
* attempt to add a tier config for the new third tier to an institution via the API -> success
* attempt normal admin interactions with this institution in the UI -> success
* attempt normal user interactions with this institution in the UI -> TODO

Warning: running this tool in an environment without #6353 will cause `getCdrVersionsByTier()` to return an error because it requires a default CDR for all tiers.  The UI becomes unusable when this call does not succeed.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
