### PR TITLE
[risk=no][no ticket] Fix e2e user-profile-admin.spec

### DIFF
--- a/e2e/app/page/workspace-edit-page.ts
+++ b/e2e/app/page/workspace-edit-page.ts
@@ -7,7 +7,7 @@ import { ElementType } from 'app/xpath-options';
 import { ElementHandle, Page } from 'puppeteer';
 import { waitForDocumentTitle, waitWhileLoading } from 'utils/waits-utils';
 import { buildXPath } from 'app/xpath-builders';
-import { LinkText } from 'app/text-labels';
+import { AccessTierDisplayNames, LinkText } from 'app/text-labels';
 import NewWorkspaceModal from 'app/modal/new-workspace-modal';
 import WorkspaceBase, { UseFreeCredits } from './workspace-base';
 import { config } from 'resources/workbench-config';
@@ -270,11 +270,6 @@ export const FIELD = {
 export enum AccessTierShortNames {
   Registered = 'registered',
   Controlled = 'controlled'
-}
-
-export enum AccessTierDisplayNames {
-  Registered = 'Registered Tier',
-  Controlled = 'Controlled Tier'
 }
 
 export default class WorkspaceEditPage extends WorkspaceBase {

--- a/e2e/app/page/workspaces-page.ts
+++ b/e2e/app/page/workspaces-page.ts
@@ -1,7 +1,7 @@
 import { Page } from 'puppeteer';
 import Button from 'app/element/button';
-import { LinkText, PageUrl, Tabs } from 'app/text-labels';
-import WorkspaceEditPage, { AccessTierDisplayNames, FIELD as EDIT_FIELD } from 'app/page/workspace-edit-page';
+import { AccessTierDisplayNames, LinkText, PageUrl, Tabs } from 'app/text-labels';
+import WorkspaceEditPage, { FIELD as EDIT_FIELD } from 'app/page/workspace-edit-page';
 import RadioButton from 'app/element/radiobutton';
 import { waitForDocumentTitle, waitWhileLoading } from 'utils/waits-utils';
 import ReactSelect from 'app/element/react-select';

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -1,5 +1,6 @@
 import { config } from 'resources/workbench-config';
 import { IPageUrl } from 'types';
+
 const { LOGIN_URL_DOMAIN_NAME, WORKSPACES_URL_PATH, ADMIN_URL_PATH, PROFILE_URL_PATH } = config;
 
 export const PageUrl: IPageUrl = {
@@ -233,4 +234,9 @@ export enum Tabs {
   CohortReviews = 'Cohort Reviews',
   ConceptSets = 'Concept Sets',
   ShowAll = 'Show All'
+}
+
+export enum AccessTierDisplayNames {
+  Registered = 'Registered Tier',
+  Controlled = 'Controlled Tier'
 }

--- a/e2e/tests/nightly/admin/user-profile-admin.spec.ts
+++ b/e2e/tests/nightly/admin/user-profile-admin.spec.ts
@@ -1,17 +1,17 @@
-import UserAdminPage from 'app/page/admin-user-list-page';
-import { asyncFilter, parseForNumericalStrings, signInWithAccessToken } from 'utils/test-utils';
+import { ElementHandle, Page } from 'puppeteer';
 import { config } from 'resources/workbench-config';
 import navigation, { NavLink } from 'app/component/navigation';
 import AdminTable from 'app/component/admin-table';
 import UserProfileInfo from 'app/page/admin-user-profile-info';
 import UserProfileAdminPage from 'app/page/admin/user-profile-admin-page';
-import { ElementHandle, Page } from 'puppeteer';
-import { waitForText, waitWhileLoading } from 'utils/waits-utils';
-import { Institution, InstitutionRole } from 'app/text-labels';
-import { getPropValue, getStyleValue } from 'utils/element-utils';
+import UserAdminPage from 'app/page/admin-user-list-page';
+import { AccessTierDisplayNames, Institution, InstitutionRole } from 'app/text-labels';
 import Cell, { CellContent } from 'app/component/cell';
 import UserAuditPage from 'app/page/admin-user-audit-page';
+import { getPropValue, getStyleValue } from 'utils/element-utils';
 import { isBlank } from 'utils/str-utils';
+import { waitForText, waitWhileLoading } from 'utils/waits-utils';
+import { asyncFilter, parseForNumericalStrings, signInWithAccessToken } from 'utils/test-utils';
 import fp from 'lodash/fp';
 
 /**
@@ -31,7 +31,7 @@ import fp from 'lodash/fp';
  * These institutions also exist: Broad, Google, Verily, Vanderbilt
  *
  */
-describe('User Profile Admin', () => {
+describe('User Profile Admin page', () => {
   enum TableColumns {
     ACCESS_MODULE = 'Access module',
     STATUS = 'Status',
@@ -71,11 +71,6 @@ describe('User Profile Admin', () => {
     AccessModules.UPDATE_PROFILE,
     AccessModules.PUBLICATION
   ];
-
-  enum Tiers {
-    RT = 'Registered Tier',
-    CT = 'Controlled Tier'
-  }
 
   const CHANGED_BACKGROUND_COLOR = 'rgb(248, 201, 84)';
   const BACKGROUND_COLOR = 'rgb(255, 255, 255)';
@@ -167,10 +162,10 @@ describe('User Profile Admin', () => {
     // note: assumes ERA required for both tiers
     for (const accessModule of accessModules) {
       const cell = await accountAccessTable.getCellByValue(accessModule, TableColumns.REQUIRED_FOR_TIER);
-      expect(await hasTierBadge(cell, Tiers.CT)).toBe(true);
+      expect(await hasTierBadge(cell, AccessTierDisplayNames.Controlled)).toBe(true);
       accessModule === AccessModules.CT_TRAINING
-        ? expect(await hasTierBadge(cell, Tiers.RT)).toBe(false)
-        : expect(await hasTierBadge(cell, Tiers.RT)).toBe(true);
+        ? expect(await hasTierBadge(cell, AccessTierDisplayNames.Registered)).toBe(false)
+        : expect(await hasTierBadge(cell, AccessTierDisplayNames.Registered)).toBe(true);
     }
 
     // Verify Status displayed correctly
@@ -520,7 +515,7 @@ describe('User Profile Admin', () => {
     await newPage.close();
   }
 
-  async function hasTierBadge(cell: Cell, tier: Tiers): Promise<boolean> {
+  async function hasTierBadge(cell: Cell, tier: AccessTierDisplayNames): Promise<boolean> {
     const elements: ElementHandle[] = await cell.getContent(CellContent.SVG);
     const svg: ElementHandle[] = await asyncFilter(
       elements,

--- a/e2e/tests/nightly/admin/user-profile-admin.spec.ts
+++ b/e2e/tests/nightly/admin/user-profile-admin.spec.ts
@@ -74,7 +74,7 @@ describe('User Profile Admin', () => {
 
   enum Tiers {
     RT = 'Registered Tier',
-    CT = 'Controlled tier'
+    CT = 'Controlled Tier'
   }
 
   const CHANGED_BACKGROUND_COLOR = 'rgb(248, 201, 84)';

--- a/e2e/tests/nightly/dataproc-to-gce.spec.ts
+++ b/e2e/tests/nightly/dataproc-to-gce.spec.ts
@@ -1,10 +1,9 @@
 import RuntimePanel, { ComputeType, RuntimePreset, StartStopIconState } from 'app/sidebar/runtime-panel';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import { LinkText, ResourceCard } from 'app/text-labels';
+import { AccessTierDisplayNames, LinkText, ResourceCard } from 'app/text-labels';
 import { config } from 'resources/workbench-config';
 import { makeRandomName } from 'utils/str-utils';
 import { findOrCreateWorkspace, signInWithAccessToken } from 'utils/test-utils';
-import { AccessTierDisplayNames } from 'app/page/workspace-edit-page';
 
 // This test could take a long time to run
 jest.setTimeout(40 * 60 * 1000);

--- a/e2e/tests/nightly/gce-to-dataproc.spec.ts
+++ b/e2e/tests/nightly/gce-to-dataproc.spec.ts
@@ -3,8 +3,7 @@ import { config } from 'resources/workbench-config';
 import { findOrCreateWorkspace, signInWithAccessToken } from 'utils/test-utils';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import { makeRandomName } from 'utils/str-utils';
-import { ResourceCard } from 'app/text-labels';
-import { AccessTierDisplayNames } from 'app/page/workspace-edit-page';
+import { AccessTierDisplayNames, ResourceCard } from 'app/text-labels';
 
 // This test could take a long time to run
 jest.setTimeout(40 * 60 * 1000);

--- a/e2e/tests/nightly/genomic-extraction-to-vcf.spec.ts
+++ b/e2e/tests/nightly/genomic-extraction-to-vcf.spec.ts
@@ -1,7 +1,15 @@
 import { findOrCreateWorkspace, signInWithAccessToken } from 'utils/test-utils';
 import { config } from 'resources/workbench-config';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
-import { AgeSelectionRadioButton, AnalysisTool, ConceptSets, DataSets, Language, LinkText } from 'app/text-labels';
+import {
+  AccessTierDisplayNames,
+  AgeSelectionRadioButton,
+  AnalysisTool,
+  ConceptSets,
+  DataSets,
+  Language,
+  LinkText
+} from 'app/text-labels';
 import CohortActionsPage from 'app/page/cohort-actions-page';
 import { makeRandomName } from 'utils/str-utils';
 import GenomicsVariantExtractConfirmationModal from 'app/modal/genomic-extract-confirmation-modal';
@@ -12,7 +20,6 @@ import GenomicExtractionsSidebar from 'app/sidebar/genomic-extractions-sidebar';
 import { Page } from 'puppeteer';
 import { takeScreenshot } from 'utils/save-file-utils';
 import expect from 'expect';
-import { AccessTierDisplayNames } from 'app/page/workspace-edit-page';
 
 // 60 minutes. Test could take a long time.
 // Since refresh token expires in 60 min. test can fail if running takes longer than 60 min.

--- a/e2e/tests/workspace/workspace-create.spec.ts
+++ b/e2e/tests/workspace/workspace-create.spec.ts
@@ -1,11 +1,11 @@
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import WorkspacesPage from 'app/page/workspaces-page';
-import { signInWithAccessToken, performActions } from 'utils/test-utils';
+import { performActions, signInWithAccessToken } from 'utils/test-utils';
 import * as testData from 'resources/data/workspace-data';
 import { makeWorkspaceName } from 'utils/str-utils';
 import { UseFreeCredits } from 'app/page/workspace-base';
-import { AccessTierDisplayNames } from 'app/page/workspace-edit-page';
 import { config } from 'resources/workbench-config';
+import { AccessTierDisplayNames } from 'app/text-labels';
 
 describe('Creating new workspaces', () => {
   beforeEach(async () => {

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -8,7 +8,16 @@ import * as fs from 'fs';
 import * as fp from 'lodash/fp';
 import { ElementHandle, Page } from 'puppeteer';
 import WorkspaceCard from 'app/component/card/workspace-card';
-import { Cohorts, ConceptSets, Language, PageUrl, ResourceCard, Tabs, WorkspaceAccessLevel } from 'app/text-labels';
+import {
+  AccessTierDisplayNames,
+  Cohorts,
+  ConceptSets,
+  Language,
+  PageUrl,
+  ResourceCard,
+  Tabs,
+  WorkspaceAccessLevel
+} from 'app/text-labels';
 import WorkspacesPage from 'app/page/workspaces-page';
 import Navigation, { NavLink } from 'app/component/navigation';
 import { isBlank, makeWorkspaceName } from './str-utils';
@@ -16,7 +25,6 @@ import { config } from 'resources/workbench-config';
 import { logger } from 'libs/logger';
 import { authenticator } from 'otplib';
 import AuthenticatedPage from 'app/page/authenticated-page';
-import { AccessTierDisplayNames } from 'app/page/workspace-edit-page';
 import Tab from 'app/element/tab';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import DataResourceCard from 'app/component/card/data-resource-card';


### PR DESCRIPTION
Description:
Updated Tier Badge textContent due to a recent change in UI which has caused test to fail.
After update, `enum Tier` in `user-profile-admin.spec` become the same as in `enum AccessTierDisplayNames` in `workspace-edit.page`. So it makes sense to move `enum AccessTierDisplayNames` from `workspace-edit.page` to `text-labels.ts`.

<img width="600" alt="Screen Shot 2022-03-10 at 10 51 51 AM" src="https://user-images.githubusercontent.com/35533885/157700026-664d1d81-6fd6-4516-8578-758e88c082d8.png">

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
