### PR TITLE
[RW-8614][risk=low] Remove 1.6/hr check to support more machine types

### DIFF
--- a/ui/src/app/utils/machines.ts
+++ b/ui/src/app/utils/machines.ts
@@ -356,26 +356,18 @@ export const allMachineTypes: Machine[] = fp.map(
   machineBases
 ); // adding prices for ephemeral IP's, per https://cloud.google.com/compute/network-pricing#ipaddress
 
-// Initial price restriction to limit against larger machines being used with free tier.
-// This can be reevaluated later, if researchers really want to use very large machines
-// with their own billing accounts.
-const maxMachinePrice = 1.6;
-
 // Following constraints follow findings on RW-5763, last tested 11/19/20. Using
 // machine types below this limit results in either an immediate ERROR status,
 // or a delayed ERROR status after the runtime times out in the CREATING state.
 // See also https://broadworkbench.atlassian.net/browse/SATURN-1337, where the
 // determination was made for Dataproc master machines only.
-const validPricedTypes = allMachineTypes.filter(
-  ({ price }) => price < maxMachinePrice
-);
-export const validLeoGceMachineTypes = validPricedTypes.filter(
+export const validLeoGceMachineTypes = allMachineTypes.filter(
   ({ memory }) => memory >= 2
 );
-export const validLeoDataprocMasterMachineTypes = validPricedTypes.filter(
+export const validLeoDataprocMasterMachineTypes = allMachineTypes.filter(
   ({ memory }) => memory > 4
 );
-export const validLeoDataprocWorkerMachineTypes = validPricedTypes.filter(
+export const validLeoDataprocWorkerMachineTypes = allMachineTypes.filter(
   ({ memory }) => memory >= 3
 );
 


### PR DESCRIPTION
Description:
Background discussion: https://pmi-engteam.slack.com/archives/CHRN2R51N/p1658164436741819
We added a total cost check including disk size, gpu, dataproc worker. The 1.6 seems to be an legacy one and we can remove.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
