### PR TITLE
[RW-8420][risk=no] fix long load times for concept sets

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
@@ -45,6 +45,14 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
   }
 
   @Override
+  public ResponseEntity<Long> countConceptsInConceptSet(
+      String workspaceNamespace, String workspaceId, Long conceptSetId) {
+    workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
+        workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
+    return ResponseEntity.ok(conceptSetService.countConceptsInConceptSet(conceptSetId));
+  }
+
+  @Override
   public ResponseEntity<ConceptSet> createConceptSet(
       String workspaceNamespace, String workspaceId, CreateConceptSetRequest request) {
     // Fail fast if request is not valid

--- a/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ConceptSetsController.java
@@ -45,7 +45,7 @@ public class ConceptSetsController implements ConceptSetsApiDelegate {
   }
 
   @Override
-  public ResponseEntity<Long> countConceptsInConceptSet(
+  public ResponseEntity<Integer> countConceptsInConceptSet(
       String workspaceNamespace, String workspaceId, Long conceptSetId) {
     workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);

--- a/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
@@ -181,7 +181,7 @@ public class ConceptSetService {
         .collect(Collectors.toList());
   }
 
-  public Long countConceptsInConceptSet(Long conceptSetId) {
+  public Integer countConceptsInConceptSet(Long conceptSetId) {
     return conceptSetDao.countByConceptSetId(conceptSetId);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/conceptset/ConceptSetService.java
@@ -157,6 +157,7 @@ public class ConceptSetService {
     conceptSetDao.deleteById(conceptSetId);
   }
 
+  /** Read concept-sets with hydrated collection of concept ids. */
   public ConceptSet getConceptSet(Long workspaceId, Long conceptSetId) {
     DbConceptSet dbConceptSet = getDbConceptSet(workspaceId, conceptSetId);
     return toHydratedConcepts(
@@ -169,10 +170,19 @@ public class ConceptSetService {
         .collect(Collectors.toList());
   }
 
+  /**
+   * Read concept-sets with empty collection of concept ids. If the collection of concept ids needs
+   * to be populated please use: {@link ConceptSetService#getConceptSet(Long, Long)}. In most cases,
+   * there is not a need to load all the concept ids, so this call should be sufficient.
+   */
   public List<ConceptSet> findByWorkspaceId(long workspaceId) {
     return conceptSetDao.findByWorkspaceId(workspaceId).stream()
-        .map(conceptSet -> toHydratedConcepts(conceptSetMapper.dbModelToClient(conceptSet)))
+        .map(conceptSetMapper::dbModelToClient)
         .collect(Collectors.toList());
+  }
+
+  public Long countConceptsInConceptSet(Long conceptSetId) {
+    return conceptSetDao.countByConceptSetId(conceptSetId);
   }
 
   @Transactional

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
@@ -27,5 +27,5 @@ public interface ConceptSetDao extends CrudRepository<DbConceptSet, Long> {
               + "from concept_set_concept_id "
               + "where concept_set_id = :conceptSetId",
       nativeQuery = true)
-  long countByConceptSetId(@Param("conceptSetId") Long conceptSetId);
+  int countByConceptSetId(@Param("conceptSetId") Long conceptSetId);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
@@ -4,7 +4,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.pmiops.workbench.db.model.DbConceptSet;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface ConceptSetDao extends CrudRepository<DbConceptSet, Long> {
 
@@ -19,5 +21,11 @@ public interface ConceptSetDao extends CrudRepository<DbConceptSet, Long> {
 
   int countByWorkspaceId(long workspaceId);
 
-  long countByConceptSetId(long conceptSetId);
+  @Query(
+      value =
+          "select count(*) "
+              + "from concept_set_concept_id "
+              + "where concept_set_id = :conceptSetId",
+      nativeQuery = true)
+  long countByConceptSetId(@Param("conceptSetId") Long conceptSetId);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ConceptSetDao.java
@@ -18,4 +18,6 @@ public interface ConceptSetDao extends CrudRepository<DbConceptSet, Long> {
   List<DbConceptSet> findAllByConceptSetIdIn(Collection<Long> conceptSetIds);
 
   int countByWorkspaceId(long workspaceId);
+
+  long countByConceptSetId(long conceptSetId);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2355,6 +2355,22 @@ paths:
           description: ACCEPTED
           schema:
             "$ref": "#/definitions/EmptyResponse"
+  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/concept-sets/{conceptSetId}/concept-count":
+    parameters:
+    - "$ref": "#/parameters/workspaceNamespace"
+    - "$ref": "#/parameters/workspaceId"
+    - "$ref": "#/parameters/conceptSetId"
+    get:
+      tags:
+      - conceptSets
+      description: The number of concepts in this concept-set.
+      operationId: countConceptsInConceptSet
+      responses:
+        200:
+          description: A count of concepts
+          schema:
+            type: integer
+            format: int64
   "/v1/workspaces/{workspaceNamespace}/{workspaceId}/concept-sets/{conceptSetId}/concepts":
     parameters:
     - "$ref": "#/parameters/workspaceNamespace"

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2370,7 +2370,6 @@ paths:
           description: A count of concepts
           schema:
             type: integer
-            format: int64
   "/v1/workspaces/{workspaceNamespace}/{workspaceId}/concept-sets/{conceptSetId}/concepts":
     parameters:
     - "$ref": "#/parameters/workspaceNamespace"

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -667,7 +667,18 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(1);
-    assertThat(response).contains(defaultConceptSet);
+    assertConceptSet(response.get(0), defaultConceptSet);
+  }
+
+  @Test
+  public void countConceptsInConceptSet() {
+    // use defaultConceptSet
+    assertThat(
+            conceptSetsController
+                .countConceptsInConceptSet(
+                    workspace.getNamespace(), workspace.getId(), defaultConceptSet.getId())
+                .getBody())
+        .isEqualTo(1);
   }
 
   @Test
@@ -705,7 +716,14 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(4);
-    assertThat(response).containsExactly(defaultConceptSet, conceptSet2, conceptSet3, conceptSet4);
+    // defaultConceptSet
+    assertConceptSet(response.get(0), defaultConceptSet);
+    // conceptSet2
+    assertConceptSet(response.get(1), conceptSet2);
+    // conceptSet3
+    assertConceptSet(response.get(2), conceptSet3);
+    // conceptSet4
+    assertConceptSet(response.get(3), conceptSet4);
   }
 
   @Test
@@ -733,7 +751,7 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(1);
-    assertThat(response).contains(defaultConceptSet);
+    assertConceptSet(response.get(0), defaultConceptSet);
   }
 
   @Test
@@ -749,7 +767,7 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(1);
-    assertThat(response).contains(defaultConceptSet);
+    assertConceptSet(response.get(0), defaultConceptSet);
   }
 
   @Test
@@ -765,7 +783,7 @@ public class ConceptSetsControllerTest {
             .getItems();
 
     assertThat(response.size()).isEqualTo(1);
-    assertThat(response).contains(defaultConceptSet);
+    assertConceptSet(response.get(0), defaultConceptSet);
   }
 
   @Test
@@ -1609,5 +1627,16 @@ public class ConceptSetsControllerTest {
         .addName(criteria.getName())
         .addFullText("+[" + criteria.getDomainId() + "_rank1]")
         .build();
+  }
+
+  private void assertConceptSet(ConceptSet actualConceptSet, ConceptSet expectedConceptSet) {
+    assertThat(actualConceptSet.getCriteriums()).isNotNull();
+    assertThat(actualConceptSet.getCreationTime()).isEqualTo(expectedConceptSet.getCreationTime());
+    assertThat(actualConceptSet.getDescription()).isEqualTo(expectedConceptSet.getDescription());
+    assertThat(actualConceptSet.getDomain()).isEqualTo(expectedConceptSet.getDomain());
+    assertThat(actualConceptSet.getEtag()).isEqualTo(expectedConceptSet.getEtag());
+    assertThat(actualConceptSet.getLastModifiedTime())
+        .isEqualTo(expectedConceptSet.getLastModifiedTime());
+    assertThat(actualConceptSet.getName()).isEqualTo(expectedConceptSet.getName());
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/ConceptSetDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/ConceptSetDaoTest.java
@@ -78,6 +78,11 @@ public class ConceptSetDaoTest {
   }
 
   @Test
+  public void countByConceptSetId() {
+    assertThat(conceptSetDao.countByConceptSetId(dbConceptSet.getConceptSetId())).isEqualTo(1);
+  }
+
+  @Test
   public void findConceptSetByNameAndWorkspaceId() {
     assertThat(
             conceptSetDao.findConceptSetByNameAndWorkspaceId(

--- a/ui/src/app/pages/data/concept/concept-add-modal.tsx
+++ b/ui/src/app/pages/data/concept/concept-add-modal.tsx
@@ -118,7 +118,7 @@ export const ConceptAddModal = withCurrentWorkspace()(
           selectedConceptsInDomain: filterConcepts(selectedConcepts, domain),
           loading: false,
         });
-        if (conceptSetsInDomain && conceptSetsInDomain[0]) {
+        if (conceptSetsInDomain?.[0]) {
           this.selectConceptSet(conceptSetsInDomain[0]);
         }
       } catch (error) {

--- a/ui/src/testing/stubs/concept-sets-api-stub.ts
+++ b/ui/src/testing/stubs/concept-sets-api-stub.ts
@@ -258,6 +258,12 @@ export class ConceptSetsApiStub extends ConceptSetsApi {
     });
   }
 
+  public countConceptsInConceptSet(workspaceNamespace: string, workspaceId: string, conceptSetId: number, options?: any): Promise<number> {
+    return new Promise<number>((resolve) => {
+      resolve(this.conceptSets[0].criteriums.length);
+    })
+  }
+
   copyConceptSet(): Promise<any> {
     return new Promise<any>((resolve) => {
       resolve({});

--- a/ui/src/testing/stubs/concept-sets-api-stub.ts
+++ b/ui/src/testing/stubs/concept-sets-api-stub.ts
@@ -258,10 +258,10 @@ export class ConceptSetsApiStub extends ConceptSetsApi {
     });
   }
 
-  public countConceptsInConceptSet(workspaceNamespace: string, workspaceId: string, conceptSetId: number, options?: any): Promise<number> {
+  public countConceptsInConceptSet(): Promise<number> {
     return new Promise<number>((resolve) => {
       resolve(this.conceptSets[0].criteriums.length);
-    })
+    });
   }
 
   copyConceptSet(): Promise<any> {


### PR DESCRIPTION
Fix long load times for concept sets by removing the concept set hydrate method.

Details are here: https://precisionmedicineinitiative.atlassian.net/browse/RW-8420


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
