### PR TITLE
[no-ticket][risk=no] Run only failed tests when re-running from failed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -580,8 +580,8 @@ jobs:
             git clone --branch="$CIRCLE_BRANCH" --depth=1 \
               https://github.com/"$CIRCLE_PROJECT_USERNAME"/"$CIRCLE_PROJECT_REPONAME".git .
             (cd aou-utils/; git submodule update --init)
-      - attach_workspace:
-          at: .
+      - restore_cache:
+          key: failed-tests-{{ .Revision }}
       - run:
           name: Run tests
           working_directory: e2ev2
@@ -597,8 +597,8 @@ jobs:
             export PR_SITE_NUM="$(expr $PR_NUM % $PR_SITE_COUNT)"
 
             ./src/circle-run-tests.sh
-      - persist_to_workspace:
-          root: .
+      - save_cache:
+          key: failed-tests-{{ .Revision }}
           paths:
             - e2ev2/failed-tests.txt
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -580,8 +580,6 @@ jobs:
             git clone --branch="$CIRCLE_BRANCH" --depth=1 \
               https://github.com/"$CIRCLE_PROJECT_USERNAME"/"$CIRCLE_PROJECT_REPONAME".git .
             (cd aou-utils/; git submodule update --init)
-      - restore_cache:
-          key: failed-tests-{{ .Revision }}
       - run:
           name: Run tests
           working_directory: e2ev2
@@ -592,16 +590,13 @@ jobs:
             export SA_KEY_JSON="$(echo "$GCLOUD_CREDENTIALS" \
               | openssl enc -d -md sha256 -aes-256-cbc -base64 -A \
               -k "$GCLOUD_CREDENTIALS_KEY" 2>/dev/null)"
+            SA_EMAIL="$(echo "$SA_KEY_JSON" | jq -r .client_email)"
+            echo "$SA_KEY_JSON" | gcloud auth activate-service-account "$SA_EMAIL" --key-file=-
 
             export PR_NUM="$(echo "$CIRCLE_PULL_REQUEST" | perl -ne "/(\d+)\$/; print \$1")"
             export PR_SITE_NUM="$(expr $PR_NUM % $PR_SITE_COUNT)"
 
             ./src/circle-run-tests.sh
-      - save_cache:
-          when: on_fail
-          key: failed-tests-{{ .Revision }}
-          paths:
-            - e2ev2/failed-tests.txt
       - store_artifacts:
           path: e2ev2/screenshots
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -580,6 +580,8 @@ jobs:
             git clone --branch="$CIRCLE_BRANCH" --depth=1 \
               https://github.com/"$CIRCLE_PROJECT_USERNAME"/"$CIRCLE_PROJECT_REPONAME".git .
             (cd aou-utils/; git submodule update --init)
+      - attach_workspace:
+          at: .
       - run:
           name: Run tests
           working_directory: e2ev2
@@ -595,6 +597,10 @@ jobs:
             export PR_SITE_NUM="$(expr $PR_NUM % $PR_SITE_COUNT)"
 
             ./src/circle-run-tests.sh
+      - persist_to_workspace:
+          root: .
+          paths:
+            - e2ev2/failed-tests.txt
       - store_artifacts:
           path: e2ev2/screenshots
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -598,6 +598,7 @@ jobs:
 
             ./src/circle-run-tests.sh
       - save_cache:
+          when: on_fail
           key: failed-tests-{{ .Revision }}
           paths:
             - e2ev2/failed-tests.txt
@@ -858,7 +859,8 @@ workflows:
 
   playground:
     jobs:
-      - playground
+      - playground:
+          <<: *filter-pr-branch
   e2etests:
     jobs:
       - e2etests-deploy-ui:

--- a/e2ev2/src/circle-run-tests.sh
+++ b/e2ev2/src/circle-run-tests.sh
@@ -22,12 +22,10 @@ FAILED_TESTS=$(gsutil cat $BKT_ROOT/\*.$CIRCLE_SHA1.txt || echo -n)
 gsutil rm $BKT_ROOT/\*.$CIRCLE_SHA1.txt || true
 
 set +e
-if [[ -z $FAILED_TESTS ]]; then
-  yarn test $FAILED_TESTS \
-    --reporters=jest-silent-reporter --reporters=./src/failure-reporter.js
-else
-  yarn test --reporters=jest-silent-reporter --reporters=./src/failure-reporter.js
-fi
+# This should do the right thing. If $FAILED_TESTS is empty, nothing is specified, so Jest runs
+# all tests.
+yarn test $FAILED_TESTS \
+  --reporters=jest-silent-reporter --reporters=./src/failure-reporter.js
 TESTS_EXIT_CODE=$?
 set -e
 

--- a/e2ev2/src/circle-run-tests.sh
+++ b/e2ev2/src/circle-run-tests.sh
@@ -23,9 +23,10 @@ gsutil rm $BKT_ROOT/\*.$CIRCLE_SHA1.txt || true
 
 set +e
 if [[ -e failed-tests.txt ]]; then
-  yarn test $(<failed-tests.txt) --reporters=./src/failure-reporter.js
+  yarn test $(<failed-tests.txt) \
+    --reporters=jest-silent-reporter --reporters=./src/failure-reporter.js
 else
-  yarn test --reporters=./src/failure-reporter.js
+  yarn test --reporters=jest-silent-reporter --reporters=./src/failure-reporter.js
 fi
 TESTS_EXIT_CODE=$?
 set -e

--- a/e2ev2/src/circle-run-tests.sh
+++ b/e2ev2/src/circle-run-tests.sh
@@ -17,8 +17,17 @@ export PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome
 export JEST_SILENT_REPORTER_DOTS=true
 export JEST_SILENT_REPORTER_SHOW_PATHS=true
 
+BKT_ROOT=gs://all-of-us-workbench-test.appspot.com/circle-failed-tests
+gsutil cp $BKT_ROOT/\*.$CIRCLE_SHA1.txt failed-tests.txt || true
+
 if [[ -e failed-tests.txt ]]; then
-  yarn test $(<test-failures.txt) --reporters=./src/failure-reporter.js
+  yarn test $(<failed-tests.txt) --reporters=./src/failure-reporter.js
 else
   yarn test --reporters=./src/failure-reporter.js
 fi
+
+gsutil cp failed-tests.txt $BKT_ROOT/$CIRCLE_BUILD_NUM.$CIRCLE_SHA1.txt || true
+
+# Collect garbage
+gsutil ls $BKT_ROOT | tail -n 10 > latest.txt
+gsutil ls $BKT_ROOT | grep -v -F -f latest.txt | gsutil rm || true

--- a/e2ev2/src/circle-run-tests.sh
+++ b/e2ev2/src/circle-run-tests.sh
@@ -18,12 +18,12 @@ export JEST_SILENT_REPORTER_DOTS=true
 export JEST_SILENT_REPORTER_SHOW_PATHS=true
 
 BKT_ROOT=gs://all-of-us-workbench-test.appspot.com/circle-failed-tests
-gsutil cp $BKT_ROOT/\*.$CIRCLE_SHA1.txt failed-tests.txt || true
+FAILED_TESTS=$(gsutil cat $BKT_ROOT/\*.$CIRCLE_SHA1.txt || echo -n)
 gsutil rm $BKT_ROOT/\*.$CIRCLE_SHA1.txt || true
 
 set +e
-if [[ -e failed-tests.txt ]]; then
-  yarn test $(<failed-tests.txt) \
+if [[ -z $FAILED_TESTS ]]; then
+  yarn test $FAILED_TESTS \
     --reporters=jest-silent-reporter --reporters=./src/failure-reporter.js
 else
   yarn test --reporters=jest-silent-reporter --reporters=./src/failure-reporter.js

--- a/e2ev2/src/circle-run-tests.sh
+++ b/e2ev2/src/circle-run-tests.sh
@@ -19,6 +19,7 @@ export JEST_SILENT_REPORTER_SHOW_PATHS=true
 
 BKT_ROOT=gs://all-of-us-workbench-test.appspot.com/circle-failed-tests
 gsutil cp $BKT_ROOT/\*.$CIRCLE_SHA1.txt failed-tests.txt || true
+gsutil rm $BKT_ROOT/\*.$CIRCLE_SHA1.txt || true
 
 function save-failures {
   gsutil cp failed-tests.txt $BKT_ROOT/$CIRCLE_BUILD_NUM.$CIRCLE_SHA1.txt || true

--- a/e2ev2/src/circle-run-tests.sh
+++ b/e2ev2/src/circle-run-tests.sh
@@ -22,6 +22,7 @@ FAILED_TESTS=$(gsutil cat $BKT_ROOT/\*.$CIRCLE_SHA1.txt || echo -n)
 gsutil rm $BKT_ROOT/\*.$CIRCLE_SHA1.txt || true
 
 set +e
+export FAILED_TESTS_LOG=failed-tests.txt
 # This should do the right thing. If $FAILED_TESTS is empty, nothing is specified, so Jest runs
 # all tests.
 yarn test $FAILED_TESTS \
@@ -30,7 +31,7 @@ TESTS_EXIT_CODE=$?
 set -e
 
 if [[ $TESTS_EXIT_CODE -ne 0 ]]; then
-  gsutil cp failed-tests.txt $BKT_ROOT/$CIRCLE_BUILD_NUM.$CIRCLE_SHA1.txt || true
+  gsutil cp $FAILED_TESTS_LOG $BKT_ROOT/$CIRCLE_BUILD_NUM.$CIRCLE_SHA1.txt || true
 
   # Collect garbage
   gsutil ls $BKT_ROOT | tail -n 10 > latest.txt

--- a/e2ev2/src/circle-run-tests.sh
+++ b/e2ev2/src/circle-run-tests.sh
@@ -16,4 +16,9 @@ export UI_HOSTNAME=pr-"$PR_SITE_NUM"-dot-all-of-us-workbench-test.appspot.com
 export PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome
 export JEST_SILENT_REPORTER_DOTS=true
 export JEST_SILENT_REPORTER_SHOW_PATHS=true
-yarn test --reporters=jest-silent-reporter
+
+if [[ -e failed-tests.txt ]]; then
+  yarn test $(<test-failures.txt) --reporters=./src/failure-reporter.js
+else
+  yarn test --reporters=./src/failure-reporter.js
+fi

--- a/e2ev2/src/failure-reporter.js
+++ b/e2ev2/src/failure-reporter.js
@@ -6,13 +6,8 @@ const fileExists = p => {
 }
 
 class FailureReporter {
-  constructor(globalConfig, options = {}) {
-    this._globalConfig = globalConfig;
-  }
-
   onRunStart() {
     if (fileExists(logFileName)) {
-      console.log('\n', fs.readFileSync(logFileName, 'utf8'))
       fs.rmSync(logFileName)
     }
   }
@@ -23,14 +18,6 @@ class FailureReporter {
 
       if (hasFailures) {
         fs.writeFileSync(logFileName, test.path.slice(process.env.PWD.length+1)+'\n', {flag: 'a'})
-      }
-      if (testResult.failureMessage)
-        console.log('\n', testResult.failureMessage);
-      if (testResult.console) {
-        testResult.console
-          .filter(entry => ['error', 'warn'].includes(entry.type) && entry.message)
-          .map(entry => entry.message)
-          .forEach(console.log);
       }
     }
   }

--- a/e2ev2/src/failure-reporter.js
+++ b/e2ev2/src/failure-reporter.js
@@ -4,7 +4,8 @@ class FailureReporter {
   onTestResult(test, testResult) {
     // Stole this "isFailed" check from another reporter.
     if (!testResult.skipped && testResult.failureMessage) {
-      fs.writeFileSync(logFileName, test.path.slice(process.env.PWD.length+1)+'\n', {flag: 'a'})
+      fs.writeFileSync(process.env.FAILED_TESTS_LOG,
+        test.path.slice(process.env.PWD.length+1)+'\n', {flag: 'a'})
     }
   }
 }

--- a/e2ev2/src/failure-reporter.js
+++ b/e2ev2/src/failure-reporter.js
@@ -1,24 +1,10 @@
 const fs = require('fs')
 
-const logFileName = 'failed-tests.txt'
-const fileExists = p => {
-  try { fs.accessSync(p, fs.constants.R_OK); return true } catch (e) { return false }
-}
-
 class FailureReporter {
-  onRunStart() {
-    if (fileExists(logFileName)) {
-      fs.rmSync(logFileName)
-    }
-  }
-
   onTestResult(test, testResult) {
-    if (!testResult.skipped) {
-      const hasFailures = testResult.failureMessage
-
-      if (hasFailures) {
-        fs.writeFileSync(logFileName, test.path.slice(process.env.PWD.length+1)+'\n', {flag: 'a'})
-      }
+    // Stole this "isFailed" check from another reporter.
+    if (!testResult.skipped && testResult.failureMessage) {
+      fs.writeFileSync(logFileName, test.path.slice(process.env.PWD.length+1)+'\n', {flag: 'a'})
     }
   }
 }

--- a/e2ev2/src/failure-reporter.js
+++ b/e2ev2/src/failure-reporter.js
@@ -1,0 +1,39 @@
+const fs = require('fs')
+
+const logFileName = 'failed-tests.txt'
+const fileExists = p => {
+  try { fs.accessSync(p, fs.constants.R_OK); return true } catch (e) { return false }
+}
+
+class FailureReporter {
+  constructor(globalConfig, options = {}) {
+    this._globalConfig = globalConfig;
+  }
+
+  onRunStart() {
+    if (fileExists(logFileName)) {
+      console.log('\n', fs.readFileSync(logFileName, 'utf8'))
+      fs.rmSync(logFileName)
+    }
+  }
+
+  onTestResult(test, testResult) {
+    if (!testResult.skipped) {
+      const hasFailures = testResult.failureMessage
+
+      if (hasFailures) {
+        fs.writeFileSync(logFileName, test.path.slice(process.env.PWD.length+1)+'\n', {flag: 'a'})
+      }
+      if (testResult.failureMessage)
+        console.log('\n', testResult.failureMessage);
+      if (testResult.console) {
+        testResult.console
+          .filter(entry => ['error', 'warn'].includes(entry.type) && entry.message)
+          .map(entry => entry.message)
+          .forEach(console.log);
+      }
+    }
+  }
+}
+
+module.exports = FailureReporter

--- a/e2ev2/tests/flaky.test.js
+++ b/e2ev2/tests/flaky.test.js
@@ -1,0 +1,4 @@
+test('Fails around half the time', () => {
+  expect(Math.random() < 0.5).toBe(true)
+})
+

--- a/e2ev2/tests/flaky.test.js
+++ b/e2ev2/tests/flaky.test.js
@@ -1,4 +1,0 @@
-test('Fails around half the time', () => {
-  expect(Math.random() < 0.5).toBe(true)
-})
-


### PR DESCRIPTION
No ticket. Changes in test code only.

The objective here is to minimize the time necessary to determine if a test failure is due to a behavior change vs. infrastructure reliability.

This change saves a list of failed tests so Circle's "Re-Run from Failed" button will only run those tests that have previously failed. The file is keyed on the git hash, so any code changes will run all tests.