### PR TITLE
[RW-8147][risk=no] Capture inactivity tracking on all Jupyter pages, not just notebooks

### DIFF
--- a/api/src/main/webapp/static/initialize_notebook_runtime.sh
+++ b/api/src/main/webapp/static/initialize_notebook_runtime.sh
@@ -18,7 +18,10 @@ set -x
 # own default extensions: https://github.com/DataBiosphere/terra-docker/blob/master/terra-jupyter-base/scripts/extension/install_jupyter_contrib_nbextensions.sh
 sudo -E -u jupyter /opt/conda/bin/jupyter nbextension enable snippets_menu/main
 
-# Section represents the jupyter page to which the extension will be applied to
+# Enable activity checking on all views, not just notebooks, e.g. to capture terminal or tree interactions.
+sudo -E -u jupyter /opt/conda/bin/jupyter nbextension enable activity-checker-extension/main --section=common
+
+# Install on the tree view, which is the only place where this extension applies.
 sudo -E -u jupyter /opt/conda/bin/jupyter nbextension enable aou-file-tree-policy-extension/main --section=tree
 
 sudo -E -u jupyter /opt/conda/bin/nbstripout --install --global


### PR DESCRIPTION
Prior bug: interactions with iframed Jupyter pages such as the terminal do not affect the inactivity timer

Tested by manually running the command on my notebook server, and observing activity signal being sent from the terminal application after refresh.