### PR TITLE
[risk=low][RW-8353] Add DB tables and entity model for Demo Survey V2

### DIFF
--- a/api/db/changelog/db.changelog-196-add-demographic-survey-v2.xml
+++ b/api/db/changelog/db.changelog-196-add-demographic-survey-v2.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="thibault" id="changelog-196-add-demographic-survey-v2">
+
+    <createTable tableName="demographic_survey_v2">
+      <column name="demographic_survey_v2_id" type="bigint" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="user_id" type="bigint">
+        <constraints nullable="false" foreignKeyName="demographic_survey_v2_user_id" references="user(user_id)"/>
+      </column>
+      <column name="completion_time" type="timestamp">
+        <constraints nullable="false"/>
+      </column>
+      <column name="ethnicity_ai_an_other_text" type="VARCHAR(200)"/>
+      <column name="ethnicity_asian_other_text" type="VARCHAR(200)"/>
+      <column name="ethnicity_other_text" type="VARCHAR(200)"/>
+      <column name="gender_other_text" type="VARCHAR(200)"/>
+      <column name="orientation_other_text" type="VARCHAR(200)"/>
+      <column name="sex_at_birth" type="ENUM('FEMALE','INTERSEX','MALE','OTHER','PREFER_NOT_TO_ANSWER')"/>
+      <column name="sex_at_birth_other_text" type="VARCHAR(200)"/>
+      <column name="year_of_birth" type="smallint"/>
+      <column name="year_of_birth_prefer_not" type="boolean"/>
+      <column name="disability_hearing" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disability_seeing" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disability_concentrating" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disability_walking" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disability_dressing" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disability_errands" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disability_other_text" type="VARCHAR(200)"/>
+      <column name="education" type="ENUM('NO_EDUCATION','GRADES_1_12','UNDERGRADUATE','COLLEGE_GRADUATE','MASTER','DOCTORATE','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disadvantaged" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
+    </createTable>
+
+    <createTable tableName="demographic_survey_v2_ethnic_category">
+      <column name="demographic_survey_v2_id" type="bigint">
+        <constraints nullable="false" foreignKeyName="demographic_survey_v2_ethnic_category" references="demographic_survey_v2(demographic_survey_v2_id)"/>
+      </column>
+      <column name="ethnic_category" type="ENUM('AI_AN','AI_AN_CENTRAL_SOUTH','AI_AN_OTHER','ASIAN','ASIAN_INDIAN','ASIAN_CAMBODIAN','ASIAN_CHINESE','ASIAN_FILIPINO','ASIAN_HMONG','ASIAN_JAPANESE','ASIAN_KOREAN','ASIAN_LAO','ASIAN_PAKISTANI','ASIAN_VIETNAMESE','ASIAN_OTHER','BLACK','HISPANIC','MENA','NHPI','WHITE','OTHER','PREFER_NOT_TO_ANSWER')">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <createTable tableName="demographic_survey_v2_gender_identity">
+      <column name="demographic_survey_v2_id" type="bigint">
+        <constraints nullable="false" foreignKeyName="demographic_survey_v2_gender_identity" references="demographic_survey_v2(demographic_survey_v2_id)"/>
+      </column>
+      <column name="gender_identity" type="ENUM('GENDERQUEER','MAN','NON_BINARY','QUESTIONING','TRANS_MAN','TRANS_WOMAN','TWO_SPIRIT','WOMAN','OTHER','PREFER_NOT_TO_ANSWER')">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <createTable tableName="demographic_survey_v2_sexual_orientation">
+      <column name="demographic_survey_v2_id" type="bigint">
+        <constraints nullable="false" foreignKeyName="demographic_survey_v2_sexual_orientation" references="demographic_survey_v2(demographic_survey_v2_id)"/>
+      </column>
+      <column name="sexual_orientation" type="ENUM('ASEXUAL','BISEXUAL','GAY','LESBIAN','POLYSEXUAL','QUEER','QUESTIONING','SAME_GENDER','STRAIGHT','TWO_SPIRIT','OTHER','PREFER_NOT_TO_ANSWER')">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <rollback>
+      <dropTable tableName="demographic_survey_v2_sexual_orientation"/>
+      <dropTable tableName="demographic_survey_v2_gender_identity"/>
+      <dropTable tableName="demographic_survey_v2_ethnic_category"/>
+      <dropTable tableName="demographic_survey_v2"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-196-add-demographic-survey-v2.xml
+++ b/api/db/changelog/db.changelog-196-add-demographic-survey-v2.xml
@@ -38,7 +38,7 @@
 
     <createTable tableName="demographic_survey_v2_ethnic_category">
       <column name="demographic_survey_v2_id" type="bigint">
-        <constraints nullable="false" foreignKeyName="demographic_survey_v2_ethnic_category" references="demographic_survey_v2(demographic_survey_v2_id)"/>
+        <constraints nullable="false" foreignKeyName="fk_demographic_survey_v2_ethnic_category" references="demographic_survey_v2(demographic_survey_v2_id)"/>
       </column>
       <column name="ethnic_category" type="ENUM('AI_AN','AI_AN_CENTRAL_SOUTH','AI_AN_OTHER','ASIAN','ASIAN_INDIAN','ASIAN_CAMBODIAN','ASIAN_CHINESE','ASIAN_FILIPINO','ASIAN_HMONG','ASIAN_JAPANESE','ASIAN_KOREAN','ASIAN_LAO','ASIAN_PAKISTANI','ASIAN_VIETNAMESE','ASIAN_OTHER','BLACK','HISPANIC','MENA','NHPI','WHITE','OTHER','PREFER_NOT_TO_ANSWER')">
         <constraints nullable="false"/>
@@ -47,7 +47,7 @@
 
     <createTable tableName="demographic_survey_v2_gender_identity">
       <column name="demographic_survey_v2_id" type="bigint">
-        <constraints nullable="false" foreignKeyName="demographic_survey_v2_gender_identity" references="demographic_survey_v2(demographic_survey_v2_id)"/>
+        <constraints nullable="false" foreignKeyName="fk_demographic_survey_v2_gender_identity" references="demographic_survey_v2(demographic_survey_v2_id)"/>
       </column>
       <column name="gender_identity" type="ENUM('GENDERQUEER','MAN','NON_BINARY','QUESTIONING','TRANS_MAN','TRANS_WOMAN','TWO_SPIRIT','WOMAN','OTHER','PREFER_NOT_TO_ANSWER')">
         <constraints nullable="false"/>
@@ -56,7 +56,7 @@
 
     <createTable tableName="demographic_survey_v2_sexual_orientation">
       <column name="demographic_survey_v2_id" type="bigint">
-        <constraints nullable="false" foreignKeyName="demographic_survey_v2_sexual_orientation" references="demographic_survey_v2(demographic_survey_v2_id)"/>
+        <constraints nullable="false" foreignKeyName="fk_demographic_survey_v2_sexual_orientation" references="demographic_survey_v2(demographic_survey_v2_id)"/>
       </column>
       <column name="sexual_orientation" type="ENUM('ASEXUAL','BISEXUAL','GAY','LESBIAN','POLYSEXUAL','QUEER','QUESTIONING','SAME_GENDER','STRAIGHT','TWO_SPIRIT','OTHER','PREFER_NOT_TO_ANSWER')">
         <constraints nullable="false"/>

--- a/api/db/changelog/db.changelog-196-add-demographic-survey-v2.xml
+++ b/api/db/changelog/db.changelog-196-add-demographic-survey-v2.xml
@@ -25,15 +25,15 @@
       <column name="sex_at_birth_other_text" type="VARCHAR(200)"/>
       <column name="year_of_birth" type="smallint"/>
       <column name="year_of_birth_prefer_not" type="boolean"/>
-      <column name="disability_hearing" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
-      <column name="disability_seeing" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
-      <column name="disability_concentrating" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
-      <column name="disability_walking" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
-      <column name="disability_dressing" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
-      <column name="disability_errands" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disability_hearing" type="ENUM('YES','NO','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disability_seeing" type="ENUM('YES','NO','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disability_concentrating" type="ENUM('YES','NO','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disability_walking" type="ENUM('YES','NO','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disability_dressing" type="ENUM('YES','NO','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disability_errands" type="ENUM('YES','NO','PREFER_NOT_TO_ANSWER')"/>
       <column name="disability_other_text" type="VARCHAR(200)"/>
       <column name="education" type="ENUM('NO_EDUCATION','GRADES_1_12','UNDERGRADUATE','COLLEGE_GRADUATE','MASTER','DOCTORATE','PREFER_NOT_TO_ANSWER')"/>
-      <column name="disadvantaged" type="ENUM('TRUE','FALSE','PREFER_NOT_TO_ANSWER')"/>
+      <column name="disadvantaged" type="ENUM('YES','NO','PREFER_NOT_TO_ANSWER')"/>
     </createTable>
 
     <createTable tableName="demographic_survey_v2_ethnic_category">

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -203,6 +203,7 @@
   <include file="changelog/db.changelog-193-institution-add-request-access-url.xml"/>
   <include file="changelog/db.changelog-194-add-terra-agreement-time.xml"/>
   <include file="changelog/db.changelog-195-add-filter-set-name.xml"/>
+  <include file="changelog/db.changelog-196-add-demographic-survey-v2.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurveyV2.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurveyV2.java
@@ -389,10 +389,9 @@ public class DbDemographicSurveyV2 {
     PREFER_NOT_TO_ANSWER
   }
 
-  // Swagger auto-translates YES/NO to TRUE/FALSE so we don't really benefit from using YES/NO here
   public enum DbYesNoPreferNot {
-    TRUE,
-    FALSE,
+    YES,
+    NO,
     PREFER_NOT_TO_ANSWER
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurveyV2.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurveyV2.java
@@ -39,7 +39,7 @@ public class DbDemographicSurveyV2 {
   private DbYesNoPreferNot disabilityDressing;
   private DbYesNoPreferNot disabilityErrands;
   private String disabilityOtherText;
-  private DbEducation education;
+  private DbEducationV2 education;
   private DbYesNoPreferNot disadvantaged;
 
   // singular names for these because Hibernate seems to require
@@ -298,11 +298,11 @@ public class DbDemographicSurveyV2 {
 
   @Enumerated(EnumType.STRING)
   @Column(name = "education")
-  public DbEducation getEducation() {
+  public DbEducationV2 getEducation() {
     return education;
   }
 
-  public DbDemographicSurveyV2 setEducation(DbEducation education) {
+  public DbDemographicSurveyV2 setEducation(DbEducationV2 education) {
     this.education = education;
     return this;
   }
@@ -379,14 +379,14 @@ public class DbDemographicSurveyV2 {
     PREFER_NOT_TO_ANSWER
   }
 
-  public enum DbEducation {
+  public enum DbEducationV2 {
     NO_EDUCATION,
     GRADES_1_12,
     UNDERGRADUATE,
     COLLEGE_GRADUATE,
     MASTER,
     DOCTORATE,
-    PREFER_NO_ANSWER
+    PREFER_NOT_TO_ANSWER
   }
 
   // Swagger auto-translates YES/NO to TRUE/FALSE so we don't really benefit from using YES/NO here

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurveyV2.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurveyV2.java
@@ -1,0 +1,398 @@
+package org.pmiops.workbench.db.model;
+
+import java.sql.Timestamp;
+import java.util.Set;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@Entity
+@Table(name = "demographic_survey_v2")
+public class DbDemographicSurveyV2 {
+  private long id;
+  private DbUser user;
+  private Timestamp completionTime;
+  private String ethnicityAiAnOtherText;
+  private String ethnicityAsianOtherText;
+  private String ethnicityOtherText;
+  private String genderOtherText;
+  private String orientationOtherText;
+  private DbSexAtBirthV2 sexAtBirth;
+  private String sexAtBirthOtherText;
+  private Long yearOfBirth;
+  private Boolean yearOfBirthPreferNot;
+  private DbYesNoPreferNot disabilityHearing;
+  private DbYesNoPreferNot disabilitySeeing;
+  private DbYesNoPreferNot disabilityConcentrating;
+  private DbYesNoPreferNot disabilityWalking;
+  private DbYesNoPreferNot disabilityDressing;
+  private DbYesNoPreferNot disabilityErrands;
+  private String disabilityOtherText;
+  private DbEducation education;
+  private DbYesNoPreferNot disadvantaged;
+
+  // singular names for these because Hibernate seems to require
+  // that they match the column names in the join tables
+
+  private Set<DbEthnicCategory> ethnicCategory;
+  private Set<DbGenderIdentityV2> genderIdentity;
+  private Set<DbSexualOrientationV2> sexualOrientation;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "demographic_survey_v2_id", nullable = false)
+  public long getId() {
+    return id;
+  }
+
+  public DbDemographicSurveyV2 setId(long demographic_survey_id) {
+    this.id = demographic_survey_id;
+    return this;
+  }
+
+  @OneToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  public DbUser getUser() {
+    return user;
+  }
+
+  public DbDemographicSurveyV2 setUser(DbUser user) {
+    this.user = user;
+    return this;
+  }
+
+  @LastModifiedDate
+  @Column(name = "completion_time")
+  public Timestamp getCompletionTime() {
+    return completionTime;
+  }
+
+  public DbDemographicSurveyV2 setCompletionTime(Timestamp completionTime) {
+    this.completionTime = completionTime;
+    return this;
+  }
+
+  @ElementCollection(fetch = FetchType.LAZY)
+  @Enumerated(EnumType.STRING)
+  @CollectionTable(
+      name = "demographic_survey_v2_ethnic_category",
+      joinColumns = @JoinColumn(name = "demographic_survey_v2_id"))
+  @Column(name = "ethnic_category")
+  public Set<DbEthnicCategory> getEthnicCategory() {
+    return ethnicCategory;
+  }
+
+  public DbDemographicSurveyV2 setEthnicCategory(Set<DbEthnicCategory> ethnicCategory) {
+    this.ethnicCategory = ethnicCategory;
+    return this;
+  }
+
+  @Column(name = "ethnicity_ai_an_other_text")
+  public String getEthnicityAiAnOtherText() {
+    return ethnicityAiAnOtherText;
+  }
+
+  public DbDemographicSurveyV2 setEthnicityAiAnOtherText(String ethnicityAiAnOtherText) {
+    this.ethnicityAiAnOtherText = ethnicityAiAnOtherText;
+    return this;
+  }
+
+  @Column(name = "ethnicity_asian_other_text")
+  public String getEthnicityAsianOtherText() {
+    return ethnicityAsianOtherText;
+  }
+
+  public DbDemographicSurveyV2 setEthnicityAsianOtherText(String ethnicityAsianOtherText) {
+    this.ethnicityAsianOtherText = ethnicityAsianOtherText;
+    return this;
+  }
+
+  @Column(name = "ethnicity_other_text")
+  public String getEthnicityOtherText() {
+    return ethnicityOtherText;
+  }
+
+  public DbDemographicSurveyV2 setEthnicityOtherText(String ethnicityOtherText) {
+    this.ethnicityOtherText = ethnicityOtherText;
+    return this;
+  }
+
+  @ElementCollection(fetch = FetchType.LAZY)
+  @Enumerated(EnumType.STRING)
+  @CollectionTable(
+      name = "demographic_survey_v2_gender_identity",
+      joinColumns = @JoinColumn(name = "demographic_survey_v2_id"))
+  @Column(name = "gender_identity")
+  public Set<DbGenderIdentityV2> getGenderIdentity() {
+    return genderIdentity;
+  }
+
+  public DbDemographicSurveyV2 setGenderIdentity(Set<DbGenderIdentityV2> genderIdentity) {
+    this.genderIdentity = genderIdentity;
+    return this;
+  }
+
+  @Column(name = "gender_other_text")
+  public String getGenderOtherText() {
+    return genderOtherText;
+  }
+
+  public DbDemographicSurveyV2 setGenderOtherText(String genderOtherText) {
+    this.genderOtherText = genderOtherText;
+    return this;
+  }
+
+  @ElementCollection(fetch = FetchType.LAZY)
+  @Enumerated(EnumType.STRING)
+  @CollectionTable(
+      name = "demographic_survey_v2_sexual_orientation",
+      joinColumns = @JoinColumn(name = "demographic_survey_v2_id"))
+  @Column(name = "sexual_orientation")
+  public Set<DbSexualOrientationV2> getSexualOrientation() {
+    return sexualOrientation;
+  }
+
+  public DbDemographicSurveyV2 setSexualOrientation(Set<DbSexualOrientationV2> sexualOrientation) {
+    this.sexualOrientation = sexualOrientation;
+    return this;
+  }
+
+  @Column(name = "orientation_other_text")
+  public String getOrientationOtherText() {
+    return orientationOtherText;
+  }
+
+  public DbDemographicSurveyV2 setOrientationOtherText(String orientationOtherText) {
+    this.orientationOtherText = orientationOtherText;
+    return this;
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "sex_at_birth")
+  public DbSexAtBirthV2 getSexAtBirth() {
+    return sexAtBirth;
+  }
+
+  public DbDemographicSurveyV2 setSexAtBirth(DbSexAtBirthV2 sexAtBirth) {
+    this.sexAtBirth = sexAtBirth;
+    return this;
+  }
+
+  @Column(name = "sex_at_birth_other_text")
+  public String getSexAtBirthOtherText() {
+    return sexAtBirthOtherText;
+  }
+
+  public DbDemographicSurveyV2 setSexAtBirthOtherText(String sexAtBirthOtherText) {
+    this.sexAtBirthOtherText = sexAtBirthOtherText;
+    return this;
+  }
+
+  @Column(name = "year_of_birth")
+  public Long getYearOfBirth() {
+    return yearOfBirth;
+  }
+
+  public DbDemographicSurveyV2 setYearOfBirth(Long yearOfBirth) {
+    this.yearOfBirth = yearOfBirth;
+    return this;
+  }
+
+  @Column(name = "year_of_birth_prefer_not")
+  public Boolean getYearOfBirthPreferNot() {
+    return yearOfBirthPreferNot;
+  }
+
+  public DbDemographicSurveyV2 setYearOfBirthPreferNot(Boolean yearOfBirthPreferNot) {
+    this.yearOfBirthPreferNot = yearOfBirthPreferNot;
+    return this;
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "disability_hearing")
+  public DbYesNoPreferNot getDisabilityHearing() {
+    return disabilityHearing;
+  }
+
+  public DbDemographicSurveyV2 setDisabilityHearing(DbYesNoPreferNot disabilityHearing) {
+    this.disabilityHearing = disabilityHearing;
+    return this;
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "disability_seeing")
+  public DbYesNoPreferNot getDisabilitySeeing() {
+    return disabilitySeeing;
+  }
+
+  public DbDemographicSurveyV2 setDisabilitySeeing(DbYesNoPreferNot disabilitySeeing) {
+    this.disabilitySeeing = disabilitySeeing;
+    return this;
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "disability_concentrating")
+  public DbYesNoPreferNot getDisabilityConcentrating() {
+    return disabilityConcentrating;
+  }
+
+  public DbDemographicSurveyV2 setDisabilityConcentrating(
+      DbYesNoPreferNot disabilityConcentrating) {
+    this.disabilityConcentrating = disabilityConcentrating;
+    return this;
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "disability_walking")
+  public DbYesNoPreferNot getDisabilityWalking() {
+    return disabilityWalking;
+  }
+
+  public DbDemographicSurveyV2 setDisabilityWalking(DbYesNoPreferNot disabilityWalking) {
+    this.disabilityWalking = disabilityWalking;
+    return this;
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "disability_dressing")
+  public DbYesNoPreferNot getDisabilityDressing() {
+    return disabilityDressing;
+  }
+
+  public DbDemographicSurveyV2 setDisabilityDressing(DbYesNoPreferNot disabilityDressing) {
+    this.disabilityDressing = disabilityDressing;
+    return this;
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "disability_errands")
+  public DbYesNoPreferNot getDisabilityErrands() {
+    return disabilityErrands;
+  }
+
+  public DbDemographicSurveyV2 setDisabilityErrands(DbYesNoPreferNot disabilityErrands) {
+    this.disabilityErrands = disabilityErrands;
+    return this;
+  }
+
+  @Column(name = "disability_other_text")
+  public String getDisabilityOtherText() {
+    return disabilityOtherText;
+  }
+
+  public DbDemographicSurveyV2 setDisabilityOtherText(String disabilityOtherText) {
+    this.disabilityOtherText = disabilityOtherText;
+    return this;
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "education")
+  public DbEducation getEducation() {
+    return education;
+  }
+
+  public DbDemographicSurveyV2 setEducation(DbEducation education) {
+    this.education = education;
+    return this;
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "disadvantaged")
+  public DbYesNoPreferNot getDisadvantaged() {
+    return disadvantaged;
+  }
+
+  public DbDemographicSurveyV2 setDisadvantaged(DbYesNoPreferNot disadvantaged) {
+    this.disadvantaged = disadvantaged;
+    return this;
+  }
+
+  public enum DbEthnicCategory {
+    AI_AN,
+    AI_AN_CENTRAL_SOUTH,
+    AI_AN_OTHER,
+    ASIAN,
+    ASIAN_INDIAN,
+    ASIAN_CAMBODIAN,
+    ASIAN_CHINESE,
+    ASIAN_FILIPINO,
+    ASIAN_HMONG,
+    ASIAN_JAPANESE,
+    ASIAN_KOREAN,
+    ASIAN_LAO,
+    ASIAN_PAKISTANI,
+    ASIAN_VIETNAMESE,
+    ASIAN_OTHER,
+    BLACK,
+    HISPANIC,
+    MENA,
+    NHPI,
+    WHITE,
+    OTHER,
+    PREFER_NOT_TO_ANSWER
+  }
+
+  public enum DbGenderIdentityV2 {
+    GENDERQUEER,
+    MAN,
+    NON_BINARY,
+    QUESTIONING,
+    TRANS_MAN,
+    TRANS_WOMAN,
+    TWO_SPIRIT,
+    WOMAN,
+    OTHER,
+    PREFER_NOT_TO_ANSWER
+  }
+
+  public enum DbSexualOrientationV2 {
+    ASEXUAL,
+    BISEXUAL,
+    GAY,
+    LESBIAN,
+    POLYSEXUAL,
+    QUEER,
+    QUESTIONING,
+    SAME_GENDER,
+    STRAIGHT,
+    TWO_SPIRIT,
+    OTHER,
+    PREFER_NOT_TO_ANSWER
+  }
+
+  public enum DbSexAtBirthV2 {
+    FEMALE,
+    INTERSEX,
+    MALE,
+    OTHER,
+    PREFER_NOT_TO_ANSWER
+  }
+
+  public enum DbEducation {
+    NO_EDUCATION,
+    GRADES_1_12,
+    UNDERGRADUATE,
+    COLLEGE_GRADUATE,
+    MASTER,
+    DOCTORATE,
+    PREFER_NO_ANSWER
+  }
+
+  // Swagger auto-translates YES/NO to TRUE/FALSE so we don't really benefit from using YES/NO here
+  public enum DbYesNoPreferNot {
+    TRUE,
+    FALSE,
+    PREFER_NOT_TO_ANSWER
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -78,6 +78,7 @@ public class DbUser {
   private Timestamp eraCommonsLinkExpireTime;
   private String rasLinkLoginGovUsername;
   private DbUserCodeOfConductAgreement duccAgreement;
+  private DbDemographicSurveyV2 demographicSurveyV2;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -399,6 +400,21 @@ public class DbUser {
     this.computeSecuritySuspendedUntil = computeSecuritySuspendedUntil;
     return this;
   }
+
+  @OneToOne(
+      cascade = CascadeType.ALL,
+      orphanRemoval = true,
+      fetch = FetchType.LAZY,
+      mappedBy = "user")
+  public DbDemographicSurveyV2 getDemographicSurveyV2() {
+    return demographicSurveyV2;
+  }
+
+  public DbUser setDemographicSurveyV2(DbDemographicSurveyV2 demographicSurveyV2) {
+    this.demographicSurveyV2 = demographicSurveyV2;
+    return this;
+  }
+
   // null-friendly versions of equals() and hashCode() for DbVerifiedInstitutionalAffiliation
   // can be removed once we have a proper equals() / hashCode()
 

--- a/api/src/main/java/org/pmiops/workbench/profile/DemographicSurveyMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/DemographicSurveyMapper.java
@@ -3,8 +3,10 @@ package org.pmiops.workbench.profile;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
+import org.pmiops.workbench.db.model.DbDemographicSurveyV2;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.model.DemographicSurvey;
+import org.pmiops.workbench.model.DemographicSurveyV2;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
@@ -29,4 +31,19 @@ public interface DemographicSurveyMapper {
   @Mapping(target = "sexAtBirthEnum", source = "sexAtBirth")
   @Mapping(target = "user", ignore = true) // set by UserService.createUser
   DbDemographicSurvey demographicSurveyToDbDemographicSurvey(DemographicSurvey demographicSurvey);
+
+  // DbDemographicSurveyV2 has singular names for these because Hibernate seems to require
+  // that they match the column names in the join tables
+
+  @Mapping(source = "ethnicCategory", target = "ethnicCategories")
+  @Mapping(source = "genderIdentity", target = "genderIdentities")
+  @Mapping(source = "sexualOrientation", target = "sexualOrientations")
+  DemographicSurveyV2 toDemographicSurveyV2(DbDemographicSurveyV2 dbDemographicSurvey);
+
+  @Mapping(source = "ethnicCategories", target = "ethnicCategory")
+  @Mapping(source = "genderIdentities", target = "genderIdentity")
+  @Mapping(source = "sexualOrientations", target = "sexualOrientation")
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "user", ignore = true)
+  DbDemographicSurveyV2 toDbDemographicSurveyV2(DemographicSurveyV2 demographicSurvey);
 }

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
@@ -38,6 +38,7 @@ public interface ProfileMapper {
   @Mapping(source = "dbUser.duccAgreement.signedVersion", target = "duccSignedVersion")
   @Mapping(source = "dbUser.duccAgreement.userInitials", target = "duccSignedInitials")
   @Mapping(source = "dbUser.duccAgreement.completionTime", target = "duccCompletionTimeEpochMillis")
+  @Mapping(source = "dbUser.demographicSurveyV2", target = "demographicSurveyV2")
   Profile toModel(
       DbUser dbUser,
       VerifiedInstitutionalAffiliation verifiedInstitutionalAffiliation,

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -277,11 +277,16 @@ public class ProfileService {
   }
 
   private void populateDemographicSurveyV2(DbUser dbUser, Profile updatedProfile) {
-    DbDemographicSurveyV2 dbDemoSurvey =
+    DbDemographicSurveyV2 newDemoSurvey =
         demographicSurveyMapper.toDbDemographicSurveyV2(updatedProfile.getDemographicSurveyV2());
-    if (dbDemoSurvey != null) {
-      dbUser.setDemographicSurveyV2(dbDemoSurvey);
-      dbDemoSurvey.setUser(dbUser);
+
+    if (newDemoSurvey != null) {
+      DbDemographicSurveyV2 existingSurvey = dbUser.getDemographicSurveyV2();
+      if (existingSurvey != null) {
+        newDemoSurvey.setId(existingSurvey.getId());
+      }
+      dbUser.setDemographicSurveyV2(newDemoSurvey);
+      newDemoSurvey.setUser(dbUser);
     }
   }
 

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -279,10 +279,10 @@ public class ProfileService {
   private void populateDemographicSurveyV2(DbUser dbUser, Profile updatedProfile) {
     DbDemographicSurveyV2 dbDemoSurvey =
         demographicSurveyMapper.toDbDemographicSurveyV2(updatedProfile.getDemographicSurveyV2());
-    if (dbDemoSurvey != null && dbDemoSurvey.getUser() == null) {
+    if (dbDemoSurvey != null) {
+      dbUser.setDemographicSurveyV2(dbDemoSurvey);
       dbDemoSurvey.setUser(dbUser);
     }
-    dbUser.setDemographicSurveyV2(dbDemoSurvey);
   }
 
   // Save the verified institutional affiliation in the DB. The affiliation has already been

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrMapper.java
@@ -22,6 +22,7 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.Degree;
+import org.pmiops.workbench.model.DemographicSurveyV2;
 import org.pmiops.workbench.model.Disability;
 import org.pmiops.workbench.model.Education;
 import org.pmiops.workbench.model.Ethnicity;
@@ -33,6 +34,7 @@ import org.pmiops.workbench.model.SpecificPopulationEnum;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.pmiops.workbench.rdr.model.RdrAccessTier;
 import org.pmiops.workbench.rdr.model.RdrDegree;
+import org.pmiops.workbench.rdr.model.RdrDemographicSurveyV2;
 import org.pmiops.workbench.rdr.model.RdrDisability;
 import org.pmiops.workbench.rdr.model.RdrEducation;
 import org.pmiops.workbench.rdr.model.RdrEthnicity;
@@ -95,6 +97,9 @@ public interface RdrMapper {
   @Mapping(source = "dbUser.demographicSurvey.lgbtqIdentity", target = "lgbtqIdentity")
   @Mapping(source = "dbUser.demographicSurvey.identifiesAsLgbtq", target = "identifiesAsLgbtq")
   @Mapping(source = "accessTiers", target = "accessTierShortNames")
+  // re-enable with feature flag in RW-8355
+  // @Mapping(source = "dbUser.demographicSurveyV2", target = "demographicSurveyV2")
+  @Mapping(ignore = true, target = "demographicSurveyV2")
   RdrResearcher toRdrResearcher(
       DbUser dbUser,
       List<DbAccessTier> accessTiers,
@@ -260,4 +265,6 @@ public interface RdrMapper {
 
     return rdrDemographic;
   }
+
+  RdrDemographicSurveyV2 toDemographicSurveyV2(DemographicSurveyV2 demoSurveyV2);
 }

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrMapper.java
@@ -99,7 +99,6 @@ public interface RdrMapper {
   @Mapping(source = "accessTiers", target = "accessTierShortNames")
   // re-enable with feature flag in RW-8355
   // @Mapping(source = "dbUser.demographicSurveyV2", target = "demographicSurveyV2")
-  @Mapping(ignore = true, target = "demographicSurveyV2")
   RdrResearcher toRdrResearcher(
       DbUser dbUser,
       List<DbAccessTier> accessTiers,

--- a/api/src/main/resources/rdr.yaml
+++ b/api/src/main/resources/rdr.yaml
@@ -534,6 +534,7 @@ definitions:
       - ASIAN_HMONG
       - ASIAN_JAPANESE
       - ASIAN_KOREAN
+      - ASIAN_LAO
       - ASIAN_PAKISTANI
       - ASIAN_VIETNAMESE
       - ASIAN_OTHER           # Asian / None of these fully describe me, and I want to specify

--- a/api/src/main/resources/rdr.yaml
+++ b/api/src/main/resources/rdr.yaml
@@ -325,6 +325,8 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/AccessTier'
+      demographicSurveyV2:
+        $ref: '#/definitions/DemographicSurveyV2'
 
   ResearcherVerifiedInstitutionalAffiliation:
     type: object
@@ -433,3 +435,161 @@ definitions:
       - BA
       - BS
       - BSN
+
+  DemographicSurveyV2:
+    type: object
+    properties:
+      completionTime:
+        type: string
+        format: date-time
+        description: The time the user most recently completed the survey
+      ethnicCategories:
+        type: array
+        items:
+          "$ref": "#/definitions/EthnicCategory"
+      ethnicityAiAnOtherText:
+        type: string
+        description: American Indian or Alaska Native /  None of these fully describe me, and I want to specify.  Max length 200.
+      ethnicityAsianOtherText:
+        type: string
+        description: Asian / None of these fully describe me, and I want to specify.  Max length 200.
+      ethnicityOtherText:
+        type: string
+        description: None of these fully describe me, and I want to specify.  Max length 200.
+      genderIdentities:
+        type: array
+        items:
+          "$ref": "#/definitions/GenderIdentityV2"
+      genderOtherText:
+        type: string
+        description: None of these fully describe me, and I want to specify.  Max length 200.
+      sexualOrientations:
+        type: array
+        items:
+          "$ref": "#/definitions/SexualOrientationV2"
+      orientationOtherText:
+        type: string
+        description: None of these fully describe me, and I want to specify.  Max length 200.
+      sexAtBirth:
+        "$ref": "#/definitions/SexAtBirthV2"
+      sexAtBirthOtherText:
+        type: string
+        description: None of these fully describe me, and I want to specify.  Max length 200.
+      yearOfBirth:
+        type: integer
+      yearOfBirthPreferNot:
+        type: boolean
+      disabilityHearing:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: >
+          Are you deaf or do you have serious difficulty hearing?
+          (Note: Some people who are deaf or have serious difficulty
+          hearing use assistive devices to communicate by phone.)
+      disabilitySeeing:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: Are you blind or do you have serious difficulty seeing, even when wearing glasses?
+      disabilityConcentrating:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: >
+          Because of a physical, cognitive, or emotional condition,
+          do you have serious difficulty concentrating, remembering, or making decisions?
+      disabilityWalking:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: Do you have serious difficulty walking or climbing stairs?
+      disabilityDressing:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: Do you have difficulty dressing or bathing?
+      disabilityErrands:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: >
+          Because of a physical, mental, or emotional condition,
+          do you have difficulty doing errands alone such as visiting
+          a doctor’s office or shopping?
+      disabilityOtherText:
+        type: string
+        description: >
+          Do you have a physical, cognitive, and/or emotional condition that
+          substantially inhibits one or more life activities not specified
+          through the above questions, and want to share more? Please describe.
+      education:
+        "$ref": "#/definitions/Education"
+      disadvantaged:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: >
+          Are you an individual from a disadvantaged background,
+          as defined by NIH Diversity in Extramural Programs?
+
+  EthnicCategory:
+    type: string
+    description: 'Which categories describe you? (Select all that apply). Note, you may select more than one group.'
+    enum:
+      - AI_AN                 # American Indian or Alaska Native (no additional qualifier)
+      - AI_AN_CENTRAL_SOUTH   # American Indian or Alaska Native / Central or South American Indian
+      - AI_AN_OTHER           # American Indian or Alaska Native / None of these fully describe me, and I want to specify
+      - ASIAN
+      - ASIAN_INDIAN
+      - ASIAN_CAMBODIAN
+      - ASIAN_CHINESE
+      - ASIAN_FILIPINO
+      - ASIAN_HMONG
+      - ASIAN_JAPANESE
+      - ASIAN_KOREAN
+      - ASIAN_PAKISTANI
+      - ASIAN_VIETNAMESE
+      - ASIAN_OTHER           # Asian / None of these fully describe me, and I want to specify
+      - BLACK                 # Black, African American, or of African descent
+      - HISPANIC              # Hispanic, Latino, or Spanish descent
+      - MENA                  # Middle Eastern or North African
+      - NHPI                  # Native Hawaiian or other Pacific Islander
+      - WHITE                 # White, or of European descent
+      - OTHER                 # None of these fully describe me, and I want to specify
+      - PREFER_NOT_TO_ANSWER
+
+  GenderIdentityV2:
+    type: string
+    description: 'Which terms best express how you describe your current gender identity? (Select all that apply)'
+    enum:
+      - GENDERQUEER
+      - MAN
+      - NON_BINARY
+      - TRANS_MAN             # Trans man/Transgender man
+      - TRANS_WOMAN           # Trans woman/Transgender woman
+      - TWO_SPIRIT
+      - WOMAN
+      - OTHER                 # None of these fully describe me, and I want to specify
+      - PREFER_NOT_TO_ANSWER
+
+  SexualOrientationV2:
+    type: string
+    description: 'Which terms best express how you describe your current sexual orientation? (Select all that apply)'
+    enum:
+      - ASEXUAL
+      - BISEXUAL
+      - GAY
+      - LESBIAN
+      - POLYSEXUAL            # Polysexual, omnisexual, or pansexual
+      - QUEER
+      - QUESTIONING           # Questioning or unsure of my sexual orientation
+      - SAME_GENDER           # Same-gender loving
+      - STRAIGHT              # Straight or heterosexual
+      - TWO_SPIRIT
+      - OTHER                 # None of these fully describe me, and I want to specify
+      - PREFER_NOT_TO_ANSWER
+
+  SexAtBirthV2:
+    type: string
+    description: 'What was the sex assigned to you at birth, such as on your original birth certificate?'
+    enum:
+      - FEMALE
+      - INTERSEX
+      - MALE
+      - OTHER                 # None of these fully describe me, and I want to specify
+      - PREFER_NOT_TO_ANSWER
+
+  YesNoPreferNot:
+    type: string
+    # note: swagger converts these to TRUE/FALSE!  https://github.com/swagger-api/swagger-parser/issues/1205
+    enum:
+      - YES
+      - NO
+      - PREFER_NOT_TO_ANSWER

--- a/api/src/main/resources/rdr.yaml
+++ b/api/src/main/resources/rdr.yaml
@@ -325,8 +325,6 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/AccessTier'
-      demographicSurveyV2:
-        $ref: '#/definitions/DemographicSurveyV2'
 
   ResearcherVerifiedInstitutionalAffiliation:
     type: object

--- a/api/src/main/resources/rdr.yaml
+++ b/api/src/main/resources/rdr.yaml
@@ -553,6 +553,7 @@ definitions:
       - GENDERQUEER
       - MAN
       - NON_BINARY
+      - QUESTIONING           # Questioning or unsure of my gender identity
       - TRANS_MAN             # Trans man/Transgender man
       - TRANS_WOMAN           # Trans woman/Transgender woman
       - TWO_SPIRIT

--- a/api/src/main/resources/rdr.yaml
+++ b/api/src/main/resources/rdr.yaml
@@ -600,12 +600,9 @@ definitions:
       - DOCTORATE
       - PREFER_NOT_TO_ANSWER
 
-  # Note: Swagger and the YAML standard would auto-convert YES/NO to TRUE/FALSE, so we can't use those values
-  # https://github.com/swagger-api/swagger-parser/issues/1205
-  # https://hitchdev.com/strictyaml/why/implicit-typing-removed/
   YesNoPreferNot:
     type: string
     enum:
-      - TRUE
-      - FALSE
+      - 'YES'   # quotes needed so Swagger/YAML doesn't autoconvert this to "true"
+      - 'NO'    # quotes needed so Swagger/YAML doesn't autoconvert this to "false"
       - PREFER_NOT_TO_ANSWER

--- a/api/src/main/resources/rdr.yaml
+++ b/api/src/main/resources/rdr.yaml
@@ -512,7 +512,7 @@ definitions:
           substantially inhibits one or more life activities not specified
           through the above questions, and want to share more? Please describe.
       education:
-        "$ref": "#/definitions/Education"
+        "$ref": "#/definitions/EducationV2"
       disadvantaged:
         "$ref": "#/definitions/YesNoPreferNot"
         description: >
@@ -588,10 +588,24 @@ definitions:
       - OTHER                 # None of these fully describe me, and I want to specify
       - PREFER_NOT_TO_ANSWER
 
+  EducationV2:
+    type: string
+    description: 'Highest Level of Education Completed'
+    enum:
+      - NO_EDUCATION          # Never attended school/No formal education
+      - GRADES_1_12           # Primary/Middle School/High School (Grades 1 through 12/GED)
+      - UNDERGRADUATE         # Some college, Associate Degree or Technical School (1 to 3 years) or current undergraduate student
+      - COLLEGE_GRADUATE      # College graduate (4 years or more) or current post-graduate trainee
+      - MASTER
+      - DOCTORATE
+      - PREFER_NOT_TO_ANSWER
+
+  # Note: Swagger and the YAML standard would auto-convert YES/NO to TRUE/FALSE, so we can't use those values
+  # https://github.com/swagger-api/swagger-parser/issues/1205
+  # https://hitchdev.com/strictyaml/why/implicit-typing-removed/
   YesNoPreferNot:
     type: string
-    # note: swagger converts these to TRUE/FALSE!  https://github.com/swagger-api/swagger-parser/issues/1205
     enum:
-      - YES
-      - NO
+      - TRUE
+      - FALSE
       - PREFER_NOT_TO_ANSWER

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9583,7 +9583,7 @@ definitions:
           substantially inhibits one or more life activities not specified
           through the above questions, and want to share more? Please describe.
       education:
-        "$ref": "#/definitions/Education"
+        "$ref": "#/definitions/EducationV2"
       disadvantaged:
         "$ref": "#/definitions/YesNoPreferNot"
         description: >
@@ -9655,6 +9655,18 @@ definitions:
       - INTERSEX
       - MALE
       - OTHER                 # None of these fully describe me, and I want to specify
+      - PREFER_NOT_TO_ANSWER
+
+  EducationV2:
+    type: string
+    description: 'Highest Level of Education Completed'
+    enum:
+      - NO_EDUCATION          # Never attended school/No formal education
+      - GRADES_1_12           # Primary/Middle School/High School (Grades 1 through 12/GED)
+      - UNDERGRADUATE         # Some college, Associate Degree or Technical School (1 to 3 years) or current undergraduate student
+      - COLLEGE_GRADUATE      # College graduate (4 years or more) or current post-graduate trainee
+      - MASTER
+      - DOCTORATE
       - PREFER_NOT_TO_ANSWER
 
   YesNoPreferNot:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9671,10 +9671,12 @@ definitions:
       - DOCTORATE
       - PREFER_NOT_TO_ANSWER
 
+  # Note: Swagger and the YAML standard would auto-convert YES/NO to TRUE/FALSE, so we can't use those values
+  # https://github.com/swagger-api/swagger-parser/issues/1205
+  # https://hitchdev.com/strictyaml/why/implicit-typing-removed/
   YesNoPreferNot:
     type: string
-    # note: swagger converts these to TRUE/FALSE!  https://github.com/swagger-api/swagger-parser/issues/1205
     enum:
-      - YES
-      - NO
+      - TRUE
+      - FALSE
       - PREFER_NOT_TO_ANSWER

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -5834,6 +5834,8 @@ definitions:
             description: >
               DEPRECATED - RW-8236. Remove after one cycle. Whether any modules have expired. Expiration information is also included with each
               module in the array; this field is provided for convenience.
+      demographicSurveyV2:
+        $ref: '#/definitions/DemographicSurveyV2'
 
   AccessModuleStatus:
     type: object
@@ -9504,3 +9506,161 @@ definitions:
       eraRequired:
          type: boolean
          description: If eRA Commons linking is required for this access tier.
+
+  DemographicSurveyV2:
+    type: object
+    properties:
+      completionTime:
+        type: string
+        format: date-time
+        description: The time the user most recently completed the survey
+      ethnicCategories:
+        type: array
+        items:
+          "$ref": "#/definitions/EthnicCategory"
+      ethnicityAiAnOtherText:
+        type: string
+        description: American Indian or Alaska Native /  None of these fully describe me, and I want to specify.  Max length 200.
+      ethnicityAsianOtherText:
+        type: string
+        description: Asian / None of these fully describe me, and I want to specify.  Max length 200.
+      ethnicityOtherText:
+        type: string
+        description: None of these fully describe me, and I want to specify.  Max length 200.
+      genderIdentities:
+        type: array
+        items:
+          "$ref": "#/definitions/GenderIdentityV2"
+      genderOtherText:
+        type: string
+        description: None of these fully describe me, and I want to specify.  Max length 200.
+      sexualOrientations:
+        type: array
+        items:
+          "$ref": "#/definitions/SexualOrientationV2"
+      orientationOtherText:
+        type: string
+        description: None of these fully describe me, and I want to specify.  Max length 200.
+      sexAtBirth:
+        "$ref": "#/definitions/SexAtBirthV2"
+      sexAtBirthOtherText:
+        type: string
+        description: None of these fully describe me, and I want to specify.  Max length 200.
+      yearOfBirth:
+        type: integer
+      yearOfBirthPreferNot:
+        type: boolean
+      disabilityHearing:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: >
+          Are you deaf or do you have serious difficulty hearing?
+          (Note: Some people who are deaf or have serious difficulty
+          hearing use assistive devices to communicate by phone.)
+      disabilitySeeing:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: Are you blind or do you have serious difficulty seeing, even when wearing glasses?
+      disabilityConcentrating:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: >
+          Because of a physical, cognitive, or emotional condition,
+          do you have serious difficulty concentrating, remembering, or making decisions?
+      disabilityWalking:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: Do you have serious difficulty walking or climbing stairs?
+      disabilityDressing:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: Do you have difficulty dressing or bathing?
+      disabilityErrands:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: >
+          Because of a physical, mental, or emotional condition,
+          do you have difficulty doing errands alone such as visiting
+          a doctor’s office or shopping?
+      disabilityOtherText:
+        type: string
+        description: >
+          Do you have a physical, cognitive, and/or emotional condition that
+          substantially inhibits one or more life activities not specified
+          through the above questions, and want to share more? Please describe.
+      education:
+        "$ref": "#/definitions/Education"
+      disadvantaged:
+        "$ref": "#/definitions/YesNoPreferNot"
+        description: >
+          Are you an individual from a disadvantaged background,
+          as defined by NIH Diversity in Extramural Programs?
+
+  EthnicCategory:
+    type: string
+    description: 'Which categories describe you? (Select all that apply). Note, you may select more than one group.'
+    enum:
+      - AI_AN                 # American Indian or Alaska Native (no additional qualifier)
+      - AI_AN_CENTRAL_SOUTH   # American Indian or Alaska Native / Central or South American Indian
+      - AI_AN_OTHER           # American Indian or Alaska Native / None of these fully describe me, and I want to specify
+      - ASIAN
+      - ASIAN_INDIAN
+      - ASIAN_CAMBODIAN
+      - ASIAN_CHINESE
+      - ASIAN_FILIPINO
+      - ASIAN_HMONG
+      - ASIAN_JAPANESE
+      - ASIAN_KOREAN
+      - ASIAN_PAKISTANI
+      - ASIAN_VIETNAMESE
+      - ASIAN_OTHER           # Asian / None of these fully describe me, and I want to specify
+      - BLACK                 # Black, African American, or of African descent
+      - HISPANIC              # Hispanic, Latino, or Spanish descent
+      - MENA                  # Middle Eastern or North African
+      - NHPI                  # Native Hawaiian or other Pacific Islander
+      - WHITE                 # White, or of European descent
+      - OTHER                 # None of these fully describe me, and I want to specify
+      - PREFER_NOT_TO_ANSWER
+
+  GenderIdentityV2:
+    type: string
+    description: 'Which terms best express how you describe your current gender identity? (Select all that apply)'
+    enum:
+      - GENDERQUEER
+      - MAN
+      - NON_BINARY
+      - TRANS_MAN             # Trans man/Transgender man
+      - TRANS_WOMAN           # Trans woman/Transgender woman
+      - TWO_SPIRIT
+      - WOMAN
+      - OTHER                 # None of these fully describe me, and I want to specify
+      - PREFER_NOT_TO_ANSWER
+
+  SexualOrientationV2:
+    type: string
+    description: 'Which terms best express how you describe your current sexual orientation? (Select all that apply)'
+    enum:
+      - ASEXUAL
+      - BISEXUAL
+      - GAY
+      - LESBIAN
+      - POLYSEXUAL            # Polysexual, omnisexual, or pansexual
+      - QUEER
+      - QUESTIONING           # Questioning or unsure of my sexual orientation
+      - SAME_GENDER           # Same-gender loving
+      - STRAIGHT              # Straight or heterosexual
+      - TWO_SPIRIT
+      - OTHER                 # None of these fully describe me, and I want to specify
+      - PREFER_NOT_TO_ANSWER
+
+  SexAtBirthV2:
+    type: string
+    description: 'What was the sex assigned to you at birth, such as on your original birth certificate?'
+    enum:
+      - FEMALE
+      - INTERSEX
+      - MALE
+      - OTHER                 # None of these fully describe me, and I want to specify
+      - PREFER_NOT_TO_ANSWER
+
+  YesNoPreferNot:
+    type: string
+    # note: swagger converts these to TRUE/FALSE!  https://github.com/swagger-api/swagger-parser/issues/1205
+    enum:
+      - YES
+      - NO
+      - PREFER_NOT_TO_ANSWER

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9624,6 +9624,7 @@ definitions:
       - GENDERQUEER
       - MAN
       - NON_BINARY
+      - QUESTIONING           # Questioning or unsure of my gender identity
       - TRANS_MAN             # Trans man/Transgender man
       - TRANS_WOMAN           # Trans woman/Transgender woman
       - TWO_SPIRIT

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9605,6 +9605,7 @@ definitions:
       - ASIAN_HMONG
       - ASIAN_JAPANESE
       - ASIAN_KOREAN
+      - ASIAN_LAO
       - ASIAN_PAKISTANI
       - ASIAN_VIETNAMESE
       - ASIAN_OTHER           # Asian / None of these fully describe me, and I want to specify

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9671,12 +9671,9 @@ definitions:
       - DOCTORATE
       - PREFER_NOT_TO_ANSWER
 
-  # Note: Swagger and the YAML standard would auto-convert YES/NO to TRUE/FALSE, so we can't use those values
-  # https://github.com/swagger-api/swagger-parser/issues/1205
-  # https://hitchdev.com/strictyaml/why/implicit-typing-removed/
   YesNoPreferNot:
     type: string
     enum:
-      - TRUE
-      - FALSE
+      - 'YES'   # quotes needed so Swagger/YAML doesn't autoconvert this to "true"
+      - 'NO'    # quotes needed so Swagger/YAML doesn't autoconvert this to "false"
       - PREFER_NOT_TO_ANSWER

--- a/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
@@ -47,7 +47,7 @@ import org.pmiops.workbench.model.Address;
 import org.pmiops.workbench.model.AdminTableUser;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.DemographicSurveyV2;
-import org.pmiops.workbench.model.Education;
+import org.pmiops.workbench.model.EducationV2;
 import org.pmiops.workbench.model.EthnicCategory;
 import org.pmiops.workbench.model.GenderIdentityV2;
 import org.pmiops.workbench.model.InstitutionalRole;
@@ -545,7 +545,7 @@ public class ProfileServiceTest {
             .yearOfBirthPreferNot(true)
             .disabilityHearing(YesNoPreferNot.FALSE)
             .disabilitySeeing(YesNoPreferNot.TRUE)
-            .education(Education.DOCTORATE)
+            .education(EducationV2.DOCTORATE)
             .disadvantaged(YesNoPreferNot.PREFER_NOT_TO_ANSWER);
 
     Profile previousProfile = createValidProfile();
@@ -577,7 +577,7 @@ public class ProfileServiceTest {
             .yearOfBirthPreferNot(true)
             .disabilityHearing(YesNoPreferNot.FALSE)
             .disabilitySeeing(YesNoPreferNot.TRUE)
-            .education(Education.DOCTORATE)
+            .education(EducationV2.DOCTORATE)
             .disadvantaged(YesNoPreferNot.PREFER_NOT_TO_ANSWER);
 
     DemographicSurveyV2 updatedV2Survey =
@@ -589,7 +589,7 @@ public class ProfileServiceTest {
             .yearOfBirth(1995)
             .disabilityHearing(YesNoPreferNot.FALSE)
             .disabilitySeeing(YesNoPreferNot.FALSE)
-            .education(Education.PREFER_NO_ANSWER)
+            .education(EducationV2.PREFER_NOT_TO_ANSWER)
             .disadvantaged(YesNoPreferNot.FALSE);
 
     Profile previousProfile = createValidProfile().demographicSurveyV2(v2Survey);

--- a/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
@@ -543,8 +543,8 @@ public class ProfileServiceTest {
             .sexualOrientations(ImmutableList.of(SexualOrientationV2.QUEER))
             .sexAtBirth(SexAtBirthV2.PREFER_NOT_TO_ANSWER)
             .yearOfBirthPreferNot(true)
-            .disabilityHearing(YesNoPreferNot.FALSE)
-            .disabilitySeeing(YesNoPreferNot.TRUE)
+            .disabilityHearing(YesNoPreferNot.NO)
+            .disabilitySeeing(YesNoPreferNot.YES)
             .education(EducationV2.DOCTORATE)
             .disadvantaged(YesNoPreferNot.PREFER_NOT_TO_ANSWER);
 
@@ -575,8 +575,8 @@ public class ProfileServiceTest {
             .sexualOrientations(ImmutableList.of(SexualOrientationV2.QUEER))
             .sexAtBirth(SexAtBirthV2.PREFER_NOT_TO_ANSWER)
             .yearOfBirthPreferNot(true)
-            .disabilityHearing(YesNoPreferNot.FALSE)
-            .disabilitySeeing(YesNoPreferNot.TRUE)
+            .disabilityHearing(YesNoPreferNot.NO)
+            .disabilitySeeing(YesNoPreferNot.YES)
             .education(EducationV2.DOCTORATE)
             .disadvantaged(YesNoPreferNot.PREFER_NOT_TO_ANSWER);
 
@@ -587,10 +587,10 @@ public class ProfileServiceTest {
             .sexualOrientations(ImmutableList.of(SexualOrientationV2.PREFER_NOT_TO_ANSWER))
             .sexAtBirth(SexAtBirthV2.FEMALE)
             .yearOfBirth(1995)
-            .disabilityHearing(YesNoPreferNot.FALSE)
-            .disabilitySeeing(YesNoPreferNot.FALSE)
+            .disabilityHearing(YesNoPreferNot.NO)
+            .disabilitySeeing(YesNoPreferNot.NO)
             .education(EducationV2.PREFER_NOT_TO_ANSWER)
-            .disadvantaged(YesNoPreferNot.FALSE);
+            .disadvantaged(YesNoPreferNot.NO);
 
     Profile previousProfile = createValidProfile().demographicSurveyV2(v2Survey);
     Profile updatedProfile = createValidProfile().demographicSurveyV2(updatedV2Survey);


### PR DESCRIPTION
Tested locally by manually setting DB fields and observing Profile responses.  Unit tests confirm that updateProfile() updates the survey.

Incorporates most of #6675 

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
