### PR TITLE
[risk=low][RW-8126] Show a link to the signed DUCC in the Profile

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/UserAccessModuleMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/access/UserAccessModuleMapper.java
@@ -1,13 +1,8 @@
 package org.pmiops.workbench.access;
 
 import java.sql.Timestamp;
-import javax.annotation.Nullable;
-import org.mapstruct.AfterMapping;
-import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
-import org.mapstruct.NullValueMappingStrategy;
 import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.model.AccessModuleStatus;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
@@ -15,22 +10,11 @@ import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
 @Mapper(
     config = MapStructConfig.class,
-    uses = {CommonMappers.class, AccessModuleNameMapper.class},
-    nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
+    uses = {CommonMappers.class, AccessModuleNameMapper.class})
 public interface UserAccessModuleMapper {
-  @Mapping(target = "moduleName", source = "accessModule.name")
-  @Mapping(target = "completionEpochMillis", source = "completionTime")
-  @Mapping(target = "bypassEpochMillis", source = "bypassTime")
-  // expirationEpochMillis is derived value, will calculate & set it later.
-  @Mapping(target = "expirationEpochMillis", ignore = true)
-  AccessModuleStatus dbToModule(DbUserAccessModule source, @Context Timestamp expirationTime);
-
-  @AfterMapping
-  default void afterMappingDbToModel(
-      @MappingTarget AccessModuleStatus accessModuleStatus,
-      @Nullable @Context Timestamp expirationTime) {
-    if (expirationTime != null) {
-      accessModuleStatus.setExpirationEpochMillis(expirationTime.getTime());
-    }
-  }
+  @Mapping(target = "moduleName", source = "source.accessModule.name")
+  @Mapping(target = "completionEpochMillis", source = "source.completionTime")
+  @Mapping(target = "bypassEpochMillis", source = "source.bypassTime")
+  @Mapping(target = "expirationEpochMillis", source = "expirationTime")
+  AccessModuleStatus dbToModule(DbUserAccessModule source, Timestamp expirationTime);
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -77,5 +77,6 @@ public interface WorkbenchConfigMapper {
   @Mapping(target = "rasClientId", source = "config.ras.clientId")
   @Mapping(target = "rasLogoutUrl", source = "config.ras.logoutUrl")
   @Mapping(target = "freeTierBillingAccountId", source = "config.billing.accountId")
+  @Mapping(target = "currentDuccVersions", source = "config.access.currentDuccVersions")
   ConfigResponse toModel(WorkbenchConfig config, List<DbAccessModule> accessModules);
 }

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
@@ -36,6 +36,8 @@ public interface ProfileMapper {
   @Mapping(source = "latestTermsOfService.aouAgreementTime", target = "latestTermsOfServiceTime")
   @Mapping(source = "dbUser.userId", target = "userId")
   @Mapping(source = "dbUser.duccAgreement.signedVersion", target = "duccSignedVersion")
+  @Mapping(source = "dbUser.duccAgreement.userInitials", target = "duccSignedInitials")
+  @Mapping(source = "dbUser.duccAgreement.completionTime", target = "duccCompletionTimeEpochMillis")
   Profile toModel(
       DbUser dbUser,
       VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation,

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5963,6 +5963,13 @@ definitions:
         type: integer
         format: int32
         description: Version of the data user code of conduct agreement that the user last signed.
+      duccSignedInitials:
+        type: string
+        description: The initials used for the user's most recent signing of the DUCC
+      duccCompletionTimeEpochMillis:
+        type: integer
+        format: int64
+        description: The date of the user's most recent signature of the DUCC
       address:
         "$ref": "#/definitions/Address"
       freeTierUsage:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4459,6 +4459,11 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/AccessModuleConfig"
+      currentDuccVersions:
+        type: array
+        items:
+          type: integer
+
   RuntimeImage:
     type: object
     properties:

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
@@ -181,6 +181,8 @@ const DuccContentPage = (props: ContentProps) => (
 
 interface SignatureProps {
   signatureState: DuccSignatureState;
+  signedInitials?: string;
+  signedDate?: number;
   errors;
   submitting: boolean;
   fullName: string;
@@ -217,6 +219,7 @@ const DuccSignaturePage = (props: SignatureProps) => (
       <InitialsAgreement
         onChange={(v) => props.onChangeMonitoring(v)}
         signatureState={props.signatureState}
+        signedValue={props.signedInitials}
       >
         My work, including any external data, files, or software I upload into
         the Researcher Workbench, will be logged and monitored by the <AoU />{' '}
@@ -225,6 +228,7 @@ const DuccSignaturePage = (props: SignatureProps) => (
       <InitialsAgreement
         onChange={(v) => props.onChangePublic(v)}
         signatureState={props.signatureState}
+        signedValue={props.signedInitials}
       >
         My name, affiliation, profile information and research description will
         be made public. My research description will be used by the <AoU />{' '}
@@ -234,6 +238,7 @@ const DuccSignaturePage = (props: SignatureProps) => (
       <InitialsAgreement
         onChange={(v) => props.onChangeAccess(v)}
         signatureState={props.signatureState}
+        signedValue={props.signedInitials}
       >
         <AoU /> retains the discretion to make decisions about my access,
         including the provision or revocation thereof, at any time that take
@@ -286,7 +291,11 @@ const DuccSignaturePage = (props: SignatureProps) => (
       <ReadOnlyTextField
         signatureState={props.signatureState}
         type='text'
-        value={new Date().toLocaleDateString()}
+        value={
+          props.signedDate
+            ? new Date(props.signedDate).toLocaleDateString()
+            : new Date().toLocaleDateString()
+        }
       />
     </FlexColumn>
     {props.signatureState === DuccSignatureState.UNSIGNED && (
@@ -396,7 +405,15 @@ export const DataUserCodeOfConduct = fp.flow(
 
     render() {
       const {
-        profileState: { profile },
+        profileState: {
+          profile: {
+            username,
+            givenName,
+            familyName,
+            duccSignedInitials,
+            duccCompletionTimeEpochMillis,
+          },
+        },
         signatureState,
       } = this.props;
       const {
@@ -447,9 +464,10 @@ export const DataUserCodeOfConduct = fp.flow(
           {(signatureState === DuccSignatureState.SIGNED ||
             page === DataUserCodeOfConductPage.SIGNATURE) && (
             <DuccSignaturePage
-              {...{ errors, submitting, signatureState }}
-              fullName={profile.givenName + ' ' + profile.familyName}
-              username={profile.username}
+              {...{ errors, submitting, signatureState, username }}
+              fullName={givenName + ' ' + familyName}
+              signedInitials={duccSignedInitials}
+              signedDate={duccCompletionTimeEpochMillis}
               onChangeMonitoring={(v) =>
                 this.setState({ initialMonitoring: v })
               }

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
@@ -62,6 +62,9 @@ const styles = reactStyles({
     fontSize: 10,
     borderRadius: 6,
   },
+  signature: {
+    margin: '0 3.5rem',
+  },
   signedText: {
     margin: '0 1ex',
     fontWeight: 'bold',
@@ -235,7 +238,7 @@ const DuccSignaturePage = (props: SignatureProps) => {
     onAccept,
   } = props;
   return (
-    <div data-test-id='ducc-signature-page'>
+    <div data-test-id='ducc-signature-page' style={styles.signature}>
       <FlexColumn>
         {submitting && <SpinnerOverlay />}
         {signatureState === DuccSignatureState.UNSIGNED && (

--- a/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
+++ b/ui/src/app/pages/profile/data-user-code-of-conduct.tsx
@@ -6,7 +6,7 @@ import { validate } from 'validate.js';
 
 import { Profile } from 'generated/fetch';
 
-import { Button } from 'app/components/buttons';
+import { Button, StyledRouterLink } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { flexStyle } from 'app/components/flex';
 import { HtmlViewer } from 'app/components/html-viewer';
@@ -21,7 +21,11 @@ import colors from 'app/styles/colors';
 import { reactStyles, withUserProfile } from 'app/utils';
 import { wasReferredFromRenewal } from 'app/utils/access-utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
-import { getLiveDUCCVersion, getVersionInfo } from 'app/utils/code-of-conduct';
+import {
+  canRenderSignedDucc,
+  getDuccRenderingInfo,
+  getLiveDUCCVersion,
+} from 'app/utils/code-of-conduct';
 import { NavigationProps } from 'app/utils/navigation';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 
@@ -76,6 +80,23 @@ export const enum DuccSignatureState {
   SIGNED,
 }
 
+const SignedVersionFailure = (props: { duccSignedVersion: number }) => {
+  const reason = props.duccSignedVersion
+    ? 'this user has signed an older version of the Data User Code of Conduct ' +
+      `(version id ${props.duccSignedVersion}) which we are unable to display in signed form.`
+    : 'this user has not signed a Data User Code of Conduct.';
+  return (
+    <>
+      <div>Error: {reason}</div>
+      <div>
+        Signing the latest version of the Data User Code of Conduct will grant
+        access to a signed copy. This version can be accessed{' '}
+        <StyledRouterLink path='/data-code-of-conduct'>here</StyledRouterLink>.
+      </div>
+    </>
+  );
+};
+
 interface DuccTextInputProps {
   value?: string;
   placeholder?: string;
@@ -108,25 +129,24 @@ interface ReadOnlyProps extends DuccTextInputProps {
   signatureState: DuccSignatureState;
 }
 const ReadOnlyTextField = (props: ReadOnlyProps) =>
-  props.signatureState === DuccSignatureState.UNSIGNED ? (
-    <DuccTextInput {...fp.omit(['signatureState'], props)} disabled={true} />
-  ) : (
+  props.signatureState === DuccSignatureState.SIGNED ? (
     <SignedText text={props.value} />
+  ) : (
+    <DuccTextInput {...fp.omit(['signatureState'], props)} disabled={true} />
   );
 
 interface InitialsProps {
   signatureState: DuccSignatureState;
   onChange: (v: string) => void;
-  signedValue?: string;
+  signedInitials?: string;
   children;
 }
 
 const InitialsAgreement = (props: InitialsProps) => (
   <div style={{ display: 'flex', marginTop: '0.5rem' }}>
-    {props.signatureState === DuccSignatureState.SIGNED && (
-      <SignedText text={props.signedValue?.toLocaleUpperCase()} />
-    )}
-    {props.signatureState === DuccSignatureState.UNSIGNED && (
+    {props.signatureState === DuccSignatureState.SIGNED ? (
+      <SignedText text={props.signedInitials?.toLocaleUpperCase()} />
+    ) : (
       <DuccTextInput
         onChange={props.onChange}
         placeholder='INITIALS'
@@ -146,42 +166,42 @@ interface ContentProps {
   onClick: () => void;
 }
 const DuccContentPage = (props: ContentProps) => {
-  const versionInfo = getVersionInfo(props.versionToRender);
+  const versionInfo = getDuccRenderingInfo(props.versionToRender);
 
-  return versionInfo ? (
-    <>
-      <HtmlViewer
-        ariaLabel='data user code of conduct agreement'
-        containerStyles={{ margin: '1rem 0 1rem', height: versionInfo.height }}
-        filePath={versionInfo.path}
-        onLastPage={() => props.onLastPage()}
-      />
-      {props.signatureState === DuccSignatureState.UNSIGNED && (
-        <FlexRow style={styles.dataUserCodeOfConductFooter}>
-          Please read the above document in its entirety before proceeding to
-          sign the Data User Code of Conduct.
-          <Button
-            type={'link'}
-            style={{ marginLeft: 'auto' }}
-            onClick={() => history.back()}
-          >
-            Back
-          </Button>
-          <Button
-            data-test-id={'ducc-next-button'}
-            disabled={props.buttonDisabled}
-            onClick={() => props.onClick()}
-          >
-            Proceed
-          </Button>
-        </FlexRow>
-      )}
-    </>
-  ) : (
-    <div>
-      Error: cannot render Data User Code of Conduct version '
-      {props.versionToRender}'
-    </div>
+  return (
+    versionInfo && (
+      <div data-test-id='ducc-content-page'>
+        <HtmlViewer
+          ariaLabel='data user code of conduct agreement'
+          containerStyles={{
+            margin: '1rem 0 1rem',
+            height: versionInfo.height,
+          }}
+          filePath={versionInfo.path}
+          onLastPage={() => props.onLastPage()}
+        />
+        {props.signatureState === DuccSignatureState.UNSIGNED && (
+          <FlexRow style={styles.dataUserCodeOfConductFooter}>
+            Please read the above document in its entirety before proceeding to
+            sign the Data User Code of Conduct.
+            <Button
+              type={'link'}
+              style={{ marginLeft: 'auto' }}
+              onClick={() => history.back()}
+            >
+              Back
+            </Button>
+            <Button
+              data-test-id={'ducc-next-button'}
+              disabled={props.buttonDisabled}
+              onClick={() => props.onClick()}
+            >
+              Proceed
+            </Button>
+          </FlexRow>
+        )}
+      </div>
+    )
   );
 };
 
@@ -199,143 +219,156 @@ interface SignatureProps {
   onBack: () => void;
   onAccept: () => void;
 }
-const DuccSignaturePage = (props: SignatureProps) => (
-  <>
-    <FlexColumn>
-      {props.submitting && <SpinnerOverlay />}
-      {props.signatureState === DuccSignatureState.UNSIGNED && (
-        <h1>Accept Data User Code of Conduct</h1>
-      )}
-      <div style={{ ...styles.bold, ...styles.smallTopMargin }}>
-        I,
+const DuccSignaturePage = (props: SignatureProps) => {
+  const {
+    signatureState,
+    signedInitials,
+    signedDate,
+    fullName,
+    username,
+    errors,
+    submitting,
+    onChangeMonitoring,
+    onChangePublic,
+    onChangeAccess,
+    onBack,
+    onAccept,
+  } = props;
+  return (
+    <div data-test-id='ducc-signature-page'>
+      <FlexColumn>
+        {submitting && <SpinnerOverlay />}
+        {signatureState === DuccSignatureState.UNSIGNED && (
+          <h1>Accept Data User Code of Conduct</h1>
+        )}
+        <div style={{ ...styles.bold, ...styles.smallTopMargin }}>
+          I,
+          <ReadOnlyTextField
+            {...{ signatureState }}
+            style={{ margin: '0 1ex' }}
+            value={fullName}
+            dataTestId='ducc-name-input'
+          />
+          ("Authorized Data User"), have personally reviewed this Data User Code
+          of Conduct. I agree to follow each of the policies and procedures it
+          describes.
+        </div>
+        <div style={styles.smallTopMargin}>
+          By entering my initials next to each statement below, I acknowledge
+          that:
+        </div>
+        <InitialsAgreement
+          {...{ signatureState, signedInitials }}
+          onChange={(v) => onChangeMonitoring(v)}
+        >
+          My work, including any external data, files, or software I upload into
+          the Researcher Workbench, will be logged and monitored by the <AoU />{' '}
+          Research Program to ensure compliance with policies and procedures.
+        </InitialsAgreement>
+        <InitialsAgreement
+          {...{ signatureState, signedInitials }}
+          onChange={(v) => onChangePublic(v)}
+        >
+          My name, affiliation, profile information and research description
+          will be made public. My research description will be used by the{' '}
+          <AoU /> Research Program to provide participants with meaningful
+          information about the research being conducted.
+        </InitialsAgreement>
+        <InitialsAgreement
+          {...{ signatureState, signedInitials }}
+          onChange={(v) => onChangeAccess(v)}
+        >
+          <AoU /> retains the discretion to make decisions about my access,
+          including the provision or revocation thereof, at any time that take
+          into account any data use violations, data management incidents,
+          research misconduct, and legal or regulatory violations related to the
+          conduct of research for which I’ve been penalized in the past or that
+          I may commit or am found to have committed subsequent to becoming an{' '}
+          <AoU /> Authorized Data User.
+        </InitialsAgreement>
+        <div style={{ ...styles.bold, ...styles.smallTopMargin }}>
+          I acknowledge that failure to comply with the requirements outlined in
+          this Data User Code of Conduct may result in termination of my <AoU />{' '}
+          Research Program account and/or other sanctions, including, but not
+          limited to:
+        </div>
+        <ul style={{ ...styles.bold, ...styles.smallTopMargin }}>
+          <li>
+            the posting of my name and affiliation on a publicly accessible list
+            of violators, and
+          </li>
+          <li>
+            notification of the National Institutes of Health or other federal
+            agencies as to my actions.
+          </li>
+        </ul>
+        <div style={{ ...styles.bold, ...styles.smallTopMargin }}>
+          I understand that failure to comply with these requirements may also
+          carry financial or legal repercussions. Any misuse of the <AoU />{' '}
+          Research Hub, Researcher Workbench or data resources is taken very
+          seriously, and other sanctions may be sought.
+        </div>
+        <label style={{ ...styles.bold, ...styles.largeTopMargin }}>
+          Authorized Data User Name
+        </label>
         <ReadOnlyTextField
-          signatureState={props.signatureState}
-          style={{ margin: '0 1ex' }}
-          value={props.fullName}
-          dataTestId='ducc-name-input'
+          {...{ signatureState }}
+          disabled
+          dataTestId='ducc-username-input'
+          value={fullName}
         />
-        ("Authorized Data User"), have personally reviewed this Data User Code
-        of Conduct. I agree to follow each of the policies and procedures it
-        describes.
-      </div>
-      <div style={styles.smallTopMargin}>
-        By entering my initials next to each statement below, I acknowledge
-        that:
-      </div>
-      <InitialsAgreement
-        onChange={(v) => props.onChangeMonitoring(v)}
-        signatureState={props.signatureState}
-        signedValue={props.signedInitials}
-      >
-        My work, including any external data, files, or software I upload into
-        the Researcher Workbench, will be logged and monitored by the <AoU />{' '}
-        Research Program to ensure compliance with policies and procedures.
-      </InitialsAgreement>
-      <InitialsAgreement
-        onChange={(v) => props.onChangePublic(v)}
-        signatureState={props.signatureState}
-        signedValue={props.signedInitials}
-      >
-        My name, affiliation, profile information and research description will
-        be made public. My research description will be used by the <AoU />{' '}
-        Research Program to provide participants with meaningful information
-        about the research being conducted.
-      </InitialsAgreement>
-      <InitialsAgreement
-        onChange={(v) => props.onChangeAccess(v)}
-        signatureState={props.signatureState}
-        signedValue={props.signedInitials}
-      >
-        <AoU /> retains the discretion to make decisions about my access,
-        including the provision or revocation thereof, at any time that take
-        into account any data use violations, data management incidents,
-        research misconduct, and legal or regulatory violations related to the
-        conduct of research for which I’ve been penalized in the past or that I
-        may commit or am found to have committed subsequent to becoming an{' '}
-        <AoU /> Authorized Data User.
-      </InitialsAgreement>
-      <div style={{ ...styles.bold, ...styles.smallTopMargin }}>
-        I acknowledge that failure to comply with the requirements outlined in
-        this Data User Code of Conduct may result in termination of my <AoU />{' '}
-        Research Program account and/or other sanctions, including, but not
-        limited to:
-      </div>
-      <ul style={{ ...styles.bold, ...styles.smallTopMargin }}>
-        <li>
-          the posting of my name and affiliation on a publicly accessible list
-          of violators, and
-        </li>
-        <li>
-          notification of the National Institutes of Health or other federal
-          agencies as to my actions.
-        </li>
-      </ul>
-      <div style={{ ...styles.bold, ...styles.smallTopMargin }}>
-        I understand that failure to comply with these requirements may also
-        carry financial or legal repercussions. Any misuse of the <AoU />{' '}
-        Research Hub, Researcher Workbench or data resources is taken very
-        seriously, and other sanctions may be sought.
-      </div>
-      <label style={{ ...styles.bold, ...styles.largeTopMargin }}>
-        Authorized Data User Name
-      </label>
-      <ReadOnlyTextField
-        signatureState={props.signatureState}
-        disabled
-        dataTestId='ducc-username-input'
-        value={props.fullName}
-      />
-      <label style={{ ...styles.bold, ...styles.largeTopMargin }}>
-        User ID
-      </label>
-      <ReadOnlyTextField
-        signatureState={props.signatureState}
-        dataTestId='ducc-user-id-input'
-        value={props.username}
-      />
-      <label style={{ ...styles.bold, ...styles.largeTopMargin }}>Date</label>
-      <ReadOnlyTextField
-        signatureState={props.signatureState}
-        type='text'
-        value={
-          props.signedDate
-            ? new Date(props.signedDate).toLocaleDateString()
-            : new Date().toLocaleDateString()
-        }
-      />
-    </FlexColumn>
-    {props.signatureState === DuccSignatureState.UNSIGNED && (
-      <FlexRow style={styles.dataUserCodeOfConductFooter}>
-        <Button
-          type='link'
-          style={{ marginLeft: 'auto' }}
-          onClick={() => props.onBack()}
-        >
-          Back
-        </Button>
-        <TooltipTrigger
-          content={
-            props.errors && (
-              <div>
-                <div>All fields must be initialed</div>
-                <div>All initials must match</div>
-                <div>Initials must be six letters or fewer</div>
-              </div>
-            )
+        <label style={{ ...styles.bold, ...styles.largeTopMargin }}>
+          User ID
+        </label>
+        <ReadOnlyTextField
+          {...{ signatureState }}
+          dataTestId='ducc-user-id-input'
+          value={username}
+        />
+        <label style={{ ...styles.bold, ...styles.largeTopMargin }}>Date</label>
+        <ReadOnlyTextField
+          {...{ signatureState }}
+          type='text'
+          value={
+            signatureState === DuccSignatureState.SIGNED
+              ? new Date(signedDate).toLocaleDateString()
+              : new Date().toLocaleDateString()
           }
-        >
+        />
+      </FlexColumn>
+      {signatureState === DuccSignatureState.UNSIGNED && (
+        <FlexRow style={styles.dataUserCodeOfConductFooter}>
           <Button
-            data-test-id='submit-ducc-button'
-            disabled={props.errors || props.submitting}
-            onClick={() => props.onAccept()}
+            type='link'
+            style={{ marginLeft: 'auto' }}
+            onClick={() => onBack()}
           >
-            Accept
+            Back
           </Button>
-        </TooltipTrigger>
-      </FlexRow>
-    )}
-  </>
-);
+          <TooltipTrigger
+            content={
+              errors && (
+                <div>
+                  <div>All fields must be initialed</div>
+                  <div>All initials must match</div>
+                  <div>Initials must be six letters or fewer</div>
+                </div>
+              )
+            }
+          >
+            <Button
+              data-test-id='submit-ducc-button'
+              disabled={errors || submitting}
+              onClick={() => onAccept()}
+            >
+              Accept
+            </Button>
+          </TooltipTrigger>
+        </FlexRow>
+      )}
+    </div>
+  );
+};
 
 interface Props
   extends WithSpinnerOverlayProps,
@@ -390,15 +423,16 @@ export const DataUserCodeOfConduct = fp.flow(
         message: 'Please try submitting the agreement again.',
       })
     )(async (initials) => {
-      const duccVersion = getLiveDUCCVersion();
-      const profile = await profileApi().submitDUCC(duccVersion, initials);
+      const profile = await profileApi().submitDUCC(
+        getLiveDUCCVersion(),
+        initials
+      );
       this.props.profileState.updateCache(profile);
     });
 
     submitDataUserCodeOfConduct(initials) {
-      const duccVersion = getLiveDUCCVersion();
       profileApi()
-        .submitDUCC(duccVersion, initials)
+        .submitDUCC(getLiveDUCCVersion(), initials)
         .then((profile) => {
           this.props.profileState.updateCache(profile);
           history.back();
@@ -451,18 +485,33 @@ export const DataUserCodeOfConduct = fp.flow(
 
       const containerStyle: CSSProperties = {
         ...styles.dataUserCodeOfConductPage,
-        ...(signatureState === DuccSignatureState.UNSIGNED &&
-          // FlexColumn is appropriate styling only for the UNSIGNED case, due to iframe height styling conflicts
-          flexStyle.column),
+        // FlexColumn is appropriate styling only for the UNSIGNED case, due to iframe height styling conflicts
+        ...(signatureState === DuccSignatureState.UNSIGNED && flexStyle.column),
       };
+
+      const showContentPage =
+        signatureState === DuccSignatureState.SIGNED
+          ? canRenderSignedDucc(duccSignedVersion)
+          : page === DataUserCodeOfConductPage.CONTENT;
+      const showSignaturePage =
+        signatureState === DuccSignatureState.SIGNED
+          ? canRenderSignedDucc(duccSignedVersion)
+          : page === DataUserCodeOfConductPage.SIGNATURE;
+
       return (
         <div style={containerStyle}>
-          {(signatureState === DuccSignatureState.SIGNED ||
-            page === DataUserCodeOfConductPage.CONTENT) && (
+          {signatureState === DuccSignatureState.SIGNED &&
+            !canRenderSignedDucc(duccSignedVersion) && (
+              <SignedVersionFailure {...{ duccSignedVersion }} />
+            )}
+          {showContentPage && (
             <DuccContentPage
               {...{ signatureState }}
-              versionToRender={3}
-              //              versionToRender={duccSignedVersion ?? getLiveDUCCVersion()}
+              versionToRender={
+                signatureState === DuccSignatureState.SIGNED
+                  ? duccSignedVersion
+                  : getLiveDUCCVersion()
+              }
               buttonDisabled={proceedDisabled}
               onLastPage={() => this.setState({ proceedDisabled: false })}
               onClick={() =>
@@ -470,8 +519,7 @@ export const DataUserCodeOfConduct = fp.flow(
               }
             />
           )}
-          {(signatureState === DuccSignatureState.SIGNED ||
-            page === DataUserCodeOfConductPage.SIGNATURE) && (
+          {showSignaturePage && (
             <DuccSignaturePage
               {...{ errors, submitting, signatureState, username }}
               fullName={givenName + ' ' + familyName}

--- a/ui/src/app/pages/profile/demographic-survey-panel.tsx
+++ b/ui/src/app/pages/profile/demographic-survey-panel.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { Button } from 'app/components/buttons';
-import colors from 'app/styles/colors';
 import { displayDateWithoutHours } from 'app/utils/dates';
 
 import { styles } from './profile-styles';

--- a/ui/src/app/pages/profile/demographic-survey-panel.tsx
+++ b/ui/src/app/pages/profile/demographic-survey-panel.tsx
@@ -14,10 +14,10 @@ interface Props {
 export const DemographicSurveyPanel = (props: Props) => {
   const { demographicSurveyCompletionTime, firstSignInTime, onClick } = props;
   return (
-    <div style={{ marginTop: '1rem', marginLeft: '1rem' }}>
+    <div style={styles.panel}>
       <div style={styles.title}>Optional Demographics Survey</div>
       <hr style={{ ...styles.verticalLine }} />
-      <div style={{ color: colors.primary, fontSize: '14px' }}>
+      <div style={styles.panelBody}>
         <div>Survey Completed</div>
         {/* If a user has created an account, they have, by definition, completed the demographic survey*/}
         <div>

--- a/ui/src/app/pages/profile/profile-component.tsx
+++ b/ui/src/app/pages/profile/profile-component.tsx
@@ -33,6 +33,7 @@ import { institutionApi, profileApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { withUserProfile } from 'app/utils';
 import { wasReferredFromRenewal } from 'app/utils/access-utils';
+import { canRenderSignedDucc } from 'app/utils/code-of-conduct';
 import { convertAPIError, reportError } from 'app/utils/errors';
 import { NavigationProps } from 'app/utils/navigation';
 import { canonicalizeUrl } from 'app/utils/urls';
@@ -42,6 +43,7 @@ import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { DataAccessPanel } from './data-access-panel';
 import { DemographicSurveyPanel } from './demographic-survey-panel';
 import { InitialCreditsPanel } from './initial-credits-panel';
+import { SignedDuccPanel } from './signed-ducc-panel';
 
 const validators = {
   givenName: { ...required, ...notTooLong(80) },
@@ -544,6 +546,11 @@ export const ProfileComponent = fp.flow(
                     this.setState({ showDemographicSurveyModal: true })
                   }
                 />
+                {canRenderSignedDucc(profile.duccSignedVersion) && (
+                  <SignedDuccPanel
+                    signedDate={profile.duccCompletionTimeEpochMillis}
+                  />
+                )}
               </div>
             </FlexRow>
             <div style={{ display: 'flex' }}>

--- a/ui/src/app/pages/profile/profile-styles.ts
+++ b/ui/src/app/pages/profile/profile-styles.ts
@@ -89,4 +89,6 @@ export const styles = reactStyles({
     marginRight: '0.75rem',
     border: `1px solid ${colors.warning}`,
   },
+  panel: { marginTop: '1rem', marginLeft: '1rem' },
+  panelBody: { color: colors.primary, fontSize: '14px' },
 });

--- a/ui/src/app/pages/profile/signed-ducc-panel.tsx
+++ b/ui/src/app/pages/profile/signed-ducc-panel.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+import { StyledRouterLink } from 'app/components/buttons';
+import { displayDateWithoutHours } from 'app/utils/dates';
+
+import { styles } from './profile-styles';
+
+interface Props {
+  signedDate: number;
+}
+export const SignedDuccPanel = (props: Props) => (
+  <div style={styles.panel}>
+    <div style={styles.title}>Data User Code of Conduct</div>
+    <hr style={{ ...styles.verticalLine }} />
+    <div style={styles.panelBody}>
+      <div>Signed On</div>
+      <div>{displayDateWithoutHours(props.signedDate)}</div>
+      <StyledRouterLink path='/signed-ducc'>
+        View Signed Data User Code of Conduct
+      </StyledRouterLink>
+    </div>
+  </div>
+);

--- a/ui/src/app/pages/profile/signed-ducc-panel.tsx
+++ b/ui/src/app/pages/profile/signed-ducc-panel.tsx
@@ -9,7 +9,7 @@ interface Props {
   signedDate: number;
 }
 export const SignedDuccPanel = (props: Props) => (
-  <div style={styles.panel}>
+  <div style={styles.panel} data-test-id='signed-ducc-panel'>
     <div style={styles.title}>Data User Code of Conduct</div>
     <hr style={{ ...styles.verticalLine }} />
     <div style={styles.panelBody}>

--- a/ui/src/app/routing/signed-in-app-routing.tsx
+++ b/ui/src/app/routing/signed-in-app-routing.tsx
@@ -300,7 +300,7 @@ export const SignedInRoutes = () => {
           signatureState={DuccSignatureState.UNSIGNED}
         />
       </AppRoute>
-      <AppRoute exact path='/signed-ducc'>
+      <AppRoute exact path='/signed-ducc' guards={[getAccessModuleGuard()]}>
         <DataUserCodeOfConductPage
           routeData={{
             title: 'Data User Code of Conduct (Signed)',

--- a/ui/src/app/routing/signed-in-app-routing.tsx
+++ b/ui/src/app/routing/signed-in-app-routing.tsx
@@ -297,8 +297,16 @@ export const SignedInRoutes = () => {
             title: 'Data User Code of Conduct',
             minimizeChrome: true,
           }}
-          // see RW-8126 and RW-8296
           signatureState={DuccSignatureState.UNSIGNED}
+        />
+      </AppRoute>
+      <AppRoute exact path='/signed-ducc'>
+        <DataUserCodeOfConductPage
+          routeData={{
+            title: 'Data User Code of Conduct (Signed)',
+            minimizeChrome: true,
+          }}
+          signatureState={DuccSignatureState.SIGNED}
         />
       </AppRoute>
       <AppRoute exact path='/profile'>

--- a/ui/src/app/utils/code-of-conduct.tsx
+++ b/ui/src/app/utils/code-of-conduct.tsx
@@ -25,7 +25,7 @@ const VERSIONS: VersionInfo[] = [
   {
     version: 4,
     path: '/data-user-code-of-conduct-v4.html',
-    height: '90rem',
+    height: '80rem',
   },
 ];
 

--- a/ui/src/app/utils/code-of-conduct.tsx
+++ b/ui/src/app/utils/code-of-conduct.tsx
@@ -7,6 +7,22 @@
  * could likely eliminate this helper function. This needs further design
  * thinking though. For now just consolidate DUCC logic through this package.
  */
-export function getLiveDUCCVersion(): number {
-  return 4;
+export const getLiveDUCCVersion = () => 4;
+
+interface VersionInfo {
+  version: number;
+  path: string;
+  height: string;
 }
+
+const versions: VersionInfo[] = [
+  {
+    version: 4,
+    path: '/data-user-code-of-conduct-v4.html',
+    height: '90rem',
+  },
+];
+
+export const getVersionInfo = (versionToFind: number): VersionInfo => {
+  return versions.find(({ version }) => version === versionToFind);
+};

--- a/ui/src/app/utils/code-of-conduct.tsx
+++ b/ui/src/app/utils/code-of-conduct.tsx
@@ -1,15 +1,16 @@
 import { serverConfigStore } from './stores';
 
 /**
- * Returns the list of current-for-compliance DUCC version.  One of these versions must be signed in order to receive
- * registered data access.
+ * Returns the list of current-for-compliance DUCC versions.
+ * One of these versions must be signed in order to receive Registered Tier and Controlled Tier data access.
  */
 export const getCurrentDUCCVersions = (): number[] =>
   serverConfigStore.get().config.currentDuccVersions;
 
 /**
- * Returns the latest version of the DUCC, to be displayed when the user requests to sign it.  This may not be the only
- * "current" DUCC version; use getCurrentDUCCVersions() to retrieve the full list.
+ * Returns the latest version of the DUCC, to be displayed when the user requests to sign it.
+ * This may not be the only DUCC version considered to be current for access tier membership requirements;
+ * use getCurrentDUCCVersions() to retrieve the full list.
  */
 export const getLiveDUCCVersion = (): number =>
   Math.max(...getCurrentDUCCVersions());
@@ -20,7 +21,7 @@ interface VersionInfo {
   height: string;
 }
 
-const versions: VersionInfo[] = [
+const VERSIONS: VersionInfo[] = [
   {
     version: 4,
     path: '/data-user-code-of-conduct-v4.html',
@@ -28,6 +29,9 @@ const versions: VersionInfo[] = [
   },
 ];
 
-export const getVersionInfo = (versionToFind: number): VersionInfo => {
-  return versions.find(({ version }) => version === versionToFind);
+export const getDuccRenderingInfo = (versionToFind: number): VersionInfo => {
+  return VERSIONS.find(({ version }) => version === versionToFind);
 };
+
+export const canRenderSignedDucc = (versionToFind: number): boolean =>
+  !!getDuccRenderingInfo(versionToFind);

--- a/ui/src/app/utils/code-of-conduct.tsx
+++ b/ui/src/app/utils/code-of-conduct.tsx
@@ -1,13 +1,18 @@
+import { serverConfigStore } from './stores';
+
 /**
- * Returns the currently live DUCC version. This version should be displayed when
- * completing the DUCC and this exact version must be signed in order to receive
+ * Returns the list of current-for-compliance DUCC version.  One of these versions must be signed in order to receive
  * registered data access.
- *
- * Note: If we instead returned a live DUCC version in the server config, we
- * could likely eliminate this helper function. This needs further design
- * thinking though. For now just consolidate DUCC logic through this package.
  */
-export const getLiveDUCCVersion = () => 4;
+export const getCurrentDUCCVersions = (): number[] =>
+  serverConfigStore.get().config.currentDuccVersions;
+
+/**
+ * Returns the latest version of the DUCC, to be displayed when the user requests to sign it.  This may not be the only
+ * "current" DUCC version; use getCurrentDUCCVersions() to retrieve the full list.
+ */
+export const getLiveDUCCVersion = (): number =>
+  Math.max(...getCurrentDUCCVersions());
 
 interface VersionInfo {
   version: number;

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -82,6 +82,7 @@ const defaultServerConfig: ConfigResponse = {
   complianceTrainingRenewalLookback: 30,
   freeTierBillingAccountId: 'freetier',
   accessModules: defaultAccessModuleConfig,
+  currentDuccVersions: [3, 4],
 };
 
 export default defaultServerConfig;

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -31,6 +31,9 @@ export class ProfileStubVariables {
     authorities: [],
     freeTierUsage: 1.23,
     freeTierDollarQuota: 34.56,
+    duccSignedVersion: 4,
+    duccSignedInitials: 'abc',
+    duccCompletionTimeEpochMillis: 1,
     address: {
       streetAddress1: 'Main street',
       city: 'Cambridge',


### PR DESCRIPTION
If a user has signed **the latest version of the** DUCC, a link to view it will appear in their profile:
![signed-ducc](https://user-images.githubusercontent.com/2701406/167498629-7024dead-dd40-4a8c-8623-33fdcec40a76.gif)


If a user has not signed the DUCC, they will not see this link in their profile.  If they happen to type `/signed-ducc` manually into their browser (unlikely!) they would see this:
<img width="527" alt="no-ducc" src="https://user-images.githubusercontent.com/2701406/167498607-87bfd7e9-1f53-4fc7-9185-c513dafffa67.png">

Users who have signed older versions of the DUCC, they will also not see this link in their profile.  If they happen to type `/signed-ducc` manually into their browser (unlikely!) they would see this:
<img width="985" alt="old-ducc" src="https://user-images.githubusercontent.com/2701406/167503022-9246854c-57ff-44cf-9328-c370b1cfbaaf.png">

 See also the prototype at #6651 

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
