### PR TITLE
[RW-8627][risk=no]  Update UI to point to new /resources GET endpoint

### DIFF
--- a/ui/src/app/pages/data/data-component.tsx
+++ b/ui/src/app/pages/data/data-component.tsx
@@ -80,11 +80,11 @@ const descriptions = {
   cohorts: 'A cohort is a group of participants based on specific criteria.',
 };
 
-const resourceTypesToFetch = [
-  ResourceType.COHORT,
-  ResourceType.COHORTREVIEW,
-  ResourceType.CONCEPTSET,
-  ResourceType.DATASET,
+const resourceTypesStrToFetch = [
+  ResourceType.COHORT.toString(),
+  ResourceType.COHORTREVIEW.toString(),
+  ResourceType.CONCEPTSET.toString(),
+  ResourceType.DATASET.toString(),
 ];
 
 interface Props extends WithSpinnerOverlayProps {
@@ -109,10 +109,10 @@ export const DataComponent = withCurrentWorkspace()((props: Props) => {
     try {
       setIsLoading(true);
       setResourceList(
-        await workspacesApi().getWorkspaceResources(
+        await workspacesApi().getWorkspaceResourcesV2(
           workspace.namespace,
           workspace.id,
-          { typesToFetch: resourceTypesToFetch }
+          resourceTypesStrToFetch
         )
       );
     } catch (error) {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -2137,11 +2137,12 @@ export const DatasetPage = fp.flow(
               <CreateModal
                 entityName='Dataset'
                 getExistingNames={async () => {
-                  const resources = await workspacesApi().getWorkspaceResources(
-                    namespace,
-                    id,
-                    { typesToFetch: [ResourceType.DATASET] }
-                  );
+                  const resources =
+                    await workspacesApi().getWorkspaceResourcesV2(
+                      namespace,
+                      id,
+                      [ResourceType.DATASET.toString()]
+                    );
                   return resources.map((resource) => resource.dataSet.name);
                 }}
                 save={(name, desc) => createDataset(name, desc)}


### PR DESCRIPTION
Tested the following scenarios:

- Recent resource list is populated under the DATA Tab


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
