### PR TITLE
[RW-8084][risk=no] Reattach to existing disk by default, if possible

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -700,6 +700,26 @@ describe('RuntimePanel', () => {
     }
   );
 
+  it('should reattach to an existing disk by default, for deleted VMs', async () => {
+    setCurrentDisk(existingDisk());
+    setCurrentRuntime({
+      ...runtimeApiStub.runtime,
+      status: RuntimeStatus.Deleted,
+      configurationType: RuntimeConfigurationType.UserOverride,
+      gceConfig: {
+        ...defaultGceConfig(),
+        machineType: 'n1-standard-16',
+      },
+      dataprocConfig: null,
+    });
+
+    const wrapper = await component();
+
+    const getDetachableRadio = () =>
+      wrapper.find({ name: 'detachableDisk' }).first();
+    expect(getDetachableRadio().prop('checked')).toBeTruthy();
+  });
+
   it('should allow configuration via dataproc preset from modified form', async () => {
     setCurrentRuntime(null);
 

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -65,12 +65,12 @@ import { applyPresetOverride, runtimePresets } from 'app/utils/runtime-presets';
 import {
   AnalysisConfig,
   AnalysisDiff,
-  maybeWithExistingDisk,
   diffsToUpdateMessaging,
   DiskConfig,
   diskTypeLabels,
   fromAnalysisConfig,
   getAnalysisConfigDiffs,
+  maybeWithExistingDisk,
   maybeWithExistingDiskName,
   RuntimeStatusRequest,
   toAnalysisConfig,
@@ -1722,7 +1722,8 @@ const RuntimePanel = fp.flow(
         // The attached disk information is lost for deleted runtimes. In any case,
         // by default we want to offer that the user reattach their existing disk,
         // if any and if the configuration allows it.
-        maybeWithExistingDisk(currentRuntime, persistentDisk));
+        maybeWithExistingDisk(currentRuntime, persistentDisk)
+      );
     }
 
     const [status, setRuntimeStatus] = useRuntimeStatus(

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -65,6 +65,7 @@ import { applyPresetOverride, runtimePresets } from 'app/utils/runtime-presets';
 import {
   AnalysisConfig,
   AnalysisDiff,
+  maybeWithExistingDisk,
   diffsToUpdateMessaging,
   DiskConfig,
   diskTypeLabels,
@@ -1717,7 +1718,11 @@ const RuntimePanel = fp.flow(
       useCustomRuntime(namespace, persistentDisk);
     // If the runtime has been deleted, it's possible that the default preset values have changed since its creation
     if (currentRuntime && currentRuntime.status === RuntimeStatus.Deleted) {
-      currentRuntime = applyPresetOverride(currentRuntime);
+      currentRuntime = applyPresetOverride(
+        // The attached disk information is lost for deleted runtimes. In any case,
+        // by default we want to offer that the user reattach their existing disk,
+        // if any and if the configuration allows it.
+        maybeWithExistingDisk(currentRuntime, persistentDisk));
     }
 
     const [status, setRuntimeStatus] = useRuntimeStatus(

--- a/ui/src/app/utils/runtime-presets.ts
+++ b/ui/src/app/utils/runtime-presets.ts
@@ -1,6 +1,6 @@
 import * as fp from 'lodash/fp';
 
-import { Runtime, RuntimeConfigurationType } from 'generated/fetch';
+import { Disk, Runtime, RuntimeConfigurationType } from 'generated/fetch';
 
 import { DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES } from './machines';
 

--- a/ui/src/app/utils/runtime-presets.ts
+++ b/ui/src/app/utils/runtime-presets.ts
@@ -1,6 +1,6 @@
 import * as fp from 'lodash/fp';
 
-import { Disk, Runtime, RuntimeConfigurationType } from 'generated/fetch';
+import { Runtime, RuntimeConfigurationType } from 'generated/fetch';
 
 import { DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES } from './machines';
 

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -625,6 +625,26 @@ export const maybeWithExistingDiskName = (
   return { ...c, existingDiskName: null };
 };
 
+// Attach an existing disk to the given runtime, if the configuration allows it.
+export const maybeWithExistingDisk = (runtime: Runtime, existingDisk: Disk|null): Runtime => {
+  if (!runtime || !existingDisk || runtime.dataprocConfig) {
+    return runtime;
+  }
+
+  return {
+    ...runtime,
+    gceConfig: null,
+    gceWithPdConfig: {
+      ...runtime.gceConfig,
+      persistentDisk: {
+        name: existingDisk.name,
+        size: existingDisk.size,
+        diskType: existingDisk.diskType
+      }
+    }
+  };
+};
+
 export const withAnalysisConfigDefaults = (
   r: AnalysisConfig,
   existingDisk: Disk | null

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -626,7 +626,10 @@ export const maybeWithExistingDiskName = (
 };
 
 // Attach an existing disk to the given runtime, if the configuration allows it.
-export const maybeWithExistingDisk = (runtime: Runtime, existingDisk: Disk|null): Runtime => {
+export const maybeWithExistingDisk = (
+  runtime: Runtime,
+  existingDisk: Disk | null
+): Runtime => {
   if (!runtime || !existingDisk || runtime.dataprocConfig) {
     return runtime;
   }
@@ -639,9 +642,9 @@ export const maybeWithExistingDisk = (runtime: Runtime, existingDisk: Disk|null)
       persistentDisk: {
         name: existingDisk.name,
         size: existingDisk.size,
-        diskType: existingDisk.diskType
-      }
-    }
+        diskType: existingDisk.diskType,
+      },
+    },
   };
 };
 


### PR DESCRIPTION
In the event that a user has an existing disk, but no cloud environment, we should select their PD by default when they go to create a new runtime.