### PR TITLE
[RW-8327][risk=no] Handle the runtime error state on notebook pages

### DIFF
--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -207,8 +207,8 @@ export const InteractiveNotebook = fp.flow(
         );
         onRuntimeReady();
       } catch (e) {
+        this.setState({ userRequestedExecutableNotebook: false });
         if (e instanceof InitialRuntimeNotFoundError) {
-          this.setState({ userRequestedExecutableNotebook: false });
           // By awaiting the promise here, we're effectively blocking on the
           // user's input to the runtime intializer modal. We invoke this
           // callback with the targetRuntime configuration, or null if the user

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -16,13 +16,20 @@ import { ConfirmPlaygroundModeModal } from 'app/pages/analysis/confirm-playgroun
 import { NotebookInUseModal } from 'app/pages/analysis/notebook-in-use-modal';
 import { notebooksApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
-import { hasNewValidProps, reactStyles, withCurrentWorkspace } from 'app/utils';
+import {
+  cond,
+  hasNewValidProps,
+  reactStyles,
+  withCurrentWorkspace,
+} from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { InitialRuntimeNotFoundError } from 'app/utils/leo-runtime-initializer';
 import { NavigationProps } from 'app/utils/navigation';
 import {
   ComputeSecuritySuspendedError,
   maybeInitializeRuntime,
+  RUNTIME_ERROR_STATUS_MESSAGE_SHORT,
+  RuntimeStatusError,
   withRuntimeStore,
 } from 'app/utils/runtime-utils';
 import { MatchParams, profileStore, RuntimeStore } from 'app/utils/stores';
@@ -200,8 +207,8 @@ export const InteractiveNotebook = fp.flow(
         );
         onRuntimeReady();
       } catch (e) {
-        this.setState({ userRequestedExecutableNotebook: false });
         if (e instanceof InitialRuntimeNotFoundError) {
+          this.setState({ userRequestedExecutableNotebook: false });
           // By awaiting the promise here, we're effectively blocking on the
           // user's input to the runtime intializer modal. We invoke this
           // callback with the targetRuntime configuration, or null if the user
@@ -360,6 +367,13 @@ export const InteractiveNotebook = fp.flow(
             </NotebookFrameError>
           );
         }
+        if (error instanceof RuntimeStatusError) {
+          return (
+            <NotebookFrameError errorMode={ErrorMode.ERROR}>
+              {RUNTIME_ERROR_STATUS_MESSAGE_SHORT}
+            </NotebookFrameError>
+          );
+        }
         const status = error instanceof Response ? error.status : 500;
         if (status === 412) {
           return (
@@ -412,57 +426,64 @@ export const InteractiveNotebook = fp.flow(
             <div style={{ ...styles.navBarItem, ...styles.active }}>
               Preview (Read-Only)
             </div>
-            {userRequestedExecutableNotebook && !error ? (
-              <div style={{ ...styles.navBarItem, textTransform: 'none' }}>
-                <ClrIcon
-                  shape='sync'
-                  style={{ ...styles.navBarIcon, ...styles.rotate }}
-                />
-                {this.renderNotebookText()}
-              </div>
-            ) : (
-              <div style={{ display: 'flex' }}>
-                <TooltipTrigger
-                  content={
-                    this.billingLocked && ACTION_DISABLED_INVALID_BILLING
-                  }
-                >
-                  <div
-                    style={this.buttonStyleObj}
-                    onClick={() => {
-                      AnalyticsTracker.Notebooks.Edit();
-                      this.startEditMode();
-                    }}
-                  >
-                    <EditComponentReact
-                      enableHoverEffect={false}
-                      disabled={!this.canStartRuntimes}
-                      style={styles.navBarIcon}
+            {cond(
+              [!!error, () => null],
+              [
+                userRequestedExecutableNotebook,
+                () => (
+                  <div style={{ ...styles.navBarItem, textTransform: 'none' }}>
+                    <ClrIcon
+                      shape='sync'
+                      style={{ ...styles.navBarIcon, ...styles.rotate }}
                     />
-                    Edit {this.notebookInUse && '(In Use)'}
+                    {this.renderNotebookText()}
                   </div>
-                </TooltipTrigger>
-                <TooltipTrigger
-                  content={
-                    this.billingLocked && ACTION_DISABLED_INVALID_BILLING
-                  }
-                >
-                  <div
-                    style={this.buttonStyleObj}
-                    onClick={() => {
-                      AnalyticsTracker.Notebooks.Run();
-                      this.onPlaygroundModeClick();
-                    }}
+                ),
+              ],
+              () => (
+                <div style={{ display: 'flex' }}>
+                  <TooltipTrigger
+                    content={
+                      this.billingLocked && ACTION_DISABLED_INVALID_BILLING
+                    }
                   >
-                    <IconButton
-                      icon={PlaygroundIcon}
-                      disabled={!this.canStartRuntimes}
-                      style={styles.navBarIcon}
-                    />
-                    Run (Playground Mode)
-                  </div>
-                </TooltipTrigger>
-              </div>
+                    <div
+                      style={this.buttonStyleObj}
+                      onClick={() => {
+                        AnalyticsTracker.Notebooks.Edit();
+                        this.startEditMode();
+                      }}
+                    >
+                      <EditComponentReact
+                        enableHoverEffect={false}
+                        disabled={!this.canStartRuntimes}
+                        style={styles.navBarIcon}
+                      />
+                      Edit {this.notebookInUse && '(In Use)'}
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipTrigger
+                    content={
+                      this.billingLocked && ACTION_DISABLED_INVALID_BILLING
+                    }
+                  >
+                    <div
+                      style={this.buttonStyleObj}
+                      onClick={() => {
+                        AnalyticsTracker.Notebooks.Run();
+                        this.onPlaygroundModeClick();
+                      }}
+                    >
+                      <IconButton
+                        icon={PlaygroundIcon}
+                        disabled={!this.canStartRuntimes}
+                        style={styles.navBarIcon}
+                      />
+                      Run (Playground Mode)
+                    </div>
+                  </TooltipTrigger>
+                </div>
+              )
             )}
           </div>
           <div style={styles.previewDiv}>{this.renderPreviewContents()}</div>

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -34,6 +34,8 @@ import { fetchAbortableRetry } from 'app/utils/retry';
 import {
   ComputeSecuritySuspendedError,
   maybeInitializeRuntime,
+  RUNTIME_ERROR_STATUS_MESSAGE_SHORT,
+  RuntimeStatusError,
   withRuntimeStore,
 } from 'app/utils/runtime-utils';
 import { MatchParams, RuntimeStore } from 'app/utils/stores';
@@ -711,6 +713,12 @@ export const LeonardoAppLauncher = fp.flow(
           return (
             <NotebookFrameError errorMode={ErrorMode.FORBIDDEN}>
               <SecuritySuspendedMessage error={error} />
+            </NotebookFrameError>
+          );
+        } else if (error instanceof RuntimeStatusError) {
+          return (
+            <NotebookFrameError errorMode={ErrorMode.ERROR}>
+              {RUNTIME_ERROR_STATUS_MESSAGE_SHORT}
             </NotebookFrameError>
           );
         } else if (error instanceof InitialRuntimeNotFoundError) {


### PR DESCRIPTION
Due to a regression ~8 months ago, when a runtime hit the error state the preview and notebook redirect pages would simply continue as if the runtime were ready to go. This results in a bunch of spurious 500 errors, and a confusing UX. Note that when a user does hit this scenario, they will also get a pop-up modal. This screen is mostly background, and is what they will see upon closing the modal.

https://user-images.githubusercontent.com/822298/170149067-dcc6aff5-219d-497f-b069-19e2ca3309f1.mp4
