### PR TITLE
[none][risk=no] Updated Annual Renewal Header.

### DIFF
--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -71,6 +71,11 @@ export const styles = reactStyles({
     fontWeight: 600,
     gridArea: 'header',
     alignSelf: 'center',
+    marginBottom: '20px',
+  },
+  renewalHeaderYearlyExpired: {
+    lineHeight: '40px',
+    marginBottom: '0px',
   },
   renewalHeaderRequirements: {
     color: colors.primary,
@@ -471,7 +476,10 @@ const AnnualInnerHeader = (props: { hasExpired: boolean }) => (
     )}
     <div
       data-test-id='annual-renewal-header'
-      style={styles.renewalHeaderYearly}
+      style={{
+        ...{ ...styles.renewalHeaderYearly },
+        ...(props.hasExpired && styles.renewalHeaderYearlyExpired),
+      }}
     >
       {props.hasExpired
         ? 'Researcher workbench access has expired'

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -465,37 +465,40 @@ const InitialInnerHeader = () => (
   </div>
 );
 
-const AnnualInnerHeader = (props: { hasExpired: boolean }) => (
-  <div style={styles.renewalInnerHeaderContainer}>
-    {props.hasExpired && (
-      <ExclamationTriangle
-        size={40}
-        color={colors.warning}
-        style={styles.renewalInnerHeaderIcon}
-      />
-    )}
-    <div
-      data-test-id='annual-renewal-header'
-      style={{
-        ...{ ...styles.renewalHeaderYearly },
-        ...(props.hasExpired && styles.renewalHeaderYearlyExpired),
-      }}
-    >
-      {props.hasExpired
-        ? 'Researcher workbench access has expired'
-        : 'Yearly Researcher Workbench access renewal'}
-    </div>
-    <div style={styles.renewalHeaderRequirements}>
-      <RenewalRequirementsText />
-      <div style={{ marginTop: '0.5rem' }}>
-        For any questions, please contact <SupportMailto />.
+const AnnualInnerHeader = (props: { hasExpired: boolean }) => {
+  const { hasExpired } = props;
+  return (
+    <div style={styles.renewalInnerHeaderContainer}>
+      {hasExpired && (
+        <ExclamationTriangle
+          size={40}
+          color={colors.warning}
+          style={styles.renewalInnerHeaderIcon}
+        />
+      )}
+      <div
+        data-test-id='annual-renewal-header'
+        style={{
+          ...{ ...styles.renewalHeaderYearly },
+          ...(hasExpired && styles.renewalHeaderYearlyExpired),
+        }}
+      >
+        {hasExpired
+          ? 'Researcher workbench access has expired'
+          : 'Yearly Researcher Workbench access renewal'}
+      </div>
+      <div style={styles.renewalHeaderRequirements}>
+        <RenewalRequirementsText />
+        <div style={{ marginTop: '0.5rem' }}>
+          For any questions, please contact <SupportMailto />.
+        </div>
+      </div>
+      <div style={styles.pleaseComplete}>
+        Please complete the following steps.
       </div>
     </div>
-    <div style={styles.pleaseComplete}>
-      Please complete the following steps.
-    </div>
-  </div>
-);
+  );
+};
 
 const InnerHeader = (props: { pageMode: DARPageMode; hasExpired: boolean }) =>
   props.pageMode === DARPageMode.INITIAL_REGISTRATION ? (

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -9,6 +9,7 @@ import { Button } from 'app/components/buttons';
 import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { Header } from 'app/components/headers';
+import { ExclamationTriangle } from 'app/components/icons';
 import { withErrorModal } from 'app/components/modals';
 import { SupportMailto } from 'app/components/support';
 import { AoU } from 'app/components/text-wrappers';
@@ -29,6 +30,7 @@ import {
   isCompliant,
   isEligibleModule,
   isRenewalCompleteForModule,
+  maybeDaysRemaining,
   syncModulesExternal,
 } from 'app/utils/access-utils';
 import { profileStore, serverConfigStore, useStore } from 'app/utils/stores';
@@ -67,12 +69,14 @@ export const styles = reactStyles({
     color: colors.primary,
     fontSize: 20,
     fontWeight: 600,
-    marginBottom: '1em',
+    gridArea: 'header',
+    alignSelf: 'center',
   },
   renewalHeaderRequirements: {
     color: colors.primary,
     fontSize: 14,
     marginBottom: '1em',
+    gridArea: 'explanation',
   },
   completed: {
     height: '87px',
@@ -120,6 +124,7 @@ export const styles = reactStyles({
     color: colors.primary,
     fontSize: 16,
     fontWeight: 600,
+    gridArea: 'instructions',
   },
   card: {
     width: '1195px',
@@ -244,6 +249,18 @@ export const styles = reactStyles({
     opacity: '0.5',
     fontSize: '12px',
     lineHeight: '22px',
+  },
+  renewalInnerHeaderContainer: {
+    display: 'grid',
+    width: '1195px',
+    gridTemplateAreas: `'icon header'
+      '. explanation'
+      'instructions instructions'
+    `,
+  },
+  renewalInnerHeaderIcon: {
+    gridArea: 'icon',
+    marginRight: '0.5rem',
   },
 });
 
@@ -443,13 +460,22 @@ const InitialInnerHeader = () => (
   </div>
 );
 
-const AnnualInnerHeader = () => (
-  <FlexColumn>
+const AnnualInnerHeader = (props: { hasExpired: boolean }) => (
+  <div style={styles.renewalInnerHeaderContainer}>
+    {props.hasExpired && (
+      <ExclamationTriangle
+        size={40}
+        color={colors.warning}
+        style={styles.renewalInnerHeaderIcon}
+      />
+    )}
     <div
       data-test-id='annual-renewal-header'
       style={styles.renewalHeaderYearly}
     >
-      Yearly Researcher Workbench access renewal
+      {props.hasExpired
+        ? 'Researcher workbench access has expired'
+        : 'Yearly Researcher Workbench access renewal'}
     </div>
     <div style={styles.renewalHeaderRequirements}>
       <RenewalRequirementsText /> For any questions, please contact{' '}
@@ -458,14 +484,14 @@ const AnnualInnerHeader = () => (
     <div style={styles.pleaseComplete}>
       Please complete the following steps.
     </div>
-  </FlexColumn>
+  </div>
 );
 
-const InnerHeader = (props: { pageMode: DARPageMode }) =>
+const InnerHeader = (props: { pageMode: DARPageMode; hasExpired: boolean }) =>
   props.pageMode === DARPageMode.INITIAL_REGISTRATION ? (
     <InitialInnerHeader />
   ) : (
-    <AnnualInnerHeader />
+    <AnnualInnerHeader hasExpired={props.hasExpired} />
   );
 
 const SelfBypass = (props: { onClick: () => void }) => (
@@ -610,12 +636,12 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
     }, []);
 
     /*
-      TODO Move these into the effect with an empty dependency array.
-       I suspect that these are only called when the component is reloaded,
-        so the initial effect should be run again. My goal here is that effects should
-        only depend on props or local state. When this is the case, we can them above the local
-        variables.
-     */
+        TODO Move these into the effect with an empty dependency array.
+         I suspect that these are only called when the component is reloaded,
+          so the initial effect should be run again. My goal here is that effects should
+          only depend on props or local state. When this is the case, we can them above the local
+          variables.
+       */
     // handle the route /nih-callback?token=<token>
     useEffect(() => {
       if (token) {
@@ -641,6 +667,9 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
       );
     }, [nextActive, nextRequired]);
 
+    const daysRemaining = maybeDaysRemaining(profile);
+    const hasExpired = daysRemaining && daysRemaining <= 0;
+
     return (
       <FlexColumn style={styles.pageWrapper}>
         <OuterHeader {...{ pageMode }} />
@@ -649,7 +678,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
           <SelfBypass onClick={async () => selfBypass(spinnerProps, reload)} />
         )}
         <FadeBox style={styles.fadeBox}>
-          <InnerHeader {...{ pageMode }} />
+          <InnerHeader {...{ pageMode, hasExpired }} />
           <React.Fragment>{cards}</React.Fragment>
         </FadeBox>
       </FlexColumn>

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -478,8 +478,10 @@ const AnnualInnerHeader = (props: { hasExpired: boolean }) => (
         : 'Yearly Researcher Workbench access renewal'}
     </div>
     <div style={styles.renewalHeaderRequirements}>
-      <RenewalRequirementsText /> For any questions, please contact{' '}
-      <SupportMailto />.
+      <RenewalRequirementsText />
+      <div style={{ marginTop: '0.5rem' }}>
+        For any questions, please contact <SupportMailto />.
+      </div>
     </div>
     <div style={styles.pleaseComplete}>
       Please complete the following steps.


### PR DESCRIPTION
Description: Updated Annual renewal header.

Updated Expired Version:
![image](https://user-images.githubusercontent.com/24514630/169395963-adf8777d-e4c8-42f8-88fb-ee85b20443c1.png)
Unexpired version
![image](https://user-images.githubusercontent.com/24514630/169396090-6a104b33-4c2c-4de6-b5e2-021ffbbef752.png)



<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
