### PR TITLE
[RW-6566][risk=no] Add first enabled time for RT,CT

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
@@ -38,6 +38,12 @@ public enum UserColumnValueExtractor implements ColumnValueExtractor<ReportingUs
   FIRST_REGISTRATION_COMPLETION_TIME(
       "first_registration_completion_time",
       u -> toInsertRowString(u.getFirstRegistrationCompletionTime())),
+  REGISTERED_TIER_FIRST_ENABLED_TIME(
+      "registered_tier_first_enabled_time",
+      u -> toInsertRowString(u.getRegisteredTierFirstEnabledTime())),
+  CONTROLLED_TIER_FIRST_ENABLED_TIME(
+      "controlled_tier_first_enabled_time",
+      u -> toInsertRowString(u.getControlledTierFirstEnabledTime())),
   FIRST_SIGN_IN_TIME("first_sign_in_time", u -> toInsertRowString(u.getFirstSignInTime())),
   FREE_TIER_CREDITS_LIMIT_DOLLARS_OVERRIDE(
       "free_tier_credits_limit_dollars_override",

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8954,6 +8954,18 @@ definitions:
         type: string
         format: date-time
         description: Time user first completed registration.
+      registeredTierFirstEnabledTime:
+        type: string
+        format: date-time
+        description: |-
+          The time at which this user's registered tier access was first granted, if ever.
+          Note: expiration of access does not affect this field.
+      controlledTierFirstEnabledTime:
+        type: string
+        format: date-time
+        description: |-
+          The time at which this user's controlled tier access was first granted, if ever.
+          Note: expiration of access does not affect this field.
       firstSignInTime:
         type: string
         format: date-time


### PR DESCRIPTION
Dependent on applying https://github.com/all-of-us/workbench-terraform-modules/pull/36

Tested locally via `reporting/curl/upload-snapshot-local.sh`

See the third row below, where I reverted a CT bypass for one of my users locally:

![image](https://user-images.githubusercontent.com/822298/170391488-5e8f0bb1-25df-4c41-9cd9-6bf2fb5c85f3.png)