### PR TITLE
[no ticket][risk=no] allow for queries with multiple ends with terms

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -103,35 +103,6 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomC
           "select c "
               + "from DbCriteria c "
               + "where standard=:standard "
-              + "and match(fullText, concat('+[', :domain, '_rank1]')) > 0 "
-              + "and upper(c.name) like upper(:endsWith) "
-              + "order by c.count desc, c.name asc")
-  Page<DbCriteria> findCriteriaByDomainAndStandardAndNameEndsWith(
-      @Param("domain") String domain,
-      @Param("standard") Boolean standard,
-      @Param("endsWith") String endsWith,
-      Pageable page);
-
-  @Query(
-      value =
-          "select c "
-              + "from DbCriteria c "
-              + "where standard=:standard "
-              + "and match(fullText, concat(:term, '+[', :domain, '_rank1]')) > 0 "
-              + "and upper(c.name) like upper(:endsWith) "
-              + "order by c.count desc, c.name asc")
-  Page<DbCriteria> findCriteriaByDomainAndStandardAndTermAndNameEndsWith(
-      @Param("domain") String domain,
-      @Param("standard") Boolean standard,
-      @Param("term") String term,
-      @Param("endsWith") String endsWith,
-      Pageable page);
-
-  @Query(
-      value =
-          "select c "
-              + "from DbCriteria c "
-              + "where standard=:standard "
               + "and match(fullText, concat(:term, '+[', :domain, '_rank1]')) > 0 "
               + "order by c.count desc, c.name asc")
   Page<DbCriteria> findCriteriaByDomainAndFullTextAndStandard(

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -20,7 +20,7 @@ import org.springframework.data.repository.query.Param;
  * matches in the tree for a specific concept_id. This allows us to use the full text index and
  * makes the query much faster.
  */
-public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long> {
+public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomCBCriteriaDao {
 
   @Query(
       value =

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDao.java
@@ -1,0 +1,14 @@
+package org.pmiops.workbench.cdr.dao;
+
+import java.util.List;
+import org.pmiops.workbench.cdr.model.DbCriteria;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomCBCriteriaDao {
+  Page<DbCriteria> findCriteriaByDomainAndStandardAndNameEndsWith(
+      String domain, Boolean standard, List<String> endsWithList, Pageable page);
+
+  Page<DbCriteria> findCriteriaByDomainAndStandardAndTermAndNameEndsWith(
+      String domain, Boolean standard, String term, List<String> endsWithList, Pageable page);
+}

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -143,27 +142,28 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
   private static class DBCriteriaRowMapper implements RowMapper<DbCriteria> {
     @Override
     public DbCriteria mapRow(@NotNull ResultSet rs, int rowNum) throws SQLException {
-      return DbCriteria.builder().addId(rs.getLong("id"))
-              .addParentId(rs.getLong("parent_id"))
-              .addDomainId(rs.getString("domain_id"))
-              .addStandard(rs.getBoolean("is_standard"))
-              .addType(rs.getString("type"))
-              .addSubtype(rs.getString("subtype"))
-              .addConceptId(rs.getString("concept_id"))
-              .addCode(rs.getString("code"))
-              .addName(rs.getString("name"))
-              .addValue(rs.getString("value"))
-              .addCount(rs.getLong("est_count"))
-              .addGroup(rs.getBoolean("is_group"))
-              .addSelectable(rs.getBoolean("is_selectable"))
-              .addAttribute(rs.getBoolean("has_attribute"))
-              .addHierarchy(rs.getBoolean("has_hierarchy"))
-              .addAncestorData(rs.getBoolean("has_ancestor_data"))
-              .addPath(rs.getString("path"))
-              .addParentCount(rs.getLong("rollup_count"))
-              .addChildCount(rs.getLong("item_count"))
-              .addSynonyms(rs.getString("display_synonyms"))
-              .build();
+      return DbCriteria.builder()
+          .addId(rs.getLong("id"))
+          .addParentId(rs.getLong("parent_id"))
+          .addDomainId(rs.getString("domain_id"))
+          .addStandard(rs.getBoolean("is_standard"))
+          .addType(rs.getString("type"))
+          .addSubtype(rs.getString("subtype"))
+          .addConceptId(rs.getString("concept_id"))
+          .addCode(rs.getString("code"))
+          .addName(rs.getString("name"))
+          .addValue(rs.getString("value"))
+          .addCount(rs.getLong("est_count"))
+          .addGroup(rs.getBoolean("is_group"))
+          .addSelectable(rs.getBoolean("is_selectable"))
+          .addAttribute(rs.getBoolean("has_attribute"))
+          .addHierarchy(rs.getBoolean("has_hierarchy"))
+          .addAncestorData(rs.getBoolean("has_ancestor_data"))
+          .addPath(rs.getString("path"))
+          .addParentCount(rs.getLong("rollup_count"))
+          .addChildCount(rs.getLong("item_count"))
+          .addSynonyms(rs.getString("display_synonyms"))
+          .build();
     }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
@@ -143,7 +143,27 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
   private static class DBCriteriaRowMapper implements RowMapper<DbCriteria> {
     @Override
     public DbCriteria mapRow(@NotNull ResultSet rs, int rowNum) throws SQLException {
-      return (new BeanPropertyRowMapper<>(DbCriteria.class)).mapRow(rs, rowNum);
+      return DbCriteria.builder().addId(rs.getLong("id"))
+              .addParentId(rs.getLong("parent_id"))
+              .addDomainId(rs.getString("domain_id"))
+              .addStandard(rs.getBoolean("is_standard"))
+              .addType(rs.getString("type"))
+              .addSubtype(rs.getString("subtype"))
+              .addConceptId(rs.getString("concept_id"))
+              .addCode(rs.getString("code"))
+              .addName(rs.getString("name"))
+              .addValue(rs.getString("value"))
+              .addCount(rs.getLong("est_count"))
+              .addGroup(rs.getBoolean("is_group"))
+              .addSelectable(rs.getBoolean("is_selectable"))
+              .addAttribute(rs.getBoolean("has_attribute"))
+              .addHierarchy(rs.getBoolean("has_hierarchy"))
+              .addAncestorData(rs.getBoolean("has_ancestor_data"))
+              .addPath(rs.getString("path"))
+              .addParentCount(rs.getLong("rollup_count"))
+              .addChildCount(rs.getLong("item_count"))
+              .addSynonyms(rs.getString("display_synonyms"))
+              .build();
     }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
@@ -1,0 +1,132 @@
+package org.pmiops.workbench.cdr.dao;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import java.util.StringJoiner;
+import java.util.stream.IntStream;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.pmiops.workbench.cdr.model.DbCriteria;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
+
+  public static class QueryAndParameters {
+
+    private final String query;
+    private final MapSqlParameterSource parameters;
+
+    QueryAndParameters(String query, MapSqlParameterSource parameters) {
+      this.query = query;
+      this.parameters = parameters;
+    }
+
+    public String getQuery() {
+      return query;
+    }
+
+    public MapSqlParameterSource getParameters() {
+      return parameters;
+    }
+  }
+
+  private static final String ENDS_WITH_WITHOUT_TERM =
+      "select *\n"
+          + "from cb_criteria\n"
+          + "where is_standard = :standard\n"
+          + "and match(full_text) against(concat('+[', :domain, '_rank1]') in boolean mode)\n"
+          + "and (%s)\n"
+          + "order by est_count desc, name asc\n";
+
+  private static final String ENDS_WITH_WITH_TERM =
+      "select *\n"
+          + "from cb_criteria\n"
+          + "where is_standard = :standard\n"
+          + "and match(full_text) against(concat(:term, '+[', :domain, '_rank1]') in boolean mode)\n"
+          + "and (%s)\n"
+          + "order by est_count desc, name asc\n";
+
+  private static final String DYNAMIC_SQL = "upper(name) like upper(%s)";
+
+  private static final String LIMIT_OFFSET = "limit %s offset %s\n";
+
+  private static final String OR = "\nor\n";
+
+  @Autowired private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+  @Override
+  public Page<DbCriteria> findCriteriaByDomainAndStandardAndNameEndsWith(
+      String domain, Boolean standard, List<String> endsWithList, Pageable page) {
+    QueryAndParameters queryAndParameters =
+        generateQueryAndParameters(ENDS_WITH_WITHOUT_TERM, domain, standard, Optional.empty(), endsWithList);
+    return new PageImpl<>(
+        queryForPaginatedList(page, queryAndParameters), page, count(queryAndParameters));
+  }
+
+  @Override
+  public Page<DbCriteria> findCriteriaByDomainAndStandardAndTermAndNameEndsWith(
+      String domain, Boolean standard, String term, List<String> endsWithList, Pageable page) {
+    QueryAndParameters queryAndParameters =
+        generateQueryAndParameters(
+            ENDS_WITH_WITH_TERM, domain, standard, Optional.of(term), endsWithList);
+    return new PageImpl<>(
+        queryForPaginatedList(page, queryAndParameters), page, count(queryAndParameters));
+  }
+
+  protected QueryAndParameters generateQueryAndParameters(
+      String sql, String domain, Boolean standard, Optional term, List<String> endsWithList) {
+    MapSqlParameterSource parameters = new MapSqlParameterSource();
+    parameters.addValue("domain", domain).addValue("standard", standard);
+    if (term.isPresent()) {
+      parameters.addValue("term", term.get());
+    }
+    StringJoiner joiner = new StringJoiner(OR);
+
+    IntStream.range(0, endsWithList.size())
+        .forEach(
+            idx -> {
+              String endsWith = endsWithList.get(idx);
+              String parameterName = "endsWith" + idx;
+              parameters.addValue(parameterName, endsWith);
+              joiner.add(String.format(DYNAMIC_SQL, ":" + parameterName));
+            });
+
+    return new QueryAndParameters(String.format(sql, joiner), parameters);
+  }
+
+  @NotNull
+  private List<DbCriteria> queryForPaginatedList(
+      Pageable page, QueryAndParameters queryAndParameters) {
+    List<DbCriteria> dbCriteriaList =
+        namedParameterJdbcTemplate.query(
+            queryAndParameters.getQuery()
+                + String.format(LIMIT_OFFSET, page.getPageSize(), page.getOffset()),
+            queryAndParameters.getParameters(),
+            new DBCriteriaRowMapper());
+    return dbCriteriaList;
+  }
+
+  @Nullable
+  private Integer count(QueryAndParameters queryAndParameters) {
+    return namedParameterJdbcTemplate.queryForObject(
+        queryAndParameters.getQuery().replace("*", "count(*)"),
+        queryAndParameters.getParameters(),
+        Integer.class);
+  }
+
+  private class DBCriteriaRowMapper implements RowMapper<DbCriteria> {
+    @Override
+    public DbCriteria mapRow(ResultSet rs, int rowNum) throws SQLException {
+      return (new BeanPropertyRowMapper<>(DbCriteria.class)).mapRow(rs, rowNum);
+    }
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
@@ -6,9 +6,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.stream.IntStream;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.pmiops.workbench.cdr.CdrDbConfig;
 import org.pmiops.workbench.cdr.CdrVersionContext;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
@@ -20,9 +21,6 @@ import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
 
@@ -71,8 +69,7 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
 
   @Autowired private CdrVersionDao cdrVersionDao;
 
-  @PersistenceContext
-  private EntityManager entityManager;
+  @PersistenceContext private EntityManager entityManager;
 
   @Override
   public Page<DbCriteria> findCriteriaByDomainAndStandardAndNameEndsWith(
@@ -105,8 +102,11 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
     }
     StringJoiner joiner = new StringJoiner(OR);
 
-
-    String tablePrefix = cdrVersionDao.findById(CdrVersionContext.getCdrVersion().getCdrVersionId()).get().getCdrDbName();
+    String tablePrefix =
+        cdrVersionDao
+            .findById(CdrVersionContext.getCdrVersion().getCdrVersionId())
+            .get()
+            .getCdrDbName();
 
     IntStream.range(0, endsWithList.size())
         .forEach(

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -721,9 +721,9 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
             });
 
     // validate here?
-    if ((modifiedTerms.size() == 1 && modifiedTerms.get(0).startsWith("-"))) {
-      throw new BadRequestException(String.format("Bad Request: Search term is invalid: %s", term));
-    }
+//    if ((modifiedTerms.size() == 1 && modifiedTerms.get(0).startsWith("-"))) {
+//      throw new BadRequestException(String.format("Bad Request: Search term is invalid: %s", term));
+//    }
     // create strings for endsWithTerms and modifiedTerms
     retMap.put(ENDS_WITH_TERMS, endsWith.stream().collect(Collectors.joining(",")));
     retMap.put(

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -43,7 +43,6 @@ import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.cdr.model.DbCriteriaAttribute;
 import org.pmiops.workbench.cohortbuilder.mapper.CohortBuilderMapper;
 import org.pmiops.workbench.db.model.DbConceptSetConceptId;
-import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -720,10 +719,6 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
               }
             });
 
-    // validate here?
-//    if ((modifiedTerms.size() == 1 && modifiedTerms.get(0).startsWith("-"))) {
-//      throw new BadRequestException(String.format("Bad Request: Search term is invalid: %s", term));
-//    }
     // create strings for endsWithTerms and modifiedTerms
     retMap.put(ENDS_WITH_TERMS, endsWith.stream().collect(Collectors.joining(",")));
     retMap.put(

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -274,29 +274,6 @@ public class CBCriteriaDaoTest {
   }
 
   @Test
-  public void findCriteriaByDomainAndStandardAndTermAndNameEndsWith() {
-    PageRequest page = PageRequest.of(0, 10);
-    List<DbCriteria> actual =
-        cbCriteriaDao
-            .findCriteriaByDomainAndStandardAndTermAndNameEndsWith(
-                Domain.DRUG.toString(), true, "AdultAspirin", "%Aspirin", page)
-            .getContent();
-    assertThat(actual).containsExactly(drugCriteria2);
-  }
-
-  @Test
-  public void findCriteriaByDomainAndStandardAndNameEndsWith() {
-    PageRequest page = PageRequest.of(0, 10);
-    List<DbCriteria> actual =
-        cbCriteriaDao
-            .findCriteriaByDomainAndStandardAndNameEndsWith(
-                Domain.DRUG.toString(), true, "%aspirin", page)
-            .getContent();
-    assertThat(actual)
-        .containsExactlyElementsIn(ImmutableList.of(drugCriteria, drugCriteria2, drugCriteria3));
-  }
-
-  @Test
   public void findCriteriaByDomainAndFullTextAndStandard() {
     PageRequest page = PageRequest.of(0, 10);
     List<DbCriteria> measurements =
@@ -311,13 +288,6 @@ public class CBCriteriaDaoTest {
                 Domain.MEASUREMENT.toString(), "001", true, page)
             .getContent();
     assertThat(measurements).containsExactly(measurementCriteria);
-  }
-
-  @Test
-  public void findCriteriaByDomainAndStandardAndNameEndsWith() {
-    PageRequest page = PageRequest.of(2, 10);
-    cbCriteriaDao.findCriteriaByDomainAndStandardAndNameEndsWith(
-        Domain.CONDITION.toString(), Boolean.TRUE, Arrays.asList("%statin", "%brian"), page);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -314,6 +314,13 @@ public class CBCriteriaDaoTest {
   }
 
   @Test
+  public void findCriteriaByDomainAndStandardAndNameEndsWith() {
+    PageRequest page = PageRequest.of(2, 10);
+    cbCriteriaDao.findCriteriaByDomainAndStandardAndNameEndsWith(
+        Domain.CONDITION.toString(), Boolean.TRUE, Arrays.asList("%statin", "%brian"), page);
+  }
+
+  @Test
   public void findCriteriaTopCountsByStandard() {
     PageRequest page = PageRequest.of(0, 10);
     List<DbCriteria> conditions =

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImplTest.java
@@ -121,10 +121,7 @@ class CohortBuilderServiceImplTest {
     return Stream.of(
         // special chars are filtered by the UI-except ("\"", "+", "-", "*")
         Arguments.of("Search term: ", "-pita", "one term starts with -"),
-        Arguments.of("Search term: ", "*statin -pita", "two term starts with - and *"),
-        Arguments.of("Search term: ", "*statin *pita", "two terms starts *"),
-        Arguments.of("Search term: ", "*statin other *pita", "two terms starts *"),
-        Arguments.of("Search term: ", "*statin other *pita -minus", "two terms starts *"));
+        Arguments.of("Search term: ", "*statin -pita", "two term starts with - and *"));
   }
 
   private static Stream<Arguments> getModifyTermMatchEndsWithParameters() {

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImplTest.java
@@ -97,16 +97,6 @@ class CohortBuilderServiceImplTest {
     assertWithMessage(testInput).that(actual.get("modifiedTerms")).isEqualTo(expected);
   }
 
-  @ParameterizedTest(name = "modifyTermMatchUseEndsWith: {0} {1}=>{2}")
-  @MethodSource("getModifyTermMatchEndsWithInvalidParameters")
-  void modifyTermMatchUseEndsWithInvalidTerm(String testInput, String term) {
-    Throwable exception =
-        assertThrows(
-            BadRequestException.class,
-            () -> cohortBuilderService.modifyTermMatchUseEndsWithTerms(term));
-    assertThat(exception).hasMessageThat().containsMatch("Bad Request: Search term is invalid");
-  }
-
   @ParameterizedTest(name = "modifyTermMatch: {0} {1}=>{2}")
   @MethodSource("getModifyTermMatchParameters")
   void modifyTermMatch(String testInput, String term, String expected) {

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImplTest.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.cohortbuilder;
 
-import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
@@ -30,7 +29,6 @@ import org.pmiops.workbench.cdr.dao.PersonDao;
 import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
 import org.pmiops.workbench.cohortbuilder.mapper.CohortBuilderMapper;
 import org.pmiops.workbench.cohortbuilder.mapper.CohortBuilderMapperImpl;
-import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.workspaces.WorkspaceAuthService;
@@ -136,7 +134,11 @@ class CohortBuilderServiceImplTest {
         Arguments.of("Search term: ", "type-2-diabetes", "+\"type-2-diabetes\""),
         Arguments.of("Search term: ", "*statin pita", "+pita*"),
         Arguments.of("Search term: ", "*statin +pita", "+pita*"),
-        Arguments.of("Search term: ", "-pita brea", "-pita+brea*"));
+        Arguments.of("Search term: ", "-pita brea", "-pita+brea*"),
+        Arguments.of("Search term: ", "*statin -pita", "-pita"),
+        Arguments.of("Search term: ", "*statin *pita", ""),
+        Arguments.of("Search term: ", "*statin other *pita", "+other*"),
+        Arguments.of("Search term: ", "*statin other *pita -minus", "+other*-minus"));
   }
 
   private static Stream<Arguments> getModifyTermMatchParameters() {


### PR DESCRIPTION
Description: Allow for queries with multiple ends with terms. This PR utilizes a custom dao implementation to all us to build a sql statement dynamically depending on how many ends with search terms are present in the parameter list.


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
