### PR TITLE
[RW-8446][risk=no] Add missing RDR backfill parameter on cloud task

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskRdrExportController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskRdrExportController.java
@@ -26,12 +26,12 @@ public class CloudTaskRdrExportController implements CloudTaskRdrExportApiDelega
    * @return
    */
   @Override
-  public ResponseEntity<Void> exportResearcherData(ArrayOfLong researcherIds) {
+  public ResponseEntity<Void> exportResearcherData(ArrayOfLong researcherIds, Boolean backfill) {
     if (researcherIds == null || researcherIds.isEmpty()) {
       log.severe(" call to export Researcher Data had no Ids");
       return ResponseEntity.noContent().build();
     }
-    rdrExportService.exportUsers(researcherIds, false);
+    rdrExportService.exportUsers(researcherIds, Boolean.TRUE.equals(backfill));
 
     return ResponseEntity.noContent().build();
   }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2749,6 +2749,10 @@ paths:
       consumes:
       - application/json
       parameters:
+      - in: query
+        name: backfill
+        type: boolean
+        required: false
       - in: body
         name: researcherIds
         required: true

--- a/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/CloudTaskInterceptorTest.java
@@ -49,7 +49,8 @@ public class CloudTaskInterceptorTest {
     when(request.getMethod()).thenReturn(HttpMethods.POST);
     when(handler.getMethod())
         .thenReturn(
-            CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, ArrayOfLong.class));
+            CloudTaskRdrExportApi.class.getMethod(
+                CLOUD_TASK_METHOD_NAME, ArrayOfLong.class, Boolean.class));
     assertThat(interceptor.preHandle(request, response, handler)).isFalse();
   }
 
@@ -58,7 +59,8 @@ public class CloudTaskInterceptorTest {
     when(request.getMethod()).thenReturn(HttpMethods.POST);
     when(handler.getMethod())
         .thenReturn(
-            CloudTaskRdrExportApi.class.getMethod(CLOUD_TASK_METHOD_NAME, ArrayOfLong.class));
+            CloudTaskRdrExportApi.class.getMethod(
+                CLOUD_TASK_METHOD_NAME, ArrayOfLong.class, Boolean.class));
     when(request.getHeader(CloudTaskInterceptor.QUEUE_NAME_REQUEST_HEADER))
         .thenReturn("rdrExportQueue");
     assertThat(interceptor.preHandle(request, response, handler)).isTrue();


### PR DESCRIPTION
Missed this in https://github.com/all-of-us/workbench/pull/6751 ; without it, we never pass backfill=true to the RDR.