### PR TITLE
[risk=low][RW-7586] Inform the user when workspace sharing does not grant workflow runner roles

### DIFF
--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -194,12 +194,15 @@ const WorkflowRolesErrorModal = (props: WorkflowRolesProps) => (
         must occur, in order:
         <ol>
           <li>
-            The researchers must log in to the <AoU /> Research Workbench
+            The researchers must log in to the <AoU /> Research Workbench and
+            accept the updated <AoU /> Terms of Service agreement.
           </li>
-          <li>This workspace must be shared with the researchers as Readers</li>
+          <li>
+            This workspace must be shared with the researchers as Readers.
+          </li>
           <li>
             This workspace must then be shared with the researchers as Writers
-            or Owners
+            or Owners.
           </li>
         </ol>
       </div>

--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -174,15 +174,16 @@ interface WorkflowRolesProps {
 }
 const WorkflowRolesErrorModal = (props: WorkflowRolesProps) => (
   <Modal>
-    <ModalTitle>Workflow sharing successful but incomplete</ModalTitle>
+    <ModalTitle>Workspace sharing was successful but incomplete</ModalTitle>
     <ModalBody>
       <div style={styles.workflowRolesText}>
         The Researcher Workbench has successfully shared the workspace with the
-        specified collaborators, but with limited functionality for some.
+        specified collaborators, but with limited functionality for some
+        researchers.
       </div>
       <div style={styles.workflowRolesText}>
         For compliance reasons, we were unable to grant the following
-        researchers appropriate access to run workflows in this workspace:
+        researchers the appropriate access to run workflows in this workspace:
         <ul>
           {props.usernames.sort().map((item) => (
             <li>{item}</li>
@@ -198,11 +199,12 @@ const WorkflowRolesErrorModal = (props: WorkflowRolesProps) => (
             accept the updated <AoU /> Terms of Service agreement.
           </li>
           <li>
-            This workspace must be shared with the researchers as Readers.
+            The workspace access level for these users must be changed to
+            Reader.
           </li>
           <li>
-            This workspace must then be shared with the researchers as Writers
-            or Owners.
+            The workspace access levels for these users may then be changed to
+            Writers or Owners, as appropriate.
           </li>
         </ol>
       </div>

--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -141,7 +141,6 @@ const styles = reactStyles({
     color: colors.primary,
     margin: '1em 0 1em 0',
     fontSize: 14,
-    fontWeight: 500,
   },
 });
 
@@ -312,11 +311,7 @@ export const WorkspaceShare = fp.flow(withUserProfile())(
       if (this.state.saving) {
         return;
       }
-      this.setState({
-        saving: true,
-        workspaceShareError: false,
-        workflowRolesErrors: [],
-      });
+      this.setState({ saving: true });
       workspacesApi()
         .shareWorkspacePatch(
           this.props.workspace.namespace,

--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -21,6 +21,7 @@ import {
 } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
 import { Spinner, SpinnerOverlay } from 'app/components/spinners';
+import { SupportMailto } from 'app/components/support';
 import { AoU } from 'app/components/text-wrappers';
 import { userApi, workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
@@ -209,7 +210,8 @@ const WorkflowRolesErrorModal = (props: WorkflowRolesProps) => (
         </ol>
       </div>
       <div style={styles.workflowRolesText}>
-        We apologize for the inconvenience.
+        We apologize for the inconvenience. For any questions, please contact{' '}
+        <SupportMailto />
       </div>
     </ModalBody>
     <ModalFooter>


### PR DESCRIPTION
Here's an initial attempt to explain that the Workflow Runner role has not been granted to ToS-non-compliant collaborators, and the current steps required to fully recover from this scenario.

<img width="464" alt="Workflow Runner grant failures" src="https://user-images.githubusercontent.com/2701406/164515202-32604b5f-0ca7-45bd-8741-15eb3ff11add.png">

In this video, the user joelt3 is ToS-**compliant** and the users joel2 and joel4 are ToS-**non-compliant**
(text is a bit out of date, see above for latest)

![Workflow Runner grant failures](https://user-images.githubusercontent.com/2701406/164316728-7fb3869e-15a4-453b-abb0-e4fe71a02a1d.gif)

Not included here:
* UX for the opposite problem: failure to remove a Workflow Runner role from ToS-non-compliant users after unsharing (or access level downgrade)
* UX for failure-to-grant when Duplicating Workspace, which has the same problem

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
