### PR TITLE
[risk=no][RW-7598] Don't crash AdminUserProfile when a module status is missing

### DIFF
--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -41,8 +41,8 @@ import {
   orderedAccessTierShortNames,
 } from 'app/utils/access-tiers';
 import {
-  AccessModulesStatus,
   accessRenewalModules,
+  AccessRenewalStatus,
   computeRenewalDisplayDates,
   getAccessModuleConfig,
   getAccessModuleStatusByName,
@@ -173,19 +173,22 @@ export const getUpdatedProfileValue = (
   }
 };
 
-const getModuleStatus = (profile, moduleName) =>
+const getModuleStatus = (
+  profile: Profile,
+  moduleName: AccessModule
+): AccessRenewalStatus =>
   computeRenewalDisplayDates(getAccessModuleStatusByName(profile, moduleName))
     .moduleStatus;
 
 const moduleStatusStyle = (moduleStatus) =>
   cond(
     [
-      moduleStatus === AccessModulesStatus.INCOMPLETE ||
-        moduleStatus === AccessModulesStatus.EXPIRING_SOON,
+      moduleStatus === AccessRenewalStatus.INCOMPLETE ||
+        moduleStatus === AccessRenewalStatus.EXPIRING_SOON,
       () => commonStyles.incompleteOrExpiringModule,
     ],
     [
-      moduleStatus === AccessModulesStatus.EXPIRED,
+      moduleStatus === AccessRenewalStatus.EXPIRED,
       () => commonStyles.expiredModule,
     ],
     () => commonStyles.completeModule

--- a/ui/src/app/utils/access-utils.spec.tsx
+++ b/ui/src/app/utils/access-utils.spec.tsx
@@ -14,7 +14,7 @@ import {
   registerApiClient,
 } from 'app/services/swagger-fetch-clients';
 import {
-  AccessModulesStatus,
+  AccessRenewalStatus,
   buildRasRedirectUrl,
   computeRenewalDisplayDates,
   getTwoFactorSetupUrl,
@@ -161,7 +161,7 @@ describe('computeRenewalDisplayDates', () => {
     expect(computeRenewalDisplayDates({})).toStrictEqual({
       lastConfirmedDate: 'Unavailable (not completed)',
       nextReviewDate: 'Unavailable (not completed)',
-      moduleStatus: AccessModulesStatus.INCOMPLETE,
+      moduleStatus: AccessRenewalStatus.INCOMPLETE,
     });
   });
 
@@ -169,7 +169,7 @@ describe('computeRenewalDisplayDates', () => {
     expect(computeRenewalDisplayDates(undefined)).toStrictEqual({
       lastConfirmedDate: 'Unavailable (not completed)',
       nextReviewDate: 'Unavailable (not completed)',
-      moduleStatus: AccessModulesStatus.INCOMPLETE,
+      moduleStatus: AccessRenewalStatus.INCOMPLETE,
     });
   });
 
@@ -177,7 +177,7 @@ describe('computeRenewalDisplayDates', () => {
     expect(computeRenewalDisplayDates(null)).toStrictEqual({
       lastConfirmedDate: 'Unavailable (not completed)',
       nextReviewDate: 'Unavailable (not completed)',
-      moduleStatus: AccessModulesStatus.INCOMPLETE,
+      moduleStatus: AccessRenewalStatus.INCOMPLETE,
     });
   });
 
@@ -190,7 +190,7 @@ describe('computeRenewalDisplayDates', () => {
     expect(computeRenewalDisplayDates(status)).toStrictEqual({
       lastConfirmedDate: 'Unavailable (not completed)',
       nextReviewDate: 'Unavailable (not completed)',
-      moduleStatus: AccessModulesStatus.INCOMPLETE,
+      moduleStatus: AccessRenewalStatus.INCOMPLETE,
     });
   });
 
@@ -203,7 +203,7 @@ describe('computeRenewalDisplayDates', () => {
     expect(computeRenewalDisplayDates(status)).toStrictEqual({
       lastConfirmedDate: displayDateWithoutHours(bypassDate),
       nextReviewDate: 'Unavailable (bypassed)',
-      moduleStatus: AccessModulesStatus.BYPASSED,
+      moduleStatus: AccessRenewalStatus.BYPASSED,
     });
   });
 
@@ -224,7 +224,7 @@ describe('computeRenewalDisplayDates', () => {
     expect(computeRenewalDisplayDates(status)).toStrictEqual({
       lastConfirmedDate: displayDateWithoutHours(bypassDate),
       nextReviewDate: 'Unavailable (bypassed)',
-      moduleStatus: AccessModulesStatus.BYPASSED,
+      moduleStatus: AccessRenewalStatus.BYPASSED,
     });
   });
 
@@ -250,7 +250,7 @@ describe('computeRenewalDisplayDates', () => {
       nextReviewDate: `${displayDateWithoutHours(expirationDate)} (${
         EXPIRATION_DAYS - completionDaysPast
       } days)`,
-      moduleStatus: AccessModulesStatus.EXPIRING_SOON,
+      moduleStatus: AccessRenewalStatus.EXPIRING_SOON,
     });
   });
 
@@ -276,7 +276,7 @@ describe('computeRenewalDisplayDates', () => {
       nextReviewDate: `${displayDateWithoutHours(expirationDate)} (${
         EXPIRATION_DAYS - completionDaysPast
       } days)`,
-      moduleStatus: AccessModulesStatus.CURRENT,
+      moduleStatus: AccessRenewalStatus.CURRENT,
     });
   });
 
@@ -294,7 +294,7 @@ describe('computeRenewalDisplayDates', () => {
     expect(computeRenewalDisplayDates(status)).toStrictEqual({
       lastConfirmedDate: displayDateWithoutHours(completionDate),
       nextReviewDate: `${displayDateWithoutHours(expirationDate)} (expired)`,
-      moduleStatus: AccessModulesStatus.EXPIRED,
+      moduleStatus: AccessRenewalStatus.EXPIRED,
     });
   });
 });

--- a/ui/src/app/utils/access-utils.spec.tsx
+++ b/ui/src/app/utils/access-utils.spec.tsx
@@ -165,6 +165,22 @@ describe('computeRenewalDisplayDates', () => {
     });
   });
 
+  it('returns Unavailable/Incomplete when the module is undefined', () => {
+    expect(computeRenewalDisplayDates(undefined)).toStrictEqual({
+      lastConfirmedDate: 'Unavailable (not completed)',
+      nextReviewDate: 'Unavailable (not completed)',
+      moduleStatus: AccessModulesStatus.INCOMPLETE,
+    });
+  });
+
+  it('returns Unavailable/Incomplete when the module is null', () => {
+    expect(computeRenewalDisplayDates(null)).toStrictEqual({
+      lastConfirmedDate: 'Unavailable (not completed)',
+      nextReviewDate: 'Unavailable (not completed)',
+      moduleStatus: AccessModulesStatus.INCOMPLETE,
+    });
+  });
+
   it('returns Unavailable/Incomplete when the module is incomplete, regardless of expiration date', () => {
     const expirationDate = nowPlusDays(25);
     const status: AccessModuleStatus = {

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -405,11 +405,9 @@ const withInvalidDateHandling = (date) => {
   }
 };
 
-export const computeRenewalDisplayDates = ({
-  completionEpochMillis,
-  expirationEpochMillis,
-  bypassEpochMillis,
-}: AccessModuleStatus) => {
+export const computeRenewalDisplayDates = (status: AccessModuleStatus) => {
+  const { completionEpochMillis, expirationEpochMillis, bypassEpochMillis } =
+    status || {};
   const userCompletedModule = !!completionEpochMillis;
   const userBypassedModule = !!bypassEpochMillis;
   const lastConfirmedDate = withInvalidDateHandling(completionEpochMillis);


### PR DESCRIPTION
A proper test would be to remove a module status and show AdminUserProfile works.  I have not yet done that, but this change should be safe and an improvement regardless.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
