### PR TITLE
[RW-8053][risk=no] Add additional validation during CDR publishing

### DIFF
--- a/api/db-cdr/generate-cdr/copy-bq-dataset.sh
+++ b/api/db-cdr/generate-cdr/copy-bq-dataset.sh
@@ -13,12 +13,17 @@ export DEST_DATASET=$2  # project2:dataset2
 export JOB_PROJECT=$3 # project3
 export MATCH_FILTER=$4 # table grep filter to include
 export SKIP_FILTER=$5 # table grep filter to skip
+export MAYBE_DRY_RUN=$6 # --dry-run for dry run, anything else is ignored
 
+bq_cmd="bq"
+if [ "${MAYBE_DRY_RUN}" = "--dry-run" ]; then
+  bq_cmd="echo bq"
+fi
 for f in $(bq ls -n 1000 $SOURCE_DATASET |
              grep TABLE |
              awk '{print $1}' |
              grep "${MATCH_FILTER}" |
              grep -v "${SKIP_FILTER}")
 do
-  bq --project_id="${JOB_PROJECT}" cp -f "${SOURCE_DATASET}.${f}" "${DEST_DATASET}.${f}"
+  ${bq_cmd} --project_id="${JOB_PROJECT}" cp -f "${SOURCE_DATASET}.${f}" "${DEST_DATASET}.${f}"
 done

--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -74,14 +74,14 @@ def bq_ingest(tier, tier_name, source_project, source_dataset_name, dest_dataset
   ingest_args = %W{./copy-bq-dataset.sh
       #{source_fq_dataset} #{ingest_fq_dataset} #{source_project}
       #{table_match_filter} #{table_skip_filter}}
-  ingest_dry_stdout = common.capture_stdout(ingest_args + %W{--dry-run}, err = nil)
+  ingest_dry_stdout = common.capture_stdout(ingest_args + %W{--dry-run}, nil)
   common.run_inline ingest_args
 
   common.run_inline %W{bq mk -f --dataset #{dest_fq_dataset}}
   publish_args = %W{./copy-bq-dataset.sh
       #{ingest_fq_dataset} #{dest_fq_dataset} #{tier.fetch(:ingest_cdr_project)}
       #{table_match_filter} #{table_skip_filter}}
-  publish_dry_stdout = common.capture_stdout(publish_args + %W{--dry-run}, err = nil)
+  publish_dry_stdout = common.capture_stdout(publish_args + %W{--dry-run}, nil)
 
   unless ingest_dry_stdout.lines.length == publish_dry_stdout.lines.length
     raise RuntimeError.new(


### PR DESCRIPTION
Verify that a dry run of the table copy shows the same number of lines for: source -> ingest, as ingest -> dest