### PR TITLE
[RW-8266][risk=low] Add initial genomic file manifest publish tooling

### DIFF
--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -333,16 +333,11 @@ def publish_cdr_files(cmd_name, args)
     "A version 'id' suitable for display in the published GCS directory. Conventionally " +
     "this matches the CDR version display name in the product, e.g. 'v5'"
   )
-  op.add_option(
-    "--file-types [type1,type2,...]",
-    ->(opts, v) { opts.file_types = v},
-    "File types to publish; defaults to all supported types"
-  )
   supported_types = ["CRAM"]
   op.opts.data_types = supported_types
   op.add_option(
     "--data-types [CRAM,...]",
-    ->(opts, v) { opts.data_types = v},
+    ->(opts, v) { opts.data_types = v.split(",")},
     "Data types to publish; defaults to all supported types: #{supported_types}"
   )
   # TODO(RW-8266): Add support for STAGE_INGEST, PUBLISH.
@@ -350,7 +345,7 @@ def publish_cdr_files(cmd_name, args)
   op.opts.tasks = supported_tasks
   op.add_option(
     "--tasks [CREATE_MANIFESTS,...]",
-    ->(opts, v) { opts.data_types = v},
+    ->(opts, v) { opts.tasks = v.split(",")},
     "Publishing tasks to execute; defaults to all tasks: #{supported_tasks}"
   )
   op.opts.tier = "controlled"
@@ -360,9 +355,9 @@ def publish_cdr_files(cmd_name, args)
      "The access tier associated with this CDR, e.g. controlled." +
      "Default is controlled (WGS only exists in controlled tier, for the foreseeable future)."
   )
-  op.add_validator ->(opts) { raise ArgumentError unless opts.project and opts.tier and opts.wgs_rids_file and opts.data_types and opts.tasks }
-  op.add_validator ->(opts) { raise ArgumentError.new("unsupported data types: #{opts.data_types}") unless (opts.data_types.split(",") - supported_types).empty?}
-  op.add_validator ->(opts) { raise ArgumentError.new("unsupported tasks: #{opts.tasks}") unless (opts.tasks.split(",") - supported_tasks).empty?}
+  op.add_validator ->(opts) { raise ArgumentError unless opts.project }
+  op.add_validator ->(opts) { raise ArgumentError.new("unsupported data types: #{opts.data_types}") unless (opts.data_types - supported_types).empty?}
+  op.add_validator ->(opts) { raise ArgumentError.new("unsupported tasks: #{opts.tasks}") unless (opts.tasks - supported_tasks).empty?}
   op.add_validator ->(opts) { raise ArgumentError.new("unsupported project: #{opts.project}") unless ENVIRONMENTS.key? opts.project }
   op.add_validator ->(opts) { raise ArgumentError.new("unsupported tier: #{opts.tier}") unless ENVIRONMENTS[opts.project][:accessTiers].key? opts.tier }
   op.parse.validate

--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -331,7 +331,8 @@ def publish_cdr_files(cmd_name, args)
     "--display-version-id [version]",
     ->(opts, v) { opts.display_version_id = v},
     "A version 'id' suitable for display in the published GCS directory. Conventionally " +
-    "this matches the CDR version display name in the product, e.g. 'v5'"
+    "this matches the CDR version display name in the product, e.g. 'v5'. This ID will be " +
+    "included in the published file directory structure."
   )
   supported_types = ["CRAM"]
   op.opts.data_types = supported_types
@@ -355,7 +356,7 @@ def publish_cdr_files(cmd_name, args)
      "The access tier associated with this CDR, e.g. controlled." +
      "Default is controlled (WGS only exists in controlled tier, for the foreseeable future)."
   )
-  op.add_validator ->(opts) { raise ArgumentError unless opts.project }
+  op.add_validator ->(opts) { raise ArgumentError unless opts.project and opts.wgs_rids_file and opts.display_version_id }
   op.add_validator ->(opts) { raise ArgumentError.new("unsupported data types: #{opts.data_types}") unless (opts.data_types - supported_types).empty?}
   op.add_validator ->(opts) { raise ArgumentError.new("unsupported tasks: #{opts.tasks}") unless (opts.tasks - supported_tasks).empty?}
   op.add_validator ->(opts) { raise ArgumentError.new("unsupported project: #{opts.project}") unless ENVIRONMENTS.key? opts.project }

--- a/api/db-cdr/generate-cdr/libproject/genomic_manifests.rb
+++ b/api/db-cdr/generate-cdr/libproject/genomic_manifests.rb
@@ -1,0 +1,140 @@
+require "csv"
+require "date"
+
+PROD_SOURCE_CONFIG = {
+  # XXX: sample value
+  # :wgs_aw4_glob => "/usr/local/google/home/calbach/aou/data-ops/2022q2_june_release/aw4_sample/*"
+  # XXX: fake, but more real value
+  :wgs_aw4_prefix => "/usr/local/google/home/calbach/aou/data-ops/2022q2_june_release/aw4s/AoU_DRCB_SEQ_"
+  # XXX: Real value
+  # :wgs_aw4_glob => "gs://prod-drc-broad/AW4_wgs_manifest/*"
+}
+
+
+FILE_ENVIRONMENTS = {
+  "all-of-us-rw-preprod" => {
+    :source_config => PROD_SOURCE_CONFIG,
+  },
+  "all-of-us-rw-prod" => {
+    :source_config => PROD_SOURCE_CONFIG
+  }
+}
+
+FILE_PREFIX_REPLACEMENTS = {
+  :wgs_cram => {
+    :match => /^[^\/]+\.cram/,
+    :replacementFn => ->(rid) { "wgs_#{rid}.cram" }
+  }
+}
+
+def _aw4_filename_to_datetime(aw4_prefix, f)
+  common = Common.new
+
+  date_match = f.delete_prefix(aw4_prefix).match(/([\d-]+)(_\d+)?.csv/)
+  if not date_match
+    common.warning "AW4 filename does not match expected date format, assuming old: #{f}"
+    return DateTime.new(1970)
+  end
+  date_part = date_match[1]
+  begin
+    return DateTime.strptime(date_part, "%Y-%m-%d-%H-%M-%S")
+  rescue Date::Error
+    common.warning "Found date-part in AW4 filename but cannot parse it, assuming old: #{date_part}"
+    return DateTime.new(1970)
+  end
+end
+
+def _read_research_id_csvs(aw4_prefix, ridset)
+  common = Common.new
+
+  # TODO: doc link for AW4s
+  # Expected WGS header:
+  # biobank_id,sample_id,sex_at_birth,site_id,vcf_hf_path,vcf_hf_md5_path,vcf_hf_index_path,vcf_raw_path,vcf_raw_md5_path,vcf_raw_index_path,gvcf_path,gvcf_md5_path,cram_path,cram_md5_path,crai_path,research_id,qc_status,drc_sex_concordance,drc_contamination,drc_mean_coverage,drc_fp_concordance,pass_to_research_pipeline
+
+  # Read all AW4s into a CSV::Row[]
+  matching_aw4_rows = Dir.glob(aw4_prefix + "*").flat_map do |f|
+    filename_date = _aw4_filename_to_datetime(aw4_prefix, f)
+
+    aw4_rows = CSV.read(f, headers: true)
+    aw4_rows.each do |row|
+      # Parse the filename for the effective datetime for downstream disambiguation.
+      row["aw4_datetime"] = filename_date
+    end
+
+    aw4_rows.filter do |row|
+      # Filter out rids which weren't requested for publishing.
+      not row.header_row? and ridset.include? row["research_id"]
+    end
+  end
+
+  # Transform into a dict of research ID -> CSV::Row to dedupe
+  by_rid = {}
+  matching_aw4_rows.each do |aw4_row|
+    # Prefer the most recent row for each
+    rid = aw4_row["research_id"]
+    aw4_time = aw4_row["aw4_datetime"]
+    if by_rid.key? rid
+      common.warning "found multiple AW4 rows for #{rid}, using the most recent"
+    end
+    if not by_rid.key? rid or aw4_time < by_rid[rid]["aw4_datetime"]
+      by_rid[rid] = aw4_row
+    end
+  end
+
+  missing_rids = ridset - by_rid.keys
+  unless missing_rids.empty?
+    raise ArgumentError.new("AW4 manifests do not contain information for requested research IDs:\n" + missing_rids.join(","))
+  end
+
+  # The input resarch ID set should already account for these properties, these
+  # warnings indicate an upstream data issue or an issue with the AW4.
+  by_rid.each_value do |aw4_row|
+    rid = aw4_row["research_id"]
+    qc = aw4_row["qc_status"]
+    unless qc == "PASS"
+      common.warning "given research ID #{rid} most recent AW4 has qc status: #{qc}"
+    end
+
+    # Early AW4s don't have this column. Skip in this case.
+    pass_to_research = aw4_row["pass_to_research_pipeline"]
+    unless pass_to_research.nil? or pass_to_research == "True"
+      common.warning "given research ID #{rid} most recent AW4 has pass_to_research_pipeline: #{pass_to_research}"
+    end
+  end
+
+  by_rid.values
+end
+
+def read_all_wgs_aw4s(project, ridset)
+  _read_research_id_csvs(FILE_ENVIRONMENTS[project][:source_config][:wgs_aw4_prefix], ridset)
+end
+
+
+def read_all_microarry_aw4s(project, ridset)
+end
+
+
+def build_cram_manifest(project, ingest_bucket, dest_bucket, display_version_id, ridset)
+  raise ArgumentError.new("manifest generation is unconfigured for #{project}") unless FILE_ENVIRONMENTS.key? project
+
+  wgs_aw4s = read_all_wgs_aw4s(project, ridset)
+  replace_config = FILE_PREFIX_REPLACEMENTS[:wgs_cram]
+
+  # TODO(RW-8269): Support delta directories.
+  path_prefix = "pooled/wgs/cram/#{display_version_id}_base"
+  ingest_base_path = File.join(ingest_bucket, path_prefix)
+  dest_base_path = File.join(dest_bucket, path_prefix)
+
+  return wgs_aw4s.flat_map do |aw4_entry|
+    [aw4_entry["cram_path"], aw4_entry["crai_path"]].map do |source_path|
+      source_name = File.basename(source_path)
+      dest_name = source_name.sub(replace_config[:match], replace_config[:replacementFn].call(aw4_entry["sample_id"]))
+      {
+        :source_path => source_path,
+        :ingest_path => File.join(ingest_base_path, dest_name),
+        :dest_path => File.join(dest_base_path, dest_name),
+        :dest_storage_class => "nearline"
+      }
+    end
+  end
+end

--- a/api/db-cdr/generate-cdr/libproject/genomic_manifests.rb
+++ b/api/db-cdr/generate-cdr/libproject/genomic_manifests.rb
@@ -28,7 +28,7 @@ def _aw4_filename_to_datetime(aw4_prefix, f)
   common = Common.new
 
   date_match = f.delete_prefix(aw4_prefix).match(/([\d-]+)(_\d+)?.csv/)
-  if not date_match
+  unless date_match
     common.warning "AW4 filename does not match expected date format, assuming old: #{f}"
     return DateTime.new(1970)
   end

--- a/api/libproject/environments.rb
+++ b/api/libproject/environments.rb
@@ -133,6 +133,8 @@ ENVIRONMENTS = {
       "controlled" => {
         :ingest_cdr_project => "fc-aou-vpc-ingest-preprod-ct",
         :dest_cdr_project => "fc-aou-cdr-preprod-ct",
+        :ingest_cdr_bucket => "gs://fc-aou-preprod-datasets-controlled-ingest",
+        :dest_cdr_bucket => "gs://fc-aou-preprod-datasets-controlled",
         :auth_domain_group_email => "all-of-us-controlled-preprod@firecloud.org",
       }
     }
@@ -153,6 +155,8 @@ ENVIRONMENTS = {
       "controlled" => {
         :ingest_cdr_project => "fc-aou-vpc-ingest-prod-ct",
         :dest_cdr_project => "fc-aou-cdr-prod-ct",
+        :ingest_cdr_bucket => "gs://fc-aou-datasets-controlled-ingest",
+        :dest_cdr_bucket => "gs://fc-aou-datasets-controlled",
         :auth_domain_group_email => "all-of-us-controlled-prod@firecloud.org",
       }
     }


### PR DESCRIPTION
(Part 1 / x)

Add a new command `./project.rb publish-cdr-files` which generates a manifest of files to publish/copy. Initially, this tool takes a single slice through the eventual target capabilities, specifically:

- only targets CRAMs
- only generates the manifest, doesn't yet handle the copy
- eventually, I would like to upload logs / manifests to GCS for provenance

Currently outputs a CSV with the following headers:
```
source_path,ingest_path,dest_path,dest_storage_class
```

This is intended to be generic across file types, not just CRAMs.

Some of the requirements this is meeting:

- In the case of CRAMs (and some other file types), we want to rename individual files
- We need to publish the data via the ingest bucket, due to VPC-SC
- We need to specify a destination storage class

## Alternative considered

I looked a fair amount into Cloud Storage Transfer Service. Rejected for now as it seemed to lack the ability to rename files during the transfer, which is one of our requirements. It would also require testing to better understand whether it can seamlessly handle our VPC-SC ingest process, in addition to needing system-level changes.