### PR TITLE
[RW-8266][risk=low] Implement CDR file publishing via Cloud Storage Transfer Service

### DIFF
--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -400,9 +400,7 @@ def publish_cdr_files(cmd_name, args)
     common.status "Starting: copy manifest creation"
     copy_manifests = {}
     output_manifests = {}
-    def output_manifest_path(working_dir, source_name)
-      "#{working_dir}/#{source_name}_output_manifest.csv"
-    end
+    output_manifest_path = -> (source_name) { "#{working_dir}/#{source_name}_output_manifest.csv" }
 
     input_manifest = parse_input_manifest(op.opts.input_manifest_file)
 
@@ -416,7 +414,7 @@ def publish_cdr_files(cmd_name, args)
       aw4_microarray_sources.each do |source_name, section|
         common.status("building manifest for '#{source_name}'")
         copy, output = build_manifests_for_aw4_section(
-          section, tier[:ingest_cdr_bucket], tier[:dest_cdr_bucket], op.opts.display_version_id, microarray_aw4_rows, output_manifest_path(working_dir, source_name))
+          section, tier[:ingest_cdr_bucket], tier[:dest_cdr_bucket], op.opts.display_version_id, microarray_aw4_rows, output_manifest_path.call(source_name))
         key_name = "aw4_microarray_" + source_name
         copy_manifests[key_name] = copy
         unless output.nil?
@@ -473,7 +471,7 @@ def publish_cdr_files(cmd_name, args)
       copy_manifest_files.push(path)
     end
     output_manifests.each do |source_name, output_manifest|
-      path = output_manifest_path(working_dir, source_name)
+      path = output_manifest_path.call(source_name)
       CSV.open(path, 'wb') do |f|
         f << output_manifest.first.keys
         output_manifest.each { |c| f << c.values }

--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -400,6 +400,9 @@ def publish_cdr_files(cmd_name, args)
     common.status "Starting: copy manifest creation"
     copy_manifests = {}
     output_manifests = {}
+    def output_manifest_path(working_dir, source_name)
+      "#{working_dir}/#{source_name}_output_manifest.csv"
+    end
 
     input_manifest = parse_input_manifest(op.opts.input_manifest_file)
 
@@ -413,7 +416,7 @@ def publish_cdr_files(cmd_name, args)
       aw4_microarray_sources.each do |source_name, section|
         common.status("building manifest for '#{source_name}'")
         copy, output = build_manifests_for_aw4_section(
-          section, tier[:ingest_cdr_bucket], tier[:dest_cdr_bucket], op.opts.display_version_id, microarray_aw4_rows)
+          section, tier[:ingest_cdr_bucket], tier[:dest_cdr_bucket], op.opts.display_version_id, microarray_aw4_rows, output_manifest_path(working_dir, source_name))
         key_name = "aw4_microarray_" + source_name
         copy_manifests[key_name] = copy
         unless output.nil?
@@ -432,7 +435,7 @@ def publish_cdr_files(cmd_name, args)
       aw4_wgs_sources.each do |source_name, section|
         common.status("building manifest for '#{source_name}'")
         copy, output = build_manifests_for_aw4_section(
-          section, tier[:ingest_cdr_bucket], tier[:dest_cdr_bucket], op.opts.display_version_id, wgs_aw4_rows)
+          section, tier[:ingest_cdr_bucket], tier[:dest_cdr_bucket], op.opts.display_version_id, wgs_aw4_rows, output_manifest_path(working_dir, source_name))
         key_name = "aw4_wgs_" + source_name
         copy_manifests[key_name] = copy
         unless output.nil?
@@ -470,7 +473,7 @@ def publish_cdr_files(cmd_name, args)
       copy_manifest_files.push(path)
     end
     output_manifests.each do |source_name, output_manifest|
-      path = "#{working_dir}/#{source_name}_output_manifest.csv"
+      path = output_manifest_path(working_dir, source_name)
       CSV.open(path, 'wb') do |f|
         f << output_manifest.first.keys
         output_manifest.each { |c| f << c.values }

--- a/api/db-cdr/generate-cdr/libproject/genomic_manifests.rb
+++ b/api/db-cdr/generate-cdr/libproject/genomic_manifests.rb
@@ -41,6 +41,11 @@ require_relative "../../../libproject/environments"
 PROD_BROAD_BUCKET = "gs://prod-drc-broad"
 OLD_ARRAYS_PATH_INFIX = "array_old_egt_files"
 
+
+CURATION_SYNTHETIC_SOURCE_CONFIG = {
+  :wgs_aw4_prefix => "gs://all-of-us-workbench-test-genomics/aw4_wgs/"
+}
+
 CURATION_PROD_SOURCE_CONFIG = {
   # Optional: to speed up iteration with this script, download and run against a local directory instead.
   :wgs_aw4_prefix => "#{PROD_BROAD_BUCKET}/AW4_wgs_manifest/AoU_DRCB_SEQ_",
@@ -50,6 +55,18 @@ CURATION_PROD_SOURCE_CONFIG = {
 }
 
 FILE_ENVIRONMENTS = {
+  "all-of-us-workbench-test" => {
+    :source_config => CURATION_SYNTHETIC_SOURCE_CONFIG,
+  },
+  "all-of-us-rw-perf" => {
+    :source_config => CURATION_SYNTHETIC_SOURCE_CONFIG,
+  },
+  "all-of-us-rw-staging" => {
+    :source_config => CURATION_SYNTHETIC_SOURCE_CONFIG,
+  },
+  "all-of-us-rw-stable" => {
+    :source_config => CURATION_SYNTHETIC_SOURCE_CONFIG,
+  },
   "all-of-us-rw-preprod" => {
     :source_config => CURATION_PROD_SOURCE_CONFIG,
   },

--- a/api/libproject/affirm.rb
+++ b/api/libproject/affirm.rb
@@ -6,7 +6,7 @@ YES_RESPONSES = ['roger', 'affirmative', 'yes', 'yep', 'positively', 'aye', 'def
 def get_user_confirmation(message)
   yes_response = YES_RESPONSES.sample
 
-  while true
+  loop do
     Common.new.status("#{message} [#{yes_response}/N]")
     answer = STDIN.gets.chomp
     if answer.downcase == yes_response

--- a/api/libproject/affirm.rb
+++ b/api/libproject/affirm.rb
@@ -1,0 +1,19 @@
+require_relative "../../aou-utils/utils/common"
+
+YES_RESPONSES = ['roger', 'affirmative', 'yes', 'yep', 'positively', 'aye', 'definitely']
+
+# Get user confirmation
+def get_user_confirmation(message)
+  yes_response = YES_RESPONSES.sample
+
+  while true
+    Common.new.status("#{message} [#{yes_response}/N]")
+    answer = STDIN.gets.chomp
+    if answer.downcase == yes_response
+      return
+    elsif answer.downcase == 'n'
+      raise RuntimeError.new("Operation cancelled by user.")
+    end
+    # Try again, not an unambiguous yes or no
+  end
+end

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -5,6 +5,7 @@
 require_relative "../../aou-utils/serviceaccounts"
 require_relative "../../aou-utils/utils/common"
 require_relative "../../aou-utils/workbench"
+require_relative "affirm"
 require_relative "cloudsqlproxycontext"
 require_relative "environments"
 require_relative "gcloudcontext"
@@ -402,19 +403,6 @@ def liquibase_gradlew_command(command, argument = '', run_list = '')
   end
 
   full_cmd_array
-end
-
-YES_RESPONSES = ['roger', 'affirmative', 'indubitably', 'yep', 'positively', 'aye', 'definitely']
-
-# Get user confirmation
-def get_user_confirmation(message)
-  yes_response = YES_RESPONSES.sample
-  Common.new.status("#{message} [#{yes_response}/N]")
-
-  answer = STDIN.gets.chomp
-  unless answer.downcase == yes_response
-    raise RuntimeError.new("Operation cancelled by user.")
-  end
 end
 
 # Run a Liquibase command against the specified project. Where possible, show SQL


### PR DESCRIPTION
Significant changes:
- Support CDR output manifests for use with [genomic data versioning](https://docs.google.com/document/d/1-ayWRzbz654JiE90x9aMFOqoq4oMnhmIXwlaYbDZkVg/edit)
- File staging layout change: I realized that Cloud Transfer Service can only do path prefixes (includes / excludes), and my interleaved Nearline CRAMs with standard CRAM indexes would therefore be impossible to transfer. My workaround is to add a path prefix within the ingest bucket for any files destined for non-standard storage.

Also:
- a handful of fixes around file staging..
- factor out the "get_user_confirmation" method and fix some of its papercuts