### PR TITLE
[risk=none][RW-8569] Modified routing spinner overlay to stay centered in the screen.

### DIFF
--- a/ui/src/app/components/with-routing-spinner.tsx
+++ b/ui/src/app/components/with-routing-spinner.tsx
@@ -5,5 +5,5 @@ import { withSpinnerOverlay } from './with-spinner-overlay';
 export const withRoutingSpinner = withSpinnerOverlay(true, {
   dark: true,
   opacity: 0.8,
-  overrideStylesOverlay: { backgroundColor: colors.black },
+  overrideStylesOverlay: { backgroundColor: colors.black, position: 'fixed' },
 });

--- a/ui/src/app/pages/demographic-survey.tsx
+++ b/ui/src/app/pages/demographic-survey.tsx
@@ -16,6 +16,7 @@ export const DemographicSurvey = (props: WithSpinnerOverlayProps) => {
   const [initialSurvey, setInitialSurvey] = useState(null);
   const [profile, setProfile] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
   const [, navigateByUrl] = useNavigation();
 
   const { hideSpinner, showSpinner } = props;
@@ -56,10 +57,12 @@ export const DemographicSurvey = (props: WithSpinnerOverlayProps) => {
   }, [profile]);
 
   const handleSubmit = async () => {
+    setSubmitting(true);
     showSpinner();
     await profileApi().updateProfile(profile);
     await profileStore.get().reload();
     hideSpinner();
+    setSubmitting(false);
     navigateByUrl('/profile');
   };
 
@@ -110,7 +113,7 @@ export const DemographicSurvey = (props: WithSpinnerOverlayProps) => {
         }
       >
         <Button
-          disabled={!!errors || !changed}
+          disabled={!!errors || !changed || submitting}
           type='primary'
           onClick={handleSubmit}
           style={{ margin: '1rem 0rem' }}

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -144,6 +144,7 @@ interface SignInState {
   captcha: boolean;
   captchaToken: string;
   currentStep: SignInStep;
+  loading: boolean;
   profile: Profile;
   // Tracks the Terms of Service version that was viewed and acknowledged by the user.
   // This is an optional parameter in the createUser API call.
@@ -224,6 +225,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
       captcha: false,
       captchaToken: null,
       currentStep: props.initialStep ? props.initialStep : SignInStep.LANDING,
+      loading: false,
       termsOfServiceVersion: null,
       // This defines the profile state for a new user flow. This will get passed to each
       // step component as a prop. When each sub-step completes, it will pass the updated Profile
@@ -414,6 +416,9 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
   }
 
   private onSubmit = async () => {
+    this.setState({
+      loading: true,
+    });
     this.props.showSpinner();
 
     try {
@@ -426,6 +431,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
       this.setState({
         profile: newProfile,
         currentStep: this.getNextStep(this.state.currentStep),
+        loading: false,
         isPreviousStep: false,
       });
     } catch (error) {
@@ -435,7 +441,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
       if (environment.enableCaptcha) {
         // Reset captcha
         this.captchaRef.current.reset();
-        this.setState({ captchaToken: null, captcha: true });
+        this.setState({ captchaToken: null, captcha: true, loading: false });
       }
     }
 
@@ -451,7 +457,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
       serverConfigStore.get().config.enableUpdatedDemographicSurvey &&
       currentStep === SignInStep.DEMOGRAPHIC_SURVEY
     ) {
-      const { errors } = this.state;
+      const { errors, loading } = this.state;
       return (
         <div
           style={{
@@ -508,7 +514,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
               }
             >
               <Button
-                disabled={!!errors || !this.state.captcha}
+                disabled={!!errors || !this.state.captcha || loading}
                 type='primary'
                 data-test-id={'submit-button'}
                 onClick={this.onSubmit}


### PR DESCRIPTION
**Description**:
Modified routing spinner overlay to stay centered in the screen.

Looked over spinners throughout the application. Details can be found in this [gist](https://gist.github.com/evrii/1237f8288add9f453dc5a44d7e4235a7).
I verified the overlay's behavior on the components that either make use of both hideSpinner and showSpinner as well as components where I saw the spinner overlay while using the application.

**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
