### PR TITLE
[RW-8085][risk=no] Fixed - conceptCounts and UI navigation

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -289,6 +289,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
               + "where code like upper(concat(:term,'%')) "
               + "and is_standard = :standard "
               + "and domain_id in (:domains) "
+              + "and full_text like '%_rank1]' "
               + "group by domain_id "
               + "order by count desc",
       nativeQuery = true)

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -289,7 +289,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
               + "where code like upper(concat(:term,'%')) "
               + "and is_standard = :standard "
               + "and domain_id in (:domains) "
-              + "and full_text like '%_rank1]' "
+              + "and full_text like '%_rank1]%' "
               + "group by domain_id "
               + "order by count desc",
       nativeQuery = true)

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -272,6 +272,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
           "select domain_id as domainId, domain_id as name, count(*) as count "
               + "from cb_criteria "
               + "where match(full_text) against(:term in boolean mode) "
+              + "and full_text like '%_rank1%' "
               + "and is_standard = :standard "
               + "and domain_id in (:domains) "
               + "group by domain_id "
@@ -289,7 +290,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
               + "where code like upper(concat(:term,'%')) "
               + "and is_standard = :standard "
               + "and domain_id in (:domains) "
-              + "and full_text like '%_rank1]%' "
+              + "and full_text like '%_rank1%' "
               + "group by domain_id "
               + "order by count desc",
       nativeQuery = true)

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -291,8 +291,9 @@ export const ConceptHomepage = fp.flow(
       await Promise.all([getDomainCards, getSurveyInfo]);
       if (cohortContext?.searchTerms) {
         await this.updateCardCounts();
+      } else {
+        this.setState({ loadingConceptCounts: false });
       }
-      this.setState({ loadingConceptCounts: false });
     }
 
     async updateCardCounts() {


### PR DESCRIPTION
Description:

- new findConcepCounts API - interim fixed concept-counts using `full_text like` clause 'FULLTEXT" index is not used. 
- UI navigation back to concept-search page is fixed. 

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
