### PR TITLE
[risk=no][no ticket] rename AccessModuleName to DbAccessModuleName

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
@@ -3,7 +3,7 @@ package org.pmiops.workbench.access;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.AccessBypassRequest;
 import org.pmiops.workbench.model.AccessModule;
@@ -17,7 +17,8 @@ public interface AccessModuleService {
   void updateBypassTime(long userId, AccessModule accessModuleName, boolean isBypassed);
 
   /** Update module status to complete for a user. */
-  void updateCompletionTime(DbUser dbUser, AccessModuleName accessModuleName, Timestamp timestamp);
+  void updateCompletionTime(
+      DbUser dbUser, DbAccessModuleName accessModuleName, Timestamp timestamp);
 
   /** Retrieves all {@link AccessModuleStatus} for a user. */
   List<AccessModuleStatus> getAccessModuleStatus(DbUser user);
@@ -28,17 +29,17 @@ public interface AccessModuleService {
    * @return
    */
   Optional<AccessModuleStatus> getAccessModuleStatus(
-      DbUser user, AccessModuleName accessModuleName);
+      DbUser user, DbAccessModuleName accessModuleName);
 
   /**
    * Returns true if the access module is compliant.
    *
    * <p>The module can be bypassed OR (completed but not expired).
    */
-  boolean isModuleCompliant(DbUser dbUser, AccessModuleName accessModuleName);
+  boolean isModuleCompliant(DbUser dbUser, DbAccessModuleName accessModuleName);
 
   /** Returns true if the access module is bypassable and bypassed */
-  boolean isModuleBypassed(DbUser dbUser, AccessModuleName accessModuleName);
+  boolean isModuleBypassed(DbUser dbUser, DbAccessModuleName accessModuleName);
 
   boolean isSignedDuccVersionCurrent(Integer signedVersion);
 

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
@@ -21,7 +21,7 @@ import org.pmiops.workbench.config.WorkbenchConfig.AccessConfig;
 import org.pmiops.workbench.db.dao.UserAccessModuleDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
@@ -100,7 +100,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
 
   @Override
   public void updateCompletionTime(
-      DbUser dbUser, AccessModuleName accessModuleName, @Nullable Timestamp timestamp) {
+      DbUser dbUser, DbAccessModuleName accessModuleName, @Nullable Timestamp timestamp) {
     DbAccessModule dbAccessModule =
         getDbAccessModuleOrThrow(dbAccessModulesProvider.get(), accessModuleName);
     DbUserAccessModule userAccessModuleToUpdate =
@@ -119,7 +119,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
 
   @Override
   public Optional<AccessModuleStatus> getAccessModuleStatus(
-      DbUser user, AccessModuleName accessModuleName) {
+      DbUser user, DbAccessModuleName accessModuleName) {
     DbAccessModule dbAccessModule =
         getDbAccessModuleOrThrow(dbAccessModulesProvider.get(), accessModuleName);
     DbUserAccessModule userAccessModule = retrieveUserAccessModuleOrCreate(user, dbAccessModule);
@@ -150,7 +150,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
   }
 
   @Override
-  public boolean isModuleCompliant(DbUser dbUser, AccessModuleName accessModuleName) {
+  public boolean isModuleCompliant(DbUser dbUser, DbAccessModuleName accessModuleName) {
     DbAccessModule dbAccessModule =
         getDbAccessModuleOrThrow(dbAccessModulesProvider.get(), accessModuleName);
     // if the module is not required, the user is always compliant
@@ -162,7 +162,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
     boolean isCompleted = userAccessModule.getCompletionTime() != null;
 
     // we have an additional check before considering DUCC "complete"
-    if (isCompleted && accessModuleName == AccessModuleName.DATA_USER_CODE_OF_CONDUCT) {
+    if (isCompleted && accessModuleName == DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT) {
       isCompleted = hasUserSignedACurrentDucc(dbUser);
     }
 
@@ -176,7 +176,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
   }
 
   @Override
-  public boolean isModuleBypassed(DbUser dbUser, AccessModuleName accessModuleName) {
+  public boolean isModuleBypassed(DbUser dbUser, DbAccessModuleName accessModuleName) {
     DbAccessModule dbAccessModule =
         getDbAccessModuleOrThrow(dbAccessModulesProvider.get(), accessModuleName);
     return dbAccessModule.getBypassable()
@@ -218,7 +218,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
   }
 
   private static DbAccessModule getDbAccessModuleOrThrow(
-      List<DbAccessModule> dbAccessModules, AccessModuleName accessModuleName) {
+      List<DbAccessModule> dbAccessModules, DbAccessModuleName accessModuleName) {
     return dbAccessModules.stream()
         .filter(a -> a.getName() == accessModuleName)
         .findFirst()

--- a/api/src/main/java/org/pmiops/workbench/access/AccessUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessUtils.java
@@ -5,7 +5,7 @@ import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.pmiops.workbench.actionaudit.targetproperties.BypassTimeTargetProperty;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.model.AccessModule;
@@ -14,54 +14,54 @@ import org.pmiops.workbench.model.AccessModule;
 public class AccessUtils {
   private AccessUtils() {}
 
-  private static final BiMap<AccessModule, AccessModuleName> CLIENT_TO_STORAGE_ACCESS_MODULE =
-      ImmutableBiMap.<AccessModule, AccessModuleName>builder()
-          .put(AccessModule.TWO_FACTOR_AUTH, AccessModuleName.TWO_FACTOR_AUTH)
-          .put(AccessModule.ERA_COMMONS, AccessModuleName.ERA_COMMONS)
-          .put(AccessModule.COMPLIANCE_TRAINING, AccessModuleName.RT_COMPLIANCE_TRAINING)
-          .put(AccessModule.CT_COMPLIANCE_TRAINING, AccessModuleName.CT_COMPLIANCE_TRAINING)
-          .put(AccessModule.RAS_LINK_LOGIN_GOV, AccessModuleName.RAS_LOGIN_GOV)
-          .put(AccessModule.DATA_USER_CODE_OF_CONDUCT, AccessModuleName.DATA_USER_CODE_OF_CONDUCT)
-          .put(AccessModule.PUBLICATION_CONFIRMATION, AccessModuleName.PUBLICATION_CONFIRMATION)
-          .put(AccessModule.PROFILE_CONFIRMATION, AccessModuleName.PROFILE_CONFIRMATION)
+  private static final BiMap<AccessModule, DbAccessModuleName> CLIENT_TO_STORAGE_ACCESS_MODULE =
+      ImmutableBiMap.<AccessModule, DbAccessModuleName>builder()
+          .put(AccessModule.TWO_FACTOR_AUTH, DbAccessModuleName.TWO_FACTOR_AUTH)
+          .put(AccessModule.ERA_COMMONS, DbAccessModuleName.ERA_COMMONS)
+          .put(AccessModule.COMPLIANCE_TRAINING, DbAccessModuleName.RT_COMPLIANCE_TRAINING)
+          .put(AccessModule.CT_COMPLIANCE_TRAINING, DbAccessModuleName.CT_COMPLIANCE_TRAINING)
+          .put(AccessModule.RAS_LINK_LOGIN_GOV, DbAccessModuleName.RAS_LOGIN_GOV)
+          .put(AccessModule.DATA_USER_CODE_OF_CONDUCT, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT)
+          .put(AccessModule.PUBLICATION_CONFIRMATION, DbAccessModuleName.PUBLICATION_CONFIRMATION)
+          .put(AccessModule.PROFILE_CONFIRMATION, DbAccessModuleName.PROFILE_CONFIRMATION)
           .build();
 
-  private static final BiMap<BypassTimeTargetProperty, AccessModuleName>
+  private static final BiMap<BypassTimeTargetProperty, DbAccessModuleName>
       AUDIT_TO_STORAGE_ACCESS_MODULE =
-          ImmutableBiMap.<BypassTimeTargetProperty, AccessModuleName>builder()
-              .put(BypassTimeTargetProperty.ERA_COMMONS_BYPASS_TIME, AccessModuleName.ERA_COMMONS)
+          ImmutableBiMap.<BypassTimeTargetProperty, DbAccessModuleName>builder()
+              .put(BypassTimeTargetProperty.ERA_COMMONS_BYPASS_TIME, DbAccessModuleName.ERA_COMMONS)
               .put(
                   BypassTimeTargetProperty.COMPLIANCE_TRAINING_BYPASS_TIME,
-                  AccessModuleName.RT_COMPLIANCE_TRAINING)
+                  DbAccessModuleName.RT_COMPLIANCE_TRAINING)
               .put(
                   BypassTimeTargetProperty.CT_COMPLIANCE_TRAINING_BYPASS_TIME,
-                  AccessModuleName.CT_COMPLIANCE_TRAINING)
+                  DbAccessModuleName.CT_COMPLIANCE_TRAINING)
               .put(
                   BypassTimeTargetProperty.TWO_FACTOR_AUTH_BYPASS_TIME,
-                  AccessModuleName.TWO_FACTOR_AUTH)
-              .put(BypassTimeTargetProperty.RAS_LINK_LOGIN_GOV, AccessModuleName.RAS_LOGIN_GOV)
+                  DbAccessModuleName.TWO_FACTOR_AUTH)
+              .put(BypassTimeTargetProperty.RAS_LINK_LOGIN_GOV, DbAccessModuleName.RAS_LOGIN_GOV)
               .put(
                   BypassTimeTargetProperty.DATA_USE_AGREEMENT_BYPASS_TIME,
-                  AccessModuleName.DATA_USER_CODE_OF_CONDUCT)
+                  DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT)
               .build();
 
-  /** Converts {@link AccessModule} to {@link AccessModuleName}. */
-  public static AccessModuleName clientAccessModuleToStorage(AccessModule s) {
+  /** Converts {@link AccessModule} to {@link DbAccessModuleName}. */
+  public static DbAccessModuleName clientAccessModuleToStorage(AccessModule s) {
     return CLIENT_TO_STORAGE_ACCESS_MODULE.get(s);
   }
 
-  /** Converts {@link AccessModuleName} to {@link AccessModule}. */
-  public static AccessModule storageAccessModuleToClient(AccessModuleName s) {
+  /** Converts {@link DbAccessModuleName} to {@link AccessModule}. */
+  public static AccessModule storageAccessModuleToClient(DbAccessModuleName s) {
     return CLIENT_TO_STORAGE_ACCESS_MODULE.inverse().get(s);
   }
 
-  /** Converts {@link BypassTimeTargetProperty} to {@link AccessModuleName}. */
-  public static AccessModuleName auditAccessModuleToStorage(BypassTimeTargetProperty b) {
+  /** Converts {@link BypassTimeTargetProperty} to {@link DbAccessModuleName}. */
+  public static DbAccessModuleName auditAccessModuleToStorage(BypassTimeTargetProperty b) {
     return AUDIT_TO_STORAGE_ACCESS_MODULE.get(b);
   }
 
-  /** Converts {@link AccessModuleName} to {@link BypassTimeTargetProperty}. */
-  public static BypassTimeTargetProperty auditAccessModuleFromStorage(AccessModuleName s) {
+  /** Converts {@link DbAccessModuleName} to {@link BypassTimeTargetProperty}. */
+  public static BypassTimeTargetProperty auditAccessModuleFromStorage(DbAccessModuleName s) {
     return AUDIT_TO_STORAGE_ACCESS_MODULE.inverse().get(s);
   }
 
@@ -80,22 +80,22 @@ public class AccessUtils {
 
   // missing ERA_COMMONS (special-cased)
   // see also: AccessModuleServiceImpl.isModuleRequiredInEnvironment()
-  public static final List<AccessModuleName> REQUIRED_MODULES_FOR_REGISTERED_TIER =
+  public static final List<DbAccessModuleName> REQUIRED_MODULES_FOR_REGISTERED_TIER =
       ImmutableList.of(
-          AccessModuleName.DATA_USER_CODE_OF_CONDUCT,
-          AccessModuleName.PROFILE_CONFIRMATION,
-          AccessModuleName.PUBLICATION_CONFIRMATION,
-          AccessModuleName.RAS_LOGIN_GOV,
-          AccessModuleName.RT_COMPLIANCE_TRAINING,
-          AccessModuleName.TWO_FACTOR_AUTH);
+          DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT,
+          DbAccessModuleName.PROFILE_CONFIRMATION,
+          DbAccessModuleName.PUBLICATION_CONFIRMATION,
+          DbAccessModuleName.RAS_LOGIN_GOV,
+          DbAccessModuleName.RT_COMPLIANCE_TRAINING,
+          DbAccessModuleName.TWO_FACTOR_AUTH);
 
-  public static final List<AccessModuleName> REQUIRED_MODULES_FOR_CONTROLLED_TIER =
+  public static final List<DbAccessModuleName> REQUIRED_MODULES_FOR_CONTROLLED_TIER =
       ImmutableList.of(
-          AccessModuleName.CT_COMPLIANCE_TRAINING,
-          AccessModuleName.DATA_USER_CODE_OF_CONDUCT,
-          AccessModuleName.PROFILE_CONFIRMATION,
-          AccessModuleName.PUBLICATION_CONFIRMATION,
-          AccessModuleName.RAS_LOGIN_GOV,
-          AccessModuleName.RT_COMPLIANCE_TRAINING,
-          AccessModuleName.TWO_FACTOR_AUTH);
+          DbAccessModuleName.CT_COMPLIANCE_TRAINING,
+          DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT,
+          DbAccessModuleName.PROFILE_CONFIRMATION,
+          DbAccessModuleName.PUBLICATION_CONFIRMATION,
+          DbAccessModuleName.RAS_LOGIN_GOV,
+          DbAccessModuleName.RT_COMPLIANCE_TRAINING,
+          DbAccessModuleName.TWO_FACTOR_AUTH);
 }

--- a/api/src/main/java/org/pmiops/workbench/access/UserAccessModuleMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/access/UserAccessModuleMapper.java
@@ -11,7 +11,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 import org.mapstruct.NullValueMappingStrategy;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.model.AccessModule;
 import org.pmiops.workbench.model.AccessModuleStatus;
@@ -34,7 +34,7 @@ public interface UserAccessModuleMapper {
   AccessModuleStatus dbToModule(DbUserAccessModule source, @Context Timestamp expirationTime);
 
   @Named("moduleNameToModel")
-  default AccessModule accessModuleDbToModel(AccessModuleName moduleName) {
+  default AccessModule accessModuleDbToModel(DbAccessModuleName moduleName) {
     return storageAccessModuleToClient(moduleName);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskUserController.java
@@ -13,7 +13,7 @@ import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserService;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.google.CloudResourceManagerService;
@@ -126,7 +126,7 @@ public class CloudTaskUserController implements CloudTaskUserApiDelegate {
         // bother checking them either.
         if (!user.getDisabled()) {
           Optional<AccessModuleStatus> status =
-              accessModuleService.getAccessModuleStatus(user, AccessModuleName.TWO_FACTOR_AUTH);
+              accessModuleService.getAccessModuleStatus(user, DbAccessModuleName.TWO_FACTOR_AUTH);
           if (status.isPresent() && status.get().getCompletionEpochMillis() != null) {
             user = userService.syncTwoFactorAuthStatus(user, Agent.asSystem());
           }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/AccessModuleDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/AccessModuleDao.java
@@ -3,11 +3,11 @@ package org.pmiops.workbench.db.dao;
 import java.util.List;
 import java.util.Optional;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.springframework.data.repository.CrudRepository;
 
 public interface AccessModuleDao extends CrudRepository<DbAccessModule, Long> {
   List<DbAccessModule> findAll();
 
-  Optional<DbAccessModule> findOneByName(AccessModuleName name);
+  Optional<DbAccessModule> findOneByName(DbAccessModuleName name);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbAccessModule.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbAccessModule.java
@@ -19,7 +19,7 @@ public class DbAccessModule {
   private long accessModuleId;
   private boolean expirable;
   private boolean bypassable;
-  private AccessModuleName name;
+  private DbAccessModuleName name;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -55,11 +55,11 @@ public class DbAccessModule {
 
   @Enumerated(EnumType.STRING)
   @Column(name = "name", nullable = false)
-  public AccessModuleName getName() {
+  public DbAccessModuleName getName() {
     return name;
   }
 
-  public DbAccessModule setName(AccessModuleName name) {
+  public DbAccessModule setName(DbAccessModuleName name) {
     this.name = name;
     return this;
   }
@@ -74,7 +74,7 @@ public class DbAccessModule {
     return REQUIRED_MODULES_FOR_CONTROLLED_TIER.contains(name);
   }
 
-  public enum AccessModuleName {
+  public enum DbAccessModuleName {
     ERA_COMMONS,
     TWO_FACTOR_AUTH,
     RAS_LOGIN_GOV,

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
@@ -22,7 +22,7 @@ import org.pmiops.workbench.db.dao.AccessModuleDao;
 import org.pmiops.workbench.db.dao.UserAccessModuleDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.exceptions.ForbiddenException;
@@ -95,7 +95,7 @@ public class AccessModuleServiceTest {
     List<DbUserAccessModule> userAccessModule = userAccessModuleDao.getAllByUser(user);
     assertThat(userAccessModule.size()).isEqualTo(1);
     assertThat(userAccessModule.get(0).getAccessModule().getName())
-        .isEqualTo(AccessModuleName.TWO_FACTOR_AUTH);
+        .isEqualTo(DbAccessModuleName.TWO_FACTOR_AUTH);
     assertThat(userAccessModule.get(0).getBypassTime()).isEqualTo(FakeClockConfiguration.NOW);
 
     verify(mockUserServiceAuditAdapter)
@@ -110,7 +110,7 @@ public class AccessModuleServiceTest {
   public void testBypassSuccess_updateExistingEntity() {
     // A TWO_FACTOR_AUTH module exists in DbUserAccessModule
     DbAccessModule twoFactorAuthModule =
-        accessModuleDao.findOneByName(AccessModuleName.TWO_FACTOR_AUTH).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.TWO_FACTOR_AUTH).get();
     Timestamp existingBypasstime = Timestamp.from(Instant.parse("2000-01-01T00:00:00.00Z"));
     DbUserAccessModule existingDbUserAccessModule =
         new DbUserAccessModule()
@@ -124,7 +124,7 @@ public class AccessModuleServiceTest {
     List<DbUserAccessModule> userAccessModule = userAccessModuleDao.getAllByUser(user);
     assertThat(userAccessModule.size()).isEqualTo(1);
     assertThat(userAccessModule.get(0).getAccessModule().getName())
-        .isEqualTo(AccessModuleName.TWO_FACTOR_AUTH);
+        .isEqualTo(DbAccessModuleName.TWO_FACTOR_AUTH);
     assertThat(userAccessModule.get(0).getBypassTime()).isEqualTo(FakeClockConfiguration.NOW);
     verify(mockUserServiceAuditAdapter)
         .fireAdministrativeBypassTime(
@@ -142,7 +142,7 @@ public class AccessModuleServiceTest {
     List<DbUserAccessModule> userAccessModule = userAccessModuleDao.getAllByUser(user);
     assertThat(userAccessModule.size()).isEqualTo(1);
     assertThat(userAccessModule.get(0).getAccessModule().getName())
-        .isEqualTo(AccessModuleName.TWO_FACTOR_AUTH);
+        .isEqualTo(DbAccessModuleName.TWO_FACTOR_AUTH);
     assertThat(userAccessModule.get(0).getBypassTime()).isNull();
     verify(mockUserServiceAuditAdapter)
         .fireAdministrativeBypassTime(
@@ -156,7 +156,7 @@ public class AccessModuleServiceTest {
   public void testUnBypassSuccess_updateExistingEntity() {
     // A TWO_FACTOR_AUTH module exists in DbUserAccessModule
     DbAccessModule twoFactorAuthModule =
-        accessModuleDao.findOneByName(AccessModuleName.TWO_FACTOR_AUTH).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.TWO_FACTOR_AUTH).get();
     Timestamp existingBypasstime = Timestamp.from(Instant.parse("2000-01-01T00:00:00.00Z"));
     DbUserAccessModule existingDbUserAccessModule =
         new DbUserAccessModule()
@@ -170,7 +170,7 @@ public class AccessModuleServiceTest {
     List<DbUserAccessModule> userAccessModule = userAccessModuleDao.getAllByUser(user);
     assertThat(userAccessModule.size()).isEqualTo(1);
     assertThat(userAccessModule.get(0).getAccessModule().getName())
-        .isEqualTo(AccessModuleName.TWO_FACTOR_AUTH);
+        .isEqualTo(DbAccessModuleName.TWO_FACTOR_AUTH);
     assertThat(userAccessModule.get(0).getBypassTime()).isNull();
     verify(mockUserServiceAuditAdapter)
         .fireAdministrativeBypassTime(
@@ -195,15 +195,15 @@ public class AccessModuleServiceTest {
     long expiryDays = 365L;
     config.access.renewal.expiryDays = expiryDays;
     DbAccessModule twoFactorAuthModule =
-        accessModuleDao.findOneByName(AccessModuleName.TWO_FACTOR_AUTH).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.TWO_FACTOR_AUTH).get();
     DbAccessModule rtTrainingModule =
-        accessModuleDao.findOneByName(AccessModuleName.RT_COMPLIANCE_TRAINING).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.RT_COMPLIANCE_TRAINING).get();
     DbAccessModule profileConfirmModule =
-        accessModuleDao.findOneByName(AccessModuleName.PROFILE_CONFIRMATION).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.PROFILE_CONFIRMATION).get();
     DbAccessModule publicationModule =
-        accessModuleDao.findOneByName(AccessModuleName.PUBLICATION_CONFIRMATION).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.PUBLICATION_CONFIRMATION).get();
     DbAccessModule ducc =
-        accessModuleDao.findOneByName(AccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
 
     // 2FA module: Module is not expirable, so no expiration date present.
     Timestamp twoFactorCompletionTime = Timestamp.from(now.minus(expiryDays + 10, ChronoUnit.DAYS));
@@ -292,7 +292,7 @@ public class AccessModuleServiceTest {
 
     assertThat(
             accessModuleService.getAccessModuleStatus(
-                user, AccessModuleName.DATA_USER_CODE_OF_CONDUCT))
+                user, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT))
         .isEqualTo(Optional.of(expectedDuccModuleStatus));
   }
 
@@ -303,9 +303,9 @@ public class AccessModuleServiceTest {
     config.access.renewal.expiryDays = expiryDays;
     config.access.enableComplianceTraining = false;
     DbAccessModule twoFactorAuthModule =
-        accessModuleDao.findOneByName(AccessModuleName.TWO_FACTOR_AUTH).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.TWO_FACTOR_AUTH).get();
     DbAccessModule rtTrainingModule =
-        accessModuleDao.findOneByName(AccessModuleName.RT_COMPLIANCE_TRAINING).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.RT_COMPLIANCE_TRAINING).get();
 
     // 2FA module: Module is not expirable, so no expiration date present.
     Timestamp twoFactorCompletionTime = Timestamp.from(now.minus(expiryDays + 10, ChronoUnit.DAYS));
@@ -333,11 +333,11 @@ public class AccessModuleServiceTest {
     assertThat(accessModuleService.getAccessModuleStatus(user))
         .containsExactly(expected2FAModuleStatus);
 
-    assertThat(accessModuleService.getAccessModuleStatus(user, AccessModuleName.TWO_FACTOR_AUTH))
+    assertThat(accessModuleService.getAccessModuleStatus(user, DbAccessModuleName.TWO_FACTOR_AUTH))
         .isEqualTo(Optional.of(expected2FAModuleStatus));
     assertThat(
             accessModuleService.getAccessModuleStatus(
-                user, AccessModuleName.RT_COMPLIANCE_TRAINING))
+                user, DbAccessModuleName.RT_COMPLIANCE_TRAINING))
         .isEqualTo(Optional.empty());
   }
 
@@ -347,7 +347,7 @@ public class AccessModuleServiceTest {
     long expiryDays = 365L;
     config.access.renewal.expiryDays = expiryDays;
     DbAccessModule duccModule =
-        accessModuleDao.findOneByName(AccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
     Timestamp completionTime = Timestamp.from(now.minus(expiryDays + 10, ChronoUnit.DAYS));
     Timestamp bypassTime = Timestamp.from(Instant.parse("2000-01-01T00:00:00.00Z"));
 
@@ -360,7 +360,8 @@ public class AccessModuleServiceTest {
     userAccessModuleDao.save(duccDbUserAccessModule);
 
     assertThat(
-            accessModuleService.isModuleCompliant(user, AccessModuleName.DATA_USER_CODE_OF_CONDUCT))
+            accessModuleService.isModuleCompliant(
+                user, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT))
         .isTrue();
   }
 
@@ -370,9 +371,9 @@ public class AccessModuleServiceTest {
     long expiryDays = 365L;
     config.access.renewal.expiryDays = expiryDays;
     DbAccessModule duccModule =
-        accessModuleDao.findOneByName(AccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
     DbAccessModule twoFactorAuthModule =
-        accessModuleDao.findOneByName(AccessModuleName.TWO_FACTOR_AUTH).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.TWO_FACTOR_AUTH).get();
     Timestamp completionTime = Timestamp.from(now.minus(expiryDays + 10, ChronoUnit.DAYS));
 
     DbUserAccessModule duccDbUserAccessModule =
@@ -390,9 +391,10 @@ public class AccessModuleServiceTest {
 
     // DUCC expired, but 2FA not because it is not expirable
     assertThat(
-            accessModuleService.isModuleCompliant(user, AccessModuleName.DATA_USER_CODE_OF_CONDUCT))
+            accessModuleService.isModuleCompliant(
+                user, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT))
         .isFalse();
-    assertThat(accessModuleService.isModuleCompliant(user, AccessModuleName.TWO_FACTOR_AUTH))
+    assertThat(accessModuleService.isModuleCompliant(user, DbAccessModuleName.TWO_FACTOR_AUTH))
         .isTrue();
   }
 
@@ -403,7 +405,7 @@ public class AccessModuleServiceTest {
     config.access.renewal.expiryDays = expiryDays;
 
     DbAccessModule duccModule =
-        accessModuleDao.findOneByName(AccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
     Timestamp completionTime = Timestamp.from(now.minus(expiryDays - 10, ChronoUnit.DAYS));
 
     DbUserAccessModule existingDbUserAccessModule =
@@ -414,7 +416,8 @@ public class AccessModuleServiceTest {
     userAccessModuleDao.save(existingDbUserAccessModule);
 
     assertThat(
-            accessModuleService.isModuleCompliant(user, AccessModuleName.DATA_USER_CODE_OF_CONDUCT))
+            accessModuleService.isModuleCompliant(
+                user, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT))
         .isTrue();
   }
 
@@ -422,26 +425,29 @@ public class AccessModuleServiceTest {
   public void testModuleCompliant_moduleNotEnabled() {
     config.access.enableComplianceTraining = false;
     DbAccessModule rtTrainingModule =
-        accessModuleDao.findOneByName(AccessModuleName.RT_COMPLIANCE_TRAINING).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.RT_COMPLIANCE_TRAINING).get();
 
     DbUserAccessModule existingDbUserAccessModule =
         new DbUserAccessModule().setAccessModule(rtTrainingModule).setUser(user);
     userAccessModuleDao.save(existingDbUserAccessModule);
-    assertThat(accessModuleService.isModuleCompliant(user, AccessModuleName.RT_COMPLIANCE_TRAINING))
+    assertThat(
+            accessModuleService.isModuleCompliant(user, DbAccessModuleName.RT_COMPLIANCE_TRAINING))
         .isTrue();
   }
 
   @Test
   public void testModuleCompliant_moduleNotEnabled_notExistInDb() {
     config.access.enableComplianceTraining = false;
-    assertThat(accessModuleService.isModuleCompliant(user, AccessModuleName.RT_COMPLIANCE_TRAINING))
+    assertThat(
+            accessModuleService.isModuleCompliant(user, DbAccessModuleName.RT_COMPLIANCE_TRAINING))
         .isTrue();
   }
 
   @Test
   public void testModuleCompliant_moduleNotExist() {
     assertThat(
-            accessModuleService.isModuleCompliant(user, AccessModuleName.DATA_USER_CODE_OF_CONDUCT))
+            accessModuleService.isModuleCompliant(
+                user, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT))
         .isFalse();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/access/AccessUtilsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessUtilsTest.java
@@ -10,7 +10,7 @@ import static org.pmiops.workbench.utils.TestMockFactory.DEFAULT_ACCESS_MODULES;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.actionaudit.targetproperties.BypassTimeTargetProperty;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.model.AccessModule;
 
 /**
@@ -22,7 +22,7 @@ public class AccessUtilsTest {
   @Test
   public void test_clientAccessModuleToStorage() {
     for (final AccessModule original : AccessModule.values()) {
-      final AccessModuleName converted = clientAccessModuleToStorage(original);
+      final DbAccessModuleName converted = clientAccessModuleToStorage(original);
       assertWithMessage(original.toString()).that(converted).isNotNull();
       final AccessModule roundTrip = storageAccessModuleToClient(converted);
       assertWithMessage(converted.toString()).that(roundTrip).isEqualTo(original);
@@ -31,10 +31,10 @@ public class AccessUtilsTest {
 
   @Test
   public void test_storageAccessModuleToClient() {
-    for (final AccessModuleName original : AccessModuleName.values()) {
+    for (final DbAccessModuleName original : DbAccessModuleName.values()) {
       final AccessModule converted = storageAccessModuleToClient(original);
       assertWithMessage(original.toString()).that(converted).isNotNull();
-      final AccessModuleName roundTrip = clientAccessModuleToStorage(converted);
+      final DbAccessModuleName roundTrip = clientAccessModuleToStorage(converted);
       assertWithMessage(converted.toString()).that(roundTrip).isEqualTo(original);
     }
   }
@@ -42,7 +42,7 @@ public class AccessUtilsTest {
   @Test
   public void test_auditAccessModuleToStorage() {
     for (final BypassTimeTargetProperty original : BypassTimeTargetProperty.values()) {
-      final AccessModuleName converted = auditAccessModuleToStorage(original);
+      final DbAccessModuleName converted = auditAccessModuleToStorage(original);
       assertWithMessage(original.toString()).that(converted).isNotNull();
       final BypassTimeTargetProperty roundTrip = auditAccessModuleFromStorage(converted);
       assertWithMessage(converted.toString()).that(roundTrip).isEqualTo(original);
@@ -59,7 +59,7 @@ public class AccessUtilsTest {
             original -> {
               final BypassTimeTargetProperty converted = auditAccessModuleFromStorage(original);
               assertWithMessage(original.toString()).that(converted).isNotNull();
-              final AccessModuleName roundTrip = auditAccessModuleToStorage(converted);
+              final DbAccessModuleName roundTrip = auditAccessModuleToStorage(converted);
               assertWithMessage(converted.toString()).that(roundTrip).isEqualTo(original);
             });
   }

--- a/api/src/test/java/org/pmiops/workbench/access/UserAccessModuleMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserAccessModuleMapperTest.java
@@ -7,7 +7,7 @@ import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.model.AccessModule;
 import org.pmiops.workbench.model.AccessModuleStatus;
@@ -31,7 +31,7 @@ public class UserAccessModuleMapperTest {
     DbUserAccessModule dbUserAccessModule =
         new DbUserAccessModule()
             .setBypassTime(bypassTime)
-            .setAccessModule(new DbAccessModule().setName(AccessModuleName.ERA_COMMONS))
+            .setAccessModule(new DbAccessModule().setName(DbAccessModuleName.ERA_COMMONS))
             .setCompletionTime(completionTime);
 
     assertThat(mapper.dbToModule(dbUserAccessModule, expirationTime))
@@ -51,7 +51,7 @@ public class UserAccessModuleMapperTest {
     DbUserAccessModule dbUserAccessModule =
         new DbUserAccessModule()
             .setBypassTime(bypassTime)
-            .setAccessModule(new DbAccessModule().setName(AccessModuleName.ERA_COMMONS))
+            .setAccessModule(new DbAccessModule().setName(DbAccessModuleName.ERA_COMMONS))
             .setCompletionTime(completionTime);
 
     assertThat(mapper.dbToModule(dbUserAccessModule, expirationTime))

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -33,7 +33,7 @@ import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.dao.VerifiedInstitutionalAffiliationDao;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbUser;
@@ -234,7 +234,7 @@ public class UserServiceAccessTest {
 
     dbUser.setDuccAgreement(signCurrentDucc(dbUser));
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpireAfter(Duration.ofDays(1)));
+        dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpireAfter(Duration.ofDays(1)));
     dbUser = updateUserWithRetries(this::removeDuccBypass);
 
     // User is compliant
@@ -247,7 +247,9 @@ public class UserServiceAccessTest {
 
     // Simulate user filling out DUCC, becoming compliant again
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, new Timestamp(PROVIDED_CLOCK.millis()));
+        dbUser,
+        DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT,
+        new Timestamp(PROVIDED_CLOCK.millis()));
     dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
@@ -317,7 +319,7 @@ public class UserServiceAccessTest {
           accessModuleService.updateBypassTime(
               dbUser.getUserId(), AccessModule.COMPLIANCE_TRAINING, false);
           accessModuleService.updateCompletionTime(
-              dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, willExpire);
+              dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, willExpire);
 
           advanceClockDays(EXPIRATION_DAYS + 1);
 
@@ -345,7 +347,7 @@ public class UserServiceAccessTest {
           accessModuleService.updateBypassTime(
               dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
           accessModuleService.updateCompletionTime(
-              dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, Timestamp.from(START_INSTANT));
+              dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, Timestamp.from(START_INSTANT));
           return userDao.save(user);
         });
   }
@@ -359,7 +361,7 @@ public class UserServiceAccessTest {
           accessModuleService.updateBypassTime(
               dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
           accessModuleService.updateCompletionTime(
-              dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, Timestamp.from(START_INSTANT));
+              dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, Timestamp.from(START_INSTANT));
           user.setDuccAgreement(signDucc(user, 3));
           return userDao.save(user);
         });
@@ -373,7 +375,7 @@ public class UserServiceAccessTest {
           accessModuleService.updateBypassTime(
               dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
           accessModuleService.updateCompletionTime(
-              dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpire);
+              dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpire);
 
           user.setDuccAgreement(signCurrentDucc(user));
 
@@ -390,7 +392,7 @@ public class UserServiceAccessTest {
     testUnregistration(
         user -> {
           accessModuleService.updateCompletionTime(
-              dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, null);
+              dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, null);
           return userDao.save(user);
         });
   }
@@ -401,7 +403,7 @@ public class UserServiceAccessTest {
         user -> {
           final Timestamp willExpire = Timestamp.from(START_INSTANT);
           accessModuleService.updateCompletionTime(
-              dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, willExpire);
+              dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, willExpire);
           advanceClockDays(EXPIRATION_DAYS + 1);
 
           return userDao.save(user);
@@ -415,7 +417,7 @@ public class UserServiceAccessTest {
     testUnregistration(
         user -> {
           accessModuleService.updateCompletionTime(
-              dbUser, AccessModuleName.PROFILE_CONFIRMATION, null);
+              dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, null);
           return userDao.save(user);
         });
   }
@@ -426,7 +428,7 @@ public class UserServiceAccessTest {
         user -> {
           final Timestamp willExpire = Timestamp.from(START_INSTANT);
           accessModuleService.updateCompletionTime(
-              dbUser, AccessModuleName.PROFILE_CONFIRMATION, willExpire);
+              dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, willExpire);
           advanceClockDays(EXPIRATION_DAYS + 1);
 
           return userDao.save(user);
@@ -436,12 +438,13 @@ public class UserServiceAccessTest {
   @Test
   public void test_maybeSendAccessExpirationEmail_up_to_date() {
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, now);
+        dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
+    accessModuleService.updateCompletionTime(
+        dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, now);
 
     // a completion requirement for DUCC
     dbUser.setDuccAgreement(signCurrentDucc(dbUser));
@@ -463,9 +466,9 @@ public class UserServiceAccessTest {
         dbUser.getUserId(), AccessModule.COMPLIANCE_TRAINING, true);
 
     // these 2 are not bypassable
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, now);
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -477,10 +480,10 @@ public class UserServiceAccessTest {
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
+        dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
     dbUser.setDuccAgreement(signCurrentDucc(dbUser));
@@ -490,7 +493,7 @@ public class UserServiceAccessTest {
     final Duration oneDayPlusSome = daysPlusSome(1);
     final Instant expirationTime = PROVIDED_CLOCK.instant().plus(oneDayPlusSome);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(oneDayPlusSome));
+        dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(oneDayPlusSome));
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -505,18 +508,18 @@ public class UserServiceAccessTest {
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
 
     // expiring in 1 day (plus some) would trigger the 1-day warning...
 
     final Duration oneDayPlusSome = daysPlusSome(1);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(oneDayPlusSome));
+        dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(oneDayPlusSome));
 
     // but this module is incomplete (and also not bypassed)
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, null);
+        dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, null);
     accessModuleService.updateBypassTime(
         dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
 
@@ -533,9 +536,9 @@ public class UserServiceAccessTest {
       throws MessagingException {
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, now);
 
     // this is bypassed
     accessModuleService.updateBypassTime(
@@ -546,7 +549,7 @@ public class UserServiceAccessTest {
     final Duration oneDayPlusSome = daysPlusSome(1);
     final Instant expirationTime = PROVIDED_CLOCK.instant().plus(oneDayPlusSome);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(oneDayPlusSome));
+        dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(oneDayPlusSome));
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -560,16 +563,16 @@ public class UserServiceAccessTest {
       throws MessagingException {
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, now);
 
     // expiring in 1 day (plus some) will trigger the 1-day warning
 
     final Duration oneDayPlusSome = daysPlusSome(1);
     final Instant expirationTime = PROVIDED_CLOCK.instant().plus(oneDayPlusSome);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(oneDayPlusSome));
+        dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(oneDayPlusSome));
 
     // a bypass which would "expire" in 30 days does NOT trigger a 30-day warning
     accessModuleService.updateBypassTime(
@@ -587,11 +590,11 @@ public class UserServiceAccessTest {
   public void test_maybeSendAccessExpirationEmail_expiring_today() {
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
+        dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
     dbUser.setDuccAgreement(signCurrentDucc(dbUser));
@@ -600,7 +603,7 @@ public class UserServiceAccessTest {
 
     final Duration halfDay = Duration.ofHours(12);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(halfDay));
+        dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(halfDay));
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -611,11 +614,11 @@ public class UserServiceAccessTest {
   public void test_maybeSendAccessExpirationEmail_expiring_30() throws MessagingException {
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
+        dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
     dbUser.setDuccAgreement(signCurrentDucc(dbUser));
@@ -625,7 +628,7 @@ public class UserServiceAccessTest {
     final Duration thirtyPlus = daysPlusSome(30);
     final Instant expirationTime = PROVIDED_CLOCK.instant().plus(thirtyPlus);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(thirtyPlus));
+        dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(thirtyPlus));
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -636,18 +639,18 @@ public class UserServiceAccessTest {
   public void test_maybeSendAccessExpirationEmail_expiring_31() {
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
+        dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
     dbUser.setDuccAgreement(signCurrentDucc(dbUser));
 
     // expiring in 31 days (plus) will not trigger a warning
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(daysPlusSome(31)));
+        dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(daysPlusSome(31)));
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -660,9 +663,9 @@ public class UserServiceAccessTest {
   public void test_maybeSendAccessExpirationEmail_expiring_15_and_30() throws MessagingException {
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, now);
 
     // a completion requirement for DUCC
     dbUser.setDuccAgreement(signCurrentDucc(dbUser));
@@ -671,13 +674,13 @@ public class UserServiceAccessTest {
     final Duration thirtyPlus = daysPlusSome(30);
     final Instant expirationTime30 = PROVIDED_CLOCK.instant().plus(thirtyPlus);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(thirtyPlus));
+        dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(thirtyPlus));
 
     // but 15 days (plus) is sooner, so trigger 15 instead
     final Duration fifteenPlus = daysPlusSome(15);
     final Instant expirationTime15 = PROVIDED_CLOCK.instant().plus(fifteenPlus);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpireAfter(fifteenPlus));
+        dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpireAfter(fifteenPlus));
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -693,20 +696,20 @@ public class UserServiceAccessTest {
   public void test_maybeSendAccessExpirationEmail_expiring_14_and_15() {
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, now);
 
     // a completion requirement for DUCC
     dbUser.setDuccAgreement(signCurrentDucc(dbUser));
 
     // expiring in 15 days (plus) would trigger the 15-day warning...
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(daysPlusSome(15)));
+        dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, willExpireAfter(daysPlusSome(15)));
 
     // but 14 days (plus) is sooner, so no email is sent
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpireAfter(daysPlusSome(14)));
+        dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, willExpireAfter(daysPlusSome(14)));
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -717,11 +720,11 @@ public class UserServiceAccessTest {
   public void test_maybeSendAccessExpirationEmail_expired() throws MessagingException {
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
+        dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
     dbUser.setDuccAgreement(signCurrentDucc(dbUser));
@@ -730,7 +733,7 @@ public class UserServiceAccessTest {
     final Duration oneHour = Duration.ofHours(1);
     final Instant expirationTime = PROVIDED_CLOCK.instant().minus(oneHour);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, expiredBy(oneHour));
+        dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, expiredBy(oneHour));
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -744,11 +747,11 @@ public class UserServiceAccessTest {
   public void test_maybeSendAccessExpirationEmail_extra_expired() {
     // these are up to date
     final Timestamp now = new Timestamp(PROVIDED_CLOCK.millis());
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.PROFILE_CONFIRMATION, now);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, now);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, now);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
+        dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, now);
 
     // a completion requirement for DUCC
     dbUser.setDuccAgreement(signCurrentDucc(dbUser));
@@ -760,7 +763,7 @@ public class UserServiceAccessTest {
         Timestamp.from(aYearAgo.minus(Duration.ofDays(1)).minus(Duration.ofHours(1)));
 
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, extraExpired);
+        dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, extraExpired);
 
     userService.maybeSendAccessExpirationEmail(dbUser);
 
@@ -866,7 +869,7 @@ public class UserServiceAccessTest {
 
     // Now make user eRA not complete, expect user removed from Registered tier;
     accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.ERA_COMMONS, null);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.ERA_COMMONS, null);
     dbUser = updateUserAccessTiers();
     assertRegisteredTierDisabled(dbUser);
 
@@ -889,7 +892,7 @@ public class UserServiceAccessTest {
         institution.getShortName(),
         institution.tierConfigs(ImmutableList.of(rtTierConfig.eraRequired(false))));
     accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.ERA_COMMONS, null);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.ERA_COMMONS, null);
     dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
 
@@ -910,7 +913,7 @@ public class UserServiceAccessTest {
         institution.getShortName(),
         institution.tierConfigs(ImmutableList.of(rtTierConfig.eraRequired(true))));
     accessModuleService.updateBypassTime(dbUser.getUserId(), AccessModule.ERA_COMMONS, false);
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.ERA_COMMONS, null);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.ERA_COMMONS, null);
     dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
@@ -930,7 +933,7 @@ public class UserServiceAccessTest {
 
     // Complete RAS Linking, verify user become registered
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RAS_LOGIN_GOV, new Timestamp(PROVIDED_CLOCK.millis()));
+        dbUser, DbAccessModuleName.RAS_LOGIN_GOV, new Timestamp(PROVIDED_CLOCK.millis()));
     dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
@@ -968,7 +971,7 @@ public class UserServiceAccessTest {
 
     // Complete RAS Linking, verify user become registered
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RAS_LOGIN_GOV, new Timestamp(PROVIDED_CLOCK.millis()));
+        dbUser, DbAccessModuleName.RAS_LOGIN_GOV, new Timestamp(PROVIDED_CLOCK.millis()));
     dbUser = updateUserAccessTiers();
     assertRegisteredTierEnabled(dbUser);
   }
@@ -1297,9 +1300,9 @@ public class UserServiceAccessTest {
     accessModuleService.updateBypassTime(user.getUserId(), AccessModule.RAS_LINK_LOGIN_GOV, true);
 
     accessModuleService.updateCompletionTime(
-        user, AccessModuleName.PUBLICATION_CONFIRMATION, timestamp);
+        user, DbAccessModuleName.PUBLICATION_CONFIRMATION, timestamp);
     accessModuleService.updateCompletionTime(
-        user, AccessModuleName.PROFILE_CONFIRMATION, timestamp);
+        user, DbAccessModuleName.PROFILE_CONFIRMATION, timestamp);
 
     createAffiliation(user);
     return user;

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskUserControllerTest.java
@@ -18,7 +18,7 @@ import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserService;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.google.CloudResourceManagerService;
 import org.pmiops.workbench.model.AccessModuleStatus;
@@ -84,9 +84,9 @@ public class CloudTaskUserControllerTest {
 
   @Test
   public void testSynchronizeAccess() {
-    when(mockAccessModuleService.getAccessModuleStatus(userA, AccessModuleName.TWO_FACTOR_AUTH))
+    when(mockAccessModuleService.getAccessModuleStatus(userA, DbAccessModuleName.TWO_FACTOR_AUTH))
         .thenReturn(Optional.of(new AccessModuleStatus().completionEpochMillis(123L)));
-    when(mockAccessModuleService.getAccessModuleStatus(userB, AccessModuleName.TWO_FACTOR_AUTH))
+    when(mockAccessModuleService.getAccessModuleStatus(userB, DbAccessModuleName.TWO_FACTOR_AUTH))
         .thenReturn(Optional.of(new AccessModuleStatus()));
 
     // kluge to prevent test NPEs on the return value of syncDuccVersionStatus()

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -57,7 +57,7 @@ import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserServiceImpl;
 import org.pmiops.workbench.db.dao.UserTermsOfServiceDao;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
@@ -532,15 +532,15 @@ public class ProfileControllerTest extends BaseControllerTest {
 
     // bypass the other access requirements
     final DbUser dbUser = userDao.findUserByUserId(userId);
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.ERA_COMMONS, TIMESTAMP);
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.RAS_LOGIN_GOV, TIMESTAMP);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.ERA_COMMONS, TIMESTAMP);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.RAS_LOGIN_GOV, TIMESTAMP);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.RT_COMPLIANCE_TRAINING, TIMESTAMP);
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.TWO_FACTOR_AUTH, TIMESTAMP);
+        dbUser, DbAccessModuleName.RT_COMPLIANCE_TRAINING, TIMESTAMP);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.TWO_FACTOR_AUTH, TIMESTAMP);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PUBLICATION_CONFIRMATION, TIMESTAMP);
+        dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, TIMESTAMP);
     accessModuleService.updateCompletionTime(
-        dbUser, AccessModuleName.PROFILE_CONFIRMATION, TIMESTAMP);
+        dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, TIMESTAMP);
 
     // arbitrary; at coding time the current version is 3
     final int versionA = 5;
@@ -1574,7 +1574,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
     dbUser.setRasLinkLoginGovUsername(loginGovUsername);
     dbUser = userDao.save(dbUser);
-    accessModuleService.updateCompletionTime(dbUser, AccessModuleName.RAS_LOGIN_GOV, TIMESTAMP);
+    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.RAS_LOGIN_GOV, TIMESTAMP);
 
     when(mockRasLinkService.linkRasLoginGovAccount(body.getAuthCode(), body.getRedirectUrl()))
         .thenReturn(dbUser);

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessModuleDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessModuleDaoTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.config.CommonConfig;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.utils.TestMockFactory;
@@ -38,8 +38,9 @@ public class UserAccessModuleDaoTest {
     user = userDao.save(user);
 
     TestMockFactory.createAccessModules(accessModuleDao);
-    twoFactorAuthModule = accessModuleDao.findOneByName(AccessModuleName.TWO_FACTOR_AUTH).get();
-    rtTrainingModule = accessModuleDao.findOneByName(AccessModuleName.RT_COMPLIANCE_TRAINING).get();
+    twoFactorAuthModule = accessModuleDao.findOneByName(DbAccessModuleName.TWO_FACTOR_AUTH).get();
+    rtTrainingModule =
+        accessModuleDao.findOneByName(DbAccessModuleName.RT_COMPLIANCE_TRAINING).get();
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
@@ -15,7 +15,7 @@ import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.db.dao.UserDao.DbAdminTableUser;
 import org.pmiops.workbench.db.dao.UserDao.UserCountByDisabledAndAccessTiers;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbInstitution;
@@ -176,17 +176,17 @@ public class UserDaoTest {
     addUserToTier(user, registeredTier);
 
     final DbAccessModule twoFactorAuthModule =
-        accessModuleDao.findOneByName(AccessModuleName.TWO_FACTOR_AUTH).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.TWO_FACTOR_AUTH).get();
     final DbAccessModule rtTrainingModule =
-        accessModuleDao.findOneByName(AccessModuleName.RT_COMPLIANCE_TRAINING).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.RT_COMPLIANCE_TRAINING).get();
     final DbAccessModule ctTrainingModule =
-        accessModuleDao.findOneByName(AccessModuleName.CT_COMPLIANCE_TRAINING).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.CT_COMPLIANCE_TRAINING).get();
     final DbAccessModule eRACommonsModule =
-        accessModuleDao.findOneByName(AccessModuleName.ERA_COMMONS).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.ERA_COMMONS).get();
     final DbAccessModule duccModule =
-        accessModuleDao.findOneByName(AccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
     final DbAccessModule rasConfirmModule =
-        accessModuleDao.findOneByName(AccessModuleName.RAS_LOGIN_GOV).get();
+        accessModuleDao.findOneByName(DbAccessModuleName.RAS_LOGIN_GOV).get();
     Instant now = Instant.now();
     Timestamp twoFactorAuthBypassTime = Timestamp.from(now.minusSeconds(10));
     Timestamp twoFactorAuthCompleteTime = Timestamp.from(now.minusSeconds(20));

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -40,7 +40,7 @@ import org.pmiops.workbench.compliance.ComplianceService;
 import org.pmiops.workbench.compliance.ComplianceService.BadgeName;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
@@ -181,14 +181,14 @@ public class UserServiceTest {
     // The user should be updated in the database with a non-empty completion.
     DbUser user = userDao.findUserByUsername(USERNAME);
     assertModuleCompletionEqual(
-        AccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
+        DbAccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
 
     // Completion timestamp should not change when the method is called again.
     tick();
     userService.syncComplianceTrainingStatusV2();
 
     assertModuleCompletionEqual(
-        AccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
+        DbAccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
   }
 
   @Test
@@ -206,14 +206,14 @@ public class UserServiceTest {
     // The user should be updated in the database with a non-empty completion time.
     DbUser user = userDao.findUserByUsername(USERNAME);
     assertModuleCompletionEqual(
-        AccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
+        DbAccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
 
     // Deprecate the old training.
     retBadge.setValid(false);
 
     // Completion timestamp should be wiped out by the expiry timestamp passing.
     userService.syncComplianceTrainingStatusV2();
-    assertModuleCompletionEqual(AccessModuleName.RT_COMPLIANCE_TRAINING, user, null);
+    assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, user, null);
 
     // The user does a new training.
     retBadge.lastissued(issued + 5).valid(true);
@@ -221,7 +221,7 @@ public class UserServiceTest {
     // Completion and expiry timestamp should be updated.
     userService.syncComplianceTrainingStatusV2();
     assertModuleCompletionEqual(
-        AccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
+        DbAccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
 
     // Time passes, user renews training
     retBadge.lastissued(fakeClock.instant().getEpochSecond() + 1);
@@ -230,7 +230,7 @@ public class UserServiceTest {
     // Completion should be updated to the current time.
     userService.syncComplianceTrainingStatusV2();
     assertModuleCompletionEqual(
-        AccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(fakeClock.instant()));
+        DbAccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(fakeClock.instant()));
   }
 
   @Test
@@ -252,9 +252,9 @@ public class UserServiceTest {
     // The user should be updated in the database with a non-empty completion time.
     DbUser user = userDao.findUserByUsername(USERNAME);
     assertModuleCompletionEqual(
-        AccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
+        DbAccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
     assertModuleCompletionEqual(
-        AccessModuleName.CT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
+        DbAccessModuleName.CT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
 
     ctBadge.lastissued(fakeClock.instant().getEpochSecond() + 1);
     fakeClock.increment(5000);
@@ -262,9 +262,9 @@ public class UserServiceTest {
     // Renewing training updates completion.
     userService.syncComplianceTrainingStatusV2();
     assertModuleCompletionEqual(
-        AccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
+        DbAccessModuleName.RT_COMPLIANCE_TRAINING, user, Timestamp.from(START_INSTANT));
     assertModuleCompletionEqual(
-        AccessModuleName.CT_COMPLIANCE_TRAINING, user, Timestamp.from(fakeClock.instant()));
+        DbAccessModuleName.CT_COMPLIANCE_TRAINING, user, Timestamp.from(fakeClock.instant()));
   }
 
   private void tick() {
@@ -277,7 +277,7 @@ public class UserServiceTest {
 
     DbUser user = userDao.findUserByUsername(USERNAME);
     accessModuleService.updateCompletionTime(
-        user, AccessModuleName.RT_COMPLIANCE_TRAINING, new Timestamp(12345));
+        user, DbAccessModuleName.RT_COMPLIANCE_TRAINING, new Timestamp(12345));
 
     // An empty map should be returned when we have no badge information.
     Map<BadgeName, BadgeDetailsV2> userBadgesByName = new HashMap<>();
@@ -286,7 +286,7 @@ public class UserServiceTest {
 
     userService.syncComplianceTrainingStatusV2();
     user = userDao.findUserByUsername(USERNAME);
-    assertModuleCompletionEqual(AccessModuleName.RT_COMPLIANCE_TRAINING, user, null);
+    assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, user, null);
   }
 
   @Test
@@ -319,7 +319,8 @@ public class UserServiceTest {
     userService.syncEraCommonsStatus();
 
     DbUser user = userDao.findUserByUsername(USERNAME);
-    assertModuleCompletionEqual(AccessModuleName.ERA_COMMONS, user, Timestamp.from(START_INSTANT));
+    assertModuleCompletionEqual(
+        DbAccessModuleName.ERA_COMMONS, user, Timestamp.from(START_INSTANT));
 
     assertThat(user.getEraCommonsLinkExpireTime()).isEqualTo(Timestamp.from(START_INSTANT));
     assertThat(user.getEraCommonsLinkedNihUsername()).isEqualTo("nih-user");
@@ -328,7 +329,8 @@ public class UserServiceTest {
     tick();
     userService.syncEraCommonsStatus();
 
-    assertModuleCompletionEqual(AccessModuleName.ERA_COMMONS, user, Timestamp.from(START_INSTANT));
+    assertModuleCompletionEqual(
+        DbAccessModuleName.ERA_COMMONS, user, Timestamp.from(START_INSTANT));
   }
 
   @Test
@@ -339,12 +341,12 @@ public class UserServiceTest {
     testUser = userDao.save(testUser);
 
     accessModuleService.updateCompletionTime(
-        testUser, AccessModuleName.ERA_COMMONS, Timestamp.from(START_INSTANT));
+        testUser, DbAccessModuleName.ERA_COMMONS, Timestamp.from(START_INSTANT));
 
     userService.syncEraCommonsStatus();
 
     DbUser retrievedUser = userDao.findUserByUsername(USERNAME);
-    assertModuleCompletionEqual(AccessModuleName.ERA_COMMONS, retrievedUser, null);
+    assertModuleCompletionEqual(DbAccessModuleName.ERA_COMMONS, retrievedUser, null);
   }
 
   @Test
@@ -383,7 +385,7 @@ public class UserServiceTest {
     userService.updateRasLinkLoginGovStatus(loginGovName);
     assertThat(providedDbUser.getRasLinkLoginGovUsername()).isEqualTo(loginGovName);
     assertModuleCompletionEqual(
-        AccessModuleName.RAS_LOGIN_GOV, providedDbUser, Timestamp.from(START_INSTANT));
+        DbAccessModuleName.RAS_LOGIN_GOV, providedDbUser, Timestamp.from(START_INSTANT));
   }
 
   @Test
@@ -397,20 +399,20 @@ public class UserServiceTest {
     // twoFactorAuthCompletionTime should now be set
     DbUser user = userDao.findUserByUsername(USERNAME);
     Timestamp twoFactorAuthCompletionTime =
-        getModuleCompletionTime(AccessModuleName.TWO_FACTOR_AUTH, user);
+        getModuleCompletionTime(DbAccessModuleName.TWO_FACTOR_AUTH, user);
     assertThat(twoFactorAuthCompletionTime).isNotNull();
 
     // twoFactorAuthCompletionTime should not change when already set
     tick();
     userService.syncTwoFactorAuthStatus();
     assertModuleCompletionEqual(
-        AccessModuleName.TWO_FACTOR_AUTH, providedDbUser, twoFactorAuthCompletionTime);
+        DbAccessModuleName.TWO_FACTOR_AUTH, providedDbUser, twoFactorAuthCompletionTime);
 
     // unset 2FA in google and check that twoFactorAuthCompletionTime is set to null
     googleUser.setIsEnrolledIn2Sv(false);
     userService.syncTwoFactorAuthStatus();
     user = userDao.findUserByUsername(USERNAME);
-    assertModuleCompletionEqual(AccessModuleName.TWO_FACTOR_AUTH, providedDbUser, null);
+    assertModuleCompletionEqual(DbAccessModuleName.TWO_FACTOR_AUTH, providedDbUser, null);
   }
 
   @Test
@@ -475,7 +477,7 @@ public class UserServiceTest {
     userService.syncDuccVersionStatus(user, Agent.asSystem());
 
     verify(accessModuleService)
-        .updateCompletionTime(user, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, null);
+        .updateCompletionTime(user, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, null);
   }
 
   @Test
@@ -485,7 +487,7 @@ public class UserServiceTest {
     userService.syncDuccVersionStatus(user, Agent.asSystem());
 
     verify(accessModuleService)
-        .updateCompletionTime(user, AccessModuleName.DATA_USER_CODE_OF_CONDUCT, null);
+        .updateCompletionTime(user, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, null);
   }
 
   @Test
@@ -513,39 +515,39 @@ public class UserServiceTest {
 
   @Test
   public void test_confirmProfile() {
-    assertModuleIncomplete(AccessModuleName.PROFILE_CONFIRMATION, providedDbUser);
+    assertModuleIncomplete(DbAccessModuleName.PROFILE_CONFIRMATION, providedDbUser);
 
     // user confirms profile, so confirmation time is set to START_INSTANT
 
     userService.confirmProfile(providedDbUser);
     assertModuleCompletionEqual(
-        AccessModuleName.PROFILE_CONFIRMATION, providedDbUser, Timestamp.from(START_INSTANT));
+        DbAccessModuleName.PROFILE_CONFIRMATION, providedDbUser, Timestamp.from(START_INSTANT));
 
     // time passes, user confirms again, confirmation time is updated
 
     tick();
 
     userService.confirmProfile(providedDbUser);
-    assertThat(getModuleCompletionTime(AccessModuleName.PROFILE_CONFIRMATION, providedDbUser))
+    assertThat(getModuleCompletionTime(DbAccessModuleName.PROFILE_CONFIRMATION, providedDbUser))
         .isGreaterThan(Timestamp.from(START_INSTANT));
   }
 
   @Test
   public void test_confirmPublications() {
-    assertModuleIncomplete(AccessModuleName.PUBLICATION_CONFIRMATION, providedDbUser);
+    assertModuleIncomplete(DbAccessModuleName.PUBLICATION_CONFIRMATION, providedDbUser);
 
     // user confirms profile, so confirmation time is set to START_INSTANT
 
     userService.confirmPublications();
     assertModuleCompletionEqual(
-        AccessModuleName.PUBLICATION_CONFIRMATION, providedDbUser, Timestamp.from(START_INSTANT));
+        DbAccessModuleName.PUBLICATION_CONFIRMATION, providedDbUser, Timestamp.from(START_INSTANT));
 
     // time passes, user confirms again, confirmation time is updated
 
     tick();
 
     userService.confirmPublications();
-    assertThat(getModuleCompletionTime(AccessModuleName.PUBLICATION_CONFIRMATION, providedDbUser))
+    assertThat(getModuleCompletionTime(DbAccessModuleName.PUBLICATION_CONFIRMATION, providedDbUser))
         .isGreaterThan(Timestamp.from(START_INSTANT));
   }
 
@@ -604,18 +606,18 @@ public class UserServiceTest {
   }
 
   private void assertModuleCompletionEqual(
-      AccessModuleName moduleName, DbUser user, Timestamp timestamp) {
+      DbAccessModuleName moduleName, DbUser user, Timestamp timestamp) {
     assertThat(getModuleCompletionTime(moduleName, user)).isEqualTo(timestamp);
   }
 
-  private Timestamp getModuleCompletionTime(AccessModuleName moduleName, DbUser user) {
+  private Timestamp getModuleCompletionTime(DbAccessModuleName moduleName, DbUser user) {
     return userAccessModuleDao
         .getByUserAndAccessModule(user, accessModuleDao.findOneByName(moduleName).get())
         .get()
         .getCompletionTime();
   }
 
-  private void assertModuleIncomplete(AccessModuleName moduleName, DbUser user) {
+  private void assertModuleIncomplete(DbAccessModuleName moduleName, DbUser user) {
     // assert that the module is either not present or explicitly null
     userAccessModuleDao
         .getByUserAndAccessModule(user, accessModuleDao.findOneByName(moduleName).get())

--- a/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
@@ -41,7 +41,7 @@ import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.VerifiedInstitutionalAffiliationDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbCohort;
@@ -131,10 +131,11 @@ public class ReportingQueryServiceTest {
     controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
     TestMockFactory.createAccessModules(accessModuleDao);
     dbInstitution = createDbInstitution();
-    twoFactorAuthModule = accessModuleDao.findOneByName(AccessModuleName.TWO_FACTOR_AUTH).get();
-    rtTrainingModule = accessModuleDao.findOneByName(AccessModuleName.RT_COMPLIANCE_TRAINING).get();
-    eRACommonsModule = accessModuleDao.findOneByName(AccessModuleName.ERA_COMMONS).get();
-    duccModule = accessModuleDao.findOneByName(AccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
+    twoFactorAuthModule = accessModuleDao.findOneByName(DbAccessModuleName.TWO_FACTOR_AUTH).get();
+    rtTrainingModule =
+        accessModuleDao.findOneByName(DbAccessModuleName.RT_COMPLIANCE_TRAINING).get();
+    eRACommonsModule = accessModuleDao.findOneByName(DbAccessModuleName.ERA_COMMONS).get();
+    duccModule = accessModuleDao.findOneByName(DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
@@ -42,7 +42,7 @@ import org.pmiops.workbench.db.dao.UserAccessModuleDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.exceptions.ForbiddenException;
@@ -215,8 +215,8 @@ public class RasLinkServiceTest {
 
     assertThat(userDao.findUserByUserId(userId).getRasLinkLoginGovUsername())
         .isEqualTo(LOGIN_GOV_USERNAME);
-    assertModuleCompletionTime(AccessModuleName.RAS_LOGIN_GOV, NOW);
-    assertModuleCompletionTime(AccessModuleName.ERA_COMMONS, null);
+    assertModuleCompletionTime(DbAccessModuleName.RAS_LOGIN_GOV, NOW);
+    assertModuleCompletionTime(DbAccessModuleName.ERA_COMMONS, null);
   }
 
   @Test
@@ -231,15 +231,15 @@ public class RasLinkServiceTest {
         .isEqualTo(LOGIN_GOV_USERNAME);
     assertThat(userDao.findUserByUserId(userId).getEraCommonsLinkedNihUsername())
         .isEqualTo("eraUserId");
-    assertModuleCompletionTime(AccessModuleName.RAS_LOGIN_GOV, NOW);
-    assertModuleCompletionTime(AccessModuleName.ERA_COMMONS, NOW);
+    assertModuleCompletionTime(DbAccessModuleName.RAS_LOGIN_GOV, NOW);
+    assertModuleCompletionTime(DbAccessModuleName.ERA_COMMONS, NOW);
   }
 
   @Test
   public void testLinkRasSuccess_eRAAlreadyLinked() throws Exception {
     // ERA is linked before, expect ERA record not update by RAS linking again.
     Timestamp eRATime = Timestamp.from(Instant.parse("2000-01-01T00:00:00.00Z"));
-    accessModuleService.updateCompletionTime(currentUser, AccessModuleName.ERA_COMMONS, eRATime);
+    accessModuleService.updateCompletionTime(currentUser, DbAccessModuleName.ERA_COMMONS, eRATime);
     when(mockOidcClient.codeExchange(AUTH_CODE, REDIRECT_URL, RAS_AUTH_CODE_SCOPES))
         .thenReturn(TOKEN_RESPONSE_IAL2);
     when(mockOidcClient.fetchUserInfo(ACCESS_TOKEN))
@@ -248,8 +248,8 @@ public class RasLinkServiceTest {
 
     assertThat(userDao.findUserByUserId(userId).getRasLinkLoginGovUsername())
         .isEqualTo(LOGIN_GOV_USERNAME);
-    assertModuleCompletionTime(AccessModuleName.RAS_LOGIN_GOV, NOW);
-    assertModuleCompletionTime(AccessModuleName.ERA_COMMONS, eRATime);
+    assertModuleCompletionTime(DbAccessModuleName.RAS_LOGIN_GOV, NOW);
+    assertModuleCompletionTime(DbAccessModuleName.ERA_COMMONS, eRATime);
   }
 
   @Test
@@ -272,7 +272,7 @@ public class RasLinkServiceTest {
         () -> rasLinkService.linkRasLoginGovAccount(AUTH_CODE, REDIRECT_URL));
   }
 
-  private void assertModuleCompletionTime(AccessModuleName moduleName, Timestamp timestamp) {
+  private void assertModuleCompletionTime(DbAccessModuleName moduleName, Timestamp timestamp) {
     Optional<DbUserAccessModule> dbAccessModule =
         userAccessModuleDao.getByUserAndAccessModule(
             currentUser, accessModuleDao.findOneByName(moduleName).get());

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -23,7 +23,7 @@ import org.pmiops.workbench.db.dao.AccessModuleDao;
 import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
@@ -68,35 +68,35 @@ public class TestMockFactory {
   public static final List<DbAccessModule> DEFAULT_ACCESS_MODULES =
       ImmutableList.of(
           new DbAccessModule()
-              .setName(AccessModuleName.TWO_FACTOR_AUTH)
+              .setName(DbAccessModuleName.TWO_FACTOR_AUTH)
               .setExpirable(false)
               .setBypassable(true),
           new DbAccessModule()
-              .setName(AccessModuleName.ERA_COMMONS)
+              .setName(DbAccessModuleName.ERA_COMMONS)
               .setExpirable(false)
               .setBypassable(true),
           new DbAccessModule()
-              .setName(AccessModuleName.RAS_LOGIN_GOV)
+              .setName(DbAccessModuleName.RAS_LOGIN_GOV)
               .setExpirable(false)
               .setBypassable(true),
           new DbAccessModule()
-              .setName(AccessModuleName.DATA_USER_CODE_OF_CONDUCT)
+              .setName(DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT)
               .setExpirable(true)
               .setBypassable(true),
           new DbAccessModule()
-              .setName(AccessModuleName.RT_COMPLIANCE_TRAINING)
+              .setName(DbAccessModuleName.RT_COMPLIANCE_TRAINING)
               .setExpirable(true)
               .setBypassable(true),
           new DbAccessModule()
-              .setName(AccessModuleName.CT_COMPLIANCE_TRAINING)
+              .setName(DbAccessModuleName.CT_COMPLIANCE_TRAINING)
               .setExpirable(false)
               .setBypassable(true),
           new DbAccessModule()
-              .setName(AccessModuleName.PROFILE_CONFIRMATION)
+              .setName(DbAccessModuleName.PROFILE_CONFIRMATION)
               .setExpirable(true)
               .setBypassable(false),
           new DbAccessModule()
-              .setName(AccessModuleName.PUBLICATION_CONFIRMATION)
+              .setName(DbAccessModuleName.PUBLICATION_CONFIRMATION)
               .setExpirable(true)
               .setBypassable(false));
 

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/SetAccessModuleTimestamps.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/SetAccessModuleTimestamps.java
@@ -17,7 +17,7 @@ import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditorImpl;
 import org.pmiops.workbench.audit.ActionAuditSpringConfiguration;
 import org.pmiops.workbench.config.CacheAccessModuleConfiguration;
 import org.pmiops.workbench.db.dao.UserDao;
-import org.pmiops.workbench.db.model.DbAccessModule.AccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -60,7 +60,7 @@ public class SetAccessModuleTimestamps {
   void updateCompletionTime(
       AccessModuleService accessModuleService,
       String username,
-      AccessModuleName moduleName,
+      DbAccessModuleName moduleName,
       @Nullable Timestamp timestamp) {
     accessModuleService.updateCompletionTime(dbUser, moduleName, timestamp);
 
@@ -82,7 +82,7 @@ public class SetAccessModuleTimestamps {
       updateCompletionTime(
           accessModuleService,
           username,
-          AccessModuleName.PROFILE_CONFIRMATION,
+          DbAccessModuleName.PROFILE_CONFIRMATION,
           PROFILE_CONFIRMATION_TIMESTAMP);
     };
   }


### PR DESCRIPTION
Not super exciting by itself, but this is one step in a larger effort to address the confusion between the very similar `AccessModule` API entity enum and the `AccessModuleName` DB enum.  See #6328 for more on this idea and #6325 for a speculative extension.

Split into smaller PRs for easier digestion.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
