### PR TITLE
Chavanr/notebook reader writer update

### DIFF
--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -19,7 +19,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
   }
 
   async isLoaded(): Promise<boolean> {
-    await Promise.all([waitForDocumentTitle(this.page, PageTitle), this.createNewNotebookLink().waitUntilEnabled()]);
+    await waitForDocumentTitle(this.page, PageTitle);
     await waitWhileLoading(this.page);
     return true;
   }

--- a/e2e/tests/notebook/notebook-reader-actions.spec.ts
+++ b/e2e/tests/notebook/notebook-reader-actions.spec.ts
@@ -55,7 +55,7 @@ describe('Workspace READER Jupyter notebook action tests', () => {
   });
 
   // TODO(RW-7312): update and re-enable
-  test.skip('Workspace READER copy notebook to another workspace', async () => {
+  test('Workspace READER copy notebook to another workspace', async () => {
     // READER log in.
     await signInWithAccessToken(page, config.READER_USER);
 
@@ -147,7 +147,7 @@ describe('Workspace READER Jupyter notebook action tests', () => {
   });
 
   // TODO(RW-7312): update and re-enable
-  test.skip('Workspace READER edit copy of notebook in workspace clone', async () => {
+  test('Workspace READER edit copy of notebook in workspace clone', async () => {
     // READER log in.
     await signInWithAccessToken(page, config.READER_USER);
 

--- a/e2e/tests/notebook/notebook-writer-actions.spec.ts
+++ b/e2e/tests/notebook/notebook-writer-actions.spec.ts
@@ -18,7 +18,7 @@ import expect from 'expect';
 jest.setTimeout(30 * 60 * 1000);
 
 // TODO (RW-7312): Re-enable once issue is fixed.
-xdescribe('Workspace WRITER Jupyter notebook action tests', () => {
+describe('Workspace WRITER Jupyter notebook action tests', () => {
   // All tests use same workspace and notebook.
   const workspaceName = makeWorkspaceName();
   const notebookName = makeRandomName('py3');


### PR DESCRIPTION
Enabled the following tests:

- notebook-reader-actions.spec.ts
- notebook-writer-actions.spec.ts


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
