### PR TITLE
[RW-8041][risk=low]Added the ability to use the custom request access url from the regis…

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/institution/VerifiedInstitutionalAffiliationMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/VerifiedInstitutionalAffiliationMapper.java
@@ -40,5 +40,6 @@ public interface VerifiedInstitutionalAffiliationMapper {
 
   @Mapping(target = "institutionShortName", source = "institution.shortName")
   @Mapping(target = "institutionDisplayName", source = "institution.displayName")
+  @Mapping(target = "institutionRequestAccessUrl", source = "institution.requestAccessUrl")
   VerifiedInstitutionalAffiliation dbToModel(DbVerifiedInstitutionalAffiliation dbObject);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6913,6 +6913,9 @@ definitions:
         "$ref": "#/definitions/InstitutionMembershipRequirement"
         description: 'Type of Registered tier requirement the institution has signed, email domains
          or restricted to a defined set of specific researchers'
+      requestAccessUrl:
+        type: string
+        description: Request access url for users to use during registration.
   InstitutionUserInstructions:
     type: object
     description: Institution-specific instructions for users to perform after registration.

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6878,7 +6878,7 @@ definitions:
           if its enumerated type is OTHER'
       requestAccessUrl:
         type: string
-        description: Request access url for users to use during registration.
+        description: Optional url for institution's handling their own access requests
       userInstructions:
         description: Institution-specific instructions for users to be sent in email
         type: string
@@ -7003,6 +7003,9 @@ definitions:
         description: 'The longer, more descriptive name of the Institution where the
           user has a Verified Affiliation, such as ''Vanderbilt University Medical
           Center'''
+      institutionRequestAccessUrl:
+        type: string
+        description: Optional url for institution's handling their own access requests
       institutionalRoleEnum:
         "$ref": "#/definitions/InstitutionalRole"
         description: 'The user''s Institutional Role at this Institution if it is

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6915,7 +6915,7 @@ definitions:
          or restricted to a defined set of specific researchers'
       requestAccessUrl:
         type: string
-        description: Request access url for users to use during registration.
+        description: Optional url for institution's handling their own access requests
   InstitutionUserInstructions:
     type: object
     description: Institution-specific instructions for users to perform after registration.

--- a/ui/src/app/components/support.tsx
+++ b/ui/src/app/components/support.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { getCustomOrDefaultUrl } from 'app/utils/urls';
-
-import { Button, StyledExternalLink } from './buttons';
+import { StyledExternalLink } from './buttons';
 
 export const SUPPORT_EMAIL = 'support@researchallofus.org';
 
@@ -10,18 +8,4 @@ export const SupportMailto = ({ label = SUPPORT_EMAIL, style = {} }) => (
   <StyledExternalLink style={style} href={`mailto:${SUPPORT_EMAIL}`}>
     {label}
   </StyledExternalLink>
-);
-
-const handleClickSupportButton = (url) => () => {
-  const adjustedUrl = getCustomOrDefaultUrl(url, `mailto:${SUPPORT_EMAIL}`);
-  window.open(adjustedUrl);
-};
-export const SupportButton = ({
-  label = SUPPORT_EMAIL,
-  url = '',
-  style = {},
-}) => (
-  <Button style={style} onClick={handleClickSupportButton(url)}>
-    {label}
-  </Button>
 );

--- a/ui/src/app/components/support.tsx
+++ b/ui/src/app/components/support.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { canonicalizeUrl, isValidUrl } from 'app/utils/urls';
+
 import { Button, StyledExternalLink } from './buttons';
 
 export const SUPPORT_EMAIL = 'support@researchallofus.org';
@@ -10,8 +12,21 @@ export const SupportMailto = ({ label = SUPPORT_EMAIL, style = {} }) => (
   </StyledExternalLink>
 );
 
-export const SupportButton = ({ label = SUPPORT_EMAIL, style = {} }) => (
-  <Button style={style} onClick={() => window.open(`mailto:${SUPPORT_EMAIL}`)}>
+const handleClickSupportButton = (url) => () => {
+  if (url) {
+    const adjustedUrl = canonicalizeUrl(url);
+    if (isValidUrl(adjustedUrl)) {
+      url = adjustedUrl;
+    }
+  }
+  window.open(url ?? `mailto:${SUPPORT_EMAIL}`);
+};
+export const SupportButton = ({
+  label = SUPPORT_EMAIL,
+  url = '',
+  style = {},
+}) => (
+  <Button style={style} onClick={handleClickSupportButton(url)}>
     {label}
   </Button>
 );

--- a/ui/src/app/components/support.tsx
+++ b/ui/src/app/components/support.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { canonicalizeUrl, isValidUrl } from 'app/utils/urls';
+import { getCustomOrDefaultUrl } from 'app/utils/urls';
 
 import { Button, StyledExternalLink } from './buttons';
 
@@ -13,13 +13,8 @@ export const SupportMailto = ({ label = SUPPORT_EMAIL, style = {} }) => (
 );
 
 const handleClickSupportButton = (url) => () => {
-  if (url) {
-    const adjustedUrl = canonicalizeUrl(url);
-    if (isValidUrl(adjustedUrl)) {
-      url = adjustedUrl;
-    }
-  }
-  window.open(url ?? `mailto:${SUPPORT_EMAIL}`);
+  const adjustedUrl = getCustomOrDefaultUrl(url, `mailto:${SUPPORT_EMAIL}`);
+  window.open(adjustedUrl);
 };
 export const SupportButton = ({
   label = SUPPORT_EMAIL,

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -18,7 +18,7 @@ import {
   Repeat,
 } from 'app/components/icons';
 import { withErrorModal } from 'app/components/modals';
-import { SupportButton } from 'app/components/support';
+import { SUPPORT_EMAIL } from 'app/components/support';
 import { AoU } from 'app/components/text-wrappers';
 import { withProfileErrorModal } from 'app/components/with-error-modal';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
@@ -45,6 +45,7 @@ import { AnalyticsTracker } from 'app/utils/analytics';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { useNavigation } from 'app/utils/navigation';
 import { profileStore, serverConfigStore, useStore } from 'app/utils/stores';
+import { getCustomOrDefaultUrl } from 'app/utils/urls';
 import { openZendeskWidget } from 'app/utils/zendesk';
 import { ReactComponent as additional } from 'assets/icons/DAR/additional.svg';
 import { ReactComponent as electronic } from 'assets/icons/DAR/electronic.svg';
@@ -874,6 +875,11 @@ const RegisteredTierCard = (props: {
   );
 };
 
+const handleClickSupportButton = (url) => () => {
+  const adjustedUrl = getCustomOrDefaultUrl(url, `mailto:${SUPPORT_EMAIL}`);
+  window.open(adjustedUrl);
+};
+
 const ControlledTierStep = (props: { enabled: boolean; text: String }) => {
   return (
     <FlexRow>
@@ -955,10 +961,11 @@ const ControlledTierCard = (props: {
               is required.
             </div>
             <div style={styles.requestAccess}>
-              <SupportButton
-                label='Request Access'
-                url={institutionRequestAccessUrl}
-              />
+              <Button
+                onClick={handleClickSupportButton(institutionRequestAccessUrl)}
+              >
+                Request Access
+              </Button>
             </div>
           </div>
         )}

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -918,7 +918,10 @@ const ControlledTierCard = (props: {
   const isSigned = !!controlledTierEligibility;
   const isEligible = isSigned && controlledTierEligibility.eligible;
   const {
-    verifiedInstitutionalAffiliation: { institutionDisplayName },
+    verifiedInstitutionalAffiliation: {
+      institutionDisplayName,
+      institutionRequestAccessUrl,
+    },
   } = profile;
   // Display era in CT if:
   // 1) Institution has signed the CT institution agreement,
@@ -952,7 +955,10 @@ const ControlledTierCard = (props: {
               is required.
             </div>
             <div style={styles.requestAccess}>
-              <SupportButton label='Request Access' />
+              <SupportButton
+                label='Request Access'
+                url={institutionRequestAccessUrl}
+              />
             </div>
           </div>
         )}

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -15,7 +15,7 @@ import { AccountCreationOptions } from 'app/pages/login/account-creation/account
 import { institutionApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { AccessTierShortNames } from 'app/utils/access-tiers';
-import { canonicalizeUrl, isValidUrl } from 'app/utils/urls';
+import { getCustomOrDefaultUrl } from 'app/utils/urls';
 
 import { isAbortError } from './errors';
 import { cond, isBlank, switchCase } from './index';
@@ -48,14 +48,8 @@ const EmailAddressMismatchErrorMessage = ({
 }: {
   requestAccessUrl: string;
 }) => {
-  let url = 'https://www.researchallofus.org/institutional-agreements';
-
-  if (requestAccessUrl) {
-    const adjustedUrl = canonicalizeUrl(requestAccessUrl);
-    if (isValidUrl(adjustedUrl)) {
-      url = adjustedUrl;
-    }
-  }
+  const defaultUrl = 'https://www.researchallofus.org/institutional-agreements';
+  const url = getCustomOrDefaultUrl(requestAccessUrl, defaultUrl);
 
   return (
     <div data-test-id='email-error-message' style={{ color: colors.danger }}>

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -43,7 +43,11 @@ export async function checkInstitutionalEmail(
   }
 }
 
-const EmailAddressMismatchErrorMessage = ({ requestAccessUrl }) => {
+const EmailAddressMismatchErrorMessage = ({
+  requestAccessUrl,
+}: {
+  requestAccessUrl: string;
+}) => {
   let url = 'https://www.researchallofus.org/institutional-agreements';
 
   if (requestAccessUrl) {

--- a/ui/src/app/utils/urls.ts
+++ b/ui/src/app/utils/urls.ts
@@ -10,11 +10,22 @@ export function canonicalizeUrl(url: string): string {
   return `http://${url}`;
 }
 
-export function isValidUrl(potentialUrl: string): boolean {
+function isValidUrl(potentialUrl: string): boolean {
   try {
     new URL(potentialUrl);
     return true;
   } catch (e) {
     return false;
   }
+}
+
+export function getCustomOrDefaultUrl(customUrl: string, defaultUrl: string) {
+  let url = defaultUrl;
+  if (customUrl) {
+    const adjustedUrl = canonicalizeUrl(customUrl);
+    if (isValidUrl(adjustedUrl)) {
+      url = adjustedUrl;
+    }
+  }
+  return url;
 }

--- a/ui/src/app/utils/urls.ts
+++ b/ui/src/app/utils/urls.ts
@@ -9,3 +9,12 @@ export function canonicalizeUrl(url: string): string {
   // and https:// may yield a bad certificate if not configured.
   return `http://${url}`;
 }
+
+export function isValidUrl(potentialUrl: string): boolean {
+  try {
+    new URL(potentialUrl);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
Description: Added the ability to use the custom request access url from the registration page when a registrant attempts to register for an institute that requires only specific email addresses.


https://user-images.githubusercontent.com/24514630/159502948-0d6cdff7-b330-4ba3-8e45-9d01dbadd96f.mov

https://user-images.githubusercontent.com/24514630/159574644-f0a9f05b-eb75-428e-af7e-937c7e9950be.mov



<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
