### PR TITLE
wait additional 10 min after workspace clone

### DIFF
--- a/e2e/app/page/authenticated-page.ts
+++ b/e2e/app/page/authenticated-page.ts
@@ -21,17 +21,18 @@ export default abstract class AuthenticatedPage extends BasePage {
    * Method to be implemented by children classes.
    * Check whether current page has specified web elements.
    */
-  abstract isLoaded(): Promise<boolean>;
+  abstract isLoaded(opts?: { timeout?: number }): Promise<boolean>;
 
   /**
    * Wait until current page is loaded and without spinners spinning.
    */
-  async waitForLoad(): Promise<this> {
+  async waitForLoad(opts: { timeout?: number } = {}): Promise<this> {
+    const { timeout } = opts;
     const signedIn = await this.isSignedIn();
     if (!signedIn) {
       throw new Error(`Failed to find signed-in web-element. xpath="${process.env.AUTHENTICATED_TEST_ID_XPATH}"`);
     }
-    await this.isLoaded();
+    await this.isLoaded({ timeout });
     await this.closeHelpSidebarIfOpen();
     const pageTitle = await this.page.title();
     logger.info(`"${pageTitle}" page loaded.`);

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -18,9 +18,10 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
     super(page);
   }
 
-  async isLoaded(): Promise<boolean> {
+  async isLoaded(opts: { timeout?: number } = {}): Promise<boolean> {
+    const { timeout } = opts;
     await Promise.all([waitForDocumentTitle(this.page, PageTitle), this.createNewNotebookLink().waitUntilEnabled()]);
-    await waitWhileLoading(this.page);
+    await waitWhileLoading(this.page, { timeout });
     return true;
   }
 

--- a/e2e/tests/notebook/notebook-writer-clone-workspace.spec.ts
+++ b/e2e/tests/notebook/notebook-writer-clone-workspace.spec.ts
@@ -9,6 +9,7 @@ import { waitWhileLoading } from 'utils/waits-utils';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import { makeRandomName } from 'utils/str-utils';
 import expect from 'expect';
+import Tab from 'app/element/tab';
 
 // 30 minutes.
 jest.setTimeout(30 * 60 * 1000);
@@ -67,8 +68,15 @@ describe('WRITER clone workspace and notebook tests', () => {
     await dataPage.cloneWorkspace();
 
     // Currently displayed workspace is the workspace clone.
+    // Open Analysis tab to verify notebook also cloned successfully.
+
+    const tab = new Tab(page, Tabs.Analysis);
+    await tab.click().catch((err) => {
+      console.error(err);
+    });
+
     const workspaceCloneAnalysisPage = new WorkspaceAnalysisPage(page);
-    await openTab(page, Tabs.Analysis, workspaceCloneAnalysisPage);
+    await workspaceCloneAnalysisPage.waitForLoad({ timeout: 10 * 60 * 1000 });
 
     // Create Notebook button is enabled.
     expect(await workspaceCloneAnalysisPage.createNewNotebookLink().isCursorNotAllowed()).toBe(false);


### PR DESCRIPTION
Cloning a workspace that has a notebook is now taking longer time.

<img width="646" alt="Screen Shot 2022-05-02 at 7 40 07 PM" src="https://user-images.githubusercontent.com/35533885/166343040-923ec7d3-120b-491b-8f55-94dfcf90af82.png">

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
