### PR TITLE
[risk=no] Fix stale egress event status picker

### DIFF
--- a/ui/src/app/pages/admin/egress-events-table.spec.tsx
+++ b/ui/src/app/pages/admin/egress-events-table.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import * as fp from 'lodash/fp';
+import { ReactWrapper } from 'enzyme';
 
 import { EgressEventsAdminApi, EgressEventStatus } from 'generated/fetch';
 
@@ -27,6 +28,19 @@ describe('EgressEventsTable', () => {
   afterEach(() => {
     jest.useRealTimers();
   });
+
+  const editRowToFalsePositive = async (
+    wrapper: ReactWrapper,
+    rowIndex: number
+  ) => {
+    wrapper.find('.p-row-editor-init').at(rowIndex).simulate('click');
+    wrapper
+      .find('.p-dropdown-item')
+      .find({ 'aria-label': EgressEventStatus.VERIFIEDFALSEPOSITIVE })
+      .simulate('click');
+    wrapper.find('.p-row-editor-save-icon').simulate('click');
+    await waitForFakeTimersAndUpdate(wrapper);
+  };
 
   it('should render basic', async () => {
     const wrapper = mountWithRouter(<EgressEventsTable />);
@@ -77,14 +91,7 @@ describe('EgressEventsTable', () => {
     const wrapper = mountWithRouter(<EgressEventsTable />);
     await waitForFakeTimersAndUpdate(wrapper);
 
-    wrapper.find('.p-row-editor-init').at(2).simulate('click');
-    wrapper
-      .find('.p-dropdown-item')
-      .find({ 'aria-label': EgressEventStatus.VERIFIEDFALSEPOSITIVE })
-      .simulate('click');
-    wrapper.find('.p-row-editor-save-icon').simulate('click');
-
-    await waitForFakeTimersAndUpdate(wrapper);
+    await editRowToFalsePositive(wrapper, 2);
     expect(eventsStub.events[2].status).toBe(
       EgressEventStatus.VERIFIEDFALSEPOSITIVE
     );
@@ -96,21 +103,8 @@ describe('EgressEventsTable', () => {
     const wrapper = mountWithRouter(<EgressEventsTable />);
     await waitForFakeTimersAndUpdate(wrapper);
 
-    wrapper.find('.p-row-editor-init').at(2).simulate('click');
-    wrapper
-      .find('.p-dropdown-item')
-      .find({ 'aria-label': EgressEventStatus.VERIFIEDFALSEPOSITIVE })
-      .simulate('click');
-    wrapper.find('.p-row-editor-save-icon').simulate('click');
-    await waitForFakeTimersAndUpdate(wrapper);
-
-    wrapper.find('.p-row-editor-init').at(3).simulate('click');
-    wrapper
-      .find('.p-dropdown-item')
-      .find({ 'aria-label': EgressEventStatus.VERIFIEDFALSEPOSITIVE })
-      .simulate('click');
-    wrapper.find('.p-row-editor-save-icon').simulate('click');
-    await waitForFakeTimersAndUpdate(wrapper);
+    await editRowToFalsePositive(wrapper, 2);
+    await editRowToFalsePositive(wrapper, 3);
 
     expect(eventsStub.events[2].status).toBe(
       EgressEventStatus.VERIFIEDFALSEPOSITIVE

--- a/ui/src/app/pages/admin/egress-events-table.spec.tsx
+++ b/ui/src/app/pages/admin/egress-events-table.spec.tsx
@@ -89,4 +89,34 @@ describe('EgressEventsTable', () => {
       EgressEventStatus.VERIFIEDFALSEPOSITIVE
     );
   });
+
+  it('should allow multiple event status updates', async () => {
+    eventsStub.events = fp.times(() => eventsStub.simulateNewEvent(), 5);
+
+    const wrapper = mountWithRouter(<EgressEventsTable />);
+    await waitForFakeTimersAndUpdate(wrapper);
+
+    wrapper.find('.p-row-editor-init').at(2).simulate('click');
+    wrapper
+      .find('.p-dropdown-item')
+      .find({ 'aria-label': EgressEventStatus.VERIFIEDFALSEPOSITIVE })
+      .simulate('click');
+    wrapper.find('.p-row-editor-save-icon').simulate('click');
+    await waitForFakeTimersAndUpdate(wrapper);
+
+    wrapper.find('.p-row-editor-init').at(3).simulate('click');
+    wrapper
+      .find('.p-dropdown-item')
+      .find({ 'aria-label': EgressEventStatus.VERIFIEDFALSEPOSITIVE })
+      .simulate('click');
+    wrapper.find('.p-row-editor-save-icon').simulate('click');
+    await waitForFakeTimersAndUpdate(wrapper);
+
+    expect(eventsStub.events[2].status).toBe(
+      EgressEventStatus.VERIFIEDFALSEPOSITIVE
+    );
+    expect(eventsStub.events[3].status).toBe(
+      EgressEventStatus.VERIFIEDFALSEPOSITIVE
+    );
+  });
 });

--- a/ui/src/app/pages/admin/egress-events-table.tsx
+++ b/ui/src/app/pages/admin/egress-events-table.tsx
@@ -84,6 +84,7 @@ export const EgressEventsTable = ({
     const updatedEvents = events.slice();
     updatedEvents.splice(i, 1, updatedEvent);
     setEvents(updatedEvents);
+    setPendingUpdateEvent(null);
     setLoading(false);
   }, [events, pendingUpdateEvent]);
 


### PR DESCRIPTION
Bug: when changing the status for multiple events within the same client session, the picker state would bleed across rows and show the most recent updated state. This meant you had to switch the state back/forth before saving to actually make it update properly.

Added regression test which fails without this fix.

https://user-images.githubusercontent.com/822298/161840986-12ad9de0-d511-41d5-8503-d129bb465c2b.mp4

