### PR TITLE
[RW-5780][risk=no] Switch the local API server to use alternate auth domains

### DIFF
--- a/api/config/cdr_config_local.json
+++ b/api/config/cdr_config_local.json
@@ -5,8 +5,8 @@
       "shortName": "registered",
       "displayName": "Registered Tier",
       "servicePerimeter": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test",
-      "authDomainName": "all-of-us-registered-test",
-      "authDomainGroupEmail": "GROUP_all-of-us-registered-test@dev.test.firecloud.org",
+      "authDomainName": "all-of-us-registered-local",
+      "authDomainGroupEmail": "all-of-us-registered-local@dev.test.firecloud.org",
       "datasetsBucket": "gs://fc-aou-test-datasets-registered/",
       "enableUserWorkflows": false
     },
@@ -15,8 +15,8 @@
       "shortName": "controlled",
       "displayName": "Controlled Tier",
       "servicePerimeter": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test_2",
-      "authDomainName": "all-of-us-test-prototype-3",
-      "authDomainGroupEmail": "all-of-us-test-prototype-3@dev.test.firecloud.org",
+      "authDomainName": "all-of-us-controlled-local",
+      "authDomainGroupEmail": "all-of-us-controlled-local@dev.test.firecloud.org",
       "datasetsBucket": "gs://fc-aou-test-datasets-controlled/",
       "enableUserWorkflows": true
     }

--- a/api/libproject/environments.rb
+++ b/api/libproject/environments.rb
@@ -24,7 +24,20 @@ ENVIRONMENTS = {
   "local" => env_with_defaults("local", {
     :api_endpoint_host => "localhost:8081",
     :cdr_sql_instance => "workbench",
-    :source_cdr_project => "all-of-us-ehr-dev"
+    :source_cdr_project => "all-of-us-ehr-dev",
+    :source_cdr_wgs_project => "all-of-us-workbench-test",
+    :accessTiers => {
+      "registered" => {
+        :ingest_cdr_project => "fc-aou-vpc-ingest-test",
+        :dest_cdr_project => "fc-aou-cdr-synth-test",
+        :auth_domain_group_email => "all-of-us-registered-local@dev.test.firecloud.org",
+      },
+      "controlled" => {
+        :ingest_cdr_project => "fc-aou-cdr-ingest-test-2",
+        :dest_cdr_project => "fc-aou-cdr-synth-test-2",
+        :auth_domain_group_email => "all-of-us-controlled-local@dev.test.firecloud.org"
+      }
+    }
   }),
   "all-of-us-workbench-test" => env_with_defaults("test", {
     :api_endpoint_host => "api-dot-#{TEST_PROJECT}.appspot.com",


### PR DESCRIPTION
Normally when you start a local API server, your membership in the test auth domain might be affected, if access module completion is divergent. This can result in confusing access failures in the test env. To avoid this issue, I created another set of auth domains exclusively for local.

- publish-cdr --project all-of-us-workbench-test now adds both the test auth domain, and the local auth domain
- after this merges, local group membership may need to be refreshed, e.g. via the admin table disable/enable, running the access sync cron (this might run on start) - or simply by resetting your local DB