### PR TITLE
[no ticket][risk=no] Avoid e2e dataset export to notebook test coverage redundancy

### DIFF
--- a/e2e/tests/datasets/dataset-export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/dataset-export-py-notebook.spec.ts
@@ -4,17 +4,12 @@ import { Language, LinkText, MenuOption, ResourceCard } from 'app/text-labels';
 import { makeRandomName } from 'utils/str-utils';
 import { findOrCreateDataset, findOrCreateWorkspace, signInWithAccessToken } from 'utils/test-utils';
 
-// 10 minutes.
-jest.setTimeout(10 * 60 * 1000);
-
-describe('Dataset card snowman menu', () => {
-  const KernelLanguages = [{ LANGUAGE: Language.R }, { LANGUAGE: Language.Python }];
-
+describe('Export Dataset to Notebook Test', () => {
   beforeEach(async () => {
     await signInWithAccessToken(page);
   });
 
-  const workspaceName = 'e2eDatasetSnowmanMenuExportToNotebookTest';
+  const workspaceName = 'e2eDatasetSnowmanMenuExportToPyNotebookTest';
 
   /**
    * Test:
@@ -22,12 +17,11 @@ describe('Dataset card snowman menu', () => {
    * - Export dataset to notebook via snowman menu.
    * - Notebook runtime is not started.
    */
-  test.each(KernelLanguages)('Export to %s Jupyter notebook', async (kernelLanguage) => {
+  test('Export to Python kernel Jupyter notebook via dataset card snowman menu', async () => {
     await findOrCreateWorkspace(page, { workspaceName });
-
     const datasetName = await findOrCreateDataset(page, { openEditPage: false });
 
-    // Find Dataset card.
+    // Find Dataset card. Select menu option "Export to Notebook"
     const datasetCard = await new DataResourceCard(page).findCard({
       name: datasetName,
       cardType: ResourceCard.Dataset
@@ -41,7 +35,7 @@ describe('Dataset card snowman menu', () => {
     expect(await exportModal.waitForButton(LinkText.Export).isCursorNotAllowed()).toBe(true);
 
     const notebookName = makeRandomName('pyNotebook');
-    const notebookPreviewPage = await exportModal.fillInModal(notebookName, kernelLanguage.LANGUAGE);
+    const notebookPreviewPage = await exportModal.fillInModal(notebookName, Language.Python);
 
     // Verify notebook created successfully. Not going to start notebook runtime.
     const currentPageUrl = page.url();

--- a/e2e/tests/datasets/dataset-export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/dataset-export-r-notebook.spec.ts
@@ -35,8 +35,8 @@ describe('Export Dataset to Notebook Test', () => {
     // Verify few randomly selected code snippet
     expect(previewCodeLines.some((line) => line.includes('library(tidyverse)'))).toBe(true);
     expect(previewCodeLines.some((line) => line.includes('library(bigrquery)'))).toBe(true);
-
     logger.info({ previewCodeLines });
+
     await exportModal.clickExportButton();
 
     // Verify Notebook preview. Not going to start the Jupyter notebook.

--- a/e2e/tests/datasets/dataset-export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/dataset-export-r-notebook.spec.ts
@@ -5,6 +5,7 @@ import { Language, ResourceCard, Tabs } from 'app/text-labels';
 import { getPropValue } from 'utils/element-utils';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import DatasetBuildPage from 'app/page/dataset-build-page';
+import { logger } from 'libs/logger';
 
 describe('Export Dataset to Notebook Test', () => {
   beforeEach(async () => {
@@ -34,8 +35,8 @@ describe('Export Dataset to Notebook Test', () => {
     // Verify few randomly selected code snippet
     expect(previewCodeLines.some((line) => line.includes('library(tidyverse)'))).toBe(true);
     expect(previewCodeLines.some((line) => line.includes('library(bigrquery)'))).toBe(true);
-    expect(previewCodeLines.some((line) => line.includes('Sys.getenv("GOOGLE_PROJECT")'))).toBe(true);
 
+    logger.info({ previewCodeLines });
     await exportModal.clickExportButton();
 
     // Verify Notebook preview. Not going to start the Jupyter notebook.
@@ -48,6 +49,7 @@ describe('Export Dataset to Notebook Test', () => {
     // Verify few randomly selected code snippet
     expect(previewCodeLines.some((line) => line.includes('Sys.getenv("OWNER_EMAIL")'))).toBe(true);
     expect(previewCodeLines.some((line) => line.includes('Sys.getenv("WORKSPACE_CDR")'))).toBe(true);
+    expect(previewCodeLines.some((line) => line.includes('Sys.getenv("GOOGLE_PROJECT")'))).toBe(true);
 
     // Open notebook in Edit mode.
     const notebookPage = await notebookPreviewPage.openEditMode(notebookName);


### PR DESCRIPTION
Description:

`dataset-export-notebook.spec.ts` and `dataset-snowman-menu-export-notebook.spec.ts` are testing the same  thing, export to R and Python kernel notebooks. Both tests take very long time to run.

Refactoring tests to remove test coverage and code redundancy:
-  `dataset-export-r-notebook.spec.ts` test export to R notebook.
- `dataset-export-py-notebook.spec.ts` test export to Python notebook.


**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
