### PR TITLE
[RW-7918][risk=no] Updated styling for datatable for frozen columns

### DIFF
--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -268,5 +268,4 @@ iframe#launcher {
   border-left: 1px solid #c8c8c8;
   border-right: 1px solid #c8c8c8;
   border-top: 1px solid #c8c8c8;
-
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -264,7 +264,7 @@ iframe#launcher {
 
 .p-datatable-scrollable-wrapper > .p-datatable-frozen-view > .p-datatable-scrollable-body > table > .p-datatable-tbody > tr > td,
 .p-datatable-scrollable-wrapper > .p-datatable-frozen-view > .p-datatable-scrollable-header > .p-datatable-scrollable-header-box > table > .p-datatable-thead > tr > th {
-  border: none;
+  border-bottom: none;
   border-left: 1px solid #c8c8c8;
   border-right: 1px solid #c8c8c8;
   border-top: 1px solid #c8c8c8;

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -253,13 +253,6 @@ iframe#launcher {
   border-collapse: separate;
 }
 
-.p-datatable-scrollable-wrapper > .p-datatable-frozen-view > .p-datatable-scrollable-body > table > .p-datatable-tbody > tr > td,
-.p-datatable-scrollable-wrapper > .p-datatable-frozen-view > .p-datatable-scrollable-header > .p-datatable-scrollable-header-box > table > .p-datatable-thead > tr > th {
-  border: none;
-  border-top: 1px solid #c8c8c8;
-  border-right: 1px solid #c8c8c8;
-}
-
 .p-datatable-scrollable-wrapper > .p-datatable-frozen-view > .p-datatable-scrollable-body > table {
   border-bottom: 1px solid #c8c8c8;
 }
@@ -267,4 +260,13 @@ iframe#launcher {
 .p-datatable-frozen-view + .p-datatable-unfrozen-view .p-datatable-thead > tr > th:first-child,
 .p-datatable-frozen-view + .p-datatable-unfrozen-view .p-datatable-tbody > tr > td:first-child {
   border-left: 0 none;
+}
+
+.p-datatable-scrollable-wrapper > .p-datatable-frozen-view > .p-datatable-scrollable-body > table > .p-datatable-tbody > tr > td,
+.p-datatable-scrollable-wrapper > .p-datatable-frozen-view > .p-datatable-scrollable-header > .p-datatable-scrollable-header-box > table > .p-datatable-thead > tr > th {
+  border: none;
+  border-left: 1px solid #c8c8c8;
+  border-right: 1px solid #c8c8c8;
+  border-top: 1px solid #c8c8c8;
+
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -248,3 +248,23 @@ iframe#launcher {
   --hover-opacity: initial;
   --hover-textDecoration: initial;
 }
+
+.p-datatable-frozen-view table {
+  border-collapse: separate;
+}
+
+.p-datatable-scrollable-wrapper > .p-datatable-frozen-view > .p-datatable-scrollable-body > table > .p-datatable-tbody > tr > td,
+.p-datatable-scrollable-wrapper > .p-datatable-frozen-view > .p-datatable-scrollable-header > .p-datatable-scrollable-header-box > table > .p-datatable-thead > tr > th {
+  border: none;
+  border-top: 1px solid #c8c8c8;
+  border-right: 1px solid #c8c8c8;
+}
+
+.p-datatable-scrollable-wrapper > .p-datatable-frozen-view > .p-datatable-scrollable-body > table {
+  border-bottom: 1px solid #c8c8c8;
+}
+
+.p-datatable-frozen-view + .p-datatable-unfrozen-view .p-datatable-thead > tr > th:first-child,
+.p-datatable-frozen-view + .p-datatable-unfrozen-view .p-datatable-tbody > tr > td:first-child {
+  border-left: 0 none;
+}


### PR DESCRIPTION

https://user-images.githubusercontent.com/24514630/165165792-4a939102-35dd-4cc8-8fb4-e253a650e078.mov


Description:
Updated styling to include a border on the right side of the frozen columns. The lack of border was [a design choice by the component library (PrimeReact). ](https://github.com/primefaces/primeng/issues/7755)

Alternatives considered:

- Placing the styling directly on the admin user page - decided against this, because we will want this styling to be consistent across all instances of datatable.
- Placing styling in a new file called datatable.css - there is already a file called datatable.ts that contains styling for a few specialized instances of datatable. I suspect that this will need to be moved somewhere else before datatable gets a css file for the generic case in order to prevent any confusion.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
