### PR TITLE
[RW-8562][risk=no] Check max concept count when editing concept set

### DIFF
--- a/ui/src/app/pages/data/concept/concept-add-modal.tsx
+++ b/ui/src/app/pages/data/concept/concept-add-modal.tsx
@@ -45,7 +45,7 @@ const filterConcepts = (concepts: any[], domain: Domain) => {
     : concepts;
 };
 
-const CONCEPT_SET_CONCEPT_LIMIT = 1000;
+export const CONCEPT_SET_CONCEPT_LIMIT = 1000;
 
 export const ConceptAddModal = withCurrentWorkspace()(
   class extends React.Component<

--- a/ui/src/app/pages/data/concept/concept-list.tsx
+++ b/ui/src/app/pages/data/concept/concept-list.tsx
@@ -13,8 +13,12 @@ import { domainToTitle } from 'app/cohort-search/utils';
 import { Button } from 'app/components/buttons';
 import { FlexRow, FlexRowWrap } from 'app/components/flex';
 import { ClrIcon } from 'app/components/icons';
+import { TooltipTrigger } from 'app/components/popups';
 import { SpinnerOverlay } from 'app/components/spinners';
-import { ConceptAddModal } from 'app/pages/data/concept/concept-add-modal';
+import {
+  CONCEPT_SET_CONCEPT_LIMIT,
+  ConceptAddModal,
+} from 'app/pages/data/concept/concept-add-modal';
 import { LOCAL_STORAGE_KEY_CRITERIA_SELECTIONS } from 'app/pages/data/criteria-search';
 import { conceptSetsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
@@ -201,6 +205,7 @@ export const ConceptListPage = fp.flow(
         updating ||
         !concept ||
         concept.length === 0 ||
+        concept.length > CONCEPT_SET_CONCEPT_LIMIT ||
         (!!conceptSet &&
           JSON.stringify(conceptSet.criteriums.sort()) ===
             JSON.stringify(concept.sort()))
@@ -291,14 +296,24 @@ export const ConceptListPage = fp.flow(
           <FlexRowWrap
             style={{ flexDirection: 'row-reverse', marginTop: '1rem' }}
           >
-            <Button
-              type='primary'
-              style={styles.saveButton}
-              disabled={this.disableSaveConceptButton}
-              onClick={() => this.onSaveConceptSetClick()}
+            <TooltipTrigger
+              content={
+                <div>
+                  Concept count cannot exceed{' '}
+                  {CONCEPT_SET_CONCEPT_LIMIT.toLocaleString()}
+                </div>
+              }
+              disabled={concept.length <= CONCEPT_SET_CONCEPT_LIMIT}
             >
-              Save Concept Set
-            </Button>
+              <Button
+                type='primary'
+                style={styles.saveButton}
+                disabled={this.disableSaveConceptButton}
+                onClick={() => this.onSaveConceptSetClick()}
+              >
+                Save Concept Set
+              </Button>
+            </TooltipTrigger>
             <Button
               type='link'
               style={{ color: colors.primary, left: 0 }}


### PR DESCRIPTION
Add check for max concept selection limit when editing an existing concept set
![Screen Shot 2022-07-05 at 11 36 53 AM](https://user-images.githubusercontent.com/40036095/177376418-fbdc877d-43f4-4465-88e7-08ff3125da80.png)

@chenchals FYI

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
