### PR TITLE
[no ticket][risk=no] promoting RT/CT preprod cdr

### DIFF
--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -100,7 +100,7 @@
       "creationTime": "2021-08-10 00:00:00Z",
       "releaseNumber": 7,
       "numParticipants": 329070,
-      "cdrDbName": "r_2021q3_9",
+      "cdrDbName": "r_2021q3_10",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"
@@ -115,7 +115,7 @@
       "creationTime": "2021-10-06 00:00:00Z",
       "releaseNumber": 8,
       "numParticipants": 331382,
-      "cdrDbName": "c_2021q3_10",
+      "cdrDbName": "c_2021q3_11",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "controlled",


### PR DESCRIPTION
Promoting RT/CT preprod cdr.  Adding @yonghaoy as reviewer since he is the release engineer for the week of 5/16. Please be sure to run the publish commands below from the  /api directory in workbench before releasing to preprod:

RT
db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-preprod --bq-dataset R2021Q3R5 --tier registered --table-prefixes cb_,ds_

CT
db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-preprod --bq-dataset C2021Q3R6 --tier controlled --table-prefixes cb_,ds_