### PR TITLE
[RW-8258][risk=no] Add rdr_export index on entity

### DIFF
--- a/api/db/changelog/db.changelog-198-index-rdr-export-entities.xml
+++ b/api/db/changelog/db.changelog-198-index-rdr-export-entities.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  <changeSet author="calbach" id="changelog-198-index-rdr-export-entities">
+    <createIndex tableName="rdr_export" indexName="rdr_export_entity_idx" unique="true">
+      <column name="entity_id"/>
+      <column name="entity_type"/>
+    </createIndex>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -205,6 +205,7 @@
   <include file="changelog/db.changelog-195-add-filter-set-name.xml"/>
   <include file="changelog/db.changelog-196-add-demographic-survey-v2.xml"/>
   <include file="changelog/db.changelog-197-add-genomic-cdr-paths.xml"/>
+  <include file="changelog/db.changelog-198-index-rdr-export-entities.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`


### PR DESCRIPTION
[This join](https://cs.github.com/all-of-us/workbench/blob/903d3f541c5ebc78b9d73b0542423f15ff1141aa/api/src/main/java/org/pmiops/workbench/db/dao/RdrExportDao.java?q=rdrexportdao#L22-L25) is very slow. The index seems to have the desired effect, testing on a local DB:

Before:
```
explain SELECT w.workspace_id FROM workspace w LEFT JOIN rdr_export rdr ON (w.workspace_id = rdr.entity_id AND rdr.entity_type = 2) WHERE w.last_modified_time > rdr.last_export_date OR rdr.entity_id IS NULL;        
+----+-------------+-------+------------+------+---------------+------+---------+------+--------+----------+----------------------------------------------------+
| id | select_type | table | partitions | type | possible_keys | key  | key_len | ref  | rows   | filtered | Extra                                              |
+----+-------------+-------+------------+------+---------------+------+---------+------+--------+----------+----------------------------------------------------+
|  1 | SIMPLE      | w     | NULL       | ALL  | NULL          | NULL | NULL    | NULL | 164056 |   100.00 | NULL                                               |
|  1 | SIMPLE      | rdr   | NULL       | ALL  | NULL          | NULL | NULL    | NULL |  61007 |    40.00 | Using where; Using join buffer (Block Nested Loop) |
+----+-------------+-------+------------+------+---------------+------+---------+------+--------+----------+----------------------------------------------------+
```

After:

```
explain SELECT w.workspace_id FROM workspace w LEFT JOIN rdr_export rdr ON (w.workspace_id = rdr.entity_id AND rdr.entity_type = 2) WHERE w.last_modified_time > rdr.last_export_date OR rdr.entity_id IS NULL;                                                                                                                                                                                                  
+------+-------------+-------+--------+-----------------------+-----------------------+---------+--------------------------------+------+-------------+                                                            
| id   | select_type | table | type   | possible_keys         | key                   | key_len | ref                            | rows | Extra       |                                                            
+------+-------------+-------+--------+-----------------------+-----------------------+---------+--------------------------------+------+-------------+                                                            
|    1 | SIMPLE      | w     | ALL    | NULL                  | NULL                  | NULL    | NULL                           |   29 |             |                                                            
|    1 | SIMPLE      | rdr   | eq_ref | rdr_export_entity_idx | rdr_export_entity_idx | 9       | workbench.w.workspace_id,const |    1 | Using where |                                                            
+------+-------------+-------+--------+-----------------------+-----------------------+---------+--------------------------------+------+-------------+ 
```