### PR TITLE
[RW-8044][risk=no] Bump async polling timeout from 3m -> 6m

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -236,7 +236,7 @@ const NEW_ACL_DELAY_POLL_TIMEOUT_MS = 60 * 1000;
 const NEW_ACL_DELAY_POLL_INTERVAL_MS = 10 * 1000;
 
 // Poll parameters for checking the result of an async Workspace Create or Duplicate operation
-const WORKSPACE_OPERATION_POLL_TIMEOUT_MS = 3 * 60 * 1000;
+const WORKSPACE_OPERATION_POLL_TIMEOUT_MS = 6 * 60 * 1000;
 const WORKSPACE_OPERATION_POLL_INTERVAL_MS = 5 * 1000;
 
 const OPERATION_PENDING_STATES = [


### PR DESCRIPTION
I'm observing that sometimes the retry does actually succeed - in which case the operation can still be a success after 4-5m. I've yet to see a success which took more than 6 minutes.