### PR TITLE
[RW-8647][risk=no] Updated parent option logic to clear child other text field

### DIFF
--- a/ui/src/app/components/demographic-survey-v2.tsx
+++ b/ui/src/app/components/demographic-survey-v2.tsx
@@ -279,7 +279,12 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
                   },
                 ],
                 showSubOptions: showAiAnOptions,
-                onChange: (value) => setShowAiAnOptions(value),
+                onChange: (checked) => {
+                  if (!checked) {
+                    onUpdate('ethnicityAiAnOtherText', null);
+                  }
+                  setShowAiAnOptions(checked);
+                },
                 onExpand: () => setShowAiAnOptions(!showAiAnOptions),
               },
 
@@ -317,7 +322,12 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
                   },
                 ],
                 showSubOptions: showAsianOptions,
-                onChange: (value) => setShowAsianOptions(value),
+                onChange: (checked) => {
+                  if (!checked) {
+                    onUpdate('ethnicityAsianOtherText', null);
+                  }
+                  setShowAsianOptions(checked);
+                },
                 onExpand: () => setShowAsianOptions(!showAsianOptions),
               },
               {
@@ -358,7 +368,12 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
                   },
                 ],
                 showSubOptions: showBlackOptions,
-                onChange: (value) => setShowBlackOptions(value),
+                onChange: (checked) => {
+                  if (!checked) {
+                    onUpdate('ethnicityBlackOtherText', null);
+                  }
+                  setShowBlackOptions(checked);
+                },
                 onExpand: () => setShowBlackOptions(!showBlackOptions),
               },
               {
@@ -409,7 +424,12 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
                   },
                 ],
                 showSubOptions: showHispanicOptions,
-                onChange: (value) => setShowHispanicOptions(value),
+                onChange: (checked) => {
+                  if (!checked) {
+                    onUpdate('ethnicityHispanicOtherText', null);
+                  }
+                  setShowHispanicOptions(checked);
+                },
                 onExpand: () => setShowHispanicOptions(!showHispanicOptions),
               },
               {
@@ -455,7 +475,12 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
                   },
                 ],
                 showSubOptions: showMeNaOptions,
-                onChange: (value) => setShowMeNaOptions(value),
+                onChange: (checked) => {
+                  if (!checked) {
+                    onUpdate('ethnicityMeNaOtherText', null);
+                  }
+                  setShowMeNaOptions(checked);
+                },
                 onExpand: () => setShowMeNaOptions(!showMeNaOptions),
               },
               {
@@ -503,7 +528,12 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
                   },
                 ],
                 showSubOptions: showNhPiOptions,
-                onChange: (value) => setShowNhPiOptions(value),
+                onChange: (checked) => {
+                  if (!checked) {
+                    onUpdate('ethnicityNhPiOtherText', null);
+                  }
+                  setShowNhPiOptions(checked);
+                },
                 onExpand: () => setShowNhPiOptions(!showNhPiOptions),
               },
               {
@@ -553,7 +583,12 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
                   },
                 ],
                 showSubOptions: showWhiteOptions,
-                onChange: (value) => setShowWhiteOptions(value),
+                onChange: (checked) => {
+                  if (!checked) {
+                    onUpdate('ethnicityWhiteOtherText', null);
+                  }
+                  setShowWhiteOptions(checked);
+                },
                 onExpand: () => {
                   setShowWhiteOptions(!showWhiteOptions);
                 },

--- a/ui/src/app/components/demographic-survey-v2.tsx
+++ b/ui/src/app/components/demographic-survey-v2.tsx
@@ -594,6 +594,16 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
                 },
               },
               {
+                label: 'Prefer not to answer',
+                value: EthnicCategory.PREFERNOTTOANSWER,
+                onChange: (checked) => {
+                  onUpdate(
+                    'ethnicCategories',
+                    checked ? [EthnicCategory.PREFERNOTTOANSWER] : []
+                  );
+                },
+              },
+              {
                 label: NONE_FULLY_DESCRIBE,
                 value: EthnicCategory.OTHER,
                 showInput: true,
@@ -607,16 +617,6 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
                 },
                 onChangeOtherText: (value) =>
                   onUpdate('ethnicityOtherText', value),
-              },
-              {
-                label: 'Prefer not to answer',
-                value: EthnicCategory.PREFERNOTTOANSWER,
-                onChange: (checked) => {
-                  onUpdate(
-                    'ethnicCategories',
-                    checked ? [EthnicCategory.PREFERNOTTOANSWER] : []
-                  );
-                },
               },
             ]}
             multiple
@@ -768,6 +768,15 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
                 value: SexualOrientationV2.QUESTIONING,
               },
               {
+                label: 'Prefer not to answer',
+                value: SexualOrientationV2.PREFERNOTTOANSWER,
+                onChange: (checked) =>
+                  onUpdate(
+                    'sexualOrientations',
+                    checked ? [SexualOrientationV2.PREFERNOTTOANSWER] : []
+                  ),
+              },
+              {
                 label: NONE_FULLY_DESCRIBE,
                 value: SexualOrientationV2.OTHER,
                 showInput: true,
@@ -781,15 +790,6 @@ export const DemographicSurvey = fp.flow(withProfileErrorModal)(
                 },
                 onChangeOtherText: (value) =>
                   onUpdate('orientationOtherText', value),
-              },
-              {
-                label: 'Prefer not to answer',
-                value: SexualOrientationV2.PREFERNOTTOANSWER,
-                onChange: (checked) =>
-                  onUpdate(
-                    'sexualOrientations',
-                    checked ? [SexualOrientationV2.PREFERNOTTOANSWER] : []
-                  ),
               },
             ]}
             multiple


### PR DESCRIPTION
Description:
 Updated parent option logic to clear child other text field.




https://user-images.githubusercontent.com/24514630/179573033-4c1dd9a5-a3cd-48d8-b3f9-aea741f154e1.mov


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
