### PR TITLE
[risk=low][RW-7917] Restore filtering to username and contact email in AdminUserTable

### DIFF
--- a/ui/src/app/pages/admin/user/admin-user-table.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-table.tsx
@@ -257,72 +257,76 @@ export const AdminUserTable = withUserProfile()(
                 style={styles.tableStyle}
               >
                 <Column
+                  header='Name'
                   field='name'
-                  bodyStyle={{ ...styles.colStyle }}
+                  sortField='nameText'
                   filterField='nameText'
                   filterMatchMode='contains'
+                  sortable={true}
                   frozen={true}
-                  header='Name'
+                  bodyStyle={styles.colStyle}
                   headerStyle={{ ...styles.colStyle, width: '200px' }}
-                  sortable={true}
-                  sortField='nameText'
                 />
                 <Column
-                  field='username'
-                  bodyStyle={{ ...styles.colStyle }}
                   header='Username'
-                  headerStyle={{ ...styles.colStyle, width: '200px' }}
-                  sortable={true}
+                  field='username'
                   sortField='usernameText'
+                  filterField='usernameText'
+                  filterMatchMode='contains'
+                  sortable={true}
+                  bodyStyle={styles.colStyle}
+                  headerStyle={{ ...styles.colStyle, width: '200px' }}
                 />
                 <Column
-                  field='contactEmail'
-                  bodyStyle={{ ...styles.colStyle }}
                   header='Contact Email'
-                  headerStyle={{ ...styles.colStyle, width: '180px' }}
-                  sortable={true}
+                  field='contactEmail'
                   sortField='contactEmailText'
+                  filterField='contactEmailText'
+                  filterMatchMode='contains'
+                  sortable={true}
+                  bodyStyle={styles.colStyle}
+                  headerStyle={{ ...styles.colStyle, width: '180px' }}
                 />
                 <Column
-                  field='institutionName'
-                  bodyStyle={{ ...styles.colStyle }}
                   header='Institution'
-                  headerStyle={{ ...styles.colStyle, width: '180px' }}
-                  sortable={true}
+                  field='institutionName'
                   sortField='institutionNameText'
-                />
-                <Column
-                  field='enabled'
-                  bodyStyle={{ ...styles.colStyle }}
-                  excludeGlobalFilter={true}
-                  header='Enabled'
-                  headerStyle={{ ...styles.colStyle, width: '150px' }}
-                  sortable={false}
-                />
-                <Column
-                  field='dataAccess'
-                  bodyStyle={{ ...styles.colStyle }}
-                  excludeGlobalFilter={true}
-                  header='Data Access'
-                  headerStyle={{ ...styles.colStyle, width: '100px' }}
-                  sortable={false}
-                />
-                <Column
-                  field='bypass'
-                  bodyStyle={{ ...styles.colStyle }}
-                  excludeGlobalFilter={true}
-                  header='Access Module Bypass'
-                  headerStyle={{ ...styles.colStyle, width: '150px' }}
-                  sortable={false}
-                />
-                <Column
-                  field='firstSignInTime'
-                  bodyStyle={{ ...styles.colStyle }}
-                  excludeGlobalFilter={true}
-                  header='First Sign-in'
-                  headerStyle={{ ...styles.colStyle, width: '180px' }}
                   sortable={true}
+                  bodyStyle={styles.colStyle}
+                  headerStyle={{ ...styles.colStyle, width: '180px' }}
+                />
+                <Column
+                  header='Enabled'
+                  field='enabled'
+                  sortable={false}
+                  excludeGlobalFilter={true}
+                  bodyStyle={{ ...styles.colStyle }}
+                  headerStyle={{ ...styles.colStyle, width: '150px' }}
+                />
+                <Column
+                  header='Data Access'
+                  field='dataAccess'
+                  sortable={false}
+                  excludeGlobalFilter={true}
+                  bodyStyle={{ ...styles.colStyle }}
+                  headerStyle={{ ...styles.colStyle, width: '100px' }}
+                />
+                <Column
+                  header='Access Module Bypass'
+                  field='bypass'
+                  sortable={false}
+                  excludeGlobalFilter={true}
+                  bodyStyle={{ ...styles.colStyle }}
+                  headerStyle={{ ...styles.colStyle, width: '150px' }}
+                />
+                <Column
+                  header='First Sign-in'
+                  field='firstSignInTime'
                   sortField='firstSignInTime'
+                  sortable={true}
+                  excludeGlobalFilter={true}
+                  bodyStyle={{ ...styles.colStyle }}
+                  headerStyle={{ ...styles.colStyle, width: '180px' }}
                 />
               </DataTable>
             </div>


### PR DESCRIPTION
Broken by #6629 and other AdminUserTable updates because we changed some of the string fields to components, which made them unfilterable.

Here I add an explicit `filterField` to userName and contactEmail to make filtering work again.  I also reordered column props for consistency, to make it obvious when fields are missing.  I wanted to use a sub-component to do this, but it didn't work for some reason: #6696 

Search matches Name
<img width="663" alt="Screen Shot 2022-05-18 at 10 09 14 AM" src="https://user-images.githubusercontent.com/2701406/169061985-0367b893-dd14-48ae-896c-ab0312b2f3f1.png">


Search matches Username
<img width="472" alt="Screen Shot 2022-05-18 at 10 08 34 AM" src="https://user-images.githubusercontent.com/2701406/169061906-4a82ceed-dc25-4c00-aa37-52dc21f2ecaa.png">


Search matches Contact Email
<img width="665" alt="Screen Shot 2022-05-18 at 10 08 48 AM" src="https://user-images.githubusercontent.com/2701406/169061951-a068ed17-4246-4060-a241-9f659771d42f.png">

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
