### PR TITLE
[RW-8175][risk=no] E2E nightly egress test

### DIFF
--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -558,9 +558,6 @@ export default class NotebookPage extends NotebookFrame {
     const fileSizeElement = await newPage.waitForXPath(fileSizeXpath, { visible: true });
     const fileSize = await getPropValue(fileSizeElement, 'textContent');
 
-    // In case page has to be checked after finish.
-    await takeScreenshot(newPage, `notebook-upload-file-${fileName}`);
-
     // Fail if upload proceeded without a dialog prompt.
     expect(await waitForFn(() => sawDialog)).toBeTruthy();
 

--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -1,4 +1,6 @@
 import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { Dialog, ElementHandle, Frame, Page } from 'puppeteer';
 import { getPropValue } from 'utils/element-utils';
 import { waitForDocumentTitle, waitForFn, waitForNumericalString, waitWhileLoading } from 'utils/waits-utils';
@@ -131,23 +133,42 @@ export default class NotebookPage extends NotebookFrame {
           `//*[@id="notebook_list"]//a[@class="item_link"][span[text()="${filename}"]]/preceding-sibling::input`,
           { visible: true }
         )
-        .then((e) => e.click());
+        .then((e) => e.click())
+        .then(() => treePage.waitForTimeout(500));
     await findAndClickCheckbox();
+
+    const downloadPath = fs.mkdtempSync(path.join(os.tmpdir(), 'egress-'));
+    const client = await treePage.target().createCDPSession();
+    await client.send('Page.setDownloadBehavior', {
+      behavior: 'allow',
+      downloadPath
+    });
 
     let sawDialog = false;
     treePage.once('dialog', async (d: Dialog) => {
       await this.acceptDataUseDownloadDialog(treePage, d);
       sawDialog = true;
     });
-    await treePage.waitForXPath('//button[@aria-label="Download selected"]', { visible: true }).then((e) => e.click());
+
+    await treePage
+      .waitForXPath('//button[@aria-label="Download selected"]', { visible: true })
+      .then((e) => e.click())
+      .then(() => treePage.waitForTimeout(500));
 
     // Uncheck afterwards, to restore the original state of the page.
-    await treePage.waitForTimeout(500);
     await findAndClickCheckbox();
-    await treePage.waitForTimeout(500);
+
+    // Wait for file existence locally, to confirm download completion.
+    const downloadFilename = path.join(downloadPath, filename);
+    expect(
+      await waitForFn(() => fs.existsSync(downloadFilename), /* interval */ undefined, /* timeout */ 90 * 1000)
+    ).toBeTruthy();
+
+    const downloadSizeMB = fs.statSync(downloadFilename).size / 1e6;
+    logger.info(`confirmed download @ ${downloadFilename} of ${downloadSizeMB.toFixed(2)} MB`);
 
     // Fail if file download proceeded without a dialog prompt.
-    expect(await waitForFn(() => sawDialog)).toBeTruthy();
+    expect(sawDialog).toBeTruthy();
     return treePage;
   }
 

--- a/e2e/app/sidebar/runtime-panel.ts
+++ b/e2e/app/sidebar/runtime-panel.ts
@@ -394,4 +394,10 @@ export default class RuntimePanel extends BaseSidebar {
     await this.clickButton(LinkText.DeleteEnvironment);
     await this.clickButton(LinkText.Delete);
   }
+
+  async isRuntimeSuspended(): Promise<boolean> {
+    return exists(this.page, '//*[@data-test-id="runtime-status-icon-container"]/*[@data-icon="lock"]', {
+      timeout: 2000
+    });
+  }
 }

--- a/e2e/tests/nightly/egress-suspension.spec.ts
+++ b/e2e/tests/nightly/egress-suspension.spec.ts
@@ -1,4 +1,4 @@
-import { findOrCreateWorkspace, signInWithAccessToken } from 'utils/test-utils';
+import { createWorkspace, signInWithAccessToken } from 'utils/test-utils';
 import { config } from 'resources/workbench-config';
 import { makeRandomName } from 'utils/str-utils';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
@@ -29,7 +29,7 @@ describe('egress suspension', () => {
   });
 
   test("VM egress suspends user's compute", async () => {
-    await findOrCreateWorkspace(page);
+    await createWorkspace(page);
 
     const dataPage = new WorkspaceDataPage(page);
     const notebookPage = await dataPage.createNotebook(notebookName);

--- a/e2e/tests/nightly/egress-suspension.spec.ts
+++ b/e2e/tests/nightly/egress-suspension.spec.ts
@@ -11,8 +11,6 @@ import { logger } from 'libs/logger';
 jest.setTimeout(45 * 60 * 1000);
 
 describe('egress suspension', () => {
-  let notebookUrl: string;
-
   const notebookName = makeRandomName('egress-notebook');
   const dataGenFilename = 'create-data-files.py';
   const dataGenFilePath = path.relative(process.cwd(), __dirname + `../../../resources/python-code/${dataGenFilename}`);
@@ -48,16 +46,9 @@ describe('egress suspension', () => {
 
     logger.info('Awaiting security suspension in the notebook page');
     await page.bringToFront();
-    notebookUrl = page.url();
     await notebookPage.waitForLoad();
 
     await waitForSecuritySuspendedStatus(page);
-  });
-
-  test('Cloud Analysis Environment is auto suspended', async () => {
-    await signInWithAccessToken(page, config.EGRESS_TEST_USER);
-    await page.goto(notebookUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 });
-    await waitForSecuritySuspendedStatus(page, true, 30 * 1000);
 
     // egress handling will auto. suspend cloud analysis environment.
     const runtimePanel = new RuntimePanel(page);

--- a/e2e/utils/runtime-utils.ts
+++ b/e2e/utils/runtime-utils.ts
@@ -20,7 +20,7 @@ export async function initializeRuntimeIfModalPresented(page: Page): Promise<voi
 }
 
 async function isSecuritySuspended(page: Page): Promise<boolean> {
-  return exists(page, '//*[@data-test-id="security-suspended-msg"]');
+  return exists(page, '//*[@data-test-id="security-suspended-msg"]', { timeout: 5000 });
 }
 
 export async function waitForSecuritySuspendedStatus(
@@ -32,7 +32,7 @@ export async function waitForSecuritySuspendedStatus(
   const pollPeriod = 20 * 1000;
 
   while (true) {
-    await page.reload({ waitUntil: ['load', 'domcontentloaded'], timeout: 60 * 1000 });
+    await page.reload({ waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 });
 
     if ((await isSecuritySuspended(page)) === suspended) {
       // Success
@@ -40,7 +40,7 @@ export async function waitForSecuritySuspendedStatus(
     }
 
     if (Date.now() - startTime > timeOut - pollPeriod) {
-      throw new Error('timed out waiting for security suspension status = ' + suspended);
+      throw new Error(`Timed out waiting for security suspension status = ${suspended}`);
     }
     await page.waitForTimeout(pollPeriod);
   }

--- a/e2e/utils/runtime-utils.ts
+++ b/e2e/utils/runtime-utils.ts
@@ -37,13 +37,14 @@ export async function waitForSecuritySuspendedStatus(
 
     if ((await isSecuritySuspended(page)) === suspended) {
       // Success
-      logger.info(`Egress security suspended took ${(Date.now() - startTime) / 1000 / 60} minutes`);
       break;
     }
 
-    if (Date.now() - startTime > timeOut - pollPeriod) {
+    const waited = Date.now() - startTime;
+    if (waited > timeOut - pollPeriod) {
       throw new Error(`Timed out waiting for egress security suspension status = ${suspended}`);
     }
+    logger.info(`Waited for ${(waited / 1000 / 60).toFixed(2)} minutes`);
     await page.waitForTimeout(pollPeriod);
   }
 }

--- a/e2e/utils/runtime-utils.ts
+++ b/e2e/utils/runtime-utils.ts
@@ -1,6 +1,7 @@
 import { Page } from 'puppeteer';
 import Button from 'app/element/button';
 import { exists } from './element-utils';
+import { logger } from 'libs/logger';
 
 const Selector = {
   runtimeInitializerCreateButton: '//*[@role="dialog"]//*[text()="Create Environment" and @role="button"]'
@@ -20,7 +21,7 @@ export async function initializeRuntimeIfModalPresented(page: Page): Promise<voi
 }
 
 async function isSecuritySuspended(page: Page): Promise<boolean> {
-  return exists(page, '//*[@data-test-id="security-suspended-msg"]', { timeout: 5000 });
+  return exists(page, '//*[@data-test-id="security-suspended-msg"]', { timeout: 10000 });
 }
 
 export async function waitForSecuritySuspendedStatus(
@@ -36,11 +37,12 @@ export async function waitForSecuritySuspendedStatus(
 
     if ((await isSecuritySuspended(page)) === suspended) {
       // Success
+      logger.info(`Egress security suspended took ${(Date.now() - startTime) / 1000 / 60} minutes`);
       break;
     }
 
     if (Date.now() - startTime > timeOut - pollPeriod) {
-      throw new Error(`Timed out waiting for security suspension status = ${suspended}`);
+      throw new Error(`Timed out waiting for egress security suspension status = ${suspended}`);
     }
     await page.waitForTimeout(pollPeriod);
   }


### PR DESCRIPTION
Propose some changes hopefully to make the test run reliably.

<img width="600" alt="Screen Shot 2022-04-14 at 1 14 07 PM" src="https://user-images.githubusercontent.com/35533885/163439959-8c00d1d7-4afc-4e1c-adab-f5c68f7a5934.png">


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
