### PR TITLE
POC: Quick and dirty async CreateWorkspace

### DIFF
--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -892,6 +892,42 @@ paths:
           description: The workspace that was created.
           schema:
             "$ref": "#/definitions/Workspace"
+  "/v1/workspaces/createAsync":
+    post:
+      tags:
+      - workspaces
+      consumes:
+      - application/json
+      description: Creates a workspace
+      operationId: createWorkspaceAsync
+      parameters:
+      - in: body
+        name: workspace
+        description: workspace definition
+        schema:
+          "$ref": "#/definitions/Workspace"
+      responses:
+        200:
+          description: The workspace that was created.
+          schema:
+            "$ref": "#/definitions/WorkspaceOperation"
+  "/v1/workspaces/operations/{id}":
+    parameters:
+    - in: path
+      name: id
+      type: string
+      description: The workspace operation ID
+      required: true
+    get:
+      tags:
+      - workspaces
+      description: Returns a workspace operation, only accessible to the creator of the operation.
+      operationId: getWorkspaceOperation
+      responses:
+        200:
+          description: The asynchronous workspace operation.
+          schema:
+            "$ref": "#/definitions/WorkspaceOperation"
   "/v1/workspaces/published":
     get:
       tags:
@@ -1082,6 +1118,28 @@ paths:
           description: Successful duplicate response
           schema:
             "$ref": "#/definitions/CloneWorkspaceResponse"
+  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/duplicateAsync":
+    parameters:
+    - "$ref": "#/parameters/workspaceNamespace"
+    - "$ref": "#/parameters/workspaceId"
+    post:
+      tags:
+      - workspaces
+      consumes:
+      - application/json
+      description: |
+        Asynchronously clone an existing workspace. Semantics otherwise match cloneWorkspace.
+      operationId: cloneWorkspaceAsync
+      parameters:
+      - in: body
+        name: body
+        schema:
+          "$ref": "#/definitions/CloneWorkspaceRequest"
+      responses:
+        200:
+          description: Successful duplicate response
+          schema:
+            "$ref": "#/definitions/WorkspaceOperation"
   "/v1/workspaces/{workspaceNamespace}/{workspaceId}/userRoles":
     parameters:
     - "$ref": "#/parameters/workspaceNamespace"
@@ -2796,6 +2854,27 @@ paths:
       responses:
         200:
           description: 'Egress event processed successfully'
+  "/v1/cloudTask/createWorkspace":
+    post:
+      tags:
+      - workspaces
+      - cloudTask
+      description: >
+        Asynchronously creates a workspace. Note: unlike other cloud tasks,
+        this task requires passing along the user's auth credential header.
+      operationId: processCreateWorkspaceTask
+      consumes:
+      - application/json
+      parameters:
+      - in: body
+        name: request
+        required: true
+        description: Workspace creation task to process.
+        schema:
+          "$ref": "#/definitions/CreateWorkspaceTaskRequest"
+      responses:
+        200:
+          description: 'Workspace created'
   "/v1/institutions":
     x-aou-note: Institution endpoints, for Verified Institutional Affiliation
     get:
@@ -4723,6 +4802,18 @@ definitions:
       workspace:
         "$ref": "#/definitions/Workspace"
         description: The newly created workspace duplicate.
+  WorkspaceOperation:
+    type: object
+    properties:
+      id:
+        description: The identifier for this operation
+        type: string
+      status:
+        description: The status of the async operation
+        "$ref": "#/definitions/WorkspaceOperationStatus"
+      workspace:
+        description: The newly created workspace
+        "$ref": "#/definitions/Workspace"
   UpdateWorkspaceRequest:
     type: object
     required:
@@ -4745,6 +4836,13 @@ definitions:
     enum:
     - ACTIVE
     - DELETED
+  WorkspaceOperationStatus:
+    type: string
+    description: ''
+    enum:
+    - PENDING
+    - ERROR
+    - SUCCESS
   ResearchPurpose:
     type: object
     required:
@@ -8595,6 +8693,18 @@ definitions:
         description: 'Egress event ID to be processed'
         type: integer
         format: int64
+
+  CreateWorkspaceTaskRequest:
+    type: object
+    required:
+      - operationId
+    properties:
+      operationId:
+        description: 'Workspace operation ID'
+        type: string
+      workspace:
+        description: 'Requested workspace to create'
+        "$ref": "#/definitions/Workspace"
 
   WorkspaceAuditLogQueryResponse:
     type: object

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillWorkspacesToRdr.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/BackfillWorkspacesToRdr.java
@@ -65,7 +65,8 @@ public class BackfillWorkspacesToRdr {
       WorkbenchLocationConfigService locationConfigService,
       Provider<CloudTasksClient> cloudTasksClientProvider,
       Provider<WorkbenchConfig> configProvider) {
-    return new TaskQueueService(locationConfigService, cloudTasksClientProvider, configProvider);
+    return new TaskQueueService(
+        locationConfigService, cloudTasksClientProvider, configProvider, () -> null);
   }
 
   @Bean


### PR DESCRIPTION
This shows a proof-of-concept async CreateWorkspace approach. This is "working", but needs a fair amount of cleanup.

The approach:

- createWorkspaceAsync() returns a workspace op
  - it does some simple validation, and then dispatches a cloud task /processCreateWorkspaceTask, **including the Authorization header**
  - it stores an operation by ID (for POC purposes only - in a static memory map, NOTE: this will only work locally, not GAE)
- processCreateWorkspaceTask runs, and simply calls a normal `createWorkspace` (authenticated as the user, per the header)
  - on success, it updates the operation store status and adds the workspace to the operation
  - on failure / exception, it sets the operation status to error

Additional areas to de-risk:

- Based on documentation, it seems this approach of passing an auth token into a cloud task via header does actually work. We should validate there are no issues with this on actual GAE - though it looks promising.

Major functional gaps:

- this shows the implementation of create; need parallel implementation for clone (including cloud task, not shown here)
- read/write ops to the database
- getWorkspaceOperation should restrict access to the op creator (we should store the creator user id too)
- fallback timeout check. This could simply be client-side initially, but there should be a maximum time after which we simply give up on the client if the task fails for some reason

Additional setup not shown:

- Cloud task queue config / creation