### PR TITLE
[RW-7932][risk-low] CDR indices - remove wait calls in shell scripts and delete temp tables

### DIFF
--- a/api/db-cdr/generate-cdr/build-cb-criteria-cpt4.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-cpt4.sh
@@ -321,11 +321,7 @@ and is_standard = 0
 and is_group = 0
 and is_selectable = 1"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-cpToMain "$TBL_CBA" &
-cpToMain "$TBL_ANC" &
-wait
-
+# copy temp tables back to main tables in parallel then delete temp tables
+cpToMainThenRmTmpTable "$TBL_CBC" &
+cpToMainThenRmTmpTable "$TBL_CBA" &
+cpToMainThenRmTmpTable "$TBL_ANC" &

--- a/api/db-cdr/generate-cdr/build-cb-criteria-demographics.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-demographics.sh
@@ -263,9 +263,5 @@ FROM
 LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.ethnicity_concept_id = b.concept_id
 WHERE b.concept_id is not null"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-wait
-
+# copy temp table back to main table then delete temp table
+cpToMainThenRmTmpTable "$TBL_CBC"

--- a/api/db-cdr/generate-cdr/build-cb-criteria-device.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-device.sh
@@ -71,9 +71,5 @@ FROM
         GROUP BY 1,2,3,4
     ) x"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-wait
-
+# copy temp table back to main table then delete temp table
+cpToMainThenRmTmpTable "$TBL_CBC"

--- a/api/db-cdr/generate-cdr/build-cb-criteria-drug.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-drug.sh
@@ -591,11 +591,7 @@ and descendant_concept_id in
         FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\`
     )"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-cpToMain "$TBL_PCA" &
-cpToMain "$TBL_CBA" &
-wait
-
+# copy temp tables back to main tables in parallel then delete temp tables
+cpToMainThenRmTmpTable "$TBL_CBC" &
+cpToMainThenRmTmpTable "$TBL_PCA" &
+cpToMainThenRmTmpTable "$TBL_CBA" &

--- a/api/db-cdr/generate-cdr/build-cb-criteria-fitbit.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-fitbit.sh
@@ -43,9 +43,5 @@ SELECT
     , 0
     , 0"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-wait
-
+# copy temp table back to main table then delete temp table
+cpToMainThenRmTmpTable "$TBL_CBC"

--- a/api/db-cdr/generate-cdr/build-cb-criteria-icd10-cm.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-icd10-cm.sh
@@ -307,11 +307,7 @@ WHERE x.concept_id = y.concept_id
 AND x.type = 'ICD10CM'
 AND x.is_standard = 0"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-cpToMain "$TBL_PAS" &
-cpToMain "$TBL_PCA" &
-wait
-
+# copy temp tables back to main tables in parallel then delete temp tables
+cpToMainThenRmTmpTable "$TBL_CBC" &
+cpToMainThenRmTmpTable "$TBL_PAS" &
+cpToMainThenRmTmpTable "$TBL_PCA" &

--- a/api/db-cdr/generate-cdr/build-cb-criteria-icd10-pcs.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-icd10-pcs.sh
@@ -334,12 +334,9 @@ and is_standard = 0
 and is_group = 0
 and is_selectable = 1"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-cpToMain "$TBL_CBA" &
-cpToMain "$TBL_PAS" &
-cpToMain "$TBL_PCA" &
-wait
+# copy temp tables back to main tables in parallel then delete temp tables
+cpToMainThenRmTmpTable "$TBL_CBC" &
+cpToMainThenRmTmpTable "$TBL_CBA" &
+cpToMainThenRmTmpTable "$TBL_PAS" &
+cpToMainThenRmTmpTable "$TBL_PCA" &
 

--- a/api/db-cdr/generate-cdr/build-cb-criteria-icd9.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-icd9.sh
@@ -471,12 +471,8 @@ and is_selectable = 1"
 
 # TODO there are still some parents that don't actually have any children and never will. WHAT TO DO?
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-cpToMain "$TBL_CBA" &
-cpToMain "$TBL_PAS" &
-cpToMain "$TBL_PCA" &
-wait
-
+# copy temp tables back to main tables in parallel then delete temp tables
+cpToMainThenRmTmpTable "$TBL_CBC" &
+cpToMainThenRmTmpTable "$TBL_CBA" &
+cpToMainThenRmTmpTable "$TBL_PAS" &
+cpToMainThenRmTmpTable "$TBL_PCA" &

--- a/api/db-cdr/generate-cdr/build-cb-criteria-meas-clin.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-meas-clin.sh
@@ -91,9 +91,5 @@ bq --quiet --project_id=$BQ_PROJECT query --batch --nouse_legacy_sql \
     GROUP BY 1,2,3
     ) a) b"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-wait
-
+# copy temp table back to main table then delete temp table
+cpToMainThenRmTmpTable "$TBL_CBC"

--- a/api/db-cdr/generate-cdr/build-cb-criteria-meas-labs.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-meas-labs.sh
@@ -518,10 +518,7 @@ WHERE x.type = 'LOINC'
     and x.subtype = 'LAB'
     and x.name = 'Uncategorized'"
 
-#wait for process to end before copying
-wait
-cpToMain "$TBL_CBC" &
-cpToMain "$TBL_PAS" &
-cpToMain "$TBL_PCA" &
-wait
-
+# copy temp tables back to main tables in parallel then delete temp tables
+cpToMainThenRmTmpTable "$TBL_CBC" &
+cpToMainThenRmTmpTable "$TBL_PAS" &
+cpToMainThenRmTmpTable "$TBL_PCA" &

--- a/api/db-cdr/generate-cdr/build-cb-criteria-meas-snomed.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-meas-snomed.sh
@@ -364,11 +364,7 @@ WHERE x.concept_id = y.concept_id
     and x.is_standard = 1
     and x.is_group = 1"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-cpToMain "$TBL_PAS" &
-cpToMain "$TBL_PCA" &
-wait
-
+# copy temp tables back to main tables in parallel then delete temp tables
+cpToMainThenRmTmpTable "$TBL_CBC" &
+cpToMainThenRmTmpTable "$TBL_PAS" &
+cpToMainThenRmTmpTable "$TBL_PCA" &

--- a/api/db-cdr/generate-cdr/build-cb-criteria-observation.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-observation.sh
@@ -203,10 +203,6 @@ WHERE domain_id = 'OBSERVATION'
         FROM \`$BQ_PROJECT.$BQ_DATASET.$TBL_CBAT\`
     )"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-cpToMain "$TBL_CBAT" &
-wait
-
+# copy temp tables back to main tables in parallel then delete temp tables
+cpToMainThenRmTmpTable "$TBL_CBC" &
+cpToMainThenRmTmpTable "$TBL_CBAT" &

--- a/api/db-cdr/generate-cdr/build-cb-criteria-pm-cs.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-pm-cs.sh
@@ -71,8 +71,5 @@ JOIN
         GROUP BY 1
     ) b on a.concept_id = b.measurement_source_concept_id"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-wait
+# copy temp table back to main table then delete temp table
+cpToMainThenRmTmpTable "$TBL_CBC"

--- a/api/db-cdr/generate-cdr/build-cb-criteria-pm.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-pm.sh
@@ -224,8 +224,5 @@ WHERE domain_id = 'PHYSICAL_MEASUREMENT'
     and name = 'Blood Pressure'
     and is_selectable = 1"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-wait
+# copy temp table back to main table then delete temp table
+cpToMainThenRmTmpTable "$TBL_CBC"

--- a/api/db-cdr/generate-cdr/build-cb-criteria-snomed-condition.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-snomed-condition.sh
@@ -430,11 +430,7 @@ WHERE x.concept_id = y.concept_id
     and x.is_standard = 1
     and x.is_group = 1"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-cpToMain "$TBL_PAS" &
-cpToMain "$TBL_PCA" &
-wait
-
+# copy temp tables back to main tables in parallel then delete temp tables
+cpToMainThenRmTmpTable "$TBL_CBC" &
+cpToMainThenRmTmpTable "$TBL_PAS" &
+cpToMainThenRmTmpTable "$TBL_PCA" &

--- a/api/db-cdr/generate-cdr/build-cb-criteria-snomed-procedure.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-snomed-procedure.sh
@@ -413,11 +413,7 @@ WHERE x.concept_id = y.concept_id
     and x.is_standard = 1
     and x.is_group = 1"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-cpToMain "$TBL_PAS" &
-cpToMain "$TBL_PCA" &
-wait
-
+# copy temp tables back to main tables in parallel then delete temp tables
+cpToMainThenRmTmpTable "$TBL_CBC" &
+cpToMainThenRmTmpTable "$TBL_PAS" &
+cpToMainThenRmTmpTable "$TBL_PCA" &

--- a/api/db-cdr/generate-cdr/build-cb-criteria-surveys.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-surveys.sh
@@ -278,10 +278,6 @@ FROM
 WHERE x.domain_id = 'SURVEY'
     and x.concept_id = y.ancestor_concept_id"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-cpToMain "$TBL_PCA" &
-wait
-
+# copy temp tables back to main tables in parallel then delete temp tables
+cpToMainThenRmTmpTable "$TBL_CBC" &
+cpToMainThenRmTmpTable "$TBL_PCA" &

--- a/api/db-cdr/generate-cdr/build-cb-criteria-visit.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-visit.sh
@@ -61,9 +61,5 @@ FROM
         GROUP BY 1, 2
     ) a"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-wait
-
+# copy temp table back to main table then delete temp table
+cpToMainThenRmTmpTable "$TBL_CBC"

--- a/api/db-cdr/generate-cdr/build-cb-criteria-wgs.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-wgs.sh
@@ -10,8 +10,8 @@ ID_PREFIX=$3
 ####### common block for all make-cb-criteria-dd-*.sh scripts ###########
 source ./generate-cdr/cb-criteria-utils.sh
 echo "Running in parallel and Multitable mode - " "$ID_PREFIX - $SQL_FOR"
-CB_CRITERIA_START_ID=$[$ID_PREFIX*10**9] # 3  billion
-CB_CRITERIA_END_ID=$[$[ID_PREFIX+1]*10**9] # 4  billion
+CB_CRITERIA_START_ID=$[$ID_PREFIX*10**9]
+CB_CRITERIA_END_ID=$[$[ID_PREFIX+1]*10**9]
 echo "Creating temp table for $TBL_CBC"
 TBL_CBC=$(createTmpTable $TBL_CBC)
 ####### end common block ###########
@@ -43,8 +43,5 @@ SELECT
     , 0
     , 0"
 
-#wait for process to end before copying
-wait
-## copy temp tables back to main tables, and delete temp?
-cpToMain "$TBL_CBC" &
-wait
+# copy temp table back to main table then delete temp table
+cpToMainThenRmTmpTable "$TBL_CBC"

--- a/api/db-cdr/generate-cdr/cb-criteria-utils.sh
+++ b/api/db-cdr/generate-cdr/cb-criteria-utils.sh
@@ -6,10 +6,11 @@ function createTmpTable(){
   echo $res >&2
   echo "$tmpTbl"
 }
-function cpToMainThenRmTmpTableThenRmTmpTable(){
+function cpToMainThenRmTmpTable(){
   local tbl_to=$(echo "$1" | sed -e 's/prep_temp_\(.*\)_[0-9]*/\1/')
-  bq cp --append_table=true --quiet --project_id=$BQ_PROJECT \
-     "$BQ_DATASET.$1" "$BQ_DATASET.$tbl_to"
+  res=$(bq cp --append_table=true --quiet --project_id=$BQ_PROJECT \
+     "$BQ_DATASET.$1" "$BQ_DATASET.$tbl_to")
+  echo $res >&2
   echo "Deleting temp table $1"
-  bq rm --quiet --project_id=$BQ_PROJECT "$BQ_DATASET.$1"
+  bq rm --force --project_id=$BQ_PROJECT "$BQ_DATASET.$1"
 }

--- a/api/db-cdr/generate-cdr/cb-criteria-utils.sh
+++ b/api/db-cdr/generate-cdr/cb-criteria-utils.sh
@@ -6,8 +6,10 @@ function createTmpTable(){
   echo $res >&2
   echo "$tmpTbl"
 }
-function cpToMain(){
+function cpToMainThenRmTmpTableThenRmTmpTable(){
   local tbl_to=$(echo "$1" | sed -e 's/prep_temp_\(.*\)_[0-9]*/\1/')
   bq cp --append_table=true --quiet --project_id=$BQ_PROJECT \
      "$BQ_DATASET.$1" "$BQ_DATASET.$tbl_to"
+  echo "Deleting temp table $1"
+  bq rm --quiet --project_id=$BQ_PROJECT "$BQ_DATASET.$1"
 }

--- a/api/db-cdr/generate-cdr/cb-criteria-utils.sh
+++ b/api/db-cdr/generate-cdr/cb-criteria-utils.sh
@@ -12,5 +12,5 @@ function cpToMainThenRmTmpTable(){
      "$BQ_DATASET.$1" "$BQ_DATASET.$tbl_to")
   echo $res >&2
   echo "Deleting temp table $1"
-  bq rm --force --project_id=$BQ_PROJECT "$BQ_DATASET.$1"
+  bq rm --force --project_id="$BQ_PROJECT" "$BQ_DATASET.$1"
 }


### PR DESCRIPTION
Description:

- Removed `wait` from build-cb-criteria-* scripts
- Edited function in `cb-criteria-utils.sh` to delete temp table after copying to destination table

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
