### PR TITLE
[risk=low][RW-7961] fix bug for incomplete-publications users

### DIFF
--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -468,32 +468,27 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
               />
               <RadioButton
                 id={noReportId}
-                disabled={
-                  !isModuleExpiring(
-                    getAccessModuleStatusByNameOrEmpty(
-                      modules,
-                      AccessModule.PUBLICATIONCONFIRMATION
-                    )
+                disabled={bypassedOrCompleteAndNotExpiring(
+                  getAccessModuleStatusByNameOrEmpty(
+                    modules,
+                    AccessModule.PUBLICATIONCONFIRMATION
                   )
-                }
+                )}
                 style={{ justifySelf: 'end' }}
                 checked={publications === true}
                 onChange={() => setPublications(true)}
               />
               <label htmlFor={noReportId}>
-                {' '}
-                At this time, I have nothing to report{' '}
+                At this time, I have nothing to report
               </label>
               <RadioButton
                 id={reportId}
-                disabled={
-                  !isModuleExpiring(
-                    getAccessModuleStatusByNameOrEmpty(
-                      modules,
-                      AccessModule.PUBLICATIONCONFIRMATION
-                    )
+                disabled={bypassedOrCompleteAndNotExpiring(
+                  getAccessModuleStatusByNameOrEmpty(
+                    modules,
+                    AccessModule.PUBLICATIONCONFIRMATION
                   )
-                }
+                )}
                 style={{ justifySelf: 'end' }}
                 checked={publications === false}
                 onChange={() => setPublications(false)}

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -467,6 +467,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
                 style={{ gridRow: '1 / span 2', marginRight: '0.25rem' }}
               />
               <RadioButton
+                data-test-id='nothing-to-report'
                 id={noReportId}
                 disabled={bypassedOrCompleteAndNotExpiring(
                   getAccessModuleStatusByNameOrEmpty(
@@ -482,6 +483,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
                 At this time, I have nothing to report
               </label>
               <RadioButton
+                data-test-id='report-submitted'
                 id={reportId}
                 disabled={bypassedOrCompleteAndNotExpiring(
                   getAccessModuleStatusByNameOrEmpty(

--- a/ui/src/app/pages/workspace/workspace-library.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-library.spec.tsx
@@ -14,7 +14,11 @@ import {
 import { AccessTierShortNames } from 'app/utils/access-tiers';
 import { profileStore } from 'app/utils/stores';
 
-import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
+import {
+  expectButtonDisabled,
+  expectButtonEnabled,
+  waitOneTickAndUpdate,
+} from 'testing/react-test-helpers';
 import { FeaturedWorkspacesConfigApiStub } from 'testing/stubs/featured-workspaces-config-api-stub';
 import { ProfileApiStub } from 'testing/stubs/profile-api-stub';
 import { buildWorkspaceStubs } from 'testing/stubs/workspaces';
@@ -158,12 +162,12 @@ describe('WorkspaceLibrary', () => {
       .map((c) => c.text());
     expect(cardNameList.length).toEqual(1);
 
-    const styleCursor = wrapper
-      .find('[data-test-id="workspace-card"]')
-      .first()
-      .find('[role="button"]')
-      .map((c) => c.prop('style').cursor);
-    expect(styleCursor).toEqual(['not-allowed']);
+    expectButtonDisabled(
+      wrapper
+        .find('[data-test-id="workspace-card"]')
+        .first()
+        .find('[role="button"]')
+    );
   });
 
   it('controlled tier workspace is clickable for ct user', async () => {
@@ -191,11 +195,11 @@ describe('WorkspaceLibrary', () => {
     wrapper.find('[data-test-id="Phenotype Library"]').simulate('click');
     await waitOneTickAndUpdate(wrapper);
 
-    const styleCursor = wrapper
-      .find('[data-test-id="workspace-card"]')
-      .first()
-      .find('[role="button"]')
-      .map((c) => c.prop('style').cursor);
-    expect(styleCursor).toEqual(['pointer']);
+    expectButtonEnabled(
+      wrapper
+        .find('[data-test-id="workspace-card"]')
+        .first()
+        .find('[role="button"]')
+    );
   });
 });

--- a/ui/src/testing/react-test-helpers.tsx
+++ b/ui/src/testing/react-test-helpers.tsx
@@ -109,3 +109,13 @@ export const simulateTextInputChange = async (
   wrapper.simulate('change', { target: { value } });
   return await waitOneTickAndUpdate(wrapper);
 };
+
+export const expectButtonState = (wrapper: ReactWrapper, enabled: boolean) => {
+  const buttonStyle: React.CSSProperties = wrapper.prop('style');
+  expect(buttonStyle.cursor).toEqual(enabled ? 'pointer' : 'not-allowed');
+};
+
+export const expectButtonEnabled = (buttonWrapper: ReactWrapper) =>
+  expectButtonState(buttonWrapper, true);
+export const expectButtonDisabled = (buttonWrapper: ReactWrapper) =>
+  expectButtonState(buttonWrapper, false);


### PR DESCRIPTION
Users with incomplete Publications could not complete access renewal.

Note: it's not expected that such a user can get to the access renewal page, because we expect that even new users have complete Publications.   But we have seen bugs where this did not happen, and test users might get into this state.  It's an easy fix, so let's do it.

This does not complete RW-7961.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
