### PR TITLE
SWR for genomic extractions, initial approach

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -84,6 +84,7 @@
     "rxjs": "^5.5.6",
     "stackdriver-errors-js": "^0.4.0",
     "stacktrace-js": "^2.0.0",
+    "swr": "^1.3.0",
     "typescript": "^4.1.2",
     "validate.js": "^0.12.0",
     "yarn": "^1.22.0"

--- a/ui/src/app/components/genomics-extraction-menu.tsx
+++ b/ui/src/app/components/genomics-extraction-menu.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import * as React from 'react';
-import * as fp from 'lodash/fp';
 import { faBan, faEllipsisV, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faLocationCircle } from '@fortawesome/pro-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -34,10 +33,17 @@ const styles = {
 interface Props {
   job: GenomicExtractionJob;
   workspace: WorkspaceData;
-  mutateJob: (updateFn: () => Promise<void>, optimisticValue: GenomicExtractionJob) => void;
+  mutateJob: (
+    updateFn: () => Promise<void>,
+    optimisticValue: GenomicExtractionJob
+  ) => void;
 }
 
-export const GenomicsExtractionMenu = ({ job, workspace, mutateJob }: Props) => {
+export const GenomicsExtractionMenu = ({
+  job,
+  workspace,
+  mutateJob,
+}: Props) => {
   const isRunning = job.status === TerraJobStatus.RUNNING;
   const canWrite = WorkspacePermissionsUtil.canWrite(workspace.accessLevel);
   const tooltip = switchCase(
@@ -76,16 +82,19 @@ export const GenomicsExtractionMenu = ({ job, workspace, mutateJob }: Props) => 
               faIcon={faBan}
               disabled={!isRunning || !canWrite}
               onClick={() => {
-                mutateJob(async () => {
-                  await dataSetApi().abortGenomicExtractionJob(
-                    workspace.namespace,
-                    workspace.id,
-                    job.genomicExtractionJobId.toString()
-                  );
-                }, {
-                  ...job,
-                  status: TerraJobStatus.ABORTING
-                });
+                mutateJob(
+                  async () => {
+                    await dataSetApi().abortGenomicExtractionJob(
+                      workspace.namespace,
+                      workspace.id,
+                      job.genomicExtractionJobId.toString()
+                    );
+                  },
+                  {
+                    ...job,
+                    status: TerraJobStatus.ABORTING,
+                  }
+                );
               }}
               tooltip={tooltip}
             >

--- a/ui/src/app/components/genomics-extraction-table.tsx
+++ b/ui/src/app/components/genomics-extraction-table.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useEffect, useState } from 'react';
 import { CSSTransition, SwitchTransition } from 'react-transition-group';
 import * as fp from 'lodash/fp';
 import { Column } from 'primereact/column';
@@ -22,15 +21,11 @@ import { TextColumn } from 'app/components/text-column';
 import colors from 'app/styles/colors';
 import { DEFAULT, switchCase, withCurrentWorkspace } from 'app/utils';
 import { formatUsd } from 'app/utils/numbers';
-import {
-  genomicExtractionJobsSWRKey,
-  useGenomicExtractionJobs,
-} from 'app/utils/stores';
+import { useGenomicExtractionJobs } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import moment from 'moment';
 
 import { SupportMailto } from './support';
-import { useSWRConfig } from 'swr';
 
 const styles = {
   spinStyles: {
@@ -106,7 +101,10 @@ const MissingCell = () => <span style={{ fontSize: '.4rem' }}>&mdash;</span>;
 const mapJobToTableRow = (
   job: GenomicExtractionJob,
   workspace: WorkspaceData,
-  mutateJob: (updateFn: () => Promise<void>, optimisticValue: GenomicExtractionJob) => void
+  mutateJob: (
+    updateFn: () => Promise<void>,
+    optimisticValue: GenomicExtractionJob
+  ) => void
 ) => {
   const iconConfig = getIconConfigForStatus(job.status);
   const durationMoment =
@@ -173,7 +171,7 @@ const mapJobToTableRow = (
       ) : (
         (job.vcfSizeMb / 1000).toFixed(1) + 'GB'
       ),
-    menuJsx: <GenomicsExtractionMenu {...{job, workspace, mutateJob}} />,
+    menuJsx: <GenomicsExtractionMenu {...{ job, workspace, mutateJob }} />,
   };
 };
 
@@ -218,114 +216,127 @@ const FailedRequestMessage = () => (
   </div>
 );
 
-export const GenomicsExtractionTable = fp.flow(
-  withCurrentWorkspace(),
-)(({ workspace }) => {
-  const {data: jobs, error, mutate} = useGenomicExtractionJobs(workspace.namespace, workspace.id);
+export const GenomicsExtractionTable = fp.flow(withCurrentWorkspace())(
+  ({ workspace }) => {
+    const {
+      data: jobs,
+      error,
+      mutate,
+    } = useGenomicExtractionJobs(workspace.namespace, workspace.id);
 
-  return (
-    <div
-      id='extraction-data-table-container'
-      className='extraction-data-table-container'
-    >
-      <div className='slim-scroll-bar'>
-        <SwitchTransition>
-          <CSSTransition
-            key={!jobs}
-            classNames='switch-transition'
-            addEndListener={(node, done) => {
-              node.addEventListener(
-                'transitionend',
-                (e) => {
-                  if (node.isEqualNode(e.target)) {
-                    done(e);
-                  }
-                },
-                false
-              );
-            }}
-          >
-            {!jobs ? (
-              <Spinner style={{ display: 'block', margin: '3rem auto' }} />
-            ) : error ? (
-              <FailedRequestMessage />
-            ) : (
-              <DataTable
-                autoLayout
-                emptyMessage={<EmptyTableMessage />}
-                sortField={
-                  !jobs ||
-                  jobs.length > 0
-                    ? 'dateStarted'
-                    : ''
-                }
-                sortOrder={-1}
-                value={jobs.map((job) =>
-                  mapJobToTableRow(job, workspace, (updateFn, optimisticValue) => {
-                    // Update the extraction job list optimistically.
-                    const optimisticData = jobs.map(j => {
-                      if (j.genomicExtractionJobId === job.genomicExtractionJobId) {
-                        return optimisticValue;
+    return (
+      <div
+        id='extraction-data-table-container'
+        className='extraction-data-table-container'
+      >
+        <div className='slim-scroll-bar'>
+          <SwitchTransition>
+            <CSSTransition
+              key={!jobs}
+              classNames='switch-transition'
+              addEndListener={(node, done) => {
+                node.addEventListener(
+                  'transitionend',
+                  (e) => {
+                    if (node.isEqualNode(e.target)) {
+                      done(e);
+                    }
+                  },
+                  false
+                );
+              }}
+            >
+              {!jobs ? (
+                <Spinner style={{ display: 'block', margin: '3rem auto' }} />
+              ) : error ? (
+                <FailedRequestMessage />
+              ) : (
+                <DataTable
+                  autoLayout
+                  emptyMessage={<EmptyTableMessage />}
+                  sortField={!jobs || jobs.length > 0 ? 'dateStarted' : ''}
+                  sortOrder={-1}
+                  value={jobs.map((job) =>
+                    mapJobToTableRow(
+                      job,
+                      workspace,
+                      (updateFn, optimisticValue) => {
+                        // Update the extraction job list optimistically.
+                        const optimisticData = jobs.map((j) => {
+                          if (
+                            j.genomicExtractionJobId ===
+                            job.genomicExtractionJobId
+                          ) {
+                            return optimisticValue;
+                          }
+                          return j;
+                        });
+                        mutate(
+                          async () => {
+                            await updateFn();
+                            // Callback result is ignored due to populateCache: false
+                            return undefined;
+                          },
+                          {
+                            optimisticData,
+                            populateCache: false,
+                            rollbackOnError: true,
+                          }
+                        );
                       }
-                      return j;
-                    });
-                    mutate(async () => {
-                      await updateFn();
-                      // Callback result is ignored due to populateCache: false
-                      return undefined;
-                    }, { optimisticData, populateCache: false, rollbackOnError: true });
-                  })
-                )}
-                style={{ marginLeft: '0.5rem', marginRight: '0.5rem' }}
-              >
-                <Column
-                  header='Dataset Name'
-                  field='datasetNameDisplay'
-                  sortable
-                  sortField='datasetName'
-                  style={{
-                    maxWidth: '8rem',
-                    textOverflow: 'ellipsis',
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                  }}
-                />
-                <Column
-                  header='Status'
-                  field='statusDisplay'
-                  sortable
-                  sortField='statusOrdinal'
-                />
-                <Column
-                  header='Date Started'
-                  field='dateStartedDisplay'
-                  sortable
-                  sortField='dateStarted'
-                />
-                <Column
-                  header='Cost'
-                  field='costDisplay'
-                  sortable
-                  sortField='cost'
-                />
-                <Column
-                  header='Size'
-                  field='sizeDisplay'
-                  sortable
-                  sortField='size'
-                />
-                <Column
-                  header='Duration'
-                  field='durationDisplay'
-                  sortable
-                  sortField='duration'
-                />
-                <Column header='' field='menuJsx' />
-              </DataTable>
-            )}
-          </CSSTransition>
-        </SwitchTransition>
+                    )
+                  )}
+                  style={{ marginLeft: '0.5rem', marginRight: '0.5rem' }}
+                >
+                  <Column
+                    header='Dataset Name'
+                    field='datasetNameDisplay'
+                    sortable
+                    sortField='datasetName'
+                    style={{
+                      maxWidth: '8rem',
+                      textOverflow: 'ellipsis',
+                      overflow: 'hidden',
+                      whiteSpace: 'nowrap',
+                    }}
+                  />
+                  <Column
+                    header='Status'
+                    field='statusDisplay'
+                    sortable
+                    sortField='statusOrdinal'
+                  />
+                  <Column
+                    header='Date Started'
+                    field='dateStartedDisplay'
+                    sortable
+                    sortField='dateStarted'
+                  />
+                  <Column
+                    header='Cost'
+                    field='costDisplay'
+                    sortable
+                    sortField='cost'
+                  />
+                  <Column
+                    header='Size'
+                    field='sizeDisplay'
+                    sortable
+                    sortField='size'
+                  />
+                  <Column
+                    header='Duration'
+                    field='durationDisplay'
+                    sortable
+                    sortField='duration'
+                  />
+                  <Column header='' field='menuJsx' />
+                </DataTable>
+              )}
+            </CSSTransition>
+          </SwitchTransition>
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -45,7 +45,6 @@ import { ConceptListPage } from 'app/pages/data/concept/concept-list';
 import { WorkspaceActionsMenu } from 'app/pages/workspace/workspace-actions-menu';
 import { WorkspaceShare } from 'app/pages/workspace/workspace-share';
 import { participantStore } from 'app/services/review-state.service';
-import { dataSetApi } from 'app/services/swagger-fetch-clients';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import {
@@ -500,7 +499,6 @@ export const HelpSidebar = fp.flow(
           }
         })
       );
-
     }
 
     componentDidUpdate(prevProps: Readonly<Props>): void {
@@ -704,7 +702,7 @@ export const HelpSidebar = fp.flow(
     }
 
     displayExtractionIcon(icon: IconConfig) {
-      const {genomicExtractionJobs} = this.props;
+      const { genomicExtractionJobs } = this.props;
       const jobsByStatus = fp.groupBy('status', genomicExtractionJobs);
       let status;
       // If any jobs are currently active, show the 'sync' icon corresponding to their status.

--- a/ui/src/app/pages/data/data-set/genomic-extraction-modal.tsx
+++ b/ui/src/app/pages/data/data-set/genomic-extraction-modal.tsx
@@ -173,15 +173,13 @@ export const GenomicExtractionModal = ({
           onClick={async () => {
             setLaunching(true);
             try {
-              await mutate(async () => {
-                const job = await dataSetApi().extractGenomicData(
-                  workspaceNamespace,
-                  workspaceFirecloudName,
-                  dataSet.id
-                );
-                closeFunction();
-                return fp.concat(jobs, job);
-              });
+              const job = await dataSetApi().extractGenomicData(
+                workspaceNamespace,
+                workspaceFirecloudName,
+                dataSet.id
+              );
+              mutate(fp.concat(jobs, job));
+              closeFunction();
             } catch (e) {
               const errJson = (await e.json().catch(() => {})) || {};
               setError({

--- a/ui/src/app/pages/data/data-set/genomic-extraction-modal.tsx
+++ b/ui/src/app/pages/data/data-set/genomic-extraction-modal.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useEffect } from 'react';
 import * as fp from 'lodash/fp';
 
 import { DataSet, GenomicExtractionJob, TerraJobStatus } from 'generated/fetch';
@@ -15,14 +14,9 @@ import {
 import { TooltipTrigger } from 'app/components/popups';
 import { TextColumn } from 'app/components/text-column';
 import { dataSetApi } from 'app/services/swagger-fetch-clients';
-import {
-  genomicExtractionJobsSWRKey,
-  useGenomicExtractionJobs,
-  useStore,
-} from 'app/utils/stores';
+import { useGenomicExtractionJobs } from 'app/utils/stores';
 import { supportUrls } from 'app/utils/zendesk';
 import moment from 'moment';
-import { useSWRConfig } from 'swr';
 
 const { useState } = React;
 
@@ -64,8 +58,10 @@ export const GenomicExtractionModal = ({
   const [error, setError] = useState<{ status: number; message: string }>(null);
   const isClientError = error && 400 <= error.status && error.status < 500;
 
-  const {mutate} = useSWRConfig();
-  const {data: jobs} = useGenomicExtractionJobs(workspaceNamespace, workspaceFirecloudName);
+  const { data: jobs, mutate } = useGenomicExtractionJobs(
+    workspaceNamespace,
+    workspaceFirecloudName
+  );
   const mostRecentExtract: GenomicExtractionJob = fp.flow(
     fp.filter(
       (extract: GenomicExtractionJob) => extract.datasetName === dataSet.name
@@ -80,8 +76,6 @@ export const GenomicExtractionModal = ({
   )(jobs || []);
 
   const loading = !jobs || launching;
-
-  const jobsSWRKey = genomicExtractionJobsSWRKey(workspaceNamespace, workspaceFirecloudName);
 
   const runningExtract =
     mostRecentExtract && mostRecentExtract.status === TerraJobStatus.RUNNING;
@@ -179,7 +173,7 @@ export const GenomicExtractionModal = ({
           onClick={async () => {
             setLaunching(true);
             try {
-              await mutate(jobsSWRKey, async () => {
+              await mutate(async () => {
                 const job = await dataSetApi().extractGenomicData(
                   workspaceNamespace,
                   workspaceFirecloudName,

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -5,15 +5,16 @@ import {
   CdrVersionTier,
   ConfigResponse,
   Disk,
-  GenomicExtractionJob,
   Profile,
   Runtime,
+  TerraJobStatus,
 } from 'generated/fetch';
 
 import { BreadcrumbType } from 'app/components/breadcrumb-type';
-import { profileApi } from 'app/services/swagger-fetch-clients';
+import { dataSetApi, profileApi } from 'app/services/swagger-fetch-clients';
 import { Atom, atom } from 'app/utils/subscribable';
 import { StackdriverErrorReporter } from 'stackdriver-errors-js';
+import useSWR from 'swr';
 
 const { useEffect, useState } = React;
 
@@ -46,20 +47,32 @@ interface CdrVersionStore {
 
 export const cdrVersionStore = atom<CdrVersionStore>({});
 
-export interface GenomicExtractionStore {
-  [workspaceNamespace: string]: GenomicExtractionJob[];
-}
+export const genomicExtractionJobsSWRKey = (workspaceNamespace: string, workspaceId: string) =>
+  `/api/workspaces/${workspaceNamespace}/${workspaceId}/genomicExtractionJobs`;
 
-export const genomicExtractionStore = atom<GenomicExtractionStore>({});
+export const useGenomicExtractionJobs = (workspaceNamespace: string, workspaceId: string, pollWhileNonTerminal = true) =>
+ useSWR(genomicExtractionJobsSWRKey(workspaceNamespace, workspaceId),
+         () => dataSetApi().getGenomicExtractionJobs(workspaceNamespace, workspaceId).then(({jobs}) => jobs), {
+           refreshInterval: (data) => {
+             if (pollWhileNonTerminal &&
+                 (data || []).some(({status}) => [TerraJobStatus.RUNNING, TerraJobStatus.ABORTING].includes(status))) {
+               return 10 * 1000;
+             }
+             return 0;
+           }
+         });
 
-export const updateGenomicExtractionStore = (
-  workspaceNamespace: string,
-  extractions: GenomicExtractionJob[]
-) => {
-  genomicExtractionStore.set({
-    ...genomicExtractionStore.get(),
-    [workspaceNamespace]: extractions,
-  });
+
+// HOC for genomic extraction jobs compatibility with class-based components.
+// New components should use the useGenomicExtractionJobs() hook.
+export const withGenomicExtractionJobs = (WrappedComponent) => (props) => {
+  const {data} = useGenomicExtractionJobs(props.workspace.namespace, props.workspace.id);
+  return (
+    <WrappedComponent
+      genomicExtractionJobs={data}
+      {...props}
+    />
+  );
 };
 
 export interface ProfileStore {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -13283,6 +13283,11 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+swr@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.3.0.tgz#c6531866a35b4db37b38b72c45a63171faf9f4e8"
+  integrity sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==
+
 symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"


### PR DESCRIPTION
Demonstrates integrating SWR into the Workbench, specifically for Genomic Extraction job tracking which is split across multiple components in the app and currently doesn't poll/refresh (though there is a clear need to do this). SWR is used in this PR to coordinate data across these components and implement that polling/refresh.

Overall, it's a bit chattier by default than I might like (re-requests data when you return to the page, for example), but it was pretty easy to set up. This is behavior that can be tuned if we want to.

This PR shows an approach which I won't include in the final version, which is a mutation with an optimistic data update. This is supported, though more complicated than standard usage. Unfortunately it's not helpful here because Cromwell does not function as expected w.r.t. abortJob (the job continues int he running state, and then almost immediately transitions to ABORTED). The optimistic update is immediately reverted on refresh.

# General pattern

## Define a custom SWR hook

```
const useGenomicExtractionJobs = (ns, name) =>
  useSWR(
    // The convention for the key is to match the API path, but it's just an arbitrary unique key for deduplication within the app.
    // I omit "v1" here, but we could also omit "${name}", since it doesn't add uniqueness beyond the namespace.
    `/api/workspaces/${ns}/${name}/genomicExtractionJobs`,
    () =>
      dataSetApi()
        .getGenomicExtractionJobs(ns, name)
        .then(({ jobs }) => jobs));
```

## Use the hook

```
const {data, error} = useGenomicExtractionJobs(...);
if (!data) {
  return <Loading />;
}
...
```

## Signal a mutation to invalidate the cache

```
const {data, mutate} = useGenomicExtractionJobs(...);

...
  onclick={async () => {
    await datasetsApi.abortJob(...);
    mutate();
  }}
```