### PR TITLE
[risk=low][no ticket] rename the local version of vars.env to local-vars.env

### DIFF
--- a/api/db/local-vars.env
+++ b/api/db/local-vars.env
@@ -1,3 +1,6 @@
+# This is the vars.env file for running the local AoU API DB.
+# Cloud-SQL vars.env files are located in their projects' respective credentials buckets
+
 DB_DRIVER=com.mysql.jdbc.Driver
 # "db" hostname is established for the local docker network via docker-compose.yaml
 DB_HOST=db

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   db:
     image: mariadb:10.2
     env_file:
-      - db/vars.env
+      - db/local-vars.env
     volumes:
       - db:/var/lib/mysql
     ports:

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -80,7 +80,7 @@ def start_local_db_service()
   bm = Benchmark.measure {
     common.run_inline %W{docker-compose up -d db}
 
-    root_pass = Workbench.read_vars_file("db/vars.env")["MYSQL_ROOT_PASSWORD"]
+    root_pass = Workbench.read_vars_file("db/local-vars.env")["MYSQL_ROOT_PASSWORD"]
 
     common.status "waiting up to #{deadlineSec}s for mysql service to start..."
     start = Time.now
@@ -148,7 +148,7 @@ Common.register_command({
 })
 
 def setup_local_environment()
-  ENV.update(Workbench.read_vars_file("db/vars.env"))
+  ENV.update(Workbench.read_vars_file("db/local-vars.env"))
   ENV.update(must_get_env_value("local", :gae_vars))
   ENV.update({"WORKBENCH_ENV" => "local"})
   ENV["DB_HOST"] = "127.0.0.1"


### PR DESCRIPTION
Tested by running
`./project.rb dev-up`
`./project.rb connect-to-db`
`./project.rb connect-to-cloud-db`

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
