### PR TITLE
[risk=no][no ticket] Update the disable-users project.rb tool to use the newer API

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1614,9 +1614,9 @@ def update_user_disabled_status(cmd_name, args)
     "Disabled state to set: true/false"
   )
   op.add_option(
-    "--account [admin_account_email]",
+    "--admin_account [admin_account_email]",
     ->(opts, v) { opts.account = v},
-    "Workbench admin account to perform update disabled status as"
+    "Workbench account with ACCESS_CONTROL_ADMIN Authority to perform the update disabled status action"
   )
   op.add_option(
     "--user [target_email]",
@@ -1648,7 +1648,7 @@ Common.register_command({
                   "they are redirected to a page which explains that they are disabled. This is currently the \n" \
                   "only automated means by which the user is notified of their disabled status.\n" \
                   "This tool can be used as a manual backup to the Workbench user admin UI, which supports the same disable function.\n" \
-                  "Requires four flags: --project [env project] --disabled [true/false], --account [admin email], and --user [target user email]",
+                  "Requires four flags: --project [env project] --disabled [true/false], --admin_account [admin email], and --user [target user email]",
   :fn => ->(*args) { update_user_disabled_status(UPDATE_USER_DISABLED_CMD, args) }
 })
 

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1602,6 +1602,7 @@ Common.register_command({
 def update_user_disabled_status(cmd_name, args)
   common = Common.new
   op = WbOptionsParser.new(cmd_name, args)
+  op.opts.project = TEST_PROJECT
   op.add_option(
     "--project [project]",
     ->(opts, v) { opts.project = v},
@@ -1623,7 +1624,7 @@ def update_user_disabled_status(cmd_name, args)
     "User to update the disabled status for"
   )
   op.add_validator ->(opts) {
-    raise ArgumentError unless (opts.project and opts.disabled != nil and opts.account and opts.user)
+    raise ArgumentError unless (opts.disabled != nil and opts.account and opts.user)
   }
   op.parse.validate
 

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1637,8 +1637,10 @@ def update_user_disabled_status(cmd_name, args)
       -d #{payload} https://#{ENVIRONMENTS[op.opts.project][:api_endpoint_host]}/v1/auth-domain/users}
 end
 
+UPDATE_USER_DISABLED_CMD = "update-user-disabled-status"
+
 Common.register_command({
-  :invocation => "update-user-disabled-status",
+  :invocation => UPDATE_USER_DISABLED_CMD,
   :description => "Set a Workbench user's disabled status by email, using another Workbench admin account.\n" \
                   "Disabling a user immediately revokes CDR access and restricted API access in the \n" \
                   "Workbench, if they had access to begin with. When a disabled user loads the Workbench UI, \n" \
@@ -1646,7 +1648,7 @@ Common.register_command({
                   "only automated means by which the user is notified of their disabled status.\n" \
                   "This tool can be used as a manual backup to the Workbench user admin UI, which supports the same disable function.\n" \
                   "Requires four flags: --project [env project] --disabled [true/false], --account [admin email], and --user [target user email]",
-  :fn => ->(*args) { update_user_disabled_status("update_user_registered_status", args) }
+  :fn => ->(*args) { update_user_disabled_status(UPDATE_USER_DISABLED_CMD, args) }
 })
 
 def fetch_firecloud_user_profile(cmd_name, *args)

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1633,9 +1633,10 @@ def update_user_disabled_status(cmd_name, args)
   token = token.chomp
   header = "Authorization: Bearer #{token}"
   content_type = "Content-type: application/json"
-  payload = "{\"email\": \"#{op.opts.user}\", \"disabled\": \"#{op.opts.disabled}\"}"
+  payload = "{\"username\": \"#{op.opts.user}\", \"accountDisabledStatus\": {\"disabled\": \"#{op.opts.disabled}\"}}"
+  endpoint = "/v1/admin/users/updateAccount"
   common.run_inline %W{curl -X POST -H #{header} -H #{content_type}
-      -d #{payload} https://#{ENVIRONMENTS[op.opts.project][:api_endpoint_host]}/v1/auth-domain/users}
+      -d #{payload} https://#{ENVIRONMENTS[op.opts.project][:api_endpoint_host]}#{endpoint}}
 end
 
 UPDATE_USER_DISABLED_CMD = "update-user-disabled-status"


### PR DESCRIPTION
The project.rb tool `update-user-disabled-status` is the only remaining user of `/v1/auth-domain/users` (nice catch @evrii) so let's migrate it to the newer endpoint `/v1/admin/users/updateAccount`.

Tested by running the command with a few configurations and observing the change on the Admin User page.

Example run:
```
 ./project.rb update-user-disabled-status \
  --user joel14@fake-research-aou.org \
  --admin_account joel@fake-research-aou.org \
  --disabled false
```

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
