### PR TITLE
[RW-8228][risk=no] Bump runtime min disk size

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -356,7 +356,6 @@ describe('RuntimePanel', () => {
     // TODO(RW-7152): This test is incorrectly depending on "default" values in runtime-panel, and
     // not general analysis. Ensure this test passes for the right reasons when fixing.
     const computeDefaults = wrapper.find('#compute-resources').first();
-    // defaults to generalAnalysis preset, which is a n1-standard-4 machine with a 120GB disk
     expect(computeDefaults.text()).toEqual(
       '- Compute size of 4 CPUs, 15 GB memory, and a 120 GB disk'
     );
@@ -1108,19 +1107,17 @@ describe('RuntimePanel', () => {
     expect(runningCost().text()).toEqual('$0.20/hour');
     expect(storageCost().text()).toEqual('< $0.01/hour');
 
-    // Change the machine to n1-standard-8 and bump the storage to 300GB. This should make the running cost 40 cents an hour and the storage cost 2 cents an hour.
+    // Change the machine to n1-standard-8 and bump the storage to 300GB.
     await pickMainCpu(wrapper, 8);
     await pickMainRam(wrapper, 30);
     await pickMainDiskSize(wrapper, 300);
     expect(runningCost().text()).toEqual('$0.40/hour');
     expect(storageCost().text()).toEqual('$0.02/hour');
 
-    // Selecting the General Analysis preset should bring the machine back to n1-standard-4 with 100GB storage.
     await pickPreset(wrapper, { displayName: 'General Analysis' });
     expect(runningCost().text()).toEqual('$0.20/hour');
     expect(storageCost().text()).toEqual('< $0.01/hour');
 
-    // After selecting Dataproc, the Dataproc defaults should make the running cost 72 cents an hour. The storage cost increases due to worker disk.
     await pickComputeType(wrapper, ComputeType.Dataproc);
     expect(runningCost().text()).toEqual('$0.73/hour');
     expect(storageCost().text()).toEqual('$0.02/hour');

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -25,8 +25,6 @@ import { WarningMessage } from 'app/components/messages';
 import { Spinner } from 'app/components/spinners';
 import {
   ConfirmDelete,
-  DATAPROC_WORKER_MIN_DISK_SIZE_GB,
-  MIN_DISK_SIZE_GB,
   Props,
   RuntimePanelWrapper,
 } from 'app/pages/analysis/runtime-panel';
@@ -36,7 +34,12 @@ import {
   registerApiClient,
   runtimeApi,
 } from 'app/services/swagger-fetch-clients';
-import { ComputeType, findMachineByName } from 'app/utils/machines';
+import {
+  ComputeType,
+  DATAPROC_WORKER_MIN_DISK_SIZE_GB,
+  findMachineByName,
+  MIN_DISK_SIZE_GB,
+} from 'app/utils/machines';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 import { runtimePresets } from 'app/utils/runtime-presets';
 import { diskTypeLabels } from 'app/utils/runtime-utils';

--- a/ui/src/app/pages/analysis/runtime-panel.spec.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.spec.tsx
@@ -356,9 +356,9 @@ describe('RuntimePanel', () => {
     // TODO(RW-7152): This test is incorrectly depending on "default" values in runtime-panel, and
     // not general analysis. Ensure this test passes for the right reasons when fixing.
     const computeDefaults = wrapper.find('#compute-resources').first();
-    // defaults to generalAnalysis preset, which is a n1-standard-4 machine with a 100GB disk
+    // defaults to generalAnalysis preset, which is a n1-standard-4 machine with a 120GB disk
     expect(computeDefaults.text()).toEqual(
-      '- Compute size of 4 CPUs, 15 GB memory, and a 100 GB disk'
+      '- Compute size of 4 CPUs, 15 GB memory, and a 120 GB disk'
     );
   });
 
@@ -457,7 +457,7 @@ describe('RuntimePanel', () => {
       gceConfig: {
         ...defaultGceConfig(),
         machineType: 'n1-standard-16',
-        diskSize: 100,
+        diskSize: MIN_DISK_SIZE_GB,
       },
       dataprocConfig: null,
     });
@@ -479,7 +479,7 @@ describe('RuntimePanel', () => {
       gceConfig: {
         ...defaultGceConfig(),
         machineType: 'n1-standard-16',
-        diskSize: 100,
+        diskSize: MIN_DISK_SIZE_GB,
       },
       dataprocConfig: null,
     });
@@ -735,7 +735,7 @@ describe('RuntimePanel', () => {
     // the Hail preset selection.
     await pickMainCpu(wrapper, 2);
     await pickMainRam(wrapper, 7.5);
-    await pickMainDiskSize(wrapper, 100);
+    await pickMainDiskSize(wrapper, MIN_DISK_SIZE_GB);
     await pickComputeType(wrapper, ComputeType.Dataproc);
 
     await pickWorkerCpu(wrapper, 8);
@@ -1122,7 +1122,7 @@ describe('RuntimePanel', () => {
 
     // After selecting Dataproc, the Dataproc defaults should make the running cost 72 cents an hour. The storage cost increases due to worker disk.
     await pickComputeType(wrapper, ComputeType.Dataproc);
-    expect(runningCost().text()).toEqual('$0.72/hour');
+    expect(runningCost().text()).toEqual('$0.73/hour');
     expect(storageCost().text()).toEqual('$0.02/hour');
 
     // Bump up all the worker values to increase the price on everything.
@@ -1131,7 +1131,7 @@ describe('RuntimePanel', () => {
     await pickWorkerCpu(wrapper, 8);
     await pickWorkerRam(wrapper, 30);
     await pickWorkerDiskSize(wrapper, 300);
-    expect(runningCost().text()).toEqual('$2.87/hour');
+    expect(runningCost().text()).toEqual('$2.88/hour');
     expect(storageCost().text()).toEqual('$0.14/hour');
   });
 

--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -47,6 +47,7 @@ import { findCdrVersion } from 'app/utils/cdr-versions';
 import {
   AutopauseMinuteThresholds,
   ComputeType,
+  DATAPROC_WORKER_MIN_DISK_SIZE_GB,
   DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES,
   DEFAULT_MACHINE_NAME,
   DEFAULT_MACHINE_TYPE,
@@ -56,6 +57,7 @@ import {
   gpuTypeToDisplayName,
   Machine,
   machineRunningCost,
+  MIN_DISK_SIZE_GB,
   validLeoDataprocMasterMachineTypes,
   validLeoDataprocWorkerMachineTypes,
   validLeoGceMachineTypes,
@@ -244,10 +246,6 @@ const styles = reactStyles({
     fontWeight: 500,
   },
 });
-
-// exported for testing
-export const MIN_DISK_SIZE_GB = 100;
-export const DATAPROC_WORKER_MIN_DISK_SIZE_GB = 150;
 
 enum PanelContent {
   Create = 'Create',

--- a/ui/src/app/utils/machines.ts
+++ b/ui/src/app/utils/machines.ts
@@ -385,7 +385,7 @@ export const findMachineByName = (machineToFind: string) =>
 export const DEFAULT_MACHINE_NAME = 'n1-standard-4';
 export const DEFAULT_MACHINE_TYPE: Machine =
   findMachineByName(DEFAULT_MACHINE_NAME);
-export const DEFAULT_DISK_SIZE = 100;
+export const DEFAULT_DISK_SIZE = MIN_DISK_SIZE_GB;
 
 const approxHoursPerMonth = 730;
 export const diskPricePerMonth = 0.04; // per GB month

--- a/ui/src/app/utils/machines.ts
+++ b/ui/src/app/utils/machines.ts
@@ -8,6 +8,9 @@ import { AnalysisConfig, DiskConfig } from './runtime-utils';
 
 // Copied from https://github.com/DataBiosphere/terra-ui/blob/219b063b07d56499ccc38013fd88f4f0b88f8cd6/src/data/machines.js
 
+export const MIN_DISK_SIZE_GB = 120;
+export const DATAPROC_WORKER_MIN_DISK_SIZE_GB = 150;
+
 export enum ComputeType {
   Standard = 'Standard VM',
   Dataproc = 'Dataproc Cluster',

--- a/ui/src/app/utils/runtime-presets.ts
+++ b/ui/src/app/utils/runtime-presets.ts
@@ -5,6 +5,7 @@ import { Runtime, RuntimeConfigurationType } from 'generated/fetch';
 import {
   DATAPROC_WORKER_MIN_DISK_SIZE_GB,
   DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES,
+  DEFAULT_MACHINE_NAME,
   MIN_DISK_SIZE_GB,
 } from './machines';
 
@@ -21,7 +22,7 @@ export const runtimePresets: {
       autopauseThreshold: DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES,
       // TODO: Support specifying toolDockerImage here.
       gceConfig: {
-        machineType: 'n1-standard-4',
+        machineType: DEFAULT_MACHINE_NAME,
         diskSize: MIN_DISK_SIZE_GB,
         gpuConfig: null,
       },
@@ -33,9 +34,9 @@ export const runtimePresets: {
       configurationType: RuntimeConfigurationType.HailGenomicAnalysis,
       autopauseThreshold: DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES,
       dataprocConfig: {
-        masterMachineType: 'n1-standard-4',
+        masterMachineType: DEFAULT_MACHINE_NAME,
         masterDiskSize: MIN_DISK_SIZE_GB,
-        workerMachineType: 'n1-standard-4',
+        workerMachineType: DEFAULT_MACHINE_NAME,
         workerDiskSize: DATAPROC_WORKER_MIN_DISK_SIZE_GB,
         numberOfWorkers: 2,
         numberOfPreemptibleWorkers: 0,

--- a/ui/src/app/utils/runtime-presets.ts
+++ b/ui/src/app/utils/runtime-presets.ts
@@ -2,7 +2,11 @@ import * as fp from 'lodash/fp';
 
 import { Runtime, RuntimeConfigurationType } from 'generated/fetch';
 
-import { DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES } from './machines';
+import {
+  DATAPROC_WORKER_MIN_DISK_SIZE_GB,
+  DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES,
+  MIN_DISK_SIZE_GB,
+} from './machines';
 
 export const runtimePresets: {
   [runtimePresetName: string]: {
@@ -18,7 +22,7 @@ export const runtimePresets: {
       // TODO: Support specifying toolDockerImage here.
       gceConfig: {
         machineType: 'n1-standard-4',
-        diskSize: 100,
+        diskSize: MIN_DISK_SIZE_GB,
         gpuConfig: null,
       },
     },
@@ -30,9 +34,9 @@ export const runtimePresets: {
       autopauseThreshold: DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES,
       dataprocConfig: {
         masterMachineType: 'n1-standard-4',
-        masterDiskSize: 100,
+        masterDiskSize: MIN_DISK_SIZE_GB,
         workerMachineType: 'n1-standard-4',
-        workerDiskSize: 150,
+        workerDiskSize: DATAPROC_WORKER_MIN_DISK_SIZE_GB,
         numberOfWorkers: 2,
         numberOfPreemptibleWorkers: 0,
       },

--- a/ui/src/testing/stubs/runtime-api-stub.ts
+++ b/ui/src/testing/stubs/runtime-api-stub.ts
@@ -19,7 +19,7 @@ import { stubNotImplementedError } from 'testing/stubs/stub-utils';
 import { DiskApiStub, stubDisk } from './disk-api-stub';
 
 export const defaultGceConfig = (): GceConfig => ({
-  diskSize: 120,
+  diskSize: MIN_DISK_SIZE_GB + 30,
   machineType: 'n1-standard-4',
 });
 

--- a/ui/src/testing/stubs/runtime-api-stub.ts
+++ b/ui/src/testing/stubs/runtime-api-stub.ts
@@ -8,11 +8,11 @@ import {
   RuntimeStatus,
 } from 'generated/fetch';
 
+import { diskApi } from 'app/services/swagger-fetch-clients';
 import {
   DATAPROC_WORKER_MIN_DISK_SIZE_GB,
   MIN_DISK_SIZE_GB,
-} from 'app/pages/analysis/runtime-panel';
-import { diskApi } from 'app/services/swagger-fetch-clients';
+} from 'app/utils/machines';
 
 import { stubNotImplementedError } from 'testing/stubs/stub-utils';
 

--- a/ui/src/testing/stubs/runtime-api-stub.ts
+++ b/ui/src/testing/stubs/runtime-api-stub.ts
@@ -19,6 +19,8 @@ import { stubNotImplementedError } from 'testing/stubs/stub-utils';
 import { DiskApiStub, stubDisk } from './disk-api-stub';
 
 export const defaultGceConfig = (): GceConfig => ({
+  // Set the default disk size a bit over the minimum for ease of testing
+  // decreases in the disk size.
   diskSize: MIN_DISK_SIZE_GB + 30,
   machineType: 'n1-standard-4',
 });


### PR DESCRIPTION
According to Leo team, this may be causing some creations to time out.

Refactor min disk size to a central location.