### PR TITLE
[RW-7635][risk=no] Use egress group as FROM line for egress emails, add CC

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -145,7 +145,8 @@
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": false,
-    "notifyFromEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
+    "notifyFromEmail": "security-alerts@researchallofus.org",
+    "notifyCcEmails": ["workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com"],
     "escalations": [{
       "afterIncidentCount": 1,
       "suspendCompute": {

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -144,7 +144,8 @@
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": false,
-    "notifyFromEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
+    "notifyFromEmail": "security-alerts@researchallofus.org",
+    "notifyCcEmails": ["workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com"],
     "escalations": [{
       "afterIncidentCount": 1,
       "suspendCompute": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -145,6 +145,7 @@
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": true,
     "notifyFromEmail": "security-alerts@researchallofus.org",
+    "notifyCcEmails": ["security-alerts@researchallofus.org"],
     "escalations": [{
       "afterIncidentCount": 1,
       "suspendCompute": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -144,7 +144,7 @@
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": true,
-    "notifyFromEmail": "egress@pmi-ops.org",
+    "notifyFromEmail": "security-alerts@researchallofus.org",
     "escalations": [{
       "afterIncidentCount": 1,
       "suspendCompute": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -144,7 +144,8 @@
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": false,
-    "notifyFromEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
+    "notifyFromEmail": "security-alerts@researchallofus.org",
+    "notifyCcEmails": ["workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com"],
     "escalations": [{
       "afterIncidentCount": 1,
       "suspendCompute": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -144,7 +144,8 @@
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": false,
-    "notifyFromEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
+    "notifyFromEmail": "security-alerts@researchallofus.org",
+    "notifyCcEmails": ["workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com"],
     "escalations": [{
       "afterIncidentCount": 1,
       "suspendCompute": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -144,7 +144,8 @@
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": false,
-    "notifyFromEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
+    "notifyFromEmail": "security-alerts@researchallofus.org",
+    "notifyCcEmails": ["workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com"],
     "escalations": [{
       "afterIncidentCount": 1,
       "suspendCompute": {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -378,6 +378,7 @@ public class WorkbenchConfig {
     }
 
     public String notifyFromEmail;
+    public List<String> notifyCcEmails;
     public boolean enableJiraTicketing;
     public List<Escalation> escalations;
   }

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -27,6 +28,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.text.StringSubstitutor;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.config.WorkbenchConfig.EgressAlertRemediationPolicy;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.ServerErrorException;
@@ -307,10 +309,12 @@ public class MailServiceImpl implements MailService {
                 .put(EmailSubstitutionField.EGRESS_REMEDIATION_DESCRIPTION, remediationDescription)
                 .build());
 
+    EgressAlertRemediationPolicy egressPolicy =
+        workbenchConfigProvider.get().egressAlertRemediationPolicy;
     sendWithRetriesFrom(
-        workbenchConfigProvider.get().egressAlertRemediationPolicy.notifyFromEmail,
+        egressPolicy.notifyFromEmail,
         ImmutableList.of(dbUser.getContactEmail()),
-        ImmutableList.of(),
+        Optional.ofNullable(egressPolicy.notifyCcEmails).orElse(ImmutableList.of()),
         "[Response Required] AoU Researcher Workbench High Data Egress Alert",
         String.format("Egress remediation email for %s", dbUser.getUsername()),
         htmlMessage);


### PR DESCRIPTION
I added  a "CC" config here so we could maintain the integration with the slack test channel (we cannot send email from this name), and also so that the security team gets notified when this event occurs in prod.

To test this, I ran the following locally:

(replace project_name with a project that exists in your local DB)

```
curl -X POST \
  http://localhost:8081/v1/admin/sumo/egressEvent \curl -X POST \
  http://localhost:8081/v1/admin/sumo/egressEvent \
  -H 'Content-Type: application/json' \
  -H "X-API-KEY: $(gsutil cat gs://all-of-us-workbench-test-credentials/inbound-sumologic-keys.txt)" \
  -d '{"eventsJsonArray": "[{ \"vm_prefix\": \"all-of-us-1\",  \"egress_mib\": 171.9241180419922,  \"environment\": \"TEST\",  \"project_name\": \"terra-vpc-sc-dev-d83bee39\",  \"gce_egress_mib\": 171.9241180419922,  \"time_window_start\": 1647836400000,  \"egress_mib_threshold\": 150,  \"time_window_duration\": 600,  \"dataproc_master_egress_mib\": 0,  \"dataproc_worker_egress_mib\": 0}]"}'
  -H 'Content-Type: application/json' \
  -H "X-API-KEY: $(gsutil cat gs://all-of-us-workbench-test-credentials/inbound-sumologic-keys.txt)" \
  -d '{"eventsJsonArray": "[{ \"vm_prefix\": \"all-of-us-1\",  \"egress_mib\": 171.9241180419922,  \"environment\": \"TEST\",  \"project_name\": \"terra-vpc-sc-dev-d83bee39\",  \"gce_egress_mib\": 171.9241180419922,  \"time_window_start\": 1647836400000,  \"egress_mib_threshold\": 150,  \"time_window_duration\": 600,  \"dataproc_master_egress_mib\": 0,  \"dataproc_worker_egress_mib\": 0}]"}'
```