### PR TITLE
[risk=low][RW-8203] Consolidate access module routing and special-case the non-bypassable modules

### DIFF
--- a/ui/src/app/routing/guards.spec.tsx
+++ b/ui/src/app/routing/guards.spec.tsx
@@ -155,7 +155,8 @@ describe('redirectTo', () => {
     ],
     [
       'all bypassed except Profile and Publications are missing',
-      undefined,
+      // Access Renewal is the only page which allows progress on these modules
+      ACCESS_RENEWAL_PATH,
       {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [AccessTierShortNames.Registered],
@@ -225,9 +226,10 @@ describe('redirectTo', () => {
         },
       },
     ],
-    // RW-8203 this fails
+    // RW-8203
     [
       'all complete but missing one (renewable, not initial)',
+      // Access Renewal is the only page which allows progress on PUBLICATIONCONFIRMATION
       ACCESS_RENEWAL_PATH,
       {
         ...ProfileStubVariables.PROFILE_STUB,
@@ -238,9 +240,10 @@ describe('redirectTo', () => {
         },
       },
     ],
-    // RW-8203 this fails
+    // RW-8203
     [
       'all complete but missing one each (1 renewable, 1 initial)',
+      // Access Renewal is the only page which allows progress on PUBLICATIONCONFIRMATION
       ACCESS_RENEWAL_PATH,
       {
         ...ProfileStubVariables.PROFILE_STUB,
@@ -251,7 +254,7 @@ describe('redirectTo', () => {
         },
       },
     ],
-    // RW-8203 this fails
+    // RW-8203
     [
       'all complete but Profile + Publication Confirmations are missing',
       // Access Renewal is the only page which allows progress on these modules
@@ -265,7 +268,7 @@ describe('redirectTo', () => {
         },
       },
     ],
-    // RW-8203 this fails
+    // RW-8203
     [
       'all incomplete',
       // Such a user would have to visit Access Renewal first, allowing progress on Profile + Publication.
@@ -281,7 +284,7 @@ describe('redirectTo', () => {
         },
       },
     ],
-  ])('%s', (desc, expected: AccessModulesRedirection, profile: Profile) => {
+  ])('%s', (desc, expected: string, profile: Profile) => {
     expect(shouldRedirectTo(profile)).toEqual(expected);
   });
 });

--- a/ui/src/app/routing/guards.spec.tsx
+++ b/ui/src/app/routing/guards.spec.tsx
@@ -39,11 +39,23 @@ const allCompleteExpiringSoon: AccessModuleStatus[] = Object.keys(
   expirationEpochMillis: nowPlusDays(1),
 }));
 
-// DUCC is expired
-const allCompleteOneExpired: AccessModuleStatus[] = allCompleteNotExpiring
-  .filter(({ moduleName }) => moduleName !== AccessModule.DATAUSERCODEOFCONDUCT)
-  .concat({
-    moduleName: AccessModule.DATAUSERCODEOFCONDUCT,
+// 2FA is missing (initial, not renewable)
+const allCompleteMissingOneInitial: AccessModuleStatus[] =
+  allCompleteNotExpiring.filter(
+    ({ moduleName }) => moduleName !== AccessModule.TWOFACTORAUTH
+  );
+
+// RW-8203
+// artificial state for test users - Publications is missing (renewable, not initial registration)
+const allCompleteMissingOneRenewable: AccessModuleStatus[] =
+  allCompleteNotExpiring.filter(
+    ({ moduleName }) => moduleName !== AccessModule.PUBLICATIONCONFIRMATION
+  );
+
+// PUBLICATIONCONFIRMATION is expired
+const allCompleteOneExpired: AccessModuleStatus[] =
+  allCompleteMissingOneRenewable.concat({
+    moduleName: AccessModule.PUBLICATIONCONFIRMATION,
     completionEpochMillis: Date.now(),
     expirationEpochMillis: nowPlusDays(-1),
   });
@@ -110,6 +122,31 @@ describe('redirectTo', () => {
         accessModules: {
           anyModuleHasExpired: true,
           modules: allCompleteOneExpired,
+        },
+      },
+    ],
+    [
+      'all complete but missing one (initial, not expirable/renewable)',
+      AccessModulesRedirection.DATA_ACCESS_REQUIREMENTS,
+      {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessTierShortNames: [],
+        accessModules: {
+          anyModuleHasExpired: false,
+          modules: allCompleteMissingOneInitial,
+        },
+      },
+    ],
+    // RW-8203 this fails
+    [
+      'all complete but missing one (renewable, not initial)',
+      AccessModulesRedirection.ACCESS_RENEWAL,
+      {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessTierShortNames: [],
+        accessModules: {
+          anyModuleHasExpired: false,
+          modules: allCompleteMissingOneRenewable,
         },
       },
     ],

--- a/ui/src/app/routing/guards.spec.tsx
+++ b/ui/src/app/routing/guards.spec.tsx
@@ -11,7 +11,7 @@ import { serverConfigStore } from 'app/utils/stores';
 import defaultServerConfig from 'testing/default-server-config';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
 
-import { shouldRedirectTo } from './guards';
+import { shouldRedirectToMaybe } from './guards';
 
 // a newly-created user will have Profile and Publications newly completed, and no others
 const newUserModuleState: AccessModuleStatus[] = [
@@ -285,6 +285,6 @@ describe('redirectTo', () => {
       },
     ],
   ])('%s', (desc, expected: string, profile: Profile) => {
-    expect(shouldRedirectTo(profile)).toEqual(expected);
+    expect(shouldRedirectToMaybe(profile)).toEqual(expected);
   });
 });

--- a/ui/src/app/routing/guards.spec.tsx
+++ b/ui/src/app/routing/guards.spec.tsx
@@ -159,7 +159,7 @@ describe('redirectTo', () => {
       ACCESS_RENEWAL_PATH,
       {
         ...ProfileStubVariables.PROFILE_STUB,
-        accessTierShortNames: [AccessTierShortNames.Registered],
+        accessTierShortNames: [],
         accessModules: {
           anyModuleHasExpired: false,
           modules: allBypassedMissingPP,

--- a/ui/src/app/routing/guards.spec.tsx
+++ b/ui/src/app/routing/guards.spec.tsx
@@ -1,0 +1,149 @@
+import { AccessModule, AccessModuleStatus, Profile } from 'generated/fetch';
+
+import { AccessTierShortNames } from 'app/utils/access-tiers';
+import { nowPlusDays } from 'app/utils/dates';
+import { serverConfigStore } from 'app/utils/stores';
+
+import defaultServerConfig from 'testing/default-server-config';
+import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
+
+import { AccessModulesRedirection, redirectTo } from './guards';
+
+// a newly-created user will have Profile and Publications newly completed, and no others
+const newUserModuleState: AccessModuleStatus[] = [
+  {
+    moduleName: AccessModule.PROFILECONFIRMATION,
+    completionEpochMillis: Date.now(),
+    expirationEpochMillis: nowPlusDays(365),
+  },
+  {
+    moduleName: AccessModule.PUBLICATIONCONFIRMATION,
+    completionEpochMillis: Date.now(),
+    expirationEpochMillis: nowPlusDays(365),
+  },
+];
+
+const allCompleteNotExpiring: AccessModuleStatus[] = Object.keys(
+  AccessModule
+).map((key) => ({
+  moduleName: AccessModule[key],
+  completionEpochMillis: Date.now(),
+  expirationEpochMillis: nowPlusDays(365),
+}));
+
+const allCompleteExpiringSoon: AccessModuleStatus[] = Object.keys(
+  AccessModule
+).map((key) => ({
+  moduleName: AccessModule[key],
+  completionEpochMillis: Date.now(),
+  expirationEpochMillis: nowPlusDays(1),
+}));
+
+// DUCC is expired
+const allCompleteOneExpired: AccessModuleStatus[] = allCompleteNotExpiring
+  .filter(({ moduleName }) => moduleName !== AccessModule.DATAUSERCODEOFCONDUCT)
+  .concat({
+    moduleName: AccessModule.DATAUSERCODEOFCONDUCT,
+    completionEpochMillis: Date.now(),
+    expirationEpochMillis: nowPlusDays(-1),
+  });
+
+// RW-8203
+// artificial state for test users - all complete but Profile/Publications are missing
+const allCompleteMissingPP: AccessModuleStatus[] =
+  allCompleteNotExpiring.filter(
+    ({ moduleName }) =>
+      ![
+        AccessModule.PROFILECONFIRMATION,
+        AccessModule.PUBLICATIONCONFIRMATION,
+      ].includes(moduleName)
+  );
+
+describe('redirectTo', () => {
+  beforeEach(() => {
+    serverConfigStore.set({ config: defaultServerConfig });
+  });
+
+  test.each([
+    [
+      'all complete and not expiring',
+      AccessModulesRedirection.NO_REDIRECT,
+      {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessTierShortNames: [AccessTierShortNames.Registered],
+        accessModules: {
+          anyModuleHasExpired: false,
+          modules: allCompleteNotExpiring,
+        },
+      },
+    ],
+    [
+      'all complete but expiring soon',
+      AccessModulesRedirection.NO_REDIRECT,
+      {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessTierShortNames: [AccessTierShortNames.Registered],
+        accessModules: {
+          anyModuleHasExpired: false,
+          modules: allCompleteExpiringSoon,
+        },
+      },
+    ],
+    [
+      'initially created state',
+      AccessModulesRedirection.DATA_ACCESS_REQUIREMENTS,
+      {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessTierShortNames: [],
+        accessModules: {
+          anyModuleHasExpired: false,
+          modules: newUserModuleState,
+        },
+      },
+    ],
+    [
+      'all complete but one module is expired',
+      AccessModulesRedirection.ACCESS_RENEWAL,
+      {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessTierShortNames: [],
+        accessModules: {
+          anyModuleHasExpired: true,
+          modules: allCompleteOneExpired,
+        },
+      },
+    ],
+    // RW-8203 this fails
+    [
+      'all complete but Profile + Publication Confirmations are missing',
+      // Access Renewal is the only page which allows progress on these modules
+      AccessModulesRedirection.ACCESS_RENEWAL,
+      {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessTierShortNames: [],
+        accessModules: {
+          anyModuleHasExpired: false,
+          modules: allCompleteMissingPP,
+        },
+      },
+    ],
+    // RW-8203 this fails
+    [
+      'all incomplete',
+      // such a user would have to visit Access Renewal first, allowing progress on Profile + Publication
+      // after the user does this, they are in the "initially created" state with respect to modules
+      // so they would be redirected to Data Access Requirements
+      AccessModulesRedirection.ACCESS_RENEWAL,
+      {
+        ...ProfileStubVariables.PROFILE_STUB,
+        accessTierShortNames: [],
+        accessModules: {
+          anyModuleHasExpired: false,
+          modules: [],
+        },
+      },
+    ],
+  ])('%s', (desc, expected: AccessModulesRedirection, profile: Profile) => {
+    expect(redirectTo(profile)).toEqual(expected);
+  });
+});

--- a/ui/src/app/routing/guards.spec.tsx
+++ b/ui/src/app/routing/guards.spec.tsx
@@ -7,7 +7,7 @@ import { serverConfigStore } from 'app/utils/stores';
 import defaultServerConfig from 'testing/default-server-config';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
 
-import { AccessModulesRedirection, redirectTo } from './guards';
+import { AccessModulesRedirection, shouldRedirectTo } from './guards';
 
 // a newly-created user will have Profile and Publications newly completed, and no others
 const newUserModuleState: AccessModuleStatus[] = [
@@ -181,6 +181,6 @@ describe('redirectTo', () => {
       },
     ],
   ])('%s', (desc, expected: AccessModulesRedirection, profile: Profile) => {
-    expect(redirectTo(profile)).toEqual(expected);
+    expect(shouldRedirectTo(profile)).toEqual(expected);
   });
 });

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -70,14 +70,14 @@ export const redirectTo = (profile: Profile): AccessModulesRedirection => {
 // TODO combine these into an "RT Access Guard" or similar?
 export const registrationGuard: Guard = {
   allowed: () =>
-    redirectTo(profileStore.get().profile) ===
+    redirectTo(profileStore.get().profile) !==
     AccessModulesRedirection.DATA_ACCESS_REQUIREMENTS,
   redirectPath: DATA_ACCESS_REQUIREMENTS_PATH,
 };
 
 export const rtExpiredGuard: Guard = {
   allowed: () =>
-    redirectTo(profileStore.get().profile) ===
+    redirectTo(profileStore.get().profile) !==
     AccessModulesRedirection.ACCESS_RENEWAL,
   redirectPath: ACCESS_RENEWAL_PATH,
 };

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -56,7 +56,7 @@ const allCompleteOrBypassed = (
 };
 
 // use this for all access-module routing decisions, to ensure only one routing is chosen
-export const shouldRedirectTo = (profile: Profile): string => {
+export const shouldRedirectToMaybe = (profile: Profile): string | undefined => {
   return cond(
     [profile?.accessModules?.anyModuleHasExpired, () => ACCESS_RENEWAL_PATH],
     // not a common scenario (mainly test users) but AAR is the only way to recover if these modules are missing
@@ -74,7 +74,7 @@ export const shouldRedirectTo = (profile: Profile): string => {
 
 // use this for all access-module routing decisions, to ensure only one routing is chosen
 export const getAccessModuleGuard = (): Guard => {
-  const redirectPath = shouldRedirectTo(profileStore.get().profile);
+  const redirectPath = shouldRedirectToMaybe(profileStore.get().profile);
   return {
     allowed: () => !redirectPath,
     redirectPath,

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -1,4 +1,4 @@
-import { AccessModule, AccessModuleStatus, Profile } from 'generated/fetch';
+import { AccessModule, Profile } from 'generated/fetch';
 
 import { Guard } from 'app/components/app-router';
 import { cond } from 'app/utils';

--- a/ui/src/app/routing/signed-in-app-routing.tsx
+++ b/ui/src/app/routing/signed-in-app-routing.tsx
@@ -43,7 +43,7 @@ import {
 } from 'app/utils/access-utils';
 import { AuthorityGuardedAction } from 'app/utils/authorities';
 
-import { authorityGuard, registrationGuard, rtExpiredGuard } from './guards';
+import { authorityGuard, getAccessModuleGuard } from './guards';
 
 const AccessRenewalPage = fp.flow(
   withRouteData,
@@ -127,7 +127,7 @@ const WorkspaceSearchAdminPage = fp.flow(
 export const SignedInRoutes = () => {
   return (
     <Switch>
-      <AppRoute exact path='/' guards={[rtExpiredGuard, registrationGuard]}>
+      <AppRoute exact path='/' guards={[getAccessModuleGuard()]}>
         <HomepagePage routeData={{ title: 'Homepage' }} />
       </AppRoute>
       <AppRoute exact path={ACCESS_RENEWAL_PATH}>
@@ -317,20 +317,12 @@ export const SignedInRoutes = () => {
           routeData={{ title: 'Data Access Requirements' }}
         />
       </AppRoute>
-      <AppRoute
-        exact
-        path='/library'
-        guards={[rtExpiredGuard, registrationGuard]}
-      >
+      <AppRoute exact path='/library' guards={[getAccessModuleGuard()]}>
         <WorkspaceLibraryPage
           routeData={{ title: 'Workspace Library', minimizeChrome: false }}
         />
       </AppRoute>
-      <AppRoute
-        exact
-        path='/workspaces'
-        guards={[rtExpiredGuard, registrationGuard]}
-      >
+      <AppRoute exact path='/workspaces' guards={[getAccessModuleGuard()]}>
         <WorkspaceListPage
           routeData={{
             title: 'View Workspaces',
@@ -341,7 +333,7 @@ export const SignedInRoutes = () => {
       <AppRoute
         exact
         path='/workspaces/build'
-        guards={[rtExpiredGuard, registrationGuard]}
+        guards={[getAccessModuleGuard()]}
       >
         <WorkspaceEditPage
           routeData={{ title: 'Create Workspace' }}
@@ -351,7 +343,7 @@ export const SignedInRoutes = () => {
       <AppRoute
         path='/workspaces/:ns/:wsid'
         exact={false}
-        guards={[rtExpiredGuard, registrationGuard]}
+        guards={[getAccessModuleGuard()]}
       >
         <WorkspaceWrapperPage intermediaryRoute={true} routeData={{}} />
       </AppRoute>


### PR DESCRIPTION
Last week I noticed that my user got into a state where it couldn't recover because it was being forcibly routed to DAR when it had a non-DAR module that needed updating.  My solution was #6569 

However, this introduced additional problems.  For example, new users (who by definition have incomplete modules) were being forcibly routed to AAR, where they could not complete the set of modules required by DAR.  So I reverted this: #6584

I believe that this now handles all combinations in the right way.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
