### PR TITLE
[risk=no][RW-8036] rm env flag enableAsyncWorkspaceOperations

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -15,7 +15,6 @@ import {
   WorkspacesApi,
 } from 'generated/fetch';
 
-import { environment } from 'environments/environment';
 import {
   WorkspaceEdit,
   WorkspaceEditMode,
@@ -383,36 +382,7 @@ describe('WorkspaceEdit', () => {
     await waitOneTickAndUpdate(wrapper);
   });
 
-  it('supports successful duplication in synchronous mode', async () => {
-    environment.enableAsyncWorkspaceOperations = false;
-    workspaceEditMode = WorkspaceEditMode.Duplicate;
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-
-    wrapper
-      .find('[data-test-id="review-request-btn-false"]')
-      .first()
-      .simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    const numBefore = workspacesApi.workspaces.length;
-    wrapper
-      .find('[data-test-id="workspace-save-btn"]')
-      .first()
-      .simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    wrapper
-      .find('[data-test-id="workspace-confirm-save-btn"]')
-      .first()
-      .simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-    expect(workspacesApi.workspaces.length).toEqual(numBefore + 1);
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
-  });
-
   it('supports successful duplication in asynchronous mode', async () => {
-    environment.enableAsyncWorkspaceOperations = true;
     workspaceEditMode = WorkspaceEditMode.Duplicate;
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
@@ -439,44 +409,7 @@ describe('WorkspaceEdit', () => {
     expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
 
-  it('defaults to upgrading the CDR Version when synchronously duplicating a workspace with an older CDR Version', async () => {
-    environment.enableAsyncWorkspaceOperations = false;
-    // init the workspace to a non-default CDR version value
-    const altCdrWorkspace = {
-      ...workspace,
-      cdrVersionId: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION_ID,
-    };
-    currentWorkspaceStore.next(altCdrWorkspace);
-
-    // duplication will involve a CDR version upgrade by default
-    workspaceEditMode = WorkspaceEditMode.Duplicate;
-
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-
-    const cdrSelection = wrapper
-      .find('[data-test-id="select-cdr-version"]')
-      .find('select')
-      .props().value;
-
-    // default CDR version, not the existing workspace's alt CDR version
-    expect(cdrSelection).toBe(
-      CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID
-    );
-
-    const { ALT_WORKSPACE_CDR_VERSION, DEFAULT_WORKSPACE_CDR_VERSION } =
-      CdrVersionsStubVariables;
-    const expectedUpgradeMessage = `${ALT_WORKSPACE_CDR_VERSION} to ${DEFAULT_WORKSPACE_CDR_VERSION}.`;
-    const cdrUpgradeMessage = wrapper
-      .find('[data-test-id="cdr-version-upgrade"]')
-      .first()
-      .text();
-    expect(cdrUpgradeMessage).toContain(altCdrWorkspace.name);
-    expect(cdrUpgradeMessage).toContain(expectedUpgradeMessage);
-  });
-
   it('defaults to upgrading the CDR Version when asynchronously duplicating a workspace with an older CDR Version', async () => {
-    environment.enableAsyncWorkspaceOperations = true;
     // init the workspace to a non-default CDR version value
     const altCdrWorkspace = {
       ...workspace,
@@ -512,7 +445,6 @@ describe('WorkspaceEdit', () => {
   });
 
   it('does not display the CDR Version upgrade message when duplicating a workspace with the latest CDR Version', async () => {
-    environment.enableAsyncWorkspaceOperations = true;
     // the standard test workspace already has the latest CDR Version but let's make it explicit with a new const
     const defaultCdrWorkspace = {
       ...workspace,
@@ -706,51 +638,8 @@ describe('WorkspaceEdit', () => {
     await expectNoTierChangesAllowed();
   });
 
-  // regression test for RW-5132 - sync version
-  it('prevents multiple (sync) Workspace creations via the same confirmation dialog', async () => {
-    environment.enableAsyncWorkspaceOperations = false;
-    workspaceEditMode = WorkspaceEditMode.Duplicate;
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-
-    wrapper
-      .find('[data-test-id="review-request-btn-false"]')
-      .first()
-      .simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    const numBefore = workspacesApi.workspaces.length;
-    wrapper
-      .find('[data-test-id="workspace-save-btn"]')
-      .first()
-      .simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    wrapper
-      .find('[data-test-id="workspace-confirm-save-btn"]')
-      .first()
-      .simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    wrapper
-      .find('[data-test-id="workspace-confirm-save-btn"]')
-      .first()
-      .simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    wrapper
-      .find('[data-test-id="workspace-confirm-save-btn"]')
-      .first()
-      .simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(workspacesApi.workspaces.length).toEqual(numBefore + 1);
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
-  });
-
   // regression test for RW-5132 - async version
   it('prevents multiple (async) Workspace creations via the same confirmation dialog', async () => {
-    environment.enableAsyncWorkspaceOperations = true;
     workspaceEditMode = WorkspaceEditMode.Duplicate;
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -19,7 +19,6 @@ import {
   WorkspaceOperationStatus,
 } from 'generated/fetch';
 
-import { environment } from 'environments/environment';
 import { Button, LinkButton, StyledExternalLink } from 'app/components/buttons';
 import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow } from 'app/components/flex';
@@ -1112,20 +1111,6 @@ export const WorkspaceEdit = fp.flow(
       );
     }
 
-    // the API endpoint is synchronous in that it waits for the Terra call
-    // but we still need an `async` method to call it here
-    private async apiDuplicateWorkspace(): Promise<Workspace> {
-      const duplicateResponse = await workspacesApi().cloneWorkspace(
-        this.props.workspace.namespace,
-        this.props.workspace.id,
-        {
-          includeUserRoles: this.state.cloneUserRole,
-          workspace: this.state.workspace,
-        }
-      );
-      return duplicateResponse.workspace;
-    }
-
     async saveWorkspace() {
       try {
         this.setState({ loading: true });
@@ -1135,13 +1120,9 @@ export const WorkspaceEdit = fp.flow(
         }
 
         if (this.isMode(WorkspaceEditMode.Create)) {
-          workspace = environment.enableAsyncWorkspaceOperations
-            ? await this.apiCreateWorkspaceAsync()
-            : await workspacesApi().createWorkspace(this.state.workspace);
+          workspace = await this.apiCreateWorkspaceAsync();
         } else if (this.isMode(WorkspaceEditMode.Duplicate)) {
-          workspace = environment.enableAsyncWorkspaceOperations
-            ? await this.apiDuplicateWorkspaceAsync()
-            : await this.apiDuplicateWorkspace();
+          workspace = await this.apiDuplicateWorkspaceAsync();
         } else {
           workspace.researchPurpose.needsReviewPrompt = false;
           workspace = await workspacesApi().updateWorkspace(

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -66,9 +66,6 @@ export interface EnvironmentBase {
   // The UI environment config should be restricted to truly UI-specific environment variables, such
   // as server API endpoints and client IDs.
 
-  // RW-7973 whether we should use async operations for Create and Duplicate Workspace
-  enableAsyncWorkspaceOperations: boolean;
-
   // RW-7764 merge access-renewal into data-access-requirements
   mergedAccessRenewal: boolean;
 }

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -22,6 +22,5 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  enableAsyncWorkspaceOperations: true,
   mergedAccessRenewal: true,
 };

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -22,6 +22,5 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  enableAsyncWorkspaceOperations: true,
   mergedAccessRenewal: false,
 };

--- a/ui/src/environments/environment.preprod.ts
+++ b/ui/src/environments/environment.preprod.ts
@@ -21,6 +21,5 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  enableAsyncWorkspaceOperations: true,
   mergedAccessRenewal: false,
 };

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -21,6 +21,5 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  enableAsyncWorkspaceOperations: true,
   mergedAccessRenewal: false,
 };

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -21,6 +21,5 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  enableAsyncWorkspaceOperations: true,
   mergedAccessRenewal: false,
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -21,6 +21,5 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  enableAsyncWorkspaceOperations: true,
   mergedAccessRenewal: false,
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -25,6 +25,5 @@ export const testEnvironmentBase: EnvironmentBase = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
-  enableAsyncWorkspaceOperations: true,
   mergedAccessRenewal: true,
 };


### PR DESCRIPTION
Now that the async create/duplicate workspace code has been running smoothly in all environments for a while, we can remove it associated UI flag.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
