### PR TITLE
[risk=no][no ticket] style publications radio button text as disabled where appropriate

### DIFF
--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -305,63 +305,70 @@ export const RenewalCardBody = (props: {
     ],
     [
       AccessModule.PUBLICATIONCONFIRMATION,
-      () => (
-        <React.Fragment>
-          <Dates />
-          <div style={textStyle}>
-            The <AoU /> Publication and Presentation Policy requires that you
-            report any upcoming publication or presentation resulting from the
-            use of <AoU /> Research Program Data at least two weeks before the
-            date of publication. If you are lead on or part of a publication or
-            presentation that hasn’t been reported to the program,{' '}
-            <a
-              target='_blank'
-              style={{ textDecoration: 'underline' }}
-              href={REDCAP_PUBLICATIONS_SURVEY}
-            >
-              please report it now.
-            </a>{' '}
-            For any questions, please contact <SupportMailto />
-          </div>
-          <TimeEstimate />
-          <div
-            style={{ ...renewalStyle.publicationConfirmation, ...textStyle }}
-          >
-            <ActionButton
-              actionButtonText='Confirm'
-              completedButtonText='Confirmed'
-              moduleStatus={moduleStatus}
-              onClick={async () => {
-                setLoading(true);
-                await confirmPublications();
-                setLoading(false);
-              }}
-              disabled={publications === null}
-              style={{ gridRow: '1 / span 2', marginRight: '0.25rem' }}
-            />
-            <RadioButton
-              data-test-id='nothing-to-report'
-              id={noReportId}
-              disabled={isRenewalCompleteForModule(moduleStatus)}
-              style={{ justifySelf: 'end' }}
-              checked={publications === true}
-              onChange={() => setPublications(true)}
-            />
-            <label htmlFor={noReportId}>
-              At this time, I have nothing to report
-            </label>
-            <RadioButton
-              data-test-id='report-submitted'
-              id={reportId}
-              disabled={isRenewalCompleteForModule(moduleStatus)}
-              style={{ justifySelf: 'end' }}
-              checked={publications === false}
-              onChange={() => setPublications(false)}
-            />
-            <label htmlFor={reportId}>Report submitted</label>
-          </div>
-        </React.Fragment>
-      ),
+      () => {
+        const buttonsStyle = {
+          ...renewalStyle.publicationConfirmation,
+          ...textStyle,
+          color: isRenewalCompleteForModule(moduleStatus)
+            ? colors.disabled
+            : colors.primary,
+        };
+        return (
+          <React.Fragment>
+            <Dates />
+            <div style={textStyle}>
+              The <AoU /> Publication and Presentation Policy requires that you
+              report any upcoming publication or presentation resulting from the
+              use of <AoU /> Research Program Data at least two weeks before the
+              date of publication. If you are lead on or part of a publication
+              or presentation that hasn’t been reported to the program,{' '}
+              <a
+                target='_blank'
+                style={{ textDecoration: 'underline' }}
+                href={REDCAP_PUBLICATIONS_SURVEY}
+              >
+                please report it now.
+              </a>{' '}
+              For any questions, please contact <SupportMailto />
+            </div>
+            <TimeEstimate />
+            <div style={buttonsStyle}>
+              <ActionButton
+                actionButtonText='Confirm'
+                completedButtonText='Confirmed'
+                moduleStatus={moduleStatus}
+                onClick={async () => {
+                  setLoading(true);
+                  await confirmPublications();
+                  setLoading(false);
+                }}
+                disabled={publications === null}
+                style={{ gridRow: '1 / span 2', marginRight: '0.25rem' }}
+              />
+              <RadioButton
+                data-test-id='nothing-to-report'
+                id={noReportId}
+                disabled={isRenewalCompleteForModule(moduleStatus)}
+                style={{ justifySelf: 'end' }}
+                checked={publications === true}
+                onChange={() => setPublications(true)}
+              />
+              <label htmlFor={noReportId}>
+                At this time, I have nothing to report
+              </label>
+              <RadioButton
+                data-test-id='report-submitted'
+                id={reportId}
+                disabled={isRenewalCompleteForModule(moduleStatus)}
+                style={{ justifySelf: 'end' }}
+                checked={publications === false}
+                onChange={() => setPublications(false)}
+              />
+              <label htmlFor={reportId}>Report submitted</label>
+            </div>
+          </React.Fragment>
+        );
+      },
     ],
     [
       AccessModule.COMPLIANCETRAINING,


### PR DESCRIPTION
On the AAR and DAR-Renewal-Mode pages, make the radio button text grey if the buttons can't be clicked. 

Before
<img width="482" alt="Screen Shot 2022-03-30 at 10 20 50 AM" src="https://user-images.githubusercontent.com/2701406/160858070-28c9cfd5-3615-40fc-aff1-f6165a0c19cb.png">


After
<img width="473" alt="Screen Shot 2022-03-30 at 10 20 57 AM" src="https://user-images.githubusercontent.com/2701406/160858087-34d9a29a-733a-4884-8b7b-f5be8f8b466e.png">


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
