### PR TITLE
[RW-8369][risk=no] Multiple Cohort Review - add new implementation for getParticipantCohortStatuses

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -417,7 +417,6 @@ public class CohortReviewController implements CohortReviewApiDelegate {
     DbWorkspace dbWorkspace =
         workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
             workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
-    long cdrVersionId = dbWorkspace.getCdrVersion().getCdrVersionId();
 
     CohortReview cohortReview;
     List<ParticipantCohortStatus> participantCohortStatuses = new ArrayList<>();

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -425,14 +425,10 @@ public class CohortReviewController implements CohortReviewApiDelegate {
     PageRequest pageRequest = createPageRequest(request);
     convertGenderRaceEthnicitySortOrder(pageRequest);
 
-    try {
-      cohortReview =
-          cohortReviewService.findCohortReviewForWorkspace(cohort.getCohortId(), cohortReviewId);
-      participantCohortStatuses =
-          cohortReviewService.findAll(cohortReview.getCohortReviewId(), pageRequest);
-    } catch (NotFoundException nfe) {
-      cohortReview = cohortReviewService.initializeCohortReview(cdrVersionId, cohort);
-    }
+    cohortReview =
+        cohortReviewService.findCohortReviewForWorkspace(cohort.getCohortId(), cohortReviewId);
+    participantCohortStatuses =
+        cohortReviewService.findAll(cohortReview.getCohortReviewId(), pageRequest);
 
     cohortReview.participantCohortStatuses(participantCohortStatuses);
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3086,6 +3086,32 @@ paths:
           description: A collection of participants
           schema:
             "$ref": "#/definitions/CohortReviewWithCountResponse"
+  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/{cohortReviewId}/participants":
+    parameters:
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
+      - "$ref": "#/parameters/cohortId"
+      - "$ref": "#/parameters/cohortReviewId"
+    post:
+      tags:
+        - cohortReview
+      consumes:
+        - application/json
+      description: 'Returns a collection of participants for the specified cohortId.
+          This endpoint does pagination based on page, limit, order and column.'
+      operationId: getParticipantCohortStatuses
+      parameters:
+        - in: body
+          name: request
+          required: true
+          description: request body for getting list of ParticipantCohortStatuses.
+          schema:
+            "$ref": "#/definitions/PageFilterRequest"
+      responses:
+        200:
+          description: A collection of participants
+          schema:
+            "$ref": "#/definitions/CohortReviewWithCountResponse"
   "/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}":
     parameters:
     - "$ref": "#/parameters/workspaceNamespace"

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -2048,27 +2048,6 @@ public class CohortReviewControllerTest {
     assertNotFoundExceptionNoCohort(worngCohortId, exception);
   }
 
-  @Test
-  public void getParticipantCohortStatusesNoCohortReview() {
-    stubWorkspaceAccessLevel(workspace, WorkspaceAccessLevel.READER);
-    stubBigQueryCohortCalls();
-
-    Long wrongCohortReviewId = -1L;
-
-    CohortReview actualReview =
-        cohortReviewController
-            .getParticipantCohortStatuses(
-                workspace.getNamespace(),
-                workspace.getId(),
-                cohort.getCohortId(),
-                wrongCohortReviewId,
-                new PageFilterRequest())
-            .getBody()
-            .getCohortReview();
-
-    assertThat(actualReview.getParticipantCohortStatuses()).isEmpty();
-  }
-
   @ParameterizedTest(
       name = "getParticipantCohortStatusesSortByFilterColumn SortOrder={0}, FilterColumns={1}")
   @MethodSource("paramsSortByFilterColumn")

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -1883,9 +1883,9 @@ public class CohortReviewControllerTest {
     assertForbiddenException(exception);
   }
 
-  ////////// getParticipantCohortStatuses  //////////
+  ////////// getParticipantCohortStatusesOld  //////////
   @Test
-  public void getParticipantCohortStatusesWrongWorkspace() {
+  public void getParticipantCohortStatusesOldWrongWorkspace() {
     stubWorkspaceAccessLevel(workspace2, WorkspaceAccessLevel.READER);
 
     Long cohortId = cohort.getCohortId();
@@ -1904,7 +1904,7 @@ public class CohortReviewControllerTest {
   }
 
   @Test
-  public void getParticipantCohortStatusesNoCohort() {
+  public void getParticipantCohortStatusesOldNoCohort() {
     stubWorkspaceAccessLevel(workspace, WorkspaceAccessLevel.READER);
 
     Long worngCohortId = -1L;
@@ -1923,9 +1923,9 @@ public class CohortReviewControllerTest {
   }
 
   @ParameterizedTest(
-      name = "getParticipantCohortStatusesSortByFilterColumn SortOrder={0}, FilterColumns={1}")
+      name = "getParticipantCohortStatusesOldSortByFilterColumn SortOrder={0}, FilterColumns={1}")
   @MethodSource("paramsSortByFilterColumn")
-  public void getParticipantCohortStatusesSortByFilterColumn(
+  public void getParticipantCohortStatusesOldSortByFilterColumn(
       SortOrder sortOrder, FilterColumns filterColumns) {
     CohortReview expectedReview =
         createCohortReview(
@@ -1940,6 +1940,154 @@ public class CohortReviewControllerTest {
                 workspace.getNamespace(),
                 workspace.getId(),
                 cohort.getCohortId(),
+                pageFilterRequest)
+            .getBody()
+            .getCohortReview();
+
+    verify(userRecentResourceService, atLeastOnce())
+        .updateCohortEntry(anyLong(), anyLong(), anyLong());
+    assertCohortReviewParticipantCohortStatuses(
+        actualReview, expectedReview, filterColumns, sortOrder);
+  }
+
+  @ParameterizedTest(
+      name = "getParticipantCohortStatusesOldAllowedAccessLevel WorkspaceAccessLevel={0}")
+  @EnumSource(
+      value = WorkspaceAccessLevel.class,
+      names = {"OWNER", "WRITER", "READER"})
+  public void getParticipantCohortStatusesOldAllowedAccessLevel(
+      WorkspaceAccessLevel workspaceAccessLevel) {
+    CohortReview expectedReview =
+        createCohortReview(
+            cohortReview, ImmutableList.of(participantCohortStatus1, participantCohortStatus2));
+
+    // change access, call and check
+    stubWorkspaceAccessLevel(workspace, workspaceAccessLevel);
+
+    CohortReview actualReview =
+        cohortReviewController
+            .getParticipantCohortStatusesOld(
+                workspace.getNamespace(),
+                workspace.getId(),
+                cohort.getCohortId(),
+                new PageFilterRequest())
+            .getBody()
+            .getCohortReview();
+
+    verify(userRecentResourceService, atLeastOnce())
+        .updateCohortEntry(anyLong(), anyLong(), anyLong());
+    // PageFilterRequest defaults to participantId, ascending (if not given)
+    assertCohortReviewParticipantCohortStatuses(
+        actualReview, expectedReview, FilterColumns.PARTICIPANTID, SortOrder.ASC);
+  }
+
+  @ParameterizedTest(
+      name = "getParticipantCohortStatusesOldForbiddenAccessLevel WorkspaceAccessLevel={0}")
+  @EnumSource(
+      value = WorkspaceAccessLevel.class,
+      names = {"NO_ACCESS"})
+  public void getParticipantCohortStatusesOldForbiddenAccessLevel(
+      WorkspaceAccessLevel workspaceAccessLevel) {
+    createCohortReview(
+        cohortReview, ImmutableList.of(participantCohortStatus1, participantCohortStatus2));
+
+    // change access, call and check
+    stubWorkspaceAccessLevel(workspace, workspaceAccessLevel);
+
+    Throwable exception =
+        assertThrows(
+            ForbiddenException.class,
+            () ->
+                cohortReviewController.getParticipantCohortStatusesOld(
+                    workspace.getNamespace(),
+                    workspace.getId(),
+                    cohort.getCohortId(),
+                    new PageFilterRequest()));
+
+    assertForbiddenException(exception);
+  }
+
+  ////////// getParticipantCohortStatuses  //////////
+  @Test
+  public void getParticipantCohortStatusesWrongWorkspace() {
+    stubWorkspaceAccessLevel(workspace2, WorkspaceAccessLevel.READER);
+
+    Long cohortId = cohort.getCohortId();
+
+    Throwable exception =
+        assertThrows(
+            NotFoundException.class,
+            () ->
+                cohortReviewController.getParticipantCohortStatuses(
+                    workspace2.getNamespace(),
+                    workspace2.getId(),
+                    cohortId,
+                    cohortReview.getCohortReviewId(),
+                    new PageFilterRequest()));
+
+    assertNotFoundExceptionNoCohort(cohortId, exception);
+  }
+
+  @Test
+  public void getParticipantCohortStatusesNoCohort() {
+    stubWorkspaceAccessLevel(workspace, WorkspaceAccessLevel.READER);
+
+    Long worngCohortId = -1L;
+
+    Throwable exception =
+        assertThrows(
+            NotFoundException.class,
+            () ->
+                cohortReviewController.getParticipantCohortStatuses(
+                    workspace.getNamespace(),
+                    workspace.getId(),
+                    worngCohortId,
+                    cohortReview.getCohortReviewId(),
+                    new PageFilterRequest()));
+
+    assertNotFoundExceptionNoCohort(worngCohortId, exception);
+  }
+
+  @Test
+  public void getParticipantCohortStatusesNoCohortReview() {
+    stubWorkspaceAccessLevel(workspace, WorkspaceAccessLevel.READER);
+    stubBigQueryCohortCalls();
+
+    Long wrongCohortReviewId = -1L;
+
+    CohortReview actualReview =
+        cohortReviewController
+            .getParticipantCohortStatuses(
+                workspace.getNamespace(),
+                workspace.getId(),
+                cohort.getCohortId(),
+                wrongCohortReviewId,
+                new PageFilterRequest())
+            .getBody()
+            .getCohortReview();
+
+    assertThat(actualReview.getParticipantCohortStatuses()).isEmpty();
+  }
+
+  @ParameterizedTest(
+      name = "getParticipantCohortStatusesSortByFilterColumn SortOrder={0}, FilterColumns={1}")
+  @MethodSource("paramsSortByFilterColumn")
+  public void getParticipantCohortStatusesSortByFilterColumn(
+      SortOrder sortOrder, FilterColumns filterColumns) {
+    CohortReview expectedReview =
+        createCohortReview(
+            cohortReview, ImmutableList.of(participantCohortStatus1, participantCohortStatus2));
+    // default filterColumn=participant_id
+    PageFilterRequest pageFilterRequest =
+        new PageFilterRequest().sortOrder(sortOrder).sortColumn(filterColumns);
+
+    CohortReview actualReview =
+        cohortReviewController
+            .getParticipantCohortStatuses(
+                workspace.getNamespace(),
+                workspace.getId(),
+                cohort.getCohortId(),
+                cohortReview.getCohortReviewId(),
                 pageFilterRequest)
             .getBody()
             .getCohortReview();
@@ -1966,10 +2114,11 @@ public class CohortReviewControllerTest {
 
     CohortReview actualReview =
         cohortReviewController
-            .getParticipantCohortStatusesOld(
+            .getParticipantCohortStatuses(
                 workspace.getNamespace(),
                 workspace.getId(),
                 cohort.getCohortId(),
+                cohortReview.getCohortReviewId(),
                 new PageFilterRequest())
             .getBody()
             .getCohortReview();
@@ -1981,7 +2130,8 @@ public class CohortReviewControllerTest {
         actualReview, expectedReview, FilterColumns.PARTICIPANTID, SortOrder.ASC);
   }
 
-  @ParameterizedTest(name = "getParticipantDataForbiddenAccessLevel WorkspaceAccessLevel={0}")
+  @ParameterizedTest(
+      name = "getParticipantCohortStatusesForbiddenAccessLevel WorkspaceAccessLevel={0}")
   @EnumSource(
       value = WorkspaceAccessLevel.class,
       names = {"NO_ACCESS"})
@@ -1997,10 +2147,11 @@ public class CohortReviewControllerTest {
         assertThrows(
             ForbiddenException.class,
             () ->
-                cohortReviewController.getParticipantCohortStatusesOld(
+                cohortReviewController.getParticipantCohortStatuses(
                     workspace.getNamespace(),
                     workspace.getId(),
                     cohort.getCohortId(),
+                    cohortReview.getCohortReviewId(),
                     new PageFilterRequest()));
 
     assertForbiddenException(exception);


### PR DESCRIPTION
Description:

updated impl for getParticipantCohortStatuses api, tests

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
