### PR TITLE
[no ticket][risk=no] update clickCreateFinishButton function

### DIFF
--- a/e2e/app/modal/cohort-save-as-modal.ts
+++ b/e2e/app/modal/cohort-save-as-modal.ts
@@ -26,7 +26,7 @@ export default class CohortSaveAsModal extends Modal {
   }
 
   async clickSaveButton(): Promise<void> {
-    await this.clickButton(LinkText.Save, { waitForNav: true, waitForClose: true, timeout: 2 * 60 * 1000 });
+    await this.clickButton(LinkText.Save, { waitForClose: true, timeout: 2 * 60 * 1000 });
     await waitWhileLoading(this.page);
   }
 }

--- a/e2e/app/modal/dataset-create-modal.ts
+++ b/e2e/app/modal/dataset-create-modal.ts
@@ -34,7 +34,7 @@ export default class DatasetCreateModal extends Modal {
     await nameTextbox.clearTextInput();
     await nameTextbox.type(newDatasetName);
 
-    await this.clickButton(LinkText.Save, { waitForClose: true, waitForNav: true });
+    await this.clickButton(LinkText.Save, { waitForClose: true });
     await waitWhileLoading(this.page);
 
     logger.info(`Created Dataset "${newDatasetName}"`);

--- a/e2e/app/modal/new-notebook-modal.ts
+++ b/e2e/app/modal/new-notebook-modal.ts
@@ -35,7 +35,6 @@ export default class NewNotebookModal extends Modal {
     await radio.select();
     return this.clickButton(LinkText.CreateNotebook, {
       waitForClose: true,
-      waitForNav: true,
       waitForLoadingSpinner: false
     });
   }

--- a/e2e/app/modal/warning-discard-changes-modal.ts
+++ b/e2e/app/modal/warning-discard-changes-modal.ts
@@ -17,13 +17,13 @@ export default class WarningDiscardChangesModal extends Modal {
 
   async clickDiscardChangesButton(): Promise<string[]> {
     const contentText = await this.getTextContent();
-    await this.clickButton(LinkText.DiscardChanges, { waitForNav: true, waitForClose: true });
+    await this.clickButton(LinkText.DiscardChanges, { waitForClose: true });
     return contentText;
   }
 
   async clickYesDeleteButton(): Promise<string[]> {
     const contentText = await this.getTextContent();
-    await this.clickButton(LinkText.YesDelete, { waitForNav: false, waitForClose: true });
+    await this.clickButton(LinkText.YesDelete, { waitForClose: true });
     return contentText;
   }
 }

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -485,7 +485,12 @@ export default class WorkspaceEditPage extends WorkspaceBase {
     const modal = new NewWorkspaceModal(this.page);
     await modal.waitForLoad();
     const modalTextContent = await modal.getTextContent();
-    await modal.clickButton(LinkText.Confirm, { waitForClose: true, waitForNav: true, timeout: 3 * 60 * 1000 });
+    await modal.clickButton(LinkText.Confirm, {
+      waitForClose: true,
+      waitForNav: true,
+      waitForLoadingSpinner: false,
+      timeout: 3 * 60 * 1000
+    });
     await waitWhileLoading(this.page);
     return modalTextContent;
   }

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -488,7 +488,7 @@ export default class WorkspaceEditPage extends WorkspaceBase {
     await modal.clickButton(LinkText.Confirm, {
       waitForClose: true,
       waitForLoadingSpinner: false,
-      timeout: 3 * 60 * 1000
+      timeout: 4 * 60 * 1000
     });
     await waitWhileLoading(this.page);
     return modalTextContent;

--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -487,7 +487,6 @@ export default class WorkspaceEditPage extends WorkspaceBase {
     const modalTextContent = await modal.getTextContent();
     await modal.clickButton(LinkText.Confirm, {
       waitForClose: true,
-      waitForNav: true,
       waitForLoadingSpinner: false,
       timeout: 3 * 60 * 1000
     });


### PR DESCRIPTION
Fix `clickButton()` because it didn't throw exception.
Issue: Puppeteer `waitForNavigation` function has failed before timeout and `fp` swallowed exceptions. `clickButton()` should have thrown exception.

Sample log after fix:

```
[3/9/2022, 13:46:00] - "[Test] Create Workspace | All of Us Researcher Workbench" page loaded.
[3/9/2022, 13:46:13] - Modal "Create Workspace" is open
[3/9/2022, 13:46:15] - Request finished: 200 POST https://api-dot-all-of-us-workbench-test.appspot.com/v1/workspaces/createAsync
{
  "id": 1803,
  "status": "QUEUED",
  "workspace": null
}
[3/9/2022, 13:49:13] - Request finished: 200 GET https://api-dot-all-of-us-workbench-test.appspot.com/v1/workspaces/operations/1803
{
  "id": 1803,
  "status": "PROCESSING",
  "workspace": null
}

[3/9/2022, 13:49:14] - FAIL: WaitUntilClose failed for modal "Create Workspace". Modal xpath: "//*[@id="popup-root"]/*[@class="ReactModalPortal"][1]//*[@role="dialog" and @aria-modal="true" and contains(@class, "after-open")]"

[3/9/2022, 13:49:14] - TimeoutError: waiting for function failed: timeout 180000ms exceeded
    at new WaitTask (/Users/bweng/projects/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:505:34)
    at DOMWorld.waitForFunction (/Users/bweng/projects/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:460:26)
    at Frame.waitForFunction (/Users/bweng/projects/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/FrameManager.js:910:32)
    at Page.waitForFunction (/Users/bweng/projects/workbench/e2e/node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:1291:33)
    at NewWorkspaceModal.waitUntilClose (/Users/bweng/projects/workbench/e2e/app/modal/base-modal.ts:93:23)



Tests Summary
----------------------------------------------
test name: Upload file and run Python code
status: failed
failure: [
  'Error: TimeoutError: waiting for function failed: timeout 180000ms exceeded\n' +
    '    at NewWorkspaceModal.waitUntilClose (/Users/bweng/projects/workbench/e2e/app/modal/base-modal.ts:107:13)\n' +
    '    at NewWorkspaceModal.clickButton (/Users/bweng/projects/workbench/e2e/app/container.ts:60:7)\n' +
    '    at WorkspaceEditPage.clickCreateFinishButton (/Users/bweng/projects/workbench/e2e/app/page/workspace-edit-page.ts:488:5)\n' +
    '    at WorkspacesPage.createWorkspace (/Users/bweng/projects/workbench/e2e/app/page/workspaces-page.ts:118:26)\n' +
    '    at createWorkspace (/Users/bweng/projects/workbench/e2e/utils/test-utils.ts:162:3)\n' +
    '    at Object.<anonymous> (/Users/bweng/projects/workbench/e2e/tests/notebook/notebook-upload-file.spec.ts:22:5)'
]


```
