### PR TITLE
[risk=low][RW-7586] Keep going after failing to set Workflow Runner roles

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/iam/IamService.java
+++ b/api/src/main/java/org/pmiops/workbench/iam/IamService.java
@@ -17,7 +17,7 @@ public interface IamService {
    * <p>The users' Terra PET service accounts will get: lifesciences.workflowsRunner and
    * serviceAccountUser (on the petSA itself).
    *
-   * @return the list of users whose pet SAs we failed to retrieve, if any
+   * @return the list of users whose workflow runner roles we failed to grant, if any
    */
   List<String> grantWorkflowRunnerRoleForUsers(String googleProject, List<String> userEmails);
 
@@ -26,7 +26,7 @@ public interface IamService {
    *
    * <p>For now just revoke lifesciences.workflowsRunner permission but keep petSA ActAS permission.
    *
-   * @return the list of users whose pet SAs we failed to retrieve, if any
+   * @return the list of users whose workflow runner roles we failed to revoke, if any
    */
   List<String> revokeWorkflowRunnerRoleForUsers(String googleProject, List<String> userEmails);
 }

--- a/api/src/main/java/org/pmiops/workbench/iam/IamService.java
+++ b/api/src/main/java/org/pmiops/workbench/iam/IamService.java
@@ -4,26 +4,25 @@ import java.util.List;
 
 public interface IamService {
   /**
-   * Grants user permissions to run Google lifescience jobs to user in currenet context.
+   * Grants user permissions to run Google Life Sciences jobs to the user in the current context.
    *
-   * <p>The users's Terra PET service account will get: lifescienceRunner and serviceAccountUser(on
-   * the petSA itself).
+   * <p>The user's Terra PET service account will get: lifesciences.workflowsRunner and
+   * serviceAccountUser (on the petSA itself).
    */
   void grantWorkflowRunnerRoleToCurrentUser(String googleProject);
 
   /**
-   * Grants permissions to run Google lifescience jobs for the provideded user email lists.
+   * Grants permissions to run Google Life Sciences jobs for the provided user email lists.
    *
-   * <p>The users's Terra PET service account will get: lifescienceRunner and serviceAccountUser(on
-   * the petSA itself).
+   * <p>The users' Terra PET service accounts will get: lifesciences.workflowsRunner and
+   * serviceAccountUser (on the petSA itself).
    */
   void grantWorkflowRunnerRoleForUsers(String googleProject, List<String> userEmails);
 
   /**
-   * Revokes permissions to run Google lifescience jobs for the provideded user email lists.
+   * Revokes permissions to run Google Life Sciences jobs for the provided user email lists.
    *
-   * <p>The users's Terra PET service account will get: lifescienceRunner. For now just revoke
-   * lifescience runner permisison but keep petSA ActAS permission.
+   * <p>For now just revoke lifesciences.workflowsRunner permission but keep petSA ActAS permission.
    */
   void revokeWorkflowRunnerRoleForUsers(String googleProject, List<String> userEmails);
 }

--- a/api/src/main/java/org/pmiops/workbench/iam/IamService.java
+++ b/api/src/main/java/org/pmiops/workbench/iam/IamService.java
@@ -16,13 +16,17 @@ public interface IamService {
    *
    * <p>The users' Terra PET service accounts will get: lifesciences.workflowsRunner and
    * serviceAccountUser (on the petSA itself).
+   *
+   * @return the list of users whose pet SAs we failed to retrieve, if any
    */
-  void grantWorkflowRunnerRoleForUsers(String googleProject, List<String> userEmails);
+  List<String> grantWorkflowRunnerRoleForUsers(String googleProject, List<String> userEmails);
 
   /**
    * Revokes permissions to run Google Life Sciences jobs for the provided user email lists.
    *
    * <p>For now just revoke lifesciences.workflowsRunner permission but keep petSA ActAS permission.
+   *
+   * @return the list of users whose pet SAs we failed to retrieve, if any
    */
-  void revokeWorkflowRunnerRoleForUsers(String googleProject, List<String> userEmails);
+  List<String> revokeWorkflowRunnerRoleForUsers(String googleProject, List<String> userEmails);
 }

--- a/api/src/main/java/org/pmiops/workbench/iam/IamServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/iam/IamServiceImpl.java
@@ -113,6 +113,7 @@ public class IamServiceImpl implements IamService {
     try {
       List<String> petServiceAccountsToGrantPermission = new ArrayList<>();
       for (String userEmail : userEmails) {
+        // TODO can we make these requests in parallel?
         Optional<String> petSaMaybe =
             getOrCreatePetServiceAccountUsingImpersonation(googleProject, userEmail);
         if (petSaMaybe.isPresent()) {
@@ -138,6 +139,7 @@ public class IamServiceImpl implements IamService {
     try {
       List<String> petServiceAccountsToRevokePermission = new ArrayList<>();
       for (String userEmail : userEmails) {
+        // TODO can we make these requests in parallel?
         Optional<String> petSaMaybe =
             getOrCreatePetServiceAccountUsingImpersonation(googleProject, userEmail);
         if (petSaMaybe.isPresent()) {

--- a/api/src/main/java/org/pmiops/workbench/iam/IamServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/iam/IamServiceImpl.java
@@ -67,7 +67,7 @@ public class IamServiceImpl implements IamService {
    * Gets a Terra pet service account from SAM as the given user using impersonation, if possible.
    *
    * <p>If the user has not yet accepted the latest Terms of Service, impersonation will not be
-   * possible, and ww will return Empty instead.
+   * possible, and we will return Empty instead.
    */
   private Optional<String> getOrCreatePetServiceAccountUsingImpersonation(
       String googleProject, String userEmail) throws IOException, ApiException {
@@ -108,10 +108,10 @@ public class IamServiceImpl implements IamService {
   @Override
   public List<String> grantWorkflowRunnerRoleForUsers(
       String googleProject, List<String> userEmails) {
-    List<String> petServiceAccountsToGrantPermission = new ArrayList<>();
     List<String> petServiceAccountFailures = new ArrayList<>();
 
     try {
+      List<String> petServiceAccountsToGrantPermission = new ArrayList<>();
       for (String userEmail : userEmails) {
         Optional<String> petSaMaybe =
             getOrCreatePetServiceAccountUsingImpersonation(googleProject, userEmail);
@@ -122,21 +122,21 @@ public class IamServiceImpl implements IamService {
           petServiceAccountFailures.add(userEmail);
         }
       }
+      grantLifeScienceRunnerRole(googleProject, petServiceAccountsToGrantPermission);
     } catch (IOException | ApiException e) {
       throw new ServerErrorException(e);
     }
 
-    grantLifeScienceRunnerRole(googleProject, petServiceAccountsToGrantPermission);
     return petServiceAccountFailures;
   }
 
   @Override
   public List<String> revokeWorkflowRunnerRoleForUsers(
       String googleProject, List<String> userEmails) {
-    List<String> petServiceAccountsToRevokePermission = new ArrayList<>();
     List<String> petServiceAccountFailures = new ArrayList<>();
 
     try {
+      List<String> petServiceAccountsToRevokePermission = new ArrayList<>();
       for (String userEmail : userEmails) {
         Optional<String> petSaMaybe =
             getOrCreatePetServiceAccountUsingImpersonation(googleProject, userEmail);
@@ -146,11 +146,11 @@ public class IamServiceImpl implements IamService {
           petServiceAccountFailures.add(userEmail);
         }
       }
+      revokeLifeScienceRunnerRole(googleProject, petServiceAccountsToRevokePermission);
     } catch (IOException | ApiException e) {
       throw new ServerErrorException(e);
     }
 
-    revokeLifeScienceRunnerRole(googleProject, petServiceAccountsToRevokePermission);
     return petServiceAccountFailures;
   }
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4782,6 +4782,11 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/UserRole"
+      failedWorkflowGrants:
+        description: A list of user emails to whom we were unable to grant workflow runner roles, if any
+        type: array
+        items:
+          type: string
   CopyRequest:
     type: object
     required:
@@ -4825,6 +4830,11 @@ definitions:
       workspace:
         "$ref": "#/definitions/Workspace"
         description: The newly created workspace duplicate.
+      failedWorkflowGrants:
+        description: A list of user emails to whom we were unable to grant workflow runner roles, if any
+        type: array
+        items:
+          type: string
   WorkspaceOperation:
     type: object
     required:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4787,6 +4787,11 @@ definitions:
         type: array
         items:
           type: string
+      failedWorkflowRevocations:
+        description: A list of user emails for whom we were unable to revoke workflow runner roles, if any
+        type: array
+        items:
+          type: string
   CopyRequest:
     type: object
     required:


### PR DESCRIPTION
Tested locally by itself and with #6519 
Workspace Share and Duplication continue to work, with expected API JSON output

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
