### PR TITLE
[risk=no][RW-7234] Set DB RAS_LOGIN_GOV module timestamp to null

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/SetAccessModuleTimestamps.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/SetAccessModuleTimestamps.java
@@ -86,6 +86,8 @@ public class SetAccessModuleTimestamps {
           username,
           DbAccessModuleName.PROFILE_CONFIRMATION,
           PROFILE_CONFIRMATION_TIMESTAMP);
+
+      updateCompletionTime(accessModuleService, username, DbAccessModuleName.RAS_LOGIN_GOV, null);
     };
   }
 


### PR DESCRIPTION
Part 1: revert https://github.com/all-of-us/workbench/pull/6247 to enable RAS e2e testing in `nightly/user-access.spec.ts`.
Set DB timestamp to null for RAS_LOGIN_GOV module.