### PR TITLE
[risk=low][RW-8094] don't show "workspace creation will take 1 minute" when not creating

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1438,7 +1438,6 @@ export const WorkspaceEdit = fp.flow(
       const {
         cdrVersionTiersResponse,
         profileState: { profile },
-        workspaceEditMode,
       } = this.props;
       const { freeTierDollarQuota, freeTierUsage } = profile;
       const initialCreditsBalance = freeTierDollarQuota - freeTierUsage;
@@ -2295,15 +2294,15 @@ export const WorkspaceEdit = fp.flow(
                   {loading && (
                     <SpinnerOverlay overrideStylesOverlay={styles.spinner} />
                   )}
-                  {(workspaceEditMode === WorkspaceEditMode.Create ||
-                    workspaceEditMode === WorkspaceEditMode.Duplicate) && (
-                    <div style={{ marginBottom: '1rem' }}>
-                      <b>
-                        Note: this workspace will take approximately one minute
-                        to create.
-                      </b>
-                    </div>
-                  )}
+                  {this.isMode(WorkspaceEditMode.Create) ||
+                    (this.isMode(WorkspaceEditMode.Duplicate) && (
+                      <div style={{ marginBottom: '1rem' }}>
+                        <b>
+                          Note: this workspace will take approximately one
+                          minute to create.
+                        </b>
+                      </div>
+                    ))}
                   <div>Your responses to these questions:</div>
                   <div style={{ margin: '0.25rem 0 0.25rem 1rem' }}>
                     <span style={{ fontWeight: 600 }}>

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1438,6 +1438,7 @@ export const WorkspaceEdit = fp.flow(
       const {
         cdrVersionTiersResponse,
         profileState: { profile },
+        workspaceEditMode,
       } = this.props;
       const { freeTierDollarQuota, freeTierUsage } = profile;
       const initialCreditsBalance = freeTierDollarQuota - freeTierUsage;
@@ -2294,12 +2295,15 @@ export const WorkspaceEdit = fp.flow(
                   {loading && (
                     <SpinnerOverlay overrideStylesOverlay={styles.spinner} />
                   )}
-                  <div style={{ marginBottom: '1rem' }}>
-                    <b>
-                      Note: this workspace will take approximately one minute to
-                      create.
-                    </b>
-                  </div>
+                  {(workspaceEditMode === WorkspaceEditMode.Create ||
+                    workspaceEditMode === WorkspaceEditMode.Duplicate) && (
+                    <div style={{ marginBottom: '1rem' }}>
+                      <b>
+                        Note: this workspace will take approximately one minute
+                        to create.
+                      </b>
+                    </div>
+                  )}
                   <div>Your responses to these questions:</div>
                   <div style={{ margin: '0.25rem 0 0.25rem 1rem' }}>
                     <span style={{ fontWeight: 600 }}>


### PR DESCRIPTION
Quick-fix for the problem described in RW-8094.  We may choose to do additional UX work under this story as well.

Update Workspace no longer shows the notification
![Update](https://user-images.githubusercontent.com/2701406/160139580-aaffae59-d20b-4cfd-ae31-7ab2d0fdfd0b.gif)


Duplicate Workspace still shows the notification
![Duplicate](https://user-images.githubusercontent.com/2701406/160139601-841fa8fe-b485-42a2-9410-1e6df82db6c4.gif)


Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
