### PR TITLE
[RW-8214][risk=no] Use api call to get versioned surveys in CB tree

### DIFF
--- a/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
@@ -10,7 +10,8 @@ import {
   currentWorkspaceStore,
 } from 'app/utils/navigation';
 
-import { CohortBuilderServiceStub } from 'testing/stubs/cohort-builder-service-stub';
+import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
+import { CohortBuilderServiceStub, VersionedSurveyStubVariables } from 'testing/stubs/cohort-builder-service-stub';
 import { workspaceDataStub } from 'testing/stubs/workspaces';
 
 import { NodeProp, TreeNode } from './tree-node.component';
@@ -33,20 +34,8 @@ const treeNodeStub = {
 } as NodeProp;
 
 const surveyCOPETreeNodeStub = {
+  ...VersionedSurveyStubVariables[0],
   children: [],
-  code: '',
-  conceptId: 1333342,
-  count: 0,
-  domainId: Domain.SURVEY.toString(),
-  group: true,
-  hasAttributes: false,
-  id: 328232,
-  name: 'COVID-19 Participant Experience (COPE) Survey',
-  parentId: 0,
-  predefinedAttributes: null,
-  selectable: true,
-  subtype: 'SURVEY',
-  type: 'PM',
 } as NodeProp;
 describe('TreeNode', () => {
   beforeEach(() => {
@@ -75,7 +64,7 @@ describe('TreeNode', () => {
     );
     expect(wrapper).toBeTruthy();
   });
-  it('should display Versioned if SURVEY is COPE', () => {
+  it('should display Versioned if SURVEY is COPE', async () => {
     const wrapper = mount(
       <TreeNode
         autocompleteSelection={undefined}
@@ -86,7 +75,8 @@ describe('TreeNode', () => {
         select={() => {}}
         selectedIds={[]}
         setAttributes={() => {}}
-        domain={Domain.OBSERVATION}
+        domain={Domain.SURVEY}
+        versionedSurveyIds={VersionedSurveyStubVariables.map(({id}) => id)}
       />
     );
     expect(wrapper).toBeTruthy();

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.spec.tsx
@@ -10,8 +10,10 @@ import {
   currentWorkspaceStore,
 } from 'app/utils/navigation';
 
-import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
-import { CohortBuilderServiceStub, VersionedSurveyStubVariables } from 'testing/stubs/cohort-builder-service-stub';
+import {
+  CohortBuilderServiceStub,
+  VersionedSurveyStubVariables,
+} from 'testing/stubs/cohort-builder-service-stub';
 import { workspaceDataStub } from 'testing/stubs/workspaces';
 
 import { NodeProp, TreeNode } from './tree-node.component';
@@ -76,7 +78,7 @@ describe('TreeNode', () => {
         selectedIds={[]}
         setAttributes={() => {}}
         domain={Domain.SURVEY}
-        versionedSurveyIds={VersionedSurveyStubVariables.map(({id}) => id)}
+        versionedSurveyIds={VersionedSurveyStubVariables.map(({ id }) => id)}
       />
     );
     expect(wrapper).toBeTruthy();

--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -25,8 +25,6 @@ import {
   setSidebarActiveIconStore,
 } from 'app/utils/navigation';
 
-const COPE_SURVEY_ID = 1333342;
-const MINUTE_SURVEY_ID = 765936;
 export const COPE_SURVEY_GROUP_NAME =
   'COVID-19 Participant Experience (COPE) Survey';
 export const MINUTE_SURVEY_GROUP_NAME = 'COVID-19 Vaccine Survey';
@@ -124,6 +122,7 @@ interface TreeNodeProps {
   select: Function;
   selectedIds: Array<string>;
   setAttributes: Function;
+  versionedSurveyIds?: Array<number>;
 }
 
 interface TreeNodeState {
@@ -382,18 +381,6 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
     setSidebarActiveIconStore.next('criteria');
   }
 
-  get isCOPEOrMinuteSurvey() {
-    const {
-      node: { conceptId, name, subtype },
-    } = this.props;
-    return (
-      (subtype === CriteriaSubType.SURVEY.toString() &&
-        conceptId === COPE_SURVEY_ID &&
-        name === COPE_SURVEY_GROUP_NAME) ||
-      (conceptId === MINUTE_SURVEY_ID && name === MINUTE_SURVEY_GROUP_NAME)
-    );
-  }
-
   get showCode() {
     const {
       node: { code, domainId, name },
@@ -446,6 +433,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
       select,
       selectedIds,
       setAttributes,
+      versionedSurveyIds,
     } = this.props;
     const { children, error, expanded, hover, loading, searchMatch } =
       this.state;
@@ -525,7 +513,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
                   style={searchMatch ? styles.searchMatch : {}}
                 >
                   {displayName}
-                  {this.isCOPEOrMinuteSurvey && (
+                  {versionedSurveyIds?.includes(id) && (
                     <span style={{ paddingRight: '0.1rem' }}>
                       {' '}
                       - <i> Versioned</i>{' '}

--- a/ui/src/testing/stubs/cohort-builder-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-builder-service-stub.ts
@@ -338,6 +338,51 @@ export const RootSurveyStubVariables: Criteria[] = [
   },
 ];
 
+export const VersionedSurveyStubVariables: Criteria[] = [
+  {
+    childCount: 0,
+    code: 'cope',
+    conceptId: 1333342,
+    count: 76826,
+    domainId: Domain.SURVEY.toString(),
+    group: true,
+    hasAncestorData: false,
+    hasAttributes: false,
+    hasHierarchy: true,
+    id: 331390,
+    isStandard: false,
+    name: 'COVID-19 Participant Experience (COPE) Survey',
+    parentCount: 76826,
+    parentId: 0,
+    path: '331390',
+    selectable: true,
+    subtype: CriteriaSubType.SURVEY.toString(),
+    type: CriteriaType.PPI.toString(),
+    value: '',
+  },
+  {
+    childCount: 0,
+    code: 'cope_vaccine3',
+    conceptId: 765936,
+    count: 316,
+    domainId: 'SURVEY',
+    group: true,
+    hasAncestorData: false,
+    hasAttributes: false,
+    hasHierarchy: true,
+    id: 3000005924,
+    isStandard: false,
+    name: 'COVID-19 Vaccine Survey',
+    parentCount: 316,
+    parentId: 0,
+    path: '3000005924',
+    selectable: true,
+    subtype: 'SURVEY',
+    type: 'PPI',
+    value: '',
+  },
+];
+
 export const SurveyQuestionStubVariables = {
   328047: {
     conceptId: 1585889,
@@ -458,5 +503,9 @@ export class CohortBuilderServiceStub extends CohortBuilderApi {
 
   findUniversalDomainCounts(): Promise<CardCountResponse> {
     return new Promise<CardCountResponse>((resolve) => resolve({ items: [] }));
+  }
+
+  findVersionedSurveys(): Promise<CriteriaListResponse> {
+    return new Promise<CriteriaListResponse>((resolve) => resolve({items: VersionedSurveyStubVariables}));
   }
 }

--- a/ui/src/testing/stubs/cohort-builder-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-builder-service-stub.ts
@@ -506,6 +506,8 @@ export class CohortBuilderServiceStub extends CohortBuilderApi {
   }
 
   findVersionedSurveys(): Promise<CriteriaListResponse> {
-    return new Promise<CriteriaListResponse>((resolve) => resolve({items: VersionedSurveyStubVariables}));
+    return new Promise<CriteriaListResponse>((resolve) =>
+      resolve({ items: VersionedSurveyStubVariables })
+    );
   }
 }


### PR DESCRIPTION
Use `findVersionedSurveys` call to get versioned surveys instead of checking hardcoded values.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
