### PR TITLE
[RW-1386][risk=low] Switch stable to use custom AoU domains

### DIFF
--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -64,8 +64,8 @@
     "gSuiteDomain": "stable.fake-research-aou.org"
   },
   "server": {
-    "apiBaseUrl": "https:\/\/api-dot-all-of-us-rw-stable.appspot.com",
-    "uiBaseUrl": "https:\/\/all-of-us-rw-stable.appspot.com",
+    "apiBaseUrl": "https:\/\/api.stable.fake-research-aou.org",
+    "uiBaseUrl": "https:\/\/stable.fake-research-aou.org",
     "publicApiKeyForErrorReports": "AIzaSyA4gOEvyJRkhIbW0x0Y7PkIowOSIK_Tous",
     "projectId": "all-of-us-rw-stable",
     "shortName": "Stable",
@@ -74,7 +74,7 @@
     "appEngineLocationId": "us-central"
   },
   "admin": {
-    "loginUrl": "https:\/\/all-of-us-rw-stable.appspot.com/login"
+    "loginUrl": "https:\/\/stable.fake-research-aou.org/login"
   },
   "mandrill": {
     "fromEmail": "support@researchallofus.org",

--- a/api/libproject/environments.rb
+++ b/api/libproject/environments.rb
@@ -100,7 +100,7 @@ ENVIRONMENTS = {
     }
   }),
   "all-of-us-rw-stable" => env_with_defaults("stable", {
-    :api_endpoint_host => "api-dot-all-of-us-rw-stable.appspot.com",
+    :api_endpoint_host => "api.stable.fake-research-aou.org",
     :cdr_sql_instance => "#{TEST_PROJECT}:us-central1:workbenchmaindb",
     :source_cdr_project => "all-of-us-ehr-dev",
     :source_cdr_wgs_project => "all-of-us-workbench-test",

--- a/e2e/resources/workbench-config.ts
+++ b/e2e/resources/workbench-config.ts
@@ -72,8 +72,8 @@ const staging: IEnvConfig = {
 
 // NOT WORKING: workbench stable environment
 const stable: IEnvConfig = {
-  LOGIN_URL_DOMAIN_NAME: process.env.STABLE_LOGIN_URL || 'https://all-of-us-rw-stable.appspot.com/login',
-  API_HOSTNAME: process.env.API_HOSTNAME || 'api-dot-all-of-us-rw-stable.appspot.com',
+  LOGIN_URL_DOMAIN_NAME: process.env.STABLE_LOGIN_URL || 'https://stable.fake-research-aou.org/login',
+  API_HOSTNAME: process.env.API_HOSTNAME || 'api.stable.fake-research-aou.org',
   EMAIL_DOMAIN_NAME: '@stable.fake-research-aou.org',
   DEFAULT_CDR_VERSION_NAME: 'Synthetic Dataset v4',
   OLD_CDR_VERSION_NAME: 'Synthetic Dataset v3',

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -11,7 +11,7 @@ export interface EnvironmentBase {
   //
   // The URL to use when making API requests against the AoU API. This is used
   // by the core API / fetch modules and shouldn't be needed by most other components.
-  // Example value: 'https://api-dot-all-of-us-rw-stable.appspot.com'
+  // Example value: 'https://api.stable.fake-research-aou.org'
   allOfUsApiUrl: string;
   // The OAuth2 client ID. Used by the sign-in module to authenticate the user.
   // Example value: '56507752110-ovdus1lkreopsfhlovejvfgmsosveda6.apps.googleusercontent.com'

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -3,7 +3,7 @@ import { Environment, ZendeskEnv } from 'environments/environment-type';
 export const environment: Environment = {
   displayTag: 'Stable',
   shouldShowDisplayTag: true,
-  allOfUsApiUrl: 'https://api-dot-all-of-us-rw-stable.appspot.com',
+  allOfUsApiUrl: 'https://api.stable.fake-research-aou.org',
   captchaSiteKey: '6LcKXeQUAAAAAEK734FfI8O3BTzCMhewzmI2sBeC',
   clientId:
     '56507752110-ovdus1lkreopsfhlovejvfgmsosveda6.apps.googleusercontent.com',


### PR DESCRIPTION
This aligns stable more closely with production, and enables equivalent WAF configuration. This was abandoned some time ago, and was not possible until recently when some of the DNS records were finally fixed.

Current state:
- all-of-us-rw-stable.appspot.com works, backed by api-dot-all-of-us-rw-stable.appspot.com
- stable.fake-research-aou.org works, backed by api-dot-all-of-us-rw-stable.appspot.com

State after this PR:
- all-of-us-rw-stable.appspot.com works, backed by api.stable.fake-research-aou.org
- stable.fake-research-aou.org works, backed by api.stable.fake-research-aou.org

Future state, after config changes:
- stable.fake-research-aou.org works, backed by api.stable.fake-research-aou.org
- direct external appspot traffic is blocked
- (possibly) direct appspot traffic is redirected to stable.fake-research-aou.org