### PR TITLE
[risk=low][no ticket] rm unchecked call warning: add type params to MultiKeyMap

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -202,7 +202,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     dbUser = userDao.save(dbUser);
     currentUser = dbUser;
 
-    when(cohortBuilderService.findAllDemographicsMap()).thenReturn(new MultiKeyMap());
+    when(cohortBuilderService.findAllDemographicsMap()).thenReturn(new MultiKeyMap<>());
 
     when(mockFireCloudService.getWorkspaceAclAsService(anyString(), anyString()))
         .thenReturn(

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -92,7 +92,7 @@ public interface CohortBuilderService {
    * Build a map that contains all gender/race/ethnicity/sex_at_birth names with the concept id as
    * the key.
    */
-  MultiKeyMap findAllDemographicsMap();
+  MultiKeyMap<Object, String> findAllDemographicsMap();
 
   List<String> findSortedConceptIdsByDomainIdAndType(
       String domainId, String sortColumn, String sortName);

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -492,8 +492,8 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   }
 
   @Override
-  public synchronized MultiKeyMap findAllDemographicsMap() {
-    MultiKeyMap demoMap = MultiKeyMap.multiKeyMap(new LRUMap<>());
+  public synchronized MultiKeyMap<Object, String> findAllDemographicsMap() {
+    MultiKeyMap<Object, String> demoMap = MultiKeyMap.multiKeyMap(new LRUMap<>());
     for (DbCriteria dbCriteria : cbCriteriaDao.findAllDemographics()) {
       demoMap.put(
           dbCriteria.getLongConceptId(),

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
@@ -290,7 +290,7 @@ public class CohortReviewServiceImpl implements CohortReviewService, GaugeDataCo
   }
 
   public List<ParticipantCohortStatus> findAll(Long cohortReviewId, PageRequest pageRequest) {
-    MultiKeyMap demoMap = cohortBuilderService.findAllDemographicsMap();
+    MultiKeyMap<Object, String> demoMap = cohortBuilderService.findAllDemographicsMap();
     List<ParticipantCohortStatus> returnList =
         participantCohortStatusDao.findAll(cohortReviewId, pageRequest).stream()
             .map(pcs -> participantCohortStatusMapper.dbModelToClient(pcs, demoMap))

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/mapper/ParticipantCohortStatusMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/mapper/ParticipantCohortStatusMapper.java
@@ -27,25 +27,21 @@ public interface ParticipantCohortStatusMapper {
   @Mapping(target = "sexAtBirth", ignore = true)
   @Mapping(target = "birthDate", source = "birthDate", qualifiedByName = "dateToString")
   ParticipantCohortStatus dbModelToClient(
-      DbParticipantCohortStatus dbParticipantCohortStatus, @Context MultiKeyMap demographicsMap);
+      DbParticipantCohortStatus dbParticipantCohortStatus,
+      @Context MultiKeyMap<Object, String> demographicsMap);
 
   @AfterMapping
   default void populateAfterMapping(
       @MappingTarget ParticipantCohortStatus participantCohortStatus,
-      @Context MultiKeyMap demographicsMap) {
+      @Context MultiKeyMap<Object, String> demographicsMap) {
     participantCohortStatus.setGender(
-        (String)
-            demographicsMap.get(participantCohortStatus.getGenderConceptId(), CriteriaType.GENDER));
+        demographicsMap.get(participantCohortStatus.getGenderConceptId(), CriteriaType.GENDER));
     participantCohortStatus.setRace(
-        (String)
-            demographicsMap.get(participantCohortStatus.getRaceConceptId(), CriteriaType.RACE));
+        demographicsMap.get(participantCohortStatus.getRaceConceptId(), CriteriaType.RACE));
     participantCohortStatus.setEthnicity(
-        (String)
-            demographicsMap.get(
-                participantCohortStatus.getEthnicityConceptId(), CriteriaType.ETHNICITY));
+        demographicsMap.get(
+            participantCohortStatus.getEthnicityConceptId(), CriteriaType.ETHNICITY));
     participantCohortStatus.setSexAtBirth(
-        (String)
-            demographicsMap.get(
-                participantCohortStatus.getSexAtBirthConceptId(), CriteriaType.SEX));
+        demographicsMap.get(participantCohortStatus.getSexAtBirthConceptId(), CriteriaType.SEX));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -249,8 +249,8 @@ public class CohortReviewControllerTest {
       return criteriaType;
     }
 
-    public static MultiKeyMap asMap() {
-      MultiKeyMap demoMap = MultiKeyMap.multiKeyMap(new LRUMap<>());
+    public static MultiKeyMap<Object, String> asMap() {
+      MultiKeyMap<Object, String> demoMap = MultiKeyMap.multiKeyMap(new LRUMap<>());
       for (TestConcepts testConcepts : TestConcepts.values()) {
         demoMap.put(testConcepts.getConceptId(), testConcepts.getType(), testConcepts.getName());
       }
@@ -2501,7 +2501,7 @@ public class CohortReviewControllerTest {
 
   private ParticipantCohortStatus dbParticipantCohortStatusToApi(
       DbParticipantCohortStatus dbStatus) {
-    MultiKeyMap demographicsMap = TestConcepts.asMap();
+    MultiKeyMap<Object, String> demographicsMap = TestConcepts.asMap();
     return new ParticipantCohortStatus()
         .birthDate(dbStatus.getBirthDate().toString())
         .ethnicityConceptId(dbStatus.getEthnicityConceptId())

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -382,7 +382,7 @@ public class WorkspacesControllerTest {
     currentUser = createUser(LOGGED_IN_USER_EMAIL);
     registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
 
-    when(cohortBuilderService.findAllDemographicsMap()).thenReturn(new MultiKeyMap());
+    when(cohortBuilderService.findAllDemographicsMap()).thenReturn(new MultiKeyMap<>());
 
     when(accessTierService.getAccessTierShortNamesForUser(currentUser))
         .thenReturn(Arrays.asList(AccessTierService.REGISTERED_TIER_SHORT_NAME));

--- a/api/src/test/java/org/pmiops/workbench/cohortreview/mapper/ParticipantCohortStatusMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortreview/mapper/ParticipantCohortStatusMapperTest.java
@@ -50,7 +50,7 @@ public class ParticipantCohortStatusMapperTest {
             .sexAtBirth("Male")
             .genderConceptId(4L)
             .gender("Man");
-    MultiKeyMap demoMap = MultiKeyMap.multiKeyMap(new LRUMap<>());
+    MultiKeyMap<Object, String> demoMap = MultiKeyMap.multiKeyMap(new LRUMap<>());
     demoMap.put(1L, CriteriaType.ETHNICITY, "Latino");
     demoMap.put(2L, CriteriaType.RACE, "White");
     demoMap.put(3L, CriteriaType.SEX, "Male");


### PR DESCRIPTION
I started seeing compile warnings like this recently:
```
CohortBuilderServiceImpl.java:498: warning: [unchecked] unchecked call to put(K,K,V) as a member of the raw type MultiKeyMap
      demoMap.put(
                 ^
  where K,V are type-variables:
    K extends Object declared in class MultiKeyMap
    V extends Object declared in class MultiKeyMap
```

Adding type parameters resolved it.

Looks like it started with https://github.com/all-of-us/workbench/pull/6632 so I'd like a review from Data Apps to help ensure I haven't broken any functionality.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
