### PR TITLE
[risk=low][RW-7809] Set enableDSCREntryInRecentModified to always true

### DIFF
--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -112,7 +112,7 @@
     "enablePersistentDisk": true,
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
-    "enableDSCREntryInRecentModified": false,
+    "enableDSCREntryInRecentModified": true,
     "enableUniversalSearch": true,
     "enableMultiReview": false,
     "enableUpdatedDemographicSurvey": true,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -112,7 +112,7 @@
     "enablePersistentDisk": true,
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": true,
-    "enableDSCREntryInRecentModified": false,
+    "enableDSCREntryInRecentModified": true,
     "enableUniversalSearch": true,
     "enableMultiReview": false,
     "enableUpdatedDemographicSurvey": true,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -112,7 +112,7 @@
     "enablePersistentDisk": true,
     "enablePrivateDataprocWorker": false,
     "ccSupportWhenAdminLocking": true,
-    "enableDSCREntryInRecentModified": false,
+    "enableDSCREntryInRecentModified": true,
     "enableUniversalSearch": true,
     "enableMultiReview": false,
     "enableUpdatedDemographicSurvey": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -112,7 +112,7 @@
     "enablePersistentDisk": true,
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
-    "enableDSCREntryInRecentModified": false,
+    "enableDSCREntryInRecentModified": true,
     "enableUniversalSearch": true,
     "enableMultiReview": false,
     "enableUpdatedDemographicSurvey": true,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -112,7 +112,7 @@
     "enablePersistentDisk": true,
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
-    "enableDSCREntryInRecentModified": false,
+    "enableDSCREntryInRecentModified": true,
     "enableUniversalSearch": true,
     "enableMultiReview": false,
     "enableUpdatedDemographicSurvey": true,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -112,7 +112,7 @@
     "enablePersistentDisk": true,
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
-    "enableDSCREntryInRecentModified": false,
+    "enableDSCREntryInRecentModified": true,
     "enableUniversalSearch": true,
     "enableMultiReview": true,
     "enableUpdatedDemographicSurvey": true,

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -353,15 +353,6 @@ public class CohortReviewController implements CohortReviewApiDelegate {
 
     cohortReview.participantCohortStatuses(participantCohortStatuses);
 
-    // Wrapping the following logic behind the feature flag so that only in test/local
-    // opening/creating cohort review will create an entry in user recent resource with
-    // resource type cohortReview rather than cohort,
-    // while the rest of the environments remains as is
-    if (!workbenchConfigProvider.get().featureFlags.enableDSCREntryInRecentModified) {
-      userRecentResourceService.updateCohortEntry(
-          cohort.getWorkspaceId(), userProvider.get().getUserId(), cohortId);
-    }
-
     // Cohort review id will be null if the user is creating a new Cohort Review
     // In such cases createCohort will update the entry in userrecentresource
     // Cohort review id will be populated, if  user is viewing an existing cohort review

--- a/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.dao.CohortReviewDao;
 import org.pmiops.workbench.db.dao.ConceptSetDao;
@@ -31,12 +30,10 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.test.FakeClock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Scope;
 import org.springframework.test.annotation.DirtiesContext;
 
 @DataJpaTest
@@ -68,14 +65,6 @@ public class UserRecentResourceServiceTest {
     @Bean
     public Clock clock() {
       return CLOCK;
-    }
-
-    @Bean
-    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public WorkbenchConfig getWorkbenchConfig() {
-      WorkbenchConfig config = WorkbenchConfig.createEmptyConfig();
-      config.featureFlags.enableDSCREntryInRecentModified = true;
-      return config;
     }
   }
 


### PR DESCRIPTION
This flag was mostly removed in #6335 

Remove all code depending on that FF and set to true in all environments

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
