### PR TITLE
[RW-8266][risk=low] Add staging/publishing capabilities for genomic tools

### DIFF
--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -325,16 +325,16 @@ def publish_cdr_files(cmd_name, args)
   op.add_option(
     "--wgs-rids-file [file]",
     ->(opts, v) { opts.wgs_rids_file = v},
-    "A file containing all research IDs for which WGS data should be published. This " +
-    "parameter ONLY affects manifest creation. If resuming a publish job via an existing " +
-    "manifest, this flag is ignored."
+    "A file containing all research IDs for which WGS data should be published. " +
+    "Only applicable and required for task CREATE_MANIFESTS."
   )
   op.add_option(
     "--display-version-id [version]",
     ->(opts, v) { opts.display_version_id = v},
     "A version 'id' suitable for display in the published GCS directory. Conventionally " +
     "this matches the CDR version display name in the product, e.g. 'v5'. This ID will be " +
-    "included in the published file directory structure."
+    "included in the published file directory structure. " +
+    "Only applicable and required for task CREATE_MANIFESTS."
   )
   supported_types = ["CRAM"]
   op.opts.data_types = supported_types

--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -370,20 +370,21 @@ def publish_cdr_files(cmd_name, args)
 
   common = Common.new
 
-  wgs_rids = IO.readlines(op.opts.wgs_rids_file, chomp: true).filter do |line|
-    if line.to_i() == 0
-      common.warning "skipping non-numeric research ID line: #{line}"
-      false
-    else
-      true
-    end
-  end
-
   # TODO(RW-8266): Generalize this approach for all file types.
   cram_path = 'cram_manifest.csv'
   manifests = [cram_path]
   if op.opts.tasks.include? "CREATE_MANIFESTS"
     common.status "Starting: manifest creation"
+
+    wgs_rids = IO.readlines(op.opts.wgs_rids_file, chomp: true).filter do |line|
+      if line.to_i() == 0
+        common.warning "skipping non-numeric research ID line: #{line}"
+        false
+      else
+        true
+      end
+    end
+
     cram_manifest = build_cram_manifest(
       op.opts.project,
       tier[:ingest_cdr_bucket],

--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -325,7 +325,9 @@ def publish_cdr_files(cmd_name, args)
   op.add_option(
     "--wgs-rids-file [file]",
     ->(opts, v) { opts.wgs_rids_file = v},
-    "A file containing all research IDs for which WGS data should be published."
+    "A file containing all research IDs for which WGS data should be published. This " +
+    "parameter ONLY affects manifest creation. If resuming a publish job via an existing " +
+    "manifest, this flag is ignored."
   )
   op.add_option(
     "--display-version-id [version]",
@@ -341,11 +343,10 @@ def publish_cdr_files(cmd_name, args)
     ->(opts, v) { opts.data_types = v.split(",")},
     "Data types to publish; defaults to all supported types: #{supported_types}"
   )
-  # TODO(RW-8266): Add support for STAGE_INGEST, PUBLISH.
-  supported_tasks = ["CREATE_MANIFESTS"]
+  supported_tasks = ["CREATE_MANIFESTS", "STAGE_INGEST", "PUBLISH"]
   op.opts.tasks = supported_tasks
   op.add_option(
-    "--tasks [CREATE_MANIFESTS,...]",
+    "--tasks [CREATE_MANIFESTS,STAGE_INGEST,PUBLISH]",
     ->(opts, v) { opts.tasks = v.split(",")},
     "Publishing tasks to execute; defaults to all tasks: #{supported_tasks}"
   )
@@ -356,7 +357,8 @@ def publish_cdr_files(cmd_name, args)
      "The access tier associated with this CDR, e.g. controlled." +
      "Default is controlled (WGS only exists in controlled tier, for the foreseeable future)."
   )
-  op.add_validator ->(opts) { raise ArgumentError unless opts.project and opts.wgs_rids_file and opts.display_version_id }
+  op.add_validator ->(opts) { raise ArgumentError unless opts.project }
+  op.add_validator ->(opts) { raise ArgumentError.new("--wgs-rids-file and --display-version-id are required for the CREATE_MANIFESTS task") unless !opts.tasks.include? "CREATE_MANIFESTS" or (opts.wgs_rids_file and opts.display_version_id) }
   op.add_validator ->(opts) { raise ArgumentError.new("unsupported data types: #{opts.data_types}") unless (opts.data_types - supported_types).empty?}
   op.add_validator ->(opts) { raise ArgumentError.new("unsupported tasks: #{opts.tasks}") unless (opts.tasks - supported_tasks).empty?}
   op.add_validator ->(opts) { raise ArgumentError.new("unsupported project: #{opts.project}") unless ENVIRONMENTS.key? opts.project }
@@ -377,24 +379,46 @@ def publish_cdr_files(cmd_name, args)
     end
   end
 
-  cram_manifest = build_cram_manifest(
-    op.opts.project,
-    tier[:ingest_cdr_bucket],
-    tier[:dest_cdr_bucket],
-    op.opts.display_version_id,
-    wgs_rids
-  )
-  # TODO(RW-8266): Upoad this to a manifest bucket instead. Use a publish identifier
-  # to enable resumability of publishing with different stages of tasks.
-  CSV.open('cram_manifest.csv', 'wb') do |f|
-    f << cram_manifest.first.keys
-    cram_manifest.each { |c| f << c.values }
+  # TODO(RW-8266): Generalize this approach for all file types.
+  cram_path = 'cram_manifest.csv'
+  manifests = [cram_path]
+  if op.opts.tasks.include? "CREATE_MANIFESTS"
+    common.status "Starting: manifest creation"
+    cram_manifest = build_cram_manifest(
+      op.opts.project,
+      tier[:ingest_cdr_bucket],
+      tier[:dest_cdr_bucket],
+      op.opts.display_version_id,
+      wgs_rids
+    )
+    # TODO(RW-8266): Upload this to a manifest bucket instead. Use a publish identifier
+    # to enable resumability of publishing with different stages of tasks.
+    CSV.open(cram_path, 'wb') do |f|
+      f << cram_manifest.first.keys
+      cram_manifest.each { |c| f << c.values }
+    end
+    common.status "Finished: manifests created"
+  end
+
+  logs_dir = Dir.mktmpdir("cdr-file-publish")
+  common.status "Writing logs to #{logs_dir}"
+
+  if op.opts.tasks.include? "STAGE_INGEST"
+    common.status "Starting: file staging to ingest bucket"
+    manifests.each { |m| stage_files_by_manifest(op.opts.project, m, File.join(logs_dir, "cram")) }
+    common.status "Finished: file staging"
+  end
+
+  if op.opts.tasks.include? "PUBLISH"
+    common.status "Starting: publishing to CDR bucket"
+    manifests.each { |m| publish_files_by_manifest(op.opts.project, m, File.join(logs_dir, "cram")) }
+    common.status "Finished: publishing"
   end
 end
 
 Common.register_command({
   :invocation => "publish-cdr-files",
-  :description => "Copies and/or publishes CDR files to the resaercher-accessible CDR bucket",
+  :description => "Copies and/or publishes CDR files to the researcher-accessible CDR bucket",
   :fn => ->(*args) { publish_cdr_files("publish-cdr-files", args) }
 })
 

--- a/api/db-cdr/generate-cdr/libproject/genomic_manifests.rb
+++ b/api/db-cdr/generate-cdr/libproject/genomic_manifests.rb
@@ -270,13 +270,14 @@ def _process_files_by_manifest(manifest_path, logs_dir, status_verb, num_workers
       unless value.nil?
         w.write(value + "\n")
         count += 1
-        if count % 100 == 0
-          delta_min = (Time.now.to_i - start) / 60
-          # Carriage return here to keep the progress on the same terminal line
-          printf("\r%s %d/%d files [%.02f%%] (running for %dh%dm)",
-                 status_verb, count, all_tasks.length,
-                 100*count.to_f/all_tasks.length, delta_min/60, delta_min%60)
-        end
+      end
+      # Log every 100 and at the end (when the queue is closed, i.e. value=nil)
+      if count % 100 == 0 or value.nil?
+        delta_min = (Time.now.to_i - start) / 60
+        # Carriage return here to keep the progress on the same terminal line
+        printf("\r%s %d/%d files [%.02f%%] (running for %dh%dm)",
+               status_verb, count, all_tasks.length,
+               100*count.to_f/all_tasks.length, delta_min/60, delta_min%60)
       end
     end
   end

--- a/api/db-cdr/generate-cdr/libproject/genomic_manifests.rb
+++ b/api/db-cdr/generate-cdr/libproject/genomic_manifests.rb
@@ -1,5 +1,8 @@
 require "csv"
 require "date"
+require "fileutils"
+require_relative "../../../../aou-utils/utils/common"
+require_relative "../../../libproject/environments"
 
 # Utilities for generating, managing, publishing genomic data files. At a high
 # level, this facilitiates the data flow:
@@ -35,7 +38,6 @@ CURATION_PROD_SOURCE_CONFIG = {
   :wgs_aw4_prefix => "gs://prod-drc-broad/AW4_wgs_manifest/AoU_DRCB_SEQ_"
 }
 
-
 FILE_ENVIRONMENTS = {
   "all-of-us-rw-preprod" => {
     :source_config => CURATION_PROD_SOURCE_CONFIG,
@@ -52,6 +54,8 @@ FILE_PREFIX_REPLACEMENTS = {
     :destNameFn => ->(rid) { "wgs_#{rid}.cram" }
   }
 }
+
+GSUTIL_TASK_CONCURRENCY = 16
 
 def _aw4_filename_to_datetime(aw4_prefix, f)
   common = Common.new
@@ -181,5 +185,144 @@ def build_cram_manifest(project, ingest_bucket, dest_bucket, display_version_id,
         :dest_storage_class => "nearline"
       }
     end
+  end
+end
+
+# Concurrently run the given process block over all rows in the provided manifest.
+# The block should have the following signature:
+#
+#   |manifest_row: CSV::Row, io_out: IO, io_err: IO| => [identifier: str, ok: boolean]
+#
+# where
+# - identifier is a unique output identifier for this invocation, e.g. the
+#   destination URI for a copy
+# - ok is true if the invocation succeeded, false otherwise
+#
+# If ok=false is returned too many times, this function fails.
+#
+# Under logs_dir, this function generates the following outputs:
+# - done.txt: newline-delimited output identifiers for all successful processes
+# - stdout0.txt, ..., stdout{num_threads-1}.txt: stdout for each worker thread
+# - stderr0.txt, ..., stderr{num_threads-1}.txt: stderr for each worker thread
+def _process_files_by_manifest(manifest_path, logs_dir, status_verb, num_threads)
+  common = Common.new
+
+  FileUtils.makedirs(logs_dir)
+  all_tasks = CSV.read(manifest_path, headers: true, return_headers: false)
+
+  num_threads = [all_tasks.length, num_threads].min
+
+  done = Queue.new
+  error = Queue.new
+
+  # Spawn a fixed set of threads, assign exclusive work to each
+  fail_limit = 10
+  workers = num_threads.times.map do |i|
+    t = Thread.new {
+      File.open(File.join(logs_dir, "stdout#{i}.txt"), "w") do |wout|
+        File.open(File.join(logs_dir, "stderr#{i}.txt"), "w") do |werr|
+          fail_count = 0
+
+          # Process every num_threads'th task, starting at i
+          j = i
+          while j < all_tasks.length
+            task = all_tasks[j]
+            output, ok = yield task, wout, werr
+            if ok
+              done << output
+            else
+              error << output
+              fail_count+=1
+              if fail_count >= fail_limit
+                raise IOError.new("failed to process #{fail_count} manifest rows in a single worker")
+              end
+            end
+            j += num_threads
+          end
+        end
+      end
+    }
+    t.abort_on_exception = true
+    t
+  end
+
+  # In a separate thread, await worker completion and close channels.
+  Thread.new {
+    workers.each { |w| w.join }
+    [done, error].each { |q| q.close }
+  }
+
+  # In a separate thread, consume errors off the queue
+  errors = []
+  monitor_error = Thread.new {
+    until error.closed?
+      error_out = error.pop
+      errors.push(error_out) unless error_out.nil?
+    end
+  }
+
+  # In the main thread, watch the done channel and log updates.
+  File.open(File.join(logs_dir, "done.txt"), "w") do |w|
+    start = Time.now.to_i
+    count = 0
+    until done.closed?
+      value = done.pop
+      unless value.nil?
+        w.write(value + "\n")
+        count += 1
+        if count % 100 == 0
+          delta_min = (Time.now.to_i - start) / 60
+          # Carriage return here to keep the progress on the same terminal line
+          printf("\r%s %d/%d files [%.02f%%] (running for %dh%dm)",
+                 status_verb, count, all_tasks.length,
+                 100*count.to_f/all_tasks.length, delta_min/60, delta_min%60)
+        end
+      end
+    end
+  end
+  # Force a newline to reset the carriage return interactions above.
+  puts ""
+
+  # Ensure the error monitor has closed.
+  monitor_error.join
+  unless errors.empty?
+    common.error "failed to process the following paths:\n#{errors.join("\n")}"
+  end
+end
+
+def stage_files_by_manifest(project, manifest_path, logs_dir, concurrency = GSUTIL_TASK_CONCURRENCY)
+  deploy_account = must_get_env_value(project, :publisher_account)
+
+  _process_files_by_manifest(
+      manifest_path, File.join([logs_dir, 'stage']), "Staged", concurrency) do |task, wout, werr|
+    ingest_path = task["ingest_path"]
+    [ingest_path, system(
+       "gsutil",
+       "-i",
+       deploy_account,
+       "cp",
+       task["source_path"],
+       ingest_path,
+       :out => wout,
+       :err => werr)]
+  end
+
+end
+
+def publish_files_by_manifest(project, manifest_path, logs_dir, concurrency = GSUTIL_TASK_CONCURRENCY)
+  deploy_account = must_get_env_value(project, :publisher_account)
+
+  _process_files_by_manifest(
+      manifest_path, File.join([logs_dir, 'publish']), "Published", concurrency) do |task, wout, werr|
+    dest_path = task["dest_path"]
+    [dest_path, system(
+       "gsutil",
+       "-i",
+       deploy_account,
+       "mv",
+       task["ingest_path"],
+       dest_path,
+       :out => wout,
+       :err => werr)]
   end
 end

--- a/api/db-cdr/generate-cdr/libproject/genomic_manifests.rb
+++ b/api/db-cdr/generate-cdr/libproject/genomic_manifests.rb
@@ -55,7 +55,7 @@ FILE_PREFIX_REPLACEMENTS = {
   }
 }
 
-GSUTIL_TASK_CONCURRENCY = 16
+GSUTIL_TASK_CONCURRENCY = 64
 
 def _aw4_filename_to_datetime(aw4_prefix, f)
   common = Common.new
@@ -325,6 +325,8 @@ def publish_files_by_manifest(project, manifest_path, logs_dir, concurrency = GS
        "-i",
        deploy_account,
        "mv",
+       "-s",
+       task["dest_storage_class"],
        task["ingest_path"],
        dest_path,
        :out => wout,


### PR DESCRIPTION
Adds the two remaining tasks:
- STAGE_INGEST
- PUBLISH

Implements these with a multithreaded worker pool approach.

Example output (simulated a dry run mode by adding `"echo"` in front of the manifests):
```
./project.rb publish-cdr-files --project all-of-us-rw-preprod --display-version-id v6 --wgs-rids-file rids.txt --tasks STAGE_INGEST,PUBLISH                                                                                                                                                                               
skipping non-numeric research ID line: research_id                                                                                                                                                                 
Writing logs to /tmp/cdr-file-publish20220516-753383-599xm3                                                                                                                                                        
Starting: file staging to ingest bucket                                                                  
Staged 20000/20000 files [100.00%] (running for 0h0m)                                                    
Finished: file staging                                                                                   
Starting: publishing to CDR bucket                                                                                                                                                                                 
Published 20000/20000 files [100.00%] (running for 0h0m)                                                                                                                                                           
Finished: publishing     
``` 