### PR TITLE
[RW-8375][risk=no] Change CohortReviewDao to return collection of reviews

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
@@ -158,7 +158,11 @@ public class CohortReviewServiceImpl implements CohortReviewService, GaugeDataCo
   @Override
   public CohortReview findCohortReview(Long cohortId, Long cdrVersionId) {
     DbCohortReview cohortReview =
-        cohortReviewDao.findCohortReviewByCohortIdAndCdrVersionId(cohortId, cdrVersionId);
+        cohortReviewDao
+            .findCohortReviewByCohortIdAndCdrVersionIdOrderByCohortReviewId(cohortId, cdrVersionId)
+            .stream()
+            .findFirst()
+            .orElse(null);
 
     if (cohortReview == null) {
       throw new NotFoundException(
@@ -377,7 +381,8 @@ public class CohortReviewServiceImpl implements CohortReviewService, GaugeDataCo
   public List<ParticipantCohortAnnotation> findParticipantCohortAnnotations(
       Long cohortReviewId, Long participantId) {
     return participantCohortAnnotationDao
-        .findByCohortReviewIdAndParticipantId(cohortReviewId, participantId).stream()
+        .findByCohortReviewIdAndParticipantId(cohortReviewId, participantId)
+        .stream()
         .map(participantCohortAnnotationMapper::dbModelToClient)
         .collect(Collectors.toList());
   }

--- a/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortreview/CohortReviewServiceImpl.java
@@ -381,8 +381,7 @@ public class CohortReviewServiceImpl implements CohortReviewService, GaugeDataCo
   public List<ParticipantCohortAnnotation> findParticipantCohortAnnotations(
       Long cohortReviewId, Long participantId) {
     return participantCohortAnnotationDao
-        .findByCohortReviewIdAndParticipantId(cohortReviewId, participantId)
-        .stream()
+        .findByCohortReviewIdAndParticipantId(cohortReviewId, participantId).stream()
         .map(participantCohortAnnotationMapper::dbModelToClient)
         .collect(Collectors.toList());
   }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/CohortReviewDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/CohortReviewDao.java
@@ -11,7 +11,7 @@ public interface CohortReviewDao extends JpaRepository<DbCohortReview, Long> {
 
   Set<DbCohortReview> findAllByCohortId(long cohortId);
 
-  DbCohortReview findCohortReviewByCohortIdAndCdrVersionId(
+  List<DbCohortReview> findCohortReviewByCohortIdAndCdrVersionIdOrderByCohortReviewId(
       @Param("cohortId") long cohortId, @Param("cdrVersionId") long cdrVersionId);
 
   DbCohortReview findCohortReviewByCohortReviewId(@Param("cohortReviewId") long cohortReviewId);

--- a/api/src/test/java/org/pmiops/workbench/db/dao/CohortReviewDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/CohortReviewDaoTest.java
@@ -27,7 +27,6 @@ public class CohortReviewDaoTest {
   @Autowired CohortDao cohortDao;
   @Autowired CohortReviewDao cohortReviewDao;
   private DbCohortReview cohortReview;
-  private DbCohortReview anotherCohortReview;
   private long cohortId;
 
   @BeforeEach
@@ -40,7 +39,7 @@ public class CohortReviewDaoTest {
     cohort.setWorkspaceId(workspaceDao.save(workspace).getWorkspaceId());
     cohortId = cohortDao.save(cohort).getCohortId();
     cohortReview = cohortReviewDao.save(createCohortReview());
-    anotherCohortReview = cohortReviewDao.save(createCohortReview());
+    cohortReviewDao.save(createCohortReview());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/CohortReviewDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/CohortReviewDaoTest.java
@@ -27,6 +27,7 @@ public class CohortReviewDaoTest {
   @Autowired CohortDao cohortDao;
   @Autowired CohortReviewDao cohortReviewDao;
   private DbCohortReview cohortReview;
+  private DbCohortReview anotherCohortReview;
   private long cohortId;
 
   @BeforeEach
@@ -39,6 +40,7 @@ public class CohortReviewDaoTest {
     cohort.setWorkspaceId(workspaceDao.save(workspace).getWorkspaceId());
     cohortId = cohortDao.save(cohort).getCohortId();
     cohortReview = cohortReviewDao.save(createCohortReview());
+    anotherCohortReview = cohortReviewDao.save(createCohortReview());
   }
 
   @Test
@@ -57,10 +59,14 @@ public class CohortReviewDaoTest {
   }
 
   @Test
-  public void findCohortReviewByCohortIdAndCdrVersionId() {
+  public void findCohortReviewByCohortIdAndCdrVersionIdOrderByCohortReviewId() {
     assertThat(
-            cohortReviewDao.findCohortReviewByCohortIdAndCdrVersionId(
-                cohortReview.getCohortId(), cohortReview.getCdrVersionId()))
+            cohortReviewDao
+                .findCohortReviewByCohortIdAndCdrVersionIdOrderByCohortReviewId(
+                    cohortReview.getCohortId(), cohortReview.getCdrVersionId())
+                .stream()
+                .findFirst()
+                .orElse(null))
         .isEqualTo(cohortReview);
   }
 


### PR DESCRIPTION
Change CohortReviewDao to return collection of reviews. The service layer will still return the first item on the collection, but this change is only to support the feature flag. This service method will be removed after go live of multiple cohort reviews.


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
