### PR TITLE
[risk=low][no ticket] Fix the access-renewal UI guard when RT renewable modules are incomplete

### DIFF
--- a/ui/src/app/pages/access/access-renewal.spec.tsx
+++ b/ui/src/app/pages/access/access-renewal.spec.tsx
@@ -15,7 +15,7 @@ import {
   profileApi,
   registerApiClient,
 } from 'app/services/swagger-fetch-clients';
-import { accessRenewalModules } from 'app/utils/access-utils';
+import { rtAccessRenewalModules } from 'app/utils/access-utils';
 import { nowPlusDays } from 'app/utils/dates';
 import { profileStore, serverConfigStore } from 'app/utils/stores';
 
@@ -50,7 +50,7 @@ describe('Access Renewal Page', () => {
     const newProfile = fp.set(
       'accessModules',
       {
-        modules: accessRenewalModules.map(
+        modules: rtAccessRenewalModules.map(
           (m) =>
             ({
               moduleName: m,

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -26,14 +26,15 @@ import { profileApi } from 'app/services/swagger-fetch-clients';
 import colors, { addOpacity, colorWithWhiteness } from 'app/styles/colors';
 import { cond, switchCase, useId } from 'app/utils';
 import {
-  accessRenewalModules,
   computeRenewalDisplayDates,
   getAccessModuleConfig,
   getAccessModuleStatusByNameOrEmpty,
   isExpiringOrExpired,
+  isRenewalCompleteForModule,
   maybeDaysRemaining,
   redirectToControlledTraining,
   redirectToRegisteredTraining,
+  rtAccessRenewalModules,
   syncModulesExternal,
 } from 'app/utils/access-utils';
 import { useNavigation } from 'app/utils/navigation';
@@ -153,20 +154,6 @@ export const RenewalRequirementsText = () => (
     days after the date of authorization to access <AoU /> data).
   </span>
 );
-
-// Helper Functions
-
-// is the module "renewal complete" ?
-// meaning (bypassed || (complete and not expiring))
-const isRenewalCompleteForModule = (status: AccessModuleStatus) => {
-  const isComplete = !!status?.completionEpochMillis;
-  const wasBypassed = !!status?.bypassEpochMillis;
-  return (
-    wasBypassed ||
-    (isComplete &&
-      !isExpiringOrExpired(status?.expirationEpochMillis, status.moduleName))
-  );
-};
 
 // Helper / Stateless Components
 interface CompletedButtonInterface {
@@ -547,7 +534,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
     const [loading, setLoading] = useState(false);
 
     const expirableModules = modules.filter((moduleStatus) =>
-      accessRenewalModules.includes(moduleStatus.moduleName)
+      rtAccessRenewalModules.includes(moduleStatus.moduleName)
     );
     const accessRenewalCompleted = expirableModules.every(
       isRenewalCompleteForModule

--- a/ui/src/app/pages/access/access-renewal.tsx
+++ b/ui/src/app/pages/access/access-renewal.tsx
@@ -31,6 +31,7 @@ import {
   getAccessModuleStatusByNameOrEmpty,
   isExpiringOrExpired,
   isRenewalCompleteForModule,
+  isRtRenewalComplete,
   maybeDaysRemaining,
   redirectToControlledTraining,
   redirectToRegisteredTraining,
@@ -536,9 +537,6 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
     const expirableModules = modules.filter((moduleStatus) =>
       rtAccessRenewalModules.includes(moduleStatus.moduleName)
     );
-    const accessRenewalCompleted = expirableModules.every(
-      isRenewalCompleteForModule
-    );
 
     // onMount - as we move between pages, let's make sure we have the latest profile and external module information
     useEffect(() => {
@@ -561,7 +559,7 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
 
     const maybeHeader = cond(
       // Completed - no icon or button
-      [accessRenewalCompleted, () => null],
+      [isRtRenewalComplete(profile), () => null],
       // Access expired icon
       [
         maybeDaysRemaining(profile) < 0,
@@ -604,14 +602,14 @@ export const AccessRenewal = fp.flow(withProfileErrorModal)(
           {maybeHeader}
           <div
             style={
-              accessRenewalCompleted
+              isRtRenewalComplete(profile)
                 ? { gridColumn: '1 / span 2' }
                 : { gridColumnStart: 2 }
             }
           >
             <RenewalRequirementsText />
           </div>
-          {accessRenewalCompleted && (
+          {isRtRenewalComplete(profile) && (
             <div
               style={{
                 ...renewalStyle.completionBox,

--- a/ui/src/app/pages/admin/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/admin-user-common.tsx
@@ -40,12 +40,12 @@ import {
   orderedAccessTierShortNames,
 } from 'app/utils/access-tiers';
 import {
-  accessRenewalModules,
   AccessRenewalStatus,
   computeRenewalDisplayDates,
   getAccessModuleConfig,
   getAccessModuleStatusByName,
   getAccessModuleStatusByNameOrEmpty,
+  rtAccessRenewalModules,
 } from 'app/utils/access-utils';
 import { formatDate } from 'app/utils/dates';
 import { getRoleOptions } from 'app/utils/institutions';
@@ -653,8 +653,8 @@ export const AccessModuleExpirations = ({ profile }: ExpirationProps) => {
   // compliance training is feature-flagged in some environments
   const { enableComplianceTraining } = serverConfigStore.get().config;
   const moduleNames = enableComplianceTraining
-    ? accessRenewalModules
-    : accessRenewalModules.filter(
+    ? rtAccessRenewalModules
+    : rtAccessRenewalModules.filter(
         (moduleName) => moduleName !== AccessModule.COMPLIANCETRAINING
       );
 

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -7,6 +7,7 @@ import {
   ACCESS_RENEWAL_PATH,
   DATA_ACCESS_REQUIREMENTS_PATH,
   eligibleForTier,
+  isRtRenewalComplete,
 } from 'app/utils/access-utils';
 import {
   AuthorityGuardedAction,
@@ -46,8 +47,7 @@ export const registrationGuard: Guard = {
 };
 
 export const expiredGuard: Guard = {
-  allowed: (): boolean =>
-    !profileStore.get().profile.accessModules.anyModuleHasExpired,
+  allowed: (): boolean => isRtRenewalComplete(profileStore.get().profile),
   redirectPath: ACCESS_RENEWAL_PATH,
 };
 

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -46,7 +46,7 @@ export const registrationGuard: Guard = {
   redirectPath: DATA_ACCESS_REQUIREMENTS_PATH,
 };
 
-export const expiredGuard: Guard = {
+export const rtExpiredGuard: Guard = {
   allowed: (): boolean => isRtRenewalComplete(profileStore.get().profile),
   redirectPath: ACCESS_RENEWAL_PATH,
 };

--- a/ui/src/app/routing/signed-in-app-routing.tsx
+++ b/ui/src/app/routing/signed-in-app-routing.tsx
@@ -43,7 +43,7 @@ import {
 } from 'app/utils/access-utils';
 import { AuthorityGuardedAction } from 'app/utils/authorities';
 
-import { authorityGuard, expiredGuard, registrationGuard } from './guards';
+import { authorityGuard, registrationGuard, rtExpiredGuard } from './guards';
 
 const AccessRenewalPage = fp.flow(
   withRouteData,
@@ -127,7 +127,7 @@ const WorkspaceSearchAdminPage = fp.flow(
 export const SignedInRoutes = () => {
   return (
     <Switch>
-      <AppRoute exact path='/' guards={[expiredGuard, registrationGuard]}>
+      <AppRoute exact path='/' guards={[rtExpiredGuard, registrationGuard]}>
         <HomepagePage routeData={{ title: 'Homepage' }} />
       </AppRoute>
       <AppRoute exact path={ACCESS_RENEWAL_PATH}>
@@ -320,7 +320,7 @@ export const SignedInRoutes = () => {
       <AppRoute
         exact
         path='/library'
-        guards={[expiredGuard, registrationGuard]}
+        guards={[rtExpiredGuard, registrationGuard]}
       >
         <WorkspaceLibraryPage
           routeData={{ title: 'Workspace Library', minimizeChrome: false }}
@@ -329,7 +329,7 @@ export const SignedInRoutes = () => {
       <AppRoute
         exact
         path='/workspaces'
-        guards={[expiredGuard, registrationGuard]}
+        guards={[rtExpiredGuard, registrationGuard]}
       >
         <WorkspaceListPage
           routeData={{
@@ -341,7 +341,7 @@ export const SignedInRoutes = () => {
       <AppRoute
         exact
         path='/workspaces/build'
-        guards={[expiredGuard, registrationGuard]}
+        guards={[rtExpiredGuard, registrationGuard]}
       >
         <WorkspaceEditPage
           routeData={{ title: 'Create Workspace' }}
@@ -351,7 +351,7 @@ export const SignedInRoutes = () => {
       <AppRoute
         path='/workspaces/:ns/:wsid'
         exact={false}
-        guards={[expiredGuard, registrationGuard]}
+        guards={[rtExpiredGuard, registrationGuard]}
       >
         <WorkspaceWrapperPage intermediaryRoute={true} routeData={{}} />
       </AppRoute>

--- a/ui/src/app/utils/access-utils.spec.tsx
+++ b/ui/src/app/utils/access-utils.spec.tsx
@@ -438,13 +438,11 @@ describe('hasExpired', () => {
   });
 
   it('should return hasExpired=false for a null date', () => {
-    const testTime = nowPlusDays(null);
-    expect(hasExpired(testTime)).toBeFalsy();
+    expect(hasExpired(null)).toBeFalsy();
   });
 
   it('should return hasExpired=false for an undefined date', () => {
-    const testTime = nowPlusDays(undefined);
-    expect(hasExpired(testTime)).toBeFalsy();
+    expect(hasExpired(undefined)).toBeFalsy();
   });
 });
 

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -500,11 +500,15 @@ export const isRenewalCompleteForModule = (status: AccessModuleStatus) => {
 
 export const isRtRenewalComplete = (profile: Profile): boolean => {
   const modules = profile?.accessModules?.modules;
-  return rtAccessRenewalModules.every((moduleName) =>
-    isRenewalCompleteForModule(
-      getAccessModuleStatusByNameOrEmpty(modules, moduleName)
+  return rtAccessRenewalModules
+    .filter(
+      (moduleName) => getAccessModuleConfig(moduleName).isEnabledInEnvironment
     )
-  );
+    .every((moduleName) =>
+      isRenewalCompleteForModule(
+        getAccessModuleStatusByNameOrEmpty(modules, moduleName)
+      )
+    );
 };
 
 interface RenewalDisplayDates {

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -300,8 +300,8 @@ export const getAccessModuleConfig = (
   );
 };
 
-// the modules subject to Annual Access Renewal (AAR), in the order shown on the AAR page.
-export const accessRenewalModules = [
+// the modules subject to Registered Tier Annual Access Renewal (AAR), in the order shown on the AAR page.
+export const rtAccessRenewalModules = [
   AccessModule.PROFILECONFIRMATION,
   AccessModule.PUBLICATIONCONFIRMATION,
   AccessModule.COMPLIANCETRAINING,
@@ -485,6 +485,28 @@ export const isExpiringOrExpired = (
     : serverConfigStore.get().config.accessRenewalLookback;
   return !!expiration && getWholeDaysFromNow(expiration) <= lookback;
 };
+
+// is the module "renewal complete" ?
+// meaning (bypassed || (complete and not expiring))
+export const isRenewalCompleteForModule = (status: AccessModuleStatus) => {
+  const isComplete = !!status?.completionEpochMillis;
+  const wasBypassed = !!status?.bypassEpochMillis;
+  return (
+    wasBypassed ||
+    (isComplete &&
+      !isExpiringOrExpired(status?.expirationEpochMillis, status.moduleName))
+  );
+};
+
+export const isRtRenewalComplete = (profile: Profile): boolean =>
+  rtAccessRenewalModules.every((moduleName) =>
+    isRenewalCompleteForModule(
+      getAccessModuleStatusByNameOrEmpty(
+        profile?.accessModules?.modules,
+        moduleName
+      )
+    )
+  );
 
 interface RenewalDisplayDates {
   lastConfirmedDate: string;

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -498,15 +498,14 @@ export const isRenewalCompleteForModule = (status: AccessModuleStatus) => {
   );
 };
 
-export const isRtRenewalComplete = (profile: Profile): boolean =>
-  rtAccessRenewalModules.every((moduleName) =>
+export const isRtRenewalComplete = (profile: Profile): boolean => {
+  const modules = profile?.accessModules?.modules;
+  return rtAccessRenewalModules.every((moduleName) =>
     isRenewalCompleteForModule(
-      getAccessModuleStatusByNameOrEmpty(
-        profile?.accessModules?.modules,
-        moduleName
-      )
+      getAccessModuleStatusByNameOrEmpty(modules, moduleName)
     )
   );
+};
 
 interface RenewalDisplayDates {
   lastConfirmedDate: string;


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
