### PR TITLE
[RW-7928][risk=no] e2e test workspace-edit failure workaround

### DIFF
--- a/e2e/app/component/base-card.ts
+++ b/e2e/app/component/base-card.ts
@@ -56,7 +56,7 @@ export default abstract class BaseCard extends Container {
     await menu.select(options, { waitForNav });
     // Workaround for https://precisionmedicineinitiative.atlassian.net/browse/RW-7928
     if (pageExpected !== undefined) {
-      await this.waitFor(pageExpected);
+      await this.waitFor(pageExpected, { reloadIfFail: true });
     }
   }
 }

--- a/e2e/app/component/base-card.ts
+++ b/e2e/app/component/base-card.ts
@@ -1,7 +1,8 @@
 import { ElementHandle, Page } from 'puppeteer';
 import { MenuOption } from 'app/text-labels';
 import Container from 'app/container';
-import SnowmanMenu, { snowmanIconXpath } from './snowman-menu';
+import SnowmanMenu, { snowmanIconXpath } from 'app/component/snowman-menu';
+import AuthenticatedPage from 'app/page/authenticated-page';
 
 export default abstract class BaseCard extends Container {
   protected cardElement: ElementHandle;
@@ -46,7 +47,16 @@ export default abstract class BaseCard extends Container {
     return snowmanMenu;
   }
 
-  async selectSnowmanMenu(options: MenuOption, opt: { waitForNav?: boolean } = {}): Promise<void> {
-    return this.getSnowmanMenu().then((menu) => menu.select(options, opt));
+  async selectSnowmanMenu(
+    options: MenuOption,
+    opt: { waitForNav?: boolean; pageExpected?: AuthenticatedPage } = {}
+  ): Promise<void> {
+    const { waitForNav, pageExpected } = opt;
+    const menu = await this.getSnowmanMenu();
+    await menu.select(options, { waitForNav });
+    // Workaround for https://precisionmedicineinitiative.atlassian.net/browse/RW-7928
+    if (pageExpected !== undefined) {
+      await this.waitFor(pageExpected);
+    }
   }
 }

--- a/e2e/app/component/base-card.ts
+++ b/e2e/app/component/base-card.ts
@@ -53,9 +53,9 @@ export default abstract class BaseCard extends Container {
   ): Promise<void> {
     const { waitForNav, pageExpected } = opt;
     const menu = await this.getSnowmanMenu();
-    await menu.select(options, { waitForNav });
+    await menu.select(options, { waitForNav, waitForLoadingStop: !pageExpected });
     // Workaround for https://precisionmedicineinitiative.atlassian.net/browse/RW-7928
-    if (pageExpected !== undefined) {
+    if (pageExpected) {
       await this.waitFor(pageExpected, { reloadIfFail: true });
     }
   }

--- a/e2e/app/component/base-menu.ts
+++ b/e2e/app/component/base-menu.ts
@@ -17,8 +17,11 @@ export default abstract class BaseMenu extends Container {
    * @param menuSelections
    * @param opt
    */
-  async select(menuSelections: string | MenuOption | MenuOption[], opt: { waitForNav?: boolean } = {}): Promise<void> {
-    const { waitForNav = false } = opt;
+  async select(
+    menuSelections: string | MenuOption | MenuOption[],
+    opt: { waitForNav?: boolean; waitForLoadingStop?: boolean } = {}
+  ): Promise<void> {
+    const { waitForNav = false, waitForLoadingStop = true } = opt;
 
     let maxAttempts = 3;
     const click = async (menuItem: string, xpath: string, waitForNav = false): Promise<void> => {
@@ -64,9 +67,11 @@ export default abstract class BaseMenu extends Container {
       rootXpath = `${rootXpath}/ul`; // submenu xpath
     }
 
-    // Wait for menu close and disappear.
+    // Wait until menu dropdown is closed.
     await this.waitUntilClose();
-    await waitWhileLoading(this.page);
+    if (waitForLoadingStop) {
+      await waitWhileLoading(this.page);
+    }
   }
 
   /**

--- a/e2e/app/container.ts
+++ b/e2e/app/container.ts
@@ -86,8 +86,8 @@ export default class Container {
 
   async waitFor(authenticatedPage: AuthenticatedPage, opts: { reloadIfFail?: boolean } = {}): Promise<void> {
     const { reloadIfFail = false } = opts;
-    const wait = async (p: AuthenticatedPage): Promise<boolean> => {
-      return p
+    const wait = async (aPage: AuthenticatedPage): Promise<boolean> => {
+      return aPage
         .waitForLoad()
         .then(() => {
           return true;
@@ -98,6 +98,7 @@ export default class Container {
     };
     const success = await wait(authenticatedPage);
     if (!success && reloadIfFail) {
+      await this.page.waitForTimeout(5000);
       await this.page.reload({ waitUntil: ['networkidle0', 'load', 'domcontentloaded'] });
       await wait(authenticatedPage);
     }

--- a/e2e/app/container.ts
+++ b/e2e/app/container.ts
@@ -3,6 +3,7 @@ import { waitWhileLoading } from 'utils/waits-utils';
 import * as fp from 'lodash/fp';
 import { LinkText } from 'app/text-labels';
 import Button from 'app/element/button';
+import AuthenticatedPage from 'app/page/authenticated-page';
 
 /**
  * This is the super base class.
@@ -81,5 +82,24 @@ export default class Container {
     const button = Button.findByName(this.page, { normalizeSpace: buttonLabel }, this);
     await button.waitUntilEnabled();
     return button;
+  }
+
+  async waitFor(authenticatedPage: AuthenticatedPage, opts: { reloadIfFail?: boolean } = {}): Promise<void> {
+    const { reloadIfFail = false } = opts;
+    const wait = async (p: AuthenticatedPage): Promise<boolean> => {
+      return p
+        .waitForLoad()
+        .then(() => {
+          return true;
+        })
+        .catch(() => {
+          return false;
+        });
+    };
+    const success = await wait(authenticatedPage);
+    if (!success && reloadIfFail) {
+      await this.page.reload({ waitUntil: ['networkidle0', 'load', 'domcontentloaded'] });
+      await wait(authenticatedPage);
+    }
   }
 }

--- a/e2e/tests/workspace/workspace-edit.spec.ts
+++ b/e2e/tests/workspace/workspace-edit.spec.ts
@@ -22,9 +22,8 @@ describe('Editing workspace via workspace card snowman menu', () => {
   test('User as OWNER can edit workspace', async () => {
     const workspaceCard = await findOrCreateWorkspaceCard(page, { workspaceName });
 
-    await workspaceCard.selectSnowmanMenu(MenuOption.Edit, { waitForNav: true });
-
     const workspaceEditPage = new WorkspaceEditPage(page);
+    await workspaceCard.selectSnowmanMenu(MenuOption.Edit, { waitForNav: true, pageExpected: workspaceEditPage });
 
     // Data Access Tier is readonly.
     const accessTierSelect = workspaceEditPage.getDataAccessTierSelect();

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -394,7 +394,9 @@ export async function waitWhileSpinnerDisplayed(
     }
     const spentTime = Date.now() - startTime;
     if (spentTime > maxTime) {
-      logger.error(`ERROR: Loading spinner has not stopped. Spinner css is "${spinnerCss}"`);
+      logger.error(
+        `ERROR: Waiting for loading spinner to stop has exceeded max wait-time. Spinner css: '${spinnerCss}'`
+      );
       logger.error(error.stack);
       await takeScreenshot(page, makeDateTimeStr('ERROR_Spinner_TimeOut'));
       throw new Error(error.message);


### PR DESCRIPTION
`/billingInfo` request failed but failure is sporadic. This is likely caused by edit a new workspace in a very short time frame. 
Workaround: reload Edit Workspace page after a short sleep.