### PR TITLE
[RW-7940][risk=no] new API to returning List of cohort reviews given cohortId

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -257,6 +257,17 @@ public class CohortReviewController implements CohortReviewApiDelegate {
   }
 
   @Override
+  public ResponseEntity<CohortReviewListResponse> getCohortReviewsByCohortId(
+      String workspaceNamespace, String workspaceId, Long cohortId) {
+    workspaceAuthService.enforceWorkspaceAccessLevel(
+        workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
+
+    return ResponseEntity.ok(
+        new CohortReviewListResponse()
+            .items(cohortReviewService.getCohortReviewsByCohortId(cohortId)));
+  }
+
+  @Override
   public ResponseEntity<CohortReviewListResponse> getCohortReviewsInWorkspace(
       String workspaceNamespace, String workspaceId) {
     // This also enforces registered auth domain.

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewService.java
@@ -39,6 +39,8 @@ public interface CohortReviewService {
   /** Find the {@link DbCohortReview} for the specified ns and firecloudName. */
   List<CohortReview> getRequiredWithCohortReviews(String ns, String firecloudName);
 
+  List<CohortReview> getCohortReviewsByCohortId(Long cohortId);
+
   /** Save the specified {@link CohortReview}. */
   CohortReview saveCohortReview(CohortReview cohortReview, DbUser creator);
 

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
@@ -203,6 +203,13 @@ public class CohortReviewServiceImpl implements CohortReviewService, GaugeDataCo
   }
 
   @Override
+  public List<CohortReview> getCohortReviewsByCohortId(Long cohortId) {
+    return cohortReviewDao.findAllByCohortId(cohortId).stream()
+        .map(cohortReviewMapper::dbModelToClient)
+        .collect(Collectors.toList());
+  }
+
+  @Override
   public CohortReview saveCohortReview(CohortReview cohortReview, DbUser creator) {
     return cohortReviewMapper.dbModelToClient(
         cohortReviewDao.save(cohortReviewMapper.clientToDbModel(cohortReview, creator)));

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2053,6 +2053,26 @@ paths:
           description: A list of cohort definitions.
           schema:
             "$ref": "#/definitions/CohortReviewListResponse"
+  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/cohort-reviews/{cohortId}":
+    parameters:
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
+      - in: path
+        name: cohortId
+        type: integer
+        format: int64
+        required: true
+        description: cohort primary key
+    get:
+      tags:
+        - cohortReview
+      description: Returns all cohort reviews per cohortId
+      operationId: getCohortReviewsByCohortId
+      responses:
+        200:
+          description: A list of cohort reviews.
+          schema:
+            "$ref": "#/definitions/CohortReviewListResponse"
   "/v1/workspaces/{workspaceNamespace}/{workspaceId}/cohort-reviews/{cohortReviewId}":
     parameters:
     - "$ref": "#/parameters/workspaceNamespace"


### PR DESCRIPTION
Description:

- new api for getting multiple cohort reviews for a given cohortId
- added controller test


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
