### PR TITLE
[risk=low][RW-8355] Export Demo Survey V2 to RDR but disable via Feature Flag

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -122,7 +122,8 @@
   "rdrExport": {
     "host": "pmi-drc-api-test.appspot.com",
     "queueName": "rdrExportQueue",
-    "exportObjectsPerTask": 10
+    "exportObjectsPerTask": 10,
+    "exportDemoSurveyV2": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -122,7 +122,8 @@
   "rdrExport": {
     "host": "pmi-drc-api-test.appspot.com",
     "queueName": "rdrExportQueue",
-    "exportObjectsPerTask": 10
+    "exportObjectsPerTask": 10,
+    "exportDemoSurveyV2": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -122,7 +122,8 @@
   "rdrExport": {
     "host": "all-of-us-rdr-prod.appspot.com",
     "queueName": "rdrExportQueue",
-    "exportObjectsPerTask": 10
+    "exportObjectsPerTask": 10,
+    "exportDemoSurveyV2": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -122,7 +122,8 @@
   "rdrExport": {
     "host": "all-of-us-rdr-stable.appspot.com",
     "queueName": "rdrExportQueue",
-    "exportObjectsPerTask": 10
+    "exportObjectsPerTask": 10,
+    "exportDemoSurveyV2": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -122,7 +122,8 @@
   "rdrExport": {
     "host": "all-of-us-rdr-staging.appspot.com",
     "queueName": "rdrExportQueue",
-    "exportObjectsPerTask": 10
+    "exportObjectsPerTask": 10,
+    "exportDemoSurveyV2": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -122,7 +122,8 @@
   "rdrExport": {
     "host": "pmi-drc-api-test.appspot.com",
     "queueName": "rdrExportQueue",
-    "exportObjectsPerTask": 10
+    "exportObjectsPerTask": 10,
+    "exportDemoSurveyV2": false
   },
   "captcha": {
     "enableCaptcha": true,

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -329,6 +329,8 @@ public class WorkbenchConfig {
     public String queueName;
     // Number of ids per task
     public Integer exportObjectsPerTask;
+    // feature flag: do we export V2 of the Demographic Survey to RDR
+    public boolean exportDemoSurveyV2;
   }
 
   public static class CaptchaConfig {

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -248,7 +248,7 @@ public class ProfileService {
     Optional.ofNullable(user.getAddress()).ifPresent(address -> address.setUser(user));
 
     populateDemographicSurvey(user, updatedProfile, now);
-    populateDemographicSurveyV2(user, updatedProfile);
+    populateDemographicSurveyV2(user, updatedProfile, now);
 
     // save user, update institution, and synchronize access tiers
     DbUser updatedUser =
@@ -276,7 +276,8 @@ public class ProfileService {
     user.setDemographicSurvey(dbDemographicSurvey);
   }
 
-  private void populateDemographicSurveyV2(DbUser dbUser, Profile updatedProfile) {
+  private void populateDemographicSurveyV2(
+      DbUser dbUser, Profile updatedProfile, Timestamp lastModifiedTime) {
     DbDemographicSurveyV2 newDemoSurvey =
         demographicSurveyMapper.toDbDemographicSurveyV2(updatedProfile.getDemographicSurveyV2());
 
@@ -286,6 +287,10 @@ public class ProfileService {
         newDemoSurvey.setId(existingSurvey.getId());
       }
       dbUser.setDemographicSurveyV2(newDemoSurvey);
+      // needed to trigger an RDR Export refresh for this Researcher
+      dbUser.setLastModifiedTime(lastModifiedTime);
+
+      // TODO: needed, or does Hibernate take care of both sides of this connection?
       newDemoSurvey.setUser(dbUser);
     }
   }

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -135,7 +135,7 @@ public class RdrExportServiceImpl implements RdrExportService {
    * @param userIds
    */
   @Override
-  public void exportUsers(List<Long> userId, boolean backfill) {
+  public void exportUsers(List<Long> userIds, boolean backfill) {
     try {
       rdrApiProvider
           .get()

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -133,19 +133,15 @@ public class RdrExportServiceImpl implements RdrExportService {
    * table with current date as the lastExport date
    *
    * @param userIds
+   * @param backfill
    */
   @Override
   public void exportUsers(List<Long> userIds, boolean backfill) {
-    try {
-      rdrApiProvider
-          .get()
-          .exportResearchers(
-              userIds.stream().map(this::toRdrResearcher).collect(Collectors.toList()), backfill);
+    List<RdrResearcher> rdrResearchersList =
+        userIds.stream().map(this::toRdrResearcher).collect(Collectors.toList());
 
-      if (!backfill) {
-        updateDbRdrExport(RdrEntity.USER, userIds);
-      }
-      log.info(String.format("successfully exported researcher data for user IDs: %s", userIds));
+    try {
+      rdrApiProvider.get().exportResearchers(rdrResearchersList, backfill);
     } catch (ApiException ex) {
       log.severe(
           String.format(
@@ -153,6 +149,11 @@ public class RdrExportServiceImpl implements RdrExportService {
               userIds, ex.getResponseBody()));
       throw new ServerErrorException(ex);
     }
+
+    if (!backfill) {
+      updateDbRdrExport(RdrEntity.USER, userIds);
+    }
+    log.info(String.format("successfully exported researcher data for user IDs: %s", userIds));
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -41,45 +41,44 @@ import org.springframework.stereotype.Service;
 @Service
 public class RdrExportServiceImpl implements RdrExportService {
 
-  private final AccessTierService accessTierService;
   private final Clock clock;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final Provider<RdrApi> rdrApiProvider;
-  private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final RdrExportDao rdrExportDao;
-  private final RdrMapper rdrMapper;
-  private final UserDao userDao;
-  private final VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
   private final WorkspaceDao workspaceDao;
-  private final WorkspaceService workspaceService;
+  private final UserDao userDao;
 
+  private final InstitutionService institutionService;
+  private final AccessTierService accessTierService;
+  private final WorkspaceService workspaceService;
+  private final VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
+  private final RdrMapper rdrMapper;
   private static final Logger log = Logger.getLogger(RdrExportService.class.getName());
 
   @Autowired
   public RdrExportServiceImpl(
-      AccessTierService accessTierService,
       Clock clock,
       Provider<WorkbenchConfig> workbenchConfigProvider,
       Provider<RdrApi> rdrApiProvider,
-      Provider<WorkbenchConfig> workbenchConfigProvider,
       RdrExportDao rdrExportDao,
       RdrMapper rdrMapper,
-      UserDao userDao,
       WorkspaceDao workspaceDao,
+      InstitutionService institutionService,
+      AccessTierService accessTierService,
       WorkspaceService workspaceService,
+      UserDao userDao,
       VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao) {
-    this.accessTierService = accessTierService;
     this.clock = clock;
     this.workbenchConfigProvider = workbenchConfigProvider;
     this.rdrExportDao = rdrExportDao;
     this.rdrApiProvider = rdrApiProvider;
-    this.rdrExportDao = rdrExportDao;
     this.rdrMapper = rdrMapper;
+    this.workspaceDao = workspaceDao;
+    this.institutionService = institutionService;
+    this.accessTierService = accessTierService;
+    this.workspaceService = workspaceService;
     this.userDao = userDao;
     this.verifiedInstitutionalAffiliationDao = verifiedInstitutionalAffiliationDao;
-    this.workbenchConfigProvider = workbenchConfigProvider;
-    this.workspaceDao = workspaceDao;
-    this.workspaceService = workspaceService;
   }
 
   private List<String> excludedExportUserEmails() {

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrMapper.java
@@ -18,7 +18,6 @@ import org.mapstruct.MappingConstants;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.ValueMapping;
 import org.pmiops.workbench.db.model.DbAccessTier;
-import org.pmiops.workbench.db.model.DbDemographicSurveyV2;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.db.model.DbWorkspace;
@@ -33,6 +32,7 @@ import org.pmiops.workbench.model.Race;
 import org.pmiops.workbench.model.SexAtBirth;
 import org.pmiops.workbench.model.SpecificPopulationEnum;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
+import org.pmiops.workbench.profile.DemographicSurveyMapper;
 import org.pmiops.workbench.rdr.model.RdrAccessTier;
 import org.pmiops.workbench.rdr.model.RdrDegree;
 import org.pmiops.workbench.rdr.model.RdrDemographicSurveyV2;
@@ -50,7 +50,7 @@ import org.pmiops.workbench.rdr.model.RdrWorkspaceDemographic.AgeEnum;
 import org.pmiops.workbench.rdr.model.RdrWorkspaceDemographic.RaceEthnicityEnum;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
-@Mapper(config = MapStructConfig.class)
+@Mapper(config = MapStructConfig.class, uses = DemographicSurveyMapper.class)
 public interface RdrMapper {
   ZoneOffset offset = OffsetDateTime.now().getOffset();
 
@@ -265,14 +265,8 @@ public interface RdrMapper {
     return rdrDemographic;
   }
 
-  // DbDemographicSurveyV2 has singular names for these because Hibernate seems to require
-  // that they match the column names in the join tables
+  RdrDemographicSurveyV2 toDemographicSurveyV2(DemographicSurveyV2 demoSurveyV2);
 
-  @Mapping(source = "ethnicCategory", target = "ethnicCategories")
-  @Mapping(source = "genderIdentity", target = "genderIdentities")
-  @Mapping(source = "sexualOrientation", target = "sexualOrientations")
-  RdrDemographicSurveyV2 toDemographicSurveyV2(DbDemographicSurveyV2 demoSurveyV2);
-}
   // for round trip testing only
   DemographicSurveyV2 toModelDemographicSurveyV2(RdrDemographicSurveyV2 demoSurveyV2);
 }

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrMapper.java
@@ -18,6 +18,7 @@ import org.mapstruct.MappingConstants;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.ValueMapping;
 import org.pmiops.workbench.db.model.DbAccessTier;
+import org.pmiops.workbench.db.model.DbDemographicSurveyV2;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.db.model.DbWorkspace;
@@ -97,8 +98,7 @@ public interface RdrMapper {
   @Mapping(source = "dbUser.demographicSurvey.lgbtqIdentity", target = "lgbtqIdentity")
   @Mapping(source = "dbUser.demographicSurvey.identifiesAsLgbtq", target = "identifiesAsLgbtq")
   @Mapping(source = "accessTiers", target = "accessTierShortNames")
-  // re-enable with feature flag in RW-8355
-  // @Mapping(source = "dbUser.demographicSurveyV2", target = "demographicSurveyV2")
+  @Mapping(source = "dbUser.demographicSurveyV2", target = "demographicSurveyV2")
   RdrResearcher toRdrResearcher(
       DbUser dbUser,
       List<DbAccessTier> accessTiers,
@@ -265,8 +265,14 @@ public interface RdrMapper {
     return rdrDemographic;
   }
 
-  RdrDemographicSurveyV2 toDemographicSurveyV2(DemographicSurveyV2 demoSurveyV2);
+  // DbDemographicSurveyV2 has singular names for these because Hibernate seems to require
+  // that they match the column names in the join tables
 
+  @Mapping(source = "ethnicCategory", target = "ethnicCategories")
+  @Mapping(source = "genderIdentity", target = "genderIdentities")
+  @Mapping(source = "sexualOrientation", target = "sexualOrientations")
+  RdrDemographicSurveyV2 toDemographicSurveyV2(DbDemographicSurveyV2 demoSurveyV2);
+}
   // for round trip testing only
   DemographicSurveyV2 toModelDemographicSurveyV2(RdrDemographicSurveyV2 demoSurveyV2);
 }

--- a/api/src/main/resources/rdr.yaml
+++ b/api/src/main/resources/rdr.yaml
@@ -329,6 +329,8 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/AccessTier'
+      demographicSurveyV2:
+        $ref: '#/definitions/DemographicSurveyV2'
 
   ResearcherVerifiedInstitutionalAffiliation:
     type: object

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -115,7 +115,6 @@ public class RdrExportServiceImplTest {
   @BeforeEach
   public void setUp() {
     workbenchConfig.auth.serviceAccountApiUsers = ImmutableList.of("appspot@gserviceaccount.com");
-    workbenchConfig.rdrExport.exportDemoSurveyV2 = false;
 
     rdrExportService = spy(rdrExportService);
     when(mockAccessTierService.getAccessTiersForUser(any())).thenReturn(ImmutableList.of());

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -100,6 +100,7 @@ public class RdrExportServiceImplTest {
     WorkbenchConfig workbenchConfig() {
       WorkbenchConfig workbenchConfig = WorkbenchConfig.createEmptyConfig();
       workbenchConfig.auth.serviceAccountApiUsers = ImmutableList.of("appspot@gserviceaccount.com");
+      workbenchConfig.rdrExport.exportDemoSurveyV2 = false;
       return workbenchConfig;
     }
   }

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -43,6 +43,7 @@ import org.pmiops.workbench.model.InstitutionalRole;
 import org.pmiops.workbench.model.RdrEntity;
 import org.pmiops.workbench.model.SpecificPopulationEnum;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
+import org.pmiops.workbench.profile.DemographicSurveyMapperImpl;
 import org.pmiops.workbench.rdr.api.RdrApi;
 import org.pmiops.workbench.rdr.model.RdrWorkspace;
 import org.pmiops.workbench.rdr.model.RdrWorkspaceCreator;
@@ -84,6 +85,7 @@ public class RdrExportServiceImplTest {
   @Import({
     FakeClockConfiguration.class,
     FakeJpaDateTimeConfiguration.class,
+    DemographicSurveyMapperImpl.class,
     RdrExportServiceImpl.class,
     RdrMapperImpl.class
   })

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrMapperTest.java
@@ -30,6 +30,7 @@ import org.pmiops.workbench.model.InstitutionalRole;
 import org.pmiops.workbench.model.Race;
 import org.pmiops.workbench.model.SexAtBirth;
 import org.pmiops.workbench.model.SpecificPopulationEnum;
+import org.pmiops.workbench.profile.DemographicSurveyMapperImpl;
 import org.pmiops.workbench.rdr.model.RdrAccessTier;
 import org.pmiops.workbench.rdr.model.RdrDegree;
 import org.pmiops.workbench.rdr.model.RdrDemographicSurveyV2;
@@ -67,7 +68,10 @@ public class RdrMapperTest {
   private static final Timestamp TIME2 = Timestamp.from(Instant.parse("2001-06-01T00:00:00.00Z"));
 
   @TestConfiguration
-  @Import(RdrMapperImpl.class)
+  @Import({
+    DemographicSurveyMapperImpl.class,
+    RdrMapperImpl.class,
+  })
   static class Configuration {}
 
   private @Autowired RdrMapper rdrMapper;


### PR DESCRIPTION
Add RDR Export of the Demo Survey V2 but DO NOT ENABLE because the RDR team isn't ready for it on Test yet.  We'll turn that on in #6778

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
