### PR TITLE
[no ticket][risk=no] Cleanup unused params and rename API call

### DIFF
--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3103,12 +3103,11 @@ paths:
           description: the requested annotations
           schema:
             "$ref": "#/definitions/CohortAnnotationsResponse"
-  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}":
+  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}":
     parameters:
     - "$ref": "#/parameters/workspaceNamespace"
     - "$ref": "#/parameters/workspaceId"
     - "$ref": "#/parameters/cohortId"
-    - "$ref": "#/parameters/cdrVersionId"
     post:
       tags:
       - cohortReview
@@ -3129,21 +3128,19 @@ paths:
           description: A cohortReviewId and cohort count
           schema:
             "$ref": "#/definitions/CohortReview"
-  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cdrVersionId}/participants":
+  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/participants":
     parameters:
     - "$ref": "#/parameters/workspaceNamespace"
     - "$ref": "#/parameters/workspaceId"
     - "$ref": "#/parameters/cohortId"
-    - "$ref": "#/parameters/cdrVersionId"
     post:
       tags:
       - cohortReview
       consumes:
       - application/json
-      description: 'Returns a collection of participants for the specified cohortId
-        and cdrVersionId. This endpoint does pagination based on page, limit, order
-        and column.'
-      operationId: getParticipantCohortStatuses
+      description: 'Returns a collection of participants for the specified cohortId.
+        This endpoint does pagination based on page, limit, order and column.'
+      operationId: getParticipantCohortStatusesOld
       parameters:
       - in: body
         name: request

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -580,7 +580,6 @@ public class CohortReviewControllerTest {
                     workspace.getNamespace(),
                     workspace.getId(),
                     cohort.getCohortId(),
-                    cdrVersion.getCdrVersionId(),
                     new CreateReviewRequest().size(0)));
 
     assertThat(exception)
@@ -599,7 +598,6 @@ public class CohortReviewControllerTest {
                     workspace.getNamespace(),
                     workspace.getId(),
                     cohort.getCohortId(),
-                    cdrVersion.getCdrVersionId(),
                     new CreateReviewRequest().size(10001)));
 
     assertThat(exception)
@@ -620,7 +618,6 @@ public class CohortReviewControllerTest {
                     workspace.getNamespace(),
                     workspace.getId(),
                     cohort.getCohortId(),
-                    cdrVersion.getCdrVersionId(),
                     new CreateReviewRequest().size(1)));
 
     assertThat(exception)
@@ -645,7 +642,6 @@ public class CohortReviewControllerTest {
                     workspace.getNamespace(),
                     workspace.getId(),
                     cohortId,
-                    cdrVersion.getCdrVersionId(),
                     new CreateReviewRequest().size(1)));
 
     assertNotFoundExceptionNoCohort(cohortId, exception);
@@ -666,7 +662,6 @@ public class CohortReviewControllerTest {
                 workspace.getNamespace(),
                 workspace.getId(),
                 cohortWithoutReview.getCohortId(),
-                cdrVersion.getCdrVersionId(),
                 new CreateReviewRequest().size(1))
             .getBody();
 
@@ -691,7 +686,6 @@ public class CohortReviewControllerTest {
                     workspace.getNamespace(),
                     workspace.getId(),
                     cohortWithoutReview.getCohortId(),
-                    cdrVersion.getCdrVersionId(),
                     new CreateReviewRequest().size(1)));
 
     assertForbiddenException(exception);
@@ -1900,11 +1894,10 @@ public class CohortReviewControllerTest {
         assertThrows(
             NotFoundException.class,
             () ->
-                cohortReviewController.getParticipantCohortStatuses(
+                cohortReviewController.getParticipantCohortStatusesOld(
                     workspace2.getNamespace(),
                     workspace2.getId(),
                     cohortId,
-                    cdrVersion.getCdrVersionId(),
                     new PageFilterRequest()));
 
     assertNotFoundExceptionNoCohort(cohortId, exception);
@@ -1920,11 +1913,10 @@ public class CohortReviewControllerTest {
         assertThrows(
             NotFoundException.class,
             () ->
-                cohortReviewController.getParticipantCohortStatuses(
+                cohortReviewController.getParticipantCohortStatusesOld(
                     workspace.getNamespace(),
                     workspace.getId(),
                     worngCohortId,
-                    cdrVersion.getCdrVersionId(),
                     new PageFilterRequest()));
 
     assertNotFoundExceptionNoCohort(worngCohortId, exception);
@@ -1944,11 +1936,10 @@ public class CohortReviewControllerTest {
 
     CohortReview actualReview =
         cohortReviewController
-            .getParticipantCohortStatuses(
+            .getParticipantCohortStatusesOld(
                 workspace.getNamespace(),
                 workspace.getId(),
                 cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
                 pageFilterRequest)
             .getBody()
             .getCohortReview();
@@ -1975,11 +1966,10 @@ public class CohortReviewControllerTest {
 
     CohortReview actualReview =
         cohortReviewController
-            .getParticipantCohortStatuses(
+            .getParticipantCohortStatusesOld(
                 workspace.getNamespace(),
                 workspace.getId(),
                 cohort.getCohortId(),
-                cdrVersion.getCdrVersionId(),
                 new PageFilterRequest())
             .getBody()
             .getCohortReview();
@@ -2007,11 +1997,10 @@ public class CohortReviewControllerTest {
         assertThrows(
             ForbiddenException.class,
             () ->
-                cohortReviewController.getParticipantCohortStatuses(
+                cohortReviewController.getParticipantCohortStatusesOld(
                     workspace.getNamespace(),
                     workspace.getId(),
                     cohort.getCohortId(),
-                    cdrVersion.getCdrVersionId(),
                     new PageFilterRequest()));
 
     assertForbiddenException(exception);

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -1486,12 +1486,7 @@ public class WorkspacesControllerTest {
     reviewReq.setSize(1);
     CohortReview cr1 =
         cohortReviewController
-            .createCohortReview(
-                workspace.getNamespace(),
-                workspace.getId(),
-                c1.getId(),
-                cdrVersion.getCdrVersionId(),
-                reviewReq)
+            .createCohortReview(workspace.getNamespace(), workspace.getId(), c1.getId(), reviewReq)
             .getBody();
     CohortAnnotationDefinition cad1EnumResponse =
         cohortAnnotationDefinitionController
@@ -1548,12 +1543,7 @@ public class WorkspacesControllerTest {
     reviewReq.setSize(2);
     CohortReview cr2 =
         cohortReviewController
-            .createCohortReview(
-                workspace.getNamespace(),
-                workspace.getId(),
-                c2.getId(),
-                cdrVersion.getCdrVersionId(),
-                reviewReq)
+            .createCohortReview(workspace.getNamespace(), workspace.getId(), c2.getId(), reviewReq)
             .getBody();
     CohortAnnotationDefinition cad2EnumResponse =
         cohortAnnotationDefinitionController
@@ -1699,11 +1689,10 @@ public class WorkspacesControllerTest {
 
     CohortReview gotCr1 =
         cohortReviewController
-            .getParticipantCohortStatuses(
+            .getParticipantCohortStatusesOld(
                 cloned.getNamespace(),
                 cloned.getId(),
                 cohortsByName.get("c1").getId(),
-                cdrVersion.getCdrVersionId(),
                 new PageFilterRequest())
             .getBody()
             .getCohortReview();
@@ -1734,11 +1723,10 @@ public class WorkspacesControllerTest {
 
     CohortReview gotCr2 =
         cohortReviewController
-            .getParticipantCohortStatuses(
+            .getParticipantCohortStatusesOld(
                 cloned.getNamespace(),
                 cloned.getId(),
                 cohortsByName.get("c2").getId(),
-                cdrVersion.getCdrVersionId(),
                 new PageFilterRequest())
             .getBody()
             .getCohortReview();
@@ -3364,7 +3352,6 @@ public class WorkspacesControllerTest {
                 workspace.getNamespace(),
                 workspace.getId(),
                 cohort.getId(),
-                cdrVersion.getCdrVersionId(),
                 new CreateReviewRequest().size(1))
             .getBody();
 

--- a/ui/src/app/pages/data/cohort-review/cohort-review.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review.tsx
@@ -80,14 +80,13 @@ export const CohortReview = fp.flow(
 
     loadCohort() {
       const { ns, wsid, cid } = this.props.match.params;
-      const { cdrVersionId } = this.props.workspace;
 
       if (!cid) {
         return;
       }
 
       cohortReviewApi()
-        .getParticipantCohortStatuses(ns, wsid, +cid, +cdrVersionId, {
+        .getParticipantCohortStatusesOld(ns, wsid, +cid, {
           page: 0,
           pageSize: 25,
           sortOrder: SortOrder.Asc,

--- a/ui/src/app/pages/data/cohort-review/create-review-modal.tsx
+++ b/ui/src/app/pages/data/cohort-review/create-review-modal.tsx
@@ -99,13 +99,13 @@ export const CreateReviewModal = fp.flow(
       this.setState({ creating: true });
       const {
         cohort,
-        workspace: { cdrVersionId, id, namespace },
+        workspace: { id, namespace },
       } = this.props;
       const { numberOfParticipants } = this.state;
       const request = { size: parseInt(numberOfParticipants, 10) };
 
       cohortReviewApi()
-        .createCohortReview(namespace, id, cohort.id, +cdrVersionId, request)
+        .createCohortReview(namespace, id, cohort.id, request)
         .then((response) => {
           currentCohortReviewStore.next(response);
           queryResultSizeStore.next(parseInt(numberOfParticipants, 10));

--- a/ui/src/app/pages/data/cohort-review/detail-header.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-header.component.tsx
@@ -36,7 +36,6 @@ import {
 import { triggerEvent } from 'app/utils/analytics';
 import {
   currentCohortReviewStore,
-  currentWorkspaceStore,
   NavigationProps,
 } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
@@ -327,7 +326,6 @@ export const DetailHeader = fp.flow(
 
         const { page, pageSize } = reviewPaginationStore.getValue();
         const { ns, wsid, cid } = this.props.match.params;
-        const { cdrVersionId } = currentWorkspaceStore.getValue();
         const request = {
           page: left ? page - 1 : page + 1,
           pageSize: pageSize,
@@ -335,7 +333,7 @@ export const DetailHeader = fp.flow(
           filters: { items: this.getRequestFilters() },
         } as PageFilterRequest;
         cohortReviewApi()
-          .getParticipantCohortStatuses(ns, wsid, +cid, +cdrVersionId, request)
+          .getParticipantCohortStatusesOld(ns, wsid, +cid, request)
           .then((response) => {
             currentCohortReviewStore.next(response.cohortReview);
             const status = statusGetter(

--- a/ui/src/app/pages/data/cohort-review/detail-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-page.tsx
@@ -52,7 +52,7 @@ export const DetailPage = fp.flow(
 
     async componentDidMount() {
       const {
-        workspace: { cdrVersionId, id, namespace },
+        workspace: { id, namespace },
         hideSpinner,
       } = this.props;
       hideSpinner();
@@ -60,7 +60,7 @@ export const DetailPage = fp.flow(
       const { ns, wsid, cid } = this.props.match.params;
       if (!cohortReview) {
         await cohortReviewApi()
-          .getParticipantCohortStatuses(ns, wsid, +cid, +cdrVersionId, {
+          .getParticipantCohortStatusesOld(ns, wsid, +cid, {
             page: 0,
             pageSize: 25,
             sortOrder: SortOrder.Asc,

--- a/ui/src/app/pages/data/cohort-review/query-report.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/query-report.component.tsx
@@ -257,7 +257,7 @@ export const QueryReport = fp.flow(
         request = JSON.parse(cohortReview.cohortDefinition);
       } else {
         await cohortReviewApi()
-          .getParticipantCohortStatuses(ns, wsid, +cid, +cdrVersionId, {
+          .getParticipantCohortStatusesOld(ns, wsid, +cid, {
             page: 0,
             pageSize: 25,
             sortOrder: SortOrder.Asc,

--- a/ui/src/app/pages/data/cohort-review/table-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/table-page.tsx
@@ -394,7 +394,6 @@ export const ParticipantsTable = fp.flow(
     getParticipantStatuses() {
       const { page, sortField, sortOrder } = this.state;
       const {
-        workspace: { cdrVersionId },
         match: {
           params: { ns, wsid, cid },
         },
@@ -410,11 +409,10 @@ export const ParticipantsTable = fp.flow(
           sortOrder: sortOrder === 1 ? SortOrder.Asc : SortOrder.Desc,
           filters: { items: filters },
         } as Request;
-        return cohortReviewApi().getParticipantCohortStatuses(
+        return cohortReviewApi().getParticipantCohortStatusesOld(
           ns,
           wsid,
           +cid,
-          +cdrVersionId,
           query
         );
       }

--- a/ui/src/testing/stubs/cohort-review-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-review-service-stub.ts
@@ -117,7 +117,7 @@ export class CohortReviewServiceStub extends CohortReviewApi {
     });
   }
 
-  getParticipantCohortStatuses(): Promise<CohortReviewWithCountResponse> {
+  getParticipantCohortStatusesOld(): Promise<CohortReviewWithCountResponse> {
     return new Promise<CohortReviewWithCountResponse>((resolve) =>
       resolve({ cohortReview: cohortReviewStubs[0], queryResultSize: 0 })
     );


### PR DESCRIPTION
Cleanup unused params and rename API call:

- Removing cdrVersionId from createCohortReview
- Removing cdrVersionId from getParticipantCohortStatuses and renaming to getParticipantCohortStatusesOld to allow for new API call for multiple reviews.

Updated UI and unit test as well.


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
