### PR TITLE
[RW-8118][risk=no] Add notification to top of new TOS page

### DIFF
--- a/e2e/app/page/create-account-page.ts
+++ b/e2e/app/page/create-account-page.ts
@@ -98,22 +98,17 @@ export default class CreateAccountPage extends BasePage {
   }
 
   async agreementLoaded(): Promise<boolean> {
-    const iframe = await findIframe(this.page, 'terms of service agreement');
+    const iframe = await findIframe(this.page, 'terms of use and privacy statement');
     const bodyHandle = await iframe.$('body');
     return iframe.evaluate((body) => body.scrollHeight > 0, bodyHandle);
   }
 
   async readAgreement(): Promise<Frame> {
-    const iframe = await findIframe(this.page, 'terms of service agreement');
+    const iframe = await findIframe(this.page, 'terms of use and privacy statement');
     const bodyHandle = await iframe.$('body');
     await iframe.evaluate((body) => body.scrollTo(0, body.scrollHeight), bodyHandle);
     await this.page.waitForTimeout(1000);
     return iframe;
-  }
-
-  getPrivacyStatementCheckbox(): Checkbox {
-    const selector = '//*[@id=//label[contains(normalize-space(), "All of Us Program Privacy Statement")]/@for]';
-    return new Checkbox(this.page, selector);
   }
 
   getTermsOfUseCheckbox(): Checkbox {
@@ -196,13 +191,11 @@ export default class CreateAccountPage extends BasePage {
 
   // Step 1: Accepting Terms of Use and Privacy statement.
   async acceptTermsOfUseAgreement(): Promise<void> {
-    const privacyStatementCheckbox = this.getPrivacyStatementCheckbox();
     const termsOfUseCheckbox = this.getTermsOfUseCheckbox();
 
     await this.readAgreement();
 
     // check by click on label works
-    await privacyStatementCheckbox.check();
     await termsOfUseCheckbox.check();
   }
 

--- a/e2e/tests/user/create-account-ui.spec.ts
+++ b/e2e/tests/user/create-account-ui.spec.ts
@@ -17,11 +17,6 @@ describe('Account creation UI tests:', () => {
     expect(await createAccountPage.agreementLoaded()).toBe(true);
 
     // Before user read all pdf pages, checkboxes are unchecked and disabled
-    const privacyStatementCheckbox = createAccountPage.getPrivacyStatementCheckbox();
-    expect(privacyStatementCheckbox).toBeTruthy();
-    expect(await privacyStatementCheckbox.isDisabled()).toBe(true);
-    expect(await privacyStatementCheckbox.isChecked()).toBe(false);
-
     const termsOfUseCheckbox = createAccountPage.getTermsOfUseCheckbox();
     expect(termsOfUseCheckbox).toBeTruthy();
     expect(await termsOfUseCheckbox.isDisabled()).toBe(true);
@@ -30,18 +25,15 @@ describe('Account creation UI tests:', () => {
     let nextButton = createAccountPage.getNextButton();
     expect(await nextButton.isCursorNotAllowed()).toEqual(true);
 
-    // scroll to last pdf file will enables checkboxes
+    // scroll to last pdf file will enables checkbox
     await createAccountPage.readAgreement();
-    expect(await privacyStatementCheckbox.isDisabled()).toBe(false);
     expect(await termsOfUseCheckbox.isDisabled()).toBe(false);
 
-    // check both checkboxes
-    await createAccountPage.getPrivacyStatementCheckbox().check();
+    // check checkbox
     expect(await nextButton.isCursorNotAllowed()).toEqual(true);
     await createAccountPage.getTermsOfUseCheckbox().check();
 
     // verify checked
-    expect(await privacyStatementCheckbox.isChecked()).toBe(true);
     expect(await termsOfUseCheckbox.isChecked()).toBe(true);
     expect(await nextButton.isCursorNotAllowed()).toEqual(false);
 
@@ -49,8 +41,7 @@ describe('Account creation UI tests:', () => {
     await createAccountPage.getTermsOfUseCheckbox().unCheck();
     expect(await nextButton.isCursorNotAllowed()).toEqual(true);
 
-    // check checkboxes
-    await createAccountPage.getPrivacyStatementCheckbox().check();
+    // check checkbox
     await createAccountPage.getTermsOfUseCheckbox().check();
     const agreementPageButton = createAccountPage.getNextButton();
     await agreementPageButton.clickWithEval();

--- a/ui/src/app/pages/login/account-creation/account-creation-tos.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-tos.spec.tsx
@@ -7,11 +7,8 @@ import {
 } from 'app/pages/login/account-creation/account-creation-tos';
 
 type AnyWrapper = ShallowWrapper | ReactWrapper;
-const getPrivacyCheckbox = (wrapper: AnyWrapper): AnyWrapper => {
-  return wrapper.find('input[data-test-id="privacy-statement-check"]');
-};
-const getTosCheckbox = (wrapper: AnyWrapper): AnyWrapper => {
-  return wrapper.find('input[data-test-id="terms-of-service-check"]');
+const getAgreementCheckbox = (wrapper: AnyWrapper): AnyWrapper => {
+  return wrapper.find('input[data-test-id="agreement-check"]');
 };
 const getNextButton = (wrapper: AnyWrapper): AnyWrapper => {
   return wrapper.find('[data-test-id="next-button"]');
@@ -34,11 +31,10 @@ it('should render', async () => {
   expect(wrapper.exists()).toBeTruthy();
 });
 
-it('should enable checkboxes and next button with user input', async () => {
+it('should enable checkbox and next button with user input', async () => {
   const wrapper = mount(<AccountCreationTos {...props} />);
 
-  expect(getPrivacyCheckbox(wrapper).prop('disabled')).toBeTruthy();
-  expect(getTosCheckbox(wrapper).prop('disabled')).toBeTruthy();
+  expect(getAgreementCheckbox(wrapper).prop('disabled')).toBeTruthy();
   expect(getNextButton(wrapper).prop('disabled')).toBeTruthy();
 
   // In the real world, the user can either click "Scroll to bottom" or scroll until the last page
@@ -46,15 +42,13 @@ it('should enable checkboxes and next button with user input', async () => {
   // was extremely difficult to simulate in Jest, and will be better-suited to an end-to-end test.
   //
   // As a workaround, we manually set the state here to allow us to test the input enablement.
-  wrapper.setState({ hasReadEntireTos: true });
+  wrapper.setState({ hasReadEntireAgreement: true });
 
-  expect(getPrivacyCheckbox(wrapper).prop('disabled')).toBeFalsy();
-  expect(getTosCheckbox(wrapper).prop('disabled')).toBeFalsy();
+  expect(getAgreementCheckbox(wrapper).prop('disabled')).toBeFalsy();
   expect(getNextButton(wrapper).prop('disabled')).toBeTruthy();
 
-  // Now, simulate checking both boxes, which should enable the "next" button.
-  getPrivacyCheckbox(wrapper).simulate('change', { target: { checked: true } });
-  getTosCheckbox(wrapper).simulate('change', { target: { checked: true } });
+  // Now, simulate checking the box, which should enable the "next" button.
+  getAgreementCheckbox(wrapper).simulate('change', { target: { checked: true } });
 
   expect(getNextButton(wrapper).prop('disabled')).toBeFalsy();
 });
@@ -62,9 +56,8 @@ it('should enable checkboxes and next button with user input', async () => {
 it('should call onComplete when next button is pressed', async () => {
   const wrapper = mount(<AccountCreationTos {...props} />);
 
-  wrapper.setState({ hasReadEntireTos: true });
-  getPrivacyCheckbox(wrapper).simulate('change', { target: { checked: true } });
-  getTosCheckbox(wrapper).simulate('change', { target: { checked: true } });
+  wrapper.setState({ hasReadEntireAgreement: true });
+  getAgreementCheckbox(wrapper).simulate('change', { target: { checked: true } });
 
   getNextButton(wrapper).simulate('click');
 
@@ -74,9 +67,8 @@ it('should call onComplete when next button is pressed', async () => {
 it('should disable next button when next button is pressed', async () => {
   const wrapper = mount(<AccountCreationTos {...props} />);
 
-  wrapper.setState({ hasReadEntireTos: true });
-  getPrivacyCheckbox(wrapper).simulate('change', { target: { checked: true } });
-  getTosCheckbox(wrapper).simulate('change', { target: { checked: true } });
+  wrapper.setState({ hasReadEntireAgreement: true });
+  getAgreementCheckbox(wrapper).simulate('change', { target: { checked: true } });
 
   // Next Button should be Enabled after checking Privacy and TOS checkbox
   expect(getNextButton(wrapper).prop('disabled')).toBeFalsy();
@@ -87,11 +79,10 @@ it('should disable next button when next button is pressed', async () => {
   expect(getNextButton(wrapper).prop('disabled')).toBeTruthy();
 });
 
-it('should enable NEXT button and checkboxes should be selected if page is re-visited after Institution Page', async () => {
+it('should enable NEXT button and checkbox should be selected if page is re-visited after Institution Page', async () => {
   props.afterPrev = true;
   const wrapper = mount(<AccountCreationTos {...props} />);
 
-  expect(getPrivacyCheckbox(wrapper).prop('checked')).toBeTruthy();
-  expect(getTosCheckbox(wrapper).prop('checked')).toBeTruthy();
+  expect(getAgreementCheckbox(wrapper).prop('checked')).toBeTruthy();
   expect(getNextButton(wrapper).prop('disabled')).toBeFalsy();
 });

--- a/ui/src/app/pages/login/account-creation/account-creation-tos.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-tos.spec.tsx
@@ -48,7 +48,9 @@ it('should enable checkbox and next button with user input', async () => {
   expect(getNextButton(wrapper).prop('disabled')).toBeTruthy();
 
   // Now, simulate checking the box, which should enable the "next" button.
-  getAgreementCheckbox(wrapper).simulate('change', { target: { checked: true } });
+  getAgreementCheckbox(wrapper).simulate('change', {
+    target: { checked: true },
+  });
 
   expect(getNextButton(wrapper).prop('disabled')).toBeFalsy();
 });
@@ -57,7 +59,9 @@ it('should call onComplete when next button is pressed', async () => {
   const wrapper = mount(<AccountCreationTos {...props} />);
 
   wrapper.setState({ hasReadEntireAgreement: true });
-  getAgreementCheckbox(wrapper).simulate('change', { target: { checked: true } });
+  getAgreementCheckbox(wrapper).simulate('change', {
+    target: { checked: true },
+  });
 
   getNextButton(wrapper).simulate('click');
 
@@ -68,7 +72,9 @@ it('should disable next button when next button is pressed', async () => {
   const wrapper = mount(<AccountCreationTos {...props} />);
 
   wrapper.setState({ hasReadEntireAgreement: true });
-  getAgreementCheckbox(wrapper).simulate('change', { target: { checked: true } });
+  getAgreementCheckbox(wrapper).simulate('change', {
+    target: { checked: true },
+  });
 
   // Next Button should be Enabled after checking Privacy and TOS checkbox
   expect(getNextButton(wrapper).prop('disabled')).toBeFalsy();

--- a/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
@@ -48,9 +48,8 @@ export interface AccountCreationTosProps {
 }
 
 interface AccountCreationTosState {
-  hasReadEntireTos: boolean;
-  hasAckedPrivacyStatement: boolean;
-  hasAckedTermsOfService: boolean;
+  hasReadEntireAgreement: boolean;
+  hasAckedAgreement: boolean;
   hasClickedNext: boolean;
 }
 
@@ -62,20 +61,15 @@ export class AccountCreationTos extends React.Component<
   constructor(props: AccountCreationTosProps) {
     super(props);
     this.state = {
-      hasReadEntireTos: props.afterPrev,
-      hasAckedPrivacyStatement: props.afterPrev,
-      hasAckedTermsOfService: props.afterPrev,
+      hasReadEntireAgreement: props.afterPrev,
+      hasAckedAgreement: props.afterPrev,
       hasClickedNext: false,
     };
   }
 
   render() {
-    const {
-      hasReadEntireTos,
-      hasAckedTermsOfService,
-      hasAckedPrivacyStatement,
-      hasClickedNext,
-    } = this.state;
+    const { hasReadEntireAgreement, hasAckedAgreement, hasClickedNext } =
+      this.state;
 
     return (
       <FlexColumn
@@ -83,9 +77,9 @@ export class AccountCreationTos extends React.Component<
         style={{ flex: 1, padding: '1rem 3rem 0 3rem', ...this.props.style }}
       >
         <HtmlViewer
-          ariaLabel='terms of service agreement'
+          ariaLabel='terms of use and privacy statement'
           containerStyles={{ backgroundColor: colors.white }}
-          onLastPage={() => this.setState({ hasReadEntireTos: true })}
+          onLastPage={() => this.setState({ hasReadEntireAgreement: true })}
           filePath={this.props.filePath}
         />
         {hasClickedNext && <SpinnerOverlay />}
@@ -109,51 +103,28 @@ export class AccountCreationTos extends React.Component<
               <div style={{ fontWeight: 400 }}>
                 By clicking below, or continuing with the registration process
                 or accessing the Researcher Workbench, you agree to these terms
-                and make the following certifications:
+                and make the following certification:
               </div>
-            </div>
-            <div style={{ marginBottom: '.25rem' }}>
-              <CheckBox
-                data-test-id='privacy-statement-check'
-                checked={hasAckedPrivacyStatement}
-                disabled={!hasReadEntireTos}
-                onChange={(checked) =>
-                  this.setState({ hasAckedPrivacyStatement: checked })
-                }
-                style={styles.checkbox}
-                labelStyle={
-                  hasReadEntireTos
-                    ? styles.checkboxLabel
-                    : styles.disabledCheckboxLabel
-                }
-                wrapperStyle={{ marginBottom: '0.5rem' }}
-                label={
-                  <span>
-                    I have read, understand, and agree to the <AoU /> Program
-                    Privacy Statement.
-                  </span>
-                }
-              />
             </div>
             <div>
               <CheckBox
-                data-test-id='terms-of-service-check'
-                checked={hasAckedTermsOfService}
-                disabled={!hasReadEntireTos}
+                data-test-id='agreement-check'
+                checked={hasAckedAgreement}
+                disabled={!hasReadEntireAgreement}
                 onChange={(checked) =>
-                  this.setState({ hasAckedTermsOfService: checked })
+                  this.setState({ hasAckedAgreement: checked })
                 }
                 style={styles.checkbox}
                 labelStyle={
-                  hasReadEntireTos
+                  hasReadEntireAgreement
                     ? styles.checkboxLabel
                     : styles.disabledCheckboxLabel
                 }
-                wrapperStyle={{ marginBottom: '0.5rem' }}
+                wrapperStyle={{ marginBottom: '0.5rem', display: 'flex' }}
                 label={
                   <span>
-                    I have read, understand, and agree to the Terms of Use
-                    described above.
+                    I have read, understand, and agree to the <AoU /> Terms of
+                    Use and Privacy Statement described above.
                   </span>
                 }
               />
@@ -174,10 +145,7 @@ export class AccountCreationTos extends React.Component<
                 margin: '.25rem .5rem .25rem 0',
               }}
               disabled={
-                !hasReadEntireTos ||
-                !hasAckedPrivacyStatement ||
-                !hasAckedTermsOfService ||
-                hasClickedNext
+                !hasReadEntireAgreement || !hasAckedAgreement || hasClickedNext
               }
               onClick={() => {
                 this.setState({ hasClickedNext: true });

--- a/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
@@ -76,6 +76,26 @@ export class AccountCreationTos extends React.Component<
         data-test-id='account-creation-tos'
         style={{ flex: 1, padding: '1rem 3rem 0 3rem', ...this.props.style }}
       >
+        <div
+          style={{
+            marginBottom: '0.5rem',
+            padding: '0.75rem',
+            backgroundColor: 'aliceblue',
+            borderRadius: 4,
+            boxShadow: '1px 1px 6px gray',
+          }}
+        >
+          <h3 style={{ marginTop: 0, fontWeight: 'bold' }}>
+            Please review and re-accept the <AoU /> Research Program Researcher
+            Workbench Terms of Use and Privacy Statement
+          </h3>
+          <p className="h-color" style={{ marginTop: '0.25rem' }}>
+            The Terra Platform terms, which are incorporated by reference into
+            the <AoU /> terms, have been updated. This updated replaces
+            references to specific federal datasets with a more broad reference
+            to federal datasets as a type of data.
+          </p>
+        </div>
         <HtmlViewer
           ariaLabel='terms of use and privacy statement'
           containerStyles={{ backgroundColor: colors.white }}

--- a/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
@@ -89,7 +89,7 @@ export class AccountCreationTos extends React.Component<
             Please review and re-accept the <AoU /> Research Program Researcher
             Workbench Terms of Use and Privacy Statement
           </h3>
-          <p className="h-color" style={{ marginTop: '0.25rem' }}>
+          <p className='h-color' style={{ marginTop: '0.25rem' }}>
             The Terra Platform terms, which are incorporated by reference into
             the <AoU /> terms, have been updated. This updated replaces
             references to specific federal datasets with a more broad reference

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -4,6 +4,10 @@ h3, h3 > * {
   color: rgb(38, 34, 98);
 }
 
+body .h-color {
+  color: rgb(38, 34, 98);
+}
+
 h1 {
   font-size: 36px;
 }


### PR DESCRIPTION
Asks user to re-review TOS during access renewal.

![Screen Shot 2022-04-11 at 16 21 42](https://user-images.githubusercontent.com/1545444/162829536-90558e4d-3530-4876-9790-3dbd193335be.png)

To reject the TOS for manual testing:

![Screen Shot 2022-04-11 at 16 21 58](https://user-images.githubusercontent.com/1545444/162829580-24d9a078-d56d-4850-ada0-5d64c2a3c207.png)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
