### PR TITLE
[RW-8311][risk=no] Merging survey version for duplicated questions

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -290,14 +290,12 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
 
   @Override
   public ResponseEntity<SurveyVersionListResponse> findSurveyVersionByQuestionConceptId(
-      String workspaceNamespace, String workspaceId, Long surveyConceptId, Long questionConceptId) {
+      String workspaceNamespace, String workspaceId, Long questionConceptId) {
     workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
     return ResponseEntity.ok(
         new SurveyVersionListResponse()
-            .items(
-                cohortBuilderService.findSurveyVersionByQuestionConceptId(
-                    surveyConceptId, questionConceptId)));
+            .items(cohortBuilderService.findSurveyVersionByQuestionConceptId(questionConceptId)));
   }
 
   @Override
@@ -305,7 +303,6 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
       findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
           String workspaceNamespace,
           String workspaceId,
-          Long surveyConceptId,
           Long questionConceptId,
           Long answerConceptId) {
     workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
@@ -314,7 +311,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
         new SurveyVersionListResponse()
             .items(
                 cohortBuilderService.findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
-                    surveyConceptId, questionConceptId, answerConceptId)));
+                    questionConceptId, answerConceptId)));
   }
 
   protected void validateDomain(String domain) {

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -311,7 +311,6 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
               + "order by csv.display_order) innerSql",
       nativeQuery = true)
   List<DbSurveyVersion> findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
-      @Param("surveyConceptId") Long surveyConceptId,
       @Param("questionConceptId") Long questionConceptId,
       @Param("answerConceptId") Long answerConceptId);
 

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -306,8 +306,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
               + "select distinct csv.survey_version_concept_id as surveyVersionConceptId, csv.display_name as displayName, csa.item_count as itemCount, csv.display_order "
               + "from cb_survey_version csv "
               + "join cb_survey_attribute csa on csv.survey_version_concept_id = csa.survey_version_concept_id "
-              + "where csv.survey_concept_id = :surveyConceptId "
-              + "and csa.question_concept_id = :questionConceptId "
+              + "where csa.question_concept_id = :questionConceptId "
               + "and csa.answer_concept_id = :answerConceptId "
               + "order by csv.display_order) innerSql",
       nativeQuery = true)

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -100,9 +100,8 @@ public interface CohortBuilderService {
 
   List<SurveyModule> findSurveyModules();
 
-  List<SurveyVersion> findSurveyVersionByQuestionConceptId(
-      Long surveyConceptId, Long questionConceptId);
+  List<SurveyVersion> findSurveyVersionByQuestionConceptId(Long questionConceptId);
 
   List<SurveyVersion> findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
-      Long surveyConceptId, Long questionConceptId, Long answerConceptId);
+      Long questionConceptId, Long answerConceptId);
 }

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -185,14 +185,16 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
         standardConceptIds.stream().map(Object::toString).collect(Collectors.toList());
     if (!sourceIds.isEmpty()) {
       criteriaList.addAll(
-          cbCriteriaDao.findCriteriaByDomainIdAndStandardAndConceptIds(domainId, false, sourceIds)
+          cbCriteriaDao
+              .findCriteriaByDomainIdAndStandardAndConceptIds(domainId, false, sourceIds)
               .stream()
               .map(cohortBuilderMapper::dbModelToClient)
               .collect(Collectors.toList()));
     }
     if (!standardConceptIds.isEmpty()) {
       criteriaList.addAll(
-          cbCriteriaDao.findCriteriaByDomainIdAndStandardAndConceptIds(domainId, true, standardIds)
+          cbCriteriaDao
+              .findCriteriaByDomainIdAndStandardAndConceptIds(domainId, true, standardIds)
               .stream()
               .map(cohortBuilderMapper::dbModelToClient)
               .collect(Collectors.toList()));
@@ -527,18 +529,15 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   }
 
   @Override
-  public List<SurveyVersion> findSurveyVersionByQuestionConceptId(
-      Long surveyConceptId, Long questionConceptId) {
-    return findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
-        surveyConceptId, questionConceptId, 0L);
+  public List<SurveyVersion> findSurveyVersionByQuestionConceptId(Long questionConceptId) {
+    return findSurveyVersionByQuestionConceptIdAndAnswerConceptId(questionConceptId, 0L);
   }
 
   @Override
   public List<SurveyVersion> findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
-      Long surveyConceptId, Long questionConceptId, Long answerConceptId) {
+      Long questionConceptId, Long answerConceptId) {
     return cbCriteriaDao
-        .findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
-            surveyConceptId, questionConceptId, answerConceptId)
+        .findSurveyVersionByQuestionConceptIdAndAnswerConceptId(questionConceptId, answerConceptId)
         .stream()
         .map(cohortBuilderMapper::dbModelToClient)
         .collect(Collectors.toList());

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3829,7 +3829,7 @@ paths:
           description: A collection of criteria
           schema:
             "$ref": "#/definitions/CriteriaAttributeListResponse"
-  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/survey/attribute/{surveyConceptId}/{questionConceptId}":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/survey/attribute/{questionConceptId}":
     parameters:
       - "$ref": "#/parameters/workspaceNamespace"
       - "$ref": "#/parameters/workspaceId"
@@ -3839,12 +3839,6 @@ paths:
       description: Returns SurveyVersion with counts
       operationId: findSurveyVersionByQuestionConceptId
       parameters:
-      - in: path
-        name: surveyConceptId
-        type: integer
-        format: int64
-        required: true
-        description: surveyConceptId of the survey
       - in: path
         name: questionConceptId
         type: integer
@@ -3856,7 +3850,7 @@ paths:
           description: A collection of SurveyVersion
           schema:
             "$ref": "#/definitions/SurveyVersionListResponse"
-  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/survey/attribute/{surveyConceptId}/{questionConceptId}/{answerConceptId}":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/survey/attribute/{questionConceptId}/{answerConceptId}":
     parameters:
       - "$ref": "#/parameters/workspaceNamespace"
       - "$ref": "#/parameters/workspaceId"
@@ -3866,12 +3860,6 @@ paths:
       description: Returns SurveyVersion with counts
       operationId: findSurveyVersionByQuestionConceptIdAndAnswerConceptId
       parameters:
-      - in: path
-        name: surveyConceptId
-        type: integer
-        format: int64
-        required: true
-        description: surveyConceptId of the survey
       - in: path
         name: questionConceptId
         type: integer

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -1062,8 +1062,7 @@ public class CohortBuilderControllerTest {
         "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_version_concept_id, item_count) values (6, 715713, 903096, 102, 31)");
     SurveyVersionListResponse response =
         controller
-            .findSurveyVersionByQuestionConceptId(
-                WORKSPACE_NAMESPACE, WORKSPACE_ID, 1333342L, 715713L)
+            .findSurveyVersionByQuestionConceptId(WORKSPACE_NAMESPACE, WORKSPACE_ID, 715713L)
             .getBody();
     assert response != null;
     assertThat(response.getItems().get(0).getSurveyVersionConceptId()).isEqualTo(new Long("100"));
@@ -1103,7 +1102,7 @@ public class CohortBuilderControllerTest {
     List<SurveyVersion> response =
         controller
             .findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
-                WORKSPACE_NAMESPACE, WORKSPACE_ID, 111L, 222L, 333L)
+                WORKSPACE_NAMESPACE, WORKSPACE_ID, 222L, 333L)
             .getBody()
             .getItems();
     assertThat(response.get(0).getSurveyVersionConceptId()).isEqualTo(999);

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -349,7 +349,7 @@ public class CBCriteriaDaoTest {
     jdbcTemplate.execute(
         "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_version_concept_id, item_count) values (1, 715713, 1, 100, 491)");
     List<DbSurveyVersion> dbSurveyVersions =
-        cbCriteriaDao.findSurveyVersionByQuestionConceptIdAndAnswerConceptId(1333342L, 715713L, 0L);
+        cbCriteriaDao.findSurveyVersionByQuestionConceptIdAndAnswerConceptId(715713L, 0L);
     assertThat(dbSurveyVersions).hasSize(3);
     assertThat(dbSurveyVersions.get(0).getSurveyVersionConceptId()).isEqualTo(100);
     assertThat(dbSurveyVersions.get(0).getDisplayName()).isEqualTo("May 2020");
@@ -389,7 +389,7 @@ public class CBCriteriaDaoTest {
     jdbcTemplate.execute(
         "insert into cb_survey_attribute(id, question_concept_id, answer_concept_id, survey_version_concept_id, item_count) values (6, 715713, 903096, 102, 31)");
     List<DbSurveyVersion> dbSurveyVersions =
-        cbCriteriaDao.findSurveyVersionByQuestionConceptIdAndAnswerConceptId(1333342L, 715713L, 0L);
+        cbCriteriaDao.findSurveyVersionByQuestionConceptIdAndAnswerConceptId(715713L, 0L);
     assertThat(dbSurveyVersions).hasSize(3);
     assertThat(dbSurveyVersions.get(0).getSurveyVersionConceptId()).isEqualTo(100);
     assertThat(dbSurveyVersions.get(0).getDisplayName()).isEqualTo("May 2020");

--- a/ui/src/app/cohort-search/attributes-page/attributes-page.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page/attributes-page.component.tsx
@@ -390,7 +390,6 @@ export const AttributesPage = fp.flow(
             cohortBuilderApi().findSurveyVersionByQuestionConceptId(
               namespace,
               id,
-              surveyNode.conceptId,
               conceptId
             )
           );
@@ -399,7 +398,6 @@ export const AttributesPage = fp.flow(
             cohortBuilderApi().findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
               namespace,
               id,
-              surveyNode.conceptId,
               ppiQuestions.getValue()[parentId].conceptId,
               +value
             )


### PR DESCRIPTION
This PR merges survey version for duplicated questions:

- There are several duplicated questions between the COPE Survey and Vaccine Minute Survey
- We will only display the duplicated questions in Vaccine Minute Survey since it's the active survey. 
- We show all versions in the Vaccine Minute Survey, including COPE survey versions

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
