### PR TITLE
[RW-8274][risk=low] Update GVS extract workflow in all environments

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -46,12 +46,9 @@
     "extractionPetServiceAccount": "pet-118217329794842274136@aou-wgs-cohort-extraction.iam.gserviceaccount.com",
     "extractionMethodConfigurationNamespace": "aouwgscohortextraction-test",
     "extractionMethodConfigurationName": "GvsExtractCohortFromSampleNames",
-    "extractionMethodConfigurationVersion": 14,
+    "extractionMethodConfigurationVersion": 15,
     "extractionMethodLogicalVersion": 3,
-    "extractionCohortsDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
-    "extractionTempTablesDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_temp_tables",
-    "extractionFilterSetName": "example",
     "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": false
   },

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -46,13 +46,10 @@
     "extractionPetServiceAccount": "pet-111879944971009838720@aouwgscohortextraction-perf.iam.gserviceaccount.com",
     "extractionMethodConfigurationNamespace": "aouwgscohortextraction-perf",
     "extractionMethodConfigurationName": "GvsExtractCohortFromSampleNames",
-    "extractionMethodConfigurationVersion": 4,
-    "extractionMethodLogicalVersion": 2,
-    "extractionCohortsDataset": "fc-aou-cdr-perf-ct.wgs_extraction_cohorts",
+    "extractionMethodConfigurationVersion": 5,
+    "extractionMethodLogicalVersion": 3,
     "extractionDestinationDataset": "fc-aou-cdr-perf-ct.wgs_extraction_destination",
-    "extractionTempTablesDataset": "fc-aou-cdr-perf-ct.wgs_extraction_temp_tables",
-    "extractionFilterSetName": "example",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-464-g86f1116-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -46,13 +46,10 @@
     "extractionPetServiceAccount": "pet-110393474898566940625@aouwgscohortextraction-preprod.iam.gserviceaccount.com",
     "extractionMethodConfigurationNamespace": "aouwgscohortextraction-preprod",
     "extractionMethodConfigurationName": "GvsExtractCohortFromSampleNames",
-    "extractionMethodConfigurationVersion": 4,
-    "extractionMethodLogicalVersion": 2,
-    "extractionCohortsDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_cohorts",
+    "extractionMethodConfigurationVersion": 5,
+    "extractionMethodLogicalVersion": 3,
     "extractionDestinationDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_destination",
-    "extractionTempTablesDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_temp_tables",
-    "extractionFilterSetName": "beta2_99k_row_10",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-464-g86f1116-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -46,13 +46,10 @@
     "extractionPetServiceAccount": "pet-114668949591113561197@aouwgscohortextraction-prod.iam.gserviceaccount.com",
     "extractionMethodConfigurationNamespace": "aouwgscohortextraction-prod",
     "extractionMethodConfigurationName": "GvsExtractCohortFromSampleNames",
-    "extractionMethodConfigurationVersion": 3,
-    "extractionMethodLogicalVersion": 2,
-    "extractionCohortsDataset": "fc-aou-cdr-prod-ct.wgs_extraction_cohorts",
+    "extractionMethodConfigurationVersion": 4,
+    "extractionMethodLogicalVersion": 3,
     "extractionDestinationDataset": "fc-aou-cdr-prod-ct.wgs_extraction_destination",
-    "extractionTempTablesDataset": "fc-aou-cdr-prod-ct.wgs_extraction_temp_tables",
-    "extractionFilterSetName": "beta2_99k_row_10",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-464-g86f1116-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -46,13 +46,10 @@
     "extractionPetServiceAccount": "pet-116281557770103257351@aouwgscohortextraction-stable.iam.gserviceaccount.com",
     "extractionMethodConfigurationNamespace": "aouwgscohortextraction-stable",
     "extractionMethodConfigurationName": "GvsExtractCohortFromSampleNames",
-    "extractionMethodConfigurationVersion": 4,
-    "extractionMethodLogicalVersion": 2,
-    "extractionCohortsDataset": "fc-aou-cdr-stable-ct.wgs_extraction_cohorts",
+    "extractionMethodConfigurationVersion": 5,
+    "extractionMethodLogicalVersion": 3,
     "extractionDestinationDataset": "fc-aou-cdr-stable-ct.wgs_extraction_destination",
-    "extractionTempTablesDataset": "fc-aou-cdr-stable-ct.wgs_extraction_temp_tables",
-    "extractionFilterSetName": "example",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-464-g86f1116-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -46,13 +46,10 @@
     "extractionPetServiceAccount": "pet-112406122740824430926@aouwgscohortextraction-staging.iam.gserviceaccount.com",
     "extractionMethodConfigurationNamespace": "aouwgscohortextraction-staging",
     "extractionMethodConfigurationName": "GvsExtractCohortFromSampleNames",
-    "extractionMethodConfigurationVersion": 4,
-    "extractionMethodLogicalVersion": 2,
-    "extractionCohortsDataset": "fc-aou-cdr-staging-ct.wgs_extraction_cohorts",
+    "extractionMethodConfigurationVersion": 5,
+    "extractionMethodLogicalVersion": 3,
     "extractionDestinationDataset": "fc-aou-cdr-staging-ct.wgs_extraction_destination",
-    "extractionTempTablesDataset": "fc-aou-cdr-staging-ct.wgs_extraction_temp_tables",
-    "extractionFilterSetName": "example",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-464-g86f1116-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -46,12 +46,9 @@
     "extractionPetServiceAccount": "pet-118217329794842274136@aou-wgs-cohort-extraction.iam.gserviceaccount.com",
     "extractionMethodConfigurationNamespace": "aouwgscohortextraction-test",
     "extractionMethodConfigurationName": "GvsExtractCohortFromSampleNames",
-    "extractionMethodConfigurationVersion": 14,
+    "extractionMethodConfigurationVersion": 15,
     "extractionMethodLogicalVersion": 3,
-    "extractionCohortsDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_cohorts",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
-    "extractionTempTablesDataset": "fc-aou-cdr-synth-test-2.wgs_extraction_temp_tables",
-    "extractionFilterSetName": "example",
     "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },


### PR DESCRIPTION
Also removes now unneeded config variables:
- extractionCohortsDataset
- extractionTempTablesDataset
- extractionFilterSetName

Follow-on PRs will remove the config variables entirely.

In local/test, this change should be a no-op. For completeness, I recreated the method snapshot with my merged commit @ https://github.com/broadinstitute/gatk/commit/f6fde4e9ebfce709bf6c9b22dafc7d94fb2433b0, rather than the previous snapshot which was built off my own branch (no subsequent modifications were made during PR review).