### PR TITLE
[risk=no] Add --authorities ALL for easier authority revocation

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2070,6 +2070,14 @@ def set_authority(cmd_name, *args)
   op.parse.validate
   gcc.validate
 
+  if not op.opts.remove and op.opts.authority.upcase.include? "ALL"
+    get_user_confirmation(
+      "Adding ALL authorities is redundant and rarely useful; to transitively " +
+      "grant all authorities, simply add the all-encompassing DEVELOPER authority.\n" +
+      "Do you want to add ALL authorities anyways?"
+    )
+  end
+
   with_cloud_proxy_and_db(gcc) do
     common = Common.new
     common.run_inline %W{

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2049,7 +2049,9 @@ def authority_options(cmd_name, args)
   op.add_option(
       "--authority [AUTHORITY,...]",
       ->(opts, v) { opts.authority = v},
-      "Comma-separated list of user authorities to add or remove for the users. ")
+      "Comma-separated list of user authorities to add or remove for the users. " +
+      "Include keyword ALL to include all authorities; typically that should only " +
+      "be used with removals. When granting authorities, use DEVELOPER to gain full access")
   op.add_option(
       "--remove",
       ->(opts, _) { opts.remove = "true"},

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/SetAuthority.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/SetAuthority.java
@@ -19,9 +19,10 @@ import org.springframework.context.annotation.Configuration;
 public class SetAuthority {
 
   private static final Logger log = Logger.getLogger(SetAuthority.class.getName());
+  private static final String ALL_AUTHORITIES = "ALL";
 
   private Set<String> commaDelimitedStringToSet(String str) {
-    return new HashSet<String>(Arrays.asList(str.split(",")));
+    return new HashSet<>(Arrays.asList(str.split(",")));
   }
 
   private Set<Authority> commaDelimitedStringToAuthoritySet(String str) {
@@ -30,6 +31,9 @@ public class SetAuthority {
       String cleanedValue = value.trim().toUpperCase();
       if (cleanedValue.isEmpty()) {
         continue;
+      }
+      if (ALL_AUTHORITIES.equals(cleanedValue)) {
+        return new HashSet<>(Arrays.asList(Authority.values()));
       }
       auths.add(Authority.valueOf(cleanedValue));
     }


### PR DESCRIPTION
I added a playbook entry for this: 
https://docs.google.com/document/d/1hbYNWzdxuRybTfW3M70hWZfr_TXRVd5rOMR9kZtwAFY/edit#heading=h.x2qjziypitz3

This is important for removing all authorities when turning down an account. See example: https://precisionmedicineinitiative.atlassian.net/browse/PD-7476