### PR TITLE
[RW-8611][risk=low] Delete intermediate output files from GVS extractions

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -448,7 +448,7 @@ public class GenomicExtractionService {
             .get()
             .createSubmission(
                 new FirecloudSubmissionRequest()
-                    .deleteIntermediateOutputFiles(false)
+                    .deleteIntermediateOutputFiles(true)
                     .methodConfigurationNamespace(methodConfig.getNamespace())
                     .methodConfigurationName(methodConfig.getName())
                     .useCallCache(false),


### PR DESCRIPTION
I'm double-checking with the GVS team that this should be OK... See https://precisionmedicineinitiative.atlassian.net/browse/RW-8611