### PR TITLE
[RW-7834][risk=no] Add Spinner to Account TOS page after clicking next button

### DIFF
--- a/ui/src/app/pages/login/account-creation/account-creation-tos.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-tos.spec.tsx
@@ -78,8 +78,12 @@ it('should disable next button when next button is pressed', async () => {
   getPrivacyCheckbox(wrapper).simulate('change', { target: { checked: true } });
   getTosCheckbox(wrapper).simulate('change', { target: { checked: true } });
 
+  // Next Button should be Enabled after checking Privacy and TOS checkbox
+  expect(getNextButton(wrapper).prop('disabled')).toBeFalsy();
+
   getNextButton(wrapper).simulate('click');
 
+  // After clicking Next, the button should not be disabled
   expect(getNextButton(wrapper).prop('disabled')).toBeTruthy();
 });
 

--- a/ui/src/app/pages/login/account-creation/account-creation-tos.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-tos.spec.tsx
@@ -71,6 +71,18 @@ it('should call onComplete when next button is pressed', async () => {
   expect(onCompleteSpy).toHaveBeenCalled();
 });
 
+it('should disable next button when next button is pressed', async () => {
+  const wrapper = mount(<AccountCreationTos {...props} />);
+
+  wrapper.setState({ hasReadEntireTos: true });
+  getPrivacyCheckbox(wrapper).simulate('change', { target: { checked: true } });
+  getTosCheckbox(wrapper).simulate('change', { target: { checked: true } });
+
+  getNextButton(wrapper).simulate('click');
+
+  expect(getNextButton(wrapper).prop('disabled')).toBeTruthy();
+});
+
 it('should enable NEXT button and checkboxes should be selected if page is re-visited after Institution Page', async () => {
   props.afterPrev = true;
   const wrapper = mount(<AccountCreationTos {...props} />);

--- a/ui/src/app/pages/login/account-creation/account-creation-tos.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-tos.spec.tsx
@@ -83,7 +83,7 @@ it('should disable next button when next button is pressed', async () => {
 
   getNextButton(wrapper).simulate('click');
 
-  // After clicking Next, the button should not be disabled
+  // After clicking Next, the button should be disabled
   expect(getNextButton(wrapper).prop('disabled')).toBeTruthy();
 });
 

--- a/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
@@ -176,7 +176,8 @@ export class AccountCreationTos extends React.Component<
               disabled={
                 !hasReadEntireTos ||
                 !hasAckedPrivacyStatement ||
-                !hasAckedTermsOfService
+                !hasAckedTermsOfService ||
+                hasClickedNext
               }
               onClick={() => {
                 this.setState({ hasClickedNext: true });

--- a/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
@@ -4,6 +4,7 @@ import { Button } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { HtmlViewer } from 'app/components/html-viewer';
 import { CheckBox } from 'app/components/inputs';
+import { SpinnerOverlay } from 'app/components/spinners';
 import { AoU } from 'app/components/text-wrappers';
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
@@ -50,6 +51,7 @@ interface AccountCreationTosState {
   hasReadEntireTos: boolean;
   hasAckedPrivacyStatement: boolean;
   hasAckedTermsOfService: boolean;
+  hasClickedNext: boolean;
 }
 
 // TODO: Rename this to TermsOfService
@@ -63,6 +65,7 @@ export class AccountCreationTos extends React.Component<
       hasReadEntireTos: props.afterPrev,
       hasAckedPrivacyStatement: props.afterPrev,
       hasAckedTermsOfService: props.afterPrev,
+      hasClickedNext: false,
     };
   }
 
@@ -71,6 +74,7 @@ export class AccountCreationTos extends React.Component<
       hasReadEntireTos,
       hasAckedTermsOfService,
       hasAckedPrivacyStatement,
+      hasClickedNext,
     } = this.state;
 
     return (
@@ -84,6 +88,7 @@ export class AccountCreationTos extends React.Component<
           onLastPage={() => this.setState({ hasReadEntireTos: true })}
           filePath={this.props.filePath}
         />
+        {hasClickedNext && <SpinnerOverlay />}
         <FlexRow
           style={{
             display: 'inline-flex',
@@ -173,7 +178,10 @@ export class AccountCreationTos extends React.Component<
                 !hasAckedPrivacyStatement ||
                 !hasAckedTermsOfService
               }
-              onClick={() => this.props.onComplete(LATEST_TOS_VERSION)}
+              onClick={() => {
+                this.setState({ hasClickedNext: true });
+                this.props.onComplete(LATEST_TOS_VERSION);
+              }}
             >
               Next
             </Button>


### PR DESCRIPTION
Existing functionality, on clicking next on  terms of service page, there is no way of knowing that the page is processing the request. This could create confusion for user, if the terms of service acceptance takes a long time and they might start clicking the next button multiple times.

Solution:  On clicking next: Disable Next button and show a spinner

TERRA TOS ACCEPTANCE 

https://user-images.githubusercontent.com/34481816/160721318-5ea97bd6-7c0f-43b0-835f-e25af461465f.mov


ACCOUNT CREATION FLOW (this is really quick since there is no API interaction so we see no difference):

https://user-images.githubusercontent.com/34481816/160721378-9c8e3bf8-61bb-4edf-b363-cd8eaa523805.mov



---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
