### PR TITLE
[risk=low][no ticket] Move duccCurrentVersions from config files to a new class ConfigConstants

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -98,7 +98,6 @@
     "unsafeAllowUserCreationFromGSuiteData": true,
     "enableRasLoginGovLinking": true,
     "enforceRasLoginGovLinking": true,
-    "currentDuccVersions": [3, 4, 5],
     "renewal": {
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -98,7 +98,6 @@
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasLoginGovLinking": true,
     "enforceRasLoginGovLinking": true,
-    "currentDuccVersions": [3, 4],
     "renewal": {
       "expiryDays": 3650,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -98,7 +98,6 @@
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasLoginGovLinking": false,
     "enforceRasLoginGovLinking": false,
-    "currentDuccVersions": [3, 4],
     "renewal": {
       "expiryDays": 3650,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -98,7 +98,6 @@
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasLoginGovLinking": true,
     "enforceRasLoginGovLinking": true,
-    "currentDuccVersions": [3, 4],
     "renewal": {
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -98,7 +98,6 @@
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasLoginGovLinking": true,
     "enforceRasLoginGovLinking": true,
-    "currentDuccVersions": [3, 4],
     "renewal": {
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -98,7 +98,6 @@
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasLoginGovLinking": true,
     "enforceRasLoginGovLinking": true,
-    "currentDuccVersions": [3, 4],
     "renewal": {
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -98,7 +98,6 @@
     "unsafeAllowUserCreationFromGSuiteData": true,
     "enableRasLoginGovLinking": true,
     "enforceRasLoginGovLinking": true,
-    "currentDuccVersions": [3, 4, 5],
     "renewal": {
       "expiryDays": 3650,
       "expiryDaysWarningThresholds": [1, 3, 7, 15, 30],

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.access;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
+import org.pmiops.workbench.config.ConfigConstants;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.AccessBypassRequest;
@@ -10,6 +11,10 @@ import org.pmiops.workbench.model.AccessModule;
 import org.pmiops.workbench.model.AccessModuleStatus;
 
 public interface AccessModuleService {
+  static boolean isSignedDuccVersionCurrent(Integer signedVersion) {
+    return ConfigConstants.CURRENT_DUCC_VERSIONS.contains(signedVersion);
+  }
+
   /** Updates bypass time for a module. */
   void updateBypassTime(long userId, AccessBypassRequest accessBypassRequest);
 
@@ -40,8 +45,6 @@ public interface AccessModuleService {
 
   /** Returns true if the access module is bypassable and bypassed */
   boolean isModuleBypassed(DbUser dbUser, DbAccessModuleName accessModuleName);
-
-  boolean isSignedDuccVersionCurrent(Integer signedVersion);
 
   boolean hasUserSignedACurrentDucc(DbUser targetUser);
 }

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.access;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.sql.Timestamp;
 import java.time.Clock;
@@ -135,12 +134,6 @@ public class AccessModuleServiceImpl implements AccessModuleService {
         .filter(a -> isModuleStatusReturnedInProfile(a.getModuleName()));
   }
 
-  @VisibleForTesting
-  @Override
-  public boolean isSignedDuccVersionCurrent(Integer signedVersion) {
-    return configProvider.get().access.currentDuccVersions.contains(signedVersion);
-  }
-
   @Override
   public boolean hasUserSignedACurrentDucc(DbUser targetUser) {
     final DbUserCodeOfConductAgreement duccAgreement = targetUser.getDuccAgreement();
@@ -148,7 +141,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
       return false;
     }
 
-    return isSignedDuccVersionCurrent(duccAgreement.getSignedVersion());
+    return AccessModuleService.isSignedDuccVersionCurrent(duccAgreement.getSignedVersion());
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/config/ConfigConstants.java
+++ b/api/src/main/java/org/pmiops/workbench/config/ConfigConstants.java
@@ -1,0 +1,8 @@
+package org.pmiops.workbench.config;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+
+public class ConfigConstants {
+  public static final List<Integer> CURRENT_DUCC_VERSIONS = ImmutableList.of(3, 4, 5);
+}

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -40,7 +40,6 @@ public class WorkbenchConfig {
   public static WorkbenchConfig createEmptyConfig() {
     WorkbenchConfig config = new WorkbenchConfig();
     config.access = new AccessConfig();
-    config.access.currentDuccVersions = new ArrayList<>();
     config.access.renewal = new AccessConfig.Renewal();
     config.actionAudit = new ActionAuditConfig();
     config.admin = new AdminConfig();
@@ -268,8 +267,6 @@ public class WorkbenchConfig {
     public boolean enableRasLoginGovLinking;
     // If true, all users are required to finish identity verification using RAS/login.gov
     public boolean enforceRasLoginGovLinking;
-    // Which Data User Code of Conduct (DUCC) Agreement version(s) are currently accepted as valid
-    public List<Integer> currentDuccVersions;
 
     public static class Renewal {
       // Days a user's module completion is good for until it expires

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -17,7 +17,7 @@ import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
 @Mapper(
     config = MapStructConfig.class,
-    uses = {AccessModuleNameMapper.class})
+    uses = {AccessModuleNameMapper.class, ConfigConstants.class})
 public interface WorkbenchConfigMapper {
   default RuntimeImage dataprocToModel(String imageName) {
     return new RuntimeImage().cloudService(CloudServiceEnum.DATAPROC.toString()).name(imageName);
@@ -79,7 +79,9 @@ public interface WorkbenchConfigMapper {
   @Mapping(target = "rasClientId", source = "config.ras.clientId")
   @Mapping(target = "rasLogoutUrl", source = "config.ras.logoutUrl")
   @Mapping(target = "freeTierBillingAccountId", source = "config.billing.accountId")
-  @Mapping(target = "currentDuccVersions", source = "config.access.currentDuccVersions")
+  @Mapping(
+      target = "currentDuccVersions",
+      expression = "java(ConfigConstants.CURRENT_DUCC_VERSIONS)")
   @Mapping(
       target = "enableUpdatedDemographicSurvey",
       source = "config.featureFlags.enableUpdatedDemographicSurvey")

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -407,7 +407,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
 
   @Override
   public DbUser submitDUCC(DbUser dbUser, Integer duccSignedVersion, String initials) {
-    if (!accessModuleService.isSignedDuccVersionCurrent(duccSignedVersion)) {
+    if (!AccessModuleService.isSignedDuccVersionCurrent(duccSignedVersion)) {
       throw new BadRequestException("Data User Code of Conduct Version is not up to date");
     }
     final Timestamp timestamp = clockNow();

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
@@ -82,7 +82,7 @@ public class AccessModuleServiceTest {
 
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
 
-    int signedDuccVersion = ConfigConstants.CURRENT_DUCC_VERSIONS.get(0);
+    int signedDuccVersion = ConfigConstants.CURRENT_DUCC_VERSIONS.stream().findAny().get();
 
     user = new DbUser();
     user.setUsername("user");

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.actionaudit.targetproperties.BypassTimeTargetProperty;
+import org.pmiops.workbench.config.ConfigConstants;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.AccessModuleDao;
 import org.pmiops.workbench.db.dao.UserAccessModuleDao;
@@ -78,14 +79,15 @@ public class AccessModuleServiceTest {
     config = WorkbenchConfig.createEmptyConfig();
     config.access.enableComplianceTraining = true;
     config.access.enableEraCommons = true;
-    config.access.currentDuccVersions = ImmutableList.of(10, 11); // arbitrary for test
 
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
+
+    int signedDuccVersion = ConfigConstants.CURRENT_DUCC_VERSIONS.get(0);
 
     user = new DbUser();
     user.setUsername("user");
     user.setDuccAgreement(
-        TestMockFactory.createDuccAgreement(user, 10, FakeClockConfiguration.NOW));
+        TestMockFactory.createDuccAgreement(user, signedDuccVersion, FakeClockConfiguration.NOW));
     user = userDao.save(user);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.compliance.ComplianceService;
+import org.pmiops.workbench.config.ConfigConstants;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.AccessModuleDao;
 import org.pmiops.workbench.db.dao.AccessTierDao;
@@ -164,7 +165,6 @@ public class UserServiceAccessTest {
     providedWorkbenchConfig.access.enableEraCommons = true;
     providedWorkbenchConfig.access.enforceRasLoginGovLinking = true;
     providedWorkbenchConfig.access.enableRasLoginGovLinking = true;
-    providedWorkbenchConfig.access.currentDuccVersions = ImmutableList.of(1, 2); // arbitrary
     providedWorkbenchConfig.access.renewal.expiryDays = EXPIRATION_DAYS;
     providedWorkbenchConfig.access.renewal.expiryDaysWarningThresholds =
         ImmutableList.of(1L, 3L, 7L, 15L, 30L);
@@ -354,7 +354,8 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_ducc_unbypassed_aar_wrong_version_noncompliant() {
-    providedWorkbenchConfig.access.currentDuccVersions = ImmutableList.of(4, 5);
+    int badVersion = 2;
+    assertThat(ConfigConstants.CURRENT_DUCC_VERSIONS).doesNotContain(badVersion);
 
     testUnregistration(
         user -> {
@@ -362,7 +363,7 @@ public class UserServiceAccessTest {
               dbUser.getUserId(), AccessModule.DATA_USER_CODE_OF_CONDUCT, false);
           accessModuleService.updateCompletionTime(
               dbUser, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, Timestamp.from(START_INSTANT));
-          user.setDuccAgreement(signDucc(user, 3));
+          user.setDuccAgreement(signDucc(user, badVersion));
           return userDao.save(user);
         });
   }
@@ -1200,7 +1201,7 @@ public class UserServiceAccessTest {
   }
 
   private DbUserCodeOfConductAgreement signCurrentDucc(DbUser dbUser) {
-    int aValidVersion = providedWorkbenchConfig.access.currentDuccVersions.get(0);
+    int aValidVersion = ConfigConstants.CURRENT_DUCC_VERSIONS.get(0);
     return signDucc(dbUser, aValidVersion);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -1201,7 +1201,7 @@ public class UserServiceAccessTest {
   }
 
   private DbUserCodeOfConductAgreement signCurrentDucc(DbUser dbUser) {
-    int aValidVersion = ConfigConstants.CURRENT_DUCC_VERSIONS.get(0);
+    int aValidVersion = ConfigConstants.CURRENT_DUCC_VERSIONS.stream().findAny().get();
     return signDucc(dbUser, aValidVersion);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -14,7 +14,6 @@ import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHOR
 import static org.pmiops.workbench.db.dao.UserService.LATEST_AOU_TOS_VERSION;
 
 import com.google.api.services.directory.model.User;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -38,6 +37,7 @@ import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.compliance.ComplianceService;
 import org.pmiops.workbench.compliance.ComplianceService.BadgeName;
+import org.pmiops.workbench.config.ConfigConstants;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
@@ -454,9 +454,7 @@ public class UserServiceTest {
 
   @Test
   public void testSyncDuccVersionStatus_correctVersions() {
-    providedWorkbenchConfig.access.currentDuccVersions = ImmutableList.of(3, 4, 5);
-
-    providedWorkbenchConfig.access.currentDuccVersions.forEach(
+    ConfigConstants.CURRENT_DUCC_VERSIONS.forEach(
         version -> {
           DbUser user = userDao.findUserByUsername(USERNAME);
           user.setDuccAgreement(signDucc(user, version));
@@ -468,10 +466,11 @@ public class UserServiceTest {
 
   @Test
   public void testSyncDuccVersionStatus_incorrectVersion() {
-    providedWorkbenchConfig.access.currentDuccVersions = ImmutableList.of(3, 4, 5);
+    int badVersion = 2;
+    assertThat(ConfigConstants.CURRENT_DUCC_VERSIONS).doesNotContain(badVersion);
 
     DbUser user = userDao.findUserByUsername(USERNAME);
-    user.setDuccAgreement(signDucc(user, 2));
+    user.setDuccAgreement(signDucc(user, badVersion));
     user = userDao.save(user);
 
     userService.syncDuccVersionStatus(user, Agent.asSystem());


### PR DESCRIPTION
Rather than repeat a config value which doesn't change across environments, make it a constant in the code.

Confirmed that the mapper still works, providing this config value to the UI.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
