### PR TITLE
[RW-8556][risk-low] Separate AI and AN from AI/AN

### DIFF
--- a/api/db/changelog/db.changelog-201-demographic-survey-v2-aian.xml
+++ b/api/db/changelog/db.changelog-201-demographic-survey-v2-aian.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="dmohs" id="changelog-201-demographic-survey-v2-aian">
+    <sql>
+      ALTER TABLE demographic_survey_v2_ethnic_category
+        MODIFY COLUMN ethnic_category
+        ENUM(
+          'AI_AN', 'AI_AN_AMERICAN_INDIAN', 'AI_AN_ALASKA_NATIVE', 'AI_AN_CENTRAL_SOUTH',
+          'AI_AN_OTHER',
+
+          'ASIAN', 'ASIAN_INDIAN', 'ASIAN_CAMBODIAN', 'ASIAN_CHINESE', 'ASIAN_FILIPINO',
+          'ASIAN_HMONG', 'ASIAN_JAPANESE', 'ASIAN_KOREAN', 'ASIAN_LAO', 'ASIAN_PAKISTANI',
+          'ASIAN_VIETNAMESE', 'ASIAN_OTHER',
+
+          'BLACK', 'BLACK_AA', 'BLACK_BARBADIAN', 'BLACK_CARIBBEAN', 'BLACK_ETHIOPIAN',
+          'BLACK_GHANAIAN', 'BLACK_HAITIAN', 'BLACK_JAMAICAN', 'BLACK_LIBERIAN', 'BLACK_NIGERIAN',
+          'BLACK_SOMALI', 'BLACK_SOUTH_AFRICAN', 'BLACK_OTHER',
+
+          'HISPANIC', 'HISPANIC_COLUMBIAN', 'HISPANIC_CUBAN', 'HISPANIC_DOMINICAN',
+          'HISPANIC_ECUADORIAN', 'HISPANIC_HONDURAN', 'HISPANIC_MEXICAN', 'HISPANIC_PUERTO_RICAN',
+          'HISPANIC_SALVADORAN', 'HISPANIC_SPANISH', 'HISPANIC_OTHER',
+
+          'MENA', 'MENA_AFGHAN', 'MENA_ALGERIAN', 'MENA_EGYPTIAN', 'MENA_IRANIAN', 'MENA_IRAQI',
+          'MENA_ISRAELI', 'MENA_LEBANESE', 'MENA_MOROCCAN', 'MENA_SYRIAN', 'MENA_TUNISIAN',
+          'MENA_OTHER',
+
+          'NHPI', 'NHPI_CHAMORRO', 'NHPI_CHUUKESE', 'NHPI_FIJIAN', 'NHPI_MARSHALLESE',
+          'NHPI_HAWAIIAN', 'NHPI_PALAUAN', 'NHPI_SAMOAN', 'NHPI_TAHITIAN', 'NHPI_TONGAN',
+          'NHPI_OTHER',
+
+          'WHITE', 'WHITE_DUTCH', 'WHITE_ENGLISH', 'WHITE_EUROPEAN', 'WHITE_FRENCH',
+          'WHITE_GERMAN', 'WHITE_IRISH', 'WHITE_ITALIAN', 'WHITE_NORWEGIAN', 'WHITE_POLISH',
+          'WHITE_SCOTTISH', 'WHITE_SPANISH', 'WHITE_OTHER',
+
+          'OTHER', 'PREFER_NOT_TO_ANSWER'
+        )
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -208,6 +208,7 @@
   <include file="changelog/db.changelog-198-index-rdr-export-entities.xml"/>
   <include file="changelog/db.changelog-199-update-demographic-survey-v2.xml"/>
   <include file="changelog/db.changelog-200-demographic-survey-v2-tweaks.xml"/>
+  <include file="changelog/db.changelog-201-demographic-survey-v2-aian.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurveyV2.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbDemographicSurveyV2.java
@@ -386,7 +386,8 @@ public class DbDemographicSurveyV2 {
 
   public enum DbEthnicCategory {
     AI_AN,
-    AI_AN_AI_AN,
+    AI_AN_AMERICAN_INDIAN,
+    AI_AN_ALASKA_NATIVE,
     AI_AN_CENTRAL_SOUTH,
     AI_AN_OTHER,
 

--- a/api/src/main/resources/rdr.yaml
+++ b/api/src/main/resources/rdr.yaml
@@ -546,7 +546,8 @@ definitions:
     description: 'Which categories describe you? (Select all that apply). Note, you may select more than one group.'
     enum:
       - AI_AN                 # American Indian or Alaska Native (no additional qualifier)
-      - AI_AN_AI_AN           # American Indian or Alaska Native / American Indian or Alaska Native
+      - AI_AN_AMERICAN_INDIAN # American Indian or Alaska Native / American Indian
+      - AI_AN_ALASKA_NATIVE   # American Indian or Alaska Native / Alaska Native
       - AI_AN_CENTRAL_SOUTH   # American Indian or Alaska Native / Central or South American Indian
       - AI_AN_OTHER           # American Indian or Alaska Native / None of these fully describe me, and I want to specify
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9712,7 +9712,8 @@ definitions:
     description: 'Which categories describe you? (Select all that apply). Note, you may select more than one group.'
     enum:
       - AI_AN                 # American Indian or Alaska Native (no additional qualifier)
-      - AI_AN_AI_AN           # American Indian or Alaska Native / American Indian or Alaska Native
+      - AI_AN_AMERICAN_INDIAN # American Indian or Alaska Native / American Indian
+      - AI_AN_ALASKA_NATIVE   # American Indian or Alaska Native / Alaska Native
       - AI_AN_CENTRAL_SOUTH   # American Indian or Alaska Native / Central or South American Indian
       - AI_AN_OTHER           # American Indian or Alaska Native / None of these fully describe me, and I want to specify
 

--- a/ui/src/app/components/demographic-survey-v2.tsx
+++ b/ui/src/app/components/demographic-survey-v2.tsx
@@ -338,8 +338,8 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
         </div>
         <FlexColumn>
           <MultipleChoiceQuestion
-            question='1. Which categories describe you?'
-            label='Race(s) and/or Ethnicities'
+            question='1. Which Racial and Ethnic categories describe you?'
+            label='Racial and/or Ethnic Identity/Identities'
             options={[
               {
                 label: 'American Indian or Alaska Native (AIAN)',

--- a/ui/src/app/components/demographic-survey-v2.tsx
+++ b/ui/src/app/components/demographic-survey-v2.tsx
@@ -290,7 +290,8 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
         survey.ethnicCategories.some(
           (s) =>
             s === EthnicCategory.AIAN ||
-            s === EthnicCategory.AIANAIAN ||
+            s === EthnicCategory.AIANAMERICANINDIAN ||
+            s === EthnicCategory.AIANALASKANATIVE ||
             s === EthnicCategory.AIANCENTRALSOUTH ||
             s === EthnicCategory.AIANOTHER
         )
@@ -345,8 +346,12 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
                 value: EthnicCategory.AIAN,
                 subOptions: [
                   {
-                    label: 'American Indian or Alaska Native (AIAN)',
-                    value: EthnicCategory.AIANAIAN,
+                    label: 'American Indian',
+                    value: EthnicCategory.AIANAMERICANINDIAN,
+                  },
+                  {
+                    label: 'Alaska Native',
+                    value: EthnicCategory.AIANALASKANATIVE,
                   },
                   {
                     label: 'Central or South American Indian',


### PR DESCRIPTION
Ran migration locally.

Started API server.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
