### PR TITLE
[RW-8465][risk=no] remove signout in e2e test

### DIFF
--- a/e2e/tests/examples/sign-in.spec.ts
+++ b/e2e/tests/examples/sign-in.spec.ts
@@ -1,5 +1,5 @@
 import ProfilePage from 'app/page/profile-page';
-import { signInWithAccessToken, signOut } from 'utils/test-utils';
+import { signInWithAccessToken } from 'utils/test-utils';
 import Navigation, { NavLink } from 'app/component/navigation';
 import { withPageTest, withSignIn } from 'libs/page-manager';
 import { config } from 'resources/workbench-config';
@@ -18,8 +18,6 @@ describe('login tests', () => {
       const profilePage = new ProfilePage(page);
       await profilePage.waitForLoad();
       expect(await profilePage.isLoaded()).toBe(true);
-
-      await signOut(page);
     });
   });
 

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -19,7 +19,6 @@ import {
   WorkspaceAccessLevel
 } from 'app/text-labels';
 import WorkspacesPage from 'app/page/workspaces-page';
-import Navigation, { NavLink } from 'app/component/navigation';
 import { isBlank, makeWorkspaceName } from './str-utils';
 import { config } from 'resources/workbench-config';
 import { logger } from 'libs/logger';
@@ -33,15 +32,6 @@ import CohortBuildPage from 'app/page/cohort-build-page';
 import { Ethnicity, GenderIdentity } from 'app/page/cohort-participants-group';
 import CohortActionsPage from 'app/page/cohort-actions-page';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
-
-export async function signOut(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    return 'window.setTestAccessTokenOverride(null)';
-  });
-
-  await Navigation.navMenu(page, NavLink.SIGN_OUT);
-  await page.waitForTimeout(1000);
-}
 
 // Resolve typescript error: TS2339: Property 'setTestAccessTokenOverride' does not exist on type 'Window & typeof globalThis'.
 declare const window: Window &


### PR DESCRIPTION
Description:
The new signout function will sign user out across all sessions. That makes we can not run test in parallel if using the same user. 
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
