### PR TITLE
[risk=low][RW-7796] Update DAR-Renewal-Mode with renewal text

### DIFF
--- a/ui/src/app/components/icons.tsx
+++ b/ui/src/app/components/icons.tsx
@@ -4,6 +4,7 @@ import {
   faCaretRight,
   faCheck,
   faCheckCircle,
+  faClock,
   faExclamationTriangle,
   faLongArrowAltRight,
   faMinusCircle,
@@ -177,6 +178,7 @@ export const ArrowRight = (props) => (
 export const CaretRight = (props) => <Icon shape={faCaretRight} {...props} />;
 export const Check = (props) => <Icon shape={faCheck} {...props} />;
 export const CheckCircle = (props) => <Icon shape={faCheckCircle} {...props} />;
+export const Clock = (props) => <Icon shape={faClock} {...props} />;
 export const ExclamationTriangle = (props) => (
   <Icon shape={faExclamationTriangle} color={colors.danger} {...props} />
 );

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -218,200 +218,165 @@ const BackArrow = withCircleBackground(() => (
   <Arrow style={{ height: 21, width: 18 }} />
 ));
 
-const ProfileRenewal = (props: { profileStatus: AccessModuleStatus }) => {
-  const { profileStatus } = props;
-  const [, navigateByUrl] = useNavigation();
-  return (
-    <React.Fragment>
-      <div style={{ marginBottom: '0.5rem' }}>
-        Please update your profile information if any of it has changed
-        recently.
-      </div>
-      <div>
-        Note that you are obliged by the Terms of Use of the Workbench to
-        provide keep your profile information up-to-date at all times.
-      </div>
-      <ActionButton
-        actionButtonText='Review'
-        completedButtonText='Confirmed'
-        moduleStatus={profileStatus}
-        onClick={() =>
-          navigateByUrl('profile', { queryParams: { renewal: 1 } })
-        }
-      />
-    </React.Fragment>
-  );
-};
-
-const PublicationsRenewal = (props: {
-  publicationStatus: AccessModuleStatus;
-  setLoading: (boolean) => void;
-}) => {
-  const { publicationStatus, setLoading } = props;
-  const [publications, setPublications] = useState<boolean>(null);
-  const noReportId = useId();
-  const reportId = useId();
-  return (
-    <React.Fragment>
-      <div>
-        The <AoU /> Publication and Presentation Policy requires that you report
-        any upcoming publication or presentation resulting from the use of{' '}
-        <AoU /> Research Program Data at least two weeks before the date of
-        publication. If you are lead on or part of a publication or presentation
-        that hasn’t been reported to the program,{' '}
-        <a
-          target='_blank'
-          style={{ textDecoration: 'underline' }}
-          href={'https://redcap.pmi-ops.org/surveys/?s=MKYL8MRD4N'}
-        >
-          please report it now.
-        </a>{' '}
-        For any questions, please contact <SupportMailto />
-      </div>
-      <div style={renewalStyle.publicationConfirmation}>
-        <ActionButton
-          actionButtonText='Confirm'
-          completedButtonText='Confirmed'
-          moduleStatus={publicationStatus}
-          onClick={async () => {
-            setLoading(true);
-            await confirmPublications();
-            setLoading(false);
-          }}
-          disabled={publications === null}
-          style={{ gridRow: '1 / span 2', marginRight: '0.25rem' }}
-        />
-        <RadioButton
-          data-test-id='nothing-to-report'
-          id={noReportId}
-          disabled={isRenewalCompleteForModule(publicationStatus)}
-          style={{ justifySelf: 'end' }}
-          checked={publications === true}
-          onChange={() => setPublications(true)}
-        />
-        <label htmlFor={noReportId}>
-          At this time, I have nothing to report
-        </label>
-        <RadioButton
-          data-test-id='report-submitted'
-          id={reportId}
-          disabled={isRenewalCompleteForModule(publicationStatus)}
-          style={{ justifySelf: 'end' }}
-          checked={publications === false}
-          onChange={() => setPublications(false)}
-        />
-        <label htmlFor={reportId}>Report submitted</label>
-      </div>
-    </React.Fragment>
-  );
-};
-
-const RtTrainingRenewal = (props: {
-  rtTrainingStatus: AccessModuleStatus;
-  setLoading: (boolean) => void;
-}) => {
-  const { rtTrainingStatus, setLoading } = props;
-  const [refreshButtonDisabled, setRefreshButtonDisabled] = useState(true);
-  return (
-    <React.Fragment>
-      <div>
-        You are required to complete the refreshed ethics training courses to
-        understand the privacy safeguards and the compliance requirements for
-        using the <AoU /> Dataset.
-      </div>
-      {!isRenewalCompleteForModule(rtTrainingStatus) && (
-        <div style={renewalStyle.complianceTrainingExpiring}>
-          When you have completed the training click the refresh button or
-          reload the page.
-        </div>
-      )}
-      <FlexRow style={{ marginTop: 'auto' }}>
-        <ActionButton
-          actionButtonText='Complete Training'
-          completedButtonText='Completed'
-          moduleStatus={rtTrainingStatus}
-          onClick={() => {
-            setRefreshButtonDisabled(false);
-            redirectToRegisteredTraining();
-          }}
-        />
-        {!isRenewalCompleteForModule(rtTrainingStatus) && (
-          <Button
-            disabled={refreshButtonDisabled}
-            onClick={async () => {
-              setLoading(true);
-              await syncAndReloadTraining();
-              setLoading(false);
-            }}
-            style={{
-              height: '1.6rem',
-              marginLeft: '0.75rem',
-              width: 'max-content',
-            }}
-          >
-            Refresh
-          </Button>
-        )}
-      </FlexRow>
-    </React.Fragment>
-  );
-};
-
-const DuccRenewal = (props: { duccStatus: AccessModuleStatus }) => {
-  const { duccStatus } = props;
-  const [, navigateByUrl] = useNavigation();
-  return (
-    <React.Fragment>
-      <div>
-        Please review and sign the data user code of conduct consenting to the{' '}
-        <AoU /> data use policy.
-      </div>
-      <ActionButton
-        actionButtonText='View & Sign'
-        completedButtonText='Completed'
-        moduleStatus={duccStatus}
-        onClick={() =>
-          navigateByUrl('data-code-of-conduct', {
-            queryParams: { renewal: 1 },
-          })
-        }
-      />
-    </React.Fragment>
-  );
-};
-
-const ModuleBody = (props: {
+const CardBody = (props: {
   moduleStatus: AccessModuleStatus;
   setLoading: (boolean) => void;
 }) => {
   const { moduleStatus, setLoading } = props;
+  const [, navigateByUrl] = useNavigation();
+  const [publications, setPublications] = useState<boolean>(null);
+  const [trainingRefreshButtonDisabled, setTrainingRefreshButtonDisabled] =
+    useState(true);
+  const noReportId = useId();
+  const reportId = useId();
+
   return switchCase(
     moduleStatus.moduleName,
     [
       AccessModule.PROFILECONFIRMATION,
-      () => <ProfileRenewal profileStatus={moduleStatus} />,
+      () => (
+        <React.Fragment>
+          <div style={{ marginBottom: '0.5rem' }}>
+            Please update your profile information if any of it has changed
+            recently.
+          </div>
+          <div>
+            Note that you are obliged by the Terms of Use of the Workbench to
+            provide keep your profile information up-to-date at all times.
+          </div>
+          <ActionButton
+            actionButtonText='Review'
+            completedButtonText='Confirmed'
+            moduleStatus={moduleStatus}
+            onClick={() =>
+              navigateByUrl('profile', { queryParams: { renewal: 1 } })
+            }
+          />
+        </React.Fragment>
+      ),
     ],
     [
       AccessModule.PUBLICATIONCONFIRMATION,
       () => (
-        <PublicationsRenewal
-          publicationStatus={moduleStatus}
-          setLoading={(v) => setLoading(v)}
-        />
+        <React.Fragment>
+          <div>
+            The <AoU /> Publication and Presentation Policy requires that you
+            report any upcoming publication or presentation resulting from the
+            use of <AoU /> Research Program Data at least two weeks before the
+            date of publication. If you are lead on or part of a publication or
+            presentation that hasn’t been reported to the program,{' '}
+            <a
+              target='_blank'
+              style={{ textDecoration: 'underline' }}
+              href={'https://redcap.pmi-ops.org/surveys/?s=MKYL8MRD4N'}
+            >
+              please report it now.
+            </a>{' '}
+            For any questions, please contact <SupportMailto />
+          </div>
+          <div style={renewalStyle.publicationConfirmation}>
+            <ActionButton
+              actionButtonText='Confirm'
+              completedButtonText='Confirmed'
+              moduleStatus={moduleStatus}
+              onClick={async () => {
+                setLoading(true);
+                await confirmPublications();
+                setLoading(false);
+              }}
+              disabled={publications === null}
+              style={{ gridRow: '1 / span 2', marginRight: '0.25rem' }}
+            />
+            <RadioButton
+              data-test-id='nothing-to-report'
+              id={noReportId}
+              disabled={isRenewalCompleteForModule(moduleStatus)}
+              style={{ justifySelf: 'end' }}
+              checked={publications === true}
+              onChange={() => setPublications(true)}
+            />
+            <label htmlFor={noReportId}>
+              At this time, I have nothing to report
+            </label>
+            <RadioButton
+              data-test-id='report-submitted'
+              id={reportId}
+              disabled={isRenewalCompleteForModule(moduleStatus)}
+              style={{ justifySelf: 'end' }}
+              checked={publications === false}
+              onChange={() => setPublications(false)}
+            />
+            <label htmlFor={reportId}>Report submitted</label>
+          </div>
+        </React.Fragment>
       ),
     ],
     [
       AccessModule.COMPLIANCETRAINING,
       () => (
-        <RtTrainingRenewal
-          rtTrainingStatus={moduleStatus}
-          setLoading={(v) => setLoading(v)}
-        />
+        <React.Fragment>
+          <div>
+            You are required to complete the refreshed ethics training courses
+            to understand the privacy safeguards and the compliance requirements
+            for using the <AoU /> Dataset.
+          </div>
+          {!isRenewalCompleteForModule(moduleStatus) && (
+            <div style={renewalStyle.complianceTrainingExpiring}>
+              When you have completed the training click the refresh button or
+              reload the page.
+            </div>
+          )}
+          <FlexRow style={{ marginTop: 'auto' }}>
+            <ActionButton
+              actionButtonText='Complete Training'
+              completedButtonText='Completed'
+              moduleStatus={moduleStatus}
+              onClick={() => {
+                setTrainingRefreshButtonDisabled(false);
+                redirectToRegisteredTraining();
+              }}
+            />
+            {!isRenewalCompleteForModule(moduleStatus) && (
+              <Button
+                disabled={trainingRefreshButtonDisabled}
+                onClick={async () => {
+                  setLoading(true);
+                  await syncAndReloadTraining();
+                  setLoading(false);
+                }}
+                style={{
+                  height: '1.6rem',
+                  marginLeft: '0.75rem',
+                  width: 'max-content',
+                }}
+              >
+                Refresh
+              </Button>
+            )}
+          </FlexRow>
+        </React.Fragment>
       ),
     ],
     [
       AccessModule.DATAUSERCODEOFCONDUCT,
-      () => <DuccRenewal duccStatus={moduleStatus} />,
+      () => (
+        <React.Fragment>
+          <div>
+            Please review and sign the data user code of conduct consenting to
+            the <AoU /> data use policy.
+          </div>
+          <ActionButton
+            actionButtonText='View & Sign'
+            completedButtonText='Completed'
+            moduleStatus={moduleStatus}
+            onClick={() =>
+              navigateByUrl('data-code-of-conduct', {
+                queryParams: { renewal: 1 },
+              })
+            }
+          />
+        </React.Fragment>
+      ),
     ]
   );
 };
@@ -447,10 +412,7 @@ const RenewalCard = ({ step, moduleName, modules, setLoading }: CardProps) => {
         <div>{lastConfirmedDate}</div>
         <div>{nextReviewDate}</div>
       </div>
-      <ModuleBody
-        moduleStatus={moduleStatus}
-        setLoading={(v) => setLoading(v)}
-      />
+      <CardBody moduleStatus={moduleStatus} setLoading={(v) => setLoading(v)} />
     </FlexColumn>
   );
 };

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -22,7 +22,7 @@ import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { styles } from 'app/pages/profile/profile-styles';
 import { profileApi } from 'app/services/swagger-fetch-clients';
 import colors, { addOpacity, colorWithWhiteness } from 'app/styles/colors';
-import { cond, switchCase, useId, withStyle } from 'app/utils';
+import { cond, switchCase, useId } from 'app/utils';
 import {
   accessRenewalModules,
   computeRenewalDisplayDates,
@@ -315,7 +315,6 @@ const RtTrainingRenewal = (props: {
   return (
     <React.Fragment>
       <div>
-        {' '}
         You are required to complete the refreshed ethics training courses to
         understand the privacy safeguards and the compliance requirements for
         using the <AoU /> Dataset.
@@ -423,44 +422,38 @@ interface CardProps {
   modules: AccessModuleStatus[];
   setLoading: (boolean) => void;
 }
-const RenewalCard = withStyle(renewalStyle.card)(
-  ({ step, moduleName, modules, setLoading }: CardProps) => {
-    const moduleStatus = getAccessModuleStatusByNameOrEmpty(
-      modules,
-      moduleName
-    );
-    const { AARTitleComponent } = getAccessModuleConfig(moduleName);
-    const { lastConfirmedDate, nextReviewDate } =
-      computeRenewalDisplayDates(moduleStatus);
-
-    return (
-      <FlexColumn>
-        <div style={renewalStyle.h3}>STEP {step}</div>
-        <div style={renewalStyle.h3}>
-          <AARTitleComponent />
-        </div>
-        <div
-          style={{
-            color: colors.primary,
-            margin: '0.5rem 0',
-            display: 'grid',
-            columnGap: '1rem',
-            gridTemplateColumns: 'auto 1fr',
-          }}
-        >
-          <div>Last Updated On:</div>
-          <div>Next Review:</div>
-          <div>{lastConfirmedDate}</div>
-          <div>{nextReviewDate}</div>
-        </div>
-        <ModuleBody
-          moduleStatus={moduleStatus}
-          setLoading={(v) => setLoading(v)}
-        />
-      </FlexColumn>
-    );
-  }
-);
+const RenewalCard = ({ step, moduleName, modules, setLoading }: CardProps) => {
+  const moduleStatus = getAccessModuleStatusByNameOrEmpty(modules, moduleName);
+  const { AARTitleComponent } = getAccessModuleConfig(moduleName);
+  const { lastConfirmedDate, nextReviewDate } =
+    computeRenewalDisplayDates(moduleStatus);
+  return (
+    <FlexColumn style={renewalStyle.card}>
+      <div style={renewalStyle.h3}>STEP {step}</div>
+      <div style={renewalStyle.h3}>
+        <AARTitleComponent />
+      </div>
+      <div
+        style={{
+          color: colors.primary,
+          margin: '0.5rem 0',
+          display: 'grid',
+          columnGap: '1rem',
+          gridTemplateColumns: 'auto 1fr',
+        }}
+      >
+        <div>Last Updated On:</div>
+        <div>Next Review:</div>
+        <div>{lastConfirmedDate}</div>
+        <div>{nextReviewDate}</div>
+      </div>
+      <ModuleBody
+        moduleStatus={moduleStatus}
+        setLoading={(v) => setLoading(v)}
+      />
+    </FlexColumn>
+  );
+};
 
 // Page to render
 export const AccessRenewal = fp.flow(withProfileErrorModal)(

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -386,36 +386,35 @@ const ModuleBody = (props: {
   setLoading: (boolean) => void;
 }) => {
   const { moduleStatus, setLoading } = props;
-  return () =>
-    switchCase(
-      moduleStatus.moduleName,
-      [
-        AccessModule.PROFILECONFIRMATION,
-        () => <ProfileRenewal profileStatus={moduleStatus} />,
-      ],
-      [
-        AccessModule.PROFILECONFIRMATION,
-        () => (
-          <PublicationsRenewal
-            publicationStatus={moduleStatus}
-            setLoading={(v) => setLoading(v)}
-          />
-        ),
-      ],
-      [
-        AccessModule.COMPLIANCETRAINING,
-        () => (
-          <RtTrainingRenewal
-            rtTrainingStatus={moduleStatus}
-            setLoading={(v) => setLoading(v)}
-          />
-        ),
-      ],
-      [
-        AccessModule.DATAUSERCODEOFCONDUCT,
-        () => <DuccRenewal duccStatus={moduleStatus} />,
-      ]
-    );
+  return switchCase(
+    moduleStatus.moduleName,
+    [
+      AccessModule.PROFILECONFIRMATION,
+      () => <ProfileRenewal profileStatus={moduleStatus} />,
+    ],
+    [
+      AccessModule.PUBLICATIONCONFIRMATION,
+      () => (
+        <PublicationsRenewal
+          publicationStatus={moduleStatus}
+          setLoading={(v) => setLoading(v)}
+        />
+      ),
+    ],
+    [
+      AccessModule.COMPLIANCETRAINING,
+      () => (
+        <RtTrainingRenewal
+          rtTrainingStatus={moduleStatus}
+          setLoading={(v) => setLoading(v)}
+        />
+      ),
+    ],
+    [
+      AccessModule.DATAUSERCODEOFCONDUCT,
+      () => <DuccRenewal duccStatus={moduleStatus} />,
+    ]
+  );
 };
 
 interface CardProps {

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -40,6 +40,9 @@ import { profileStore, serverConfigStore, useStore } from 'app/utils/stores';
 
 const { useState, useEffect } = React;
 
+const REDCAP_PUBLICATIONS_SURVEY =
+  'https://redcap.pmi-ops.org/surveys/?s=MKYL8MRD4N';
+
 const renewalStyle = {
   h1: {
     fontSize: '0.83rem',
@@ -314,7 +317,7 @@ export const RenewalCardBody = (props: {
             <a
               target='_blank'
               style={{ textDecoration: 'underline' }}
-              href={'https://redcap.pmi-ops.org/surveys/?s=MKYL8MRD4N'}
+              href={REDCAP_PUBLICATIONS_SURVEY}
             >
               please report it now.
             </a>{' '}

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -9,6 +9,7 @@ import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import {
   Arrow,
+  Clock,
   ClrIcon,
   ExclamationTriangle,
   withCircleBackground,
@@ -231,8 +232,15 @@ export const RenewalCardBody = (props: {
   setLoading: (boolean) => void;
   hide?: boolean;
   textStyle?: CSSProperties;
+  showTimeEstimate?: boolean;
 }) => {
-  const { moduleStatus, setLoading, hide, textStyle } = props;
+  const {
+    moduleStatus,
+    setLoading,
+    hide,
+    textStyle,
+    showTimeEstimate = false,
+  } = props;
 
   const [, navigateByUrl] = useNavigation();
   const noReportId = useId();
@@ -241,9 +249,20 @@ export const RenewalCardBody = (props: {
   const [trainingRefreshButtonDisabled, setTrainingRefreshButtonDisabled] =
     useState(true);
 
-  const { AARTitleComponent } = getAccessModuleConfig(moduleStatus.moduleName);
+  const { AARTitleComponent, renewalTimeEstimate } = getAccessModuleConfig(
+    moduleStatus.moduleName
+  );
   const { lastConfirmedDate, nextReviewDate } =
     computeRenewalDisplayDates(moduleStatus);
+  const TimeEstimate = () =>
+    showTimeEstimate ? (
+      <div>
+        <span style={{ padding: 10 }}>
+          <Clock style={{ color: colors.disabled }} />
+        </span>
+        {renewalTimeEstimate} min
+      </div>
+    ) : null;
 
   const module = switchCase(
     moduleStatus.moduleName,
@@ -259,6 +278,7 @@ export const RenewalCardBody = (props: {
             Note that you are obliged by the Terms of Use of the Workbench to
             keep your profile information up-to-date at all times.
           </div>
+          <TimeEstimate />
           <ActionButton
             actionButtonText='Review'
             completedButtonText='Confirmed'
@@ -289,6 +309,7 @@ export const RenewalCardBody = (props: {
             </a>{' '}
             For any questions, please contact <SupportMailto />
           </div>
+          <TimeEstimate />
           <div
             style={{ ...renewalStyle.publicationConfirmation, ...textStyle }}
           >
@@ -348,6 +369,7 @@ export const RenewalCardBody = (props: {
               reload the page.
             </div>
           )}
+          <TimeEstimate />
           <FlexRow style={{ marginTop: 'auto' }}>
             <ActionButton
               actionButtonText='Complete Training'
@@ -387,6 +409,7 @@ export const RenewalCardBody = (props: {
             Please review and sign the data user code of conduct consenting to
             the <AoU /> data use policy.
           </div>
+          <TimeEstimate />
           <ActionButton
             actionButtonText='View & Sign'
             completedButtonText='Completed'

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -419,13 +419,12 @@ const ModuleBody = (props: {
 
 interface CardProps {
   step: number;
-  modules: AccessModuleStatus[];
   moduleName: AccessModule;
-  style: React.CSSProperties;
-  setLoading?: (boolean) => void;
+  modules: AccessModuleStatus[];
+  setLoading: (boolean) => void;
 }
 const RenewalCard = withStyle(renewalStyle.card)(
-  ({ step, modules, moduleName, style, setLoading }: CardProps) => {
+  ({ step, moduleName, modules, setLoading }: CardProps) => {
     const moduleStatus = getAccessModuleStatusByNameOrEmpty(
       modules,
       moduleName
@@ -435,7 +434,7 @@ const RenewalCard = withStyle(renewalStyle.card)(
       computeRenewalDisplayDates(moduleStatus);
 
     return (
-      <FlexColumn style={style}>
+      <FlexColumn>
         <div style={renewalStyle.h3}>STEP {step}</div>
         <div style={renewalStyle.h3}>
           <AARTitleComponent />
@@ -585,27 +584,29 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
         >
           <RenewalCard
             step={1}
-            modules={modules}
             moduleName={AccessModule.PROFILECONFIRMATION}
+            modules={modules}
+            setLoading={(v: boolean) => setLoading(v)}
           />
           <RenewalCard
             step={2}
-            modules={modules}
             moduleName={AccessModule.PUBLICATIONCONFIRMATION}
+            modules={modules}
             setLoading={(v: boolean) => setLoading(v)}
           />
           {enableComplianceTraining && (
             <RenewalCard
               step={3}
-              modules={modules}
               moduleName={AccessModule.COMPLIANCETRAINING}
+              modules={modules}
               setLoading={(v: boolean) => setLoading(v)}
             />
           )}
           <RenewalCard
             step={enableComplianceTraining ? 4 : 3}
-            modules={modules}
             moduleName={AccessModule.DATAUSERCODEOFCONDUCT}
+            modules={modules}
+            setLoading={(v: boolean) => setLoading(v)}
           />
         </div>
         {loading && <SpinnerOverlay dark={true} opacity={0.6} />}

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -264,12 +264,22 @@ export const RenewalCardBody = (props: {
       </div>
     ) : null;
 
+  const Dates = () => (
+    <div style={{ ...renewalStyle.dates, ...textStyle }}>
+      <div>Last Updated On:</div>
+      <div>Next Review:</div>
+      <div>{lastConfirmedDate}</div>
+      <div>{nextReviewDate}</div>
+    </div>
+  );
+
   const module = switchCase(
     moduleStatus.moduleName,
     [
       AccessModule.PROFILECONFIRMATION,
       () => (
         <React.Fragment>
+          <Dates />
           <div style={{ marginBottom: '0.5rem', ...textStyle }}>
             Please update your profile information if any of it has changed
             recently.
@@ -294,6 +304,7 @@ export const RenewalCardBody = (props: {
       AccessModule.PUBLICATIONCONFIRMATION,
       () => (
         <React.Fragment>
+          <Dates />
           <div style={textStyle}>
             The <AoU /> Publication and Presentation Policy requires that you
             report any upcoming publication or presentation resulting from the
@@ -353,6 +364,7 @@ export const RenewalCardBody = (props: {
       AccessModule.COMPLIANCETRAINING,
       () => (
         <React.Fragment>
+          <Dates />
           <div style={textStyle}>
             You are required to complete the refreshed ethics training courses
             to understand the privacy safeguards and the compliance requirements
@@ -405,6 +417,7 @@ export const RenewalCardBody = (props: {
       AccessModule.DATAUSERCODEOFCONDUCT,
       () => (
         <React.Fragment>
+          <Dates />
           <div style={textStyle}>
             Please review and sign the data user code of conduct consenting to
             the <AoU /> data use policy.
@@ -430,14 +443,6 @@ export const RenewalCardBody = (props: {
       <div style={renewalStyle.h3}>
         <AARTitleComponent />
       </div>
-      {!hide && (
-        <div style={{ ...renewalStyle.dates, ...textStyle }}>
-          <div>Last Updated On:</div>
-          <div>Next Review:</div>
-          <div>{lastConfirmedDate}</div>
-          <div>{nextReviewDate}</div>
-        </div>
-      )}
       {!hide && module}
     </React.Fragment>
   );

--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -32,12 +32,12 @@ import {
 import { updateVisibleTiers } from 'testing/test-utils';
 
 import {
-  allModules,
+  allInitialModules,
   DARPageMode,
   DataAccessRequirements,
   getActiveModule,
   getEligibleModules,
-  requiredModules,
+  initialRequiredModules,
 } from './data-access-requirements';
 
 const profile = ProfileStubVariables.PROFILE_STUB as Profile;
@@ -143,8 +143,8 @@ describe('DataAccessRequirements', () => {
   });
 
   it('should return all required modules from getEligibleModules by default (all FFs enabled)', () => {
-    const enabledModules = getEligibleModules(allModules, profile);
-    requiredModules.forEach((module) =>
+    const enabledModules = getEligibleModules(allInitialModules, profile);
+    initialRequiredModules.forEach((module) =>
       expect(enabledModules.includes(module)).toBeTruthy()
     );
   });
@@ -157,7 +157,7 @@ describe('DataAccessRequirements', () => {
         enforceRasLoginGovLinking: false,
       },
     });
-    const enabledModules = getEligibleModules(allModules, profile);
+    const enabledModules = getEligibleModules(allInitialModules, profile);
     expect(enabledModules.includes(AccessModule.RASLINKLOGINGOV)).toBeFalsy();
   });
 
@@ -172,7 +172,7 @@ describe('DataAccessRequirements', () => {
           enforceRasLoginGovLinking: true,
         },
       });
-      const enabledModules = getEligibleModules(allModules, profile);
+      const enabledModules = getEligibleModules(allInitialModules, profile);
       expect(
         enabledModules.includes(AccessModule.RASLINKLOGINGOV)
       ).toBeTruthy();
@@ -183,7 +183,7 @@ describe('DataAccessRequirements', () => {
     serverConfigStore.set({
       config: { ...defaultServerConfig, enableEraCommons: false },
     });
-    const enabledModules = getEligibleModules(allModules, profile);
+    const enabledModules = getEligibleModules(allInitialModules, profile);
     expect(enabledModules.includes(AccessModule.ERACOMMONS)).toBeFalsy();
   });
 
@@ -191,17 +191,17 @@ describe('DataAccessRequirements', () => {
     serverConfigStore.set({
       config: { ...defaultServerConfig, enableComplianceTraining: false },
     });
-    const enabledModules = getEligibleModules(allModules, profile);
+    const enabledModules = getEligibleModules(allInitialModules, profile);
     expect(
       enabledModules.includes(AccessModule.COMPLIANCETRAINING)
     ).toBeFalsy();
   });
 
   it('should return the first module (2FA) from getActiveModule when no modules have been completed', () => {
-    const enabledModules = getEligibleModules(requiredModules, profile);
+    const enabledModules = getEligibleModules(initialRequiredModules, profile);
     const activeModule = getActiveModule(enabledModules, profile);
 
-    expect(activeModule).toEqual(requiredModules[0]);
+    expect(activeModule).toEqual(initialRequiredModules[0]);
     expect(activeModule).toEqual(enabledModules[0]);
 
     // update this if the order changes
@@ -218,10 +218,10 @@ describe('DataAccessRequirements', () => {
       },
     };
 
-    const enabledModules = getEligibleModules(requiredModules, profile);
+    const enabledModules = getEligibleModules(initialRequiredModules, profile);
     const activeModule = getActiveModule(enabledModules, testProfile);
 
-    expect(activeModule).toEqual(requiredModules[1]);
+    expect(activeModule).toEqual(initialRequiredModules[1]);
     expect(activeModule).toEqual(enabledModules[1]);
 
     // update this if the order changes
@@ -238,10 +238,10 @@ describe('DataAccessRequirements', () => {
       },
     };
 
-    const enabledModules = getEligibleModules(requiredModules, profile);
+    const enabledModules = getEligibleModules(initialRequiredModules, profile);
     const activeModule = getActiveModule(enabledModules, testProfile);
 
-    expect(activeModule).toEqual(requiredModules[1]);
+    expect(activeModule).toEqual(initialRequiredModules[1]);
     expect(activeModule).toEqual(enabledModules[1]);
 
     // update this if the order changes
@@ -272,7 +272,10 @@ describe('DataAccessRequirements', () => {
         },
       };
 
-      const enabledModules = getEligibleModules(requiredModules, profile);
+      const enabledModules = getEligibleModules(
+        initialRequiredModules,
+        profile
+      );
       const activeModule = getActiveModule(enabledModules, testProfile);
 
       // update this if the order changes
@@ -282,7 +285,7 @@ describe('DataAccessRequirements', () => {
       expect(activeModule).toEqual(enabledModules[1]);
 
       // but we skip requiredModules[1] because it's RAS and is not enabled
-      expect(activeModule).toEqual(requiredModules[2]);
+      expect(activeModule).toEqual(initialRequiredModules[2]);
     }
   );
 
@@ -301,10 +304,10 @@ describe('DataAccessRequirements', () => {
       },
     };
 
-    const enabledModules = getEligibleModules(requiredModules, profile);
+    const enabledModules = getEligibleModules(initialRequiredModules, profile);
     const activeModule = getActiveModule(enabledModules, testProfile);
 
-    expect(activeModule).toEqual(requiredModules[3]);
+    expect(activeModule).toEqual(initialRequiredModules[3]);
     expect(activeModule).toEqual(enabledModules[3]);
 
     // update this if the order changes
@@ -315,14 +318,14 @@ describe('DataAccessRequirements', () => {
     const testProfile = {
       ...profile,
       accessModules: {
-        modules: requiredModules.map((module) => ({
+        modules: initialRequiredModules.map((module) => ({
           moduleName: module,
           completionEpochMillis: 1,
         })),
       },
     };
 
-    const enabledModules = getEligibleModules(requiredModules, profile);
+    const enabledModules = getEligibleModules(initialRequiredModules, profile);
     const activeModule = getActiveModule(enabledModules, testProfile);
 
     expect(activeModule).toBeUndefined();
@@ -348,7 +351,7 @@ describe('DataAccessRequirements', () => {
       },
     };
 
-    const enabledModules = getEligibleModules(requiredModules, profile);
+    const enabledModules = getEligibleModules(initialRequiredModules, profile);
 
     let activeModule = getActiveModule(enabledModules, testProfile);
     expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
@@ -374,7 +377,7 @@ describe('DataAccessRequirements', () => {
 
   it('should render all required modules by default (all FFs enabled)', () => {
     const wrapper = component();
-    allModules.forEach((module) =>
+    allInitialModules.forEach((module) =>
       expect(findModule(wrapper, module).exists()).toBeTruthy()
     );
   });
@@ -426,7 +429,7 @@ describe('DataAccessRequirements', () => {
 
   it('should render all required modules as incomplete when the profile accessModules are empty', () => {
     const wrapper = component();
-    requiredModules.forEach((module) => {
+    initialRequiredModules.forEach((module) => {
       expect(findIncompleteModule(wrapper, module).exists()).toBeTruthy();
 
       expect(findCompleteModule(wrapper, module).exists()).toBeFalsy();
@@ -440,7 +443,7 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: requiredModules.map((module) => ({
+          modules: initialRequiredModules.map((module) => ({
             moduleName: module,
             completionEpochMillis: 1,
           })),
@@ -452,7 +455,7 @@ describe('DataAccessRequirements', () => {
     });
 
     const wrapper = component();
-    requiredModules.forEach((module) => {
+    initialRequiredModules.forEach((module) => {
       expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
 
       expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
@@ -468,7 +471,7 @@ describe('DataAccessRequirements', () => {
 
     // initially, the user has completed all required modules except RAS (the standard case at RAS launch time)
 
-    const allExceptRas = requiredModules.filter(
+    const allExceptRas = initialRequiredModules.filter(
       (m) => m !== AccessModule.RASLINKLOGINGOV
     );
     profileStore.set({
@@ -514,7 +517,7 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: requiredModules.map((module) => ({
+          modules: initialRequiredModules.map((module) => ({
             moduleName: module,
             completionEpochMillis: 1,
           })),
@@ -527,7 +530,7 @@ describe('DataAccessRequirements', () => {
 
     await waitForFakeTimersAndUpdate(wrapper);
 
-    requiredModules.forEach((module) => {
+    initialRequiredModules.forEach((module) => {
       expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
 
       expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
@@ -542,7 +545,7 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: requiredModules.map((module) => {
+          modules: initialRequiredModules.map((module) => {
             return { moduleName: module, bypassEpochMillis: 1 };
           }),
         },
@@ -553,7 +556,7 @@ describe('DataAccessRequirements', () => {
     });
 
     const wrapper = component();
-    requiredModules.forEach((module) => {
+    initialRequiredModules.forEach((module) => {
       expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
 
       expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
@@ -563,9 +566,9 @@ describe('DataAccessRequirements', () => {
   });
 
   it('should render a mix of complete and incomplete modules, as appropriate', () => {
-    const requiredModulesSize = requiredModules.length;
+    const requiredModulesSize = initialRequiredModules.length;
     const incompleteModules = [AccessModule.RASLINKLOGINGOV];
-    const completeModules = requiredModules.filter(
+    const completeModules = initialRequiredModules.filter(
       (module) => module !== AccessModule.RASLINKLOGINGOV
     );
     const completeModulesSize = requiredModulesSize - incompleteModules.length;
@@ -637,7 +640,7 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: requiredModules.map((module) => {
+          modules: initialRequiredModules.map((module) => {
             return { moduleName: module, completionEpochMillis: 1 };
           }),
         },
@@ -662,7 +665,7 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: requiredModules.map((module) => {
+          modules: initialRequiredModules.map((module) => {
             return { moduleName: module, completionEpochMillis: 1 };
           }),
         },
@@ -712,7 +715,7 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: requiredModules.map((module) => ({
+          modules: initialRequiredModules.map((module) => ({
             moduleName: module,
             completionEpochMillis: 1,
           })),
@@ -1378,7 +1381,7 @@ describe('DataAccessRequirements', () => {
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
-          modules: allModules.map((moduleName) => {
+          modules: allInitialModules.map((moduleName) => {
             if (
               [
                 AccessModule.CTCOMPLIANCETRAINING,

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -23,7 +23,10 @@ import { SUPPORT_EMAIL, SupportMailto } from 'app/components/support';
 import { AoU } from 'app/components/text-wrappers';
 import { withProfileErrorModal } from 'app/components/with-error-modal';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
-import { RenewalRequirementsText } from 'app/pages/access/access-renewal';
+import {
+  RenewalCardBody,
+  RenewalRequirementsText,
+} from 'app/pages/access/access-renewal';
 import { profileApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { cond, reactStyles, switchCase } from 'app/utils';
@@ -36,6 +39,7 @@ import {
   bypassAll,
   getAccessModuleConfig,
   getAccessModuleStatusByName,
+  getAccessModuleStatusByNameOrEmpty,
   GetStartedButton,
   redirectToControlledTraining,
   redirectToNiH,
@@ -137,7 +141,6 @@ const styles = reactStyles({
     fontWeight: 600,
   },
   card: {
-    height: '375px',
     width: '1195px',
     borderRadius: '0.4rem',
     marginTop: '0.7rem',
@@ -261,10 +264,15 @@ const styles = reactStyles({
 });
 
 // in display order
-const rtModules = [
+const initialRtModules = [
   AccessModule.TWOFACTORAUTH,
   AccessModule.RASLINKLOGINGOV,
   AccessModule.ERACOMMONS,
+  AccessModule.COMPLIANCETRAINING,
+];
+const renewalRtModules = [
+  AccessModule.PROFILECONFIRMATION,
+  AccessModule.PUBLICATIONCONFIRMATION,
   AccessModule.COMPLIANCETRAINING,
 ];
 const ctModule = AccessModule.CTCOMPLIANCETRAINING;
@@ -272,9 +280,16 @@ const duccModule = AccessModule.DATAUSERCODEOFCONDUCT;
 
 // in display order
 // exported for test
-export const requiredModules: AccessModule[] = [...rtModules, duccModule];
+export const initialRequiredModules: AccessModule[] = [
+  ...initialRtModules,
+  duccModule,
+];
 
-export const allModules: AccessModule[] = [...rtModules, ctModule, duccModule];
+export const allInitialModules: AccessModule[] = [
+  ...initialRtModules,
+  ctModule,
+  duccModule,
+];
 
 export enum DARPageMode {
   INITIAL_REGISTRATION = 'INITIAL_REGISTRATION',
@@ -352,7 +367,7 @@ const handleRasCallback = (
 const selfBypass = async (
   spinnerProps: WithSpinnerOverlayProps,
   reloadProfile: Function,
-  modules: AccessModule[] = allModules
+  modules: AccessModule[] = allInitialModules
 ) => {
   spinnerProps.showSpinner();
   await bypassAll(modules, true);
@@ -834,7 +849,7 @@ const Completed = () => (
   </FlexRow>
 );
 
-interface CardProps {
+interface InitialCardProps {
   profile: Profile;
   modules: AccessModule[];
   activeModule: AccessModule;
@@ -843,7 +858,7 @@ interface CardProps {
   children?: string | React.ReactNode;
 }
 
-const ModulesForCard = (props: CardProps) => {
+const ModulesForInitialRegistration = (props: InitialCardProps) => {
   const {
     profile,
     modules,
@@ -866,6 +881,47 @@ const ModulesForCard = (props: CardProps) => {
         />
       ))}
       {children}
+    </FlexColumn>
+  );
+};
+
+interface RenewalCardProps {
+  profile: Profile;
+  modules: AccessModule[];
+}
+
+const ModulesForAnnualRenewal = (props: RenewalCardProps) => {
+  const { profile, modules } = props;
+  const showingStyle = {
+    ...styles.clickableModuleBox,
+    ...styles.clickableModuleText,
+  };
+  const hiddenStyle = {
+    ...styles.backgroundModuleBox,
+    ...styles.backgroundModuleText,
+  };
+  return (
+    <FlexColumn style={styles.modulesContainer}>
+      {modules.map((moduleName) => {
+        // TODO RW-7797.  Until then, hardcode
+        const showModule = true;
+        return (
+          <FlexColumn
+            data-test-id={`module-${moduleName}`}
+            style={showModule ? showingStyle : hiddenStyle}
+          >
+            <RenewalCardBody
+              moduleStatus={getAccessModuleStatusByNameOrEmpty(
+                profile.accessModules.modules,
+                moduleName
+              )}
+              setLoading={() => {}}
+              textStyle={{ fontSize: '0.6rem' }}
+              hide={!showModule}
+            />
+          </FlexColumn>
+        );
+      })}
     </FlexColumn>
   );
 };
@@ -955,15 +1011,19 @@ const RegisteredTierCard = (props: {
         <DataDetail icon='physical' text='Physical measurements' />
         <DataDetail icon='wearable' text='Wearable devices' />
       </FlexColumn>
-      <ModulesForCard
-        profile={profile}
-        modules={getEligibleModules(rtModules, profile)}
-        activeModule={activeModule}
-        clickableModules={clickableModules}
-        spinnerProps={spinnerProps}
-      >
-        {!enableRasLoginGovLinking && <TemporaryRASModule />}
-      </ModulesForCard>
+      {pageMode === DARPageMode.INITIAL_REGISTRATION ? (
+        <ModulesForInitialRegistration
+          profile={profile}
+          modules={getEligibleModules(initialRtModules, profile)}
+          activeModule={activeModule}
+          clickableModules={clickableModules}
+          spinnerProps={spinnerProps}
+        >
+          {!enableRasLoginGovLinking && <TemporaryRASModule />}
+        </ModulesForInitialRegistration>
+      ) : (
+        <ModulesForAnnualRenewal profile={profile} modules={renewalRtModules} />
+      )}
     </FlexRow>
   );
 };
@@ -1087,7 +1147,7 @@ const ControlledTierCard = (props: {
             spinnerProps={spinnerProps}
           />
         )}
-        <ModulesForCard
+        <ModulesForInitialRegistration
           profile={profile}
           modules={[ctModule]}
           activeModule={activeModule}
@@ -1104,23 +1164,34 @@ const DuccCard = (props: {
   activeModule: AccessModule;
   clickableModules: AccessModule[];
   spinnerProps: WithSpinnerOverlayProps;
+  pageMode: DARPageMode;
   stepNumber: number;
 }) => {
-  const { profile, activeModule, clickableModules, spinnerProps, stepNumber } =
-    props;
+  const {
+    profile,
+    activeModule,
+    clickableModules,
+    spinnerProps,
+    pageMode,
+    stepNumber,
+  } = props;
   return (
-    <FlexRow style={{ ...styles.card, height: '125px' }}>
+    <FlexRow style={styles.card}>
       <FlexColumn>
         <div style={styles.cardStep}>Step {stepNumber}</div>
         <div style={styles.cardHeader}>Sign the code of conduct</div>
       </FlexColumn>
-      <ModulesForCard
-        profile={profile}
-        modules={[duccModule]}
-        activeModule={activeModule}
-        clickableModules={clickableModules}
-        spinnerProps={spinnerProps}
-      />
+      {pageMode === DARPageMode.INITIAL_REGISTRATION ? (
+        <ModulesForInitialRegistration
+          profile={profile}
+          modules={[duccModule]}
+          activeModule={activeModule}
+          clickableModules={clickableModules}
+          spinnerProps={spinnerProps}
+        />
+      ) : (
+        <ModulesForAnnualRenewal profile={profile} modules={[duccModule]} />
+      )}
     </FlexRow>
   );
 };
@@ -1135,7 +1206,10 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
     useEffect(() => {
       const onMount = async () => {
         await syncModulesExternal(
-          incompleteModules(getEligibleModules(allModules, profile), profile)
+          incompleteModules(
+            getEligibleModules(allInitialModules, profile),
+            profile
+          )
         );
         await reload();
         spinnerProps.hideSpinner();
@@ -1184,8 +1258,8 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
 
     const getNextActive = (modules: AccessModule[]) =>
       getActiveModule(getEligibleModules(modules, profile), profile);
-    const nextActive = getNextActive(allModules);
-    const nextRequired = getNextActive(requiredModules);
+    const nextActive = getNextActive(allInitialModules);
+    const nextRequired = getNextActive(initialRequiredModules);
 
     // whenever the profile changes, update the next modules to complete
     useEffect(() => {
@@ -1198,9 +1272,10 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
       );
     }, [nextActive, nextRequired]);
 
-    const showCtCard = accessTiersVisibleToUsers.includes(
-      AccessTierShortNames.Controlled
-    );
+    const showCtCard =
+      // RW-7798 add CT card for ANNUAL_RENEWAL
+      pageMode === DARPageMode.INITIAL_REGISTRATION &&
+      accessTiersVisibleToUsers.includes(AccessTierShortNames.Controlled);
 
     const rtCard = (
       <RegisteredTierCard
@@ -1229,6 +1304,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
         activeModule={activeModule}
         clickableModules={clickableModules}
         spinnerProps={spinnerProps}
+        pageMode={pageMode}
         stepNumber={showCtCard ? 3 : 2}
       />
     );

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -918,6 +918,7 @@ const ModulesForAnnualRenewal = (props: RenewalCardProps) => {
               setLoading={() => {}}
               textStyle={{ fontSize: '0.6rem' }}
               hide={!showModule}
+              showTimeEstimate={true}
             />
           </FlexColumn>
         );

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -133,6 +133,7 @@ interface AccessModuleUIConfig extends AccessModuleConfig {
   adminPageTitle: string;
   externalSyncAction?: Function;
   refreshAction?: Function;
+  renewalTimeEstimate?: number;
 }
 
 // This needs to be a function, because we want it to evaluate at call time,
@@ -234,6 +235,7 @@ export const getAccessModuleConfig = (
           await profileApi().syncComplianceTrainingStatus(),
         refreshAction: async () =>
           await profileApi().syncComplianceTrainingStatus(),
+        renewalTimeEstimate: 60,
       }),
     ],
 
@@ -252,6 +254,7 @@ export const getAccessModuleConfig = (
           await profileApi().syncComplianceTrainingStatus(),
         refreshAction: async () =>
           await profileApi().syncComplianceTrainingStatus(),
+        renewalTimeEstimate: 60,
       }),
     ],
 
@@ -263,6 +266,7 @@ export const getAccessModuleConfig = (
         AARTitleComponent: () => 'Sign Data User Code of Conduct',
         DARTitleComponent: () => <div>Sign Data User Code of Conduct</div>,
         adminPageTitle: 'Sign Data User Code of Conduct',
+        renewalTimeEstimate: 5,
       }),
     ],
 
@@ -273,6 +277,7 @@ export const getAccessModuleConfig = (
         isEnabledInEnvironment: true,
         AARTitleComponent: () => 'Update your profile',
         adminPageTitle: 'Update your profile',
+        renewalTimeEstimate: 5,
       }),
     ],
 
@@ -284,6 +289,7 @@ export const getAccessModuleConfig = (
         AARTitleComponent: () =>
           'Report any publications or presentations based on your research using the Researcher Workbench',
         adminPageTitle: 'Report any publications',
+        renewalTimeEstimate: 5,
       }),
     ]
   );


### PR DESCRIPTION
Tested locally.  Observed the following at the URL `http://localhost:4200/data-access-requirements?pageMode=ANNUAL_RENEWAL`

Styling issues may need to wait until future PRs - please note that this is feature-flagged and therefore not visible in Prod 

<img width="1463" alt="DAR-Renewal-Text" src="https://user-images.githubusercontent.com/2701406/160468496-f8c65600-a6be-426e-81ce-057fb008f959.png">

Minimal changes observed when viewing the standard modes of DAR and AAR, and these are improvements:
* AAR: removed "provide" from "to provide keep your profile information up-to-date"
* DAR: stopped hard-coding the heights of the cards, which now look more natural

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
