### PR TITLE
[RW-8184][risk=low] Do not disable billing dropdown even user has no ballence

### DIFF
--- a/api/db/vars.env
+++ b/api/db/vars.env
@@ -7,7 +7,7 @@ DB_NAME=workbench
 DB_CONNECTION_STRING=jdbc:mysql://$DB_HOST/workbench?useSSL=false
 CDR_DB_CONNECTION_STRING=jdbc:mysql://$DB_HOST/workbench?useSSL=false
 
-LIQUIBASE_DB_USER=liquibase818
+LIQUIBASE_DB_USER=liquibase
 LIQUIBASE_DB_PASSWORD=lb-notasecret
 MYSQL_ROOT_PASSWORD=root-notasecret
 WORKBENCH_DB_USER=workbench

--- a/api/db/vars.env
+++ b/api/db/vars.env
@@ -7,7 +7,7 @@ DB_NAME=workbench
 DB_CONNECTION_STRING=jdbc:mysql://$DB_HOST/workbench?useSSL=false
 CDR_DB_CONNECTION_STRING=jdbc:mysql://$DB_HOST/workbench?useSSL=false
 
-LIQUIBASE_DB_USER=liquibase
+LIQUIBASE_DB_USER=liquibase818
 LIQUIBASE_DB_PASSWORD=lb-notasecret
 MYSQL_ROOT_PASSWORD=root-notasecret
 WORKBENCH_DB_USER=workbench

--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -205,8 +205,7 @@ public class UserController implements UserApiDelegate {
   }
 
   /**
-   * @return the free tier billing account, if the user has free credits OR billing upgrade is
-   *     disabled
+   * @return the free tier billing account, if the user has free credits
    */
   private Stream<BillingAccount> maybeFreeTierBillingAccount() {
     if (!freeTierBillingService.userHasRemainingFreeTierCredits(userProvider.get())) {

--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -204,9 +204,7 @@ public class UserController implements UserApiDelegate {
         new WorkbenchListBillingAccountsResponse().billingAccounts(billingAccounts));
   }
 
-  /**
-   * @return the free tier billing account, if the user has free credits
-   */
+  /** @return the free tier billing account, if the user has free credits */
   private Stream<BillingAccount> maybeFreeTierBillingAccount() {
     if (!freeTierBillingService.userHasRemainingFreeTierCredits(userProvider.get())) {
       return Stream.empty();

--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -205,14 +205,8 @@ public class UserController implements UserApiDelegate {
   }
 
   /**
-   * The logic here is a little weird. See RW-4857.
-   *
-   * <p>When Billing Upgrade is true: return the Free Tier account only when the user has remaining
+   * <p>Return the Free Tier account only when the user has remaining
    * Free Credits.
-   *
-   * <p>When Billing Upgrade is false: the user's only option is the Free Tier account, so return it
-   * even if the user has expired their Free Credits. The UI will disable selection of this option
-   * if expired.
    *
    * @return the free tier billing account, if the user has free credits OR billing upgrade is
    *     disabled

--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -205,9 +205,6 @@ public class UserController implements UserApiDelegate {
   }
 
   /**
-   * <p>Return the Free Tier account only when the user has remaining
-   * Free Credits.
-   *
    * @return the free tier billing account, if the user has free credits OR billing upgrade is
    *     disabled
    */

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1647,7 +1647,6 @@ export const WorkspaceEdit = fp.flow(
                             style={{ width: '20rem' }}
                             value={billingAccountName}
                             options={this.buildBillingAccountOptions()}
-                            disabled={initialCreditsBalance < 0.0}
                             onChange={(e) => {
                               this.setState(
                                 fp.set(

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1439,7 +1439,6 @@ export const WorkspaceEdit = fp.flow(
         cdrVersionTiersResponse,
         profileState: { profile },
       } = this.props;
-      const { freeTierDollarQuota, freeTierUsage } = profile;
 
       const errors = this.validate();
       return (

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1440,7 +1440,6 @@ export const WorkspaceEdit = fp.flow(
         profileState: { profile },
       } = this.props;
       const { freeTierDollarQuota, freeTierUsage } = profile;
-      const initialCreditsBalance = freeTierDollarQuota - freeTierUsage;
 
       const errors = this.validate();
       return (


### PR DESCRIPTION
Description:
We can enable this dropdown because if user has no balance, there will not be the free tier billing option
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
