### PR TITLE
[RW-8293][RW-8167][RW-8150][risk=low] Bump AoU notebook image to latest in local/test

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -9,7 +9,7 @@
     "leoBaseUrl": "https:\/\/leonardo.dsde-dev.broadinstitute.org",
     "xAppIdValue": "local-AoU-RW",
     "timeoutInSeconds": 180,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.13",
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.5",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev",
     "workspaceLogsProject": "fc-aou-logs-test",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -9,7 +9,7 @@
     "leoBaseUrl": "https:\/\/leonardo.dsde-dev.broadinstitute.org",
     "xAppIdValue": "test-AoU-RW",
     "timeoutInSeconds": 180,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.0.13",
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.1.5",
     "shibbolethApiBaseUrl": "https:\/\/profile-dot-broad-shibboleth-prod.appspot.com/dev",
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev",
     "workspaceLogsProject": "fc-aou-logs-test",


### PR DESCRIPTION
Starting with local/test; I don't want the image upgrade interfering with next week's prod release. The caching update is live in dev, and is rolling out to other environments now: https://github.com/DataBiosphere/leonardo/pull/2741

See the changelog here for details: https://github.com/DataBiosphere/terra-docker/blob/master/terra-jupyter-aou/CHANGELOG.md