### PR TITLE
[RW-6988][risk=low] POST -> GET

### DIFF
--- a/api/db/local-vars.env
+++ b/api/db/local-vars.env
@@ -3,7 +3,7 @@
 
 DB_DRIVER=com.mysql.jdbc.Driver
 # "db" hostname is established for the local docker network via docker-compose.yaml
-DB_HOST=db
+DB_HOST="${DB_HOST:-db}"
 DB_PORT=3306
 DB_NAME=workbench
 

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -51,6 +51,7 @@ import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.RecentWorkspace;
 import org.pmiops.workbench.model.RecentWorkspaceResponse;
 import org.pmiops.workbench.model.ResearchPurpose;
+import org.pmiops.workbench.model.ResourceType;
 import org.pmiops.workbench.model.ShareWorkspaceRequest;
 import org.pmiops.workbench.model.UpdateWorkspaceRequest;
 import org.pmiops.workbench.model.UserRole;
@@ -873,7 +874,14 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   public ResponseEntity<WorkspaceResourceResponse> getWorkspaceResources(
       String workspaceNamespace,
       String workspaceId,
-      WorkspaceResourcesRequest workspaceResourcesRequest) {
+      WorkspaceResourcesRequest wrr) {
+    return getWorkspaceResourcesV2(workspaceNamespace, workspaceId, wrr.getTypesToFetch());
+  }
+
+  @Override
+  public ResponseEntity<WorkspaceResourceResponse> getWorkspaceResourcesV2(String workspaceNamespace,
+        String workspaceId,
+        List<ResourceType> resourceTypesToFetch) {
     WorkspaceAccessLevel workspaceAccessLevel =
         workspaceAuthService.enforceWorkspaceAccessLevel(
             workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
@@ -885,7 +893,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     WorkspaceResourceResponse workspaceResourceResponse = new WorkspaceResourceResponse();
     workspaceResourceResponse.addAll(
         workspaceResourcesService.getWorkspaceResources(
-            dbWorkspace, workspaceAccessLevel, workspaceResourcesRequest.getTypesToFetch()));
+            dbWorkspace, workspaceAccessLevel, resourceTypesToFetch));
     return ResponseEntity.ok(workspaceResourceResponse);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -878,15 +878,13 @@ public class WorkspacesController implements WorkspacesApiDelegate {
 
   @Override
   public ResponseEntity<WorkspaceResourceResponse> getWorkspaceResourcesV2(
-        String ns, String id, List<String> rtStrings) {
-    return getWorkspaceResourcesImpl(ns, id,
-      rtStrings.stream().map(ResourceType::fromValue).collect(Collectors.toList()));
+      String ns, String id, List<String> rtStrings) {
+    return getWorkspaceResourcesImpl(
+        ns, id, rtStrings.stream().map(ResourceType::fromValue).collect(Collectors.toList()));
   }
 
-  ResponseEntity<WorkspaceResourceResponse>
-      getWorkspaceResourcesImpl(
-        String workspaceNamespace, String workspaceId,
-        List<ResourceType> resourceTypesToFetch) {
+  ResponseEntity<WorkspaceResourceResponse> getWorkspaceResourcesImpl(
+      String workspaceNamespace, String workspaceId, List<ResourceType> resourceTypesToFetch) {
     WorkspaceAccessLevel workspaceAccessLevel =
         workspaceAuthService.enforceWorkspaceAccessLevel(
             workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -872,15 +872,20 @@ public class WorkspacesController implements WorkspacesApiDelegate {
 
   @Override
   public ResponseEntity<WorkspaceResourceResponse> getWorkspaceResources(
-      String workspaceNamespace,
-      String workspaceId,
-      WorkspaceResourcesRequest wrr) {
-    return getWorkspaceResourcesV2(workspaceNamespace, workspaceId, wrr.getTypesToFetch());
+      String ns, String id, WorkspaceResourcesRequest wrr) {
+    return getWorkspaceResourcesImpl(ns, id, wrr.getTypesToFetch());
   }
 
   @Override
-  public ResponseEntity<WorkspaceResourceResponse> getWorkspaceResourcesV2(String workspaceNamespace,
-        String workspaceId,
+  public ResponseEntity<WorkspaceResourceResponse> getWorkspaceResourcesV2(
+        String ns, String id, List<String> rtStrings) {
+    return getWorkspaceResourcesImpl(ns, id,
+      rtStrings.stream().map(ResourceType::fromValue).collect(Collectors.toList()));
+  }
+
+  ResponseEntity<WorkspaceResourceResponse>
+      getWorkspaceResourcesImpl(
+        String workspaceNamespace, String workspaceId,
         List<ResourceType> resourceTypesToFetch) {
     WorkspaceAccessLevel workspaceAccessLevel =
         workspaceAuthService.enforceWorkspaceAccessLevel(

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1042,6 +1042,7 @@ paths:
       operationId: getWorkspaceResources
       responses:
         200:
+          description: OK
           schema:
             "$ref": "#/definitions/WorkspaceResourceResponse"
   "/v2/workspaces/{workspaceNamespace}/{workspaceId}/resources":
@@ -1052,17 +1053,18 @@ paths:
       parameters:
         - in: query
           name: resourceTypesToFetch
-          type: array
-          items:
-            "$ref": "#/definitions/ResourceType"
           description: Types of workspace resources to fetch. Currently only supports
             Cohorts, Cohort Reviews, Concept Sets, and Datasets
+          type: array
+          items:
+            type: string
       tags:
       - workspaces
       description: Gets a user defined selection of objects contained within a workspace
       operationId: getWorkspaceResourcesV2
       responses:
         200:
+          description: OK
           schema:
             "$ref": "#/definitions/WorkspaceResourceResponse"
   "/v1/workspaces/{workspaceNamespace}/{workspaceId}/billing-usage":

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1042,7 +1042,27 @@ paths:
       operationId: getWorkspaceResources
       responses:
         200:
-          description: Returns all objects that describe a section of the CDR in a workspace.
+          schema:
+            "$ref": "#/definitions/WorkspaceResourceResponse"
+  "/v2/workspaces/{workspaceNamespace}/{workspaceId}/resources":
+    parameters:
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
+    get:
+      parameters:
+        - in: query
+          name: resourceTypesToFetch
+          type: array
+          items:
+            "$ref": "#/definitions/ResourceType"
+          description: Types of workspace resources to fetch. Currently only supports
+            Cohorts, Cohort Reviews, Concept Sets, and Datasets
+      tags:
+      - workspaces
+      description: Gets a user defined selection of objects contained within a workspace
+      operationId: getWorkspaceResourcesV2
+      responses:
+        200:
           schema:
             "$ref": "#/definitions/WorkspaceResourceResponse"
   "/v1/workspaces/{workspaceNamespace}/{workspaceId}/billing-usage":

--- a/e2ev2/README.md
+++ b/e2ev2/README.md
@@ -35,6 +35,18 @@ Full suite:
 yarn test
 ```
 
+## Useful Resources
+
+Jest's `expect` global provides assertions:
+
+https://jestjs.io/docs/expect
+
+Options for `yarn test ...`:
+
+https://jestjs.io/docs/cli
+
 ## Contributing Notes
 
 Jest's default test timeout is five seconds. If a test times out, it is a bug in the test. When a test fails because of a timeout, it should fail on a particular action, such as `page.waitForSelector`. In the common case, we expect these calls to return quickly. When we are expecting an operation to take some time, we set that timeout explicitly and give that particular test more time to finish. This convention provides higher granularity about why a test fails so that we can make the correct adjustments.
+
+These tests exercise the live system over TCP connections that can disconnect against dependent services (e.g. GCP) that occasionally fail. We should not expect them to always pass. Instead, we should expect them to transparently report failures and allow rapid re-runs.

--- a/e2ev2/src/test-utils.js
+++ b/e2ev2/src/test-utils.js
@@ -78,6 +78,6 @@ const impersonateUser = async (page, username) => {
       .map(x => x.access_token)
       .toPromise()
   await page.evaluate(t => setTestAccessTokenOverride(t), bearerToken)
-  expect(await page.waitForSelector('[data-test-id="signed-in"]', 4e3)).toBeDefined()
+  expect(await page.waitForSelector('[data-test-id="signed-in"]', {timeout: 4e3})).toBeDefined()
 }
 export_({impersonateUser})


### PR DESCRIPTION
Does not modify data, so request should be a GET when feasible.

https://precisionmedicineinitiative.atlassian.net/browse/RW-6988

Existing:
```
curl -H "Authorization: Bearer $DMFBT" 'localhost:8081/v2/workspaces/aou-rw-test-53ff4756/mohstest/resources?resourceTypesToFetch=COHORT'
[]
```

New:
```
% curl -H "Authorization: Bearer $DMFBT" 'localhost:8081/v2/workspaces/aou-rw-test-53ff4756/mohstest/resources?resourceTypesToFetch=COHORT,DATASET'
[]
```

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
