### PR TITLE
[risk=no] Capitalize CT badge title

### DIFF
--- a/ui/src/assets/icons/controlled-tier-badge.svg
+++ b/ui/src/assets/icons/controlled-tier-badge.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="25px" height="27px" viewBox="0 0 25 27" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>Controlled tier</title>
+    <title>Controlled Tier</title>
     <g id="Controlled-user" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="CT---Share" transform="translate(-399.000000, -492.000000)" fill-rule="nonzero">
             <g id="Group" transform="translate(376.000000, 88.000000)">


### PR DESCRIPTION
I noticed on hover the inconsistency with the RT badge title.