### PR TITLE
[RW-8409][risk=no] Make e2e user sharing more robust

### DIFF
--- a/e2e/app/page/workspace-about-page.ts
+++ b/e2e/app/page/workspace-about-page.ts
@@ -49,7 +49,7 @@ export default class WorkspaceAboutPage extends WorkspaceBase {
     const allCollaborators = await this.findUsersInCollaboratorList();
     for (const [access, users] of allCollaborators.entries()) {
       if (users.includes(email)) {
-        return WorkspaceAccessLevel[access];
+        return access as WorkspaceAccessLevel;
       }
     }
     return null;

--- a/e2e/tests/notebook/notebook-writer-actions.spec.ts
+++ b/e2e/tests/notebook/notebook-writer-actions.spec.ts
@@ -37,12 +37,7 @@ describe('Workspace WRITER notebook tests', () => {
     const aboutPage = new WorkspaceAboutPage(page);
     await openTab(page, Tabs.About, aboutPage);
 
-    // If workspace has not shared to the WRITER, share it now.
-    const isShared = await aboutPage.collaboratorExists(config.WRITER_USER, WorkspaceAccessLevel.Writer);
-    if (!isShared) {
-      await aboutPage.shareWorkspaceWithUser(config.WRITER_USER, WorkspaceAccessLevel.Writer);
-      await waitWhileLoading(page);
-    }
+    await aboutPage.ensureCollaboratorAccess(config.WRITER_USER, WorkspaceAccessLevel.Writer);
 
     const analysisPage = new WorkspaceAnalysisPage(page);
     await openTab(page, Tabs.Analysis, analysisPage);

--- a/e2e/tests/notebook/notebook-writer-clone-workspace.spec.ts
+++ b/e2e/tests/notebook/notebook-writer-clone-workspace.spec.ts
@@ -31,12 +31,7 @@ describe('WRITER clone workspace and notebook tests', () => {
     const aboutPage = new WorkspaceAboutPage(page);
     await openTab(page, Tabs.About, aboutPage);
 
-    // If workspace has not shared to the WRITER, share it now.
-    const isShared = await aboutPage.collaboratorExists(config.WRITER_USER, WorkspaceAccessLevel.Writer);
-    if (!isShared) {
-      await aboutPage.shareWorkspaceWithUser(config.WRITER_USER, WorkspaceAccessLevel.Writer);
-      await waitWhileLoading(page);
-    }
+    await aboutPage.ensureCollaboratorAccess(config.WRITER_USER, WorkspaceAccessLevel.Writer);
 
     const analysisPage = new WorkspaceAnalysisPage(page);
     await openTab(page, Tabs.Analysis, analysisPage);

--- a/e2e/tests/notebook/notebook-writer-clone-workspace.spec.ts
+++ b/e2e/tests/notebook/notebook-writer-clone-workspace.spec.ts
@@ -5,7 +5,6 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import { Language, ResourceCard, Tabs, WorkspaceAccessLevel } from 'app/text-labels';
 import { config } from 'resources/workbench-config';
 import { findOrCreateWorkspace, openTab, signInWithAccessToken } from 'utils/test-utils';
-import { waitWhileLoading } from 'utils/waits-utils';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
 import { makeRandomName } from 'utils/str-utils';
 import expect from 'expect';


### PR DESCRIPTION
We observed a case where somehow we shared to the writer as a reader. All subsequent test runs failed.

Allow the test to recover from this scenario.