### PR TITLE
[RW-8236][risk=no] Updated module expiration guard and deprecated anyModuleHasExpired.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -136,8 +136,16 @@ public class ProfileService {
 
     final List<AccessModuleStatus> accessModuleStatuses =
         accessModuleService.getAccessModuleStatus(userLite);
+    // TODO RW-8236 Remove anyModuleHasExpired after release.
     final ProfileAccessModules accessModules =
-        new ProfileAccessModules().modules(accessModuleStatuses);
+        new ProfileAccessModules()
+            .modules(accessModuleStatuses)
+            .anyModuleHasExpired(
+                accessModuleStatuses.stream()
+                    .anyMatch(
+                        a ->
+                            (a.getExpirationEpochMillis() != null
+                                && clock.instant().toEpochMilli() > a.getExpirationEpochMillis())));
 
     return profileMapper.toModel(
         user,

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -137,14 +137,7 @@ public class ProfileService {
     final List<AccessModuleStatus> accessModuleStatuses =
         accessModuleService.getAccessModuleStatus(userLite);
     final ProfileAccessModules accessModules =
-        new ProfileAccessModules()
-            .modules(accessModuleStatuses)
-            .anyModuleHasExpired(
-                accessModuleStatuses.stream()
-                    .anyMatch(
-                        a ->
-                            (a.getExpirationEpochMillis() != null
-                                && clock.instant().toEpochMilli() > a.getExpirationEpochMillis())));
+        new ProfileAccessModules().modules(accessModuleStatuses);
 
     return profileMapper.toModel(
         user,

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5996,7 +5996,7 @@ definitions:
           anyModuleHasExpired:
             type: boolean
             description: >
-              Whether any modules have expired. Expiration information is also included with each
+              DEPRECATED - RW-8236. Remove after one cycle. Whether any modules have expired. Expiration information is also included with each
               module in the array; this field is provided for convenience.
 
   AccessModuleStatus:

--- a/ui/src/app/routing/guards.spec.tsx
+++ b/ui/src/app/routing/guards.spec.tsx
@@ -136,7 +136,6 @@ describe('redirectTo', () => {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [AccessTierShortNames.Registered],
         accessModules: {
-          anyModuleHasExpired: false,
           modules: allCompleteNotExpiring,
         },
       },
@@ -148,7 +147,6 @@ describe('redirectTo', () => {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [AccessTierShortNames.Registered],
         accessModules: {
-          anyModuleHasExpired: false,
           modules: allCompleteExpiringSoon,
         },
       },
@@ -161,7 +159,6 @@ describe('redirectTo', () => {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [],
         accessModules: {
-          anyModuleHasExpired: false,
           modules: allBypassedMissingPP,
         },
       },
@@ -173,7 +170,6 @@ describe('redirectTo', () => {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [AccessTierShortNames.Registered],
         accessModules: {
-          anyModuleHasExpired: false,
           modules: allBypassedPPComplete,
         },
       },
@@ -185,7 +181,6 @@ describe('redirectTo', () => {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [],
         accessModules: {
-          anyModuleHasExpired: false,
           modules: newUserModuleState,
         },
       },
@@ -197,7 +192,6 @@ describe('redirectTo', () => {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [],
         accessModules: {
-          anyModuleHasExpired: true,
           modules: allCompleteOneExpired,
         },
       },
@@ -209,7 +203,6 @@ describe('redirectTo', () => {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [AccessTierShortNames.Registered],
         accessModules: {
-          anyModuleHasExpired: false,
           modules: allCompleteCtTrainingExpired,
         },
       },
@@ -221,7 +214,6 @@ describe('redirectTo', () => {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [],
         accessModules: {
-          anyModuleHasExpired: false,
           modules: allCompleteMissingOneInitial,
         },
       },
@@ -235,7 +227,6 @@ describe('redirectTo', () => {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [],
         accessModules: {
-          anyModuleHasExpired: false,
           modules: allCompleteMissingOneRenewable,
         },
       },
@@ -249,7 +240,6 @@ describe('redirectTo', () => {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [],
         accessModules: {
-          anyModuleHasExpired: false,
           modules: allCompleteMissingOneEach,
         },
       },
@@ -263,7 +253,6 @@ describe('redirectTo', () => {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [],
         accessModules: {
-          anyModuleHasExpired: false,
           modules: allCompleteMissingPP,
         },
       },
@@ -279,7 +268,6 @@ describe('redirectTo', () => {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [],
         accessModules: {
-          anyModuleHasExpired: false,
           modules: [],
         },
       },

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -11,6 +11,8 @@ import {
   DATA_ACCESS_REQUIREMENTS_PATH,
   eligibleForTier,
   getAccessModuleStatusByNameOrEmpty,
+  getExpiredModules,
+  rtAccessRenewalModules,
 } from 'app/utils/access-utils';
 import {
   AuthorityGuardedAction,
@@ -58,7 +60,10 @@ const allCompleteOrBypassed = (
 // use this for all access-module routing decisions, to ensure only one routing is chosen
 export const shouldRedirectToMaybe = (profile: Profile): string | undefined => {
   return cond(
-    [profile?.accessModules?.anyModuleHasExpired, () => ACCESS_RENEWAL_PATH],
+    [
+      getExpiredModules(rtAccessRenewalModules, profile).length > 0,
+      () => ACCESS_RENEWAL_PATH,
+    ],
     // not a common scenario (mainly test users) but AAR is the only way to recover if these modules are missing
     [
       !allCompleteOrBypassed(profile, [

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -11,8 +11,7 @@ import {
   DATA_ACCESS_REQUIREMENTS_PATH,
   eligibleForTier,
   getAccessModuleStatusByNameOrEmpty,
-  getExpiredModules,
-  rtAccessRenewalModules,
+  hasRtExpired,
 } from 'app/utils/access-utils';
 import {
   AuthorityGuardedAction,
@@ -60,10 +59,7 @@ const allCompleteOrBypassed = (
 // use this for all access-module routing decisions, to ensure only one routing is chosen
 export const shouldRedirectToMaybe = (profile: Profile): string | undefined => {
   return cond(
-    [
-      getExpiredModules(rtAccessRenewalModules, profile).length > 0,
-      () => ACCESS_RENEWAL_PATH,
-    ],
+    [hasRtExpired(profile), () => ACCESS_RENEWAL_PATH],
     // not a common scenario (mainly test users) but AAR is the only way to recover if these modules are missing
     [
       !allCompleteOrBypassed(profile, [

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -662,3 +662,20 @@ export const getStatusText = (status: AccessModuleStatus) => {
     ? `Completed on: ${displayDateWithoutHours(completionEpochMillis)}`
     : `Bypassed on: ${displayDateWithoutHours(bypassEpochMillis)}`;
 };
+
+export const getExpiredModules = (
+  modules: AccessModule[],
+  profile: Profile
+): AccessModule[] =>
+  fp.flow(
+    fp.filter((module: AccessModule) => isEligibleModule(module, profile)),
+    fp.map((module: AccessModule) =>
+      getAccessModuleStatusByName(profile, module)
+    ),
+    fp.filter((accessModuleStatus: AccessModuleStatus) =>
+      hasExpired(accessModuleStatus.expirationEpochMillis)
+    ),
+    fp.map(
+      (accessModuleStatus: AccessModuleStatus) => accessModuleStatus.moduleName
+    )
+  )(modules);

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -663,19 +663,14 @@ export const getStatusText = (status: AccessModuleStatus) => {
     : `Bypassed on: ${displayDateWithoutHours(bypassEpochMillis)}`;
 };
 
-export const getExpiredModules = (
-  modules: AccessModule[],
-  profile: Profile
-): AccessModule[] =>
-  fp.flow(
-    fp.filter((module: AccessModule) => isEligibleModule(module, profile)),
-    fp.map((module: AccessModule) =>
-      getAccessModuleStatusByName(profile, module)
-    ),
-    fp.filter((accessModuleStatus: AccessModuleStatus) =>
-      hasExpired(accessModuleStatus.expirationEpochMillis)
-    ),
-    fp.map(
-      (accessModuleStatus: AccessModuleStatus) => accessModuleStatus.moduleName
+export const hasRtExpired = (profile: Profile): boolean => {
+  return rtAccessRenewalModules
+    .filter(
+      (moduleName) => getAccessModuleConfig(moduleName).isEnabledInEnvironment
     )
-  )(modules);
+    .map((module: AccessModule) => getAccessModuleStatusByName(profile, module))
+    .some(
+      (status: AccessModuleStatus) =>
+        hasExpired(status.expirationEpochMillis) && !status?.bypassEpochMillis
+    );
+};

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -62,7 +62,6 @@ export class ProfileStubVariables {
           expirationEpochMillis: undefined,
         },
       ],
-      anyModuleHasExpired: false,
     },
     tierEligibilities: [
       {


### PR DESCRIPTION
Description: Updated module expiration redirect to only apply to RT modules. Also deprecated anyModuleHasExpired field.
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
Ran api unit tests locally. Manually expired ct modules and made sure there was no redirect. Manually expired rt modules to make sure I was brought to the annual renewal page.
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
