### PR TITLE
[risk=no] Add missing source WGS project to prod config

### DIFF
--- a/api/libproject/environments.rb
+++ b/api/libproject/environments.rb
@@ -129,6 +129,7 @@ ENVIRONMENTS = {
     :cdr_sql_instance => "all-of-us-rw-prod:us-central1:workbenchmaindb",
     :gae_vars => make_gae_vars(8, 64, 'F4'),
     :source_cdr_project => "aou-res-curation-output-prod",
+    :source_cdr_wgs_project => "aou-genomics-curation-prod",
     :publisher_account => "deploy@all-of-us-rw-prod.iam.gserviceaccount.com",
     :accessTiers => {
       "registered" => {


### PR DESCRIPTION
This config setting was needed to publish the WGS dataset to prod. Missed in previous PRs.