### PR TITLE
[RW-7992][risk=low] Configure stable/prod for genomic workflow extraction

### DIFF
--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -44,12 +44,13 @@
     "extractionPetServiceAccount": "pet-114668949591113561197@aouwgscohortextraction-prod.iam.gserviceaccount.com",
     "extractionMethodConfigurationNamespace": "aouwgscohortextraction-prod",
     "extractionMethodConfigurationName": "GvsExtractCohortFromSampleNames",
-    "extractionMethodConfigurationVersion": 2,
-    "extractionMethodLogicalVersion": 1,
+    "extractionMethodConfigurationVersion": 3,
+    "extractionMethodLogicalVersion": 2,
     "extractionCohortsDataset": "fc-aou-cdr-prod-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-prod-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-prod-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-357-gc79075c-SNAPSHOT-local.jar",
+    "extractionFilterSetName": "beta2_99k_row_10",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-464-g86f1116-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -44,12 +44,13 @@
     "extractionPetServiceAccount": "pet-116281557770103257351@aouwgscohortextraction-stable.iam.gserviceaccount.com",
     "extractionMethodConfigurationNamespace": "aouwgscohortextraction-stable",
     "extractionMethodConfigurationName": "GvsExtractCohortFromSampleNames",
-    "extractionMethodConfigurationVersion": 3,
-    "extractionMethodLogicalVersion": 1,
+    "extractionMethodConfigurationVersion": 4,
+    "extractionMethodLogicalVersion": 2,
     "extractionCohortsDataset": "fc-aou-cdr-stable-ct.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-stable-ct.wgs_extraction_destination",
     "extractionTempTablesDataset": "fc-aou-cdr-stable-ct.wgs_extraction_temp_tables",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-357-gc79075c-SNAPSHOT-local.jar",
+    "extractionFilterSetName": "example",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-464-g86f1116-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {


### PR DESCRIPTION
This will have no effect yet on the capabilities of stable/prod, as there are still no CT CDRs.