### PR TITLE
[RW-7834][risk=no] Require TOS acceptance on login when users are not Terra-TOS compliant

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -456,7 +456,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   @Override
   public void validateAllOfUsTermsOfService(Integer tosVersion) {
     if (tosVersion == null) {
-      throw new BadRequestException("Terms of Service version is NULL");
+      throw new BadRequestException("All of Us Terms of Service version is NULL");
     }
     if (tosVersion != LATEST_AOU_TOS_VERSION) {
       throw new BadRequestException("All of Us Terms of Service version is not up to date");
@@ -466,14 +466,10 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   // Returns true if user has accepted the latest AoU Terms of Service Version
   @Override
   public boolean validateAllOfUsTermsOfServiceVersion(@Nonnull DbUser dbUser) {
-    try {
-      final int tosVersion =
-          userTermsOfServiceDao.findByUserIdOrThrow(dbUser.getUserId()).getTosVersion();
-      return tosVersion == LATEST_AOU_TOS_VERSION;
-    } catch (BadRequestException ex) {
-      // In case user doesnt have any terms of service
-      return false;
-    }
+    return userTermsOfServiceDao
+        .findFirstByUserIdOrderByTosVersionDesc(dbUser.getUserId())
+        .map(u -> u.getTosVersion() == LATEST_AOU_TOS_VERSION)
+        .orElse(false);
   }
 
   // Returns true only if the user has accepted the latest version of both AoU and Terra terms of

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -662,9 +662,7 @@ public class UserServiceTest {
   private DbUser createUserWithAoUTOSVersion(int tosVersion) {
     DbUser dbUser = userDao.findUserByUsername(USERNAME);
     userTermsOfServiceDao.save(
-        new DbUserTermsOfService()
-            .setUserId(dbUser.getUserId())
-            .setTosVersion(tosVersion));
+        new DbUserTermsOfService().setUserId(dbUser.getUserId()).setTosVersion(tosVersion));
     return dbUser;
   }
 }


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
