### PR TITLE
[RW-8237][risk=no] Fix cohort e2e tests for new menu

### DIFF
--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -113,7 +113,7 @@
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableDSCREntryInRecentModified": false,
-    "enableUniversalSearch": false,
+    "enableUniversalSearch": true,
     "enableMultiReview": false
   },
   "actionAudit": {

--- a/e2e/app/component/tiered-menu.ts
+++ b/e2e/app/component/tiered-menu.ts
@@ -14,7 +14,7 @@ export default class TieredMenu extends BaseMenu {
   getMenuItemXpath(menuItemText: string): string {
     return (
       '//*[not(contains(concat(" ", normalize-space(@class), " "), " menuitem-header "))]' +
-      `/*[@role="menuitem" and contains(normalize-space(.),"${menuItemText}")]`
+      `/*[@role="menuitem" and normalize-space()="${menuItemText}"]`
     );
   }
 

--- a/e2e/app/component/tiered-menu.ts
+++ b/e2e/app/component/tiered-menu.ts
@@ -14,7 +14,7 @@ export default class TieredMenu extends BaseMenu {
   getMenuItemXpath(menuItemText: string): string {
     return (
       '//*[not(contains(concat(" ", normalize-space(@class), " "), " menuitem-header "))]' +
-      `/*[@role="menuitem" and normalize-space()="${menuItemText}"]`
+      `/*[@role="menuitem" and contains(normalize-space(.),"${menuItemText}")]`
     );
   }
 

--- a/ui/src/app/cohort-search/cohort-criteria-menu.tsx
+++ b/ui/src/app/cohort-search/cohort-criteria-menu.tsx
@@ -314,16 +314,16 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                   </div>
                 ) : (
                   menuOptions.map((category, index) => (
-                    <div key={index}>
+                    <ul key={index}>
                       {categoryHasResults(index) && (
-                        <div
+                        <li
                           style={styles.dropdownHeader}
                           className='menuitem-header'
                         >
                           <span style={styles.dropdownHeaderText}>
                             {category[0].category}
                           </span>
-                        </div>
+                        </li>
                       )}
                       {category
                         .filter(
@@ -334,8 +334,9 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                             )
                         )
                         .map((menuItem, m) => (
-                          <div
+                          <li
                             role='menuitem'
+                            aria-haspopup={menuItem.group}
                             key={m}
                             style={{
                               ...styles.dropdownItem,
@@ -383,46 +384,51 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                                   className='pi pi-sort-down'
                                 />
                                 {subMenuOpen && (
-                                  <div style={styles.subMenu}>
+                                  <ul style={styles.subMenu}>
                                     {menuItem.children?.map(
                                       (subMenuItem, s) => (
-                                        <div
-                                          key={s}
-                                          style={{
-                                            ...styles.subMenuItem,
-                                            ...(subHoverId ===
-                                            `${index}-${m}-${s}`
-                                              ? {
-                                                  background:
-                                                    colorWithWhiteness(
-                                                      colors.light,
-                                                      0.5
-                                                    ),
-                                                }
-                                              : {}),
-                                          }}
-                                          onMouseEnter={() =>
-                                            setSubHoverId(`${index}-${m}-${s}`)
-                                          }
-                                          onMouseLeave={() => {
-                                            setSubHoverId(null);
-                                          }}
-                                          onClick={(e) => {
-                                            e.stopPropagation();
-                                            onMenuItemClick(menuItem);
-                                          }}
-                                        >
-                                          {subMenuItem.name}
-                                        </div>
+                                        <li>
+                                          <div
+                                            role='menuitem'
+                                            key={s}
+                                            style={{
+                                              ...styles.subMenuItem,
+                                              ...(subHoverId ===
+                                              `${index}-${m}-${s}`
+                                                ? {
+                                                    background:
+                                                      colorWithWhiteness(
+                                                        colors.light,
+                                                        0.5
+                                                      ),
+                                                  }
+                                                : {}),
+                                            }}
+                                            onMouseEnter={() =>
+                                              setSubHoverId(
+                                                `${index}-${m}-${s}`
+                                              )
+                                            }
+                                            onMouseLeave={() => {
+                                              setSubHoverId(null);
+                                            }}
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              onMenuItemClick(subMenuItem);
+                                            }}
+                                          >
+                                            {subMenuItem.name}
+                                          </div>
+                                        </li>
                                       )
                                     )}
-                                  </div>
+                                  </ul>
                                 )}
                               </React.Fragment>
                             )}
-                          </div>
+                          </li>
                         ))}
-                    </div>
+                    </ul>
                   ))
                 )}
               </React.Fragment>

--- a/ui/src/app/cohort-search/cohort-criteria-menu.tsx
+++ b/ui/src/app/cohort-search/cohort-criteria-menu.tsx
@@ -121,7 +121,7 @@ const styles = reactStyles({
   },
   subMenu: {
     position: 'absolute',
-    top: 'calc(100% - 1.75rem)',
+    top: 'calc(100% - 3.75rem)',
     left: '100%',
     display: 'flex',
     flexDirection: 'column',

--- a/ui/src/app/cohort-search/cohort-criteria-menu.tsx
+++ b/ui/src/app/cohort-search/cohort-criteria-menu.tsx
@@ -252,6 +252,7 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
         </button>
         {menuOpen && (
           <div
+            className='p-tieredmenu p-menu-overlay-visible'
             data-test-id='criteria-menu-dropdown'
             ref={menuRef}
             style={styles.dropdownMenu}
@@ -315,7 +316,7 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                   menuOptions.map((category, index) => (
                     <div key={index}>
                       {categoryHasResults(index) && (
-                        <div style={styles.dropdownHeader}>
+                        <div style={styles.dropdownHeader} className='menuitem-header'>
                           <span style={styles.dropdownHeaderText}>
                             {category[0].category}
                           </span>
@@ -331,6 +332,7 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                         )
                         .map((menuItem, m) => (
                           <div
+                            role='menuitem'
                             key={m}
                             style={{
                               ...styles.dropdownItem,

--- a/ui/src/app/cohort-search/cohort-criteria-menu.tsx
+++ b/ui/src/app/cohort-search/cohort-criteria-menu.tsx
@@ -316,7 +316,10 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                   menuOptions.map((category, index) => (
                     <div key={index}>
                       {categoryHasResults(index) && (
-                        <div style={styles.dropdownHeader} className='menuitem-header'>
+                        <div
+                          style={styles.dropdownHeader}
+                          className='menuitem-header'
+                        >
                           <span style={styles.dropdownHeaderText}>
                             {category[0].category}
                           </span>

--- a/ui/src/app/cohort-search/cohort-criteria-menu.tsx
+++ b/ui/src/app/cohort-search/cohort-criteria-menu.tsx
@@ -111,13 +111,16 @@ const styles = reactStyles({
     lineHeight: '1.75rem',
     background: 'transparent',
     borderTop: '1px solid #cccccc',
-    color: colors.black,
     cursor: 'pointer',
-    fontSize: '12px',
-    margin: 0,
-    padding: '0 0.5rem 0 1.25rem',
     position: 'relative',
-    width: '100%',
+  },
+  dropdownLink: {
+    display: 'inline-block',
+    color: colors.black,
+    fontSize: '12px',
+    textDecoration: 'none',
+    padding: '0 0.5rem 0 1.25rem',
+    width: '90%',
   },
   subMenu: {
     position: 'absolute',
@@ -141,11 +144,15 @@ const styles = reactStyles({
     transform: 'rotate(-90deg)',
   },
   subMenuItem: {
+    color: colors.black,
+    display: 'block',
+    fontSize: '12px',
     height: '1.25rem',
     lineHeight: '1.25rem',
     cursor: 'pointer',
     margin: 0,
     padding: '0 1.25rem',
+    textDecoration: 'none',
     width: '100%',
   },
 });
@@ -335,9 +342,6 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                         )
                         .map((menuItem, m) => (
                           <li
-                            role='menuitem'
-                            aria-haspopup={menuItem.group}
-                            key={m}
                             style={{
                               ...styles.dropdownItem,
                               ...(hoverId === `${index}-${m}`
@@ -361,22 +365,29 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                                 setSubMenuOpen(false);
                               }
                             }}
-                            onClick={() => {
-                              if (!menuItem.group) {
-                                onMenuItemClick(menuItem);
-                              }
-                            }}
                           >
-                            <span style={{ verticalAlign: 'middle' }}>
-                              {menuItem.name}
-                            </span>
-                            {domainCounts !== null && (
-                              <span style={styles.count}>
-                                {domainCounts
-                                  .find((dc) => dc.domain === menuItem.domain)
-                                  .count.toLocaleString()}
+                            <a
+                              role='menuitem'
+                              aria-haspopup={menuItem.group}
+                              key={m}
+                              style={styles.dropdownLink}
+                              onClick={() => {
+                                if (!menuItem.group) {
+                                  onMenuItemClick(menuItem);
+                                }
+                              }}
+                            >
+                              <span style={{ verticalAlign: 'middle' }}>
+                                {menuItem.name}
                               </span>
-                            )}
+                              {domainCounts !== null && (
+                                <span style={styles.count}>
+                                  {domainCounts
+                                    .find((dc) => dc.domain === menuItem.domain)
+                                    .count.toLocaleString()}
+                                </span>
+                              )}
+                            </a>
                             {menuItem.group && (
                               <React.Fragment>
                                 <i
@@ -388,7 +399,7 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                                     {menuItem.children?.map(
                                       (subMenuItem, s) => (
                                         <li>
-                                          <div
+                                          <a
                                             role='menuitem'
                                             key={s}
                                             style={{
@@ -418,7 +429,7 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                                             }}
                                           >
                                             {subMenuItem.name}
-                                          </div>
+                                          </a>
                                         </li>
                                       )
                                     )}


### PR DESCRIPTION
Fix e2e tests that broke on initial flip of `enableUniversalSearch` and re-enable flag.

I ended up updating the new menu to work with the existing tests (using `ul`, `li` and `a` instead of `div`s) instead of changing the tests.


Note: If you need to test with the new menu locally, add a `!` in front of the `enableUniversalSearch` flags in these components:
- [search-group-list line 333](https://github.com/all-of-us/workbench/blob/dolbeew/RW-8237/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx#L333)
- [search-group line 744](https://github.com/all-of-us/workbench/blob/dolbeew/RW-8237/ui/src/app/cohort-search/search-group/search-group.component.tsx#L744)