### PR TITLE
[RW-8217][risk=no] Remove link to Data Browser from device concept ids

### DIFF
--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -740,12 +740,16 @@ export const ListSearch = fp.flow(
           <td
             style={{ ...columnBodyStyle, width: '10%', paddingRight: '0.5rem' }}
           >
-            <StyledExternalLink
-              href={this.getConceptLink(row.conceptId)}
-              target='_blank'
-            >
-              {row.conceptId}
-            </StyledExternalLink>
+            {row.domainId === Domain.DEVICE ? (
+              row.conceptId
+            ) : (
+              <StyledExternalLink
+                href={this.getConceptLink(row.conceptId)}
+                target='_blank'
+              >
+                {row.conceptId}
+              </StyledExternalLink>
+            )}
           </td>
           <td
             style={{ ...columnBodyStyle, width: '10%', paddingRight: '0.5rem' }}


### PR DESCRIPTION
Since Data Browser does not have device data, we will now use plain text instead of a link for the Device domain in the concept id column in cohort builder and concept search. 

Device results:
![Screen Shot 2022-07-07 at 1 36 38 PM](https://user-images.githubusercontent.com/40036095/177846119-dfc7c597-bd35-46db-8f37-67401681192d.png)

Non-device results:
![Screen Shot 2022-07-07 at 1 36 59 PM](https://user-images.githubusercontent.com/40036095/177846161-70f3948c-f337-42e1-838f-cf076a22d31b.png)

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
