### PR TITLE
[RW-5997][risk=no] Fix normal workspace card navigation

### DIFF
--- a/ui/src/app/pages/workspace/workspace-card.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.spec.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { MemoryRouter } from 'react-router';
 import { mount } from 'enzyme';
 
 import { WorkspaceAccessLevel, WorkspacesApi } from 'generated/fetch';
@@ -17,11 +18,13 @@ describe('WorkspaceCard', () => {
 
   const component = (accessLevel: WorkspaceAccessLevel) => {
     return mount(
-      <WorkspaceCard
-        accessLevel={accessLevel}
-        reload={reload}
-        workspace={workspaceStubs[0]}
-      />,
+      <MemoryRouter>
+        <WorkspaceCard
+          accessLevel={accessLevel}
+          reload={reload}
+          workspace={workspaceStubs[0]}
+        />
+      </MemoryRouter>,
       { attachTo: document.getElementById('root') }
     );
   };

--- a/ui/src/app/pages/workspace/workspace-card.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.spec.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
-import { MemoryRouter } from 'react-router';
-import { mount } from 'enzyme';
 
 import { WorkspaceAccessLevel, WorkspacesApi } from 'generated/fetch';
 
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { serverConfigStore } from 'app/utils/stores';
 
-import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
+import {
+  mountWithRouter,
+  waitOneTickAndUpdate,
+} from 'testing/react-test-helpers';
 import { workspaceStubs } from 'testing/stubs/workspaces';
 import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
 
@@ -17,14 +18,12 @@ describe('WorkspaceCard', () => {
   const reload = jest.fn();
 
   const component = (accessLevel: WorkspaceAccessLevel) => {
-    return mount(
-      <MemoryRouter>
-        <WorkspaceCard
-          accessLevel={accessLevel}
-          reload={reload}
-          workspace={workspaceStubs[0]}
-        />
-      </MemoryRouter>,
+    return mountWithRouter(
+      <WorkspaceCard
+        accessLevel={accessLevel}
+        reload={reload}
+        workspace={workspaceStubs[0]}
+      />,
       { attachTo: document.getElementById('root') }
     );
   };

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -5,7 +5,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { ResourceType, Workspace, WorkspaceAccessLevel } from 'generated/fetch';
 
-import { Button, SnowmanButton } from 'app/components/buttons';
+import {
+  Button,
+  SnowmanButton,
+  StyledRouterLink,
+} from 'app/components/buttons';
 import { WorkspaceCardBase } from 'app/components/card';
 import { ConfirmDeleteModal } from 'app/components/confirm-delete-modal';
 import { FlexColumn, FlexRow } from 'app/components/flex';
@@ -171,30 +175,11 @@ export const WorkspaceCard = fp.flow(withNavigation)(
         : triggerEvent(EVENT_CATEGORY, 'navigate', 'Click on workspace name');
     }
 
-    onClick() {
-      const {
-        workspace: { id, namespace },
-      } = this.props;
+    onClick(e) {
       if (this.requiresReviewPrompt()) {
         this.setState({ showResearchPurposeReviewModal: true });
-      } else {
-        this.trackWorkspaceNavigation();
-        this.props.navigate(['workspaces', namespace, id, 'data']);
+        e.preventDefault();
       }
-    }
-
-    getRightClickTarget() {
-      // Restrict open new tab option/right click options, if workspace requires review
-      if (this.requiresReviewPrompt()) {
-        return;
-      }
-
-      const {
-        workspace: { id, namespace },
-      } = this.props;
-
-      this.trackWorkspaceNavigation();
-      return `/workspaces/${namespace}/${id}/data`;
     }
 
     render() {
@@ -275,14 +260,15 @@ export const WorkspaceCard = fp.flow(withNavigation)(
               >
                 <FlexColumn style={{ marginBottom: 'auto' }}>
                   <FlexRow style={{ alignItems: 'flex-start' }}>
-                    <a
+                    <StyledRouterLink
                       style={
                         tierAccessDisabled
                           ? styles.workspaceNameDisabled
                           : styles.workspaceName
                       }
-                      onClick={() => this.onClick()}
-                      href={this.getRightClickTarget()}
+                      onClick={(e) => this.onClick(e)}
+                      analyticsFn={() => this.trackWorkspaceNavigation()}
+                      path={`/workspaces/${namespace}/${id}/data`}
                     >
                       <TooltipTrigger
                         content={
@@ -307,7 +293,7 @@ export const WorkspaceCard = fp.flow(withNavigation)(
                           {workspace.name}
                         </div>
                       </TooltipTrigger>
-                    </a>
+                    </StyledRouterLink>
                   </FlexRow>
                   {this.requiresReviewPrompt() && (
                     <div style={{ color: colors.warning }}>

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -268,6 +268,8 @@ export const WorkspaceCard = fp.flow(withNavigation)(
                       }
                       onClick={(e) => this.onClick(e)}
                       analyticsFn={() => this.trackWorkspaceNavigation()}
+                      data-test-id={'workspace-card-link'}
+                      propagateDataTestId
                       path={`/workspaces/${namespace}/${id}/data`}
                     >
                       <TooltipTrigger

--- a/ui/src/app/pages/workspace/workspace-library.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-library.spec.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
 
 import {
   FeaturedWorkspacesConfigApi,
@@ -16,7 +15,10 @@ import { AccessTierShortNames } from 'app/utils/access-tiers';
 import { profileStore, serverConfigStore } from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
-import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
+import {
+  mountWithRouter,
+  waitOneTickAndUpdate,
+} from 'testing/react-test-helpers';
 import { FeaturedWorkspacesConfigApiStub } from 'testing/stubs/featured-workspaces-config-api-stub';
 import { ProfileApiStub } from 'testing/stubs/profile-api-stub';
 import { buildWorkspaceStubs } from 'testing/stubs/workspaces';
@@ -43,7 +45,7 @@ describe('WorkspaceLibrary', () => {
   };
 
   const component = () => {
-    return mount(<WorkspaceLibrary {...props} />);
+    return mountWithRouter(<WorkspaceLibrary {...props} />);
   };
 
   beforeEach(async () => {

--- a/ui/src/app/pages/workspace/workspace-list.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-list.spec.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import RSelect from 'react-select';
-import { mount, ReactWrapper } from 'enzyme';
-import { mockNavigate } from 'setupTests';
+import { ReactWrapper } from 'enzyme';
 
 import {
   ProfileApi,
@@ -12,7 +11,10 @@ import {
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { profileStore, serverConfigStore } from 'app/utils/stores';
 
-import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
+import {
+  mountWithRouter,
+  waitOneTickAndUpdate,
+} from 'testing/react-test-helpers';
 import { ProfileApiStub } from 'testing/stubs/profile-api-stub';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
 import {
@@ -30,6 +32,7 @@ describe('WorkspaceList', () => {
   const load = jest.fn();
   const reload = jest.fn();
   const updateCache = jest.fn();
+
   let workspacesApiStub: WorkspacesApiStub;
 
   const props = {
@@ -38,7 +41,7 @@ describe('WorkspaceList', () => {
   };
 
   const component = () => {
-    return mount(<WorkspaceList {...props} />, {
+    return mountWithRouter(<WorkspaceList {...props} />, {
       attachTo: document.getElementById('root'),
     });
   };
@@ -84,22 +87,6 @@ describe('WorkspaceList', () => {
     const wrapper = component();
     await waitOneTickAndUpdate(wrapper);
     expect(getCardNames(wrapper)).toEqual(workspaceStubs.map((w) => w.name));
-  });
-
-  it('navigates when clicking on the workspace name', async () => {
-    const workspace = workspaceStubs[0];
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    wrapper
-      .find('[data-test-id="workspace-card-name"]')
-      .first()
-      .simulate('click');
-    expect(mockNavigate).toHaveBeenCalledWith([
-      'workspaces',
-      workspace.namespace,
-      workspace.id,
-      'data',
-    ]);
   });
 
   it('has the correct permissions classes', async () => {


### PR DESCRIPTION
- Fix a regression in https://github.com/all-of-us/workbench/pull/6474 , whereby clicking the workspace card normally resulted in a full page refresh rather than a normal navigate. While there was a normal call to navigate, there was no suppression of the regular `<a>` behavior, which is to navigate to the given URL. Switching to `StyledRouterLink` makes the behavior correct in both cases.
- Fix a regression from the same PR which would dispatch a Google Analytics tracking event every time the card is rerendered.
