### PR TITLE
[RW-8630][risk=no] Navigate to new UI when clicking cohort review resource card

### DIFF
--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -36,7 +36,7 @@ import { reactStyles, withCdrVersions, withCurrentWorkspace } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { isAbortError } from 'app/utils/errors';
 import { currentWorkspaceStore, NavigationProps } from 'app/utils/navigation';
-import { MatchParams } from 'app/utils/stores';
+import { MatchParams, serverConfigStore } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -422,7 +422,9 @@ export const ListOverview = fp.flow(
           break;
         case 'review':
           AnalyticsTracker.CohortBuilder.CohortAction('Review cohort');
-          url += `data/cohorts/${cohort.id}/review`;
+          url += `data/cohorts/${cohort.id}/review${
+            serverConfigStore.get().config.enableMultiReview ? 's' : ''
+          }`;
           break;
       }
       this.props.navigateByUrl(url);

--- a/ui/src/app/components/breadcrumb.spec.tsx
+++ b/ui/src/app/components/breadcrumb.spec.tsx
@@ -3,7 +3,9 @@ import { WorkspacesApi } from 'generated/fetch';
 import { getTrail } from 'app/components/breadcrumb';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { currentWorkspaceStore } from 'app/utils/navigation';
+import { serverConfigStore } from 'app/utils/stores';
 
+import defaultServerConfig from 'testing/default-server-config';
 import { cohortReviewStubs } from 'testing/stubs/cohort-review-service-stub';
 import { exampleCohortStubs } from 'testing/stubs/cohorts-api-stub';
 import { ConceptSetsApiStub } from 'testing/stubs/concept-sets-api-stub';
@@ -16,6 +18,12 @@ describe('getTrail', () => {
   beforeEach(() => {
     registerApiClient(WorkspacesApi, new WorkspacesApiStub());
     currentWorkspaceStore.next(workspaceDataStub);
+    serverConfigStore.set({
+      config: {
+        ...defaultServerConfig,
+        enableMultiReview: true,
+      },
+    });
   });
 
   it('works', () => {
@@ -25,7 +33,7 @@ describe('getTrail', () => {
       exampleCohortStubs[0],
       cohortReviewStubs[0],
       ConceptSetsApiStub.stubConceptSets()[0],
-      { ns: 'testns', wsid: 'testwsid', cid: '88', pid: '77' }
+      { ns: 'testns', wsid: 'testwsid', cid: '88', crid: '99', pid: '77' }
     );
     expect(trail.map((item) => item.label)).toEqual([
       'Workspaces',
@@ -34,7 +42,7 @@ describe('getTrail', () => {
       'Participant 77',
     ]);
     expect(trail[3].url).toEqual(
-      '/workspaces/testns/testwsid/data/cohorts/88/review/participants/77'
+      '/workspaces/testns/testwsid/data/cohorts/88/reviews/99/participants/77'
     );
   });
 

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -22,6 +22,7 @@ import {
   MatchParams,
   RouteDataStore,
   routeDataStore,
+  serverConfigStore,
   withStore,
 } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
@@ -60,7 +61,7 @@ export const getTrail = (
   conceptSet: ConceptSet,
   params: MatchParams
 ): Array<BreadcrumbData> => {
-  const { ns, wsid, cid, csid, pid, nbName } = params;
+  const { ns, wsid, cid, crid, csid, pid, nbName } = params;
   const prefix = `/workspaces/${ns}/${wsid}`;
   switch (type) {
     case BreadcrumbType.Workspaces:
@@ -147,7 +148,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           cohort ? cohort.name : '...',
-          `${prefix}/data/cohorts/${cid}/review/participants`
+          `${prefix}/data/cohorts/${cid}`
         ),
       ];
     case BreadcrumbType.CohortReview:
@@ -162,7 +163,9 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           cohortReview ? cohortReview.cohortName : '...',
-          `${prefix}/data/cohorts/${cid}/review/participants`
+          serverConfigStore.get().config.enableMultiReview
+            ? `${prefix}/data/cohorts/${cid}/reviews/${crid}`
+            : `${prefix}/data/cohorts/${cid}/review/participants`
         ),
       ];
     case BreadcrumbType.Participant:
@@ -177,7 +180,9 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           `Participant ${pid}`,
-          `${prefix}/data/cohorts/${cid}/review/participants/${pid}`
+          serverConfigStore.get().config.enableMultiReview
+            ? `${prefix}/data/cohorts/${cid}/reviews/${crid}/participants/${pid}`
+            : `${prefix}/data/cohorts/${cid}/review/participants/${pid}`
         ),
       ];
     case BreadcrumbType.CohortAdd:

--- a/ui/src/app/pages/data/cohort-review/annotation-definition-modals.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/annotation-definition-modals.component.tsx
@@ -19,6 +19,7 @@ import { TooltipTrigger } from 'app/components/popups';
 import { cohortAnnotationDefinitionApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, summarizeErrors } from 'app/utils';
+import { serverConfigStore } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 const styles = reactStyles({
@@ -253,7 +254,9 @@ export const EditAnnotationDefinitionsModal = withRouter(
         const {
           params: { ns, wsid, cid },
         } = matchPath(location.pathname, {
-          path: '/workspaces/:ns/:wsid/data/cohorts/:cid/review',
+          path: serverConfigStore.get().config.enableMultiReview
+            ? '/workspaces/:ns/:wsid/data/cohorts/:cid/reviews/:crid'
+            : '/workspaces/:ns/:wsid/data/cohorts/:cid/review',
         });
         this.setState({ busy: true });
         await cohortAnnotationDefinitionApi().deleteCohortAnnotationDefinition(
@@ -281,7 +284,9 @@ export const EditAnnotationDefinitionsModal = withRouter(
         const {
           params: { ns, wsid, cid },
         } = matchPath(location.pathname, {
-          path: '/workspaces/:ns/:wsid/data/cohorts/:cid/review',
+          path: serverConfigStore.get().config.enableMultiReview
+            ? '/workspaces/:ns/:wsid/data/cohorts/:cid/reviews'
+            : '/workspaces/:ns/:wsid/data/cohorts/:cid/review',
         });
         const { editId, editValue } = this.state;
         if (

--- a/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
@@ -33,7 +33,7 @@ import {
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { datatableStyles } from 'app/styles/datatable';
 import { reactStyles, withCurrentWorkspace } from 'app/utils';
-import { useNavigation } from 'app/utils/navigation';
+import { currentCohortReviewStore, useNavigation } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
 
 const styles = reactStyles({
@@ -150,6 +150,7 @@ export const CohortReviewPage = fp.flow(
           }
           return prevCohortReviews;
         });
+        currentCohortReviewStore.next(cohortReview);
         setActiveReview(cohortReview);
         hideSpinner();
       });
@@ -180,6 +181,7 @@ export const CohortReviewPage = fp.flow(
       } else {
         updateUrlWithCohortReviewId(selectedReview.cohortReviewId);
       }
+      currentCohortReviewStore.next(selectedReview);
       setActiveReview(selectedReview);
       getParticipantData(selectedReview.cohortReviewId);
     } else {
@@ -215,6 +217,7 @@ export const CohortReviewPage = fp.flow(
 
   const onReviewCreate = (review: CohortReview) => {
     updateUrlWithCohortReviewId(review.cohortReviewId);
+    currentCohortReviewStore.next(review);
     setCohortReviews((prevCohortReviews) => [...prevCohortReviews, review]);
     setActiveReview(review);
     setShowCreateModal(false);
@@ -223,6 +226,7 @@ export const CohortReviewPage = fp.flow(
   const onReviewSelect = (review: CohortReview) => {
     updateUrlWithCohortReviewId(review.cohortReviewId);
     if (review.participantCohortStatuses?.length) {
+      currentCohortReviewStore.next(review);
       setActiveReview(review);
     } else {
       getParticipantData(review.cohortReviewId);

--- a/ui/src/app/pages/data/cohort-review/cohort-review-participants-table.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-participants-table.tsx
@@ -199,7 +199,7 @@ const mapData = (participant: ParticipantCohortStatus) => {
 };
 
 export const CohortReviewParticipantsTable = ({ cohortReview }) => {
-  const { ns, wsid, cid } = useParams<MatchParams>();
+  const { ns, wsid, cid, crid } = useParams<MatchParams>();
   const [navigate] = useNavigation();
   const [apiError, setApiError] = useState(false);
   const [data, setData] = useState(null);
@@ -453,7 +453,8 @@ export const CohortReviewParticipantsTable = ({ cohortReview }) => {
       'data',
       'cohorts',
       cid,
-      'review',
+      'reviews',
+      crid,
       'participants',
       event.data.participantId,
     ]);

--- a/ui/src/app/pages/data/cohort-review/cohort-review.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review.tsx
@@ -31,7 +31,7 @@ import {
   currentCohortReviewStore,
   NavigationProps,
 } from 'app/utils/navigation';
-import { MatchParams, serverConfigStore } from 'app/utils/stores';
+import { MatchParams } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -75,20 +75,7 @@ export const CohortReview = fp.flow(
 
     componentDidMount(): void {
       this.props.hideSpinner();
-      if (serverConfigStore.get().config.enableMultiReview) {
-        const { ns, wsid, cid } = this.props.match.params;
-        this.props.navigate([
-          'workspaces',
-          ns,
-          wsid,
-          'data',
-          'cohorts',
-          cid,
-          'reviews',
-        ]);
-      } else {
-        this.loadCohort();
-      }
+      this.loadCohort();
     }
 
     loadCohort() {

--- a/ui/src/app/pages/data/cohort-review/create-review-modal.tsx
+++ b/ui/src/app/pages/data/cohort-review/create-review-modal.tsx
@@ -27,7 +27,6 @@ import {
   currentCohortReviewStore,
   NavigationProps,
 } from 'app/utils/navigation';
-import { serverConfigStore } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -115,21 +114,17 @@ export const CreateReviewModal = fp.flow(
           currentCohortReviewStore.next(response);
           queryResultSizeStore.next(parseInt(numberOfParticipants, 10));
           this.setState({ creating: false });
-          if (serverConfigStore.get().config.enableMultiReview) {
-            this.props.created(response);
-          } else {
-            this.props.created(true);
-            this.props.navigate([
-              'workspaces',
-              namespace,
-              id,
-              'data',
-              'cohorts',
-              cohort.id,
-              'review',
-              'participants',
-            ]);
-          }
+          this.props.created(true);
+          this.props.navigate([
+            'workspaces',
+            namespace,
+            id,
+            'data',
+            'cohorts',
+            cohort.id,
+            'review',
+            'participants',
+          ]);
         });
     }
 

--- a/ui/src/app/pages/data/cohort-review/detail-tabs.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-tabs.component.tsx
@@ -18,7 +18,7 @@ import {
   withCurrentWorkspace,
 } from 'app/utils';
 import { triggerEvent } from 'app/utils/analytics';
-import { MatchParams } from 'app/utils/stores';
+import { MatchParams, serverConfigStore } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 const styles = reactStyles({
@@ -445,7 +445,7 @@ export const DetailTabs = fp.flow(
     }
 
     loadParticipantChartData() {
-      const { ns, wsid, pid } = this.props.match.params;
+      const { ns, wsid, pid, crid } = this.props.match.params;
       fp.map(async (domainName: string) => {
         this.setState((prevState) => ({
           chartData: {
@@ -460,7 +460,9 @@ export const DetailTabs = fp.flow(
         const { items } = await cohortReviewApi().getParticipantChartData(
           ns,
           wsid,
-          this.props.cohortReview.cohortReviewId,
+          serverConfigStore.get().config.enableMultiReview
+            ? +crid
+            : this.props.cohortReview.cohortReviewId,
           +pid,
           domainName,
           10

--- a/ui/src/app/pages/data/cohort-review/query-report.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/query-report.component.tsx
@@ -31,7 +31,7 @@ import {
 } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
 import { currentCohortStore, NavigationProps } from 'app/utils/navigation';
-import { MatchParams } from 'app/utils/stores';
+import { MatchParams, serverConfigStore } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import moment from 'moment';
@@ -317,17 +317,21 @@ export const QueryReport = fp.flow(
     }
 
     goBack() {
-      const { ns, wsid, cid } = this.props.match.params;
-      this.props.navigate([
-        'workspaces',
-        ns,
-        wsid,
-        'data',
-        'cohorts',
-        cid,
-        'review',
-        'participants',
-      ]);
+      const { ns, wsid, cid, crid } = this.props.match.params;
+      this.props.navigate(
+        serverConfigStore.get().config.enableMultiReview
+          ? ['workspaces', ns, wsid, 'data', 'cohorts', cid, 'reviews', crid]
+          : [
+              'workspaces',
+              ns,
+              wsid,
+              'data',
+              'cohorts',
+              cid,
+              'review',
+              'participants',
+            ]
+      );
     }
 
     render() {
@@ -354,6 +358,7 @@ export const QueryReport = fp.flow(
               onClick={() => this.goBack()}
             >
               Back to review set
+              {serverConfigStore.get().config.enableMultiReview ? 's' : ''}
             </button>
           )}
           {cohortLoading && <SpinnerOverlay />}

--- a/ui/src/app/pages/data/cohort-review/table-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/table-page.tsx
@@ -44,7 +44,7 @@ import {
   currentCohortReviewStore,
   NavigationProps,
 } from 'app/utils/navigation';
-import { MatchParams } from 'app/utils/stores';
+import { MatchParams, serverConfigStore } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -395,7 +395,7 @@ export const ParticipantsTable = fp.flow(
       const { page, sortField, sortOrder } = this.state;
       const {
         match: {
-          params: { ns, wsid, cid },
+          params: { ns, wsid, cid, crid },
         },
       } = this.props;
       const filters = this.mapFilters();
@@ -409,12 +409,20 @@ export const ParticipantsTable = fp.flow(
           sortOrder: sortOrder === 1 ? SortOrder.Asc : SortOrder.Desc,
           filters: { items: filters },
         } as Request;
-        return cohortReviewApi().getParticipantCohortStatusesOld(
-          ns,
-          wsid,
-          +cid,
-          query
-        );
+        return serverConfigStore.get().config.enableMultiReview
+          ? cohortReviewApi().getParticipantCohortStatuses(
+              ns,
+              wsid,
+              +cid,
+              +crid,
+              query
+            )
+          : cohortReviewApi().getParticipantCohortStatusesOld(
+              ns,
+              wsid,
+              +cid,
+              query
+            );
       }
     }
 

--- a/ui/src/app/pages/data/cohort/cohort-actions.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-actions.tsx
@@ -20,7 +20,7 @@ import {
   withCurrentWorkspace,
 } from 'app/utils';
 import { NavigationProps } from 'app/utils/navigation';
-import { MatchParams } from 'app/utils/stores';
+import { MatchParams, serverConfigStore } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -158,7 +158,9 @@ export const CohortActions = fp.flow(
           queryParams = { cohortId: cohort.id };
           break;
         case 'review':
-          url += `data/cohorts/${cohort.id}/review`;
+          url += `data/cohorts/${cohort.id}/review${
+            serverConfigStore.get().config.enableMultiReview ? 's' : ''
+          }`;
           break;
         case 'notebook':
           url += 'notebooks';

--- a/ui/src/app/pages/data/cohort/cohort-resource-card.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-resource-card.tsx
@@ -35,6 +35,7 @@ import {
   getResourceUrl,
   getType,
 } from 'app/utils/resources';
+import { serverConfigStore } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 
 interface Props
@@ -74,7 +75,9 @@ export const CohortResourceCard = fp.flow(
 
       return (
         `/workspaces/${workspaceNamespace}/${workspaceFirecloudName}` +
-        `/data/cohorts/${cohort.id}/review`
+        `/data/cohorts/${cohort.id}/review${
+          serverConfigStore.get().config.enableMultiReview ? 's' : ''
+        }`
       );
     }
 

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -299,7 +299,7 @@ export const WorkspaceRoutes = () => {
         <ParticipantsTablePage
           routeData={{
             title: 'Review Cohort Participants',
-            breadcrumb: BreadcrumbType.Cohort,
+            breadcrumb: BreadcrumbType.CohortReview,
             workspaceNavBarTab: 'data',
             pageKey: 'reviewParticipants',
           }}
@@ -369,7 +369,7 @@ export const WorkspaceRoutes = () => {
         <CohortReviewPagePage
           routeData={{
             title: 'Review Cohort Participants',
-            breadcrumb: BreadcrumbType.Cohort,
+            breadcrumb: BreadcrumbType.CohortReview,
             workspaceNavBarTab: 'data',
             pageKey: 'reviewParticipants',
           }}

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -363,6 +363,20 @@ export const WorkspaceRoutes = () => {
       </AppRoute>
       <AppRoute
         exact
+        path={`${path}/data/cohorts/:cid/reviews/:crid`}
+        guards={[adminLockedGuard(ns, wsid)]}
+      >
+        <CohortReviewPagePage
+          routeData={{
+            title: 'Review Cohort Participants',
+            breadcrumb: BreadcrumbType.Cohort,
+            workspaceNavBarTab: 'data',
+            pageKey: 'reviewParticipants',
+          }}
+        />
+      </AppRoute>
+      <AppRoute
+        exact
         path={`${path}/data/concepts`}
         guards={[adminLockedGuard(ns, wsid)]}
       >

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -377,6 +377,20 @@ export const WorkspaceRoutes = () => {
       </AppRoute>
       <AppRoute
         exact
+        path={`${path}/data/cohorts/:cid/reviews/:crid/participants/:pid`}
+        guards={[adminLockedGuard(ns, wsid)]}
+      >
+        <DetailPagePage
+          routeData={{
+            title: 'Participant Detail',
+            breadcrumb: BreadcrumbType.Participant,
+            workspaceNavBarTab: 'data',
+            pageKey: 'reviewParticipantDetail',
+          }}
+        />
+      </AppRoute>
+      <AppRoute
+        exact
         path={`${path}/data/concepts`}
         guards={[adminLockedGuard(ns, wsid)]}
       >

--- a/ui/src/app/utils/resources.spec.tsx
+++ b/ui/src/app/utils/resources.spec.tsx
@@ -9,6 +9,7 @@ import {
 } from 'generated/fetch';
 
 import { serverConfigStore } from 'app/utils/stores';
+
 import defaultServerConfig from 'testing/default-server-config';
 import { exampleCohortStubs } from 'testing/stubs/cohorts-api-stub';
 import { stubResource } from 'testing/stubs/resources-stub';

--- a/ui/src/app/utils/resources.spec.tsx
+++ b/ui/src/app/utils/resources.spec.tsx
@@ -8,6 +8,8 @@ import {
   WorkspaceResource,
 } from 'generated/fetch';
 
+import { serverConfigStore } from 'app/utils/stores';
+import defaultServerConfig from 'testing/default-server-config';
 import { exampleCohortStubs } from 'testing/stubs/cohorts-api-stub';
 import { stubResource } from 'testing/stubs/resources-stub';
 import { WorkspaceStubVariables } from 'testing/stubs/workspaces';
@@ -92,6 +94,15 @@ const testNotebook = {
 } as WorkspaceResource;
 
 describe('resources.tsx', () => {
+  beforeEach(() => {
+    serverConfigStore.set({
+      config: {
+        ...defaultServerConfig,
+        enableMultiReview: true,
+      },
+    });
+  });
+
   it('should identify resource types', () => {
     expect(isCohort(testCohort)).toBeTruthy();
     expect(getType(testCohort)).toEqual(ResourceType.COHORT);
@@ -183,7 +194,7 @@ describe('resources.tsx', () => {
       WorkspaceStubVariables;
     const WORKSPACE_URL_PREFIX = `/workspaces/${DEFAULT_WORKSPACE_NS}/${DEFAULT_WORKSPACE_ID}`;
     const EXPECTED_COHORT_URL = `${WORKSPACE_URL_PREFIX}/data/cohorts/build?cohortId=${COHORT_ID}`;
-    const EXPECTED_COHORT_REVIEW_URL = `${WORKSPACE_URL_PREFIX}/data/cohorts/${COHORT_REVIEW_COHORT_ID}/review`;
+    const EXPECTED_COHORT_REVIEW_URL = `${WORKSPACE_URL_PREFIX}/data/cohorts/${COHORT_REVIEW_COHORT_ID}/reviews/${COHORT_REVIEW_ID}`;
     const EXPECTED_CONCEPT_SET_URL = `${WORKSPACE_URL_PREFIX}/data/concepts/sets/${CONCEPT_SET_ID}`;
     const EXPECTED_DATA_SET_URL = `${WORKSPACE_URL_PREFIX}/data/data-sets/${DATA_SET_ID}`;
     const EXPECTED_NOTEBOOK_URL = `${WORKSPACE_URL_PREFIX}/notebooks/preview/${NOTEBOOK_NAME}`;

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -12,6 +12,7 @@ import {
 } from 'generated/fetch';
 
 import { dropNotebookFileSuffix } from 'app/pages/analysis/util';
+import { serverConfigStore } from 'app/utils/stores';
 
 import { encodeURIComponentStrict, UrlObj } from './navigation';
 import { WorkspaceData } from './workspace-data';
@@ -86,7 +87,9 @@ export function getResourceUrl(resource: WorkspaceResource): UrlObj {
     [
       isCohortReview,
       (r) => ({
-        url: `${workspacePrefix}/data/cohorts/${r.cohortReview.cohortId}/reviews/${r.cohortReview.cohortReviewId}`,
+        url: serverConfigStore.get().config.enableMultiReview
+          ? `${workspacePrefix}/data/cohorts/${r.cohortReview.cohortId}/reviews/${r.cohortReview.cohortReviewId}`
+          : `${workspacePrefix}/data/cohorts/${r.cohortReview.cohortId}/review`,
       }),
     ],
     [

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -86,7 +86,7 @@ export function getResourceUrl(resource: WorkspaceResource): UrlObj {
     [
       isCohortReview,
       (r) => ({
-        url: `${workspacePrefix}/data/cohorts/${r.cohortReview.cohortId}/review`,
+        url: `${workspacePrefix}/data/cohorts/${r.cohortReview.cohortId}/reviews/${r.cohortReview.cohortReviewId}`,
       }),
     ],
     [

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -208,6 +208,7 @@ export const serverConfigStore = atom<ServerConfigStore>({});
 // If you want to add a new route param, you will need to define it here as well.
 export interface MatchParams {
   cid?: string;
+  crid?: string;
   csid?: string;
   dataSetId?: string;
   domain?: string;


### PR DESCRIPTION
Currently, when clicking a cohort review resource card, it navigates to the old cohort review route.

This pr adds a route for the new interface that takes the cohort review id (`crid`) as a url param, and will select that review in the list after navigating to the cohort review page.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
