### PR TITLE
[risk=low][RW-8426] report both ends of egress time window in JIRA and admin UI

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/EgressEventsAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/EgressEventsAdminController.java
@@ -3,7 +3,6 @@ package org.pmiops.workbench.api;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
-import com.google.gson.Gson;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.pmiops.workbench.actionaudit.auditors.EgressEventAuditor;
@@ -176,7 +175,7 @@ public class EgressEventsAdminController implements EgressEventsAdminApiDelegate
     return ResponseEntity.ok(
         new AuditEgressEventResponse()
             .egressEvent(egressEventMapper.toApiEvent(dbEgressEvent))
-            .sumologicEvent(new Gson().fromJson(dbEgressEvent.getSumologicEvent(), Object.class))
+            .sumologicEvent(egressEventMapper.toSumoLogicEvent(dbEgressEvent))
             .runtimeLogGroups(egressLogService.getRuntimeLogGroups(dbEgressEvent)));
   }
 

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/EgressEventMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/EgressEventMapper.java
@@ -31,9 +31,9 @@ public interface EgressEventMapper {
       return;
     }
 
-    Long timeWindowStart = sumoEvent.getTimeWindowStart();
-    Long timeWindowMillis = sumoEvent.getTimeWindowDuration() * 1000;
-    Long timeWindowEnd = timeWindowStart + timeWindowMillis;
+    long timeWindowStart = sumoEvent.getTimeWindowStart();
+    long timeWindowMillis = sumoEvent.getTimeWindowDuration() * 1000;
+    long timeWindowEnd = timeWindowStart + timeWindowMillis;
 
     target.timeWindowStartEpochMillis(timeWindowStart).timeWindowEndEpochMillis(timeWindowEnd);
   }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/EgressEventMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/EgressEventMapper.java
@@ -1,15 +1,21 @@
 package org.pmiops.workbench.utils.mappers;
 
+import com.google.gson.Gson;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.pmiops.workbench.db.model.DbEgressEvent;
 import org.pmiops.workbench.db.model.DbEgressEvent.DbEgressEventStatus;
 import org.pmiops.workbench.model.EgressEvent;
 import org.pmiops.workbench.model.EgressEventStatus;
+import org.pmiops.workbench.model.SumologicEgressEvent;
 
 @Mapper(config = MapStructConfig.class, uses = CommonMappers.class)
 public interface EgressEventMapper {
-
+  // these are calculated in addWindowTiming()
+  @Mapping(target = "timeWindowStartEpochMillis", ignore = true)
+  @Mapping(target = "timeWindowEndEpochMillis", ignore = true)
   @Mapping(target = "sourceUserEmail", source = "user.username")
   @Mapping(target = "sourceWorkspaceNamespace", source = "workspace.workspaceNamespace")
   @Mapping(target = "sourceGoogleProject", source = "workspace.googleProject")
@@ -18,5 +24,23 @@ public interface EgressEventMapper {
 
   EgressEventStatus toApiStatus(DbEgressEventStatus status);
 
+  @AfterMapping
+  default void addWindowTiming(DbEgressEvent source, @MappingTarget EgressEvent target) {
+    SumologicEgressEvent sumoEvent = toSumoLogicEvent(source);
+    if (sumoEvent == null) {
+      return;
+    }
+
+    Long timeWindowStart = sumoEvent.getTimeWindowStart();
+    Long timeWindowMillis = sumoEvent.getTimeWindowDuration() * 1000;
+    Long timeWindowEnd = timeWindowStart + timeWindowMillis;
+
+    target.timeWindowStartEpochMillis(timeWindowStart).timeWindowEndEpochMillis(timeWindowEnd);
+  }
+
   DbEgressEventStatus toDbStatus(EgressEventStatus status);
+
+  default SumologicEgressEvent toSumoLogicEvent(DbEgressEvent dbEgressEvent) {
+    return new Gson().fromJson(dbEgressEvent.getSumologicEvent(), SumologicEgressEvent.class);
+  }
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6688,7 +6688,15 @@ definitions:
         description: Window duration over which the egress was detected, in seconds.
       creationTime:
         type: string
-        description: Time at which the egress event was recorded, in ISO 8601 format.
+        description: Time at which the egress event was recorded in the RW DB, in ISO 8601 format.  This is NOT the event time itself.
+      timeWindowStartEpochMillis:
+        type: integer
+        format: int64
+        description: The beginning of the time window in which egress was detected, in epoch milliseconds.
+      timeWindowEndEpochMillis:
+        type: integer
+        format: int64
+        description: The end of the time window in which egress was detected, in epoch milliseconds.
       status:
         $ref: "#/definitions/EgressEventStatus"
   ArrayOfLong:

--- a/api/src/test/java/org/pmiops/workbench/api/EgressEventsAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/EgressEventsAdminControllerTest.java
@@ -107,7 +107,10 @@ public class EgressEventsAdminControllerTest {
     FakeClockConfiguration.class,
     FakeJpaDateTimeConfiguration.class
   })
-  @MockBean({BigQueryService.class, EgressEventAuditor.class})
+  @MockBean({
+    BigQueryService.class,
+    EgressEventAuditor.class,
+  })
   static class Configuration {
     @Bean
     WorkbenchConfig config() {
@@ -478,7 +481,8 @@ public class EgressEventsAdminControllerTest {
     return new DbEgressEvent()
         .setStatus(DbEgressEventStatus.PENDING)
         .setEgressWindowSeconds(600L)
-        .setSumologicEvent("{\"egressWindowStart\": 123}");
+        .setSumologicEvent(
+            "{\"egressWindowStart\": 123, \"timeWindowStart\": 123, \"timeWindowDuration\": 456}");
   }
 
   private DbUser saveNewUser(String username) {

--- a/api/src/test/java/org/pmiops/workbench/exfiltration/EgressRemediationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/exfiltration/EgressRemediationServiceTest.java
@@ -57,6 +57,8 @@ import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.SumologicEgressEvent;
 import org.pmiops.workbench.notebooks.LeonardoNotebooksClient;
 import org.pmiops.workbench.test.FakeClock;
+import org.pmiops.workbench.utils.mappers.CommonMappers;
+import org.pmiops.workbench.utils.mappers.EgressEventMapperImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -91,10 +93,14 @@ public class EgressRemediationServiceTest {
 
   @TestConfiguration
   @Import({
+    EgressEventMapperImpl.class,
     EgressRemediationService.class,
     FakeClockConfiguration.class,
     FakeJpaDateTimeConfiguration.class,
     JiraService.class
+  })
+  @MockBean({
+    CommonMappers.class,
   })
   static class Configuration {
 
@@ -229,7 +235,7 @@ public class EgressRemediationServiceTest {
     // Create 10 older events on different days.
     saveOldEvents(
         IntStream.range(1, 10)
-            .mapToObj(i -> Duration.ofDays(i))
+            .mapToObj(Duration::ofDays)
             .collect(Collectors.toList())
             .toArray(new Duration[] {}));
     egressRemediationService.remediateEgressEvent(saveNewEvent());

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/EgressEventMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/EgressEventMapperTest.java
@@ -38,6 +38,11 @@ public class EgressEventMapperTest {
 
     Instant created = FakeClockConfiguration.NOW.toInstant();
     Instant modified = created.plus(Duration.ofMinutes(5L));
+    long timeWindowStartMilli = created.minus(Duration.ofHours(1L)).toEpochMilli();
+    long timeWindowDurationSeconds = Duration.ofHours(1L).getSeconds();
+    double egressMB = 201.0;
+    double egressMib = 200.0;
+
     assertThat(
             mapper.toApiEvent(
                 new DbEgressEvent()
@@ -48,16 +53,15 @@ public class EgressEventMapperTest {
                     .setCreationTime(Timestamp.from(created))
                     .setStatus(DbEgressEventStatus.PENDING)
                     .setLastModifiedTime(Timestamp.from(modified))
-                    .setEgressMegabytes((float) 201.0)
-                    .setEgressWindowSeconds(3600L)
+                    .setEgressMegabytes((float) egressMB)
+                    .setEgressWindowSeconds(timeWindowDurationSeconds)
                     .setSumologicEvent(
                         new Gson()
                             .toJson(
                                 new SumologicEgressEvent()
-                                    .egressMib(200.0)
-                                    .timeWindowStart(
-                                        created.minus(Duration.ofHours(1L)).toEpochMilli())
-                                    .timeWindowDuration(Duration.ofHours(1L).toMillis())
+                                    .egressMib(egressMib)
+                                    .timeWindowStart(timeWindowStartMilli)
+                                    .timeWindowDuration(timeWindowDurationSeconds)
                                     .vmPrefix(user.getRuntimeName())))))
         .isEqualTo(
             new EgressEvent()
@@ -67,8 +71,10 @@ public class EgressEventMapperTest {
                 .sourceGoogleProject("proj")
                 .creationTime("2000-01-01T00:00:00Z")
                 .status(EgressEventStatus.PENDING)
-                .egressMegabytes(201.0)
-                .egressWindowSeconds(BigDecimal.valueOf(3600L)));
+                .egressMegabytes(egressMB)
+                .egressWindowSeconds(BigDecimal.valueOf(timeWindowDurationSeconds))
+                .timeWindowStartEpochMillis(timeWindowStartMilli)
+                .timeWindowEndEpochMillis(timeWindowStartMilli + timeWindowDurationSeconds * 1000));
   }
 
   @Test

--- a/ui/src/app/pages/admin/admin-egress-audit.tsx
+++ b/ui/src/app/pages/admin/admin-egress-audit.tsx
@@ -117,36 +117,46 @@ export const AdminEgressAudit = (props: WithSpinnerOverlayProps) => {
   const event = egressDetails.egressEvent;
   const eventChanged =
     !!pendingUpdateEvent && !fp.equals(pendingUpdateEvent, event);
-  const [username] = event.sourceUserEmail.split('@');
+
+  const {
+    sourceUserEmail,
+    sourceWorkspaceNamespace,
+    sourceGoogleProject,
+    status,
+    egressEventId,
+    egressMegabytes,
+    egressWindowSeconds,
+    timeWindowStartEpochMillis,
+    timeWindowEndEpochMillis,
+  } = event;
+
+  const [username] = sourceUserEmail.split('@');
+
   return (
     <div style={{ padding: '0 20px' }}>
-      <h2>Egress event {event.egressEventId}</h2>
+      <h2>Egress event {egressEventId}</h2>
       <div style={{ display: 'table', marginBottom: '15px' }}>
-        <DetailRow label='Detection time'>
-          {new Date(event.creationTime).toLocaleString()}
+        <DetailRow label='Detection window'>
+          {new Date(timeWindowStartEpochMillis).toLocaleString()} to{' '}
+          {new Date(timeWindowEndEpochMillis).toLocaleString()}
         </DetailRow>
         <DetailRow label='Source user'>
-          <AdminUserLink {...{ username }}>
-            {event.sourceUserEmail}
-          </AdminUserLink>
+          <AdminUserLink {...{ username }}>{sourceUserEmail}</AdminUserLink>
         </DetailRow>
         <DetailRow label='Source workspace'>
           <StyledRouterLink
-            path={`/admin/workspaces/${event.sourceWorkspaceNamespace}`}
+            path={`/admin/workspaces/${sourceWorkspaceNamespace}`}
           >
-            {event.sourceWorkspaceNamespace}
+            {sourceWorkspaceNamespace}
           </StyledRouterLink>
         </DetailRow>
-        <DetailRow label='Google project'>
-          {event.sourceGoogleProject}
-        </DetailRow>
+        <DetailRow label='Google project'>{sourceGoogleProject}</DetailRow>
         <DetailRow label='Egress volume'>
-          {event.egressMegabytes?.toFixed(2)} MB (over{' '}
-          {event.egressWindowSeconds / 60} min)
+          {egressMegabytes?.toFixed(2)} MB (over {egressWindowSeconds / 60} min)
         </DetailRow>
         <DetailRow label='Status'>
           <Dropdown
-            value={pendingUpdateEvent?.status ?? event.status}
+            value={pendingUpdateEvent?.status ?? status}
             options={mutableEgressEventStatuses}
             onChange={(e) => {
               setPendingUpdateEvent({


### PR DESCRIPTION
Tested the UI locally by inserting a fake egress_event row:
<img width="477" alt="Screen Shot 2022-06-01 at 1 47 57 PM" src="https://user-images.githubusercontent.com/2701406/171469841-22b97959-28e4-4e52-830b-f2d6bbde12ed.png">

I have not tested the JIRA change.
 
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
