### PR TITLE
[RW-8090][risk=no] Updating CDR for prod

### DIFF
--- a/api/config/cdr_config_prod.json
+++ b/api/config/cdr_config_prod.json
@@ -112,7 +112,7 @@
       "creationTime": "2021-08-10 00:00:00Z",
       "releaseNumber": 5,
       "numParticipants": 329070,
-      "cdrDbName": "r_2021q3_8",
+      "cdrDbName": "r_2021q3_9",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"
@@ -127,7 +127,7 @@
       "creationTime": "2021-08-10 00:00:00Z",
       "releaseNumber": 6,
       "numParticipants": 331382,
-      "cdrDbName": "c_2021q3_9",
+      "cdrDbName": "c_2021q3_10",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "controlled",


### PR DESCRIPTION
Rebuilt indices for prod:

New RT CDR indices for prod - "cdrDbName": "r_2021q3_9"
New CT CDR indices for prod - "cdrDbName": "c_2021q3_10"
Changes to cdr_config_prod.json

@aweng98 You're the release engineer. Please be sure to run the following publish commands for prod before deploying to prod.

--RT publish
api$ db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-prod --bq-dataset R2021Q3R5 --tier registered --table_prefixes cb_,ds_

--CT publish
api$ db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-prod --bq-dataset C2021Q3R6 --tier controlled --table_prefixes cb_,ds_

Referenced in Release Playbook: https://docs.google.com/document/d/17YVCqu4BhVV8ai3OutHx8u0m6V5NkdM5H9kLNxTPDdo/edit#bookmark=id.hfa4tzr0afy5
