### PR TITLE
[no ticket][risk=no] Allow API endpoints to use any version of cohort to render charts

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -373,7 +373,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
         snomedStandard,
         cpt4,
         temporalParent1,
-            temporalChild1,
+        temporalChild1,
         procedureParent1,
         procedureChild1,
         surveyNode,
@@ -904,10 +904,8 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     assertThat(items.size()).isEqualTo(3);
     assertThat(items.get(0))
         .isEqualTo(new CohortChartData().name("name10").conceptId(10L).count(1L));
-    assertThat(items.get(1))
-        .isEqualTo(new CohortChartData().name("name3").conceptId(3L).count(1L));
-    assertThat(items.get(2))
-        .isEqualTo(new CohortChartData().name("name9").conceptId(9L).count(1L));
+    assertThat(items.get(1)).isEqualTo(new CohortChartData().name("name3").conceptId(3L).count(1L));
+    assertThat(items.get(2)).isEqualTo(new CohortChartData().name("name9").conceptId(9L).count(1L));
   }
 
   @Test
@@ -942,10 +940,8 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             .getBody();
     List<CohortChartData> items = Objects.requireNonNull(response).getItems();
     assertThat(items.size()).isEqualTo(2);
-    assertThat(items.get(0))
-        .isEqualTo(new CohortChartData().name("name1").conceptId(1L).count(1L));
-    assertThat(items.get(1))
-        .isEqualTo(new CohortChartData().name("name7").conceptId(7L).count(1L));
+    assertThat(items.get(0)).isEqualTo(new CohortChartData().name("name1").conceptId(1L).count(1L));
+    assertThat(items.get(1)).isEqualTo(new CohortChartData().name("name7").conceptId(7L).count(1L));
   }
 
   @Test
@@ -963,18 +959,17 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
     List<CohortChartData> items = Objects.requireNonNull(response).getItems();
     assertThat(items.size()).isEqualTo(3);
-    assertThat(items.get(0))
-        .isEqualTo(new CohortChartData().name("name2").conceptId(2L).count(1L));
-    assertThat(items.get(1))
-        .isEqualTo(new CohortChartData().name("name4").conceptId(4L).count(1L));
-    assertThat(items.get(2))
-        .isEqualTo(new CohortChartData().name("name8").conceptId(8L).count(1L));
+    assertThat(items.get(0)).isEqualTo(new CohortChartData().name("name2").conceptId(2L).count(1L));
+    assertThat(items.get(1)).isEqualTo(new CohortChartData().name("name4").conceptId(4L).count(1L));
+    assertThat(items.get(2)).isEqualTo(new CohortChartData().name("name8").conceptId(8L).count(1L));
   }
 
   @Test
   public void findDataFilters() {
     List<DataFilter> filters =
-        Objects.requireNonNull(controller.findDataFilters(WORKSPACE_NAMESPACE, WORKSPACE_ID).getBody()).getItems();
+        Objects.requireNonNull(
+                controller.findDataFilters(WORKSPACE_NAMESPACE, WORKSPACE_ID).getBody())
+            .getItems();
     assertThat(
             filters.contains(
                 new DataFilter().dataFilterId(1L).displayName("displayName1").name("name1")))
@@ -2203,10 +2198,11 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             .sourceConceptIds(sourceConceptIds)
             .standardConceptIds(standardConceptIds);
     List<Criteria> criteriaList =
-        Objects.requireNonNull(controller
-                        .findCriteriaForCohortEdit(
-                                WORKSPACE_NAMESPACE, WORKSPACE_ID, Domain.CONDITION.toString(), request)
-                        .getBody())
+        Objects.requireNonNull(
+                controller
+                    .findCriteriaForCohortEdit(
+                        WORKSPACE_NAMESPACE, WORKSPACE_ID, Domain.CONDITION.toString(), request)
+                    .getBody())
             .getItems();
     assertThat(criteriaList).hasSize(2);
     assertThat(criteriaList.get(0).getId()).isEqualTo(icd9.getId());

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -14,6 +14,7 @@ import java.time.Period;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import javax.inject.Provider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -124,7 +125,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   private DbCriteria snomedStandard;
   private DbCriteria cpt4;
   private DbCriteria temporalParent1;
-  private DbCriteria temportalChild1;
+  private DbCriteria temporalChild1;
   private DbCriteria procedureParent1;
   private DbCriteria procedureChild1;
   private DbCriteria surveyNode;
@@ -246,10 +247,10 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 .addStandard(false)
                 .addSynonyms("+[CONDITION_rank1]")
                 .build());
-    temportalChild1 =
+    temporalChild1 =
         saveCriteriaWithPath(
             temporalParent1.getPath(),
-            temportalChild1 =
+            temporalChild1 =
                 DbCriteria.builder()
                     .addParentId(temporalParent1.getId())
                     .addAncestorData(false)
@@ -372,7 +373,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
         snomedStandard,
         cpt4,
         temporalParent1,
-        temportalChild1,
+            temporalChild1,
         procedureParent1,
         procedureChild1,
         surveyNode,
@@ -899,33 +900,13 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 createSearchRequests(
                     Domain.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>()))
             .getBody();
-    assertThat(response.getItems().size()).isEqualTo(3);
-    assertThat(response.getItems().get(0))
+    List<CohortChartData> items = Objects.requireNonNull(response).getItems();
+    assertThat(items.size()).isEqualTo(3);
+    assertThat(items.get(0))
         .isEqualTo(new CohortChartData().name("name10").conceptId(10L).count(1L));
-    assertThat(response.getItems().get(1))
+    assertThat(items.get(1))
         .isEqualTo(new CohortChartData().name("name3").conceptId(3L).count(1L));
-    assertThat(response.getItems().get(2))
-        .isEqualTo(new CohortChartData().name("name9").conceptId(9L).count(1L));
-  }
-
-  @Test
-  public void getCohortChartDataLabWithEHRData() {
-    CohortChartDataListResponse response =
-        controller
-            .getCohortChartData(
-                WORKSPACE_NAMESPACE,
-                WORKSPACE_ID,
-                Domain.LAB.name(),
-                10,
-                createSearchRequests(
-                    Domain.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>()))
-            .getBody();
-    assertThat(response.getItems().size()).isEqualTo(3);
-    assertThat(response.getItems().get(0))
-        .isEqualTo(new CohortChartData().name("name10").conceptId(10L).count(1L));
-    assertThat(response.getItems().get(1))
-        .isEqualTo(new CohortChartData().name("name3").conceptId(3L).count(1L));
-    assertThat(response.getItems().get(2))
+    assertThat(items.get(2))
         .isEqualTo(new CohortChartData().name("name9").conceptId(9L).count(1L));
   }
 
@@ -941,8 +922,9 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 createSearchRequests(
                     Domain.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>()))
             .getBody();
-    assertThat(response.getItems().size()).isEqualTo(1);
-    assertThat(response.getItems().get(0))
+    List<CohortChartData> items = Objects.requireNonNull(response).getItems();
+    assertThat(items.size()).isEqualTo(1);
+    assertThat(items.get(0))
         .isEqualTo(new CohortChartData().name("name11").conceptId(1L).count(1L));
   }
 
@@ -958,10 +940,11 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 createSearchRequests(
                     Domain.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>()))
             .getBody();
-    assertThat(response.getItems().size()).isEqualTo(2);
-    assertThat(response.getItems().get(0))
+    List<CohortChartData> items = Objects.requireNonNull(response).getItems();
+    assertThat(items.size()).isEqualTo(2);
+    assertThat(items.get(0))
         .isEqualTo(new CohortChartData().name("name1").conceptId(1L).count(1L));
-    assertThat(response.getItems().get(1))
+    assertThat(items.get(1))
         .isEqualTo(new CohortChartData().name("name7").conceptId(7L).count(1L));
   }
 
@@ -978,19 +961,20 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                     Domain.CONDITION.toString(), ImmutableList.of(icd9()), new ArrayList<>()))
             .getBody();
 
-    assertThat(response.getItems().size()).isEqualTo(3);
-    assertThat(response.getItems().get(0))
+    List<CohortChartData> items = Objects.requireNonNull(response).getItems();
+    assertThat(items.size()).isEqualTo(3);
+    assertThat(items.get(0))
         .isEqualTo(new CohortChartData().name("name2").conceptId(2L).count(1L));
-    assertThat(response.getItems().get(1))
+    assertThat(items.get(1))
         .isEqualTo(new CohortChartData().name("name4").conceptId(4L).count(1L));
-    assertThat(response.getItems().get(2))
+    assertThat(items.get(2))
         .isEqualTo(new CohortChartData().name("name8").conceptId(8L).count(1L));
   }
 
   @Test
   public void findDataFilters() {
     List<DataFilter> filters =
-        controller.findDataFilters(WORKSPACE_NAMESPACE, WORKSPACE_ID).getBody().getItems();
+        Objects.requireNonNull(controller.findDataFilters(WORKSPACE_NAMESPACE, WORKSPACE_ID).getBody()).getItems();
     assertThat(
             filters.contains(
                 new DataFilter().dataFilterId(1L).displayName("displayName1").name("name1")))
@@ -1376,7 +1360,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
-  public void countSubjectsICD9ConditioChildAgeAtEventAndOccurrencesAndEventDate() {
+  public void countSubjectsICD9ConditionChildAgeAtEventAndOccurrencesAndEventDate() {
     SearchRequest searchRequest =
         createSearchRequests(
             Domain.CONDITION.toString(),
@@ -2131,10 +2115,10 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 .name(AttrName.NUM)
                 .operator(Operator.EQUAL)
                 .operands(ImmutableList.of("7")));
-    SearchParameter ppiValueAsNumer = surveyAnswer().attributes(attributes);
+    SearchParameter ppiValueAsNumber = surveyAnswer().attributes(attributes);
     SearchRequest searchRequest =
         createSearchRequests(
-            ppiValueAsNumer.getDomain(), ImmutableList.of(ppiValueAsNumer), new ArrayList<>());
+            ppiValueAsNumber.getDomain(), ImmutableList.of(ppiValueAsNumber), new ArrayList<>());
     ResponseEntity<Long> response =
         controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest);
     assertParticipants(response, 1);
@@ -2156,7 +2140,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 AgeType.AGE.toString(),
                 searchRequest)
             .getBody();
-    assertDemographics(response);
+    assertDemographics(Objects.requireNonNull(response));
   }
 
   @Test
@@ -2168,7 +2152,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
     EthnicityInfoListResponse response =
         controller.findEthnicityInfo(WORKSPACE_NAMESPACE, WORKSPACE_ID, searchRequest).getBody();
-    assertEthnicity(response);
+    assertEthnicity(Objects.requireNonNull(response));
   }
 
   @Test
@@ -2188,7 +2172,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 AgeType.AGE_AT_CONSENT.toString(),
                 searchRequest)
             .getBody();
-    assertDemographics(response);
+    assertDemographics(Objects.requireNonNull(response));
   }
 
   @Test
@@ -2207,7 +2191,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
                 AgeType.AGE_AT_CDR.toString(),
                 searchRequest)
             .getBody();
-    assertDemographics(response);
+    assertDemographics(Objects.requireNonNull(response));
   }
 
   @Test
@@ -2219,10 +2203,10 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             .sourceConceptIds(sourceConceptIds)
             .standardConceptIds(standardConceptIds);
     List<Criteria> criteriaList =
-        controller
-            .findCriteriaForCohortEdit(
-                WORKSPACE_NAMESPACE, WORKSPACE_ID, Domain.CONDITION.toString(), request)
-            .getBody()
+        Objects.requireNonNull(controller
+                        .findCriteriaForCohortEdit(
+                                WORKSPACE_NAMESPACE, WORKSPACE_ID, Domain.CONDITION.toString(), request)
+                        .getBody())
             .getItems();
     assertThat(criteriaList).hasSize(2);
     assertThat(criteriaList.get(0).getId()).isEqualTo(icd9.getId());

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -454,6 +454,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 .operator(Operator.IN)
                 .property(FilterColumns.STANDARD_VOCABULARY)
                 .values(ImmutableList.of("ICD9CM", "SNOMED")));
+
     PageFilterRequest testFilter =
         new PageFilterRequest().domain(Domain.CONDITION).filters(new FilterList().items(filters));
 

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -16,6 +16,8 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -376,7 +378,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
             .matchedParticipantCount(reviewWithoutEHRData.getMatchedParticipantCount())
             .reviewedCount(reviewWithoutEHRData.getReviewedCount())
             .etag(Etags.fromVersion(reviewWithoutEHRData.getVersion()));
-    assertThat(controller.getCohortReviewsInWorkspace(NAMESPACE, NAME).getBody().getItems().get(0))
+    assertThat(Objects.requireNonNull(controller.getCohortReviewsInWorkspace(NAMESPACE, NAME).getBody()).getItems().get(0))
         .isEqualTo(expectedReview);
   }
 
@@ -395,7 +397,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(response, ImmutableList.of(expectedCondition1(), expectedCondition2()));
+    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedCondition1(), expectedCondition2()));
 
     // added sort order
     testFilter.sortOrder(SortOrder.DESC);
@@ -409,7 +411,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(response, ImmutableList.of(expectedCondition2(), expectedCondition1()));
+    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedCondition2(), expectedCondition1()));
   }
 
   @Test
@@ -426,7 +428,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 PARTICIPANT_ID,
                 testFilter)
             .getBody();
-    assertThat(response.getCount()).isEqualTo(2);
+    assertThat(Objects.requireNonNull(response).getCount()).isEqualTo(2);
   }
 
   @Test
@@ -459,7 +461,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(response, ImmutableList.of(expectedCondition1(), expectedCondition2()));
+    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedCondition1(), expectedCondition2()));
 
     // added sort order
     testFilter.sortOrder(SortOrder.DESC);
@@ -473,7 +475,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(response, ImmutableList.of(expectedCondition2(), expectedCondition1()));
+    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedCondition2(), expectedCondition1()));
   }
 
   @Test
@@ -494,7 +496,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(response, ImmutableList.of(expectedCondition1()));
+    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedCondition1()));
 
     // page 2 should have 1 item
     testFilter.page(1);
@@ -507,7 +509,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 PARTICIPANT_ID,
                 testFilter)
             .getBody();
-    assertResponse(response, ImmutableList.of(expectedCondition2()));
+    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedCondition2()));
   }
 
   @Test
@@ -526,7 +528,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(response, ImmutableList.of(expectedAllEvents1()));
+    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedAllEvents1()));
 
     // page 2 should have 1 item
     testFilter.page(1);
@@ -540,7 +542,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(response, ImmutableList.of(expectedAllEvents2()));
+    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedAllEvents2()));
   }
 
   @Test
@@ -558,7 +560,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(response, ImmutableList.of(expectedAllEvents1(), expectedAllEvents2()));
+    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedAllEvents1(), expectedAllEvents2()));
 
     // added sort order
     testFilter.sortOrder(SortOrder.DESC);
@@ -572,7 +574,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(response, ImmutableList.of(expectedAllEvents2(), expectedAllEvents1()));
+    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedAllEvents2(), expectedAllEvents1()));
   }
 
   @Test
@@ -602,7 +604,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
             .standardName("Typhoid and paratyphoid fevers")
             .standardVocabulary("SNOMED")
             .startDate("2008-08-01");
-    assertThat(response.getItems().size()).isEqualTo(2);
+    assertThat(Objects.requireNonNull(response).getItems().size()).isEqualTo(2);
     assertThat(expectedData1).isIn(response.getItems());
     assertThat(expectedData2).isIn(response.getItems());
   }
@@ -649,12 +651,13 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
         controller
             .getVocabularies(NAMESPACE, NAME, reviewWithoutEHRData.getCohortReviewId())
             .getBody();
-    assertThat(response.getItems().size()).isEqualTo(20);
-    assertThat(response.getItems().get(0))
+    List<Vocabulary> items = Objects.requireNonNull(response).getItems();
+    assertThat(items.size()).isEqualTo(20);
+    assertThat(items.get(0))
         .isEqualTo(new Vocabulary().type("Source").domain("ALL_EVENTS").vocabulary("CPT4"));
-    assertThat(response.getItems().get(1))
+    assertThat(items.get(1))
         .isEqualTo(new Vocabulary().type("Source").domain("ALL_EVENTS").vocabulary("ICD10CM"));
-    assertThat(response.getItems().get(2))
+    assertThat(items.get(2))
         .isEqualTo(new Vocabulary().type("Source").domain("ALL_EVENTS").vocabulary("ICD9CM"));
   }
 

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -17,7 +17,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -378,7 +377,11 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
             .matchedParticipantCount(reviewWithoutEHRData.getMatchedParticipantCount())
             .reviewedCount(reviewWithoutEHRData.getReviewedCount())
             .etag(Etags.fromVersion(reviewWithoutEHRData.getVersion()));
-    assertThat(Objects.requireNonNull(controller.getCohortReviewsInWorkspace(NAMESPACE, NAME).getBody()).getItems().get(0))
+    assertThat(
+            Objects.requireNonNull(
+                    controller.getCohortReviewsInWorkspace(NAMESPACE, NAME).getBody())
+                .getItems()
+                .get(0))
         .isEqualTo(expectedReview);
   }
 
@@ -397,7 +400,9 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedCondition1(), expectedCondition2()));
+    assertResponse(
+        Objects.requireNonNull(response),
+        ImmutableList.of(expectedCondition1(), expectedCondition2()));
 
     // added sort order
     testFilter.sortOrder(SortOrder.DESC);
@@ -411,7 +416,9 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedCondition2(), expectedCondition1()));
+    assertResponse(
+        Objects.requireNonNull(response),
+        ImmutableList.of(expectedCondition2(), expectedCondition1()));
   }
 
   @Test
@@ -461,7 +468,9 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedCondition1(), expectedCondition2()));
+    assertResponse(
+        Objects.requireNonNull(response),
+        ImmutableList.of(expectedCondition1(), expectedCondition2()));
 
     // added sort order
     testFilter.sortOrder(SortOrder.DESC);
@@ -475,7 +484,9 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedCondition2(), expectedCondition1()));
+    assertResponse(
+        Objects.requireNonNull(response),
+        ImmutableList.of(expectedCondition2(), expectedCondition1()));
   }
 
   @Test
@@ -560,7 +571,9 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedAllEvents1(), expectedAllEvents2()));
+    assertResponse(
+        Objects.requireNonNull(response),
+        ImmutableList.of(expectedAllEvents1(), expectedAllEvents2()));
 
     // added sort order
     testFilter.sortOrder(SortOrder.DESC);
@@ -574,7 +587,9 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                 testFilter)
             .getBody();
 
-    assertResponse(Objects.requireNonNull(response), ImmutableList.of(expectedAllEvents2(), expectedAllEvents1()));
+    assertResponse(
+        Objects.requireNonNull(response),
+        ImmutableList.of(expectedAllEvents2(), expectedAllEvents1()));
   }
 
   @Test

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -58,8 +58,6 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceACL;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceAccessEntry;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.CloudBillingClientImpl;
-import org.pmiops.workbench.model.CohortChartData;
-import org.pmiops.workbench.model.CohortChartDataListResponse;
 import org.pmiops.workbench.model.CohortReview;
 import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.Filter;
@@ -643,109 +641,6 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
       assertThat(bre.getMessage())
           .isEqualTo("Bad Request: Please provide a chart limit between 1 and 20.");
     }
-  }
-
-  @Test
-  public void getCohortChartDataBadLimit() {
-    try {
-      controller.getCohortChartData(
-          NAMESPACE, NAME, reviewWithoutEHRData.getCohortReviewId(), Domain.CONDITION.name(), -1);
-      fail("Should have thrown a BadRequestException!");
-    } catch (BadRequestException bre) {
-      // Success
-      assertThat(bre.getMessage())
-          .isEqualTo("Bad Request: Please provide a chart limit between 1 and 20.");
-    }
-  }
-
-  @Test
-  public void getCohortChartDataBadLimitOverHundred() {
-    try {
-      controller.getCohortChartData(
-          NAMESPACE, NAME, reviewWithoutEHRData.getCohortReviewId(), Domain.CONDITION.name(), 101);
-      fail("Should have thrown a BadRequestException!");
-    } catch (BadRequestException bre) {
-      // Success
-      assertThat(bre.getMessage())
-          .isEqualTo("Bad Request: Please provide a chart limit between 1 and 20.");
-    }
-  }
-
-  @Test
-  public void getCohortChartDataLab() {
-    CohortChartDataListResponse response =
-        controller
-            .getCohortChartData(
-                NAMESPACE, NAME, reviewWithoutEHRData.getCohortId(), Domain.LAB.name(), 10)
-            .getBody();
-    assertThat(response.getItems().size()).isEqualTo(3);
-    assertThat(response.getItems().get(0))
-        .isEqualTo(new CohortChartData().name("name10").conceptId(10L).count(1L));
-    assertThat(response.getItems().get(0))
-        .isEqualTo(new CohortChartData().name("name10").conceptId(10L).count(1L));
-    assertThat(response.getItems().get(1))
-        .isEqualTo(new CohortChartData().name("name3").conceptId(3L).count(1L));
-    assertThat(response.getItems().get(2))
-        .isEqualTo(new CohortChartData().name("name9").conceptId(9L).count(1L));
-  }
-
-  @Test
-  public void getCohortChartDataLabWithEHRData() {
-    CohortChartDataListResponse response =
-        controller
-            .getCohortChartData(
-                NAMESPACE, NAME, reviewWithEHRData.getCohortId(), Domain.LAB.name(), 10)
-            .getBody();
-    assertThat(response.getItems().size()).isEqualTo(3);
-    assertThat(response.getItems().get(0))
-        .isEqualTo(new CohortChartData().name("name10").conceptId(10L).count(1L));
-    assertThat(response.getItems().get(1))
-        .isEqualTo(new CohortChartData().name("name3").conceptId(3L).count(1L));
-    assertThat(response.getItems().get(2))
-        .isEqualTo(new CohortChartData().name("name9").conceptId(9L).count(1L));
-  }
-
-  @Test
-  public void getCohortChartDataDrug() {
-    CohortChartDataListResponse response =
-        controller
-            .getCohortChartData(
-                NAMESPACE, NAME, reviewWithoutEHRData.getCohortId(), Domain.DRUG.name(), 10)
-            .getBody();
-    assertThat(response.getItems().size()).isEqualTo(1);
-    assertThat(response.getItems().get(0))
-        .isEqualTo(new CohortChartData().name("name11").conceptId(1L).count(1L));
-  }
-
-  @Test
-  public void getCohortChartDataCondition() {
-    CohortChartDataListResponse response =
-        controller
-            .getCohortChartData(
-                NAMESPACE, NAME, reviewWithoutEHRData.getCohortId(), Domain.CONDITION.name(), 10)
-            .getBody();
-    assertThat(response.getItems().size()).isEqualTo(2);
-    assertThat(response.getItems().get(0))
-        .isEqualTo(new CohortChartData().name("name1").conceptId(1L).count(1L));
-    assertThat(response.getItems().get(1))
-        .isEqualTo(new CohortChartData().name("name7").conceptId(7L).count(1L));
-  }
-
-  @Test
-  public void getCohortChartDataProcedure() {
-    CohortChartDataListResponse response =
-        controller
-            .getCohortChartData(
-                NAMESPACE, NAME, reviewWithoutEHRData.getCohortId(), Domain.PROCEDURE.name(), 10)
-            .getBody();
-
-    assertThat(response.getItems().size()).isEqualTo(3);
-    assertThat(response.getItems().get(0))
-        .isEqualTo(new CohortChartData().name("name2").conceptId(2L).count(1L));
-    assertThat(response.getItems().get(1))
-        .isEqualTo(new CohortChartData().name("name4").conceptId(4L).count(1L));
-    assertThat(response.getItems().get(2))
-        .isEqualTo(new CohortChartData().name("name8").conceptId(8L).count(1L));
   }
 
   @Test

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -5,23 +5,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.pmiops.workbench.db.model.DbConceptSetConceptId;
-import org.pmiops.workbench.model.AgeType;
-import org.pmiops.workbench.model.AgeTypeCount;
-import org.pmiops.workbench.model.CardCount;
-import org.pmiops.workbench.model.Criteria;
-import org.pmiops.workbench.model.CriteriaAttribute;
-import org.pmiops.workbench.model.CriteriaListWithCountResponse;
-import org.pmiops.workbench.model.CriteriaMenu;
-import org.pmiops.workbench.model.CriteriaType;
-import org.pmiops.workbench.model.DataFilter;
-import org.pmiops.workbench.model.DemoChartInfo;
-import org.pmiops.workbench.model.DomainCard;
-import org.pmiops.workbench.model.EthnicityInfo;
-import org.pmiops.workbench.model.GenderOrSexType;
-import org.pmiops.workbench.model.ParticipantDemographics;
-import org.pmiops.workbench.model.SearchRequest;
-import org.pmiops.workbench.model.SurveyModule;
-import org.pmiops.workbench.model.SurveyVersion;
+import org.pmiops.workbench.model.*;
 
 public interface CohortBuilderService {
 
@@ -55,6 +39,8 @@ public interface CohortBuilderService {
   Long countParticipants(SearchRequest request);
 
   List<AgeTypeCount> findAgeTypeCounts();
+
+  List<CohortChartData> findCohortChartData(SearchRequest searchRequest, Domain domain, int limit);
 
   List<CriteriaAttribute> findCriteriaAttributeByConceptId(Long conceptId);
 

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -40,26 +40,7 @@ import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbCriteriaAttribute;
 import org.pmiops.workbench.cohortbuilder.mapper.CohortBuilderMapper;
 import org.pmiops.workbench.db.model.DbConceptSetConceptId;
-import org.pmiops.workbench.model.AgeType;
-import org.pmiops.workbench.model.AgeTypeCount;
-import org.pmiops.workbench.model.CardCount;
-import org.pmiops.workbench.model.ConceptIdName;
-import org.pmiops.workbench.model.Criteria;
-import org.pmiops.workbench.model.CriteriaAttribute;
-import org.pmiops.workbench.model.CriteriaListWithCountResponse;
-import org.pmiops.workbench.model.CriteriaMenu;
-import org.pmiops.workbench.model.CriteriaType;
-import org.pmiops.workbench.model.DataFilter;
-import org.pmiops.workbench.model.DemoChartInfo;
-import org.pmiops.workbench.model.Domain;
-import org.pmiops.workbench.model.DomainCard;
-import org.pmiops.workbench.model.EthnicityInfo;
-import org.pmiops.workbench.model.FilterColumns;
-import org.pmiops.workbench.model.GenderOrSexType;
-import org.pmiops.workbench.model.ParticipantDemographics;
-import org.pmiops.workbench.model.SearchRequest;
-import org.pmiops.workbench.model.SurveyModule;
-import org.pmiops.workbench.model.SurveyVersion;
+import org.pmiops.workbench.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -216,6 +197,27 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
     return personDao.findAgeTypeCounts().stream()
         .map(cohortBuilderMapper::dbModelToClient)
         .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<CohortChartData> findCohortChartData(
+      SearchRequest searchRequest, Domain domain, int limit) {
+    TableResult result =
+        bigQueryService.executeQuery(
+            bigQueryService.filterBigQueryConfig(
+                cohortQueryBuilder.buildDomainChartInfoCounterQuery(
+                    new ParticipantCriteria(searchRequest), domain, limit)));
+    Map<String, Integer> rm = bigQueryService.getResultMapper(result);
+
+    List<CohortChartData> cohortChartData = new ArrayList<>();
+    for (List<FieldValue> row : result.iterateAll()) {
+      cohortChartData.add(
+          new CohortChartData()
+              .name(bigQueryService.getString(row, rm.get("name")))
+              .conceptId(bigQueryService.getLong(row, rm.get("conceptId")))
+              .count(bigQueryService.getLong(row, rm.get("count"))));
+    }
+    return cohortChartData;
   }
 
   @Override

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3240,33 +3240,6 @@ paths:
           description: The Participant Chart data
           schema:
             "$ref": "#/definitions/ParticipantChartDataListResponse"
-  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/charts/{domain}":
-    parameters:
-    - "$ref": "#/parameters/workspaceNamespace"
-    - "$ref": "#/parameters/workspaceId"
-    - "$ref": "#/parameters/cohortId"
-    get:
-      tags:
-      - cohortReview
-      description: Returns a collection of CohortChartData for UI charting in cohort
-        review.
-      operationId: getCohortChartData
-      parameters:
-      - in: path
-        name: domain
-        type: string
-        required: true
-        description: specifies which domain the CohortChartData should belong to.
-      - in: query
-        name: limit
-        type: integer
-        required: false
-        description: the limit search results to
-      responses:
-        200:
-          description: A collection of CohortChartData
-          schema:
-            "$ref": "#/definitions/CohortChartDataListResponse"
   "/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/annotations":
     parameters:
     - "$ref": "#/parameters/workspaceNamespace"
@@ -3977,6 +3950,39 @@ paths:
           description: A collection of ethnicity and counts
           schema:
             "$ref": "#/definitions/EthnicityInfoListResponse"
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/top/chartinfo/{domain}/{limit}":
+    parameters:
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
+    post:
+      tags:
+      - cohortBuilder
+      consumes:
+      - application/json
+      description: Returns a collection of CohortChartData for UI charting in cohort.
+      operationId: getCohortChartData
+      parameters:
+      - in: path
+        name: domain
+        type: string
+        required: true
+        description: represents gender or sex at birth
+      - in: path
+        name: limit
+        type: integer
+        required: true
+        description: represents age, age at consent or age at cdr
+      - in: body
+        name: request
+        description: the cohort
+        schema:
+          "$ref": "#/definitions/SearchRequest"
+        required: true
+      responses:
+        200:
+          description: A collection of CohortChartData
+          schema:
+            "$ref": "#/definitions/CohortChartDataListResponse"
   "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/demographics":
     parameters:
       - "$ref": "#/parameters/workspaceNamespace"

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -99,7 +99,6 @@ import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.iam.IamService;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.AnnotationType;
-import org.pmiops.workbench.model.CohortChartData;
 import org.pmiops.workbench.model.CohortReview;
 import org.pmiops.workbench.model.CohortStatus;
 import org.pmiops.workbench.model.CreateReviewRequest;
@@ -2233,52 +2232,6 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getCohortReviewsByCohortId(
                     workspace.getNamespace(), workspace.getId(), cohort.getCohortId()));
-
-    assertForbiddenException(exception);
-  }
-
-  ////////// getCohortChartData - See CohortReviewControllerBQTest   //////////
-  @ParameterizedTest(name = "getCohortChartDataAllowedAccessLevel WorkspaceAccessLevel={0}")
-  @EnumSource(
-      value = WorkspaceAccessLevel.class,
-      names = {"OWNER", "WRITER", "READER"})
-  public void getCohortChartDataAllowedAccessLevel(WorkspaceAccessLevel workspaceAccessLevel) {
-    // change access, call and check
-    stubWorkspaceAccessLevel(workspace, workspaceAccessLevel);
-    stubBigQueryCohortCalls();
-
-    List<CohortChartData> actual =
-        cohortReviewController
-            .getCohortChartData(
-                workspace.getNamespace(),
-                workspace.getId(),
-                cohortReview.getCohortId(),
-                Domain.CONDITION.toString(),
-                1)
-            .getBody()
-            .getItems();
-
-    assertThat(actual.size()).isEqualTo(1);
-  }
-
-  @ParameterizedTest(name = "getCohortChartDataForbiddenAccessLevel WorkspaceAccessLevel={0}")
-  @EnumSource(
-      value = WorkspaceAccessLevel.class,
-      names = {"NO_ACCESS"})
-  public void getCohortChartDataForbiddenAccessLevel(WorkspaceAccessLevel workspaceAccessLevel) {
-    // change access, call and check
-    stubWorkspaceAccessLevel(workspace, workspaceAccessLevel);
-
-    Throwable exception =
-        assertThrows(
-            ForbiddenException.class,
-            () ->
-                cohortReviewController.getCohortChartData(
-                    workspace.getNamespace(),
-                    workspace.getId(),
-                    cohort.getCohortId(),
-                    Domain.CONDITION.toString(),
-                    1));
 
     assertForbiddenException(exception);
   }

--- a/ui/src/app/pages/data/cohort-review/cohort-definition.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-definition.component.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import {
-  CohortReview,
+  Cohort,
   Criteria,
   CriteriaType,
   Domain,
@@ -100,7 +100,7 @@ const modifierOperatorDisplay = (operator: Operator) => {
 };
 
 interface Props extends RouteComponentProps<MatchParams> {
-  review: CohortReview;
+  cohort: Cohort;
 }
 
 interface State {
@@ -129,9 +129,9 @@ export const CohortDefinition = withRouter(
 
     mapDefinition() {
       const {
-        review: { cohortDefinition },
+        cohort: { criteria },
       } = this.props;
-      const def = JSON.parse(cohortDefinition);
+      const def = JSON.parse(criteria);
       const definition = ['includes', 'excludes'].reduce((acc, role) => {
         if (def[role].length) {
           const roleObj = { role, groups: [] };

--- a/ui/src/app/pages/data/cohort-review/cohort-review-overview.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-overview.tsx
@@ -80,7 +80,7 @@ const domainTabs = [
   },
 ];
 
-export const CohortReviewOverview = ({ cohort }) => {
+export const CohortReviewOverview = ({ cohortReview }) => {
   const { ns, wsid } = useParams<MatchParams>();
   const [activeTab, setActiveTab] = useState(domainTabs[0].domain);
   const [demoChartData, setDemoChartData] = useState(undefined);
@@ -94,7 +94,7 @@ export const CohortReviewOverview = ({ cohort }) => {
         wsid,
         GenderOrSexType[GenderOrSexType.GENDER],
         AgeType[AgeType.AGE],
-        JSON.parse(cohort.criteria)
+        JSON.parse(cohortReview.cohortDefinition)
       )
       .then((demoChartInfo) => {
         setDemoChartData(demoChartInfo.items);
@@ -141,7 +141,7 @@ export const CohortReviewOverview = ({ cohort }) => {
                 {activeTab === Domain.PERSON ? (
                   <ComboChart mode={'stacked'} data={demoChartData} />
                 ) : (
-                  <ParticipantsCharts cohortId={cohort.id} domain={activeTab} />
+                  <ParticipantsCharts domain={activeTab} searchRequest={JSON.parse(cohortReview.cohortDefinition)} />
                 )}
               </div>
             </div>

--- a/ui/src/app/pages/data/cohort-review/cohort-review-overview.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-overview.tsx
@@ -141,7 +141,10 @@ export const CohortReviewOverview = ({ cohortReview }) => {
                 {activeTab === Domain.PERSON ? (
                   <ComboChart mode={'stacked'} data={demoChartData} />
                 ) : (
-                  <ParticipantsCharts domain={activeTab} searchRequest={JSON.parse(cohortReview.cohortDefinition)} />
+                  <ParticipantsCharts
+                    domain={activeTab}
+                    searchRequest={JSON.parse(cohortReview.cohortDefinition)}
+                  />
                 )}
               </div>
             </div>

--- a/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
@@ -254,7 +254,7 @@ export const CohortReviewPage = fp.flow(
             <div style={styles.description}>{cohort.description}</div>
           </div>
           <div>
-            <CohortReviewOverview cohort={cohort} />
+            <CohortReviewOverview cohortReview={activeReview} />
           </div>
           <div style={{ display: 'flex' }}>
             <div style={styles.reviewList}>

--- a/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
@@ -253,9 +253,9 @@ export const CohortReviewPage = fp.flow(
             </h4>
             <div style={styles.description}>{cohort.description}</div>
           </div>
-          <div>
+          {!!activeReview && (
             <CohortReviewOverview cohortReview={activeReview} />
-          </div>
+          )}
           <div style={{ display: 'flex' }}>
             <div style={styles.reviewList}>
               <div style={styles.reviewListHeader}>

--- a/ui/src/app/pages/data/cohort-review/participants-charts.tsx
+++ b/ui/src/app/pages/data/cohort-review/participants-charts.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 
+import { SearchRequest } from 'generated/fetch';
+
 import { TooltipTrigger } from 'app/components/popups';
 import { SpinnerOverlay } from 'app/components/spinners';
-import { cohortReviewApi } from 'app/services/swagger-fetch-clients';
+import { cohortBuilderApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCurrentWorkspace } from 'app/utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
@@ -100,8 +102,8 @@ const styles = reactStyles({
 });
 
 export interface ParticipantsChartsProps {
-  cohortId: number;
   domain: string;
+  searchRequest: SearchRequest;
   workspace: WorkspaceData;
 }
 
@@ -140,12 +142,12 @@ export const ParticipantsCharts = withCurrentWorkspace()(
 
     getChartData() {
       const {
-        cohortId,
         domain,
+        searchRequest,
         workspace: { id, namespace },
       } = this.props;
-      cohortReviewApi()
-        .getCohortChartData(namespace, id, cohortId, domain, 10)
+      cohortBuilderApi()
+        .getCohortChartData(namespace, id, domain, 10, searchRequest)
         .then((resp) => {
           const data = resp.items.map((item) => {
             this.nameRefs.push(React.createRef());

--- a/ui/src/app/pages/data/cohort-review/query-report.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/query-report.component.tsx
@@ -6,13 +6,11 @@ import {
   AgeType,
   CdrVersionTiersResponse,
   Cohort,
-  CohortReview,
   DemoChartInfo,
   Domain,
   EthnicityInfo,
   GenderOrSexType,
   SearchRequest,
-  SortOrder,
 } from 'generated/fetch';
 
 import { ComboChart } from 'app/components/combo-chart.component';
@@ -22,21 +20,17 @@ import { CohortDefinition } from 'app/pages/data/cohort-review/cohort-definition
 import { ParticipantsCharts } from 'app/pages/data/cohort-review/participants-charts';
 import {
   cohortBuilderApi,
-  cohortReviewApi,
   cohortsApi,
 } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import {
   reactStyles,
   withCdrVersions,
-  withCurrentCohortReview,
+  withCurrentCohort,
   withCurrentWorkspace,
 } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
-import {
-  currentCohortReviewStore,
-  NavigationProps,
-} from 'app/utils/navigation';
+import { currentCohortStore, NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
@@ -210,21 +204,21 @@ export interface QueryReportProps
     NavigationProps,
     RouteComponentProps<MatchParams> {
   cdrVersionTiersResponse: CdrVersionTiersResponse;
-  cohortReview: CohortReview;
+  cohort: Cohort;
   workspace: WorkspaceData;
 }
 export interface QueryReportState {
   cdrName: string;
-  cohort: Cohort;
   data: DemoChartInfo[];
   groupedData: any;
   chartsLoading: boolean;
-  reviewLoading: boolean;
+  cohortLoading: boolean;
+  participantCount: number;
 }
 
 export const QueryReport = fp.flow(
   withCdrVersions(),
-  withCurrentCohortReview(),
+  withCurrentCohort(),
   withCurrentWorkspace(),
   withNavigation,
   withRouter
@@ -234,60 +228,60 @@ export const QueryReport = fp.flow(
       super(props);
       this.state = {
         cdrName: null,
-        cohort: undefined,
         data: null,
         groupedData: null,
         chartsLoading: true,
-        reviewLoading: true,
+        cohortLoading: true,
+        participantCount: null,
       };
     }
 
     async componentDidMount() {
       const {
         cdrVersionTiersResponse,
-        cohortReview,
+        cohort,
         workspace: { cdrVersionId },
         hideSpinner,
       } = this.props;
       hideSpinner();
       const { ns, wsid, cid } = this.props.match.params;
       let request: SearchRequest;
-      if (cohortReview) {
-        this.setState({ reviewLoading: false });
-        request = JSON.parse(cohortReview.cohortDefinition);
+      if (cohort?.id === +cid) {
+        this.setState({ cohortLoading: false });
+        request = JSON.parse(cohort.criteria);
       } else {
-        await cohortReviewApi()
-          .getParticipantCohortStatusesOld(ns, wsid, +cid, {
-            page: 0,
-            pageSize: 25,
-            sortOrder: SortOrder.Asc,
-          })
-          .then(({ cohortReview: review }) => {
-            request = JSON.parse(review.cohortDefinition);
-            this.setState({ reviewLoading: false });
-            currentCohortReviewStore.next(review);
+        await cohortsApi()
+          .getCohort(ns, wsid, +cid)
+          .then((cohortResponse) => {
+            currentCohortStore.next(cohortResponse);
+            request = JSON.parse(cohortResponse.criteria);
+            this.setState({ cohortLoading: false });
           });
       }
-      cohortsApi()
-        .getCohort(ns, wsid, +cid)
-        .then((cohort) => this.setState({ cohort }));
+
       const cdrName = findCdrVersion(
         cdrVersionId,
         cdrVersionTiersResponse
       ).name;
       this.setState({ cdrName });
-      const [demoChartInfo, ethnicityInfo] = await Promise.all([
-        cohortBuilderApi().findDemoChartInfo(
-          ns,
-          wsid,
-          GenderOrSexType[GenderOrSexType.GENDER],
-          AgeType[AgeType.AGE],
-          request
-        ),
-        cohortBuilderApi().findEthnicityInfo(ns, wsid, request),
-      ]);
+      const [demoChartInfo, ethnicityInfo, participantCount] =
+        await Promise.all([
+          cohortBuilderApi().findDemoChartInfo(
+            ns,
+            wsid,
+            GenderOrSexType[GenderOrSexType.GENDER],
+            AgeType[AgeType.AGE],
+            request
+          ),
+          cohortBuilderApi().findEthnicityInfo(ns, wsid, request),
+          cohortBuilderApi().countParticipants(ns, wsid, request),
+        ]);
       this.groupChartData([...demoChartInfo.items, ...ethnicityInfo.items]);
-      this.setState({ data: demoChartInfo.items, chartsLoading: false });
+      this.setState({
+        data: demoChartInfo.items,
+        chartsLoading: false,
+        participantCount,
+      });
     }
 
     groupChartData(data: Array<DemoChartInfo | EthnicityInfo>) {
@@ -337,14 +331,14 @@ export const QueryReport = fp.flow(
     }
 
     render() {
-      const { cohortReview } = this.props;
+      const { cohort } = this.props;
       const {
         cdrName,
-        cohort,
         data,
         groupedData,
         chartsLoading,
-        reviewLoading,
+        cohortLoading,
+        participantCount,
       } = this.state;
       // TODO can we use the creation time from the review instead of the cohort here?
       const created = !!cohort
@@ -353,7 +347,7 @@ export const QueryReport = fp.flow(
       return (
         <React.Fragment>
           <style>{css}</style>
-          {cohortReview?.cohortReviewId && (
+          {cohort && (
             <button
               style={styles.backBtn}
               type='button'
@@ -362,8 +356,8 @@ export const QueryReport = fp.flow(
               Back to review set
             </button>
           )}
-          {reviewLoading && <SpinnerOverlay />}
-          {cohortReview && (
+          {cohortLoading && <SpinnerOverlay />}
+          {cohort && (
             <div style={styles.reportBackground}>
               <div style={styles.container}>
                 <div style={styles.row}>
@@ -372,9 +366,7 @@ export const QueryReport = fp.flow(
                       <div style={styles.row}>
                         <div style={columns.col6}>
                           <div style={styles.queryTitle}>Cohort Name</div>
-                          <div style={styles.queryContent}>
-                            {cohortReview.cohortName}
-                          </div>
+                          <div style={styles.queryContent}>{cohort.name}</div>
                           <div style={styles.queryTitle}>Created By</div>
                           <div style={styles.queryContent}>
                             {!!cohort ? cohort.creator : ''}
@@ -387,7 +379,7 @@ export const QueryReport = fp.flow(
                           <div style={styles.queryContent}>{cdrName}</div>
                         </div>
                         <div style={columns.col12}>
-                          <CohortDefinition review={cohortReview} />
+                          <CohortDefinition cohort={cohort} />
                         </div>
                       </div>
                     </div>
@@ -465,7 +457,7 @@ export const QueryReport = fp.flow(
                                 <div style={columns.col3}>
                                   {Math.round(
                                     (groupedData[group][row].count /
-                                      cohortReview.matchedParticipantCount) *
+                                      participantCount) *
                                       100
                                   )}
                                   %
@@ -527,20 +519,21 @@ export const QueryReport = fp.flow(
                             maxWidth: '83.33333%',
                           }}
                         >
-                          {domains.map((domain, i) => (
-                            <div
-                              key={i}
-                              style={{
-                                minHeight: '10rem',
-                                position: 'relative',
-                              }}
-                            >
-                              <ParticipantsCharts
-                                cohortId={cohortReview.cohortId}
-                                domain={domain}
-                              />
-                            </div>
-                          ))}
+                          {!!cohort &&
+                            domains.map((domain, i) => (
+                              <div
+                                key={i}
+                                style={{
+                                  minHeight: '10rem',
+                                  position: 'relative',
+                                }}
+                              >
+                                <ParticipantsCharts
+                                  domain={domain}
+                                  searchRequest={JSON.parse(cohort.criteria)}
+                                />
+                              </div>
+                            ))}
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
Allow API endpoints to use any version of cohort to render charts

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
