### PR TITLE
[RW-5997][risk=no] Workspace cards should be open-able in a new tab

### DIFF
--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -183,7 +183,7 @@ export const WorkspaceCard = fp.flow(withNavigation)(
       }
     }
 
-    onNameRtClick() {
+    getRightClickTarget() {
       // Restrict open new tab option/right click options, if workspace requires review
       if (this.requiresReviewPrompt()) {
         return;
@@ -282,7 +282,7 @@ export const WorkspaceCard = fp.flow(withNavigation)(
                           : styles.workspaceName
                       }
                       onClick={() => this.onClick()}
-                      href={this.onNameRtClick()}
+                      href={this.getRightClickTarget()}
                     >
                       <TooltipTrigger
                         content={

--- a/ui/src/app/pages/workspace/workspace-library.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-library.spec.tsx
@@ -11,14 +11,12 @@ import {
   profileApi,
   registerApiClient,
 } from 'app/services/swagger-fetch-clients';
+import colors from 'app/styles/colors';
 import { AccessTierShortNames } from 'app/utils/access-tiers';
-import { profileStore } from 'app/utils/stores';
+import { profileStore, serverConfigStore } from 'app/utils/stores';
 
-import {
-  expectButtonDisabled,
-  expectButtonEnabled,
-  waitOneTickAndUpdate,
-} from 'testing/react-test-helpers';
+import defaultServerConfig from 'testing/default-server-config';
+import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { FeaturedWorkspacesConfigApiStub } from 'testing/stubs/featured-workspaces-config-api-stub';
 import { ProfileApiStub } from 'testing/stubs/profile-api-stub';
 import { buildWorkspaceStubs } from 'testing/stubs/workspaces';
@@ -66,6 +64,14 @@ describe('WorkspaceLibrary', () => {
       ...w,
       published: true,
     }));
+
+    serverConfigStore.set({
+      config: {
+        ...defaultServerConfig,
+        enableResearchReviewPrompt: false,
+      },
+    });
+
     PHENOTYPE_LIBRARY_WORKSPACES = publishedWorkspaceStubs[0];
     TUTORIAL_WORKSPACE = publishedWorkspaceStubs[1];
     PUBLISHED_WORKSPACE = publishedWorkspaceStubs[2];
@@ -162,12 +168,12 @@ describe('WorkspaceLibrary', () => {
       .map((c) => c.text());
     expect(cardNameList.length).toEqual(1);
 
-    expectButtonDisabled(
-      wrapper
-        .find('[data-test-id="workspace-card"]')
-        .first()
-        .find('[role="button"]')
-    );
+    const styleCursor = wrapper
+      .find('[data-test-id="workspace-card"]')
+      .first()
+      .find('a')
+      .map((c) => c.prop('style').cursor);
+    expect(styleCursor).toEqual(['not-allowed']);
   });
 
   it('controlled tier workspace is clickable for ct user', async () => {
@@ -195,11 +201,11 @@ describe('WorkspaceLibrary', () => {
     wrapper.find('[data-test-id="Phenotype Library"]').simulate('click');
     await waitOneTickAndUpdate(wrapper);
 
-    expectButtonEnabled(
-      wrapper
-        .find('[data-test-id="workspace-card"]')
-        .first()
-        .find('[role="button"]')
-    );
+    const styleCursor = wrapper
+      .find('[data-test-id="workspace-card"]')
+      .first()
+      .find('a')
+      .map((c) => c.prop('style').color);
+    expect(styleCursor).not.toEqual(colors.disabled);
   });
 });


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->

https://user-images.githubusercontent.com/34481816/159295431-e9d42db5-d7e5-4973-a246-b7743cf9c908.mov



---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
