### PR TITLE
[no ticket][risk=no] Bumping cdr version in test/staging/stable/perf

### DIFF
--- a/api/config/cdr_config_perf.json
+++ b/api/config/cdr_config_perf.json
@@ -73,7 +73,7 @@
       "creationTime": "2021-04-20 00:00:00Z",
       "releaseNumber": 3,
       "numParticipants": 234525,
-      "cdrDbName": "synth_c_2019q4_38",
+      "cdrDbName": "synth_c_2019q4_39",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "storageBasePath": "v1",

--- a/api/config/cdr_config_stable.json
+++ b/api/config/cdr_config_stable.json
@@ -115,7 +115,7 @@
       "creationTime": "2019-09-30 00:00:00Z",
       "releaseNumber": 5,
       "numParticipants": 234525,
-      "cdrDbName": "synth_c_2019q4_38",
+      "cdrDbName": "synth_c_2019q4_39",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "controlled",

--- a/api/config/cdr_config_staging.json
+++ b/api/config/cdr_config_staging.json
@@ -117,7 +117,7 @@
       "creationTime": "2021-04-20 00:00:00Z",
       "releaseNumber": 3,
       "numParticipants": 234525,
-      "cdrDbName": "synth_c_2019q4_38",
+      "cdrDbName": "synth_c_2019q4_39",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "storageBasePath": "v1",

--- a/api/config/cdr_config_test.json
+++ b/api/config/cdr_config_test.json
@@ -89,7 +89,7 @@
       "creationTime": "2020-08-26 00:09:51Z",
       "releaseNumber": 3,
       "numParticipants": 234525,
-      "cdrDbName": "synth_c_2019q4_38",
+      "cdrDbName": "synth_c_2019q4_39",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "storageBasePath": "5",


### PR DESCRIPTION
Description:
- updated cdrDbName to point to new version
- doing a publish to test/staging/stable/perf environments
```
db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-workbench-test --bq-dataset test_R2019q4r3 --tier controlled --table-prefixes ds_

db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-staging --bq-dataset test_R2019q4r3 --tier controlled --table-prefixes ds_

db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-stable --bq-dataset test_R2019q4r3 --tier controlled --table-prefixes ds_

db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-perf --bq-dataset test_R2019q4r3 --tier controlled --table-prefixes ds_

```

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
