### PR TITLE
[risk=no][RW-8212] Update Firecloud impersonation tests for ToS

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -1,7 +1,7 @@
 package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 

--- a/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceBQTest.java
@@ -1,8 +1,8 @@
 package org.pmiops.workbench.cohorts;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/api/src/integration/java/org/pmiops/workbench/FireCloudIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/FireCloudIntegrationTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
-import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.firecloud.ApiClient;
 import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
@@ -27,6 +26,7 @@ public class FireCloudIntegrationTest extends BaseIntegrationTest {
   private static final String NON_COMPLIANT_USER = "integration-test-user@fake-research-aou.org";
   private static final String COMPLIANT_USER =
       "integration-test-user-with-tos@fake-research-aou.org";
+  private static final String COMPLIANT_USER_SUBJECT_ID = "265045784107300a16ccd";
 
   @Autowired private FireCloudService service;
   @Autowired private FirecloudApiClientFactory firecloudApiClientFactory;
@@ -70,7 +70,7 @@ public class FireCloudIntegrationTest extends BaseIntegrationTest {
     ProfileApi profileApi = new ProfileApi(apiClient);
     FirecloudMe me = profileApi.me();
     assertThat(me.getUserInfo().getUserEmail()).isEqualTo(COMPLIANT_USER);
-    assertThat(me.getUserInfo().getUserSubjectId()).isEqualTo("101727030557929965916");
+    assertThat(me.getUserInfo().getUserSubjectId()).isEqualTo(COMPLIANT_USER_SUBJECT_ID);
 
     // Run a test against a different FireCloud endpoint. This is important, because the /me/
     // endpoint is accessible even by service accounts whose subject IDs haven't been whitelisted
@@ -92,8 +92,9 @@ public class FireCloudIntegrationTest extends BaseIntegrationTest {
   public void testImpersonatedProfileCall_tos_non_compliant() throws Exception {
     ApiClient apiClient = firecloudApiClientFactory.newImpersonatedApiClient(NON_COMPLIANT_USER);
 
-    // Run the most basic API call against the /me/ endpoint.
+    // Run the most basic API call against the /me/ endpoint.  It will fail because the user is not
+    // ToS-compliant.
     ProfileApi profileApi = new ProfileApi(apiClient);
-    assertThrows(ForbiddenException.class, profileApi::me);
+    assertThrows(ApiException.class, profileApi::me);
   }
 }

--- a/api/src/integration/java/org/pmiops/workbench/FireCloudIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/FireCloudIntegrationTest.java
@@ -1,5 +1,9 @@
 package org.pmiops.workbench;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.firecloud.ApiClient;
@@ -16,17 +20,13 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 
-import java.io.IOException;
-
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
-
 public class FireCloudIntegrationTest extends BaseIntegrationTest {
   // RW-8212: This test requires that these two users keep their Terra-ToS compliance statuses
   // integration-test-user (created by gjordan) is non-compliant
   // integration-test-user-with-tos (created by thibault) is compliant
   private static final String NON_COMPLIANT_USER = "integration-test-user@fake-research-aou.org";
-  private static final String COMPLIANT_USER = "integration-test-user-with-tos@fake-research-aou.org";
+  private static final String COMPLIANT_USER =
+      "integration-test-user-with-tos@fake-research-aou.org";
 
   @Autowired private FireCloudService service;
   @Autowired private FirecloudApiClientFactory firecloudApiClientFactory;

--- a/api/src/integration/java/org/pmiops/workbench/FireCloudIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/FireCloudIntegrationTest.java
@@ -1,7 +1,7 @@
 package org.pmiops.workbench;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import org.junit.jupiter.api.Test;

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/EgressEventAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/EgressEventAuditorTest.java
@@ -1,7 +1,7 @@
 package org.pmiops.workbench.actionaudit.auditors;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/api/src/test/java/org/pmiops/workbench/api/CohortAnnotationDefinitionControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortAnnotationDefinitionControllerTest.java
@@ -1,8 +1,8 @@
 package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -2,8 +2,8 @@ package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;

--- a/api/src/test/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilderTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortreview/AnnotationQueryBuilderTest.java
@@ -1,7 +1,7 @@
 package org.pmiops.workbench.cohortreview;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohorts/CohortMaterializationServiceTest.java
@@ -1,7 +1,7 @@
 package org.pmiops.workbench.cohorts;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.common.collect.ImmutableList;

--- a/api/src/test/java/org/pmiops/workbench/db/LiquibaseTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/LiquibaseTest.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.db;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDaoTest.java
@@ -1,7 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.ImmutableList;
 import java.sql.Date;

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -1,7 +1,7 @@
 package org.pmiops.workbench.notebooks;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;


### PR DESCRIPTION
The existing user used for impersonation tests was non-tos-compliant, so the test failed.  Keep this user to show that this does fail for non-compliant users.  Add a new compliant user to meet the original test's purpose.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
