### PR TITLE
[risk=no] Bump to new AoU test user

### DIFF
--- a/e2e/.env.circleci.local
+++ b/e2e/.env.circleci.local
@@ -1,5 +1,5 @@
 # CircleCI e2e test users in local environment
-USER_NAME=puppeteer-tester-4@fake-research-aou.org
+USER_NAME=puppeteer-tester-5@fake-research-aou.org
 WRITER_USER=puppeteer-writer-1@fake-research-aou.org
 READER_USER=puppeteer-reader-2@fake-research-aou.org
 ACCESS_TEST_USER=puppet-access-tester-1@fake-research-aou.org

--- a/e2e/.env.circleci.test
+++ b/e2e/.env.circleci.test
@@ -1,5 +1,5 @@
 # CircleCI e2e test users in test environment
-USER_NAME=puppeteer-tester-4@fake-research-aou.org
+USER_NAME=puppeteer-tester-5@fake-research-aou.org
 WRITER_USER=puppeteer-writer-1@fake-research-aou.org
 READER_USER=puppeteer-reader-2@fake-research-aou.org
 ACCESS_TEST_USER=puppet-access-tester-1@fake-research-aou.org


### PR DESCRIPTION
I suspect current failures are caused by the group limit. We likely had high accumulation of groups due to the high percentage of createworkspace failures over the past several weeks.