### PR TITLE
[no ticket][risk=no] bump up waitWhileLoading timeout

### DIFF
--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -486,7 +486,7 @@ export default class WorkspaceEditPage extends WorkspaceBase {
     await modal.waitForLoad();
     const modalTextContent = await modal.getTextContent();
     await modal.clickButton(LinkText.Confirm, { waitForClose: true, waitForNav: true, timeout: 3 * 60 * 1000 });
-    await waitWhileLoading(this.page);
+    await waitWhileLoading(this.page, { timeout: 3 * 60 * 1000 });
     return modalTextContent;
   }
 


### PR DESCRIPTION
Increase timeout in `waitWhileLoading` during create and clone workspace operations. 

Match increase in timeout in this PR https://github.com/all-of-us/workbench/pull/6409

**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
