### PR TITLE
[risk=low][no ticket] Expand environmentFilePath inline and add spacing

### DIFF
--- a/ui/config-overrides.js
+++ b/ui/config-overrides.js
@@ -15,12 +15,9 @@ const removeCssMinimizer = (original) => {
 
 module.exports = {
   webpack: function(config, env) {
-    let environmentFilePath = null
     if (!process.env.REACT_APP_ENVIRONMENT) {
       throw new Error(`REACT_APP_ENVIRONMENT is not set. It must be set in order to use yarn start or dev-up. For example REACT_APP_ENVIRONMENT=local yarn dev-up`);
     }
-
-    environmentFilePath = `environment.${process.env.REACT_APP_ENVIRONMENT}.ts`
 
     if (!config.plugins) {
       config.plugins = []
@@ -28,10 +25,11 @@ module.exports = {
     config.plugins.push(
         new webpack.NormalModuleReplacementPlugin(
             /src\/environments\/environment\.ts/,
-            environmentFilePath
+            `environment.${process.env.REACT_APP_ENVIRONMENT}.ts`
         )
     );
-   config.optimization.minimizer = removeCssMinimizer(config.optimization.minimizer);
+    
+    config.optimization.minimizer = removeCssMinimizer(config.optimization.minimizer);
 
     return config;
   },


### PR DESCRIPTION
Good morning.  I'm playing around with the PRs which were merged while I was out.  #6807 works great and I think it will reduce errors related to choosing the wrong type of local UI.  What do you think of this small update to it?

Also fixed an unrelated wrong indentation.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
