### PR TITLE
[RW-8519][risk=no] Increase min scatter count to 350

### DIFF
--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -48,7 +48,7 @@
     "extractionMethodConfigurationVersion": 5,
     "extractionMethodLogicalVersion": 3,
     "extractionDestinationDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_destination",
-    "minExtractionScatterTasks": 100,
+    "minExtractionScatterTasks": 350,
     "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -48,7 +48,7 @@
     "extractionMethodConfigurationVersion": 4,
     "extractionMethodLogicalVersion": 3,
     "extractionDestinationDataset": "fc-aou-cdr-prod-ct.wgs_extraction_destination",
-    "minExtractionScatterTasks": 100,
+    "minExtractionScatterTasks": 350,
     "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },


### PR DESCRIPTION
From local experimentation, it seems even 300 is too low. The lowest known scatter count to work is 323. Use 350 for safety. Variants team is looking at possible improvements to support lower scatter counts.