### PR TITLE
[RW-8675][risk=no] Fix survey attributes for universal search results

### DIFF
--- a/ui/src/app/cohort-search/cohort-criteria-menu.tsx
+++ b/ui/src/app/cohort-search/cohort-criteria-menu.tsx
@@ -318,6 +318,10 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                   <div style={{ padding: '0.25rem 0.5rem' }}>
                     No results found
                   </div>
+                ) : menuOptions.length === 0 ? (
+                  <div style={{ textAlign: 'center' }}>
+                    <Spinner size={36} />
+                  </div>
                 ) : (
                   menuOptions
                     .filter((optionList) =>


### PR DESCRIPTION
Fix attributes call for survey nodes with attributes in universal search results.

Before:

https://user-images.githubusercontent.com/40036095/181058613-4b932596-6253-4bd6-bc35-acf8a339d25a.mov

After:

https://user-images.githubusercontent.com/40036095/181058674-04d2e82c-183f-41c8-90d3-b3dd05d246e6.mov

Also added a spinner to the universal search menu when menu items are still loading:

https://user-images.githubusercontent.com/40036095/181058826-9028b012-bbc7-4f88-a0db-ba3aa5c70ef4.mov

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
