### PR TITLE
[risk=no] Upgrade Node to v14 in Dockerfile for deploys

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN npm install --global yarn n
-# Upgrade to Node 12, above installs 10.
-RUN n 12
+# Upgrade to Node 14, above installs 10.
+RUN n 14
 
 ENV CLOUD_SDK_VERSION 321.0.0
 


### PR DESCRIPTION
Deploy to staging failed with error 
`error react-scripts@5.0.1: The engine "node" is incompatible with this module. Expected version ">=14.0.0". Got "12.22.12"`

Likely a result of upgrade to react-scripts in #6753 which requires a newer version of node.

Dry run deploy to stable was successful:
```
deploy/project.rb deploy --project all-of-us-rw-stable --account deploy@all-of-us-rw-stable.iam.gserviceaccount.com --git-version origin/main --app-version will-temp --dry-run --no-promote --no-update-jira
```

FYI @calbach @jmthibault79 