### PR TITLE
[risk=no] Add default boot disk size for Nextflow

### DIFF
--- a/api/src/main/webapp/static/initialize_notebook_runtime.sh
+++ b/api/src/main/webapp/static/initialize_notebook_runtime.sh
@@ -71,6 +71,7 @@ profiles {
       google.lifeSciences.subnetwork = "subnetwork"
       google.lifeSciences.usePrivateAddress = false
       google.lifeSciences.copyImage = "gcr.io/google.com/cloudsdktool/cloud-sdk:alpine"
+      google.lifeSciences.bootDiskSize = "20.GB"
   }
 }
 EOF


### PR DESCRIPTION
Our featured workspaces recommend using the GATK image, which requires a larger disk than default. Set a 20GB disk to cover some common images at least (going higher will require modifications to this config file.)