### PR TITLE
[risk=low][no ticket] bump GCS to 2.3.0

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -386,7 +386,7 @@ dependencies {
     compile 'com.google.cloud:google-cloud-iamcredentials:2.0.8'
     compile 'com.google.cloud:google-cloud-logging:3.5.3'
     compile 'com.google.cloud:google-cloud-monitoring:3.2.1'
-    compile 'com.google.cloud:google-cloud-storage:2.2.3'
+    compile 'com.google.cloud:google-cloud-storage:2.3.0'
     compile 'com.google.cloud:google-cloud-tasks:2.1.1'
     compile "com.google.code.gson:gson:$project.ext.GSON_VERSION"
     compile "com.google.guava:guava:31.0.1-jre"


### PR DESCRIPTION
Google has notified users of Google Cloud Storage that pre-2.3.0 versions will start failing soon:
> Update your Java Storage client to version 2.3.0 or higher to read/write Google Cloud Storage buckets with new lifecycle actions by June 20, 2022. You can find more details for the latest version in the [Maven Central Repository](https://notifications.google.com/g/p/AD-FnEzPA_Ih75WoC5dQLUhKwrdkT7xc5aiOkJ23lqxdqjxZIXLOFbkSJk23lPpzHRmhm_XrGD-XzNGdIHn_IxH-otcZFRqhT0B_-utN9EUtogftwmboJkJ-5f6KqcbwyuurbK7cXXFWXHzx4F2Ej16z1k9rfB6Wi_VwFk3GuFC4uhA).

Tested locally by running local API and creating a workspace and a notebook.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
