### PR TITLE
[risk=low][RW-8006] Add QUEUED and PROCESSING states to WorkspaceOperation

### DIFF
--- a/api/db/changelog/db.changelog-192-workspace-operation-add-queued-processing.xml
+++ b/api/db/changelog/db.changelog-192-workspace-operation-add-queued-processing.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="thibault" id="changelog-192-workspace-operation-add-queued-processing">
+    <sql>
+      ALTER TABLE workspace_operation
+        MODIFY COLUMN status
+        ENUM('PENDING', 'QUEUED', 'PROCESSING', 'ERROR', 'SUCCESS')
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -201,6 +201,7 @@
   <include file="changelog/db.changelog-189-cdr-bucket-paths.xml"/>
   <include file="changelog/db.changelog-190-billing-migration-bug-backfill.xml"/>
   <include file="changelog/db.changelog-191-workspace-operation.xml"/>
+  <include file="changelog/db.changelog-191-workspace-operation-add-queued-processing.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -201,7 +201,7 @@
   <include file="changelog/db.changelog-189-cdr-bucket-paths.xml"/>
   <include file="changelog/db.changelog-190-billing-migration-bug-backfill.xml"/>
   <include file="changelog/db.changelog-191-workspace-operation.xml"/>
-  <include file="changelog/db.changelog-191-workspace-operation-add-queued-processing.xml"/>
+  <include file="changelog/db.changelog-192-workspace-operation-add-queued-processing.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -289,7 +289,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     if (operation.getStatus() != DbWorkspaceOperationStatus.QUEUED) {
       log.info(
           String.format(
-              "processWorkspaceTask: existing because operation %d is in %s state instead of QUEUED",
+              "processWorkspaceTask: exiting because operation %d is in %s state instead of QUEUED",
               operation.getId(), operation.getStatus().toString()));
     }
 

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -296,8 +296,8 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     try {
       log.info(
           String.format(
-              "processWorkspaceTask: begin processing operation %d in %s state",
-              operation.getId(), operation.getStatus().toString()));
+              "processWorkspaceTask: begin processing operation %d by transitioning from %s to %s",
+              operation.getId(), operation.getStatus().toString(), DbWorkspaceOperationStatus.PROCESSING.toString()));
       operation =
           workspaceOperationDao.save(operation.setStatus(DbWorkspaceOperationStatus.PROCESSING));
 

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -297,7 +297,9 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       log.info(
           String.format(
               "processWorkspaceTask: begin processing operation %d by transitioning from %s to %s",
-              operation.getId(), operation.getStatus().toString(), DbWorkspaceOperationStatus.PROCESSING.toString()));
+              operation.getId(),
+              operation.getStatus().toString(),
+              DbWorkspaceOperationStatus.PROCESSING.toString()));
       operation =
           workspaceOperationDao.save(operation.setStatus(DbWorkspaceOperationStatus.PROCESSING));
 

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -287,7 +287,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
                         String.format("Workspace Operation '%d' not found", operationId)));
 
     if (operation.getStatus() != DbWorkspaceOperationStatus.QUEUED) {
-      log.info(
+      log.warning(
           String.format(
               "processWorkspaceTask: exiting because operation %d is in %s state instead of QUEUED",
               operation.getId(), operation.getStatus().toString()));

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -291,6 +291,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
           String.format(
               "processWorkspaceTask: exiting because operation %d is in %s state instead of QUEUED",
               operation.getId(), operation.getStatus().toString()));
+      return;
     }
 
     try {

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspaceOperation.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspaceOperation.java
@@ -20,7 +20,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class DbWorkspaceOperation {
   public enum DbWorkspaceOperationStatus {
-    PENDING,
+    PENDING, // Deprecated
+    QUEUED,
+    PROCESSING,
     ERROR,
     SUCCESS
   }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4864,9 +4864,11 @@ definitions:
     - DELETED
   WorkspaceOperationStatus:
     type: string
-    description: ''
+    description: 'Note: PENDING is deprecated and has been replaced by QUEUED and PROCESSING'
     enum:
     - PENDING
+    - QUEUED
+    - PROCESSING
     - ERROR
     - SUCCESS
   ResearchPurpose:

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -743,7 +743,7 @@ public class WorkspacesControllerTest {
     Workspace workspace = createWorkspace();
     WorkspaceOperation operation = workspacesController.createWorkspaceAsync(workspace).getBody();
     assertThat(operation.getId()).isNotNull();
-    assertThat(operation.getStatus()).isEqualTo(WorkspaceOperationStatus.PENDING);
+    assertThat(operation.getStatus()).isEqualTo(WorkspaceOperationStatus.QUEUED);
     assertThat(operation.getWorkspace()).isNull();
   }
 
@@ -787,7 +787,7 @@ public class WorkspacesControllerTest {
             .duplicateWorkspaceAsync(workspace.getNamespace(), workspace.getId(), request)
             .getBody();
     assertThat(operation.getId()).isNotNull();
-    assertThat(operation.getStatus()).isEqualTo(WorkspaceOperationStatus.PENDING);
+    assertThat(operation.getStatus()).isEqualTo(WorkspaceOperationStatus.QUEUED);
     assertThat(operation.getWorkspace()).isNull();
   }
 
@@ -823,15 +823,15 @@ public class WorkspacesControllerTest {
         workspaceOperationDao.save(
             new DbWorkspaceOperation()
                 .setCreatorId(currentUser.getUserId())
-                .setStatus(DbWorkspaceOperationStatus.PENDING));
+                .setStatus(DbWorkspaceOperationStatus.SUCCESS));
     assertThat(dbOperation.getId()).isNotNull();
-    assertThat(dbOperation.getStatus()).isEqualTo(DbWorkspaceOperationStatus.PENDING);
+    assertThat(dbOperation.getStatus()).isEqualTo(DbWorkspaceOperationStatus.SUCCESS);
     assertThat(dbOperation.getWorkspaceId()).isNull();
 
     WorkspaceOperation operation =
         workspacesController.getWorkspaceOperation(dbOperation.getId()).getBody();
     assertThat(operation.getId()).isEqualTo(dbOperation.getId());
-    assertThat(operation.getStatus()).isEqualTo(WorkspaceOperationStatus.PENDING);
+    assertThat(operation.getStatus()).isEqualTo(WorkspaceOperationStatus.SUCCESS);
     assertThat(operation.getWorkspace()).isNull();
   }
 
@@ -904,7 +904,7 @@ public class WorkspacesControllerTest {
     Workspace workspace = createWorkspace();
     WorkspaceOperation operation = workspacesController.createWorkspaceAsync(workspace).getBody();
     assertThat(operation.getId()).isNotNull();
-    assertThat(operation.getStatus()).isEqualTo(WorkspaceOperationStatus.PENDING);
+    assertThat(operation.getStatus()).isEqualTo(WorkspaceOperationStatus.QUEUED);
     assertThat(operation.getWorkspace()).isNull();
 
     WorkspaceOperation operation2 =

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1060,6 +1060,12 @@ export const WorkspaceEdit = fp.flow(
       operation: () => Promise<WorkspaceOperation>,
       errorText: string
     ): Promise<Workspace> {
+      const PENDING_STATES = [
+        WorkspaceOperationStatus.PENDING,
+        WorkspaceOperationStatus.QUEUED,
+        WorkspaceOperationStatus.PROCESSING,
+      ];
+
       let pollTimedOut = false;
       setTimeout(
         () => (pollTimedOut = true),
@@ -1067,10 +1073,7 @@ export const WorkspaceEdit = fp.flow(
       );
 
       let workspaceOp = await operation();
-      while (
-        !pollTimedOut &&
-        workspaceOp.status === WorkspaceOperationStatus.PENDING
-      ) {
+      while (!pollTimedOut && PENDING_STATES.includes(workspaceOp.status)) {
         await delay(WORKSPACE_OPERATION_POLL_INTERVAL_MS);
         workspaceOp = await workspacesApi().getWorkspaceOperation(
           workspaceOp.id

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -239,6 +239,12 @@ const NEW_ACL_DELAY_POLL_INTERVAL_MS = 10 * 1000;
 const WORKSPACE_OPERATION_POLL_TIMEOUT_MS = 3 * 60 * 1000;
 const WORKSPACE_OPERATION_POLL_INTERVAL_MS = 5 * 1000;
 
+const OPERATION_PENDING_STATES = [
+  WorkspaceOperationStatus.PENDING,
+  WorkspaceOperationStatus.QUEUED,
+  WorkspaceOperationStatus.PROCESSING,
+];
+
 export enum WorkspaceEditMode {
   Create = 1,
   Edit = 2,
@@ -1060,12 +1066,6 @@ export const WorkspaceEdit = fp.flow(
       operation: () => Promise<WorkspaceOperation>,
       errorText: string
     ): Promise<Workspace> {
-      const PENDING_STATES = [
-        WorkspaceOperationStatus.PENDING,
-        WorkspaceOperationStatus.QUEUED,
-        WorkspaceOperationStatus.PROCESSING,
-      ];
-
       let pollTimedOut = false;
       setTimeout(
         () => (pollTimedOut = true),
@@ -1073,7 +1073,10 @@ export const WorkspaceEdit = fp.flow(
       );
 
       let workspaceOp = await operation();
-      while (!pollTimedOut && PENDING_STATES.includes(workspaceOp.status)) {
+      while (
+        !pollTimedOut &&
+        OPERATION_PENDING_STATES.includes(workspaceOp.status)
+      ) {
         await delay(WORKSPACE_OPERATION_POLL_INTERVAL_MS);
         workspaceOp = await workspacesApi().getWorkspaceOperation(
           workspaceOp.id


### PR DESCRIPTION
Split (and deprecate) the PENDING state into QUEUED and PROCESSING for WorkspaceOperation.  Require a QUEUED state to process a queued task, to help guard against multiple execution.

Motivation is from https://cloud.google.com/tasks/docs/common-pitfalls
> Cloud Tasks aims for a strict "execute exactly once" semantic. However, in situations where a design trade-off must be made between guaranteed execution and duplicate execution, the service errs on the side of guaranteed execution. As such, a non-zero number of duplicate executions do occur. Developers should take steps to ensure that duplicate execution is not a catastrophic event. In production, more than 99.999% of tasks are executed only once.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
