### PR TITLE
[risk=low][no ticket] bump google-truth and update method calls

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -484,7 +484,7 @@ dependencies {
     testCompile 'org.mockito:mockito-core:2.18.3'
     testCompile "com.google.appengine:appengine-api-stubs:$project.ext.GAE_VERSION"
     testCompile "com.google.appengine:appengine-tools-sdk:$project.ext.GAE_VERSION"
-    testCompile 'com.google.truth:truth:0.42'
+    testCompile 'com.google.truth:truth:1.1.3'
     testCompile 'com.google.truth.extensions:truth-java8-extension:1.1.3'
     testCompile 'com.h2database:h2:1.4.194'
     testCompile 'org.liquibase:liquibase-core:4.9.0'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     ext {
         GAE_VERSION = '1.9.93'
         GSON_VERSION = '2.9.0'
+        GOOGLE_TRUTH_VERSION = '1.1.3'
         JACKSON_VERSION = '2.13.2'
         JACKSON_DATABIND_VERSION = '2.13.2.2'
         KOTLIN_VERSION = '1.5.32'
@@ -484,8 +485,8 @@ dependencies {
     testCompile 'org.mockito:mockito-core:2.18.3'
     testCompile "com.google.appengine:appengine-api-stubs:$project.ext.GAE_VERSION"
     testCompile "com.google.appengine:appengine-tools-sdk:$project.ext.GAE_VERSION"
-    testCompile 'com.google.truth:truth:1.1.3'
-    testCompile 'com.google.truth.extensions:truth-java8-extension:1.1.3'
+    testCompile "com.google.truth:truth:$project.ext.GOOGLE_TRUTH_VERSION"
+    testCompile "com.google.truth.extensions:truth-java8-extension:$project.ext.GOOGLE_TRUTH_VERSION"
     testCompile 'com.h2database:h2:1.4.194'
     testCompile 'org.liquibase:liquibase-core:4.9.0'
     testCompile 'org.bitbucket.radistao.test:before-after-spring-test-runner:0.1.0'

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -1511,7 +1511,7 @@ public class CohortReviewControllerTest {
             participantCohortAnnotationMapper.dbModelToClient(participantAnnotation),
             participantCohortAnnotationMapper.dbModelToClient(participantAnnotationDate));
 
-    assertThat(response.getItems()).containsAtLeastElementsIn(expected);
+    assertThat(response.getItems()).containsExactlyElementsIn(expected);
   }
 
   @ParameterizedTest(

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -1511,7 +1511,7 @@ public class CohortReviewControllerTest {
             participantCohortAnnotationMapper.dbModelToClient(participantAnnotation),
             participantCohortAnnotationMapper.dbModelToClient(participantAnnotationDate));
 
-    assertThat(response.getItems()).containsAllIn(expected);
+    assertThat(response.getItems()).containsAtLeastElementsIn(expected);
   }
 
   @ParameterizedTest(

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -434,7 +434,7 @@ public class CohortsControllerTest {
             .getCohortsInWorkspace(workspace.getNamespace(), workspace.getId())
             .getBody()
             .getItems();
-    assertThat(cohorts).containsAllOf(c1, c2);
+    assertThat(cohorts).containsAtLeast(c1, c2);
     assertThat(cohorts.size()).isEqualTo(2);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -434,8 +434,8 @@ public class CohortsControllerTest {
             .getCohortsInWorkspace(workspace.getNamespace(), workspace.getId())
             .getBody()
             .getItems();
-    assertThat(cohorts).containsAtLeast(c1, c2);
     assertThat(cohorts.size()).isEqualTo(2);
+    assertThat(cohorts).containsExactly(c1, c2);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -667,7 +667,7 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(1);
-    assertThat(response).containsAllIn(ImmutableList.of(defaultConceptSet));
+    assertThat(response).containsAtLeastElementsIn(ImmutableList.of(defaultConceptSet));
   }
 
   @Test
@@ -706,7 +706,8 @@ public class ConceptSetsControllerTest {
 
     assertThat(response.size()).isEqualTo(4);
     assertThat(response)
-        .containsAllIn(ImmutableList.of(defaultConceptSet, conceptSet2, conceptSet3, conceptSet4));
+        .containsAtLeastElementsIn(
+            ImmutableList.of(defaultConceptSet, conceptSet2, conceptSet3, conceptSet4));
   }
 
   @Test
@@ -734,7 +735,7 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(1);
-    assertThat(response).containsAllIn(ImmutableList.of(defaultConceptSet));
+    assertThat(response).containsAtLeastElementsIn(ImmutableList.of(defaultConceptSet));
   }
 
   @Test
@@ -750,7 +751,7 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(1);
-    assertThat(response).containsAllIn(ImmutableList.of(defaultConceptSet));
+    assertThat(response).containsAtLeastElementsIn(ImmutableList.of(defaultConceptSet));
   }
 
   @Test
@@ -766,7 +767,7 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(1);
-    assertThat(response).containsAllIn(ImmutableList.of(defaultConceptSet));
+    assertThat(response).containsAtLeastElementsIn(ImmutableList.of(defaultConceptSet));
   }
 
   @Test
@@ -1223,7 +1224,9 @@ public class ConceptSetsControllerTest {
     assertThat(conceptSetCopy.getName()).contains(conceptSet.getName());
     assertThat(conceptSetCopy.getName()).contains("_copy");
     assertThat(conceptSetCopy.getDescription()).isEqualTo(conceptSet.getDescription());
-    assertThat(conceptSet.getCriteriums()).containsAllIn(conceptSetCopy.getCriteriums()).inOrder();
+    assertThat(conceptSet.getCriteriums())
+        .containsAtLeastElementsIn(conceptSetCopy.getCriteriums())
+        .inOrder();
   }
 
   @Test
@@ -1258,7 +1261,9 @@ public class ConceptSetsControllerTest {
     assertThat(conceptSetCopy.getName()).contains(conceptSet.getName());
     assertThat(conceptSetCopy.getName()).contains("_copy");
     assertThat(conceptSetCopy.getDescription()).isEqualTo(conceptSet.getDescription());
-    assertThat(conceptSet.getCriteriums()).containsAllIn(conceptSetCopy.getCriteriums()).inOrder();
+    assertThat(conceptSet.getCriteriums())
+        .containsAtLeastElementsIn(conceptSetCopy.getCriteriums())
+        .inOrder();
   }
 
   @Test
@@ -1450,7 +1455,7 @@ public class ConceptSetsControllerTest {
   }
 
   private void assertConceptSets(ConceptSet actual, ConceptSet expected) {
-    assertThat(actual.getCriteriums()).containsAllIn(expected.getCriteriums());
+    assertThat(actual.getCriteriums()).containsAtLeastElementsIn(expected.getCriteriums());
     assertThat(actual.getDescription()).isEqualTo(UPDATED_DESC);
     assertThat(actual.getName()).isEqualTo(UPDATED_NAME);
     assertThat(actual.getDomain()).isEqualTo(expected.getDomain());
@@ -1478,7 +1483,7 @@ public class ConceptSetsControllerTest {
     assertThat(updated.getLastModifiedTime()).isGreaterThan(initial.getLastModifiedTime());
     assertThat(updated.getEtag()).isNotEqualTo(initial.getEtag());
     assertThat(updated.getCriteriums().size()).isEqualTo(expectedCriteria.size());
-    assertThat(updated.getCriteriums()).containsAllIn(expectedCriteria);
+    assertThat(updated.getCriteriums()).containsAtLeastElementsIn(expectedCriteria);
   }
 
   private void assertConceptSetAndCriteria(ConceptSet conceptSet, List<Criteria> expectedCriteria) {
@@ -1489,7 +1494,7 @@ public class ConceptSetsControllerTest {
     assertThat(conceptSet.getLastModifiedTime()).isEqualTo(NOW.toEpochMilli());
     assertThat(conceptSet.getName()).isEqualTo(CONCEPT_SET_NAME_1);
     assertThat(conceptSet.getCriteriums().size()).isEqualTo(expectedCriteria.size());
-    assertThat(conceptSet.getCriteriums()).containsAllIn(expectedCriteria);
+    assertThat(conceptSet.getCriteriums()).containsAtLeastElementsIn(expectedCriteria);
   }
 
   //////////// other helpers for setup and intermediate objects ////////////

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -667,7 +667,7 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(1);
-    assertThat(response).containsAtLeastElementsIn(ImmutableList.of(defaultConceptSet));
+    assertThat(response).contains(defaultConceptSet);
   }
 
   @Test
@@ -705,9 +705,7 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(4);
-    assertThat(response)
-        .containsAtLeastElementsIn(
-            ImmutableList.of(defaultConceptSet, conceptSet2, conceptSet3, conceptSet4));
+    assertThat(response).containsAtLeast(defaultConceptSet, conceptSet2, conceptSet3, conceptSet4);
   }
 
   @Test
@@ -735,7 +733,7 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(1);
-    assertThat(response).containsAtLeastElementsIn(ImmutableList.of(defaultConceptSet));
+    assertThat(response).contains(defaultConceptSet);
   }
 
   @Test
@@ -751,7 +749,7 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(1);
-    assertThat(response).containsAtLeastElementsIn(ImmutableList.of(defaultConceptSet));
+    assertThat(response).contains(defaultConceptSet);
   }
 
   @Test
@@ -767,7 +765,7 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(1);
-    assertThat(response).containsAtLeastElementsIn(ImmutableList.of(defaultConceptSet));
+    assertThat(response).contains(defaultConceptSet);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -705,7 +705,7 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(4);
-    assertThat(response).containsAtLeast(defaultConceptSet, conceptSet2, conceptSet3, conceptSet4);
+    assertThat(response).containsExactly(defaultConceptSet, conceptSet2, conceptSet3, conceptSet4);
   }
 
   @Test
@@ -1481,7 +1481,7 @@ public class ConceptSetsControllerTest {
     assertThat(updated.getLastModifiedTime()).isGreaterThan(initial.getLastModifiedTime());
     assertThat(updated.getEtag()).isNotEqualTo(initial.getEtag());
     assertThat(updated.getCriteriums().size()).isEqualTo(expectedCriteria.size());
-    assertThat(updated.getCriteriums()).containsAtLeastElementsIn(expectedCriteria);
+    assertThat(updated.getCriteriums()).containsExactlyElementsIn(expectedCriteria);
   }
 
   private void assertConceptSetAndCriteria(ConceptSet conceptSet, List<Criteria> expectedCriteria) {
@@ -1492,7 +1492,7 @@ public class ConceptSetsControllerTest {
     assertThat(conceptSet.getLastModifiedTime()).isEqualTo(NOW.toEpochMilli());
     assertThat(conceptSet.getName()).isEqualTo(CONCEPT_SET_NAME_1);
     assertThat(conceptSet.getCriteriums().size()).isEqualTo(expectedCriteria.size());
-    assertThat(conceptSet.getCriteriums()).containsAtLeastElementsIn(expectedCriteria);
+    assertThat(conceptSet.getCriteriums()).containsExactlyElementsIn(expectedCriteria);
   }
 
   //////////// other helpers for setup and intermediate objects ////////////

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -155,7 +155,6 @@ public class UserControllerTest {
   @Test
   public void testUserPartialStringSearch() {
     when(fireCloudService.isUserMemberOfGroupWithCache(any(), any())).thenReturn(true);
-    List<DbUser> allUsers = Lists.newArrayList(userDao.findAll());
 
     UserResponse response =
         userController

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -148,8 +148,8 @@ public class UserControllerTest {
             .userSearch(registeredTier.getShortName(), "John", null, null, null)
             .getBody();
     assertThat(response.getUsers()).hasSize(1);
-    assertThat(response.getUsers().get(0).getEmail()).isSameInstanceAs(john.getUsername());
-    assertThat(response.getUsers().get(0).getUserName()).isSameInstanceAs(john.getUsername());
+    assertThat(response.getUsers().get(0).getEmail()).isEqualTo(john.getUsername());
+    assertThat(response.getUsers().get(0).getUserName()).isEqualTo(john.getUsername());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -148,8 +148,8 @@ public class UserControllerTest {
             .userSearch(registeredTier.getShortName(), "John", null, null, null)
             .getBody();
     assertThat(response.getUsers()).hasSize(1);
-    assertThat(response.getUsers().get(0).getEmail()).isSameAs(john.getUsername());
-    assertThat(response.getUsers().get(0).getUserName()).isSameAs(john.getUsername());
+    assertThat(response.getUsers().get(0).getEmail()).isSameInstanceAs(john.getUsername());
+    assertThat(response.getUsers().get(0).getUserName()).isSameInstanceAs(john.getUsername());
   }
 
   @Test
@@ -333,16 +333,16 @@ public class UserControllerTest {
             .getBody();
 
     // Assert we have the same elements in both responses
-    assertThat(robinsonsAsc.getUsers()).containsAllIn(robinsonsDesc.getUsers());
+    assertThat(robinsonsAsc.getUsers()).containsAtLeastElementsIn(robinsonsDesc.getUsers());
 
     // Now reverse one and assert both in the same order
     List<User> descendingReversed = Lists.reverse(robinsonsDesc.getUsers());
-    assertThat(robinsonsAsc.getUsers()).containsAllIn(descendingReversed).inOrder();
+    assertThat(robinsonsAsc.getUsers()).containsAtLeastElementsIn(descendingReversed).inOrder();
 
     // Test that JPA sorting is really what we expected it to be by re-sorting one into a new list
     List<User> newAscending = Lists.newArrayList(robinsonsAsc.getUsers());
     newAscending.sort(Comparator.comparing(User::getUserName));
-    assertThat(robinsonsAsc.getUsers()).containsAllIn(newAscending).inOrder();
+    assertThat(robinsonsAsc.getUsers()).containsAtLeastElementsIn(newAscending).inOrder();
   }
 
   // Combinatorial tests for listBillingAccounts:

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -333,16 +333,16 @@ public class UserControllerTest {
             .getBody();
 
     // Assert we have the same elements in both responses
-    assertThat(robinsonsAsc.getUsers()).containsAtLeastElementsIn(robinsonsDesc.getUsers());
+    assertThat(robinsonsAsc.getUsers()).containsExactlyElementsIn(robinsonsDesc.getUsers());
 
     // Now reverse one and assert both in the same order
     List<User> descendingReversed = Lists.reverse(robinsonsDesc.getUsers());
-    assertThat(robinsonsAsc.getUsers()).containsAtLeastElementsIn(descendingReversed).inOrder();
+    assertThat(robinsonsAsc.getUsers()).containsExactlyElementsIn(descendingReversed).inOrder();
 
     // Test that JPA sorting is really what we expected it to be by re-sorting one into a new list
     List<User> newAscending = Lists.newArrayList(robinsonsAsc.getUsers());
     newAscending.sort(Comparator.comparing(User::getUserName));
-    assertThat(robinsonsAsc.getUsers()).containsAtLeastElementsIn(newAscending).inOrder();
+    assertThat(robinsonsAsc.getUsers()).containsExactlyElementsIn(newAscending).inOrder();
   }
 
   // Combinatorial tests for listBillingAccounts:

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -1692,8 +1692,8 @@ public class WorkspacesControllerTest {
             .getBody()
             .getItems();
     Map<String, Cohort> cohortsByName = Maps.uniqueIndex(cohorts, c -> c.getName());
-    assertThat(cohortsByName.keySet()).containsAtLeast("c1", "c2");
     assertThat(cohortsByName.keySet().size()).isEqualTo(2);
+    assertThat(cohortsByName.keySet()).containsExactly("c1", "c2");
     assertThat(cohorts.stream().map(c -> c.getId()).collect(Collectors.toList()))
         .containsNoneOf(c1.getId(), c2.getId());
 

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -1692,7 +1692,7 @@ public class WorkspacesControllerTest {
             .getBody()
             .getItems();
     Map<String, Cohort> cohortsByName = Maps.uniqueIndex(cohorts, c -> c.getName());
-    assertThat(cohortsByName.keySet()).containsAllOf("c1", "c2");
+    assertThat(cohortsByName.keySet()).containsAtLeast("c1", "c2");
     assertThat(cohortsByName.keySet().size()).isEqualTo(2);
     assertThat(cohorts.stream().map(c -> c.getId()).collect(Collectors.toList()))
         .containsNoneOf(c1.getId(), c2.getId());

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/DSLinkingDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/DSLinkingDaoTest.java
@@ -49,6 +49,6 @@ public class DSLinkingDaoTest {
         dsLinkingDao.findByDomainAndDenormalizedNameInOrderById(
             "Condition", ImmutableList.of("CONDITION_CONCEPT_ID", "CONDITION_STATUS_CONCEPT_NAME"));
     assertThat(sqlParts).hasSize(2);
-    assertThat(sqlParts).containsAtLeast(dbDSLinking1, dbDSLinking2);
+    assertThat(sqlParts).containsExactly(dbDSLinking1, dbDSLinking2);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/DSLinkingDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/DSLinkingDaoTest.java
@@ -49,6 +49,6 @@ public class DSLinkingDaoTest {
         dsLinkingDao.findByDomainAndDenormalizedNameInOrderById(
             "Condition", ImmutableList.of("CONDITION_CONCEPT_ID", "CONDITION_STATUS_CONCEPT_NAME"));
     assertThat(sqlParts).hasSize(2);
-    assertThat(sqlParts).containsAllOf(dbDSLinking1, dbDSLinking2);
+    assertThat(sqlParts).containsAtLeast(dbDSLinking1, dbDSLinking2);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/cohorts/CohortFactoryTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohorts/CohortFactoryTest.java
@@ -42,7 +42,7 @@ public class CohortFactoryTest {
     assertThat(dbCohort.getName()).isEqualTo(apiCohort.getName());
     assertThat(dbCohort.getType()).isEqualTo(apiCohort.getType());
     assertThat(dbCohort.getCriteria()).isEqualTo(apiCohort.getCriteria());
-    assertThat(dbCohort.getCreator()).isSameAs(user);
+    assertThat(dbCohort.getCreator()).isSameInstanceAs(user);
     assertThat(dbCohort.getWorkspaceId()).isEqualTo(workspaceId);
   }
 
@@ -65,7 +65,7 @@ public class CohortFactoryTest {
     assertThat(dbCohort.getName()).isEqualTo("new name");
     assertThat(dbCohort.getType()).isEqualTo(originalCohort.getType());
     assertThat(dbCohort.getCriteria()).isEqualTo(originalCohort.getCriteria());
-    assertThat(dbCohort.getCreator()).isSameAs(user);
+    assertThat(dbCohort.getCreator()).isSameInstanceAs(user);
     assertThat(dbCohort.getWorkspaceId()).isEqualTo(originalCohort.getWorkspaceId());
     assertThat(dbCohort.getCohortReviews()).isNull();
   }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/DataSetDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/DataSetDaoTest.java
@@ -166,7 +166,7 @@ public class DataSetDaoTest {
         dataSetDao.findDataSetsByCohortIdsAndWorkspaceIdAndInvalid(
             dbCohort.getCohortId(), workspace.getWorkspaceId(), false);
     assertThat(actual.size()).isEqualTo(2);
-    assertThat(actual).containsAtLeast(dbDataset1, dbDataset2);
+    assertThat(actual).containsExactly(dbDataset1, dbDataset2);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/DataSetDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/DataSetDaoTest.java
@@ -166,7 +166,7 @@ public class DataSetDaoTest {
         dataSetDao.findDataSetsByCohortIdsAndWorkspaceIdAndInvalid(
             dbCohort.getCohortId(), workspace.getWorkspaceId(), false);
     assertThat(actual.size()).isEqualTo(2);
-    assertThat(actual).containsAtLeastElementsIn(ImmutableList.of(dbDataset1, dbDataset2));
+    assertThat(actual).containsAtLeast(dbDataset1, dbDataset2);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/DataSetDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/DataSetDaoTest.java
@@ -166,7 +166,7 @@ public class DataSetDaoTest {
         dataSetDao.findDataSetsByCohortIdsAndWorkspaceIdAndInvalid(
             dbCohort.getCohortId(), workspace.getWorkspaceId(), false);
     assertThat(actual.size()).isEqualTo(2);
-    assertThat(actual).containsAllIn(ImmutableList.of(dbDataset1, dbDataset2));
+    assertThat(actual).containsAtLeastElementsIn(ImmutableList.of(dbDataset1, dbDataset2));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/model/StorageEnumsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/model/StorageEnumsTest.java
@@ -81,7 +81,9 @@ public class StorageEnumsTest {
       for (final Object enumValue : enumClass.getEnumConstants()) {
         final Method enumToStorageMethod = enumClassToStorageMethod.get(enumClass);
         Short shortValue = enumToStorage(enumValue, enumToStorageMethod);
-        assertThat(shortValue).named(enumClass.getName() + ":" + enumValue.toString()).isNotNull();
+        assertWithMessage(enumClass.getName() + ":" + enumValue.toString())
+            .that(shortValue)
+            .isNotNull();
         final Method storageToEnumMethod = storageMethodToEnumClass.get(enumClass);
         assertThat(storageToEnum(shortValue, storageToEnumMethod)).isEqualTo(enumValue);
       }
@@ -94,8 +96,8 @@ public class StorageEnumsTest {
 
     String invokedMethodDesc = String.format("%s(%s)", enumToStorageMethod.getName(), enumValue);
 
-    assertThat(returnValue).named(invokedMethodDesc).isNotNull();
-    assertThat(returnValue).named(invokedMethodDesc).isInstanceOf(Short.class);
+    assertWithMessage(invokedMethodDesc).that(returnValue).isNotNull();
+    assertWithMessage(invokedMethodDesc).that(returnValue).isInstanceOf(Short.class);
     return (Short) returnValue;
   }
 

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -96,7 +96,7 @@ public class InstitutionServiceTest {
 
     assertThat(service.getInstitutions()).containsExactly(roundTrippedTestInst, anotherInst);
     Comparator<Institution> comparator = Comparator.comparing(Institution::getDisplayName);
-    assertThat(service.getInstitutions()).isStrictlyOrdered(comparator);
+    assertThat(service.getInstitutions()).isInStrictOrder(comparator);
   }
 
   @Test
@@ -116,7 +116,7 @@ public class InstitutionServiceTest {
 
     assertThat(service.getInstitutions()).containsExactly(roundTrippedTestInst, anotherInst);
     Comparator<Institution> comparator = Comparator.comparing(Institution::getDisplayName);
-    assertThat(service.getInstitutions()).isStrictlyOrdered(comparator);
+    assertThat(service.getInstitutions()).isInStrictOrder(comparator);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/monitoring/LogsBasedMetricsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/LogsBasedMetricsServiceTest.java
@@ -144,9 +144,8 @@ public class LogsBasedMetricsServiceTest {
             .filter(Objects::nonNull)
             .collect(ImmutableSet.toImmutableSet());
     assertThat(metricNames)
-        .containsAtLeastElementsIn(
-            ImmutableSet.of(
-                EventMetric.NOTEBOOK_CLONE.getName(), EventMetric.NOTEBOOK_DELETE.getName()));
+        .containsAtLeast(
+            EventMetric.NOTEBOOK_CLONE.getName(), EventMetric.NOTEBOOK_DELETE.getName());
   }
 
   @Test
@@ -260,7 +259,7 @@ public class LogsBasedMetricsServiceTest {
           doReturn(mockStopwatch).when(mockStopwatch).start();
           doReturn(mockStopwatch).when(mockStopwatch).stop();
         });
-    assertThat(someSet).containsAtLeastElementsIn(ImmutableSet.of(1, 2));
+    assertThat(someSet).containsAtLeast(1, 2);
     final List<LogEntry> logEntries = getWrittenLogEntries();
     assertThat(logEntries).hasSize(1);
 

--- a/api/src/test/java/org/pmiops/workbench/monitoring/LogsBasedMetricsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/LogsBasedMetricsServiceTest.java
@@ -144,7 +144,7 @@ public class LogsBasedMetricsServiceTest {
             .filter(Objects::nonNull)
             .collect(ImmutableSet.toImmutableSet());
     assertThat(metricNames)
-        .containsAllIn(
+        .containsAtLeastElementsIn(
             ImmutableSet.of(
                 EventMetric.NOTEBOOK_CLONE.getName(), EventMetric.NOTEBOOK_DELETE.getName()));
   }
@@ -260,7 +260,7 @@ public class LogsBasedMetricsServiceTest {
           doReturn(mockStopwatch).when(mockStopwatch).start();
           doReturn(mockStopwatch).when(mockStopwatch).stop();
         });
-    assertThat(someSet).containsAllIn(ImmutableSet.of(1, 2));
+    assertThat(someSet).containsAtLeastElementsIn(ImmutableSet.of(1, 2));
     final List<LogEntry> logEntries = getWrittenLogEntries();
     assertThat(logEntries).hasSize(1);
 

--- a/api/src/test/java/org/pmiops/workbench/monitoring/LogsBasedMetricsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/LogsBasedMetricsServiceTest.java
@@ -144,7 +144,7 @@ public class LogsBasedMetricsServiceTest {
             .filter(Objects::nonNull)
             .collect(ImmutableSet.toImmutableSet());
     assertThat(metricNames)
-        .containsAtLeast(
+        .containsExactly(
             EventMetric.NOTEBOOK_CLONE.getName(), EventMetric.NOTEBOOK_DELETE.getName());
   }
 
@@ -259,7 +259,7 @@ public class LogsBasedMetricsServiceTest {
           doReturn(mockStopwatch).when(mockStopwatch).start();
           doReturn(mockStopwatch).when(mockStopwatch).stop();
         });
-    assertThat(someSet).containsAtLeast(1, 2);
+    assertThat(someSet).containsExactly(1, 2);
     final List<LogEntry> logEntries = getWrittenLogEntries();
     assertThat(logEntries).hasSize(1);
 

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -217,8 +217,8 @@ public class WorkspaceMapperTest {
         .isEqualTo(sourceDbWorkspace.getTimeRequested().toInstant().toEpochMilli());
     assertThat(rp.getTimeReviewed()).isNull();
 
-    assertThat(rp.getPopulationDetails()).containsAllIn(SPECIFIC_POPULATIONS);
-    assertThat(rp.getResearchOutcomeList()).containsAllIn(RESEARCH_OUTCOMES);
+    assertThat(rp.getPopulationDetails()).containsAtLeastElementsIn(SPECIFIC_POPULATIONS);
+    assertThat(rp.getResearchOutcomeList()).containsAtLeastElementsIn(RESEARCH_OUTCOMES);
     assertThat(rp.getDisseminateResearchFindingList()).isEmpty();
     assertThat(rp.getOtherDisseminateResearchFindings()).isEqualTo(DISSEMINATE_FINDINGS_OTHER);
   }

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -217,8 +217,8 @@ public class WorkspaceMapperTest {
         .isEqualTo(sourceDbWorkspace.getTimeRequested().toInstant().toEpochMilli());
     assertThat(rp.getTimeReviewed()).isNull();
 
-    assertThat(rp.getPopulationDetails()).containsAtLeastElementsIn(SPECIFIC_POPULATIONS);
-    assertThat(rp.getResearchOutcomeList()).containsAtLeastElementsIn(RESEARCH_OUTCOMES);
+    assertThat(rp.getPopulationDetails()).containsExactlyElementsIn(SPECIFIC_POPULATIONS);
+    assertThat(rp.getResearchOutcomeList()).containsExactlyElementsIn(RESEARCH_OUTCOMES);
     assertThat(rp.getDisseminateResearchFindingList()).isEmpty();
     assertThat(rp.getOtherDisseminateResearchFindings()).isEqualTo(DISSEMINATE_FINDINGS_OTHER);
   }

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -324,7 +324,7 @@ public class WorkspaceServiceTest {
             .stream()
             .map(DbWorkspace::getWorkspaceId)
             .collect(Collectors.toList());
-    assertThat(actualIds).containsAtLeastElementsIn(expectedIds);
+    assertThat(actualIds).containsExactlyElementsIn(expectedIds);
   }
 
   @Test
@@ -363,7 +363,7 @@ public class WorkspaceServiceTest {
             .stream()
             .map(DbWorkspace::getWorkspaceId)
             .collect(Collectors.toList());
-    assertThat(actualIds).containsAtLeastElementsIn(expectedIds);
+    assertThat(actualIds).containsExactlyElementsIn(expectedIds);
 
     currentUser.setUsername(DEFAULT_USERNAME);
     currentUser.setUserId(OTHER_USER_ID);
@@ -398,7 +398,7 @@ public class WorkspaceServiceTest {
         recentWorkspaces.stream()
             .map(DbUserRecentWorkspace::getWorkspaceId)
             .collect(Collectors.toList());
-    assertThat(actualIds).containsAtLeast(1L, 2L);
+    assertThat(actualIds).containsExactly(1L, 2L);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -324,7 +324,7 @@ public class WorkspaceServiceTest {
             .stream()
             .map(DbWorkspace::getWorkspaceId)
             .collect(Collectors.toList());
-    assertThat(actualIds).containsAllIn(expectedIds);
+    assertThat(actualIds).containsAtLeastElementsIn(expectedIds);
   }
 
   @Test
@@ -363,7 +363,7 @@ public class WorkspaceServiceTest {
             .stream()
             .map(DbWorkspace::getWorkspaceId)
             .collect(Collectors.toList());
-    assertThat(actualIds).containsAllIn(expectedIds);
+    assertThat(actualIds).containsAtLeastElementsIn(expectedIds);
 
     currentUser.setUsername(DEFAULT_USERNAME);
     currentUser.setUserId(OTHER_USER_ID);
@@ -398,7 +398,7 @@ public class WorkspaceServiceTest {
         recentWorkspaces.stream()
             .map(DbUserRecentWorkspace::getWorkspaceId)
             .collect(Collectors.toList());
-    assertThat(actualIds).containsAllOf(1L, 2L);
+    assertThat(actualIds).containsAtLeast(1L, 2L);
   }
 
   @Test


### PR DESCRIPTION
Some method calls had to be changed to their new equivalents:
`containsAllOf()` -> `containsAtLeast()`
`containsAllIn()` -> `containsAtLeastElementsIn()`
`isSameAs()` -> `isSameInstanceAs()` or `isEqualTo()`
`named()` -> `assertWithMessage()` (different syntax)
`isStrictlyOrdered()` -> `isInStrictOrder()`

I also simplified a few "contains..." which did not actually require creating a new Collection, e.g. 
```
assertThat(response).containsAllIn(ImmutableList.of(defaultConceptSet));
```
becomes
```
assertThat(response).contains(defaultConceptSet);
```

and strengthened some assertions, from "contains all" or "contains at least" to "contains exactly"


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
