### PR TITLE
[RW-7798][risk=low] Add Controlled Tier Training to Annual Renewal Page

### DIFF
--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -378,9 +378,9 @@ export const RenewalCardBody = (props: {
         <React.Fragment>
           <Dates />
           <div style={textStyle}>
-            You are required to complete the refreshed ethics training courses
-            to understand the privacy safeguards and the compliance requirements
-            for using the <AoU /> Dataset.
+            You are required to complete the refreshed Registered Tier ethics
+            training courses to understand the privacy safeguards and the
+            compliance requirements for using the <AoU /> Dataset.
           </div>
           {!isRenewalCompleteForModule(moduleStatus) && (
             <div
@@ -431,9 +431,9 @@ export const RenewalCardBody = (props: {
         <React.Fragment>
           <Dates />
           <div style={textStyle}>
-            You are required to complete the refreshed ethics training courses
-            to understand the privacy safeguards and the compliance requirements
-            for using the <AoU /> Dataset.
+            You are required to complete the refreshed Controlled Tier ethics
+            training courses to understand the privacy safeguards and the
+            compliance requirements for using the <AoU /> Dataset.
           </div>
           {!isRenewalCompleteForModule(moduleStatus) && (
             <div

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -32,6 +32,7 @@ import {
   getAccessModuleStatusByNameOrEmpty,
   isExpiringOrExpired,
   maybeDaysRemaining,
+  redirectToControlledTraining,
   redirectToRegisteredTraining,
   syncModulesExternal,
 } from 'app/utils/access-utils';
@@ -401,6 +402,59 @@ export const RenewalCardBody = (props: {
               onClick={() => {
                 setTrainingRefreshButtonDisabled(false);
                 redirectToRegisteredTraining();
+              }}
+            />
+            {!isRenewalCompleteForModule(moduleStatus) && (
+              <Button
+                disabled={trainingRefreshButtonDisabled}
+                onClick={async () => {
+                  setLoading(true);
+                  await syncAndReloadTraining();
+                  setLoading(false);
+                }}
+                style={{
+                  height: '1.6rem',
+                  marginLeft: '0.75rem',
+                  width: 'max-content',
+                }}
+              >
+                Refresh
+              </Button>
+            )}
+          </FlexRow>
+        </React.Fragment>
+      ),
+    ],
+    [
+      AccessModule.CTCOMPLIANCETRAINING,
+      () => (
+        <React.Fragment>
+          <Dates />
+          <div style={textStyle}>
+            You are required to complete the refreshed ethics training courses
+            to understand the privacy safeguards and the compliance requirements
+            for using the <AoU /> Dataset.
+          </div>
+          {!isRenewalCompleteForModule(moduleStatus) && (
+            <div
+              style={{
+                ...renewalStyle.complianceTrainingExpiring,
+                ...textStyle,
+              }}
+            >
+              When you have completed the training click the refresh button or
+              reload the page.
+            </div>
+          )}
+          <TimeEstimate />
+          <FlexRow style={{ marginTop: 'auto' }}>
+            <ActionButton
+              actionButtonText='Complete Training'
+              completedButtonText='Completed'
+              moduleStatus={moduleStatus}
+              onClick={() => {
+                setTrainingRefreshButtonDisabled(false);
+                redirectToControlledTraining();
               }}
             />
             {!isRenewalCompleteForModule(moduleStatus) && (

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -378,9 +378,9 @@ export const RenewalCardBody = (props: {
         <React.Fragment>
           <Dates />
           <div style={textStyle}>
-            You are required to complete the refreshed Registered Tier ethics
-            training courses to understand the privacy safeguards and the
-            compliance requirements for using the <AoU /> Dataset.
+            You are required to complete the refreshed ethics training courses
+            to understand the privacy safeguards and the compliance requirements
+            for using the <AoU /> Registered Tier Dataset.
           </div>
           {!isRenewalCompleteForModule(moduleStatus) && (
             <div
@@ -431,9 +431,9 @@ export const RenewalCardBody = (props: {
         <React.Fragment>
           <Dates />
           <div style={textStyle}>
-            You are required to complete the refreshed Controlled Tier ethics
-            training courses to understand the privacy safeguards and the
-            compliance requirements for using the <AoU /> Dataset.
+            You are required to complete the refreshed ethics training courses
+            to understand the privacy safeguards and the compliance requirements
+            for using the <AoU /> Controlled Tier Dataset.
           </div>
           {!isRenewalCompleteForModule(moduleStatus) && (
             <div

--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -142,15 +142,116 @@ describe('DataAccessRequirements', () => {
     jest.useRealTimers();
   });
 
-  describe('getEligibleModules', () => {
-    it('should return all required modules from getEligibleModules by default (all FFs enabled)', () => {
-      const enabledModules = getEligibleModules(allInitialModules, profile);
-      initialRequiredModules.forEach((module) =>
-        expect(enabledModules.includes(module)).toBeTruthy()
-      );
-    });
+  it('should return all required modules from getEligibleModules by default (all FFs enabled)', () => {
+    const enabledModules = getEligibleModules(allInitialModules, profile);
+    initialRequiredModules.forEach((module) =>
+      expect(enabledModules.includes(module)).toBeTruthy()
+    );
+  });
 
-    it('should not return the RAS module from getEligibleModules when its feature flag is disabled', () => {
+  it('should not return the RAS module from getEligibleModules when its feature flag is disabled', () => {
+    serverConfigStore.set({
+      config: {
+        ...defaultServerConfig,
+        enableRasLoginGovLinking: false,
+        enforceRasLoginGovLinking: false,
+      },
+    });
+    const enabledModules = getEligibleModules(allInitialModules, profile);
+    expect(enabledModules.includes(AccessModule.RASLINKLOGINGOV)).toBeFalsy();
+  });
+
+  it(
+    'should return the RAS module from getEligibleModules when ' +
+      'enforceRasLoginGovLinking is enabled, enableRasLoginGovLinking is not',
+    () => {
+      serverConfigStore.set({
+        config: {
+          ...defaultServerConfig,
+          enableRasLoginGovLinking: false,
+          enforceRasLoginGovLinking: true,
+        },
+      });
+      const enabledModules = getEligibleModules(allInitialModules, profile);
+      expect(
+        enabledModules.includes(AccessModule.RASLINKLOGINGOV)
+      ).toBeTruthy();
+    }
+  );
+
+  it('should not return the ERA module from getEligibleModules when its feature flag is disabled', () => {
+    serverConfigStore.set({
+      config: { ...defaultServerConfig, enableEraCommons: false },
+    });
+    const enabledModules = getEligibleModules(allInitialModules, profile);
+    expect(enabledModules.includes(AccessModule.ERACOMMONS)).toBeFalsy();
+  });
+
+  it('should not return the Compliance module from getEligibleModules when its feature flag is disabled', () => {
+    serverConfigStore.set({
+      config: { ...defaultServerConfig, enableComplianceTraining: false },
+    });
+    const enabledModules = getEligibleModules(allInitialModules, profile);
+    expect(
+      enabledModules.includes(AccessModule.COMPLIANCETRAINING)
+    ).toBeFalsy();
+  });
+
+  it('should return the first module (2FA) from getActiveModule when no modules have been completed', () => {
+    const enabledModules = getEligibleModules(initialRequiredModules, profile);
+    const activeModule = getActiveModule(enabledModules, profile);
+
+    expect(activeModule).toEqual(initialRequiredModules[0]);
+    expect(activeModule).toEqual(enabledModules[0]);
+
+    // update this if the order changes
+    expect(activeModule).toEqual(AccessModule.TWOFACTORAUTH);
+  });
+
+  it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been completed', () => {
+    const testProfile = {
+      ...profile,
+      accessModules: {
+        modules: [
+          { moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1 },
+        ],
+      },
+    };
+
+    const enabledModules = getEligibleModules(initialRequiredModules, profile);
+    const activeModule = getActiveModule(enabledModules, testProfile);
+
+    expect(activeModule).toEqual(initialRequiredModules[1]);
+    expect(activeModule).toEqual(enabledModules[1]);
+
+    // update this if the order changes
+    expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
+  });
+
+  it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been bypassed', () => {
+    const testProfile = {
+      ...profile,
+      accessModules: {
+        modules: [
+          { moduleName: AccessModule.TWOFACTORAUTH, bypassEpochMillis: 1 },
+        ],
+      },
+    };
+
+    const enabledModules = getEligibleModules(initialRequiredModules, profile);
+    const activeModule = getActiveModule(enabledModules, testProfile);
+
+    expect(activeModule).toEqual(initialRequiredModules[1]);
+    expect(activeModule).toEqual(enabledModules[1]);
+
+    // update this if the order changes
+    expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
+  });
+
+  it(
+    'should return the second enabled module (ERA, not RAS) from getActiveModule' +
+      ' when the first module (2FA) has been completed and RAS is disabled',
+    () => {
       serverConfigStore.set({
         config: {
           ...defaultServerConfig,
@@ -158,319 +259,729 @@ describe('DataAccessRequirements', () => {
           enforceRasLoginGovLinking: false,
         },
       });
-      const enabledModules = getEligibleModules(allInitialModules, profile);
-      expect(enabledModules.includes(AccessModule.RASLINKLOGINGOV)).toBeFalsy();
-    });
 
-    it(
-      'should return the RAS module from getEligibleModules when ' +
-        'enforceRasLoginGovLinking is enabled, enableRasLoginGovLinking is not',
-      () => {
-        serverConfigStore.set({
-          config: {
-            ...defaultServerConfig,
-            enableRasLoginGovLinking: false,
-            enforceRasLoginGovLinking: true,
+      const testProfile = {
+        ...profile,
+        accessModules: {
+          modules: [
+            {
+              moduleName: AccessModule.TWOFACTORAUTH,
+              completionEpochMillis: 1,
+            },
+          ],
+        },
+      };
+
+      const enabledModules = getEligibleModules(
+        initialRequiredModules,
+        profile
+      );
+      const activeModule = getActiveModule(enabledModules, testProfile);
+
+      // update this if the order changes
+      expect(activeModule).toEqual(AccessModule.ERACOMMONS);
+
+      // 2FA (module 0) is complete, so enabled #1 is active
+      expect(activeModule).toEqual(enabledModules[1]);
+
+      // but we skip requiredModules[1] because it's RAS and is not enabled
+      expect(activeModule).toEqual(initialRequiredModules[2]);
+    }
+  );
+
+  it('should return the fourth module (Compliance) from getActiveModule when the first 3 modules have been completed', () => {
+    const testProfile = {
+      ...profile,
+      accessModules: {
+        modules: [
+          { moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1 },
+          { moduleName: AccessModule.ERACOMMONS, completionEpochMillis: 1 },
+          {
+            moduleName: AccessModule.RASLINKLOGINGOV,
+            completionEpochMillis: 1,
           },
-        });
-        const enabledModules = getEligibleModules(allInitialModules, profile);
-        expect(
-          enabledModules.includes(AccessModule.RASLINKLOGINGOV)
-        ).toBeTruthy();
-      }
-    );
+        ],
+      },
+    };
 
-    it('should not return the ERA module from getEligibleModules when its feature flag is disabled', () => {
-      serverConfigStore.set({
-        config: { ...defaultServerConfig, enableEraCommons: false },
-      });
-      const enabledModules = getEligibleModules(allInitialModules, profile);
-      expect(enabledModules.includes(AccessModule.ERACOMMONS)).toBeFalsy();
-    });
+    const enabledModules = getEligibleModules(initialRequiredModules, profile);
+    const activeModule = getActiveModule(enabledModules, testProfile);
 
-    it('should not return the Compliance module from getEligibleModules when its feature flag is disabled', () => {
-      serverConfigStore.set({
-        config: { ...defaultServerConfig, enableComplianceTraining: false },
-      });
-      const enabledModules = getEligibleModules(allInitialModules, profile);
-      expect(
-        enabledModules.includes(AccessModule.COMPLIANCETRAINING)
-      ).toBeFalsy();
-    });
+    expect(activeModule).toEqual(initialRequiredModules[3]);
+    expect(activeModule).toEqual(enabledModules[3]);
+
+    // update this if the order changes
+    expect(activeModule).toEqual(AccessModule.COMPLIANCETRAINING);
   });
 
-  describe('getActiveModule', () => {
-    it('should return the first module (2FA) from getActiveModule when no modules have been completed', () => {
-      const enabledModules = getEligibleModules(
-        initialRequiredModules,
-        profile
-      );
-      const activeModule = getActiveModule(enabledModules, profile);
+  it('should return undefined from getActiveModule when all modules have been completed', () => {
+    const testProfile = {
+      ...profile,
+      accessModules: {
+        modules: initialRequiredModules.map((module) => ({
+          moduleName: module,
+          completionEpochMillis: 1,
+        })),
+      },
+    };
 
-      expect(activeModule).toEqual(initialRequiredModules[0]);
-      expect(activeModule).toEqual(enabledModules[0]);
+    const enabledModules = getEligibleModules(initialRequiredModules, profile);
+    const activeModule = getActiveModule(enabledModules, testProfile);
 
-      // update this if the order changes
-      expect(activeModule).toEqual(AccessModule.TWOFACTORAUTH);
-    });
+    expect(activeModule).toBeUndefined();
+  });
 
-    it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been completed', () => {
-      const testProfile = {
-        ...profile,
-        accessModules: {
-          modules: [
-            {
-              moduleName: AccessModule.TWOFACTORAUTH,
-              completionEpochMillis: 1,
-            },
-          ],
-        },
-      };
-
-      const enabledModules = getEligibleModules(
-        initialRequiredModules,
-        profile
-      );
-      const activeModule = getActiveModule(enabledModules, testProfile);
-
-      expect(activeModule).toEqual(initialRequiredModules[1]);
-      expect(activeModule).toEqual(enabledModules[1]);
-
-      // update this if the order changes
-      expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
-    });
-
-    it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been bypassed', () => {
-      const testProfile = {
-        ...profile,
-        accessModules: {
-          modules: [
-            { moduleName: AccessModule.TWOFACTORAUTH, bypassEpochMillis: 1 },
-          ],
-        },
-      };
-
-      const enabledModules = getEligibleModules(
-        initialRequiredModules,
-        profile
-      );
-      const activeModule = getActiveModule(enabledModules, testProfile);
-
-      expect(activeModule).toEqual(initialRequiredModules[1]);
-      expect(activeModule).toEqual(enabledModules[1]);
-
-      // update this if the order changes
-      expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
-    });
-
-    it(
-      'should return the second enabled module (ERA, not RAS) from getActiveModule' +
-        ' when the first module (2FA) has been completed and RAS is disabled',
-      () => {
-        serverConfigStore.set({
-          config: {
-            ...defaultServerConfig,
-            enableRasLoginGovLinking: false,
-            enforceRasLoginGovLinking: false,
+  it('should not indicate the RAS module as active when a user has completed it', () => {
+    // initially, the user has completed all required modules except RAS (the standard case at RAS launch time)
+    const testProfile = {
+      ...profile,
+      accessModules: {
+        modules: [
+          { moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1 },
+          { moduleName: AccessModule.ERACOMMONS, completionEpochMillis: 1 },
+          {
+            moduleName: AccessModule.COMPLIANCETRAINING,
+            completionEpochMillis: 1,
           },
-        });
-
-        const testProfile = {
-          ...profile,
-          accessModules: {
-            modules: [
-              {
-                moduleName: AccessModule.TWOFACTORAUTH,
-                completionEpochMillis: 1,
-              },
-            ],
+          {
+            moduleName: AccessModule.DATAUSERCODEOFCONDUCT,
+            completionEpochMillis: 1,
           },
-        };
+        ],
+      },
+    };
 
-        const enabledModules = getEligibleModules(
-          initialRequiredModules,
-          profile
-        );
-        const activeModule = getActiveModule(enabledModules, testProfile);
+    const enabledModules = getEligibleModules(initialRequiredModules, profile);
 
-        // update this if the order changes
-        expect(activeModule).toEqual(AccessModule.ERACOMMONS);
+    let activeModule = getActiveModule(enabledModules, testProfile);
+    expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
 
-        // 2FA (module 0) is complete, so enabled #1 is active
-        expect(activeModule).toEqual(enabledModules[1]);
+    // simulate handleRasCallback() by updating the profile
 
-        // but we skip requiredModules[1] because it's RAS and is not enabled
-        expect(activeModule).toEqual(initialRequiredModules[2]);
-      }
+    const updatedProfile = {
+      ...testProfile,
+      accessModules: {
+        modules: [
+          ...testProfile.accessModules.modules,
+          {
+            moduleName: AccessModule.RASLINKLOGINGOV,
+            completionEpochMillis: 1,
+          },
+        ],
+      },
+    };
+
+    activeModule = getActiveModule(enabledModules, updatedProfile);
+    expect(activeModule).toBeUndefined();
+  });
+
+  it('should render all required modules by default (all FFs enabled)', () => {
+    const wrapper = component();
+    allInitialModules.forEach((module) =>
+      expect(findModule(wrapper, module).exists()).toBeTruthy()
     );
+  });
 
-    it('should return the fourth module (Compliance) from getActiveModule when the first 3 modules have been completed', () => {
-      const testProfile = {
-        ...profile,
-        accessModules: {
-          modules: [
-            {
-              moduleName: AccessModule.TWOFACTORAUTH,
-              completionEpochMillis: 1,
-            },
-            { moduleName: AccessModule.ERACOMMONS, completionEpochMillis: 1 },
-            {
-              moduleName: AccessModule.RASLINKLOGINGOV,
-              completionEpochMillis: 1,
-            },
-          ],
-        },
-      };
-
-      const enabledModules = getEligibleModules(
-        initialRequiredModules,
-        profile
-      );
-      const activeModule = getActiveModule(enabledModules, testProfile);
-
-      expect(activeModule).toEqual(initialRequiredModules[3]);
-      expect(activeModule).toEqual(enabledModules[3]);
-
-      // update this if the order changes
-      expect(activeModule).toEqual(AccessModule.COMPLIANCETRAINING);
+  it('should not render the ERA module when its feature flag is disabled', () => {
+    serverConfigStore.set({
+      config: { ...defaultServerConfig, enableEraCommons: false },
     });
+    const wrapper = component();
+    expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeFalsy();
+  });
 
-    it('should return undefined from getActiveModule when all modules have been completed', () => {
-      const testProfile = {
-        ...profile,
+  it('should not render the Compliance module when its feature flag is disabled', () => {
+    serverConfigStore.set({
+      config: { ...defaultServerConfig, enableComplianceTraining: false },
+    });
+    const wrapper = component();
+    expect(
+      findModule(wrapper, AccessModule.COMPLIANCETRAINING).exists()
+    ).toBeFalsy();
+  });
+
+  // Temporary hack Sep 16: when enableRasLoginGovLinking is false, we DO show the module
+  // along with an Ineligible icon and some "technical difficulties" text
+  // and it never becomes an activeModule
+  it('should render the RAS module as ineligible when its feature flag is disabled', () => {
+    serverConfigStore.set({
+      config: {
+        ...defaultServerConfig,
+        enableRasLoginGovLinking: false,
+        enforceRasLoginGovLinking: false,
+      },
+    });
+    const wrapper = component();
+    expect(
+      findModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+    ).toBeTruthy();
+    expect(
+      findIneligibleModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+    ).toBeTruthy();
+
+    expect(
+      findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+    ).toBeFalsy();
+    expect(
+      findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+    ).toBeFalsy();
+  });
+
+  it('should render all required modules as incomplete when the profile accessModules are empty', () => {
+    const wrapper = component();
+    initialRequiredModules.forEach((module) => {
+      expect(findIncompleteModule(wrapper, module).exists()).toBeTruthy();
+
+      expect(findCompleteModule(wrapper, module).exists()).toBeFalsy();
+      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+    });
+    expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
+  });
+
+  it('should render all required modules as complete when the profile accessModules are all complete', () => {
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
         accessModules: {
           modules: initialRequiredModules.map((module) => ({
             moduleName: module,
             completionEpochMillis: 1,
           })),
         },
-      };
-
-      const enabledModules = getEligibleModules(
-        initialRequiredModules,
-        profile
-      );
-      const activeModule = getActiveModule(enabledModules, testProfile);
-
-      expect(activeModule).toBeUndefined();
+      },
+      load,
+      reload,
+      updateCache,
     });
 
-    it('should not indicate the RAS module as active when a user has completed it', () => {
-      // initially, the user has completed all required modules except RAS (the standard case at RAS launch time)
-      const testProfile = {
-        ...profile,
-        accessModules: {
-          modules: [
-            {
-              moduleName: AccessModule.TWOFACTORAUTH,
-              completionEpochMillis: 1,
-            },
-            { moduleName: AccessModule.ERACOMMONS, completionEpochMillis: 1 },
-            {
-              moduleName: AccessModule.COMPLIANCETRAINING,
-              completionEpochMillis: 1,
-            },
-            {
-              moduleName: AccessModule.DATAUSERCODEOFCONDUCT,
-              completionEpochMillis: 1,
-            },
-          ],
-        },
-      };
+    const wrapper = component();
+    initialRequiredModules.forEach((module) => {
+      expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
 
-      const enabledModules = getEligibleModules(
-        initialRequiredModules,
-        profile
-      );
-
-      let activeModule = getActiveModule(enabledModules, testProfile);
-      expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
-
-      // simulate handleRasCallback() by updating the profile
-
-      const updatedProfile = {
-        ...testProfile,
-        accessModules: {
-          modules: [
-            ...testProfile.accessModules.modules,
-            {
-              moduleName: AccessModule.RASLINKLOGINGOV,
-              completionEpochMillis: 1,
-            },
-          ],
-        },
-      };
-
-      activeModule = getActiveModule(enabledModules, updatedProfile);
-      expect(activeModule).toBeUndefined();
+      expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
+      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
     });
+    expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
   });
 
-  describe('bypass functionality', () => {
-    it('should not show self-bypass UI when unsafeSelfBypass is false', () => {
-      serverConfigStore.set({
-        config: {
-          ...serverConfigStore.get().config,
-          unsafeAllowSelfBypass: false,
+  // RAS launch bug (no JIRA ticket)
+  it('should render all modules as complete by transitioning to all complete', async () => {
+    // this test is subject to flakiness using real timers
+    jest.useFakeTimers();
+
+    // initially, the user has completed all required modules except RAS (the standard case at RAS launch time)
+
+    const allExceptRas = initialRequiredModules.filter(
+      (m) => m !== AccessModule.RASLINKLOGINGOV
+    );
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessModules: {
+          modules: allExceptRas.map((module) => ({
+            moduleName: module,
+            completionEpochMillis: 1,
+          })),
         },
-      });
-      const wrapper = component();
-      expect(wrapper.find('[data-test-id="self-bypass"]').exists()).toBeFalsy();
+      },
+      load,
+      reload,
+      updateCache,
     });
 
-    it('should show self-bypass when unsafeSelfBypass is true', () => {
-      serverConfigStore.set({
-        config: {
-          ...serverConfigStore.get().config,
-          unsafeAllowSelfBypass: true,
-        },
-      });
-      const wrapper = component();
-      expect(
-        wrapper.find('[data-test-id="self-bypass"]').exists()
-      ).toBeTruthy();
+    const wrapper = component();
+    allExceptRas.forEach((module) => {
+      expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
+
+      expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
+      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
     });
 
-    it('should not show self-bypass UI when all clickable modules are complete', () => {
-      serverConfigStore.set({
-        config: {
-          ...serverConfigStore.get().config,
-          unsafeAllowSelfBypass: true,
+    // RAS is not complete
+    expect(
+      findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+    ).toBeTruthy();
+
+    expect(
+      findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+    ).toBeFalsy();
+    expect(
+      findIneligibleModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+    ).toBeFalsy();
+
+    expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
+
+    // now all required modules are complete
+
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessModules: {
+          modules: initialRequiredModules.map((module) => ({
+            moduleName: module,
+            completionEpochMillis: 1,
+          })),
         },
-      });
+      },
+      load,
+      reload,
+      updateCache,
+    });
+
+    await waitForFakeTimersAndUpdate(wrapper);
+
+    initialRequiredModules.forEach((module) => {
+      expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
+
+      expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
+      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+    });
+
+    expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
+  });
+
+  it('should render all required modules as complete when the profile accessModules are all bypassed', () => {
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessModules: {
+          modules: initialRequiredModules.map((module) => {
+            return { moduleName: module, bypassEpochMillis: 1 };
+          }),
+        },
+      },
+      load,
+      reload,
+      updateCache,
+    });
+
+    const wrapper = component();
+    initialRequiredModules.forEach((module) => {
+      expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
+
+      expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
+      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+    });
+    expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
+  });
+
+  it('should render a mix of complete and incomplete modules, as appropriate', () => {
+    const requiredModulesSize = initialRequiredModules.length;
+    const incompleteModules = [AccessModule.RASLINKLOGINGOV];
+    const completeModules = initialRequiredModules.filter(
+      (module) => module !== AccessModule.RASLINKLOGINGOV
+    );
+    const completeModulesSize = requiredModulesSize - incompleteModules.length;
+
+    // sanity check
+    expect(incompleteModules.length).toEqual(1);
+    expect(completeModules.length).toEqual(completeModulesSize);
+
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessModules: {
+          modules: completeModules.map((module) => {
+            return { moduleName: module, completionEpochMillis: 1 };
+          }),
+        },
+      },
+      load,
+      reload,
+      updateCache,
+    });
+
+    const wrapper = component();
+    incompleteModules.forEach((module) => {
+      expect(findIncompleteModule(wrapper, module).exists()).toBeTruthy();
+
+      expect(findCompleteModule(wrapper, module).exists()).toBeFalsy();
+      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+    });
+    completeModules.forEach((module) => {
+      expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
+
+      expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
+      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+    });
+    expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
+  });
+
+  it('should not show self-bypass UI when unsafeSelfBypass is false', () => {
+    serverConfigStore.set({
+      config: {
+        ...serverConfigStore.get().config,
+        unsafeAllowSelfBypass: false,
+      },
+    });
+    const wrapper = component();
+    expect(wrapper.find('[data-test-id="self-bypass"]').exists()).toBeFalsy();
+  });
+
+  it('should show self-bypass when unsafeSelfBypass is true', () => {
+    serverConfigStore.set({
+      config: {
+        ...serverConfigStore.get().config,
+        unsafeAllowSelfBypass: true,
+      },
+    });
+    const wrapper = component();
+    expect(wrapper.find('[data-test-id="self-bypass"]').exists()).toBeTruthy();
+  });
+
+  it('should not show self-bypass UI when all clickable modules are complete', () => {
+    serverConfigStore.set({
+      config: {
+        ...serverConfigStore.get().config,
+        unsafeAllowSelfBypass: true,
+      },
+    });
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessModules: {
+          modules: initialRequiredModules.map((module) => {
+            return { moduleName: module, completionEpochMillis: 1 };
+          }),
+        },
+      },
+      load,
+      reload,
+      updateCache,
+    });
+
+    const wrapper = component();
+    expect(wrapper.find('[data-test-id="self-bypass"]').exists()).toBeFalsy();
+  });
+
+  it('should show self-bypass UI when optional modules are still pending', () => {
+    serverConfigStore.set({
+      config: {
+        ...serverConfigStore.get().config,
+        unsafeAllowSelfBypass: true,
+      },
+    });
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessModules: {
+          modules: initialRequiredModules.map((module) => {
+            return { moduleName: module, completionEpochMillis: 1 };
+          }),
+        },
+        tierEligibilities: [
+          {
+            accessTierShortName: AccessTierShortNames.Controlled,
+            eraRequired: true,
+            eligible: true,
+          },
+          {
+            accessTierShortName: AccessTierShortNames.Registered,
+            eraRequired: false,
+            eligible: true,
+          },
+        ],
+      },
+      load,
+      reload,
+      updateCache,
+    });
+
+    const wrapper = component();
+    expect(wrapper.find('[data-test-id="self-bypass"]').exists()).toBeTruthy();
+  });
+
+  // regression tests for RW-7384: sync external modules to gain access
+
+  it('should sync incomplete external modules', async () => {
+    // profile contains no completed modules, so we sync all (2FA, ERA, Compliance)
+    const spy2FA = jest.spyOn(profileApi(), 'syncTwoFactorAuthStatus');
+    const spyERA = jest.spyOn(profileApi(), 'syncEraCommonsStatus');
+    const spyCompliance = jest.spyOn(
+      profileApi(),
+      'syncComplianceTrainingStatus'
+    );
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(spy2FA).toHaveBeenCalledTimes(1);
+    expect(spyERA).toHaveBeenCalledTimes(1);
+    expect(spyCompliance).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not sync complete external modules', async () => {
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessModules: {
+          modules: initialRequiredModules.map((module) => ({
+            moduleName: module,
+            completionEpochMillis: 1,
+          })),
+        },
+      },
+      load,
+      reload,
+      updateCache,
+    });
+
+    const spy2FA = jest.spyOn(profileApi(), 'syncTwoFactorAuthStatus');
+    const spyERA = jest.spyOn(profileApi(), 'syncEraCommonsStatus');
+    const spyCompliance = jest.spyOn(
+      profileApi(),
+      'syncComplianceTrainingStatus'
+    );
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(spy2FA).toHaveBeenCalledTimes(0);
+    expect(spyERA).toHaveBeenCalledTimes(0);
+    expect(spyCompliance).toHaveBeenCalledTimes(0);
+  });
+
+  it('Should not show Era Commons Module for Registered Tier if the institution does not require eRa', async () => {
+    let wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeTruthy();
+
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        tierEligibilities: [
+          {
+            accessTierShortName: AccessTierShortNames.Registered,
+            eraRequired: false,
+          },
+        ],
+      },
+      load,
+      reload,
+      updateCache,
+    });
+    wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeFalsy();
+
+    // Ignore eraRequired if the accessTier is Controlled
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        tierEligibilities: [
+          {
+            accessTierShortName: AccessTierShortNames.Registered,
+            eraRequired: true,
+          },
+          {
+            accessTierShortName: AccessTierShortNames.Controlled,
+            eraRequired: false,
+          },
+        ],
+      },
+      load,
+      reload,
+      updateCache,
+    });
+    wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeTruthy();
+  });
+
+  it('Should display Institution has signed agreement when the user has a Tier Eligibility object for CT', async () => {
+    let wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        tierEligibilities: [
+          {
+            accessTierShortName: AccessTierShortNames.Controlled,
+            eraRequired: true,
+          },
+        ],
+      },
+      load,
+      reload,
+      updateCache,
+    });
+    wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(findControlledSignedStepEligible(wrapper).exists()).toBeTruthy();
+    expect(findControlledSignedStepIneligible(wrapper).exists()).toBeFalsy();
+
+    // but this is not enough; the user needs to be made eligible by email as well
+    expect(
+      findEligibleText(findControlledTierCard(wrapper)).exists()
+    ).toBeFalsy();
+    expect(
+      findIneligibleText(findControlledTierCard(wrapper)).exists()
+    ).toBeTruthy();
+  });
+
+  it("Should not display Institution has signed agreement when the user doesn't have a Tier Eligibility object for CT", async () => {
+    let wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        tierEligibilities: [
+          {
+            accessTierShortName: AccessTierShortNames.Registered,
+            eraRequired: true,
+          },
+        ],
+      },
+      load,
+      reload,
+      updateCache,
+    });
+    wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(findControlledSignedStepEligible(wrapper).exists()).toBeFalsy();
+    expect(findControlledSignedStepIneligible(wrapper).exists()).toBeTruthy();
+
+    // but this is not enough; the user needs to be made eligible by email as well
+    expect(
+      findEligibleText(findControlledTierCard(wrapper)).exists()
+    ).toBeFalsy();
+    expect(
+      findIneligibleText(findControlledTierCard(wrapper)).exists()
+    ).toBeTruthy();
+  });
+
+  it("Should display Institution allows you to access CT when the user's CT Tier Eligibility object has eligible=true", async () => {
+    let wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        tierEligibilities: [
+          {
+            accessTierShortName: AccessTierShortNames.Controlled,
+            eraRequired: true,
+            eligible: true,
+          },
+        ],
+      },
+      load,
+      reload,
+      updateCache,
+    });
+    wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(findControlledUserEligible(wrapper).exists()).toBeTruthy();
+    expect(findControlledUserIneligible(wrapper).exists()).toBeFalsy();
+
+    expect(
+      findEligibleText(findControlledTierCard(wrapper)).exists()
+    ).toBeTruthy();
+    expect(
+      findIneligibleText(findControlledTierCard(wrapper)).exists()
+    ).toBeFalsy();
+  });
+
+  it("Should not display Institution allows you to access CT when the user's CT Tier Eligibility object has eligible=false", async () => {
+    let wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        tierEligibilities: [
+          {
+            accessTierShortName: AccessTierShortNames.Controlled,
+            eraRequired: true,
+            eligible: false,
+          },
+        ],
+      },
+      load,
+      reload,
+      updateCache,
+    });
+    wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(findControlledUserEligible(wrapper).exists()).toBeFalsy();
+    expect(findControlledUserIneligible(wrapper).exists()).toBeTruthy();
+
+    expect(
+      findEligibleText(findControlledTierCard(wrapper)).exists()
+    ).toBeFalsy();
+    expect(
+      findIneligibleText(findControlledTierCard(wrapper)).exists()
+    ).toBeTruthy();
+  });
+
+  it('Should not display Institution allows you to access CT when the user does not have a CT Tier Eligibility object', async () => {
+    let wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        // no CT eligibility object
+        tierEligibilities: [
+          {
+            accessTierShortName: AccessTierShortNames.Registered,
+            eraRequired: true,
+            eligible: false,
+          },
+        ],
+      },
+      load,
+      reload,
+      updateCache,
+    });
+    wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(findControlledUserEligible(wrapper).exists()).toBeFalsy();
+    expect(findControlledUserIneligible(wrapper).exists()).toBeTruthy();
+
+    expect(
+      findEligibleText(findControlledTierCard(wrapper)).exists()
+    ).toBeFalsy();
+    expect(
+      findIneligibleText(findControlledTierCard(wrapper)).exists()
+    ).toBeTruthy();
+  });
+
+  it('Should display the CT card when the environment has a Controlled Tier', async () => {
+    updateVisibleTiers([
+      AccessTierShortNames.Registered,
+      AccessTierShortNames.Controlled,
+    ]);
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(findControlledTierCard(wrapper).exists()).toBeTruthy();
+  });
+
+  it('Should not display the CT card when the environment does not have a Controlled Tier', async () => {
+    updateVisibleTiers([AccessTierShortNames.Registered]);
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(findControlledTierCard(wrapper).exists()).toBeFalsy();
+  });
+
+  it(
+    'Should display eraCommons module in CT card ' +
+      'when the user institution has signed agreement and CT requires eraCommons and RT does not',
+    async () => {
+      updateVisibleTiers([
+        AccessTierShortNames.Registered,
+        AccessTierShortNames.Controlled,
+      ]);
+      let wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+
       profileStore.set({
         profile: {
           ...ProfileStubVariables.PROFILE_STUB,
-          accessModules: {
-            modules: initialRequiredModules.map((module) => {
-              return { moduleName: module, completionEpochMillis: 1 };
-            }),
-          },
-        },
-        load,
-        reload,
-        updateCache,
-      });
-
-      const wrapper = component();
-      expect(wrapper.find('[data-test-id="self-bypass"]').exists()).toBeFalsy();
-    });
-
-    it('should show self-bypass UI when optional modules are still pending', () => {
-      serverConfigStore.set({
-        config: {
-          ...serverConfigStore.get().config,
-          unsafeAllowSelfBypass: true,
-        },
-      });
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          accessModules: {
-            modules: initialRequiredModules.map((module) => {
-              return { moduleName: module, completionEpochMillis: 1 };
-            }),
-          },
           tierEligibilities: [
             {
               accessTierShortName: AccessTierShortNames.Controlled,
@@ -480,6 +991,44 @@ describe('DataAccessRequirements', () => {
             {
               accessTierShortName: AccessTierShortNames.Registered,
               eraRequired: false,
+              eligible: false,
+            },
+          ],
+        },
+        load,
+        reload,
+        updateCache,
+      });
+      wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+      expect(
+        findModule(
+          findControlledTierCard(wrapper),
+          AccessModule.ERACOMMONS
+        ).exists()
+      ).toBeTruthy();
+    }
+  );
+
+  it(
+    'Should not display eraCommons module in CT card ' +
+      'when RT requires eraCommons',
+    async () => {
+      let wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+
+      profileStore.set({
+        profile: {
+          ...ProfileStubVariables.PROFILE_STUB,
+          tierEligibilities: [
+            {
+              accessTierShortName: AccessTierShortNames.Registered,
+              eraRequired: true,
+              eligible: false,
+            },
+            {
+              accessTierShortName: AccessTierShortNames.Controlled,
+              eraRequired: true,
               eligible: true,
             },
           ],
@@ -488,318 +1037,139 @@ describe('DataAccessRequirements', () => {
         reload,
         updateCache,
       });
-
-      const wrapper = component();
-      expect(
-        wrapper.find('[data-test-id="self-bypass"]').exists()
-      ).toBeTruthy();
-    });
-  });
-
-  describe('regression tests for RW-7384: sync external modules to gain access', () => {
-    it('should sync incomplete external modules', async () => {
-      // profile contains no completed modules, so we sync all (2FA, ERA, Compliance)
-      const spy2FA = jest.spyOn(profileApi(), 'syncTwoFactorAuthStatus');
-      const spyERA = jest.spyOn(profileApi(), 'syncEraCommonsStatus');
-      const spyCompliance = jest.spyOn(
-        profileApi(),
-        'syncComplianceTrainingStatus'
-      );
-
-      const wrapper = component();
+      wrapper = component();
       await waitOneTickAndUpdate(wrapper);
-
-      expect(spy2FA).toHaveBeenCalledTimes(1);
-      expect(spyERA).toHaveBeenCalledTimes(1);
-      expect(spyCompliance).toHaveBeenCalledTimes(1);
-    });
-
-    it('should not sync complete external modules', async () => {
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          accessModules: {
-            modules: initialRequiredModules.map((module) => ({
-              moduleName: module,
-              completionEpochMillis: 1,
-            })),
-          },
-        },
-        load,
-        reload,
-        updateCache,
-      });
-
-      const spy2FA = jest.spyOn(profileApi(), 'syncTwoFactorAuthStatus');
-      const spyERA = jest.spyOn(profileApi(), 'syncEraCommonsStatus');
-      const spyCompliance = jest.spyOn(
-        profileApi(),
-        'syncComplianceTrainingStatus'
-      );
-
-      const wrapper = component();
-      await waitOneTickAndUpdate(wrapper);
-
-      expect(spy2FA).toHaveBeenCalledTimes(0);
-      expect(spyERA).toHaveBeenCalledTimes(0);
-      expect(spyCompliance).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  describe('rendering appropriate components', () => {
-    it('should render all required modules by default (all FFs enabled)', () => {
-      const wrapper = component();
-      allInitialModules.forEach((module) =>
-        expect(findModule(wrapper, module).exists()).toBeTruthy()
-      );
-    });
-
-    it('should not render the ERA module when its feature flag is disabled', () => {
-      serverConfigStore.set({
-        config: { ...defaultServerConfig, enableEraCommons: false },
-      });
-      const wrapper = component();
-      expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeFalsy();
-    });
-
-    it('should not render the Compliance module when its feature flag is disabled', () => {
-      serverConfigStore.set({
-        config: { ...defaultServerConfig, enableComplianceTraining: false },
-      });
-      const wrapper = component();
       expect(
-        findModule(wrapper, AccessModule.COMPLIANCETRAINING).exists()
+        findModule(
+          findControlledTierCard(wrapper),
+          AccessModule.ERACOMMONS
+        ).exists()
       ).toBeFalsy();
-    });
+    }
+  );
 
-    // Temporary hack Sep 16: when enableRasLoginGovLinking is false, we DO show the module
-    // along with an Ineligible icon and some "technical difficulties" text
-    // and it never becomes an activeModule
-    it('should render the RAS module as ineligible when its feature flag is disabled', () => {
-      serverConfigStore.set({
-        config: {
-          ...defaultServerConfig,
-          enableRasLoginGovLinking: false,
-          enforceRasLoginGovLinking: false,
-        },
-      });
-      const wrapper = component();
-      expect(
-        findModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-      ).toBeTruthy();
-      expect(
-        findIneligibleModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-      ).toBeTruthy();
-
-      expect(
-        findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-      ).toBeFalsy();
-      expect(
-        findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-      ).toBeFalsy();
-    });
-
-    it('should render all required modules as incomplete when the profile accessModules are empty', () => {
-      const wrapper = component();
-      initialRequiredModules.forEach((module) => {
-        expect(findIncompleteModule(wrapper, module).exists()).toBeTruthy();
-
-        expect(findCompleteModule(wrapper, module).exists()).toBeFalsy();
-        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-      });
-      expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
-    });
-
-    it('should render all required modules as complete when the profile accessModules are all complete', () => {
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          accessModules: {
-            modules: initialRequiredModules.map((module) => ({
-              moduleName: module,
-              completionEpochMillis: 1,
-            })),
-          },
-        },
-        load,
-        reload,
-        updateCache,
-      });
-
-      const wrapper = component();
-      initialRequiredModules.forEach((module) => {
-        expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
-
-        expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
-        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-      });
-      expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
-    });
-
-    // RAS launch bug (no JIRA ticket)
-    it('should render all modules as complete by transitioning to all complete', async () => {
-      // this test is subject to flakiness using real timers
-      jest.useFakeTimers();
-
-      // initially, the user has completed all required modules except RAS (the standard case at RAS launch time)
-
-      const allExceptRas = initialRequiredModules.filter(
-        (m) => m !== AccessModule.RASLINKLOGINGOV
-      );
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          accessModules: {
-            modules: allExceptRas.map((module) => ({
-              moduleName: module,
-              completionEpochMillis: 1,
-            })),
-          },
-        },
-        load,
-        reload,
-        updateCache,
-      });
-
-      const wrapper = component();
-      allExceptRas.forEach((module) => {
-        expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
-
-        expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
-        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-      });
-
-      // RAS is not complete
-      expect(
-        findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-      ).toBeTruthy();
-
-      expect(
-        findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-      ).toBeFalsy();
-      expect(
-        findIneligibleModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-      ).toBeFalsy();
-
-      expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
-
-      // now all required modules are complete
-
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          accessModules: {
-            modules: initialRequiredModules.map((module) => ({
-              moduleName: module,
-              completionEpochMillis: 1,
-            })),
-          },
-        },
-        load,
-        reload,
-        updateCache,
-      });
-
-      await waitForFakeTimersAndUpdate(wrapper);
-
-      initialRequiredModules.forEach((module) => {
-        expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
-
-        expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
-        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-      });
-
-      expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
-    });
-
-    it('should render all required modules as complete when the profile accessModules are all bypassed', () => {
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          accessModules: {
-            modules: initialRequiredModules.map((module) => {
-              return { moduleName: module, bypassEpochMillis: 1 };
-            }),
-          },
-        },
-        load,
-        reload,
-        updateCache,
-      });
-
-      const wrapper = component();
-      initialRequiredModules.forEach((module) => {
-        expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
-
-        expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
-        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-      });
-      expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
-    });
-
-    it('should render a mix of complete and incomplete modules, as appropriate', () => {
-      const requiredModulesSize = initialRequiredModules.length;
-      const incompleteModules = [AccessModule.RASLINKLOGINGOV];
-      const completeModules = initialRequiredModules.filter(
-        (module) => module !== AccessModule.RASLINKLOGINGOV
-      );
-      const completeModulesSize =
-        requiredModulesSize - incompleteModules.length;
-
-      // sanity check
-      expect(incompleteModules.length).toEqual(1);
-      expect(completeModules.length).toEqual(completeModulesSize);
-
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          accessModules: {
-            modules: completeModules.map((module) => {
-              return { moduleName: module, completionEpochMillis: 1 };
-            }),
-          },
-        },
-        load,
-        reload,
-        updateCache,
-      });
-
-      const wrapper = component();
-      incompleteModules.forEach((module) => {
-        expect(findIncompleteModule(wrapper, module).exists()).toBeTruthy();
-
-        expect(findCompleteModule(wrapper, module).exists()).toBeFalsy();
-        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-      });
-      completeModules.forEach((module) => {
-        expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
-
-        expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
-        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-      });
-      expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
-    });
-
-    it('Should allow CT and DUCC to be simultaneously clickable', async () => {
+  it(
+    'Should not display eraCommons module in CT card ' +
+      "when user's institution has not signed CT Institution agreement",
+    async () => {
       let wrapper = component();
       await waitOneTickAndUpdate(wrapper);
 
       profileStore.set({
         profile: {
           ...ProfileStubVariables.PROFILE_STUB,
-          accessModules: {
-            modules: allInitialModules.map((moduleName) => {
-              if (
-                [
-                  AccessModule.CTCOMPLIANCETRAINING,
-                  AccessModule.DATAUSERCODEOFCONDUCT,
-                ].includes(moduleName)
-              ) {
-                return { moduleName };
-              }
-              return { moduleName, completionEpochMillis: 1 };
-            }),
-          },
+          // no CT eligibility object
+          tierEligibilities: [
+            {
+              accessTierShortName: AccessTierShortNames.Registered,
+              eraRequired: false,
+              eligible: false,
+            },
+          ],
+        },
+        load,
+        reload,
+        updateCache,
+      });
+      wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+      expect(
+        findModule(
+          findControlledTierCard(wrapper),
+          AccessModule.ERACOMMONS
+        ).exists()
+      ).toBeFalsy();
+    }
+  );
+
+  it(
+    'Should display ineligible CT Compliance Training module in CT card ' +
+      "when user's institution has not signed CT Institution agreement",
+    async () => {
+      let wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+
+      profileStore.set({
+        profile: {
+          ...ProfileStubVariables.PROFILE_STUB,
+          // no CT eligibility object
+          tierEligibilities: [
+            {
+              accessTierShortName: AccessTierShortNames.Registered,
+              eraRequired: false,
+              eligible: false,
+            },
+          ],
+        },
+        load,
+        reload,
+        updateCache,
+      });
+      wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+      expect(
+        findIneligibleModule(
+          findControlledTierCard(wrapper),
+          AccessModule.CTCOMPLIANCETRAINING
+        ).exists()
+      ).toBeTruthy();
+    }
+  );
+
+  it(
+    'Should display ineligible CT Compliance Training module in CT card ' +
+      'when user is not eligible for CT',
+    async () => {
+      let wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+
+      profileStore.set({
+        profile: {
+          ...ProfileStubVariables.PROFILE_STUB,
+          tierEligibilities: [
+            {
+              accessTierShortName: AccessTierShortNames.Registered,
+              eraRequired: false,
+              eligible: true,
+            },
+            {
+              accessTierShortName: AccessTierShortNames.Controlled,
+              eraRequired: false,
+              // User not eligible for CT i.e user email doesnt match
+              // Institution's Controlled Tier email list
+              eligible: false,
+            },
+          ],
+        },
+        load,
+        reload,
+        updateCache,
+      });
+      wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+      expect(
+        findIneligibleModule(
+          findControlledTierCard(wrapper),
+          AccessModule.CTCOMPLIANCETRAINING
+        ).exists()
+      ).toBeTruthy();
+    }
+  );
+
+  it(
+    'Should not display eraCommons module in CT card ' +
+      'when eraCommons is disabled via the environment config',
+    async () => {
+      serverConfigStore.set({
+        config: { ...defaultServerConfig, enableEraCommons: false },
+      });
+
+      let wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+
+      profileStore.set({
+        profile: {
+          ...ProfileStubVariables.PROFILE_STUB,
           tierEligibilities: [
             {
               accessTierShortName: AccessTierShortNames.Registered,
@@ -819,728 +1189,285 @@ describe('DataAccessRequirements', () => {
       });
       wrapper = component();
       await waitOneTickAndUpdate(wrapper);
-
-      // Both are clickable.
       expect(
-        findClickableModuleText(
-          wrapper,
-          AccessModule.CTCOMPLIANCETRAINING
-        ).exists()
-      ).toBeTruthy();
-      expect(
-        findClickableModuleText(
-          wrapper,
-          AccessModule.DATAUSERCODEOFCONDUCT
-        ).exists()
-      ).toBeTruthy();
-
-      // Only the first module is active.
-      expect(
-        findNextCtaForModule(
-          wrapper,
-          AccessModule.CTCOMPLIANCETRAINING
-        ).exists()
-      ).toBeTruthy();
-      expect(
-        findNextCtaForModule(
-          wrapper,
-          AccessModule.DATAUSERCODEOFCONDUCT
+        findModule(
+          findControlledTierCard(wrapper),
+          AccessModule.ERACOMMONS
         ).exists()
       ).toBeFalsy();
+    }
+  );
+
+  it('Should show the RAS help text component when it is incomplete', async () => {
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(
+      findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+    ).toBeFalsy();
+    expect(
+      findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+    ).toBeTruthy();
+
+    expect(findContactUs(wrapper).exists()).toBeTruthy();
+  });
+
+  it('Should not show the RAS help text component when it is complete', async () => {
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessModules: {
+          modules: [
+            {
+              moduleName: AccessModule.RASLINKLOGINGOV,
+              completionEpochMillis: 1,
+            },
+          ],
+        },
+      },
+      load,
+      reload,
+      updateCache,
     });
 
-    describe('Controlled Tier', () => {
-      it('Should display Institution has signed agreement when the user has a Tier Eligibility object for CT', async () => {
-        let wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
 
-        profileStore.set({
-          profile: {
-            ...ProfileStubVariables.PROFILE_STUB,
-            tierEligibilities: [
-              {
-                accessTierShortName: AccessTierShortNames.Controlled,
-                eraRequired: true,
-              },
-            ],
-          },
-          load,
-          reload,
-          updateCache,
-        });
-        wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expect(findControlledSignedStepEligible(wrapper).exists()).toBeTruthy();
-        expect(
-          findControlledSignedStepIneligible(wrapper).exists()
-        ).toBeFalsy();
+    expect(
+      findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+    ).toBeTruthy();
+    expect(
+      findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+    ).toBeFalsy();
 
-        // but this is not enough; the user needs to be made eligible by email as well
-        expect(
-          findEligibleText(findControlledTierCard(wrapper)).exists()
-        ).toBeFalsy();
-        expect(
-          findIneligibleText(findControlledTierCard(wrapper)).exists()
-        ).toBeTruthy();
+    expect(findContactUs(wrapper).exists()).toBeFalsy();
+  });
+
+  it(
+    'Should not display ct Compliance Training module in CT card ' +
+      'when enableComplianceTraining is false',
+    async () => {
+      serverConfigStore.set({
+        config: { ...defaultServerConfig, enableComplianceTraining: false },
       });
 
-      it("Should not display Institution has signed agreement when the user doesn't have a Tier Eligibility object for CT", async () => {
-        let wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
+      let wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
 
-        profileStore.set({
-          profile: {
-            ...ProfileStubVariables.PROFILE_STUB,
-            tierEligibilities: [
-              {
-                accessTierShortName: AccessTierShortNames.Registered,
-                eraRequired: true,
-              },
-            ],
-          },
-          load,
-          reload,
-          updateCache,
-        });
-        wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expect(findControlledSignedStepEligible(wrapper).exists()).toBeFalsy();
-        expect(
-          findControlledSignedStepIneligible(wrapper).exists()
-        ).toBeTruthy();
-
-        // but this is not enough; the user needs to be made eligible by email as well
-        expect(
-          findEligibleText(findControlledTierCard(wrapper)).exists()
-        ).toBeFalsy();
-        expect(
-          findIneligibleText(findControlledTierCard(wrapper)).exists()
-        ).toBeTruthy();
-      });
-
-      it("Should display Institution allows you to access CT when the user's CT Tier Eligibility object has eligible=true", async () => {
-        let wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-
-        profileStore.set({
-          profile: {
-            ...ProfileStubVariables.PROFILE_STUB,
-            tierEligibilities: [
-              {
-                accessTierShortName: AccessTierShortNames.Controlled,
-                eraRequired: true,
-                eligible: true,
-              },
-            ],
-          },
-          load,
-          reload,
-          updateCache,
-        });
-        wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expect(findControlledUserEligible(wrapper).exists()).toBeTruthy();
-        expect(findControlledUserIneligible(wrapper).exists()).toBeFalsy();
-
-        expect(
-          findEligibleText(findControlledTierCard(wrapper)).exists()
-        ).toBeTruthy();
-        expect(
-          findIneligibleText(findControlledTierCard(wrapper)).exists()
-        ).toBeFalsy();
-      });
-
-      it("Should not display Institution allows you to access CT when the user's CT Tier Eligibility object has eligible=false", async () => {
-        let wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-
-        profileStore.set({
-          profile: {
-            ...ProfileStubVariables.PROFILE_STUB,
-            tierEligibilities: [
-              {
-                accessTierShortName: AccessTierShortNames.Controlled,
-                eraRequired: true,
-                eligible: false,
-              },
-            ],
-          },
-          load,
-          reload,
-          updateCache,
-        });
-        wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expect(findControlledUserEligible(wrapper).exists()).toBeFalsy();
-        expect(findControlledUserIneligible(wrapper).exists()).toBeTruthy();
-
-        expect(
-          findEligibleText(findControlledTierCard(wrapper)).exists()
-        ).toBeFalsy();
-        expect(
-          findIneligibleText(findControlledTierCard(wrapper)).exists()
-        ).toBeTruthy();
-      });
-
-      it('Should not display Institution allows you to access CT when the user does not have a CT Tier Eligibility object', async () => {
-        let wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-
-        profileStore.set({
-          profile: {
-            ...ProfileStubVariables.PROFILE_STUB,
-            // no CT eligibility object
-            tierEligibilities: [
-              {
-                accessTierShortName: AccessTierShortNames.Registered,
-                eraRequired: true,
-                eligible: false,
-              },
-            ],
-          },
-          load,
-          reload,
-          updateCache,
-        });
-        wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expect(findControlledUserEligible(wrapper).exists()).toBeFalsy();
-        expect(findControlledUserIneligible(wrapper).exists()).toBeTruthy();
-
-        expect(
-          findEligibleText(findControlledTierCard(wrapper)).exists()
-        ).toBeFalsy();
-        expect(
-          findIneligibleText(findControlledTierCard(wrapper)).exists()
-        ).toBeTruthy();
-      });
-
-      it('Should display the CT card when the environment has a Controlled Tier', async () => {
-        updateVisibleTiers([
-          AccessTierShortNames.Registered,
-          AccessTierShortNames.Controlled,
-        ]);
-
-        const wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expect(findControlledTierCard(wrapper).exists()).toBeTruthy();
-      });
-
-      it('Should not display the CT card when the environment does not have a Controlled Tier', async () => {
-        updateVisibleTiers([AccessTierShortNames.Registered]);
-
-        const wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expect(findControlledTierCard(wrapper).exists()).toBeFalsy();
-      });
-
-      it(
-        'Should display eraCommons module in CT card ' +
-          'when the user institution has signed agreement and CT requires eraCommons and RT does not',
-        async () => {
-          updateVisibleTiers([
-            AccessTierShortNames.Registered,
-            AccessTierShortNames.Controlled,
-          ]);
-          let wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-
-          profileStore.set({
-            profile: {
-              ...ProfileStubVariables.PROFILE_STUB,
-              tierEligibilities: [
-                {
-                  accessTierShortName: AccessTierShortNames.Controlled,
-                  eraRequired: true,
-                  eligible: true,
-                },
-                {
-                  accessTierShortName: AccessTierShortNames.Registered,
-                  eraRequired: false,
-                  eligible: false,
-                },
-              ],
+      profileStore.set({
+        profile: {
+          ...ProfileStubVariables.PROFILE_STUB,
+          tierEligibilities: [
+            {
+              accessTierShortName: AccessTierShortNames.Registered,
+              eraRequired: false,
+              eligible: false,
             },
-            load,
-            reload,
-            updateCache,
-          });
-          wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-          expect(
-            findModule(
-              findControlledTierCard(wrapper),
-              AccessModule.ERACOMMONS
-            ).exists()
-          ).toBeTruthy();
-        }
-      );
-
-      it(
-        'Should not display eraCommons module in CT card ' +
-          "when user's institution has not signed CT Institution agreement",
-        async () => {
-          let wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-
-          profileStore.set({
-            profile: {
-              ...ProfileStubVariables.PROFILE_STUB,
-              // no CT eligibility object
-              tierEligibilities: [
-                {
-                  accessTierShortName: AccessTierShortNames.Registered,
-                  eraRequired: false,
-                  eligible: false,
-                },
-              ],
+            {
+              accessTierShortName: AccessTierShortNames.Controlled,
+              eraRequired: true,
+              eligible: true,
             },
-            load,
-            reload,
-            updateCache,
-          });
-          wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-          expect(
-            findModule(
-              findControlledTierCard(wrapper),
-              AccessModule.ERACOMMONS
-            ).exists()
-          ).toBeFalsy();
-        }
-      );
-
-      it(
-        'Should display ineligible CT Compliance Training module in CT card ' +
-          "when user's institution has not signed CT Institution agreement",
-        async () => {
-          let wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-
-          profileStore.set({
-            profile: {
-              ...ProfileStubVariables.PROFILE_STUB,
-              // no CT eligibility object
-              tierEligibilities: [
-                {
-                  accessTierShortName: AccessTierShortNames.Registered,
-                  eraRequired: false,
-                  eligible: false,
-                },
-              ],
-            },
-            load,
-            reload,
-            updateCache,
-          });
-          wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-          expect(
-            findIneligibleModule(
-              findControlledTierCard(wrapper),
-              AccessModule.CTCOMPLIANCETRAINING
-            ).exists()
-          ).toBeTruthy();
-        }
-      );
-
-      it(
-        'Should display ineligible CT Compliance Training module in CT card ' +
-          'when user is not eligible for CT',
-        async () => {
-          let wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-
-          profileStore.set({
-            profile: {
-              ...ProfileStubVariables.PROFILE_STUB,
-              tierEligibilities: [
-                {
-                  accessTierShortName: AccessTierShortNames.Registered,
-                  eraRequired: false,
-                  eligible: true,
-                },
-                {
-                  accessTierShortName: AccessTierShortNames.Controlled,
-                  eraRequired: false,
-                  // User not eligible for CT i.e user email doesnt match
-                  // Institution's Controlled Tier email list
-                  eligible: false,
-                },
-              ],
-            },
-            load,
-            reload,
-            updateCache,
-          });
-          wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-          expect(
-            findIneligibleModule(
-              findControlledTierCard(wrapper),
-              AccessModule.CTCOMPLIANCETRAINING
-            ).exists()
-          ).toBeTruthy();
-        }
-      );
-
-      it(
-        'Should not display eraCommons module in CT card ' +
-          'when RT requires eraCommons',
-        async () => {
-          let wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-
-          profileStore.set({
-            profile: {
-              ...ProfileStubVariables.PROFILE_STUB,
-              tierEligibilities: [
-                {
-                  accessTierShortName: AccessTierShortNames.Registered,
-                  eraRequired: true,
-                  eligible: false,
-                },
-                {
-                  accessTierShortName: AccessTierShortNames.Controlled,
-                  eraRequired: true,
-                  eligible: true,
-                },
-              ],
-            },
-            load,
-            reload,
-            updateCache,
-          });
-          wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-          expect(
-            findModule(
-              findControlledTierCard(wrapper),
-              AccessModule.ERACOMMONS
-            ).exists()
-          ).toBeFalsy();
-        }
-      );
-
-      it(
-        'Should not display eraCommons module in CT card ' +
-          'when eraCommons is disabled via the environment config',
-        async () => {
-          serverConfigStore.set({
-            config: { ...defaultServerConfig, enableEraCommons: false },
-          });
-
-          let wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-
-          profileStore.set({
-            profile: {
-              ...ProfileStubVariables.PROFILE_STUB,
-              tierEligibilities: [
-                {
-                  accessTierShortName: AccessTierShortNames.Registered,
-                  eraRequired: false,
-                  eligible: false,
-                },
-                {
-                  accessTierShortName: AccessTierShortNames.Controlled,
-                  eraRequired: true,
-                  eligible: true,
-                },
-              ],
-            },
-            load,
-            reload,
-            updateCache,
-          });
-          wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-          expect(
-            findModule(
-              findControlledTierCard(wrapper),
-              AccessModule.ERACOMMONS
-            ).exists()
-          ).toBeFalsy();
-        }
-      );
-
-      it(
-        'Should not display ct Compliance Training module in CT card ' +
-          'when enableComplianceTraining is false',
-        async () => {
-          serverConfigStore.set({
-            config: { ...defaultServerConfig, enableComplianceTraining: false },
-          });
-
-          let wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-
-          profileStore.set({
-            profile: {
-              ...ProfileStubVariables.PROFILE_STUB,
-              tierEligibilities: [
-                {
-                  accessTierShortName: AccessTierShortNames.Registered,
-                  eraRequired: false,
-                  eligible: false,
-                },
-                {
-                  accessTierShortName: AccessTierShortNames.Controlled,
-                  eraRequired: true,
-                  eligible: true,
-                },
-              ],
-            },
-            load,
-            reload,
-            updateCache,
-          });
-          wrapper = component();
-          await waitOneTickAndUpdate(wrapper);
-          expect(
-            findModule(
-              findControlledTierCard(wrapper),
-              AccessModule.CTCOMPLIANCETRAINING
-            ).exists()
-          ).toBeFalsy();
-        }
-      );
-
-      it('Should display CT training when ineligible', async () => {
-        let wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-
-        profileStore.set({
-          profile: {
-            ...ProfileStubVariables.PROFILE_STUB,
-            tierEligibilities: [
-              {
-                accessTierShortName: AccessTierShortNames.Registered,
-                eraRequired: false,
-                eligible: false,
-              },
-              {
-                accessTierShortName: AccessTierShortNames.Controlled,
-                eraRequired: true,
-                eligible: false,
-              },
-            ],
-          },
-          load,
-          reload,
-          updateCache,
-        });
-        wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expect(
-          findIneligibleModule(
-            wrapper,
-            AccessModule.CTCOMPLIANCETRAINING
-          ).exists()
-        ).toBeTruthy();
+          ],
+        },
+        load,
+        reload,
+        updateCache,
       });
+      wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+      expect(
+        findModule(
+          findControlledTierCard(wrapper),
+          AccessModule.CTCOMPLIANCETRAINING
+        ).exists()
+      ).toBeFalsy();
+    }
+  );
 
-      it('Should display CT training when no institutional DUA', async () => {
-        let wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
+  it('Should display CT training when ineligible', async () => {
+    let wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
 
-        profileStore.set({
-          profile: {
-            ...ProfileStubVariables.PROFILE_STUB,
-            tierEligibilities: [
-              {
-                accessTierShortName: AccessTierShortNames.Registered,
-                eraRequired: false,
-                eligible: false,
-              },
-            ],
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        tierEligibilities: [
+          {
+            accessTierShortName: AccessTierShortNames.Registered,
+            eraRequired: false,
+            eligible: false,
           },
-          load,
-          reload,
-          updateCache,
-        });
-        wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expect(
-          findIneligibleModule(
-            wrapper,
-            AccessModule.CTCOMPLIANCETRAINING
-          ).exists()
-        ).toBeTruthy();
-      });
-
-      it('Should display CT training when eligible', async () => {
-        let wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-
-        profileStore.set({
-          profile: {
-            ...ProfileStubVariables.PROFILE_STUB,
-            tierEligibilities: [
-              {
-                accessTierShortName: AccessTierShortNames.Registered,
-                eraRequired: false,
-                eligible: false,
-              },
-              {
-                accessTierShortName: AccessTierShortNames.Controlled,
-                eraRequired: true,
-                eligible: true,
-              },
-            ],
+          {
+            accessTierShortName: AccessTierShortNames.Controlled,
+            eraRequired: true,
+            eligible: false,
           },
-          load,
-          reload,
-          updateCache,
-        });
-        wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expect(
-          findIncompleteModule(
-            wrapper,
-            AccessModule.CTCOMPLIANCETRAINING
-          ).exists()
-        ).toBeTruthy();
-      });
+        ],
+      },
+      load,
+      reload,
+      updateCache,
     });
+    wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(
+      findIneligibleModule(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()
+    ).toBeTruthy();
+  });
 
-    describe('Registered Tier', () => {
-      it('Should not show Era Commons Module for Registered Tier if the institution does not require eRa', async () => {
-        let wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expect(
-          findModule(wrapper, AccessModule.ERACOMMONS).exists()
-        ).toBeTruthy();
+  it('Should display CT training when no institutional DUA', async () => {
+    let wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
 
-        profileStore.set({
-          profile: {
-            ...ProfileStubVariables.PROFILE_STUB,
-            tierEligibilities: [
-              {
-                accessTierShortName: AccessTierShortNames.Registered,
-                eraRequired: false,
-              },
-            ],
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        tierEligibilities: [
+          {
+            accessTierShortName: AccessTierShortNames.Registered,
+            eraRequired: false,
+            eligible: false,
           },
-          load,
-          reload,
-          updateCache,
-        });
-        wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expect(
-          findModule(wrapper, AccessModule.ERACOMMONS).exists()
-        ).toBeFalsy();
+        ],
+      },
+      load,
+      reload,
+      updateCache,
+    });
+    wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(
+      findIneligibleModule(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()
+    ).toBeTruthy();
+  });
 
-        // Ignore eraRequired if the accessTier is Controlled
-        profileStore.set({
-          profile: {
-            ...ProfileStubVariables.PROFILE_STUB,
-            tierEligibilities: [
-              {
-                accessTierShortName: AccessTierShortNames.Registered,
-                eraRequired: true,
-              },
-              {
-                accessTierShortName: AccessTierShortNames.Controlled,
-                eraRequired: false,
-              },
-            ],
+  it('Should display CT training when eligible', async () => {
+    let wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        tierEligibilities: [
+          {
+            accessTierShortName: AccessTierShortNames.Registered,
+            eraRequired: false,
+            eligible: false,
           },
-          load,
-          reload,
-          updateCache,
-        });
-        wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expect(
-          findModule(wrapper, AccessModule.ERACOMMONS).exists()
-        ).toBeTruthy();
-      });
-    });
-
-    describe('RAS Help Text', () => {
-      it('Should show the RAS help text component when it is incomplete', async () => {
-        const wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-
-        expect(
-          findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-        ).toBeFalsy();
-        expect(
-          findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-        ).toBeTruthy();
-
-        expect(findContactUs(wrapper).exists()).toBeTruthy();
-      });
-
-      it('Should not show the RAS help text component when it is complete', async () => {
-        profileStore.set({
-          profile: {
-            ...ProfileStubVariables.PROFILE_STUB,
-            accessModules: {
-              modules: [
-                {
-                  moduleName: AccessModule.RASLINKLOGINGOV,
-                  completionEpochMillis: 1,
-                },
-              ],
-            },
+          {
+            accessTierShortName: AccessTierShortNames.Controlled,
+            eraRequired: true,
+            eligible: true,
           },
-          load,
-          reload,
-          updateCache,
-        });
-
-        const wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-
-        expect(
-          findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-        ).toBeTruthy();
-        expect(
-          findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-        ).toBeFalsy();
-
-        expect(findContactUs(wrapper).exists()).toBeFalsy();
-      });
+        ],
+      },
+      load,
+      reload,
+      updateCache,
     });
+    wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expect(
+      findIncompleteModule(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()
+    ).toBeTruthy();
+  });
 
-    describe('Testing which mode the component renders in', () => {
-      it('Should render in INITIAL_REGISTRATION mode by default (mergedAccessRenewal is true)', async () => {
-        environment.mergedAccessRenewal = true;
-        const wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
-      });
+  it('Should allow CT and DUCC to be simultaneously clickable', async () => {
+    let wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
 
-      it('Should render in INITIAL_REGISTRATION mode by default (mergedAccessRenewal is false)', async () => {
-        environment.mergedAccessRenewal = false;
-        const wrapper = component();
-        await waitOneTickAndUpdate(wrapper);
-        expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
-      });
-
-      it('Should render in ANNUAL_RENEWAL mode when specified by query param', async () => {
-        environment.mergedAccessRenewal = true;
-        const wrapper = component(DARPageMode.ANNUAL_RENEWAL);
-        await waitOneTickAndUpdate(wrapper);
-        expectPageMode(wrapper, DARPageMode.ANNUAL_RENEWAL);
-      });
-
-      it('Should not render in ANNUAL_RENEWAL mode if mergedAccessRenewal is false', async () => {
-        environment.mergedAccessRenewal = false;
-        const wrapper = component(DARPageMode.ANNUAL_RENEWAL);
-        await waitOneTickAndUpdate(wrapper);
-        expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
-      });
-
-      it('Should render in INITIAL_REGISTRATION mode if the queryParam is invalid', async () => {
-        environment.mergedAccessRenewal = true;
-        const wrapper = component('some-garbage');
-        await waitOneTickAndUpdate(wrapper);
-        expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
-      });
+    profileStore.set({
+      profile: {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessModules: {
+          modules: allInitialModules.map((moduleName) => {
+            if (
+              [
+                AccessModule.CTCOMPLIANCETRAINING,
+                AccessModule.DATAUSERCODEOFCONDUCT,
+              ].includes(moduleName)
+            ) {
+              return { moduleName };
+            }
+            return { moduleName, completionEpochMillis: 1 };
+          }),
+        },
+        tierEligibilities: [
+          {
+            accessTierShortName: AccessTierShortNames.Registered,
+            eraRequired: false,
+            eligible: false,
+          },
+          {
+            accessTierShortName: AccessTierShortNames.Controlled,
+            eraRequired: true,
+            eligible: true,
+          },
+        ],
+      },
+      load,
+      reload,
+      updateCache,
     });
+    wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    // Both are clickable.
+    expect(
+      findClickableModuleText(
+        wrapper,
+        AccessModule.CTCOMPLIANCETRAINING
+      ).exists()
+    ).toBeTruthy();
+    expect(
+      findClickableModuleText(
+        wrapper,
+        AccessModule.DATAUSERCODEOFCONDUCT
+      ).exists()
+    ).toBeTruthy();
+
+    // Only the first module is active.
+    expect(
+      findNextCtaForModule(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()
+    ).toBeTruthy();
+    expect(
+      findNextCtaForModule(wrapper, AccessModule.DATAUSERCODEOFCONDUCT).exists()
+    ).toBeFalsy();
+  });
+
+  it('Should render in INITIAL_REGISTRATION mode by default (mergedAccessRenewal is true)', async () => {
+    environment.mergedAccessRenewal = true;
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
+  });
+
+  it('Should render in INITIAL_REGISTRATION mode by default (mergedAccessRenewal is false)', async () => {
+    environment.mergedAccessRenewal = false;
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+    expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
+  });
+
+  it('Should render in ANNUAL_RENEWAL mode when specified by query param', async () => {
+    environment.mergedAccessRenewal = true;
+    const wrapper = component(DARPageMode.ANNUAL_RENEWAL);
+    await waitOneTickAndUpdate(wrapper);
+    expectPageMode(wrapper, DARPageMode.ANNUAL_RENEWAL);
+  });
+
+  it('Should not render in ANNUAL_RENEWAL mode if mergedAccessRenewal is false', async () => {
+    environment.mergedAccessRenewal = false;
+    const wrapper = component(DARPageMode.ANNUAL_RENEWAL);
+    await waitOneTickAndUpdate(wrapper);
+    expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
+  });
+
+  it('Should render in INITIAL_REGISTRATION mode if the queryParam is invalid', async () => {
+    environment.mergedAccessRenewal = true;
+    const wrapper = component('some-garbage');
+    await waitOneTickAndUpdate(wrapper);
+    expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
   });
 });

--- a/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.spec.tsx
@@ -142,116 +142,15 @@ describe('DataAccessRequirements', () => {
     jest.useRealTimers();
   });
 
-  it('should return all required modules from getEligibleModules by default (all FFs enabled)', () => {
-    const enabledModules = getEligibleModules(allInitialModules, profile);
-    initialRequiredModules.forEach((module) =>
-      expect(enabledModules.includes(module)).toBeTruthy()
-    );
-  });
-
-  it('should not return the RAS module from getEligibleModules when its feature flag is disabled', () => {
-    serverConfigStore.set({
-      config: {
-        ...defaultServerConfig,
-        enableRasLoginGovLinking: false,
-        enforceRasLoginGovLinking: false,
-      },
-    });
-    const enabledModules = getEligibleModules(allInitialModules, profile);
-    expect(enabledModules.includes(AccessModule.RASLINKLOGINGOV)).toBeFalsy();
-  });
-
-  it(
-    'should return the RAS module from getEligibleModules when ' +
-      'enforceRasLoginGovLinking is enabled, enableRasLoginGovLinking is not',
-    () => {
-      serverConfigStore.set({
-        config: {
-          ...defaultServerConfig,
-          enableRasLoginGovLinking: false,
-          enforceRasLoginGovLinking: true,
-        },
-      });
+  describe('getEligibleModules', () => {
+    it('should return all required modules from getEligibleModules by default (all FFs enabled)', () => {
       const enabledModules = getEligibleModules(allInitialModules, profile);
-      expect(
-        enabledModules.includes(AccessModule.RASLINKLOGINGOV)
-      ).toBeTruthy();
-    }
-  );
-
-  it('should not return the ERA module from getEligibleModules when its feature flag is disabled', () => {
-    serverConfigStore.set({
-      config: { ...defaultServerConfig, enableEraCommons: false },
+      initialRequiredModules.forEach((module) =>
+        expect(enabledModules.includes(module)).toBeTruthy()
+      );
     });
-    const enabledModules = getEligibleModules(allInitialModules, profile);
-    expect(enabledModules.includes(AccessModule.ERACOMMONS)).toBeFalsy();
-  });
 
-  it('should not return the Compliance module from getEligibleModules when its feature flag is disabled', () => {
-    serverConfigStore.set({
-      config: { ...defaultServerConfig, enableComplianceTraining: false },
-    });
-    const enabledModules = getEligibleModules(allInitialModules, profile);
-    expect(
-      enabledModules.includes(AccessModule.COMPLIANCETRAINING)
-    ).toBeFalsy();
-  });
-
-  it('should return the first module (2FA) from getActiveModule when no modules have been completed', () => {
-    const enabledModules = getEligibleModules(initialRequiredModules, profile);
-    const activeModule = getActiveModule(enabledModules, profile);
-
-    expect(activeModule).toEqual(initialRequiredModules[0]);
-    expect(activeModule).toEqual(enabledModules[0]);
-
-    // update this if the order changes
-    expect(activeModule).toEqual(AccessModule.TWOFACTORAUTH);
-  });
-
-  it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been completed', () => {
-    const testProfile = {
-      ...profile,
-      accessModules: {
-        modules: [
-          { moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1 },
-        ],
-      },
-    };
-
-    const enabledModules = getEligibleModules(initialRequiredModules, profile);
-    const activeModule = getActiveModule(enabledModules, testProfile);
-
-    expect(activeModule).toEqual(initialRequiredModules[1]);
-    expect(activeModule).toEqual(enabledModules[1]);
-
-    // update this if the order changes
-    expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
-  });
-
-  it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been bypassed', () => {
-    const testProfile = {
-      ...profile,
-      accessModules: {
-        modules: [
-          { moduleName: AccessModule.TWOFACTORAUTH, bypassEpochMillis: 1 },
-        ],
-      },
-    };
-
-    const enabledModules = getEligibleModules(initialRequiredModules, profile);
-    const activeModule = getActiveModule(enabledModules, testProfile);
-
-    expect(activeModule).toEqual(initialRequiredModules[1]);
-    expect(activeModule).toEqual(enabledModules[1]);
-
-    // update this if the order changes
-    expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
-  });
-
-  it(
-    'should return the second enabled module (ERA, not RAS) from getActiveModule' +
-      ' when the first module (2FA) has been completed and RAS is disabled',
-    () => {
+    it('should not return the RAS module from getEligibleModules when its feature flag is disabled', () => {
       serverConfigStore.set({
         config: {
           ...defaultServerConfig,
@@ -259,7 +158,63 @@ describe('DataAccessRequirements', () => {
           enforceRasLoginGovLinking: false,
         },
       });
+      const enabledModules = getEligibleModules(allInitialModules, profile);
+      expect(enabledModules.includes(AccessModule.RASLINKLOGINGOV)).toBeFalsy();
+    });
 
+    it(
+      'should return the RAS module from getEligibleModules when ' +
+        'enforceRasLoginGovLinking is enabled, enableRasLoginGovLinking is not',
+      () => {
+        serverConfigStore.set({
+          config: {
+            ...defaultServerConfig,
+            enableRasLoginGovLinking: false,
+            enforceRasLoginGovLinking: true,
+          },
+        });
+        const enabledModules = getEligibleModules(allInitialModules, profile);
+        expect(
+          enabledModules.includes(AccessModule.RASLINKLOGINGOV)
+        ).toBeTruthy();
+      }
+    );
+
+    it('should not return the ERA module from getEligibleModules when its feature flag is disabled', () => {
+      serverConfigStore.set({
+        config: { ...defaultServerConfig, enableEraCommons: false },
+      });
+      const enabledModules = getEligibleModules(allInitialModules, profile);
+      expect(enabledModules.includes(AccessModule.ERACOMMONS)).toBeFalsy();
+    });
+
+    it('should not return the Compliance module from getEligibleModules when its feature flag is disabled', () => {
+      serverConfigStore.set({
+        config: { ...defaultServerConfig, enableComplianceTraining: false },
+      });
+      const enabledModules = getEligibleModules(allInitialModules, profile);
+      expect(
+        enabledModules.includes(AccessModule.COMPLIANCETRAINING)
+      ).toBeFalsy();
+    });
+  });
+
+  describe('getActiveModule', () => {
+    it('should return the first module (2FA) from getActiveModule when no modules have been completed', () => {
+      const enabledModules = getEligibleModules(
+        initialRequiredModules,
+        profile
+      );
+      const activeModule = getActiveModule(enabledModules, profile);
+
+      expect(activeModule).toEqual(initialRequiredModules[0]);
+      expect(activeModule).toEqual(enabledModules[0]);
+
+      // update this if the order changes
+      expect(activeModule).toEqual(AccessModule.TWOFACTORAUTH);
+    });
+
+    it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been completed', () => {
       const testProfile = {
         ...profile,
         accessModules: {
@@ -278,985 +233,573 @@ describe('DataAccessRequirements', () => {
       );
       const activeModule = getActiveModule(enabledModules, testProfile);
 
-      // update this if the order changes
-      expect(activeModule).toEqual(AccessModule.ERACOMMONS);
-
-      // 2FA (module 0) is complete, so enabled #1 is active
+      expect(activeModule).toEqual(initialRequiredModules[1]);
       expect(activeModule).toEqual(enabledModules[1]);
 
-      // but we skip requiredModules[1] because it's RAS and is not enabled
-      expect(activeModule).toEqual(initialRequiredModules[2]);
-    }
-  );
-
-  it('should return the fourth module (Compliance) from getActiveModule when the first 3 modules have been completed', () => {
-    const testProfile = {
-      ...profile,
-      accessModules: {
-        modules: [
-          { moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1 },
-          { moduleName: AccessModule.ERACOMMONS, completionEpochMillis: 1 },
-          {
-            moduleName: AccessModule.RASLINKLOGINGOV,
-            completionEpochMillis: 1,
-          },
-        ],
-      },
-    };
-
-    const enabledModules = getEligibleModules(initialRequiredModules, profile);
-    const activeModule = getActiveModule(enabledModules, testProfile);
-
-    expect(activeModule).toEqual(initialRequiredModules[3]);
-    expect(activeModule).toEqual(enabledModules[3]);
-
-    // update this if the order changes
-    expect(activeModule).toEqual(AccessModule.COMPLIANCETRAINING);
-  });
-
-  it('should return undefined from getActiveModule when all modules have been completed', () => {
-    const testProfile = {
-      ...profile,
-      accessModules: {
-        modules: initialRequiredModules.map((module) => ({
-          moduleName: module,
-          completionEpochMillis: 1,
-        })),
-      },
-    };
-
-    const enabledModules = getEligibleModules(initialRequiredModules, profile);
-    const activeModule = getActiveModule(enabledModules, testProfile);
-
-    expect(activeModule).toBeUndefined();
-  });
-
-  it('should not indicate the RAS module as active when a user has completed it', () => {
-    // initially, the user has completed all required modules except RAS (the standard case at RAS launch time)
-    const testProfile = {
-      ...profile,
-      accessModules: {
-        modules: [
-          { moduleName: AccessModule.TWOFACTORAUTH, completionEpochMillis: 1 },
-          { moduleName: AccessModule.ERACOMMONS, completionEpochMillis: 1 },
-          {
-            moduleName: AccessModule.COMPLIANCETRAINING,
-            completionEpochMillis: 1,
-          },
-          {
-            moduleName: AccessModule.DATAUSERCODEOFCONDUCT,
-            completionEpochMillis: 1,
-          },
-        ],
-      },
-    };
-
-    const enabledModules = getEligibleModules(initialRequiredModules, profile);
-
-    let activeModule = getActiveModule(enabledModules, testProfile);
-    expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
-
-    // simulate handleRasCallback() by updating the profile
-
-    const updatedProfile = {
-      ...testProfile,
-      accessModules: {
-        modules: [
-          ...testProfile.accessModules.modules,
-          {
-            moduleName: AccessModule.RASLINKLOGINGOV,
-            completionEpochMillis: 1,
-          },
-        ],
-      },
-    };
-
-    activeModule = getActiveModule(enabledModules, updatedProfile);
-    expect(activeModule).toBeUndefined();
-  });
-
-  it('should render all required modules by default (all FFs enabled)', () => {
-    const wrapper = component();
-    allInitialModules.forEach((module) =>
-      expect(findModule(wrapper, module).exists()).toBeTruthy()
-    );
-  });
-
-  it('should not render the ERA module when its feature flag is disabled', () => {
-    serverConfigStore.set({
-      config: { ...defaultServerConfig, enableEraCommons: false },
-    });
-    const wrapper = component();
-    expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeFalsy();
-  });
-
-  it('should not render the Compliance module when its feature flag is disabled', () => {
-    serverConfigStore.set({
-      config: { ...defaultServerConfig, enableComplianceTraining: false },
-    });
-    const wrapper = component();
-    expect(
-      findModule(wrapper, AccessModule.COMPLIANCETRAINING).exists()
-    ).toBeFalsy();
-  });
-
-  // Temporary hack Sep 16: when enableRasLoginGovLinking is false, we DO show the module
-  // along with an Ineligible icon and some "technical difficulties" text
-  // and it never becomes an activeModule
-  it('should render the RAS module as ineligible when its feature flag is disabled', () => {
-    serverConfigStore.set({
-      config: {
-        ...defaultServerConfig,
-        enableRasLoginGovLinking: false,
-        enforceRasLoginGovLinking: false,
-      },
-    });
-    const wrapper = component();
-    expect(
-      findModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-    ).toBeTruthy();
-    expect(
-      findIneligibleModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-    ).toBeTruthy();
-
-    expect(
-      findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-    ).toBeFalsy();
-    expect(
-      findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-    ).toBeFalsy();
-  });
-
-  it('should render all required modules as incomplete when the profile accessModules are empty', () => {
-    const wrapper = component();
-    initialRequiredModules.forEach((module) => {
-      expect(findIncompleteModule(wrapper, module).exists()).toBeTruthy();
-
-      expect(findCompleteModule(wrapper, module).exists()).toBeFalsy();
-      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-    });
-    expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
-  });
-
-  it('should render all required modules as complete when the profile accessModules are all complete', () => {
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        accessModules: {
-          modules: initialRequiredModules.map((module) => ({
-            moduleName: module,
-            completionEpochMillis: 1,
-          })),
-        },
-      },
-      load,
-      reload,
-      updateCache,
+      // update this if the order changes
+      expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
     });
 
-    const wrapper = component();
-    initialRequiredModules.forEach((module) => {
-      expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
-
-      expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
-      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-    });
-    expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
-  });
-
-  // RAS launch bug (no JIRA ticket)
-  it('should render all modules as complete by transitioning to all complete', async () => {
-    // this test is subject to flakiness using real timers
-    jest.useFakeTimers();
-
-    // initially, the user has completed all required modules except RAS (the standard case at RAS launch time)
-
-    const allExceptRas = initialRequiredModules.filter(
-      (m) => m !== AccessModule.RASLINKLOGINGOV
-    );
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        accessModules: {
-          modules: allExceptRas.map((module) => ({
-            moduleName: module,
-            completionEpochMillis: 1,
-          })),
-        },
-      },
-      load,
-      reload,
-      updateCache,
-    });
-
-    const wrapper = component();
-    allExceptRas.forEach((module) => {
-      expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
-
-      expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
-      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-    });
-
-    // RAS is not complete
-    expect(
-      findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-    ).toBeTruthy();
-
-    expect(
-      findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-    ).toBeFalsy();
-    expect(
-      findIneligibleModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-    ).toBeFalsy();
-
-    expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
-
-    // now all required modules are complete
-
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        accessModules: {
-          modules: initialRequiredModules.map((module) => ({
-            moduleName: module,
-            completionEpochMillis: 1,
-          })),
-        },
-      },
-      load,
-      reload,
-      updateCache,
-    });
-
-    await waitForFakeTimersAndUpdate(wrapper);
-
-    initialRequiredModules.forEach((module) => {
-      expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
-
-      expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
-      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-    });
-
-    expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
-  });
-
-  it('should render all required modules as complete when the profile accessModules are all bypassed', () => {
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        accessModules: {
-          modules: initialRequiredModules.map((module) => {
-            return { moduleName: module, bypassEpochMillis: 1 };
-          }),
-        },
-      },
-      load,
-      reload,
-      updateCache,
-    });
-
-    const wrapper = component();
-    initialRequiredModules.forEach((module) => {
-      expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
-
-      expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
-      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-    });
-    expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
-  });
-
-  it('should render a mix of complete and incomplete modules, as appropriate', () => {
-    const requiredModulesSize = initialRequiredModules.length;
-    const incompleteModules = [AccessModule.RASLINKLOGINGOV];
-    const completeModules = initialRequiredModules.filter(
-      (module) => module !== AccessModule.RASLINKLOGINGOV
-    );
-    const completeModulesSize = requiredModulesSize - incompleteModules.length;
-
-    // sanity check
-    expect(incompleteModules.length).toEqual(1);
-    expect(completeModules.length).toEqual(completeModulesSize);
-
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        accessModules: {
-          modules: completeModules.map((module) => {
-            return { moduleName: module, completionEpochMillis: 1 };
-          }),
-        },
-      },
-      load,
-      reload,
-      updateCache,
-    });
-
-    const wrapper = component();
-    incompleteModules.forEach((module) => {
-      expect(findIncompleteModule(wrapper, module).exists()).toBeTruthy();
-
-      expect(findCompleteModule(wrapper, module).exists()).toBeFalsy();
-      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-    });
-    completeModules.forEach((module) => {
-      expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
-
-      expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
-      expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
-    });
-    expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
-  });
-
-  it('should not show self-bypass UI when unsafeSelfBypass is false', () => {
-    serverConfigStore.set({
-      config: {
-        ...serverConfigStore.get().config,
-        unsafeAllowSelfBypass: false,
-      },
-    });
-    const wrapper = component();
-    expect(wrapper.find('[data-test-id="self-bypass"]').exists()).toBeFalsy();
-  });
-
-  it('should show self-bypass when unsafeSelfBypass is true', () => {
-    serverConfigStore.set({
-      config: {
-        ...serverConfigStore.get().config,
-        unsafeAllowSelfBypass: true,
-      },
-    });
-    const wrapper = component();
-    expect(wrapper.find('[data-test-id="self-bypass"]').exists()).toBeTruthy();
-  });
-
-  it('should not show self-bypass UI when all clickable modules are complete', () => {
-    serverConfigStore.set({
-      config: {
-        ...serverConfigStore.get().config,
-        unsafeAllowSelfBypass: true,
-      },
-    });
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        accessModules: {
-          modules: initialRequiredModules.map((module) => {
-            return { moduleName: module, completionEpochMillis: 1 };
-          }),
-        },
-      },
-      load,
-      reload,
-      updateCache,
-    });
-
-    const wrapper = component();
-    expect(wrapper.find('[data-test-id="self-bypass"]').exists()).toBeFalsy();
-  });
-
-  it('should show self-bypass UI when optional modules are still pending', () => {
-    serverConfigStore.set({
-      config: {
-        ...serverConfigStore.get().config,
-        unsafeAllowSelfBypass: true,
-      },
-    });
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        accessModules: {
-          modules: initialRequiredModules.map((module) => {
-            return { moduleName: module, completionEpochMillis: 1 };
-          }),
-        },
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
-            eligible: true,
-          },
-          {
-            accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
-            eligible: true,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
-    });
-
-    const wrapper = component();
-    expect(wrapper.find('[data-test-id="self-bypass"]').exists()).toBeTruthy();
-  });
-
-  // regression tests for RW-7384: sync external modules to gain access
-
-  it('should sync incomplete external modules', async () => {
-    // profile contains no completed modules, so we sync all (2FA, ERA, Compliance)
-    const spy2FA = jest.spyOn(profileApi(), 'syncTwoFactorAuthStatus');
-    const spyERA = jest.spyOn(profileApi(), 'syncEraCommonsStatus');
-    const spyCompliance = jest.spyOn(
-      profileApi(),
-      'syncComplianceTrainingStatus'
-    );
-
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(spy2FA).toHaveBeenCalledTimes(1);
-    expect(spyERA).toHaveBeenCalledTimes(1);
-    expect(spyCompliance).toHaveBeenCalledTimes(1);
-  });
-
-  it('should not sync complete external modules', async () => {
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        accessModules: {
-          modules: initialRequiredModules.map((module) => ({
-            moduleName: module,
-            completionEpochMillis: 1,
-          })),
-        },
-      },
-      load,
-      reload,
-      updateCache,
-    });
-
-    const spy2FA = jest.spyOn(profileApi(), 'syncTwoFactorAuthStatus');
-    const spyERA = jest.spyOn(profileApi(), 'syncEraCommonsStatus');
-    const spyCompliance = jest.spyOn(
-      profileApi(),
-      'syncComplianceTrainingStatus'
-    );
-
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(spy2FA).toHaveBeenCalledTimes(0);
-    expect(spyERA).toHaveBeenCalledTimes(0);
-    expect(spyCompliance).toHaveBeenCalledTimes(0);
-  });
-
-  it('Should not show Era Commons Module for Registered Tier if the institution does not require eRa', async () => {
-    let wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeTruthy();
-
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
-    });
-    wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeFalsy();
-
-    // Ignore eraRequired if the accessTier is Controlled
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: true,
-          },
-          {
-            accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: false,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
-    });
-    wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeTruthy();
-  });
-
-  it('Should display Institution has signed agreement when the user has a Tier Eligibility object for CT', async () => {
-    let wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
-    });
-    wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(findControlledSignedStepEligible(wrapper).exists()).toBeTruthy();
-    expect(findControlledSignedStepIneligible(wrapper).exists()).toBeFalsy();
-
-    // but this is not enough; the user needs to be made eligible by email as well
-    expect(
-      findEligibleText(findControlledTierCard(wrapper)).exists()
-    ).toBeFalsy();
-    expect(
-      findIneligibleText(findControlledTierCard(wrapper)).exists()
-    ).toBeTruthy();
-  });
-
-  it("Should not display Institution has signed agreement when the user doesn't have a Tier Eligibility object for CT", async () => {
-    let wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: true,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
-    });
-    wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(findControlledSignedStepEligible(wrapper).exists()).toBeFalsy();
-    expect(findControlledSignedStepIneligible(wrapper).exists()).toBeTruthy();
-
-    // but this is not enough; the user needs to be made eligible by email as well
-    expect(
-      findEligibleText(findControlledTierCard(wrapper)).exists()
-    ).toBeFalsy();
-    expect(
-      findIneligibleText(findControlledTierCard(wrapper)).exists()
-    ).toBeTruthy();
-  });
-
-  it("Should display Institution allows you to access CT when the user's CT Tier Eligibility object has eligible=true", async () => {
-    let wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
-            eligible: true,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
-    });
-    wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(findControlledUserEligible(wrapper).exists()).toBeTruthy();
-    expect(findControlledUserIneligible(wrapper).exists()).toBeFalsy();
-
-    expect(
-      findEligibleText(findControlledTierCard(wrapper)).exists()
-    ).toBeTruthy();
-    expect(
-      findIneligibleText(findControlledTierCard(wrapper)).exists()
-    ).toBeFalsy();
-  });
-
-  it("Should not display Institution allows you to access CT when the user's CT Tier Eligibility object has eligible=false", async () => {
-    let wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
-            eligible: false,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
-    });
-    wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(findControlledUserEligible(wrapper).exists()).toBeFalsy();
-    expect(findControlledUserIneligible(wrapper).exists()).toBeTruthy();
-
-    expect(
-      findEligibleText(findControlledTierCard(wrapper)).exists()
-    ).toBeFalsy();
-    expect(
-      findIneligibleText(findControlledTierCard(wrapper)).exists()
-    ).toBeTruthy();
-  });
-
-  it('Should not display Institution allows you to access CT when the user does not have a CT Tier Eligibility object', async () => {
-    let wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        // no CT eligibility object
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: true,
-            eligible: false,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
-    });
-    wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(findControlledUserEligible(wrapper).exists()).toBeFalsy();
-    expect(findControlledUserIneligible(wrapper).exists()).toBeTruthy();
-
-    expect(
-      findEligibleText(findControlledTierCard(wrapper)).exists()
-    ).toBeFalsy();
-    expect(
-      findIneligibleText(findControlledTierCard(wrapper)).exists()
-    ).toBeTruthy();
-  });
-
-  it('Should display the CT card when the environment has a Controlled Tier', async () => {
-    updateVisibleTiers([
-      AccessTierShortNames.Registered,
-      AccessTierShortNames.Controlled,
-    ]);
-
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(findControlledTierCard(wrapper).exists()).toBeTruthy();
-  });
-
-  it('Should not display the CT card when the environment does not have a Controlled Tier', async () => {
-    updateVisibleTiers([AccessTierShortNames.Registered]);
-
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(findControlledTierCard(wrapper).exists()).toBeFalsy();
-  });
-
-  it(
-    'Should display eraCommons module in CT card ' +
-      'when the user institution has signed agreement and CT requires eraCommons and RT does not',
-    async () => {
-      updateVisibleTiers([
-        AccessTierShortNames.Registered,
-        AccessTierShortNames.Controlled,
-      ]);
-      let wrapper = component();
-      await waitOneTickAndUpdate(wrapper);
-
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          tierEligibilities: [
-            {
-              accessTierShortName: AccessTierShortNames.Controlled,
-              eraRequired: true,
-              eligible: true,
-            },
-            {
-              accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: false,
-              eligible: false,
-            },
-          ],
-        },
-        load,
-        reload,
-        updateCache,
-      });
-      wrapper = component();
-      await waitOneTickAndUpdate(wrapper);
-      expect(
-        findModule(
-          findControlledTierCard(wrapper),
-          AccessModule.ERACOMMONS
-        ).exists()
-      ).toBeTruthy();
-    }
-  );
-
-  it(
-    'Should not display eraCommons module in CT card ' +
-      'when RT requires eraCommons',
-    async () => {
-      let wrapper = component();
-      await waitOneTickAndUpdate(wrapper);
-
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          tierEligibilities: [
-            {
-              accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: true,
-              eligible: false,
-            },
-            {
-              accessTierShortName: AccessTierShortNames.Controlled,
-              eraRequired: true,
-              eligible: true,
-            },
-          ],
-        },
-        load,
-        reload,
-        updateCache,
-      });
-      wrapper = component();
-      await waitOneTickAndUpdate(wrapper);
-      expect(
-        findModule(
-          findControlledTierCard(wrapper),
-          AccessModule.ERACOMMONS
-        ).exists()
-      ).toBeFalsy();
-    }
-  );
-
-  it(
-    'Should not display eraCommons module in CT card ' +
-      "when user's institution has not signed CT Institution agreement",
-    async () => {
-      let wrapper = component();
-      await waitOneTickAndUpdate(wrapper);
-
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          // no CT eligibility object
-          tierEligibilities: [
-            {
-              accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: false,
-              eligible: false,
-            },
-          ],
-        },
-        load,
-        reload,
-        updateCache,
-      });
-      wrapper = component();
-      await waitOneTickAndUpdate(wrapper);
-      expect(
-        findModule(
-          findControlledTierCard(wrapper),
-          AccessModule.ERACOMMONS
-        ).exists()
-      ).toBeFalsy();
-    }
-  );
-
-  it(
-    'Should display ineligible CT Compliance Training module in CT card ' +
-      "when user's institution has not signed CT Institution agreement",
-    async () => {
-      let wrapper = component();
-      await waitOneTickAndUpdate(wrapper);
-
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          // no CT eligibility object
-          tierEligibilities: [
-            {
-              accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: false,
-              eligible: false,
-            },
-          ],
-        },
-        load,
-        reload,
-        updateCache,
-      });
-      wrapper = component();
-      await waitOneTickAndUpdate(wrapper);
-      expect(
-        findIneligibleModule(
-          findControlledTierCard(wrapper),
-          AccessModule.CTCOMPLIANCETRAINING
-        ).exists()
-      ).toBeTruthy();
-    }
-  );
-
-  it(
-    'Should display ineligible CT Compliance Training module in CT card ' +
-      'when user is not eligible for CT',
-    async () => {
-      let wrapper = component();
-      await waitOneTickAndUpdate(wrapper);
-
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          tierEligibilities: [
-            {
-              accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: false,
-              eligible: true,
-            },
-            {
-              accessTierShortName: AccessTierShortNames.Controlled,
-              eraRequired: false,
-              // User not eligible for CT i.e user email doesnt match
-              // Institution's Controlled Tier email list
-              eligible: false,
-            },
-          ],
-        },
-        load,
-        reload,
-        updateCache,
-      });
-      wrapper = component();
-      await waitOneTickAndUpdate(wrapper);
-      expect(
-        findIneligibleModule(
-          findControlledTierCard(wrapper),
-          AccessModule.CTCOMPLIANCETRAINING
-        ).exists()
-      ).toBeTruthy();
-    }
-  );
-
-  it(
-    'Should not display eraCommons module in CT card ' +
-      'when eraCommons is disabled via the environment config',
-    async () => {
-      serverConfigStore.set({
-        config: { ...defaultServerConfig, enableEraCommons: false },
-      });
-
-      let wrapper = component();
-      await waitOneTickAndUpdate(wrapper);
-
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          tierEligibilities: [
-            {
-              accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: false,
-              eligible: false,
-            },
-            {
-              accessTierShortName: AccessTierShortNames.Controlled,
-              eraRequired: true,
-              eligible: true,
-            },
-          ],
-        },
-        load,
-        reload,
-        updateCache,
-      });
-      wrapper = component();
-      await waitOneTickAndUpdate(wrapper);
-      expect(
-        findModule(
-          findControlledTierCard(wrapper),
-          AccessModule.ERACOMMONS
-        ).exists()
-      ).toBeFalsy();
-    }
-  );
-
-  it('Should show the RAS help text component when it is incomplete', async () => {
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(
-      findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-    ).toBeFalsy();
-    expect(
-      findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-    ).toBeTruthy();
-
-    expect(findContactUs(wrapper).exists()).toBeTruthy();
-  });
-
-  it('Should not show the RAS help text component when it is complete', async () => {
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
+    it('should return the second module (RAS) from getActiveModule when the first module (2FA) has been bypassed', () => {
+      const testProfile = {
+        ...profile,
         accessModules: {
           modules: [
+            { moduleName: AccessModule.TWOFACTORAUTH, bypassEpochMillis: 1 },
+          ],
+        },
+      };
+
+      const enabledModules = getEligibleModules(
+        initialRequiredModules,
+        profile
+      );
+      const activeModule = getActiveModule(enabledModules, testProfile);
+
+      expect(activeModule).toEqual(initialRequiredModules[1]);
+      expect(activeModule).toEqual(enabledModules[1]);
+
+      // update this if the order changes
+      expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
+    });
+
+    it(
+      'should return the second enabled module (ERA, not RAS) from getActiveModule' +
+        ' when the first module (2FA) has been completed and RAS is disabled',
+      () => {
+        serverConfigStore.set({
+          config: {
+            ...defaultServerConfig,
+            enableRasLoginGovLinking: false,
+            enforceRasLoginGovLinking: false,
+          },
+        });
+
+        const testProfile = {
+          ...profile,
+          accessModules: {
+            modules: [
+              {
+                moduleName: AccessModule.TWOFACTORAUTH,
+                completionEpochMillis: 1,
+              },
+            ],
+          },
+        };
+
+        const enabledModules = getEligibleModules(
+          initialRequiredModules,
+          profile
+        );
+        const activeModule = getActiveModule(enabledModules, testProfile);
+
+        // update this if the order changes
+        expect(activeModule).toEqual(AccessModule.ERACOMMONS);
+
+        // 2FA (module 0) is complete, so enabled #1 is active
+        expect(activeModule).toEqual(enabledModules[1]);
+
+        // but we skip requiredModules[1] because it's RAS and is not enabled
+        expect(activeModule).toEqual(initialRequiredModules[2]);
+      }
+    );
+
+    it('should return the fourth module (Compliance) from getActiveModule when the first 3 modules have been completed', () => {
+      const testProfile = {
+        ...profile,
+        accessModules: {
+          modules: [
+            {
+              moduleName: AccessModule.TWOFACTORAUTH,
+              completionEpochMillis: 1,
+            },
+            { moduleName: AccessModule.ERACOMMONS, completionEpochMillis: 1 },
             {
               moduleName: AccessModule.RASLINKLOGINGOV,
               completionEpochMillis: 1,
             },
           ],
         },
-      },
-      load,
-      reload,
-      updateCache,
+      };
+
+      const enabledModules = getEligibleModules(
+        initialRequiredModules,
+        profile
+      );
+      const activeModule = getActiveModule(enabledModules, testProfile);
+
+      expect(activeModule).toEqual(initialRequiredModules[3]);
+      expect(activeModule).toEqual(enabledModules[3]);
+
+      // update this if the order changes
+      expect(activeModule).toEqual(AccessModule.COMPLIANCETRAINING);
     });
 
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
+    it('should return undefined from getActiveModule when all modules have been completed', () => {
+      const testProfile = {
+        ...profile,
+        accessModules: {
+          modules: initialRequiredModules.map((module) => ({
+            moduleName: module,
+            completionEpochMillis: 1,
+          })),
+        },
+      };
 
-    expect(
-      findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-    ).toBeTruthy();
-    expect(
-      findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
-    ).toBeFalsy();
+      const enabledModules = getEligibleModules(
+        initialRequiredModules,
+        profile
+      );
+      const activeModule = getActiveModule(enabledModules, testProfile);
 
-    expect(findContactUs(wrapper).exists()).toBeFalsy();
+      expect(activeModule).toBeUndefined();
+    });
+
+    it('should not indicate the RAS module as active when a user has completed it', () => {
+      // initially, the user has completed all required modules except RAS (the standard case at RAS launch time)
+      const testProfile = {
+        ...profile,
+        accessModules: {
+          modules: [
+            {
+              moduleName: AccessModule.TWOFACTORAUTH,
+              completionEpochMillis: 1,
+            },
+            { moduleName: AccessModule.ERACOMMONS, completionEpochMillis: 1 },
+            {
+              moduleName: AccessModule.COMPLIANCETRAINING,
+              completionEpochMillis: 1,
+            },
+            {
+              moduleName: AccessModule.DATAUSERCODEOFCONDUCT,
+              completionEpochMillis: 1,
+            },
+          ],
+        },
+      };
+
+      const enabledModules = getEligibleModules(
+        initialRequiredModules,
+        profile
+      );
+
+      let activeModule = getActiveModule(enabledModules, testProfile);
+      expect(activeModule).toEqual(AccessModule.RASLINKLOGINGOV);
+
+      // simulate handleRasCallback() by updating the profile
+
+      const updatedProfile = {
+        ...testProfile,
+        accessModules: {
+          modules: [
+            ...testProfile.accessModules.modules,
+            {
+              moduleName: AccessModule.RASLINKLOGINGOV,
+              completionEpochMillis: 1,
+            },
+          ],
+        },
+      };
+
+      activeModule = getActiveModule(enabledModules, updatedProfile);
+      expect(activeModule).toBeUndefined();
+    });
   });
 
-  it(
-    'Should not display ct Compliance Training module in CT card ' +
-      'when enableComplianceTraining is false',
-    async () => {
+  describe('bypass functionality', () => {
+    it('should not show self-bypass UI when unsafeSelfBypass is false', () => {
+      serverConfigStore.set({
+        config: {
+          ...serverConfigStore.get().config,
+          unsafeAllowSelfBypass: false,
+        },
+      });
+      const wrapper = component();
+      expect(wrapper.find('[data-test-id="self-bypass"]').exists()).toBeFalsy();
+    });
+
+    it('should show self-bypass when unsafeSelfBypass is true', () => {
+      serverConfigStore.set({
+        config: {
+          ...serverConfigStore.get().config,
+          unsafeAllowSelfBypass: true,
+        },
+      });
+      const wrapper = component();
+      expect(
+        wrapper.find('[data-test-id="self-bypass"]').exists()
+      ).toBeTruthy();
+    });
+
+    it('should not show self-bypass UI when all clickable modules are complete', () => {
+      serverConfigStore.set({
+        config: {
+          ...serverConfigStore.get().config,
+          unsafeAllowSelfBypass: true,
+        },
+      });
+      profileStore.set({
+        profile: {
+          ...ProfileStubVariables.PROFILE_STUB,
+          accessModules: {
+            modules: initialRequiredModules.map((module) => {
+              return { moduleName: module, completionEpochMillis: 1 };
+            }),
+          },
+        },
+        load,
+        reload,
+        updateCache,
+      });
+
+      const wrapper = component();
+      expect(wrapper.find('[data-test-id="self-bypass"]').exists()).toBeFalsy();
+    });
+
+    it('should show self-bypass UI when optional modules are still pending', () => {
+      serverConfigStore.set({
+        config: {
+          ...serverConfigStore.get().config,
+          unsafeAllowSelfBypass: true,
+        },
+      });
+      profileStore.set({
+        profile: {
+          ...ProfileStubVariables.PROFILE_STUB,
+          accessModules: {
+            modules: initialRequiredModules.map((module) => {
+              return { moduleName: module, completionEpochMillis: 1 };
+            }),
+          },
+          tierEligibilities: [
+            {
+              accessTierShortName: AccessTierShortNames.Controlled,
+              eraRequired: true,
+              eligible: true,
+            },
+            {
+              accessTierShortName: AccessTierShortNames.Registered,
+              eraRequired: false,
+              eligible: true,
+            },
+          ],
+        },
+        load,
+        reload,
+        updateCache,
+      });
+
+      const wrapper = component();
+      expect(
+        wrapper.find('[data-test-id="self-bypass"]').exists()
+      ).toBeTruthy();
+    });
+  });
+
+  describe('regression tests for RW-7384: sync external modules to gain access', () => {
+    it('should sync incomplete external modules', async () => {
+      // profile contains no completed modules, so we sync all (2FA, ERA, Compliance)
+      const spy2FA = jest.spyOn(profileApi(), 'syncTwoFactorAuthStatus');
+      const spyERA = jest.spyOn(profileApi(), 'syncEraCommonsStatus');
+      const spyCompliance = jest.spyOn(
+        profileApi(),
+        'syncComplianceTrainingStatus'
+      );
+
+      const wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+
+      expect(spy2FA).toHaveBeenCalledTimes(1);
+      expect(spyERA).toHaveBeenCalledTimes(1);
+      expect(spyCompliance).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not sync complete external modules', async () => {
+      profileStore.set({
+        profile: {
+          ...ProfileStubVariables.PROFILE_STUB,
+          accessModules: {
+            modules: initialRequiredModules.map((module) => ({
+              moduleName: module,
+              completionEpochMillis: 1,
+            })),
+          },
+        },
+        load,
+        reload,
+        updateCache,
+      });
+
+      const spy2FA = jest.spyOn(profileApi(), 'syncTwoFactorAuthStatus');
+      const spyERA = jest.spyOn(profileApi(), 'syncEraCommonsStatus');
+      const spyCompliance = jest.spyOn(
+        profileApi(),
+        'syncComplianceTrainingStatus'
+      );
+
+      const wrapper = component();
+      await waitOneTickAndUpdate(wrapper);
+
+      expect(spy2FA).toHaveBeenCalledTimes(0);
+      expect(spyERA).toHaveBeenCalledTimes(0);
+      expect(spyCompliance).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('rendering appropriate components', () => {
+    it('should render all required modules by default (all FFs enabled)', () => {
+      const wrapper = component();
+      allInitialModules.forEach((module) =>
+        expect(findModule(wrapper, module).exists()).toBeTruthy()
+      );
+    });
+
+    it('should not render the ERA module when its feature flag is disabled', () => {
+      serverConfigStore.set({
+        config: { ...defaultServerConfig, enableEraCommons: false },
+      });
+      const wrapper = component();
+      expect(findModule(wrapper, AccessModule.ERACOMMONS).exists()).toBeFalsy();
+    });
+
+    it('should not render the Compliance module when its feature flag is disabled', () => {
       serverConfigStore.set({
         config: { ...defaultServerConfig, enableComplianceTraining: false },
       });
+      const wrapper = component();
+      expect(
+        findModule(wrapper, AccessModule.COMPLIANCETRAINING).exists()
+      ).toBeFalsy();
+    });
 
+    // Temporary hack Sep 16: when enableRasLoginGovLinking is false, we DO show the module
+    // along with an Ineligible icon and some "technical difficulties" text
+    // and it never becomes an activeModule
+    it('should render the RAS module as ineligible when its feature flag is disabled', () => {
+      serverConfigStore.set({
+        config: {
+          ...defaultServerConfig,
+          enableRasLoginGovLinking: false,
+          enforceRasLoginGovLinking: false,
+        },
+      });
+      const wrapper = component();
+      expect(
+        findModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      ).toBeTruthy();
+      expect(
+        findIneligibleModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      ).toBeTruthy();
+
+      expect(
+        findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      ).toBeFalsy();
+      expect(
+        findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      ).toBeFalsy();
+    });
+
+    it('should render all required modules as incomplete when the profile accessModules are empty', () => {
+      const wrapper = component();
+      initialRequiredModules.forEach((module) => {
+        expect(findIncompleteModule(wrapper, module).exists()).toBeTruthy();
+
+        expect(findCompleteModule(wrapper, module).exists()).toBeFalsy();
+        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+      });
+      expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
+    });
+
+    it('should render all required modules as complete when the profile accessModules are all complete', () => {
+      profileStore.set({
+        profile: {
+          ...ProfileStubVariables.PROFILE_STUB,
+          accessModules: {
+            modules: initialRequiredModules.map((module) => ({
+              moduleName: module,
+              completionEpochMillis: 1,
+            })),
+          },
+        },
+        load,
+        reload,
+        updateCache,
+      });
+
+      const wrapper = component();
+      initialRequiredModules.forEach((module) => {
+        expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
+
+        expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
+        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+      });
+      expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
+    });
+
+    // RAS launch bug (no JIRA ticket)
+    it('should render all modules as complete by transitioning to all complete', async () => {
+      // this test is subject to flakiness using real timers
+      jest.useFakeTimers();
+
+      // initially, the user has completed all required modules except RAS (the standard case at RAS launch time)
+
+      const allExceptRas = initialRequiredModules.filter(
+        (m) => m !== AccessModule.RASLINKLOGINGOV
+      );
+      profileStore.set({
+        profile: {
+          ...ProfileStubVariables.PROFILE_STUB,
+          accessModules: {
+            modules: allExceptRas.map((module) => ({
+              moduleName: module,
+              completionEpochMillis: 1,
+            })),
+          },
+        },
+        load,
+        reload,
+        updateCache,
+      });
+
+      const wrapper = component();
+      allExceptRas.forEach((module) => {
+        expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
+
+        expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
+        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+      });
+
+      // RAS is not complete
+      expect(
+        findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      ).toBeTruthy();
+
+      expect(
+        findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      ).toBeFalsy();
+      expect(
+        findIneligibleModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+      ).toBeFalsy();
+
+      expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
+
+      // now all required modules are complete
+
+      profileStore.set({
+        profile: {
+          ...ProfileStubVariables.PROFILE_STUB,
+          accessModules: {
+            modules: initialRequiredModules.map((module) => ({
+              moduleName: module,
+              completionEpochMillis: 1,
+            })),
+          },
+        },
+        load,
+        reload,
+        updateCache,
+      });
+
+      await waitForFakeTimersAndUpdate(wrapper);
+
+      initialRequiredModules.forEach((module) => {
+        expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
+
+        expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
+        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+      });
+
+      expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
+    });
+
+    it('should render all required modules as complete when the profile accessModules are all bypassed', () => {
+      profileStore.set({
+        profile: {
+          ...ProfileStubVariables.PROFILE_STUB,
+          accessModules: {
+            modules: initialRequiredModules.map((module) => {
+              return { moduleName: module, bypassEpochMillis: 1 };
+            }),
+          },
+        },
+        load,
+        reload,
+        updateCache,
+      });
+
+      const wrapper = component();
+      initialRequiredModules.forEach((module) => {
+        expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
+
+        expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
+        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+      });
+      expect(findCompletionBanner(wrapper).exists()).toBeTruthy();
+    });
+
+    it('should render a mix of complete and incomplete modules, as appropriate', () => {
+      const requiredModulesSize = initialRequiredModules.length;
+      const incompleteModules = [AccessModule.RASLINKLOGINGOV];
+      const completeModules = initialRequiredModules.filter(
+        (module) => module !== AccessModule.RASLINKLOGINGOV
+      );
+      const completeModulesSize =
+        requiredModulesSize - incompleteModules.length;
+
+      // sanity check
+      expect(incompleteModules.length).toEqual(1);
+      expect(completeModules.length).toEqual(completeModulesSize);
+
+      profileStore.set({
+        profile: {
+          ...ProfileStubVariables.PROFILE_STUB,
+          accessModules: {
+            modules: completeModules.map((module) => {
+              return { moduleName: module, completionEpochMillis: 1 };
+            }),
+          },
+        },
+        load,
+        reload,
+        updateCache,
+      });
+
+      const wrapper = component();
+      incompleteModules.forEach((module) => {
+        expect(findIncompleteModule(wrapper, module).exists()).toBeTruthy();
+
+        expect(findCompleteModule(wrapper, module).exists()).toBeFalsy();
+        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+      });
+      completeModules.forEach((module) => {
+        expect(findCompleteModule(wrapper, module).exists()).toBeTruthy();
+
+        expect(findIncompleteModule(wrapper, module).exists()).toBeFalsy();
+        expect(findIneligibleModule(wrapper, module).exists()).toBeFalsy();
+      });
+      expect(findCompletionBanner(wrapper).exists()).toBeFalsy();
+    });
+
+    it('Should allow CT and DUCC to be simultaneously clickable', async () => {
       let wrapper = component();
       await waitOneTickAndUpdate(wrapper);
 
       profileStore.set({
         profile: {
           ...ProfileStubVariables.PROFILE_STUB,
+          accessModules: {
+            modules: allInitialModules.map((moduleName) => {
+              if (
+                [
+                  AccessModule.CTCOMPLIANCETRAINING,
+                  AccessModule.DATAUSERCODEOFCONDUCT,
+                ].includes(moduleName)
+              ) {
+                return { moduleName };
+              }
+              return { moduleName, completionEpochMillis: 1 };
+            }),
+          },
           tierEligibilities: [
             {
               accessTierShortName: AccessTierShortNames.Registered,
@@ -1276,198 +819,728 @@ describe('DataAccessRequirements', () => {
       });
       wrapper = component();
       await waitOneTickAndUpdate(wrapper);
+
+      // Both are clickable.
       expect(
-        findModule(
-          findControlledTierCard(wrapper),
+        findClickableModuleText(
+          wrapper,
           AccessModule.CTCOMPLIANCETRAINING
         ).exists()
+      ).toBeTruthy();
+      expect(
+        findClickableModuleText(
+          wrapper,
+          AccessModule.DATAUSERCODEOFCONDUCT
+        ).exists()
+      ).toBeTruthy();
+
+      // Only the first module is active.
+      expect(
+        findNextCtaForModule(
+          wrapper,
+          AccessModule.CTCOMPLIANCETRAINING
+        ).exists()
+      ).toBeTruthy();
+      expect(
+        findNextCtaForModule(
+          wrapper,
+          AccessModule.DATAUSERCODEOFCONDUCT
+        ).exists()
       ).toBeFalsy();
-    }
-  );
-
-  it('Should display CT training when ineligible', async () => {
-    let wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
-            eligible: false,
-          },
-          {
-            accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
-            eligible: false,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
     });
-    wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(
-      findIneligibleModule(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()
-    ).toBeTruthy();
-  });
 
-  it('Should display CT training when no institutional DUA', async () => {
-    let wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
+    describe('Controlled Tier', () => {
+      it('Should display Institution has signed agreement when the user has a Tier Eligibility object for CT', async () => {
+        let wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
 
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
-            eligible: false,
+        profileStore.set({
+          profile: {
+            ...ProfileStubVariables.PROFILE_STUB,
+            tierEligibilities: [
+              {
+                accessTierShortName: AccessTierShortNames.Controlled,
+                eraRequired: true,
+              },
+            ],
           },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
+          load,
+          reload,
+          updateCache,
+        });
+        wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expect(findControlledSignedStepEligible(wrapper).exists()).toBeTruthy();
+        expect(
+          findControlledSignedStepIneligible(wrapper).exists()
+        ).toBeFalsy();
+
+        // but this is not enough; the user needs to be made eligible by email as well
+        expect(
+          findEligibleText(findControlledTierCard(wrapper)).exists()
+        ).toBeFalsy();
+        expect(
+          findIneligibleText(findControlledTierCard(wrapper)).exists()
+        ).toBeTruthy();
+      });
+
+      it("Should not display Institution has signed agreement when the user doesn't have a Tier Eligibility object for CT", async () => {
+        let wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+
+        profileStore.set({
+          profile: {
+            ...ProfileStubVariables.PROFILE_STUB,
+            tierEligibilities: [
+              {
+                accessTierShortName: AccessTierShortNames.Registered,
+                eraRequired: true,
+              },
+            ],
+          },
+          load,
+          reload,
+          updateCache,
+        });
+        wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expect(findControlledSignedStepEligible(wrapper).exists()).toBeFalsy();
+        expect(
+          findControlledSignedStepIneligible(wrapper).exists()
+        ).toBeTruthy();
+
+        // but this is not enough; the user needs to be made eligible by email as well
+        expect(
+          findEligibleText(findControlledTierCard(wrapper)).exists()
+        ).toBeFalsy();
+        expect(
+          findIneligibleText(findControlledTierCard(wrapper)).exists()
+        ).toBeTruthy();
+      });
+
+      it("Should display Institution allows you to access CT when the user's CT Tier Eligibility object has eligible=true", async () => {
+        let wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+
+        profileStore.set({
+          profile: {
+            ...ProfileStubVariables.PROFILE_STUB,
+            tierEligibilities: [
+              {
+                accessTierShortName: AccessTierShortNames.Controlled,
+                eraRequired: true,
+                eligible: true,
+              },
+            ],
+          },
+          load,
+          reload,
+          updateCache,
+        });
+        wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expect(findControlledUserEligible(wrapper).exists()).toBeTruthy();
+        expect(findControlledUserIneligible(wrapper).exists()).toBeFalsy();
+
+        expect(
+          findEligibleText(findControlledTierCard(wrapper)).exists()
+        ).toBeTruthy();
+        expect(
+          findIneligibleText(findControlledTierCard(wrapper)).exists()
+        ).toBeFalsy();
+      });
+
+      it("Should not display Institution allows you to access CT when the user's CT Tier Eligibility object has eligible=false", async () => {
+        let wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+
+        profileStore.set({
+          profile: {
+            ...ProfileStubVariables.PROFILE_STUB,
+            tierEligibilities: [
+              {
+                accessTierShortName: AccessTierShortNames.Controlled,
+                eraRequired: true,
+                eligible: false,
+              },
+            ],
+          },
+          load,
+          reload,
+          updateCache,
+        });
+        wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expect(findControlledUserEligible(wrapper).exists()).toBeFalsy();
+        expect(findControlledUserIneligible(wrapper).exists()).toBeTruthy();
+
+        expect(
+          findEligibleText(findControlledTierCard(wrapper)).exists()
+        ).toBeFalsy();
+        expect(
+          findIneligibleText(findControlledTierCard(wrapper)).exists()
+        ).toBeTruthy();
+      });
+
+      it('Should not display Institution allows you to access CT when the user does not have a CT Tier Eligibility object', async () => {
+        let wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+
+        profileStore.set({
+          profile: {
+            ...ProfileStubVariables.PROFILE_STUB,
+            // no CT eligibility object
+            tierEligibilities: [
+              {
+                accessTierShortName: AccessTierShortNames.Registered,
+                eraRequired: true,
+                eligible: false,
+              },
+            ],
+          },
+          load,
+          reload,
+          updateCache,
+        });
+        wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expect(findControlledUserEligible(wrapper).exists()).toBeFalsy();
+        expect(findControlledUserIneligible(wrapper).exists()).toBeTruthy();
+
+        expect(
+          findEligibleText(findControlledTierCard(wrapper)).exists()
+        ).toBeFalsy();
+        expect(
+          findIneligibleText(findControlledTierCard(wrapper)).exists()
+        ).toBeTruthy();
+      });
+
+      it('Should display the CT card when the environment has a Controlled Tier', async () => {
+        updateVisibleTiers([
+          AccessTierShortNames.Registered,
+          AccessTierShortNames.Controlled,
+        ]);
+
+        const wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expect(findControlledTierCard(wrapper).exists()).toBeTruthy();
+      });
+
+      it('Should not display the CT card when the environment does not have a Controlled Tier', async () => {
+        updateVisibleTiers([AccessTierShortNames.Registered]);
+
+        const wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expect(findControlledTierCard(wrapper).exists()).toBeFalsy();
+      });
+
+      it(
+        'Should display eraCommons module in CT card ' +
+          'when the user institution has signed agreement and CT requires eraCommons and RT does not',
+        async () => {
+          updateVisibleTiers([
+            AccessTierShortNames.Registered,
+            AccessTierShortNames.Controlled,
+          ]);
+          let wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+
+          profileStore.set({
+            profile: {
+              ...ProfileStubVariables.PROFILE_STUB,
+              tierEligibilities: [
+                {
+                  accessTierShortName: AccessTierShortNames.Controlled,
+                  eraRequired: true,
+                  eligible: true,
+                },
+                {
+                  accessTierShortName: AccessTierShortNames.Registered,
+                  eraRequired: false,
+                  eligible: false,
+                },
+              ],
+            },
+            load,
+            reload,
+            updateCache,
+          });
+          wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+          expect(
+            findModule(
+              findControlledTierCard(wrapper),
+              AccessModule.ERACOMMONS
+            ).exists()
+          ).toBeTruthy();
+        }
+      );
+
+      it(
+        'Should not display eraCommons module in CT card ' +
+          "when user's institution has not signed CT Institution agreement",
+        async () => {
+          let wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+
+          profileStore.set({
+            profile: {
+              ...ProfileStubVariables.PROFILE_STUB,
+              // no CT eligibility object
+              tierEligibilities: [
+                {
+                  accessTierShortName: AccessTierShortNames.Registered,
+                  eraRequired: false,
+                  eligible: false,
+                },
+              ],
+            },
+            load,
+            reload,
+            updateCache,
+          });
+          wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+          expect(
+            findModule(
+              findControlledTierCard(wrapper),
+              AccessModule.ERACOMMONS
+            ).exists()
+          ).toBeFalsy();
+        }
+      );
+
+      it(
+        'Should display ineligible CT Compliance Training module in CT card ' +
+          "when user's institution has not signed CT Institution agreement",
+        async () => {
+          let wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+
+          profileStore.set({
+            profile: {
+              ...ProfileStubVariables.PROFILE_STUB,
+              // no CT eligibility object
+              tierEligibilities: [
+                {
+                  accessTierShortName: AccessTierShortNames.Registered,
+                  eraRequired: false,
+                  eligible: false,
+                },
+              ],
+            },
+            load,
+            reload,
+            updateCache,
+          });
+          wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+          expect(
+            findIneligibleModule(
+              findControlledTierCard(wrapper),
+              AccessModule.CTCOMPLIANCETRAINING
+            ).exists()
+          ).toBeTruthy();
+        }
+      );
+
+      it(
+        'Should display ineligible CT Compliance Training module in CT card ' +
+          'when user is not eligible for CT',
+        async () => {
+          let wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+
+          profileStore.set({
+            profile: {
+              ...ProfileStubVariables.PROFILE_STUB,
+              tierEligibilities: [
+                {
+                  accessTierShortName: AccessTierShortNames.Registered,
+                  eraRequired: false,
+                  eligible: true,
+                },
+                {
+                  accessTierShortName: AccessTierShortNames.Controlled,
+                  eraRequired: false,
+                  // User not eligible for CT i.e user email doesnt match
+                  // Institution's Controlled Tier email list
+                  eligible: false,
+                },
+              ],
+            },
+            load,
+            reload,
+            updateCache,
+          });
+          wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+          expect(
+            findIneligibleModule(
+              findControlledTierCard(wrapper),
+              AccessModule.CTCOMPLIANCETRAINING
+            ).exists()
+          ).toBeTruthy();
+        }
+      );
+
+      it(
+        'Should not display eraCommons module in CT card ' +
+          'when RT requires eraCommons',
+        async () => {
+          let wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+
+          profileStore.set({
+            profile: {
+              ...ProfileStubVariables.PROFILE_STUB,
+              tierEligibilities: [
+                {
+                  accessTierShortName: AccessTierShortNames.Registered,
+                  eraRequired: true,
+                  eligible: false,
+                },
+                {
+                  accessTierShortName: AccessTierShortNames.Controlled,
+                  eraRequired: true,
+                  eligible: true,
+                },
+              ],
+            },
+            load,
+            reload,
+            updateCache,
+          });
+          wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+          expect(
+            findModule(
+              findControlledTierCard(wrapper),
+              AccessModule.ERACOMMONS
+            ).exists()
+          ).toBeFalsy();
+        }
+      );
+
+      it(
+        'Should not display eraCommons module in CT card ' +
+          'when eraCommons is disabled via the environment config',
+        async () => {
+          serverConfigStore.set({
+            config: { ...defaultServerConfig, enableEraCommons: false },
+          });
+
+          let wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+
+          profileStore.set({
+            profile: {
+              ...ProfileStubVariables.PROFILE_STUB,
+              tierEligibilities: [
+                {
+                  accessTierShortName: AccessTierShortNames.Registered,
+                  eraRequired: false,
+                  eligible: false,
+                },
+                {
+                  accessTierShortName: AccessTierShortNames.Controlled,
+                  eraRequired: true,
+                  eligible: true,
+                },
+              ],
+            },
+            load,
+            reload,
+            updateCache,
+          });
+          wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+          expect(
+            findModule(
+              findControlledTierCard(wrapper),
+              AccessModule.ERACOMMONS
+            ).exists()
+          ).toBeFalsy();
+        }
+      );
+
+      it(
+        'Should not display ct Compliance Training module in CT card ' +
+          'when enableComplianceTraining is false',
+        async () => {
+          serverConfigStore.set({
+            config: { ...defaultServerConfig, enableComplianceTraining: false },
+          });
+
+          let wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+
+          profileStore.set({
+            profile: {
+              ...ProfileStubVariables.PROFILE_STUB,
+              tierEligibilities: [
+                {
+                  accessTierShortName: AccessTierShortNames.Registered,
+                  eraRequired: false,
+                  eligible: false,
+                },
+                {
+                  accessTierShortName: AccessTierShortNames.Controlled,
+                  eraRequired: true,
+                  eligible: true,
+                },
+              ],
+            },
+            load,
+            reload,
+            updateCache,
+          });
+          wrapper = component();
+          await waitOneTickAndUpdate(wrapper);
+          expect(
+            findModule(
+              findControlledTierCard(wrapper),
+              AccessModule.CTCOMPLIANCETRAINING
+            ).exists()
+          ).toBeFalsy();
+        }
+      );
+
+      it('Should display CT training when ineligible', async () => {
+        let wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+
+        profileStore.set({
+          profile: {
+            ...ProfileStubVariables.PROFILE_STUB,
+            tierEligibilities: [
+              {
+                accessTierShortName: AccessTierShortNames.Registered,
+                eraRequired: false,
+                eligible: false,
+              },
+              {
+                accessTierShortName: AccessTierShortNames.Controlled,
+                eraRequired: true,
+                eligible: false,
+              },
+            ],
+          },
+          load,
+          reload,
+          updateCache,
+        });
+        wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expect(
+          findIneligibleModule(
+            wrapper,
+            AccessModule.CTCOMPLIANCETRAINING
+          ).exists()
+        ).toBeTruthy();
+      });
+
+      it('Should display CT training when no institutional DUA', async () => {
+        let wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+
+        profileStore.set({
+          profile: {
+            ...ProfileStubVariables.PROFILE_STUB,
+            tierEligibilities: [
+              {
+                accessTierShortName: AccessTierShortNames.Registered,
+                eraRequired: false,
+                eligible: false,
+              },
+            ],
+          },
+          load,
+          reload,
+          updateCache,
+        });
+        wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expect(
+          findIneligibleModule(
+            wrapper,
+            AccessModule.CTCOMPLIANCETRAINING
+          ).exists()
+        ).toBeTruthy();
+      });
+
+      it('Should display CT training when eligible', async () => {
+        let wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+
+        profileStore.set({
+          profile: {
+            ...ProfileStubVariables.PROFILE_STUB,
+            tierEligibilities: [
+              {
+                accessTierShortName: AccessTierShortNames.Registered,
+                eraRequired: false,
+                eligible: false,
+              },
+              {
+                accessTierShortName: AccessTierShortNames.Controlled,
+                eraRequired: true,
+                eligible: true,
+              },
+            ],
+          },
+          load,
+          reload,
+          updateCache,
+        });
+        wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expect(
+          findIncompleteModule(
+            wrapper,
+            AccessModule.CTCOMPLIANCETRAINING
+          ).exists()
+        ).toBeTruthy();
+      });
     });
-    wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(
-      findIneligibleModule(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()
-    ).toBeTruthy();
-  });
 
-  it('Should display CT training when eligible', async () => {
-    let wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
+    describe('Registered Tier', () => {
+      it('Should not show Era Commons Module for Registered Tier if the institution does not require eRa', async () => {
+        let wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expect(
+          findModule(wrapper, AccessModule.ERACOMMONS).exists()
+        ).toBeTruthy();
 
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
-            eligible: false,
+        profileStore.set({
+          profile: {
+            ...ProfileStubVariables.PROFILE_STUB,
+            tierEligibilities: [
+              {
+                accessTierShortName: AccessTierShortNames.Registered,
+                eraRequired: false,
+              },
+            ],
           },
-          {
-            accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
-            eligible: true,
+          load,
+          reload,
+          updateCache,
+        });
+        wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expect(
+          findModule(wrapper, AccessModule.ERACOMMONS).exists()
+        ).toBeFalsy();
+
+        // Ignore eraRequired if the accessTier is Controlled
+        profileStore.set({
+          profile: {
+            ...ProfileStubVariables.PROFILE_STUB,
+            tierEligibilities: [
+              {
+                accessTierShortName: AccessTierShortNames.Registered,
+                eraRequired: true,
+              },
+              {
+                accessTierShortName: AccessTierShortNames.Controlled,
+                eraRequired: false,
+              },
+            ],
           },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
+          load,
+          reload,
+          updateCache,
+        });
+        wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expect(
+          findModule(wrapper, AccessModule.ERACOMMONS).exists()
+        ).toBeTruthy();
+      });
     });
-    wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(
-      findIncompleteModule(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()
-    ).toBeTruthy();
-  });
 
-  it('Should allow CT and DUCC to be simultaneously clickable', async () => {
-    let wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
+    describe('RAS Help Text', () => {
+      it('Should show the RAS help text component when it is incomplete', async () => {
+        const wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
 
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        accessModules: {
-          modules: allInitialModules.map((moduleName) => {
-            if (
-              [
-                AccessModule.CTCOMPLIANCETRAINING,
-                AccessModule.DATAUSERCODEOFCONDUCT,
-              ].includes(moduleName)
-            ) {
-              return { moduleName };
-            }
-            return { moduleName, completionEpochMillis: 1 };
-          }),
-        },
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
-            eligible: false,
+        expect(
+          findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+        ).toBeFalsy();
+        expect(
+          findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+        ).toBeTruthy();
+
+        expect(findContactUs(wrapper).exists()).toBeTruthy();
+      });
+
+      it('Should not show the RAS help text component when it is complete', async () => {
+        profileStore.set({
+          profile: {
+            ...ProfileStubVariables.PROFILE_STUB,
+            accessModules: {
+              modules: [
+                {
+                  moduleName: AccessModule.RASLINKLOGINGOV,
+                  completionEpochMillis: 1,
+                },
+              ],
+            },
           },
-          {
-            accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
-            eligible: true,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
+          load,
+          reload,
+          updateCache,
+        });
+
+        const wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+
+        expect(
+          findCompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+        ).toBeTruthy();
+        expect(
+          findIncompleteModule(wrapper, AccessModule.RASLINKLOGINGOV).exists()
+        ).toBeFalsy();
+
+        expect(findContactUs(wrapper).exists()).toBeFalsy();
+      });
     });
-    wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
 
-    // Both are clickable.
-    expect(
-      findClickableModuleText(
-        wrapper,
-        AccessModule.CTCOMPLIANCETRAINING
-      ).exists()
-    ).toBeTruthy();
-    expect(
-      findClickableModuleText(
-        wrapper,
-        AccessModule.DATAUSERCODEOFCONDUCT
-      ).exists()
-    ).toBeTruthy();
+    describe('Testing which mode the component renders in', () => {
+      it('Should render in INITIAL_REGISTRATION mode by default (mergedAccessRenewal is true)', async () => {
+        environment.mergedAccessRenewal = true;
+        const wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
+      });
 
-    // Only the first module is active.
-    expect(
-      findNextCtaForModule(wrapper, AccessModule.CTCOMPLIANCETRAINING).exists()
-    ).toBeTruthy();
-    expect(
-      findNextCtaForModule(wrapper, AccessModule.DATAUSERCODEOFCONDUCT).exists()
-    ).toBeFalsy();
-  });
+      it('Should render in INITIAL_REGISTRATION mode by default (mergedAccessRenewal is false)', async () => {
+        environment.mergedAccessRenewal = false;
+        const wrapper = component();
+        await waitOneTickAndUpdate(wrapper);
+        expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
+      });
 
-  it('Should render in INITIAL_REGISTRATION mode by default (mergedAccessRenewal is true)', async () => {
-    environment.mergedAccessRenewal = true;
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
-  });
+      it('Should render in ANNUAL_RENEWAL mode when specified by query param', async () => {
+        environment.mergedAccessRenewal = true;
+        const wrapper = component(DARPageMode.ANNUAL_RENEWAL);
+        await waitOneTickAndUpdate(wrapper);
+        expectPageMode(wrapper, DARPageMode.ANNUAL_RENEWAL);
+      });
 
-  it('Should render in INITIAL_REGISTRATION mode by default (mergedAccessRenewal is false)', async () => {
-    environment.mergedAccessRenewal = false;
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
-  });
+      it('Should not render in ANNUAL_RENEWAL mode if mergedAccessRenewal is false', async () => {
+        environment.mergedAccessRenewal = false;
+        const wrapper = component(DARPageMode.ANNUAL_RENEWAL);
+        await waitOneTickAndUpdate(wrapper);
+        expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
+      });
 
-  it('Should render in ANNUAL_RENEWAL mode when specified by query param', async () => {
-    environment.mergedAccessRenewal = true;
-    const wrapper = component(DARPageMode.ANNUAL_RENEWAL);
-    await waitOneTickAndUpdate(wrapper);
-    expectPageMode(wrapper, DARPageMode.ANNUAL_RENEWAL);
-  });
-
-  it('Should not render in ANNUAL_RENEWAL mode if mergedAccessRenewal is false', async () => {
-    environment.mergedAccessRenewal = false;
-    const wrapper = component(DARPageMode.ANNUAL_RENEWAL);
-    await waitOneTickAndUpdate(wrapper);
-    expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
-  });
-
-  it('Should render in INITIAL_REGISTRATION mode if the queryParam is invalid', async () => {
-    environment.mergedAccessRenewal = true;
-    const wrapper = component('some-garbage');
-    await waitOneTickAndUpdate(wrapper);
-    expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
+      it('Should render in INITIAL_REGISTRATION mode if the queryParam is invalid', async () => {
+        environment.mergedAccessRenewal = true;
+        const wrapper = component('some-garbage');
+        await waitOneTickAndUpdate(wrapper);
+        expectPageMode(wrapper, DARPageMode.INITIAL_REGISTRATION);
+      });
+    });
   });
 });

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -999,7 +999,11 @@ const RegisteredTierCard = (props: {
     <FlexRow style={styles.card}>
       <FlexColumn>
         <div style={styles.cardStep}>Step 1</div>
-        <div style={styles.cardHeader}>Complete Registration</div>
+        <div style={styles.cardHeader}>
+          {pageMode === DARPageMode.ANNUAL_RENEWAL
+            ? 'Basic Data Access'
+            : 'Complete Registration'}
+        </div>
         <FlexRow>
           <RegisteredTierBadge />
           <div style={styles.dataHeader}>{rtDisplayName} data</div>
@@ -1274,7 +1278,6 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
     }, [nextActive, nextRequired]);
 
     const showCtCard =
-      // RW-7798 add CT card for ANNUAL_RENEWAL
       (pageMode === DARPageMode.INITIAL_REGISTRATION &&
         accessTiersVisibleToUsers.includes(AccessTierShortNames.Controlled)) ||
       pageMode === DARPageMode.ANNUAL_RENEWAL;

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -1275,9 +1275,9 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
 
     const showCtCard =
       // RW-7798 add CT card for ANNUAL_RENEWAL
-      pageMode === DARPageMode.INITIAL_REGISTRATION &&
-      accessTiersVisibleToUsers.includes(AccessTierShortNames.Controlled);
-
+      (pageMode === DARPageMode.INITIAL_REGISTRATION &&
+        accessTiersVisibleToUsers.includes(AccessTierShortNames.Controlled)) ||
+      pageMode === DARPageMode.ANNUAL_RENEWAL;
     const rtCard = (
       <RegisteredTierCard
         key='rt'

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -1155,7 +1155,13 @@ const ControlledTierCard = (props: {
           />
         )}
         {pageMode === DARPageMode.INITIAL_REGISTRATION && (
-          <ModulesForInitialRegistration {{...props, modules: [ctModule]}} />
+          <ModulesForInitialRegistration
+            profile={profile}
+            modules={[ctModule]}
+            activeModule={activeModule}
+            clickableModules={clickableModules}
+            spinnerProps={spinnerProps}
+          />
         )}
         {pageMode === DARPageMode.ANNUAL_RENEWAL && isEligible && (
           <ModulesForAnnualRenewal profile={profile} modules={[ctModule]} />

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -1155,13 +1155,7 @@ const ControlledTierCard = (props: {
           />
         )}
         {pageMode === DARPageMode.INITIAL_REGISTRATION && (
-          <ModulesForInitialRegistration
-            profile={profile}
-            modules={[ctModule]}
-            activeModule={activeModule}
-            clickableModules={clickableModules}
-            spinnerProps={spinnerProps}
-          />
+          <ModulesForInitialRegistration {{...props, modules: [ctModule]}} />
         )}
         {pageMode === DARPageMode.ANNUAL_RENEWAL && isEligible && (
           <ModulesForAnnualRenewal profile={profile} modules={[ctModule]} />

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -1071,8 +1071,10 @@ const ControlledTierCard = (props: {
   clickableModules: AccessModule[];
   reload: Function;
   spinnerProps: WithSpinnerOverlayProps;
+  pageMode: DARPageMode;
 }) => {
-  const { profile, activeModule, clickableModules, spinnerProps } = props;
+  const { profile, activeModule, clickableModules, spinnerProps, pageMode } =
+    props;
   const controlledTierEligibility = profile.tierEligibilities.find(
     (tier) => tier.accessTierShortName === AccessTierShortNames.Controlled
   );
@@ -1152,13 +1154,17 @@ const ControlledTierCard = (props: {
             spinnerProps={spinnerProps}
           />
         )}
-        <ModulesForInitialRegistration
-          profile={profile}
-          modules={[ctModule]}
-          activeModule={activeModule}
-          clickableModules={clickableModules}
-          spinnerProps={spinnerProps}
-        />
+        {pageMode === DARPageMode.INITIAL_REGISTRATION ? (
+          <ModulesForInitialRegistration
+            profile={profile}
+            modules={[ctModule]}
+            activeModule={activeModule}
+            clickableModules={clickableModules}
+            spinnerProps={spinnerProps}
+          />
+        ) : (
+          <ModulesForAnnualRenewal profile={profile} modules={[ctModule]} />
+        )}
       </FlexColumn>
     </FlexRow>
   );
@@ -1299,6 +1305,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
         clickableModules={clickableModules}
         reload={reload}
         spinnerProps={spinnerProps}
+        pageMode={pageMode}
       />
     ) : null;
     const dCard = (

--- a/ui/src/app/pages/homepage/data-access-requirements.tsx
+++ b/ui/src/app/pages/homepage/data-access-requirements.tsx
@@ -1154,7 +1154,7 @@ const ControlledTierCard = (props: {
             spinnerProps={spinnerProps}
           />
         )}
-        {pageMode === DARPageMode.INITIAL_REGISTRATION ? (
+        {pageMode === DARPageMode.INITIAL_REGISTRATION && (
           <ModulesForInitialRegistration
             profile={profile}
             modules={[ctModule]}
@@ -1162,7 +1162,8 @@ const ControlledTierCard = (props: {
             clickableModules={clickableModules}
             spinnerProps={spinnerProps}
           />
-        ) : (
+        )}
+        {pageMode === DARPageMode.ANNUAL_RENEWAL && isEligible && (
           <ModulesForAnnualRenewal profile={profile} modules={[ctModule]} />
         )}
       </FlexColumn>

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -222,7 +222,7 @@ export const getAccessModuleConfig = (
         isEnabledInEnvironment: enableComplianceTraining,
         AARTitleComponent: () => (
           <div>
-            <AoU /> Responsible Conduct of Research Training
+            Complete <AoU /> research Registered Tier training
           </div>
         ),
         DARTitleComponent: () => (

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -244,6 +244,11 @@ export const getAccessModuleConfig = (
       () => ({
         ...apiConfig,
         isEnabledInEnvironment: enableComplianceTraining,
+        AARTitleComponent: () => (
+          <div>
+            Complete <AoU /> research Controlled Tier training
+          </div>
+        ),
         DARTitleComponent: () => (
           <div>
             Complete <AoU /> research Controlled Tier training


### PR DESCRIPTION
Description:
Updated data access requirements page to include Controlled Tier training.

![image](https://user-images.githubusercontent.com/24514630/163037405-613c5024-39e6-4e51-9638-762f04c4bc91.png)
![image](https://user-images.githubusercontent.com/24514630/163037439-3f396d6d-4022-42a9-89e2-c2b2a72373b0.png)
 
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
