### PR TITLE
[risk=low][RW-4838][RW-7917] DataUseAgreementBypassTime -> DuccBypassTime and deprecate AdminUserTable completions

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -167,18 +167,23 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + "u.creation_time AS creationTime, "
               + "u.first_sign_in_time AS firstSignInTime, "
               // to be removed soon, replaced by duccBypassTime
-              + "uamd.data_use_agreement_bypass_time AS dataUseAgreementBypassTime, "
-              + "uamd.data_use_agreement_bypass_time AS duccBypassTime, "
-              + "uamd.data_use_agreement_completion_time AS dataUseAgreementCompletionTime, "
+              + "uamd.ducc_bypass_time AS dataUseAgreementBypassTime, "
+              + "uamd.ducc_bypass_time AS duccBypassTime, "
+              // to be removed soon
+              + "uamd.ducc_completion_time AS dataUseAgreementCompletionTime, "
               + "uamrt.compliance_training_bypass_time AS complianceTrainingBypassTime, "
+              // to be removed soon
               + "uamrt.compliance_training_completion_time AS complianceTrainingCompletionTime, "
               + "uamct.ct_compliance_training_bypass_time AS ctComplianceTrainingBypassTime, "
+              // to be removed soon
               + "uamct.ct_compliance_training_completion_time AS ctComplianceTrainingCompletionTime, "
               + "uame.era_commons_bypass_time AS eraCommonsBypassTime, "
+              // to be removed soon
               + "uame.era_commons_completion_time AS eraCommonsCompletionTime, "
               + "uamt.two_factor_auth_bypass_time AS twoFactorAuthBypassTime, "
               + "uamt.two_factor_auth_completion_time AS twoFactorAuthCompletionTime, "
               + "uamr.ras_link_login_gov_bypass_time AS rasLinkLoginGovBypassTime, "
+              // to be removed soon
               + "uamr.ras_link_login_gov_completion_time AS rasLinkLoginGovCompletionTime, "
               + "t.access_tier_short_names AS accessTierShortNames "
               + "FROM user u "
@@ -227,8 +232,8 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + ") as uamct ON u.user_id = uamct.user_id "
               + "LEFT JOIN ( "
               + "  SELECT uam.user_id, "
-              + "    uam.bypass_time AS data_use_agreement_bypass_time, "
-              + "    uam.completion_time AS data_use_agreement_completion_time "
+              + "    uam.bypass_time AS ducc_bypass_time, "
+              + "    uam.completion_time AS ducc_completion_time "
               + "  FROM user_access_module uam "
               + "  JOIN access_module am ON am.access_module_id=uam.access_module_id "
               + "  WHERE am.name = 'DATA_USER_CODE_OF_CONDUCT' "

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -166,6 +166,7 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + "i.short_name AS institutionShortName, "
               + "u.creation_time AS creationTime, "
               + "u.first_sign_in_time AS firstSignInTime, "
+              // to be removed soon, replaced by duccBypassTime
               + "uamd.data_use_agreement_bypass_time AS dataUseAgreementBypassTime, "
               + "uamd.data_use_agreement_bypass_time AS duccBypassTime, "
               + "uamd.data_use_agreement_completion_time AS dataUseAgreementCompletionTime, "

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -111,28 +111,37 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
 
     Timestamp getCreationTime();
 
+    @Deprecated // to be removed - use getDuccBypassTime
     Timestamp getDataUseAgreementBypassTime();
 
+    Timestamp getDuccBypassTime();
+
+    @Deprecated // to be removed
     Timestamp getDataUseAgreementCompletionTime();
 
     Timestamp getComplianceTrainingBypassTime();
 
+    @Deprecated // to be removed
     Timestamp getComplianceTrainingCompletionTime();
 
     Timestamp getCtComplianceTrainingBypassTime();
 
+    @Deprecated // to be removed
     Timestamp getCtComplianceTrainingCompletionTime();
 
     Timestamp getEraCommonsBypassTime();
 
+    @Deprecated // to be removed
     Timestamp getEraCommonsCompletionTime();
 
     Timestamp getTwoFactorAuthBypassTime();
 
+    @Deprecated // to be removed
     Timestamp getTwoFactorAuthCompletionTime();
 
     Timestamp getRasLinkLoginGovBypassTime();
 
+    @Deprecated // to be removed
     Timestamp getRasLinkLoginGovCompletionTime();
 
     String getAccessTierShortNames();
@@ -158,6 +167,7 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + "u.creation_time AS creationTime, "
               + "u.first_sign_in_time AS firstSignInTime, "
               + "uamd.data_use_agreement_bypass_time AS dataUseAgreementBypassTime, "
+              + "uamd.data_use_agreement_bypass_time AS duccBypassTime, "
               + "uamd.data_use_agreement_completion_time AS dataUseAgreementCompletionTime, "
               + "uamrt.compliance_training_bypass_time AS complianceTrainingBypassTime, "
               + "uamrt.compliance_training_completion_time AS complianceTrainingCompletionTime, "

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
@@ -46,6 +46,8 @@ public interface ProfileMapper {
       List<UserTierEligibility> tierEligibilities,
       ProfileAccessModules accessModules);
 
+  // temporary for deployment safety - will be removed after one release cycle.
+  @Mapping(source = "duccBypassTime", target = "dataUseAgreementBypassTime")
   List<AdminTableUser> adminViewToModel(List<DbAdminTableUser> adminTableUsers);
 
   // used by the generated impl of adminViewToModel()

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5845,36 +5845,46 @@ definitions:
         type: integer
         format: int64
       twoFactorAuthCompletionTime:
+        description: DEPRECATED - to be removed.
         type: integer
         format: int64
       eraCommonsBypassTime:
         type: integer
         format: int64
       eraCommonsCompletionTime:
+        description: DEPRECATED - to be removed.
         type: integer
         format: int64
       rasLinkLoginGovBypassTime:
         type: integer
         format: int64
       rasLinkLoginGovCompletionTime:
+        description: DEPRECATED - to be removed.
         type: integer
         format: int64
       complianceTrainingBypassTime:
         type: integer
         format: int64
       complianceTrainingCompletionTime:
+        description: DEPRECATED - to be removed.
         type: integer
         format: int64
       ctComplianceTrainingBypassTime:
         type: integer
         format: int64
       ctComplianceTrainingCompletionTime:
+        description: DEPRECATED - to be removed.
         type: integer
         format: int64
       dataUseAgreementBypassTime:
+        description: DEPRECATED - to be removed. use duccBypassTime.
+        type: integer
+        format: int64
+      duccBypassTime:
         type: integer
         format: int64
       dataUseAgreementCompletionTime:
+        description: DEPRECATED - to be removed.
         type: integer
         format: int64
 

--- a/ui/src/app/pages/admin/user/admin-user-bypass.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-bypass.tsx
@@ -41,9 +41,7 @@ const getBypassedModules = (user: AdminTableUser): Array<AccessModule> => {
     ...(user.ctComplianceTrainingBypassTime
       ? [AccessModule.CTCOMPLIANCETRAINING]
       : []),
-    ...(user.dataUseAgreementBypassTime
-      ? [AccessModule.DATAUSERCODEOFCONDUCT]
-      : []),
+    ...(user.duccBypassTime ? [AccessModule.DATAUSERCODEOFCONDUCT] : []),
     ...(user.eraCommonsBypassTime ? [AccessModule.ERACOMMONS] : []),
     ...(user.twoFactorAuthBypassTime ? [AccessModule.TWOFACTORAUTH] : []),
     ...(user.rasLinkLoginGovBypassTime ? [AccessModule.RASLINKLOGINGOV] : []),


### PR DESCRIPTION
Also deprecate module completion times, which are no longer used after #6629

After one release cycle, we can then remove DataUseAgreementBypassTime and module completion times from AdminUser

Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
