### PR TITLE
[RW-8089][risk=no] Updated CDR release for preProd

### DIFF
--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -100,7 +100,7 @@
       "creationTime": "2021-08-10 00:00:00Z",
       "releaseNumber": 7,
       "numParticipants": 329070,
-      "cdrDbName": "r_2021q3_8",
+      "cdrDbName": "r_2021q3_9",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"
@@ -115,7 +115,7 @@
       "creationTime": "2021-10-06 00:00:00Z",
       "releaseNumber": 8,
       "numParticipants": 331382,
-      "cdrDbName": "c_2021q3_9",
+      "cdrDbName": "c_2021q3_10",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "controlled",


### PR DESCRIPTION
Description:

Build indices for RW-8062 and RW-8046 in preprod:
- New RT CDR indices for preprod - `"cdrDbName": "r_2021q3_9"`
- New CT CDR indices for preProd - `"cdrDbName": "c_2021q3_10"`

Changes to `cdr_config_preprod.json`

@aweng98 You're the release engineer next week. Please be sure to run the following publish commands for preprod before deploying to preprod.

```
--RT publish
api$ db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-preprod --bq-dataset R2021Q3R5 --tier registered --table_prefixes cb_,ds_

--CT publish
api$ db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-preprod --bq-dataset C2021Q3R6 --tier controlled --table_prefixes cb_,ds_

Referenced in Release Playbook: https://docs.google.com/document/d/17YVCqu4BhVV8ai3OutHx8u0m6V5NkdM5H9kLNxTPDdo/edit#bookmark=id.5y2wpcggk65g

```
---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have run and tested this change locally
- [ ] I have run the E2E tests on ths change against my local UI and/or API server with `yarn test-local` or [yarn test-local-devup](https://github.com/all-of-us/workbench/blob/main/e2e/README.md#examples)
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and notified API consumers
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
