### PR TITLE
[RW-8130][risk=no]Fix full text indexing lookup in sql 

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -246,8 +246,8 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
 
   @Query(
       value =
-          "select upper(substring_index(substring_index(full_text, '[', -1), '_', 1)) as domainId, "
-              + " upper(substring_index(substring_index(full_text, '[', -1), '_', 1)) as name, "
+          "select upper(substring_index(substring_index(full_text, '[', -1), '_rank1', 1)) as domainId, "
+              + " upper(substring_index(substring_index(full_text, '[', -1), '_rank1', 1)) as name, "
               + " count(*) as count "
               + "from cb_criteria "
               + "where match(full_text) against(:term in boolean mode) "
@@ -264,8 +264,8 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
 
   @Query(
       value =
-          "select upper(substring_index(substring_index(full_text, '[', -1), '_', 1)) as domainId, "
-              + " upper(substring_index(substring_index(full_text, '[', -1), '_', 1)) as name, "
+          "select upper(substring_index(substring_index(full_text, '[', -1), '_rank1', 1)) as domainId, "
+              + " upper(substring_index(substring_index(full_text, '[', -1), '_rank1', 1)) as name, "
               + " count(*) as count "
               + "from cb_criteria "
               + "where domain_id in (:domains) "


### PR DESCRIPTION
Description:

- Fix for the full text index.  split on `'_rank1'` instead of  `'_'`
-  ref [PR#6505](https://github.com/all-of-us/workbench/pull/6505)


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
