### PR TITLE
[RW-7261][risk=low] Update GATK URI to GVS-owned bucket

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -51,7 +51,7 @@
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
     "minExtractionScatterTasks": 20,
     "extractionScatterTasksPerSample": 4,
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/gvs_quickstart_storage\/jars\/gatk-package-4.2.0.0-531-gf8f4ede-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": false
   },
   "cdr": {

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -51,7 +51,7 @@
     "extractionDestinationDataset": "fc-aou-cdr-perf-ct.wgs_extraction_destination",
     "minExtractionScatterTasks": 20,
     "extractionScatterTasksPerSample": 4,
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/gvs_quickstart_storage\/jars\/gatk-package-4.2.0.0-531-gf8f4ede-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -51,7 +51,7 @@
     "extractionDestinationDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_destination",
     "minExtractionScatterTasks": 350,
     "extractionScatterTasksPerSample": 4,
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/gvs_quickstart_storage\/jars\/gatk-package-4.2.0.0-531-gf8f4ede-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -51,7 +51,7 @@
     "extractionDestinationDataset": "fc-aou-cdr-prod-ct.wgs_extraction_destination",
     "minExtractionScatterTasks": 350,
     "extractionScatterTasksPerSample": 4,
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/gvs_quickstart_storage\/jars\/gatk-package-4.2.0.0-531-gf8f4ede-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -51,7 +51,7 @@
     "extractionDestinationDataset": "fc-aou-cdr-stable-ct.wgs_extraction_destination",
     "minExtractionScatterTasks": 20,
     "extractionScatterTasksPerSample": 4,
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/gvs_quickstart_storage\/jars\/gatk-package-4.2.0.0-531-gf8f4ede-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -51,7 +51,7 @@
     "extractionDestinationDataset": "fc-aou-cdr-staging-ct.wgs_extraction_destination",
     "minExtractionScatterTasks": 20,
     "extractionScatterTasksPerSample": 4,
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/gvs_quickstart_storage\/jars\/gatk-package-4.2.0.0-531-gf8f4ede-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -51,7 +51,7 @@
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
     "minExtractionScatterTasks": 20,
     "extractionScatterTasksPerSample": 4,
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+    "gatkJarUri": "gs:\/\/gvs_quickstart_storage\/jars\/gatk-package-4.2.0.0-531-gf8f4ede-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true
   },
   "cdr": {


### PR DESCRIPTION
**Please test this locally**

- Checkout the branch
- Run the API server
- Run the UI server (against local)
- Run the puppeteer genomics nightly test locally

Based on the timestamp of when this was built, I think it will be compatible, but I'm unsure.