### PR TITLE
[RW-8051][risk=no] Support nullable last modified dataset

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/model/DbDataset.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbDataset.java
@@ -80,8 +80,9 @@ public class DbDataset {
     return dataSetId;
   }
 
-  public void setDataSetId(long dataSetId) {
+  public DbDataset setDataSetId(long dataSetId) {
     this.dataSetId = dataSetId;
+    return this;
   }
 
   @Version
@@ -90,8 +91,9 @@ public class DbDataset {
     return version;
   }
 
-  public void setVersion(int version) {
+  public DbDataset setVersion(int version) {
     this.version = version;
+    return this;
   }
 
   @Column(name = "workspace_id")
@@ -99,8 +101,9 @@ public class DbDataset {
     return workspaceId;
   }
 
-  public void setWorkspaceId(long workspaceId) {
+  public DbDataset setWorkspaceId(long workspaceId) {
     this.workspaceId = workspaceId;
+    return this;
   }
 
   @Column(name = "name")
@@ -108,8 +111,9 @@ public class DbDataset {
     return name;
   }
 
-  public void setName(String name) {
+  public DbDataset setName(String name) {
     this.name = name;
+    return this;
   }
 
   @Column(name = "description")
@@ -117,8 +121,9 @@ public class DbDataset {
     return description;
   }
 
-  public void setDescription(String description) {
+  public DbDataset setDescription(String description) {
     this.description = description;
+    return this;
   }
 
   @Column(name = "creator_id")
@@ -126,8 +131,9 @@ public class DbDataset {
     return creatorId;
   }
 
-  public void setCreatorId(long creatorId) {
+  public DbDataset setCreatorId(long creatorId) {
     this.creatorId = creatorId;
+    return this;
   }
 
   @Column(name = "creation_time")
@@ -135,8 +141,9 @@ public class DbDataset {
     return creationTime;
   }
 
-  public void setCreationTime(Timestamp creationTime) {
+  public DbDataset setCreationTime(Timestamp creationTime) {
     this.creationTime = creationTime;
+    return this;
   }
 
   @Column(name = "last_modified_time")
@@ -144,8 +151,9 @@ public class DbDataset {
     return lastModifiedTime;
   }
 
-  public void setLastModifiedTime(Timestamp lastModifiedTime) {
+  public DbDataset setLastModifiedTime(Timestamp lastModifiedTime) {
     this.lastModifiedTime = lastModifiedTime;
+    return this;
   }
 
   @Column(name = "invalid")
@@ -153,8 +161,9 @@ public class DbDataset {
     return invalid;
   }
 
-  public void setInvalid(Boolean invalid) {
+  public DbDataset setInvalid(Boolean invalid) {
     this.invalid = invalid == null ? false : invalid;
+    return this;
   }
 
   @Column(name = "includes_all_participants")
@@ -162,8 +171,9 @@ public class DbDataset {
     return includesAllParticipants;
   }
 
-  public void setIncludesAllParticipants(Boolean includesAllParticipants) {
+  public DbDataset setIncludesAllParticipants(Boolean includesAllParticipants) {
     this.includesAllParticipants = includesAllParticipants;
+    return this;
   }
 
   @ElementCollection
@@ -173,8 +183,9 @@ public class DbDataset {
     return conceptSetIds;
   }
 
-  public void setConceptSetIds(List<Long> conceptSetIds) {
+  public DbDataset setConceptSetIds(List<Long> conceptSetIds) {
     this.conceptSetIds = conceptSetIds;
+    return this;
   }
 
   @ElementCollection
@@ -184,8 +195,9 @@ public class DbDataset {
     return cohortIds;
   }
 
-  public void setCohortIds(List<Long> cohortIds) {
+  public DbDataset setCohortIds(List<Long> cohortIds) {
     this.cohortIds = cohortIds;
+    return this;
   }
 
   @ElementCollection
@@ -195,8 +207,9 @@ public class DbDataset {
     return values;
   }
 
-  public void setValues(List<DbDatasetValue> values) {
+  public DbDataset setValues(List<DbDatasetValue> values) {
     this.values = values;
+    return this;
   }
 
   @ElementCollection(fetch = FetchType.EAGER)
@@ -208,8 +221,9 @@ public class DbDataset {
     return prePackagedConceptSet;
   }
 
-  public void setPrePackagedConceptSet(List<Short> prePackagedConceptSet) {
+  public DbDataset setPrePackagedConceptSet(List<Short> prePackagedConceptSet) {
     this.prePackagedConceptSet = prePackagedConceptSet;
+    return this;
   }
 
   @Transient
@@ -219,11 +233,12 @@ public class DbDataset {
         .collect(Collectors.toList());
   }
 
-  public void setPrePackagedConceptSetEnum(List<PrePackagedConceptSetEnum> domain) {
+  public DbDataset setPrePackagedConceptSetEnum(List<PrePackagedConceptSetEnum> domain) {
     this.prePackagedConceptSet =
         domain.stream()
             .map(DbStorageEnums::prePackagedConceptSetsToStorage)
             .collect(Collectors.toList());
+    return this;
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/ResourceFields.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/ResourceFields.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.workspaces.resources;
 
+import javax.annotation.Nullable;
 import org.pmiops.workbench.model.Cohort;
 import org.pmiops.workbench.model.CohortReview;
 import org.pmiops.workbench.model.ConceptSet;
@@ -16,53 +17,59 @@ class ResourceFields {
   private FileDetail notebook;
   private ConceptSet conceptSet;
   private DataSet dataSet;
-  private long lastModifiedEpochMillis;
+  private Long lastModifiedEpochMillis;
 
   public Cohort getCohort() {
     return cohort;
   }
 
-  public void setCohort(Cohort cohort) {
+  public ResourceFields setCohort(Cohort cohort) {
     this.cohort = cohort;
+    return this;
   }
 
   public CohortReview getCohortReview() {
     return cohortReview;
   }
 
-  public void setCohortReview(CohortReview cohortReview) {
+  public ResourceFields setCohortReview(CohortReview cohortReview) {
     this.cohortReview = cohortReview;
+    return this;
   }
 
   public FileDetail getNotebook() {
     return notebook;
   }
 
-  public void setNotebook(FileDetail notebook) {
+  public ResourceFields setNotebook(FileDetail notebook) {
     this.notebook = notebook;
+    return this;
   }
 
   public ConceptSet getConceptSet() {
     return conceptSet;
   }
 
-  public void setConceptSet(ConceptSet conceptSet) {
+  public ResourceFields setConceptSet(ConceptSet conceptSet) {
     this.conceptSet = conceptSet;
+    return this;
   }
 
   public DataSet getDataSet() {
     return dataSet;
   }
 
-  public void setDataSet(DataSet dataSet) {
+  public ResourceFields setDataSet(DataSet dataSet) {
     this.dataSet = dataSet;
+    return this;
   }
 
   public long getLastModifiedEpochMillis() {
     return lastModifiedEpochMillis;
   }
 
-  public void setLastModifiedEpochMillis(long lastModifiedEpochMillis) {
+  public ResourceFields setLastModifiedEpochMillis(@Nullable Long lastModifiedEpochMillis) {
     this.lastModifiedEpochMillis = lastModifiedEpochMillis;
+    return this;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/ResourceFields.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/ResourceFields.java
@@ -64,7 +64,7 @@ class ResourceFields {
     return this;
   }
 
-  public long getLastModifiedEpochMillis() {
+  public Long getLastModifiedEpochMillis() {
     return lastModifiedEpochMillis;
   }
 

--- a/api/src/test/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapperTest.java
@@ -1,0 +1,91 @@
+package org.pmiops.workbench.workspaces.resources;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pmiops.workbench.FakeClockConfiguration;
+import org.pmiops.workbench.cohorts.CohortMapperImpl;
+import org.pmiops.workbench.cohorts.CohortService;
+import org.pmiops.workbench.conceptset.ConceptSetService;
+import org.pmiops.workbench.conceptset.mapper.ConceptSetMapperImpl;
+import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
+import org.pmiops.workbench.db.model.DbDataset;
+import org.pmiops.workbench.db.model.DbDatasetValue;
+import org.pmiops.workbench.db.model.DbStorageEnums;
+import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.model.DataSet;
+import org.pmiops.workbench.model.Domain;
+import org.pmiops.workbench.model.PrePackagedConceptSetEnum;
+import org.pmiops.workbench.utils.mappers.CommonMappers;
+import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+public class WorkspaceResourceMapperTest {
+  private DbDataset dbDataset;
+
+  @Autowired private WorkspaceResourceMapper workspaceResourceMapper;
+
+  @TestConfiguration
+  @Import({
+    FakeClockConfiguration.class,
+    WorkspaceResourceMapperImpl.class,
+    CommonMappers.class,
+    DataSetMapperImpl.class,
+    CohortMapperImpl.class,
+    ConceptSetMapperImpl.class,
+    FirecloudMapperImpl.class,
+  })
+  @MockBean({FireCloudService.class, CohortService.class, ConceptSetService.class})
+  static class Configuration {}
+
+  @BeforeEach
+  public void setUp() {
+    dbDataset =
+        new DbDataset()
+            .setVersion(1)
+            .setDataSetId(101L)
+            .setName("name")
+            .setLastModifiedTime(FakeClockConfiguration.NOW)
+            .setIncludesAllParticipants(false)
+            .setDescription("asdf")
+            .setInvalid(false)
+            .setWorkspaceId(1L)
+            .setPrePackagedConceptSet(
+                Collections.singletonList(
+                    DbStorageEnums.prePackagedConceptSetsToStorage(PrePackagedConceptSetEnum.NONE)))
+            .setValues(
+                ImmutableList.of(
+                    new DbDatasetValue(
+                        DbStorageEnums.domainToStorage(Domain.CONDITION).toString(), "value")));
+  }
+
+  @Test
+  public void fromDbDataset() {
+    ResourceFields got = workspaceResourceMapper.fromDbDataset(dbDataset);
+    assertThat(got.getDataSet())
+        .isEqualTo(
+            new DataSet()
+                .id(101L)
+                .name("name")
+                .etag("\"1\"")
+                .includesAllParticipants(false)
+                .description("asdf")
+                .workspaceId(1L)
+                .lastModifiedTime(FakeClockConfiguration.NOW_TIME)
+                .prePackagedConceptSet(ImmutableList.of(PrePackagedConceptSetEnum.NONE)));
+  }
+
+  @Test
+  public void fromDbDatasetNullLastModified() {
+    ResourceFields got = workspaceResourceMapper.fromDbDataset(dbDataset.setLastModifiedTime(null));
+    assertThat(got.getDataSet().getLastModifiedTime()).isNull();
+  }
+}


### PR DESCRIPTION
- Dataset.lastModified is nullable, and is null for some cases in prod, ResourceFields.lastModifiedTime therefore also should support null
- Add Mapper regression test
- QOL improvements : chainable setters for DbDataset, ResourceFields

Tested with local dev server, manually nulling out dataset.last_modified in the DB.