### PR TITLE
[risk=no] Fix cohort review e2e test staging

### DIFF
--- a/e2e/tests/cohorts/cohort-review.spec.ts
+++ b/e2e/tests/cohorts/cohort-review.spec.ts
@@ -25,8 +25,8 @@ describe('Cohort review set tests', () => {
 
   const workspaceName = 'e2eCohortReviewTest';
   const cohortName = makeRandomName('auotest', { includeHyphen: false });
-  const cohortReview1Name = multiReviewDisabled ? makeRandomName('auotest', { includeHyphen: false }) : cohortName;
-  const cohortReview2Name = multiReviewDisabled ? makeRandomName('auotest', { includeHyphen: false }) : cohortName;
+  const cohortReview1Name = multiReviewDisabled ? cohortName : makeRandomName('auotest', { includeHyphen: false });
+  const cohortReview2Name = multiReviewDisabled ? cohortName : makeRandomName('auotest', { includeHyphen: false });
 
   const reviewSetNumberOfParticipants_1 = 50;
   const reviewSetNumberOfParticipants_2 = 100;


### PR DESCRIPTION
Second attempt at a fix for `cohort-review.spec.ts` for staging after the latest run failed again. Mixed up the review card names on the first commit (#6862).