### PR TITLE
[RW-8056][risk=no] Added new API for Universal Search call

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -229,6 +229,17 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
   }
 
   @Override
+  public ResponseEntity<CardCountResponse> findEhrDomainCounts(
+      String workspaceNamespace, String workspaceId, String term) {
+    workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
+        workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
+    validateTerm(term);
+
+    return ResponseEntity.ok(
+        new CardCountResponse().items(cohortBuilderService.findEhrDomainCounts(term)));
+  }
+
+  @Override
   public ResponseEntity<CardCountResponse> findConceptCounts(
       String workspaceNamespace, String workspaceId, String term) {
     workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -74,6 +74,8 @@ public interface CohortBuilderService {
 
   Long findDomainCountByStandard(String domain, String term, Boolean standard);
 
+  List<CardCount> findEhrDomainCounts(String term);
+
   List<CardCount> findDomainCounts(String term);
 
   List<DomainCard> findDomainCards();

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -370,17 +370,21 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   }
 
   @Override
+  public List<CardCount> findEhrDomainCounts(String term) {
+    return findDomainCounts(
+        term,
+        true,
+        ImmutableList.of(
+            Domain.CONDITION,
+            Domain.DRUG,
+            Domain.MEASUREMENT,
+            Domain.OBSERVATION,
+            Domain.PROCEDURE));
+  }
+
+  @Override
   public List<CardCount> findDomainCounts(String term) {
-    List<CardCount> cardCounts =
-        findDomainCounts(
-            term,
-            true,
-            ImmutableList.of(
-                Domain.CONDITION,
-                Domain.DRUG,
-                Domain.MEASUREMENT,
-                Domain.OBSERVATION,
-                Domain.PROCEDURE));
+    List<CardCount> cardCounts = findEhrDomainCounts(term);
     cardCounts.addAll(
         findDomainCounts(term, false, ImmutableList.of(Domain.PHYSICAL_MEASUREMENT_CSS)));
     cardCounts.addAll(findSurveyCounts(term));

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -379,12 +379,23 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
             Domain.DRUG,
             Domain.MEASUREMENT,
             Domain.OBSERVATION,
-            Domain.PROCEDURE));
+            Domain.PROCEDURE,
+            Domain.DEVICE,
+            Domain.VISIT));
   }
 
   @Override
   public List<CardCount> findDomainCounts(String term) {
-    List<CardCount> cardCounts = findEhrDomainCounts(term);
+    List<CardCount> cardCounts =
+        findDomainCounts(
+            term,
+            true,
+            ImmutableList.of(
+                Domain.CONDITION,
+                Domain.DRUG,
+                Domain.MEASUREMENT,
+                Domain.OBSERVATION,
+                Domain.PROCEDURE));
     cardCounts.addAll(
         findDomainCounts(term, false, ImmutableList.of(Domain.PHYSICAL_MEASUREMENT_CSS)));
     cardCounts.addAll(findSurveyCounts(term));

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3578,6 +3578,26 @@ paths:
           description: A count of matching concepts per survey
           schema:
             "$ref": "#/definitions/SurveyCount"
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/ehrDomainCounts":
+    parameters:
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
+    get:
+      tags:
+        - cohortBuilder
+      description: 'Returns a count of term matches per domain for EHR domains'
+      operationId: findEhrDomainCounts
+      parameters:
+        - in: query
+          name: term
+          type: string
+          required: true
+          description: the term to search for
+      responses:
+        200:
+          description: information about counts for EHR domains
+          schema:
+            "$ref": "#/definitions/CardCountResponse"
   "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/conceptCounts":
     parameters:
       - "$ref": "#/parameters/workspaceNamespace"
@@ -3585,7 +3605,7 @@ paths:
     get:
       tags:
         - cohortBuilder
-      description: 'Returns a count of term matches per domain for all EHR domains, Physical Measurement css, and per survey name for all survey names'
+      description: 'Returns a count of term matches per domain for EHR domains, Physical Measurement css, and per survey name for all survey names'
       operationId: findConceptCounts
       parameters:
         - in: query
@@ -3595,7 +3615,7 @@ paths:
           description: the term to search for
       responses:
         200:
-          description: information about the surveys
+          description: information about counts for EHR domains, physical Measurement CSS, and Surveys for all survey names
           schema:
             "$ref": "#/definitions/CardCountResponse"
   "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/{domain}/{standard}/search/term":


### PR DESCRIPTION
Description:
- new API call:`/criteria/ehrDomainCounts` controller call: findEhrDomainCounts
- new service call: findEhrDomainCounts
- calls existing service/dao methods
- Call cant be tested since the underlying SQL query is a `nativeQuery`

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
