### PR TITLE
[RW-8614][risk=low]: Support n2-highmem-64 

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -370,48 +370,49 @@ interface DataDictionaryPopupProps {
   dataDictionaryEntry: DataDictionaryEntry;
 }
 
-const DataDictionaryDescription: React.FunctionComponent<
-  DataDictionaryPopupProps
-> = ({ dataDictionaryEntry }) => {
-  return (
-    <div
-      style={{
-        width: '100%',
-        borderTop: `1px solid ${colorWithWhiteness(colors.dark, 0.6)}`,
-      }}
-    >
-      {dataDictionaryEntry ? (
-        <FlexColumn style={{ padding: '0.5rem' }}>
-          <div style={{ ...styles.dataDictionarySubheader, paddingTop: 0 }}>
-            Description
+const DataDictionaryDescription: React.FunctionComponent<DataDictionaryPopupProps> =
+  ({ dataDictionaryEntry }) => {
+    return (
+      <div
+        style={{
+          width: '100%',
+          borderTop: `1px solid ${colorWithWhiteness(colors.dark, 0.6)}`,
+        }}
+      >
+        {dataDictionaryEntry ? (
+          <FlexColumn style={{ padding: '0.5rem' }}>
+            <div style={{ ...styles.dataDictionarySubheader, paddingTop: 0 }}>
+              Description
+            </div>
+            <div style={styles.dataDictionaryText}>
+              {dataDictionaryEntry.description}
+            </div>
+            <div style={styles.dataDictionarySubheader}>
+              Relevant OMOP Table
+            </div>
+            <div style={styles.dataDictionaryText}>
+              {dataDictionaryEntry.relevantOmopTable}
+            </div>
+            <div style={styles.dataDictionarySubheader}>Type</div>
+            <div style={styles.dataDictionaryText}>
+              {dataDictionaryEntry.fieldType}
+            </div>
+            <div style={styles.dataDictionarySubheader}>Data Provenance</div>
+            <div style={styles.dataDictionaryText}>
+              {dataDictionaryEntry.dataProvenance}
+              {dataDictionaryEntry.dataProvenance.includes('PPI')
+                ? `: ${dataDictionaryEntry.sourcePpiModule}`
+                : null}
+            </div>
+          </FlexColumn>
+        ) : (
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <Spinner style={{ height: 36, width: 36, margin: '0.5rem' }} />
           </div>
-          <div style={styles.dataDictionaryText}>
-            {dataDictionaryEntry.description}
-          </div>
-          <div style={styles.dataDictionarySubheader}>Relevant OMOP Table</div>
-          <div style={styles.dataDictionaryText}>
-            {dataDictionaryEntry.relevantOmopTable}
-          </div>
-          <div style={styles.dataDictionarySubheader}>Type</div>
-          <div style={styles.dataDictionaryText}>
-            {dataDictionaryEntry.fieldType}
-          </div>
-          <div style={styles.dataDictionarySubheader}>Data Provenance</div>
-          <div style={styles.dataDictionaryText}>
-            {dataDictionaryEntry.dataProvenance}
-            {dataDictionaryEntry.dataProvenance.includes('PPI')
-              ? `: ${dataDictionaryEntry.sourcePpiModule}`
-              : null}
-          </div>
-        </FlexColumn>
-      ) : (
-        <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <Spinner style={{ height: 36, width: 36, margin: '0.5rem' }} />
-        </div>
-      )}
-    </div>
-  );
-};
+        )}
+      </div>
+    );
+  };
 
 interface ValueListItemProps {
   checked: boolean;

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -370,49 +370,48 @@ interface DataDictionaryPopupProps {
   dataDictionaryEntry: DataDictionaryEntry;
 }
 
-const DataDictionaryDescription: React.FunctionComponent<DataDictionaryPopupProps> =
-  ({ dataDictionaryEntry }) => {
-    return (
-      <div
-        style={{
-          width: '100%',
-          borderTop: `1px solid ${colorWithWhiteness(colors.dark, 0.6)}`,
-        }}
-      >
-        {dataDictionaryEntry ? (
-          <FlexColumn style={{ padding: '0.5rem' }}>
-            <div style={{ ...styles.dataDictionarySubheader, paddingTop: 0 }}>
-              Description
-            </div>
-            <div style={styles.dataDictionaryText}>
-              {dataDictionaryEntry.description}
-            </div>
-            <div style={styles.dataDictionarySubheader}>
-              Relevant OMOP Table
-            </div>
-            <div style={styles.dataDictionaryText}>
-              {dataDictionaryEntry.relevantOmopTable}
-            </div>
-            <div style={styles.dataDictionarySubheader}>Type</div>
-            <div style={styles.dataDictionaryText}>
-              {dataDictionaryEntry.fieldType}
-            </div>
-            <div style={styles.dataDictionarySubheader}>Data Provenance</div>
-            <div style={styles.dataDictionaryText}>
-              {dataDictionaryEntry.dataProvenance}
-              {dataDictionaryEntry.dataProvenance.includes('PPI')
-                ? `: ${dataDictionaryEntry.sourcePpiModule}`
-                : null}
-            </div>
-          </FlexColumn>
-        ) : (
-          <div style={{ display: 'flex', justifyContent: 'center' }}>
-            <Spinner style={{ height: 36, width: 36, margin: '0.5rem' }} />
+const DataDictionaryDescription: React.FunctionComponent<
+  DataDictionaryPopupProps
+> = ({ dataDictionaryEntry }) => {
+  return (
+    <div
+      style={{
+        width: '100%',
+        borderTop: `1px solid ${colorWithWhiteness(colors.dark, 0.6)}`,
+      }}
+    >
+      {dataDictionaryEntry ? (
+        <FlexColumn style={{ padding: '0.5rem' }}>
+          <div style={{ ...styles.dataDictionarySubheader, paddingTop: 0 }}>
+            Description
           </div>
-        )}
-      </div>
-    );
-  };
+          <div style={styles.dataDictionaryText}>
+            {dataDictionaryEntry.description}
+          </div>
+          <div style={styles.dataDictionarySubheader}>Relevant OMOP Table</div>
+          <div style={styles.dataDictionaryText}>
+            {dataDictionaryEntry.relevantOmopTable}
+          </div>
+          <div style={styles.dataDictionarySubheader}>Type</div>
+          <div style={styles.dataDictionaryText}>
+            {dataDictionaryEntry.fieldType}
+          </div>
+          <div style={styles.dataDictionarySubheader}>Data Provenance</div>
+          <div style={styles.dataDictionaryText}>
+            {dataDictionaryEntry.dataProvenance}
+            {dataDictionaryEntry.dataProvenance.includes('PPI')
+              ? `: ${dataDictionaryEntry.sourcePpiModule}`
+              : null}
+          </div>
+        </FlexColumn>
+      ) : (
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <Spinner style={{ height: 36, width: 36, margin: '0.5rem' }} />
+        </div>
+      )}
+    </div>
+  );
+};
 
 interface ValueListItemProps {
   checked: boolean;

--- a/ui/src/app/routing/app-routing.tsx
+++ b/ui/src/app/routing/app-routing.tsx
@@ -196,167 +196,166 @@ const useOverriddenApiUrl = () => {
   return overriddenUrl;
 };
 
-export const AppRoutingComponent: React.FunctionComponent<
-  RoutingProps
-> = () => {
-  const config = useServerConfig();
-  const { authLoaded, authError } = useAuthentication();
-  const isUserDisabledInDb = useIsUserDisabled();
-  const overriddenUrl = useOverriddenApiUrl();
+export const AppRoutingComponent: React.FunctionComponent<RoutingProps> =
+  () => {
+    const config = useServerConfig();
+    const { authLoaded, authError } = useAuthentication();
+    const isUserDisabledInDb = useIsUserDisabled();
+    const overriddenUrl = useOverriddenApiUrl();
 
-  const loadLocalStorageAccessToken = () => {
-    // Ordinarily this sort of thing would go in authentication.tsx - but setting authStore in there causes
-    // an infinite loop
-    // Enable test access token override via local storage. Intended to support
-    // Puppeteer testing flows. This is handled in the server config callback
-    // for signin timing consistency. Normally we cannot sign in until we've
-    // loaded the oauth client ID from the config service.
-    if (config && environment.allowTestAccessTokenOverride && !authLoaded) {
-      const localStorageTestAccessToken = window.localStorage.getItem(
-        LOCAL_STORAGE_KEY_TEST_ACCESS_TOKEN
-      );
-      if (localStorageTestAccessToken) {
-        // The client has already configured an access token override. Skip the normal oauth flow.
-        authStore.set({
-          ...authStore.get(),
-          authLoaded: true,
-          isSignedIn: true,
-        });
+    const loadLocalStorageAccessToken = () => {
+      // Ordinarily this sort of thing would go in authentication.tsx - but setting authStore in there causes
+      // an infinite loop
+      // Enable test access token override via local storage. Intended to support
+      // Puppeteer testing flows. This is handled in the server config callback
+      // for signin timing consistency. Normally we cannot sign in until we've
+      // loaded the oauth client ID from the config service.
+      if (config && environment.allowTestAccessTokenOverride && !authLoaded) {
+        const localStorageTestAccessToken = window.localStorage.getItem(
+          LOCAL_STORAGE_KEY_TEST_ACCESS_TOKEN
+        );
+        if (localStorageTestAccessToken) {
+          // The client has already configured an access token override. Skip the normal oauth flow.
+          authStore.set({
+            ...authStore.get(),
+            authLoaded: true,
+            isSignedIn: true,
+          });
+        }
       }
-    }
-  };
-  const doesUserNeedToAcceptTOS = useNeedsToAcceptTOS();
+    };
+    const doesUserNeedToAcceptTOS = useNeedsToAcceptTOS();
 
-  useEffect(() => {
-    if (config) {
-      // Bootstrapping that requires server config
-      bindClients();
-      loadErrorReporter();
-      initializeAnalytics();
-      loadLocalStorageAccessToken();
-    }
-  }, [config]);
+    useEffect(() => {
+      if (config) {
+        // Bootstrapping that requires server config
+        bindClients();
+        loadErrorReporter();
+        initializeAnalytics();
+        loadLocalStorageAccessToken();
+      }
+    }, [config]);
 
-  const firstPartyCookiesEnabled = cookiesEnabled();
-  const thirdPartyCookiesEnabled = !(
-    authError &&
-    authError.length > 0 &&
-    authError.includes('Cookies')
-  );
+    const firstPartyCookiesEnabled = cookiesEnabled();
+    const thirdPartyCookiesEnabled = !(
+      authError &&
+      authError.length > 0 &&
+      authError.includes('Cookies')
+    );
 
-  return (
-    <React.Fragment>
-      {/* for outdated-browser-rework https://www.npmjs.com/package/outdated-browser-rework*/}
-      {/* Check checkBrowserSupport() function defined in index.ts and implemented in setup.ts*/}
-      {/* The outdated browser banner should be shown on all pages not just for authenticated user*/}
-      <div id='outdated' />
-      {authLoaded && isUserDisabledInDb !== undefined && (
-        <React.Fragment>
-          {/* Once Angular is removed the app structure will change and we can put this in a more appropriate place */}
-          <NotificationModal />
-          {firstPartyCookiesEnabled && thirdPartyCookiesEnabled && (
-            <AppRouter>
-              <ScrollToTop />
-              {/* Previously, using a top-level Switch with AppRoute and ProtectedRoute has caused bugs: */}
-              {/* see https://github.com/all-of-us/workbench/pull/3917 for details. */}
-              {/* It should be noted that the reason this is currently working is because Switch only */}
-              {/* duck-types its children; it cares about them having a 'path' prop but doesn't validate */}
-              {/* that they are a Route or a subclass of Route. */}
-              <Switch>
-                <AppRoute exact path='/cookie-policy'>
-                  <CookiePolicyPage routeData={{ title: 'Cookie Policy' }} />
-                </AppRoute>
-                <AppRoute exact path='/login'>
-                  <SignInPage routeData={{ title: 'Sign In' }} />
-                </AppRoute>
-                <AppRoute exact path='/session-expired'>
-                  <SessionExpiredPage
-                    routeData={{ title: 'You have been signed out' }}
-                  />
-                </AppRoute>
-                <AppRoute exact path='/sign-in-again'>
-                  <SignInAgainPage
-                    routeData={{ title: 'You have been signed out' }}
-                  />
-                </AppRoute>
-                <AppRoute
-                  exact
-                  path='/user-disabled'
-                  guards={[userDisabledPageGuard(isUserDisabledInDb)]}
-                >
-                  <UserDisabledPage routeData={{ title: 'Disabled' }} />
-                </AppRoute>
-                <AppRoute exact path='/not-found'>
-                  <NotFoundPage routeData={{ title: 'Not Found' }} />
-                </AppRoute>
-                <AppRoute
-                  path=''
-                  exact={false}
-                  guards={[signInGuard, disabledGuard(isUserDisabledInDb)]}
-                >
-                  {!doesUserNeedToAcceptTOS && (
-                    <SignedInPage intermediaryRoute={true} routeData={{}} />
-                  )}
-                </AppRoute>
-              </Switch>
-            </AppRouter>
-          )}
-          {doesUserNeedToAcceptTOS && (
-            <TermsOfService
-              showReAcceptNotification={true}
-              onComplete={(tosVersion) => acceptTermsOfService(tosVersion)}
-              filePath={'/aou-tos.html'}
-              afterPrev={false}
-              style={{ height: '36rem' }}
-            />
-          )}
-          {overriddenUrl && (
-            <div style={{ position: 'absolute', top: 0, left: '1rem' }}>
-              <span style={{ fontSize: '80%', color: 'darkred' }}>
-                API URL: {overriddenUrl}
-              </span>
-            </div>
-          )}
-        </React.Fragment>
-      )}
-      {!firstPartyCookiesEnabled ||
-        (!thirdPartyCookiesEnabled && (
-          <div>
-            <div
-              style={{
-                maxWidth: '500px',
-                margin: '1rem',
-                fontFamily: 'Montserrat',
-              }}
-            >
-              <div>
-                <img alt='logo' src={logo} width='155px' />
+    return (
+      <React.Fragment>
+        {/* for outdated-browser-rework https://www.npmjs.com/package/outdated-browser-rework*/}
+        {/* Check checkBrowserSupport() function defined in index.ts and implemented in setup.ts*/}
+        {/* The outdated browser banner should be shown on all pages not just for authenticated user*/}
+        <div id='outdated' />
+        {authLoaded && isUserDisabledInDb !== undefined && (
+          <React.Fragment>
+            {/* Once Angular is removed the app structure will change and we can put this in a more appropriate place */}
+            <NotificationModal />
+            {firstPartyCookiesEnabled && thirdPartyCookiesEnabled && (
+              <AppRouter>
+                <ScrollToTop />
+                {/* Previously, using a top-level Switch with AppRoute and ProtectedRoute has caused bugs: */}
+                {/* see https://github.com/all-of-us/workbench/pull/3917 for details. */}
+                {/* It should be noted that the reason this is currently working is because Switch only */}
+                {/* duck-types its children; it cares about them having a 'path' prop but doesn't validate */}
+                {/* that they are a Route or a subclass of Route. */}
+                <Switch>
+                  <AppRoute exact path='/cookie-policy'>
+                    <CookiePolicyPage routeData={{ title: 'Cookie Policy' }} />
+                  </AppRoute>
+                  <AppRoute exact path='/login'>
+                    <SignInPage routeData={{ title: 'Sign In' }} />
+                  </AppRoute>
+                  <AppRoute exact path='/session-expired'>
+                    <SessionExpiredPage
+                      routeData={{ title: 'You have been signed out' }}
+                    />
+                  </AppRoute>
+                  <AppRoute exact path='/sign-in-again'>
+                    <SignInAgainPage
+                      routeData={{ title: 'You have been signed out' }}
+                    />
+                  </AppRoute>
+                  <AppRoute
+                    exact
+                    path='/user-disabled'
+                    guards={[userDisabledPageGuard(isUserDisabledInDb)]}
+                  >
+                    <UserDisabledPage routeData={{ title: 'Disabled' }} />
+                  </AppRoute>
+                  <AppRoute exact path='/not-found'>
+                    <NotFoundPage routeData={{ title: 'Not Found' }} />
+                  </AppRoute>
+                  <AppRoute
+                    path=''
+                    exact={false}
+                    guards={[signInGuard, disabledGuard(isUserDisabledInDb)]}
+                  >
+                    {!doesUserNeedToAcceptTOS && (
+                      <SignedInPage intermediaryRoute={true} routeData={{}} />
+                    )}
+                  </AppRoute>
+                </Switch>
+              </AppRouter>
+            )}
+            {doesUserNeedToAcceptTOS && (
+              <TermsOfService
+                showReAcceptNotification={true}
+                onComplete={(tosVersion) => acceptTermsOfService(tosVersion)}
+                filePath={'/aou-tos.html'}
+                afterPrev={false}
+                style={{ height: '36rem' }}
+              />
+            )}
+            {overriddenUrl && (
+              <div style={{ position: 'absolute', top: 0, left: '1rem' }}>
+                <span style={{ fontSize: '80%', color: 'darkred' }}>
+                  API URL: {overriddenUrl}
+                </span>
               </div>
+            )}
+          </React.Fragment>
+        )}
+        {!firstPartyCookiesEnabled ||
+          (!thirdPartyCookiesEnabled && (
+            <div>
               <div
                 style={{
-                  fontSize: '20pt',
-                  color: '#2F2E7E',
-                  padding: '1rem 0 1rem 0',
+                  maxWidth: '500px',
+                  margin: '1rem',
+                  fontFamily: 'Montserrat',
                 }}
               >
-                Cookies are Disabled
-              </div>
-              <div style={{ fontSize: '14pt', color: '#000000' }}>
-                For full functionality of this site it is necessary to enable
-                cookies. Here are the{' '}
-                <a
-                  href='https://support.google.com/accounts/answer/61416'
-                  style={{ color: '#2691D0' }}
-                  target='_blank'
-                  rel='noopener noreferrer'
+                <div>
+                  <img alt='logo' src={logo} width='155px' />
+                </div>
+                <div
+                  style={{
+                    fontSize: '20pt',
+                    color: '#2F2E7E',
+                    padding: '1rem 0 1rem 0',
+                  }}
                 >
-                  instructions how to enable cookies in your web browser
-                </a>
-                .
+                  Cookies are Disabled
+                </div>
+                <div style={{ fontSize: '14pt', color: '#000000' }}>
+                  For full functionality of this site it is necessary to enable
+                  cookies. Here are the{' '}
+                  <a
+                    href='https://support.google.com/accounts/answer/61416'
+                    style={{ color: '#2691D0' }}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                  >
+                    instructions how to enable cookies in your web browser
+                  </a>
+                  .
+                </div>
               </div>
             </div>
-          </div>
-        ))}
-    </React.Fragment>
-  );
-};
+          ))}
+      </React.Fragment>
+    );
+  };

--- a/ui/src/app/utils/machines.ts
+++ b/ui/src/app/utils/machines.ts
@@ -188,6 +188,13 @@ const machineBases: Machine[] = [
     price: 3.402,
     preemptiblePrice: 0.72,
   },
+  {
+    name: 'n2-highmem-64',
+    cpu: 64,
+    memory: 512,
+    price: 4.19,
+    preemptiblePrice: 1.01,
+  },
 ];
 
 // As of June 21, 2021:

--- a/ui/src/app/utils/machines.ts
+++ b/ui/src/app/utils/machines.ts
@@ -363,19 +363,13 @@ export const allMachineTypes: Machine[] = fp.map(
   machineBases
 ); // adding prices for ephemeral IP's, per https://cloud.google.com/compute/network-pricing#ipaddress
 
-// Initial price restriction to limit against larger machines being used with free tier.
-// This can be reevaluated later, if researchers really want to use very large machines
-// with their own billing accounts.
-const maxMachinePrice = 1.6;
-
 // Following constraints follow findings on RW-5763, last tested 11/19/20. Using
 // machine types below this limit results in either an immediate ERROR status,
 // or a delayed ERROR status after the runtime times out in the CREATING state.
 // See also https://broadworkbench.atlassian.net/browse/SATURN-1337, where the
 // determination was made for Dataproc master machines only.
-const validPricedTypes = allMachineTypes.filter(
-  ({ price }) => price < maxMachinePrice
-);
+const validPricedTypes = allMachineTypes
+
 export const validLeoGceMachineTypes = validPricedTypes.filter(
   ({ memory }) => memory >= 2
 );


### PR DESCRIPTION
Description:

N2 PREEMPTIBLE CORE:  0.007649 
N2 PREDEFINED-VM-RAM-PREEMPTIBLE 0.001025
N2-PREDEFINED-VM-CORE2 0.031611 
N2-PREDEFINED-VM-RAM 0.004237

PREEMPTIBLE (64 * 0.007649) +  (0.001025 * 512) = 1.01
Standard: (64 * 0.031611) +  (0.004237 * 512) = 4.19

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
