### PR TITLE
[risk=low][RW-8039] Fix DB conflict caused by syncModulesExternal()

### DIFF
--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -498,8 +498,17 @@ export const eligibleForTier = (
 };
 
 export const syncModulesExternal = async (moduleNames: AccessModule[]) => {
+  // RT and CT compliance training have the same external sync action.
+  // Calling both can cause conflicts, so we need to remove one.
+  // We choose to remove CT arbitrarily.
+  const filteredModuleNames = moduleNames.includes(
+    AccessModule.COMPLIANCETRAINING
+  )
+    ? moduleNames.filter((m) => m !== AccessModule.CTCOMPLIANCETRAINING)
+    : moduleNames;
+
   return Promise.all(
-    moduleNames.map(async (moduleName) => {
+    filteredModuleNames.map(async (moduleName) => {
       const { externalSyncAction } = getAccessModuleConfig(moduleName);
       if (externalSyncAction) {
         await externalSyncAction();


### PR DESCRIPTION
`syncModulesExternal()` attempts to sync all modules in parallel under the assumption that modules are independent and that updating them won't conflict.

This is not actually the case!  The RT and CT compliance modules have the same external sync endpoint, and the callback from that endpoint updates the statuses of both modules.  So whenever `syncModulesExternal()` is called with both of these specified, there is a high likelihood of conflict.  I can reliably trigger this via the `unsafeAllowUserCreationFromGSuiteData` flow which results in a permanent spinner on the DAR page.  (refreshing generally resolves this)

This PR solves the problem by calling the external training sync endpoint **once** instead of **twice** if RT and CT training are specified.

Alternate solutions
* Optimistic Locking.  This had no effect, but the attempt is #6448 
* sync external modules in sequence.  This may be with looking into.  We should do some timing experiments here

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
