### PR TITLE
[RW-7771][RW-7984][risk=low] Update preprod with beta WGS dataset and workflow

### DIFF
--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -111,7 +111,7 @@
       "isDefault": true,
       "bigqueryProject": "fc-aou-cdr-preprod-ct",
       "bigqueryDataset": "C2021Q3R5",
-      "wgsBigqueryDataset": "alpha2_prelim2",
+      "wgsBigqueryDataset": "wgs_C2021Q3_beta",
       "creationTime": "2021-10-06 00:00:00Z",
       "releaseNumber": 8,
       "numParticipants": 331382,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -44,12 +44,13 @@
     "extractionPetServiceAccount": "pet-110393474898566940625@aouwgscohortextraction-preprod.iam.gserviceaccount.com",
     "extractionMethodConfigurationNamespace": "aouwgscohortextraction-preprod",
     "extractionMethodConfigurationName": "GvsExtractCohortFromSampleNames",
-    "extractionMethodConfigurationVersion": 2,
-    "extractionMethodLogicalVersion": 1,
+    "extractionMethodConfigurationVersion": 4,
+    "extractionMethodLogicalVersion": 2,
     "extractionCohortsDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-357-gc79075c-SNAPSHOT-local.jar",
+    "extractionFilterSetName": "beta2_99k_row_10",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-464-g86f1116-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {


### PR DESCRIPTION
Confirmed this is the correct filter set for beta. Updated extraction workflow works with the new V2 GVS schema.