### PR TITLE
[RW-8118][risk=low] Re-add notification conditional

### DIFF
--- a/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
@@ -38,6 +38,7 @@ const styles = reactStyles({
 });
 
 export interface AccountCreationTosProps {
+  showReAcceptNotification: boolean;
   // Callback which will be called by this component when the user clicks "Next".
   onComplete: (tosVersion) => void;
   // Path to the Terms of Service file to be displayed.
@@ -76,26 +77,27 @@ export class AccountCreationTos extends React.Component<
         data-test-id='account-creation-tos'
         style={{ flex: 1, padding: '1rem 3rem 0 3rem', ...this.props.style }}
       >
-        <div
-          style={{
-            marginBottom: '0.5rem',
-            padding: '0.75rem',
-            backgroundColor: 'aliceblue',
-            borderRadius: 4,
-            boxShadow: '1px 1px 6px gray',
-          }}
-        >
-          <h3 style={{ marginTop: 0, fontWeight: 'bold' }}>
-            Please review and re-accept the <AoU /> Research Program Researcher
-            Workbench Terms of Use and Privacy Statement
-          </h3>
-          <p className='h-color' style={{ marginTop: '0.25rem' }}>
-            The Terra Platform terms, which are incorporated by reference into
-            the <AoU /> terms, have been updated. This updated replaces
-            references to specific federal datasets with a more broad reference
-            to federal datasets as a type of data.
-          </p>
-        </div>
+        {this.props.showReAcceptNotification &&
+          <div
+            style={{
+              marginBottom: '0.5rem',
+              padding: '0.75rem',
+              backgroundColor: 'aliceblue',
+              borderRadius: 4,
+              boxShadow: '1px 1px 6px gray',
+            }}
+          >
+            <h3 style={{ marginTop: 0, fontWeight: 'bold' }}>
+              Please review and re-accept the <AoU /> Research Program Researcher
+              Workbench Terms of Use and Privacy Statement
+            </h3>
+            <p className='h-color' style={{ marginTop: '0.25rem' }}>
+              The Terra Platform terms, which are incorporated by reference into
+              the <AoU /> terms, have been updated. This updated replaces
+              references to specific federal datasets with a more broad reference
+              to federal datasets as a type of data.
+            </p>
+          </div>}
         <HtmlViewer
           ariaLabel='terms of use and privacy statement'
           containerStyles={{ backgroundColor: colors.white }}

--- a/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-tos.tsx
@@ -77,7 +77,7 @@ export class AccountCreationTos extends React.Component<
         data-test-id='account-creation-tos'
         style={{ flex: 1, padding: '1rem 3rem 0 3rem', ...this.props.style }}
       >
-        {this.props.showReAcceptNotification &&
+        {this.props.showReAcceptNotification && (
           <div
             style={{
               marginBottom: '0.5rem',
@@ -88,16 +88,17 @@ export class AccountCreationTos extends React.Component<
             }}
           >
             <h3 style={{ marginTop: 0, fontWeight: 'bold' }}>
-              Please review and re-accept the <AoU /> Research Program Researcher
-              Workbench Terms of Use and Privacy Statement
+              Please review and re-accept the <AoU /> Research Program
+              Researcher Workbench Terms of Use and Privacy Statement
             </h3>
             <p className='h-color' style={{ marginTop: '0.25rem' }}>
               The Terra Platform terms, which are incorporated by reference into
               the <AoU /> terms, have been updated. This updated replaces
-              references to specific federal datasets with a more broad reference
-              to federal datasets as a type of data.
+              references to specific federal datasets with a more broad
+              reference to federal datasets as a type of data.
             </p>
-          </div>}
+          </div>
+        )}
         <HtmlViewer
           ariaLabel='terms of use and privacy statement'
           containerStyles={{ backgroundColor: colors.white }}

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -268,6 +268,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
       case SignInStep.TERMS_OF_SERVICE:
         return (
           <AccountCreationTos
+            showReAcceptNotification={false}
             filePath='/aou-tos.html'
             onComplete={(tosVersion) => {
               AnalyticsTracker.Registration.TOS();

--- a/ui/src/app/routing/app-routing.tsx
+++ b/ui/src/app/routing/app-routing.tsx
@@ -302,6 +302,7 @@ export const AppRoutingComponent: React.FunctionComponent<RoutingProps> =
             )}
             {doesUserNeedToAcceptTOS && (
               <AccountCreationTos
+                showReAcceptNotification={true}
                 onComplete={(tosVersion) => acceptTermsOfService(tosVersion)}
                 filePath={'/aou-tos.html'}
                 afterPrev={false}


### PR DESCRIPTION
Lost conditional for notification (based on whether the user is new or not) in original PR. Adding back.

Tested manually using existing user and then going through the first part of the flow for creating a new user. Note that incognito window results in a blank page and may be worth further investigation.
---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
