### PR TITLE
[risk=no] Switch local/test/perf VMs to us-central1-c

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -17,7 +17,7 @@
       "gce": ["test-gce-docker-image"],
       "dataproc": ["test-dataproc-docker-image"]
     },
-    "gceVmZone": "us-central1-f"
+    "gceVmZone": "us-central1-c"
   },
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -17,7 +17,7 @@
       "gce": [],
       "dataproc": []
     },
-    "gceVmZone": "us-central1-f"
+    "gceVmZone": "us-central1-c"
   },
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -17,7 +17,7 @@
       "gce": [],
       "dataproc": []
     },
-    "gceVmZone": "us-central1-f"
+    "gceVmZone": "us-central1-c"
   },
   "billing": {
     "accountId": "00293C-5DEA2D-6887E7",


### PR DESCRIPTION
We're currently seeing `ZONE_RESOURCE_POOL_EXHAUSTED` in us-central-1f