### PR TITLE
[no ticket][risk=no] Changed default cdrIndexBuild for registered to synth_r_2019q4_30 in test only

### DIFF
--- a/api/config/cdr_config_test.json
+++ b/api/config/cdr_config_test.json
@@ -58,7 +58,7 @@
       "creationTime": "2019-09-30 00:00:00Z",
       "releaseNumber": 3,
       "numParticipants": 234525,
-      "cdrDbName": "synth_r_2019q4_29",
+      "cdrDbName": "synth_r_2019q4_30",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"


### PR DESCRIPTION
Description:
- Updated cdr-indexing build as per tickets [RW-7932 ](https://precisionmedicineinitiative.atlassian.net/browse/RW-7932 ) and [RW-7891](https://precisionmedicineinitiative.atlassian.net/browse/RW-7891) 
- This PR is to test the application to compare in test environment that `search-counts` match `registered-tier` (new cdrDbName) and `controlled-tier`

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
