### PR TITLE
[risk=no][RW-7919][RW-8256] Make AdminUserTable username and contact email clickable

### DIFF
--- a/ui/src/app/components/admin/admin-user-link.tsx
+++ b/ui/src/app/components/admin/admin-user-link.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import { StyledRouterLink } from 'app/components/buttons';
+import { usernameWithoutDomain } from 'app/utils';
+
+export const AdminUserLink = ({ username, children, ...props }) => (
+  <StyledRouterLink
+    path={`/admin/users/${usernameWithoutDomain(username)}`}
+    {...props}
+  >
+    {children}
+  </StyledRouterLink>
+);

--- a/ui/src/app/pages/admin/admin-egress-audit.tsx
+++ b/ui/src/app/pages/admin/admin-egress-audit.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import * as React from 'react';
 import { useParams } from 'react-router';
 import * as fp from 'lodash/fp';
 import { Column } from 'primereact/column';
@@ -8,6 +9,7 @@ import { TabPanel, TabView } from 'primereact/tabview';
 
 import { AuditEgressEventResponse, EgressEvent } from 'generated/fetch';
 
+import { AdminUserLink } from 'app/components/admin/admin-user-link';
 import { Button, StyledRouterLink } from 'app/components/buttons';
 import { FlexRow } from 'app/components/flex';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
@@ -124,9 +126,9 @@ export const AdminEgressAudit = (props: WithSpinnerOverlayProps) => {
           {new Date(event.creationTime).toLocaleString()}
         </DetailRow>
         <DetailRow label='Source user'>
-          <StyledRouterLink path={`/admin/users/${username}`}>
+          <AdminUserLink {...{ username }}>
             {event.sourceUserEmail}
-          </StyledRouterLink>
+          </AdminUserLink>
         </DetailRow>
         <DetailRow label='Source workspace'>
           <StyledRouterLink

--- a/ui/src/app/pages/admin/egress-events-table.tsx
+++ b/ui/src/app/pages/admin/egress-events-table.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import * as React from 'react';
 import * as fp from 'lodash/fp';
 import { Column } from 'primereact/column';
 import { DataTable } from 'primereact/datatable';
@@ -6,6 +7,7 @@ import { Dropdown } from 'primereact/dropdown';
 
 import { EgressEvent } from 'generated/fetch';
 
+import { AdminUserLink } from 'app/components/admin/admin-user-link';
 import { StyledRouterLink } from 'app/components/buttons';
 import { egressEventsAdminApi } from 'app/services/swagger-fetch-clients';
 import { mutableEgressEventStatuses } from 'app/utils/egress-events';
@@ -149,11 +151,7 @@ export const EgressEventsTable = ({
         field='sourceUserEmail'
         body={({ sourceUserEmail: email }) => {
           const [username] = email.split('@');
-          return (
-            <StyledRouterLink path={`/admin/users/${username}`}>
-              {email}
-            </StyledRouterLink>
-          );
+          return <AdminUserLink {...{ username }}>{email}</AdminUserLink>;
         }}
         header='Source User'
         headerStyle={{ width: '300px' }}

--- a/ui/src/app/pages/admin/user/admin-user-table.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-table.tsx
@@ -231,7 +231,7 @@ export const AdminUserTable = withUserProfile()(
         twoFactorAuth: this.accessModuleCellContents(user, 'twoFactorAuth'),
         username: (
           <AdminUserLink username={user.username} target='_blank'>
-            {user.username}
+            {usernameWithoutDomain(user.username)}
           </AdminUserLink>
         ),
         userLockout: (

--- a/ui/src/app/pages/admin/user/admin-user-table.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-table.tsx
@@ -5,6 +5,7 @@ import { DataTable } from 'primereact/datatable';
 
 import { AdminTableUser, Profile } from 'generated/fetch';
 
+import { AdminUserLink } from 'app/components/admin/admin-user-link';
 import { Button, StyledRouterLink } from 'app/components/buttons';
 import { TooltipTrigger } from 'app/components/popups';
 import { Spinner, SpinnerOverlay } from 'app/components/spinners';
@@ -218,12 +219,9 @@ export const AdminUserTable = withUserProfile()(
         firstSignInTimestamp: user.firstSignInTime,
         institutionName: this.displayInstitutionName(user),
         name: (
-          <StyledRouterLink
-            path={`/admin/users/${usernameWithoutDomain(user.username)}`}
-            target='_blank'
-          >
+          <AdminUserLink username={user.username} target='_blank'>
             {user.familyName + ', ' + user.givenName}
-          </StyledRouterLink>
+          </AdminUserLink>
         ),
         nameText: user.familyName + ' ' + user.givenName,
         status: user.disabled ? 'Disabled' : 'Active',

--- a/ui/src/app/pages/admin/user/admin-user-table.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-table.tsx
@@ -206,7 +206,9 @@ export const AdminUserTable = withUserProfile()(
           user,
           'ctComplianceTraining'
         ),
-        contactEmail: user.contactEmail,
+        contactEmail: (
+          <a href={`mailto:${user.contactEmail}`}>{user.contactEmail}</a>
+        ),
         dataUseAgreement: this.accessModuleCellContents(
           user,
           'dataUseAgreement'
@@ -223,10 +225,15 @@ export const AdminUserTable = withUserProfile()(
             {user.familyName + ', ' + user.givenName}
           </AdminUserLink>
         ),
+        // used for filter and sorting
         nameText: user.familyName + ' ' + user.givenName,
         status: user.disabled ? 'Disabled' : 'Active',
         twoFactorAuth: this.accessModuleCellContents(user, 'twoFactorAuth'),
-        username: user.username,
+        username: (
+          <AdminUserLink username={user.username} target='_blank'>
+            {user.username}
+          </AdminUserLink>
+        ),
         userLockout: (
           <LockoutButton
             disabled={false}

--- a/ui/src/app/utils/index.spec.tsx
+++ b/ui/src/app/utils/index.spec.tsx
@@ -1,6 +1,7 @@
 import * as fp from 'lodash/fp';
 
 import * as Utils from 'app/utils';
+import { usernameWithoutDomain } from 'app/utils';
 
 describe('Helper functions', () => {
   it('(cond) Should handle conditionals and defaults correctly', async () => {
@@ -27,5 +28,12 @@ describe('Helper functions', () => {
 
     const r3 = fp.flow(Utils.maybe(setFirstName), Utils.maybe(setLastName))({});
     expect(r3).toEqual({ firstName: 'first', lastName: 'last' });
+  });
+
+  it('(usernameWithoutDomain) Should normalize usernames appropriately', () => {
+    expect(usernameWithoutDomain('user@google.com')).toEqual('user');
+    expect(usernameWithoutDomain('user')).toEqual('user');
+    expect(usernameWithoutDomain(undefined)).toEqual('');
+    expect(usernameWithoutDomain(null)).toEqual('');
   });
 });

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -585,8 +585,13 @@ export const cond = <T extends unknown>(
   }
 };
 
+// normalize username (email) to remove the domain if it exists
 export const usernameWithoutDomain = (username: string) => {
-  return username ? username.substring(0, username.indexOf('@')) : '';
+  if (!username) {
+    return '';
+  }
+  const atIdx = username.indexOf('@');
+  return atIdx === -1 ? username : username.substring(0, atIdx);
 };
 
 export const capStringWithEllipsis = (value: string, maxLength: number) =>


### PR DESCRIPTION
Contact Email is now clickable to send the user an email (not demonstrated here because my browser is not confgured for this)
Username is now clickable and opens the AdminUserProfile page for that user in a new tab

 
![user admin table fields clickable](https://user-images.githubusercontent.com/2701406/165542916-43b8d9f2-98ae-4aa8-9b15-07621502f415.gif)


Add an AdminUserLink component and add tests for usernameWithoutDomain.  Tested locally, has the same behavior:
* AdminUserTable, new tab
* AdminEgressAudit, same tab
* EgressEventsTable, same tab (no-op when it's the table within the AdminUserProfile)

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
