### PR TITLE
[risk=low][RW-8309] User Recent Resources: clean up and only read from new version

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -24,7 +24,6 @@ import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.dataset.DataSetService;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.db.model.DbUserRecentResource;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
@@ -115,12 +114,11 @@ public class UserMetricsController implements UserMetricsApiDelegate {
     // resources in the backend
     // Because we don't store notebooks in our database the way we do other resources.
     final DbWorkspace dbWorkspace = workspaceDao.getRequired(workspaceNamespace, workspaceId);
-    final DbUserRecentResource recentResource =
+    final DbUserRecentlyModifiedResource recentResource =
         userRecentResourceService.updateNotebookEntry(
             dbWorkspace.getWorkspaceId(), userProvider.get().getUserId(), notebookPath);
 
-    return ResponseEntity.ok(
-        workspaceResourceMapper.fromDbUserRecentResource(recentResource, fcWorkspace, dbWorkspace));
+    return ResponseEntity.ok(buildRecentResource(recentResource, fcWorkspace, dbWorkspace));
   }
 
   @Override
@@ -262,10 +260,20 @@ public class UserMetricsController implements UserMetricsApiDelegate {
       Map<Long, FirecloudWorkspaceResponse> idToFcWorkspaceResponse,
       DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource) {
     final long workspaceId = dbUserRecentlyModifiedResource.getWorkspaceId();
-    return workspaceResourceMapper.fromDbUserRecentlyModifiedResource(
+    return buildRecentResource(
         dbUserRecentlyModifiedResource,
         idToFcWorkspaceResponse.get(workspaceId),
-        idToDbWorkspace.get(workspaceId),
+        idToDbWorkspace.get(workspaceId));
+  }
+
+  private WorkspaceResource buildRecentResource(
+      DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource,
+      FirecloudWorkspaceResponse fcWorkspaceResponse,
+      DbWorkspace dbWorkspace) {
+    return workspaceResourceMapper.fromDbUserRecentlyModifiedResource(
+        dbUserRecentlyModifiedResource,
+        fcWorkspaceResponse,
+        dbWorkspace,
         cohortService,
         cohortReviewService,
         conceptSetService,

--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -118,7 +118,7 @@ public class UserMetricsController implements UserMetricsApiDelegate {
         userRecentResourceService.updateNotebookEntry(
             dbWorkspace.getWorkspaceId(), userProvider.get().getUserId(), notebookPath);
 
-    return ResponseEntity.ok(buildRecentResource(recentResource, fcWorkspace, dbWorkspace));
+    return ResponseEntity.ok(toWorkspaceResource(recentResource, fcWorkspace, dbWorkspace));
   }
 
   @Override
@@ -255,18 +255,20 @@ public class UserMetricsController implements UserMetricsApiDelegate {
     }
   }
 
+  // TODO: move these to WorkspaceResourceMapper or UserRecentResourceService ?
+
   private WorkspaceResource toWorkspaceResource(
       Map<Long, DbWorkspace> idToDbWorkspace,
       Map<Long, FirecloudWorkspaceResponse> idToFcWorkspaceResponse,
       DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource) {
     final long workspaceId = dbUserRecentlyModifiedResource.getWorkspaceId();
-    return buildRecentResource(
+    return toWorkspaceResource(
         dbUserRecentlyModifiedResource,
         idToFcWorkspaceResponse.get(workspaceId),
         idToDbWorkspace.get(workspaceId));
   }
 
-  private WorkspaceResource buildRecentResource(
+  private WorkspaceResource toWorkspaceResource(
       DbUserRecentlyModifiedResource dbUserRecentlyModifiedResource,
       FirecloudWorkspaceResponse fcWorkspaceResponse,
       DbWorkspace dbWorkspace) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentResourceDao.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.db.dao;
 
-import java.util.List;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbUserRecentResource;
@@ -9,8 +8,6 @@ import org.springframework.data.repository.CrudRepository;
 // This DAO will be replaced by UserRecentlyModifiedResourceDao
 @Deprecated
 public interface UserRecentResourceDao extends CrudRepository<DbUserRecentResource, Long> {
-
-  long countUserRecentResourceByUserId(long userId);
 
   DbUserRecentResource findTopByUserIdOrderByLastAccessDate(long userId);
 
@@ -22,6 +19,4 @@ public interface UserRecentResourceDao extends CrudRepository<DbUserRecentResour
 
   DbUserRecentResource findByUserIdAndWorkspaceIdAndConceptSet(
       long userId, long workspaceId, DbConceptSet conceptSet);
-
-  List<DbUserRecentResource> findUserRecentResourcesByUserIdOrderByLastAccessDateDesc(long userId);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentlyModifiedResourceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentlyModifiedResourceDao.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.CrudRepository;
 public interface UserRecentlyModifiedResourceDao
     extends CrudRepository<DbUserRecentlyModifiedResource, Long> {
 
-  long countDbUserRecentResourcesIdsByUserId(long userId);
+  long countByUserId(long userId);
 
   DbUserRecentlyModifiedResource findTopByUserIdOrderByLastAccessDate(long userId);
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentlyModifiedResourceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentlyModifiedResourceDao.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.db.dao;
 
-import java.util.Collection;
 import java.util.List;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.springframework.data.repository.CrudRepository;
@@ -12,8 +11,7 @@ public interface UserRecentlyModifiedResourceDao
 
   DbUserRecentlyModifiedResource findTopByUserIdOrderByLastAccessDate(long userId);
 
-  void deleteByUserIdAndWorkspaceIdIn(long userId, Collection<Long> ids);
-
+  // Use findDbUserRecentResources() as a shorter equivalent to this magic-JPA-named method
   DbUserRecentlyModifiedResource
       findDbUserRecentResourcesIdByUserIdAndWorkspaceIdAndResourceTypeAndResourceId(
           long userId,
@@ -21,6 +19,8 @@ public interface UserRecentlyModifiedResourceDao
           DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType resourceType,
           String resourceId);
 
+  // convenience method with a shorter name, for
+  // findDbUserRecentResourcesIdByUserIdAndWorkspaceIdAndResourceTypeAndResourceId
   default DbUserRecentlyModifiedResource findDbUserRecentResources(
       long userId,
       long workspaceId,
@@ -30,9 +30,12 @@ public interface UserRecentlyModifiedResourceDao
         userId, workspaceId, resourceType, resourceId);
   }
 
+  // Use findDbUserRecentResourcesByUserId() as a shorter equivalent to this magic-JPA-named method
   List<DbUserRecentlyModifiedResource>
       findDbUserRecentlyModifiedResourcesByUserIdOrderByLastAccessDateDesc(long userId);
 
+  // convenience method with a shorter name, for
+  // findDbUserRecentlyModifiedResourcesByUserIdOrderByLastAccessDateDesc
   default List<DbUserRecentlyModifiedResource> findDbUserRecentResourcesByUserId(long userId) {
     return this.findDbUserRecentlyModifiedResourcesByUserIdOrderByLastAccessDateDesc(userId);
   }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentlyModifiedResourceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentlyModifiedResourceDao.java
@@ -11,7 +11,7 @@ public interface UserRecentlyModifiedResourceDao
 
   DbUserRecentlyModifiedResource findTopByUserIdOrderByLastAccessDate(long userId);
 
-  // Use findDbUserRecentResources() as a shorter equivalent to this magic-JPA-named method
+  // Use getResource() as a shorter equivalent to this magic-JPA-named method
   DbUserRecentlyModifiedResource
       findDbUserRecentResourcesIdByUserIdAndWorkspaceIdAndResourceTypeAndResourceId(
           long userId,
@@ -20,8 +20,8 @@ public interface UserRecentlyModifiedResourceDao
           String resourceId);
 
   // convenience method with a shorter name, for
-  // findDbUserRecentResourcesIdByUserIdAndWorkspaceIdAndResourceTypeAndResourceId
-  default DbUserRecentlyModifiedResource findDbUserRecentResource(
+  // findDbUserRecentResourcesIdByUserIdAndWorkspaceIdAndResourceTypeAndResourceId()
+  default DbUserRecentlyModifiedResource getResource(
       long userId,
       long workspaceId,
       DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType resourceType,
@@ -30,13 +30,13 @@ public interface UserRecentlyModifiedResourceDao
         userId, workspaceId, resourceType, resourceId);
   }
 
-  // Use findDbUserRecentResourcesByUserId() as a shorter equivalent to this magic-JPA-named method
+  // Use getAllForUser() as a shorter equivalent to this magic-JPA-named method
   List<DbUserRecentlyModifiedResource>
       findDbUserRecentlyModifiedResourcesByUserIdOrderByLastAccessDateDesc(long userId);
 
   // convenience method with a shorter name, for
-  // findDbUserRecentlyModifiedResourcesByUserIdOrderByLastAccessDateDesc
-  default List<DbUserRecentlyModifiedResource> findDbUserRecentResourcesByUserId(long userId) {
+  // findDbUserRecentlyModifiedResourcesByUserIdOrderByLastAccessDateDesc()
+  default List<DbUserRecentlyModifiedResource> getAllForUser(long userId) {
     return this.findDbUserRecentlyModifiedResourcesByUserIdOrderByLastAccessDateDesc(userId);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentlyModifiedResourceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserRecentlyModifiedResourceDao.java
@@ -21,7 +21,7 @@ public interface UserRecentlyModifiedResourceDao
 
   // convenience method with a shorter name, for
   // findDbUserRecentResourcesIdByUserIdAndWorkspaceIdAndResourceTypeAndResourceId
-  default DbUserRecentlyModifiedResource findDbUserRecentResources(
+  default DbUserRecentlyModifiedResource findDbUserRecentResource(
       long userId,
       long workspaceId,
       DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType resourceType,

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceService.java
@@ -31,8 +31,5 @@ public interface UserRecentResourceService {
 
   void deleteCohortReviewEntry(long workspaceId, long userId, long cohortReviewId);
 
-  @Deprecated
-  List<DbUserRecentResource> findAllResourcesByUser(long userId);
-
   List<DbUserRecentlyModifiedResource> findAllRecentlyModifiedResourcesByUser(long userId);
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceService.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.workspaces.resources;
 
 import java.util.List;
-import org.pmiops.workbench.db.model.DbUserRecentResource;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.springframework.stereotype.Service;
 
@@ -10,7 +9,7 @@ public interface UserRecentResourceService {
 
   int USER_ENTRY_COUNT = 10;
 
-  DbUserRecentResource updateNotebookEntry(
+  DbUserRecentlyModifiedResource updateNotebookEntry(
       long workspaceId, long userId, String notebookNameWithPath);
 
   void updateCohortEntry(long workspaceId, long userId, long cohortId);

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
@@ -260,11 +260,11 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
   }
 
   /**
-   * Check number of entries in user_recent_resource for user, If it exceeds USER_ENTRY_COUNT,
-   * delete the one with earliest lastAccessTime
+   * Check number of entries in user_recently_modified_resource for user, If it exceeds
+   * USER_ENTRY_COUNT, delete the one with earliest lastAccessTime
    */
   private void handleUserLimit(long userId) {
-    long count = userRecentResourceDao.countUserRecentResourceByUserId(userId);
+    long count = userRecentlyModifiedResourceDao.countByUserId(userId);
     while (count-- >= USER_ENTRY_COUNT) {
       DbUserRecentResource resource =
           userRecentResourceDao.findTopByUserIdOrderByLastAccessDate(userId);

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
@@ -157,8 +157,7 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
       String resourceId) {
     Timestamp now = new Timestamp(clock.instant().toEpochMilli());
     DbUserRecentlyModifiedResource recentResource =
-        userRecentlyModifiedResourceDao.findDbUserRecentResource(
-            userId, workspaceId, resourceType, resourceId);
+        userRecentlyModifiedResourceDao.getResource(userId, workspaceId, resourceType, resourceId);
     if (recentResource == null) {
       recentResource =
           new DbUserRecentlyModifiedResource(workspaceId, userId, resourceType, resourceId, now);
@@ -232,8 +231,7 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
       DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType resourceType,
       String resourceId) {
     DbUserRecentlyModifiedResource resourceById =
-        userRecentlyModifiedResourceDao.findDbUserRecentResource(
-            userId, workspaceId, resourceType, resourceId);
+        userRecentlyModifiedResourceDao.getResource(userId, workspaceId, resourceType, resourceId);
     if (resourceById != null) {
       userRecentlyModifiedResourceDao.delete(resourceById);
     }
@@ -250,9 +248,7 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
   public List<DbUserRecentlyModifiedResource> findAllRecentlyModifiedResourcesByUser(long userId) {
     try {
       return DbRetryUtils.executeAndRetry(
-          () -> userRecentlyModifiedResourceDao.findDbUserRecentResourcesByUserId(userId),
-          Duration.ofSeconds(1),
-          5);
+          () -> userRecentlyModifiedResourceDao.getAllForUser(userId), Duration.ofSeconds(1), 5);
     } catch (InterruptedException e) {
       throw new ServerErrorException(
           "Unable to find Recently Modified Resources for user" + userId);

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
@@ -238,6 +238,7 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
       userRecentlyModifiedResourceDao.delete(resourceById);
     }
   }
+
   /**
    * Retrieves the list of all resources recently accessed by user in descending order of last
    * access date. This list is not filtered by visibility of these resources (for example, it may
@@ -245,20 +246,6 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
    *
    * @param userId : User id for whom the resources are returned
    */
-  @Override
-  public List<DbUserRecentResource> findAllResourcesByUser(long userId) {
-    try {
-      return DbRetryUtils.executeAndRetry(
-          () ->
-              userRecentResourceDao.findUserRecentResourcesByUserIdOrderByLastAccessDateDesc(
-                  userId),
-          Duration.ofSeconds(1),
-          5);
-    } catch (InterruptedException e) {
-      throw new ServerErrorException("Unable to find Resources for user" + userId);
-    }
-  }
-
   @Override
   public List<DbUserRecentlyModifiedResource> findAllRecentlyModifiedResourcesByUser(long userId) {
     try {

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
@@ -16,7 +16,6 @@ import org.pmiops.workbench.dataset.mapper.DataSetMapper;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbDataset;
-import org.pmiops.workbench.db.model.DbUserRecentResource;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.ServerErrorException;
@@ -89,12 +88,6 @@ public interface WorkspaceResourceMapper {
   ResourceFields fromNotebookNameAndLastModified(
       String notebook, Timestamp lastModifiedEpochMillis);
 
-  @Mapping(target = "cohortReview", ignore = true)
-  @Mapping(target = "dataSet", ignore = true)
-  @Mapping(target = "notebook", source = "notebookName")
-  @Mapping(target = "lastModifiedEpochMillis", source = "lastAccessDate")
-  ResourceFields fromDbUserRecentResource(DbUserRecentResource dbUserRecentResource);
-
   @Mapping(target = "permission", source = "accessLevel")
   WorkspaceResource mergeWorkspaceAndResourceFields(
       WorkspaceFields workspaceFields,
@@ -132,15 +125,6 @@ public interface WorkspaceResourceMapper {
       DbWorkspace dbWorkspace, WorkspaceAccessLevel accessLevel, DbDataset dbDataset) {
     return mergeWorkspaceAndResourceFields(
         fromWorkspace(dbWorkspace), accessLevel, fromDbDataset(dbDataset));
-  }
-
-  @Deprecated
-  default WorkspaceResource fromDbUserRecentResource(
-      DbUserRecentResource dbUserRecentResource,
-      FirecloudWorkspaceResponse fcWorkspace,
-      DbWorkspace dbWorkspace) {
-    return mergeWorkspaceAndResourceFields(
-        fromWorkspace(dbWorkspace), fcWorkspace, fromDbUserRecentResource(dbUserRecentResource));
   }
 
   default WorkspaceResource fromDbUserRecentlyModifiedResource(

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -36,7 +36,6 @@ import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.db.model.DbUserRecentResource;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType;
 import org.pmiops.workbench.db.model.DbWorkspace;
@@ -429,11 +428,11 @@ public class UserMetricsControllerTest {
   @Test
   public void testUpdateRecentResource() {
     Timestamp now = new Timestamp(fakeClock.instant().toEpochMilli());
-    DbUserRecentResource mockUserRecentResource = new DbUserRecentResource();
-    mockUserRecentResource.setCohort(null);
+    DbUserRecentlyModifiedResource mockUserRecentResource = new DbUserRecentlyModifiedResource();
     mockUserRecentResource.setWorkspaceId(dbWorkspace2.getWorkspaceId());
     mockUserRecentResource.setUserId(dbUser.getUserId());
-    mockUserRecentResource.setNotebookName("gs://newBucket/notebooks/notebook.ipynb");
+    mockUserRecentResource.setResourceId("gs://newBucket/notebooks/notebook.ipynb");
+    mockUserRecentResource.setResourceType(DbUserRecentlyModifiedResourceType.NOTEBOOK);
     mockUserRecentResource.setLastAccessDate(now);
     when(mockUserRecentResourceService.updateNotebookEntry(
             dbWorkspace2.getWorkspaceId(),

--- a/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
@@ -190,12 +190,11 @@ public class UserRecentResourceServiceTest {
     rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(UserRecentResourceService.USER_ENTRY_COUNT);
     DbUserRecentlyModifiedResource cache =
-        userRecentlyModifiedResourceDao
-            .findDbUserRecentResourcesIdByUserIdAndWorkspaceIdAndResourceTypeAndResourceId(
-                newWorkspace.getWorkspaceId(),
-                user.getUserId(),
-                DbUserRecentlyModifiedResourceType.NOTEBOOK,
-                "gs://someDirectory1/notebooks/notebook");
+        userRecentlyModifiedResourceDao.findDbUserRecentResources(
+            newWorkspace.getWorkspaceId(),
+            user.getUserId(),
+            DbUserRecentlyModifiedResourceType.NOTEBOOK,
+            "gs://someDirectory1/notebooks/notebook");
 
     assertThat(cache).isNull();
   }

--- a/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
@@ -190,7 +190,7 @@ public class UserRecentResourceServiceTest {
     rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(UserRecentResourceService.USER_ENTRY_COUNT);
     DbUserRecentlyModifiedResource cache =
-        userRecentlyModifiedResourceDao.findDbUserRecentResources(
+        userRecentlyModifiedResourceDao.findDbUserRecentResource(
             newWorkspace.getWorkspaceId(),
             user.getUserId(),
             DbUserRecentlyModifiedResourceType.NOTEBOOK,

--- a/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
@@ -9,41 +9,52 @@ import java.time.ZoneId;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.CohortDao;
+import org.pmiops.workbench.db.dao.CohortReviewDao;
 import org.pmiops.workbench.db.dao.ConceptSetDao;
+import org.pmiops.workbench.db.dao.DataSetDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentlyModifiedResourceDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbCohort;
+import org.pmiops.workbench.db.model.DbCohortReview;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbConceptSetConceptId;
+import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.test.FakeClock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
 import org.springframework.test.annotation.DirtiesContext;
 
 @DataJpaTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class UserRecentResourceServiceTest {
 
-  @Autowired UserDao userDao;
-  @Autowired WorkspaceDao workspaceDao;
   @Autowired CohortDao cohortDao;
-  @Autowired UserRecentlyModifiedResourceDao userRecentlyModifiedResourceDao;
+  @Autowired CohortReviewDao cohortReviewDao;
   @Autowired ConceptSetDao conceptSetDao;
+  @Autowired DataSetDao datasetDao;
+  @Autowired UserDao userDao;
+  @Autowired UserRecentlyModifiedResourceDao userRecentlyModifiedResourceDao;
+  @Autowired WorkspaceDao workspaceDao;
   @Autowired UserRecentResourceService userRecentResourceService;
 
   private DbUser user;
   private DbWorkspace workspace;
   private DbCohort cohort;
+  private DbCohortReview cohortReview;
   private DbConceptSet conceptSet;
+  private DbDataset dataset;
 
   private static final Instant NOW = Instant.now();
   private static final FakeClock CLOCK = new FakeClock(NOW, ZoneId.systemDefault());
@@ -54,6 +65,14 @@ public class UserRecentResourceServiceTest {
     @Bean
     public Clock clock() {
       return CLOCK;
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public WorkbenchConfig getWorkbenchConfig() {
+      WorkbenchConfig config = WorkbenchConfig.createEmptyConfig();
+      config.featureFlags.enableDSCREntryInRecentModified = true;
+      return config;
     }
   }
 
@@ -67,12 +86,20 @@ public class UserRecentResourceServiceTest {
     cohort.setWorkspaceId(workspace.getWorkspaceId());
     cohort = cohortDao.save(cohort);
 
+    cohortReview = new DbCohortReview();
+    cohortReview.setCohortId(cohort.getCohortId());
+    cohortReview = cohortReviewDao.save(cohortReview);
+
     DbConceptSetConceptId dbConceptSetConceptId =
         DbConceptSetConceptId.builder().addConceptId(1L).addStandard(true).build();
     conceptSet = new DbConceptSet();
     conceptSet.setWorkspaceId(workspace.getWorkspaceId());
     conceptSet.setConceptSetConceptIds(ImmutableSet.of(dbConceptSetConceptId));
     conceptSet = conceptSetDao.save(conceptSet);
+
+    dataset = new DbDataset();
+    dataset.setWorkspaceId(workspace.getWorkspaceId());
+    dataset = datasetDao.save(dataset);
   }
 
   @Test
@@ -93,6 +120,23 @@ public class UserRecentResourceServiceTest {
   }
 
   @Test
+  public void testInsertCohortReviewEntry() {
+    userRecentResourceService.updateCohortReviewEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohortReview.getCohortReviewId());
+    long rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(1);
+
+    DbCohortReview newCohortReview = new DbCohortReview();
+    newCohortReview.setCohortId(cohortReview.getCohortId());
+    newCohortReview = cohortReviewDao.save(newCohortReview);
+
+    userRecentResourceService.updateCohortReviewEntry(
+        workspace.getWorkspaceId(), user.getUserId(), newCohortReview.getCohortReviewId());
+    rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(2);
+  }
+
+  @Test
   public void testInsertConceptSetEntry() {
     userRecentResourceService.updateConceptSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
@@ -103,6 +147,21 @@ public class UserRecentResourceServiceTest {
     newConceptSet = conceptSetDao.save(newConceptSet);
     userRecentResourceService.updateConceptSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), newConceptSet.getConceptSetId());
+    rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(2);
+  }
+
+  @Test
+  public void testInsertDatasetEntry() {
+    userRecentResourceService.updateDataSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), dataset.getDataSetId());
+    long rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(1);
+    DbDataset newDataset = new DbDataset();
+    newDataset.setWorkspaceId(workspace.getWorkspaceId());
+    newDataset = datasetDao.save(newDataset);
+    userRecentResourceService.updateDataSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), newDataset.getDataSetId());
     rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(2);
   }
@@ -133,6 +192,19 @@ public class UserRecentResourceServiceTest {
   }
 
   @Test
+  public void testUpdateCohortReviewAccessTime() {
+    userRecentResourceService.updateCohortReviewEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohortReview.getCohortReviewId());
+    long rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(1);
+    CLOCK.increment(20000);
+    userRecentResourceService.updateCohortReviewEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohortReview.getCohortReviewId());
+    rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(1);
+  }
+
+  @Test
   public void testUpdateConceptSetAccessTime() {
     userRecentResourceService.updateConceptSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
@@ -141,6 +213,19 @@ public class UserRecentResourceServiceTest {
     CLOCK.increment(20000);
     userRecentResourceService.updateConceptSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
+    rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(1);
+  }
+
+  @Test
+  public void testUpdateDatasetAccessTime() {
+    userRecentResourceService.updateDataSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), dataset.getDataSetId());
+    long rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(1);
+    CLOCK.increment(20000);
+    userRecentResourceService.updateDataSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), dataset.getDataSetId());
     rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(1);
   }
@@ -199,9 +284,6 @@ public class UserRecentResourceServiceTest {
     assertThat(cache).isNull();
   }
 
-  //  We do test notebook deletion because it is a path reference
-  //  We do not test cohort or concept deletion because these are fk refs with
-  //  on delete cascade rule in place (no need to test db functionality)
   @Test
   public void testDeleteNotebookEntry() {
     userRecentResourceService.updateNotebookEntry(
@@ -220,6 +302,94 @@ public class UserRecentResourceServiceTest {
     assertThat(rowsCount).isEqualTo(0);
     userRecentResourceService.deleteNotebookEntry(
         workspace.getWorkspaceId(), user.getUserId(), "gs://someDirectory1/notebooks/notebook");
+    rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(0);
+  }
+
+  @Test
+  public void testDeleteCohortEntry() {
+    userRecentResourceService.updateCohortEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
+    long rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(1);
+    userRecentResourceService.deleteCohortEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
+    rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(0);
+  }
+
+  @Test
+  public void testDeleteNonExistentCohortEntry() {
+    long rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(0);
+    userRecentResourceService.deleteCohortEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
+    rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(0);
+  }
+
+  @Test
+  public void testDeleteCohortReviewEntry() {
+    userRecentResourceService.updateCohortReviewEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohortReview.getCohortReviewId());
+    long rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(1);
+    userRecentResourceService.deleteCohortReviewEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohortReview.getCohortReviewId());
+    rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(0);
+  }
+
+  @Test
+  public void testDeleteNonExistentCohortReviewEntry() {
+    long rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(0);
+    userRecentResourceService.deleteCohortReviewEntry(
+        workspace.getWorkspaceId(), user.getUserId(), cohortReview.getCohortReviewId());
+    rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(0);
+  }
+
+  @Test
+  public void testDeleteConceptSetEntry() {
+    userRecentResourceService.updateConceptSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
+    long rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(1);
+    userRecentResourceService.deleteConceptSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
+    rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(0);
+  }
+
+  @Test
+  public void testDeleteNonExistentConceptSetEntry() {
+    long rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(0);
+    userRecentResourceService.deleteConceptSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
+    rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(0);
+  }
+
+  @Test
+  public void testDeleteDatasetEntry() {
+    userRecentResourceService.updateDataSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), dataset.getDataSetId());
+    long rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(1);
+    userRecentResourceService.deleteDataSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), dataset.getDataSetId());
+    rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(0);
+  }
+
+  @Test
+  public void testDeleteNonExistentDatasetEntry() {
+    long rowsCount = userRecentlyModifiedResourceDao.count();
+    assertThat(rowsCount).isEqualTo(0);
+    userRecentResourceService.deleteDataSetEntry(
+        workspace.getWorkspaceId(), user.getUserId(), dataset.getDataSetId());
     rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(0);
   }

--- a/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
@@ -12,14 +12,14 @@ import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.dao.ConceptSetDao;
 import org.pmiops.workbench.db.dao.UserDao;
-import org.pmiops.workbench.db.dao.UserRecentResourceDao;
+import org.pmiops.workbench.db.dao.UserRecentlyModifiedResourceDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbConceptSet;
 import org.pmiops.workbench.db.model.DbConceptSetConceptId;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.db.model.DbUserRecentResource;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
+import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.test.FakeClock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +36,7 @@ public class UserRecentResourceServiceTest {
   @Autowired UserDao userDao;
   @Autowired WorkspaceDao workspaceDao;
   @Autowired CohortDao cohortDao;
-  @Autowired UserRecentResourceDao userRecentResourceDao;
+  @Autowired UserRecentlyModifiedResourceDao userRecentlyModifiedResourceDao;
   @Autowired ConceptSetDao conceptSetDao;
   @Autowired UserRecentResourceService userRecentResourceService;
 
@@ -79,7 +79,7 @@ public class UserRecentResourceServiceTest {
   public void testInsertCohortEntry() {
     userRecentResourceService.updateCohortEntry(
         workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
-    long rowsCount = userRecentResourceDao.count();
+    long rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(1);
 
     DbCohort newCohort = new DbCohort();
@@ -88,7 +88,7 @@ public class UserRecentResourceServiceTest {
 
     userRecentResourceService.updateCohortEntry(
         workspace.getWorkspaceId(), user.getUserId(), newCohort.getCohortId());
-    rowsCount = userRecentResourceDao.count();
+    rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(2);
   }
 
@@ -96,14 +96,14 @@ public class UserRecentResourceServiceTest {
   public void testInsertConceptSetEntry() {
     userRecentResourceService.updateConceptSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
-    long rowsCount = userRecentResourceDao.count();
+    long rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(1);
     DbConceptSet newConceptSet = new DbConceptSet();
     newConceptSet.setWorkspaceId(workspace.getWorkspaceId());
     newConceptSet = conceptSetDao.save(newConceptSet);
     userRecentResourceService.updateConceptSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), newConceptSet.getConceptSetId());
-    rowsCount = userRecentResourceDao.count();
+    rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(2);
   }
 
@@ -111,11 +111,11 @@ public class UserRecentResourceServiceTest {
   public void testInsertNotebookEntry() {
     userRecentResourceService.updateNotebookEntry(
         workspace.getWorkspaceId(), user.getUserId(), "gs://someDirectory/notebooks/notebook1");
-    long rowsCount = userRecentResourceDao.count();
+    long rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(1);
     userRecentResourceService.updateNotebookEntry(
         workspace.getWorkspaceId(), user.getUserId(), "gs://someDirectory/notebooks/notebook2");
-    rowsCount = userRecentResourceDao.count();
+    rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(2);
   }
 
@@ -123,12 +123,12 @@ public class UserRecentResourceServiceTest {
   public void testUpdateCohortAccessTime() {
     userRecentResourceService.updateCohortEntry(
         workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
-    long rowsCount = userRecentResourceDao.count();
+    long rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(1);
     CLOCK.increment(20000);
     userRecentResourceService.updateCohortEntry(
         workspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
-    rowsCount = userRecentResourceDao.count();
+    rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(1);
   }
 
@@ -136,12 +136,12 @@ public class UserRecentResourceServiceTest {
   public void testUpdateConceptSetAccessTime() {
     userRecentResourceService.updateConceptSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
-    long rowsCount = userRecentResourceDao.count();
+    long rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(1);
     CLOCK.increment(20000);
     userRecentResourceService.updateConceptSetEntry(
         workspace.getWorkspaceId(), user.getUserId(), conceptSet.getConceptSetId());
-    rowsCount = userRecentResourceDao.count();
+    rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(1);
   }
 
@@ -150,12 +150,12 @@ public class UserRecentResourceServiceTest {
 
     userRecentResourceService.updateNotebookEntry(
         workspace.getWorkspaceId(), user.getUserId(), "gs://someDirectory/notebooks/notebook1");
-    long rowsCount = userRecentResourceDao.count();
+    long rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(1);
     CLOCK.increment(200);
     userRecentResourceService.updateNotebookEntry(
         workspace.getWorkspaceId(), user.getUserId(), "gs://someDirectory/notebooks/notebook1");
-    rowsCount = userRecentResourceDao.count();
+    rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(1);
   }
 
@@ -180,20 +180,22 @@ public class UserRecentResourceServiceTest {
     }
 
     CLOCK.increment(2000);
-    long rowsCount = userRecentResourceDao.count();
+    long rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(UserRecentResourceService.USER_ENTRY_COUNT);
 
     userRecentResourceService.updateNotebookEntry(
         newWorkspace.getWorkspaceId(),
         user.getUserId(),
         "gs://someDirectory/notebooks/notebookExtra");
-    rowsCount = userRecentResourceDao.count();
+    rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(UserRecentResourceService.USER_ENTRY_COUNT);
-    DbUserRecentResource cache =
-        userRecentResourceDao.findByUserIdAndWorkspaceIdAndNotebookName(
-            newWorkspace.getWorkspaceId(),
-            user.getUserId(),
-            "gs://someDirectory1/notebooks/notebook");
+    DbUserRecentlyModifiedResource cache =
+        userRecentlyModifiedResourceDao
+            .findDbUserRecentResourcesIdByUserIdAndWorkspaceIdAndResourceTypeAndResourceId(
+                newWorkspace.getWorkspaceId(),
+                user.getUserId(),
+                DbUserRecentlyModifiedResourceType.NOTEBOOK,
+                "gs://someDirectory1/notebooks/notebook");
 
     assertThat(cache).isNull();
   }
@@ -205,21 +207,21 @@ public class UserRecentResourceServiceTest {
   public void testDeleteNotebookEntry() {
     userRecentResourceService.updateNotebookEntry(
         workspace.getWorkspaceId(), user.getUserId(), "gs://someDirectory1/notebooks/notebook1");
-    long rowsCount = userRecentResourceDao.count();
+    long rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(1);
     userRecentResourceService.deleteNotebookEntry(
         workspace.getWorkspaceId(), user.getUserId(), "gs://someDirectory1/notebooks/notebook1");
-    rowsCount = userRecentResourceDao.count();
+    rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(0);
   }
 
   @Test
   public void testDeleteNonExistentNotebookEntry() {
-    long rowsCount = userRecentResourceDao.count();
+    long rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(0);
     userRecentResourceService.deleteNotebookEntry(
         workspace.getWorkspaceId(), user.getUserId(), "gs://someDirectory1/notebooks/notebook");
-    rowsCount = userRecentResourceDao.count();
+    rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(0);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
@@ -190,7 +190,7 @@ public class UserRecentResourceServiceTest {
     rowsCount = userRecentlyModifiedResourceDao.count();
     assertThat(rowsCount).isEqualTo(UserRecentResourceService.USER_ENTRY_COUNT);
     DbUserRecentlyModifiedResource cache =
-        userRecentlyModifiedResourceDao.findDbUserRecentResource(
+        userRecentlyModifiedResourceDao.getResource(
             newWorkspace.getWorkspaceId(),
             user.getUserId(),
             DbUserRecentlyModifiedResourceType.NOTEBOOK,


### PR DESCRIPTION
We were already dual-writing the old and new versions of user-recent-resources/user_recently_modified_resource but in a few cases we were still reading from the old version.

Also remove a few references to old versions and do some general cleanup.

DOES NOT complete RW-8309

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
