### PR TITLE
[no-ticket][risk=no] Wait for page load event

### DIFF
--- a/e2ev2/src/circle-run-tests.sh
+++ b/e2ev2/src/circle-run-tests.sh
@@ -12,7 +12,7 @@ mkdir screenshots
 
 yarn install
 
-export UI_HOSTNAME=pr-"$PR_SITE_NUM"-dot-all-of-us-workbench-test.appspot.com
+export UI_HOSTNAME=pr-$PR_SITE_NUM-dot-all-of-us-workbench-test.appspot.com
 export PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome
 export JEST_SILENT_REPORTER_DOTS=true
 export JEST_SILENT_REPORTER_SHOW_PATHS=true
@@ -20,6 +20,9 @@ export JEST_SILENT_REPORTER_SHOW_PATHS=true
 BKT_ROOT=gs://all-of-us-workbench-test.appspot.com/circle-failed-tests
 FAILED_TESTS=$(gsutil cat $BKT_ROOT/\*.$CIRCLE_SHA1.txt || echo -n)
 gsutil rm $BKT_ROOT/\*.$CIRCLE_SHA1.txt || true
+
+# This warmup can take over thirty seconds, which causes timeouts in tests.
+time (curl https://pr-$PR_SITE_NUM-dot-api-dot-all-of-us-workbench-test.appspot.com; echo)
 
 set +e
 export FAILED_TESTS_LOG=failed-tests.txt

--- a/e2ev2/src/config.js
+++ b/e2ev2/src/config.js
@@ -8,7 +8,13 @@ export_({projectName})
 const usernames = ['puppeteer-tester-7@fake-research-aou.org']
 export_({usernames})
 
-const urlRoot = () => `https://${process.env.UI_HOSTNAME}`
+const urlRoot = () => {
+  assert(
+    process.env.UI_HOSTNAME,
+    'UI_HOSTNAME not defined. Try: export UI_HOSTNAME=all-of-us-workbench-test.appspot.com'
+  )
+  return `https://${process.env.UI_HOSTNAME}`
+}
 
 export_({urlRoot})
 

--- a/e2ev2/src/test-utils.js
+++ b/e2ev2/src/test-utils.js
@@ -46,7 +46,7 @@ const browserTest = testFilePath => (description, testFn, timeoutMs) =>
     await fsp.access(ssDir, fs.constants.R_OK | fs.constants.W_OK).catch(e => fsp.mkdir(ssDir))
     const browser = await launch()
     browser.initialPage = await browser.pages().then(pages => pages[0])
-    // Stolen from a recent Chrome version.
+    // Stolen from a recent Chrome version. Avoids browser warning.
     const uaString = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
       +' AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36'
     await browser.initialPage.setUserAgent(uaString)

--- a/e2ev2/tests/login.test.js
+++ b/e2ev2/tests/login.test.js
@@ -6,7 +6,7 @@ const browserTest = tu.browserTest(__filename)
 
 browserTest('sign in', async browser => {
   const page = browser.initialPage
-  await page.goto(config.urlRoot(), {waitUtil: ['domcontentloaded']})
+  await page.goto(config.urlRoot(), {waitUntil: 'domcontentloaded'})
   await tu.impersonateUser(page, config.usernames[0])
   expect(await page.waitForSelector('[data-test-id="signed-in"]', {timeout: 4e3})).toBeDefined()
 })

--- a/e2ev2/tests/login.test.js
+++ b/e2ev2/tests/login.test.js
@@ -6,7 +6,7 @@ const browserTest = tu.browserTest(__filename)
 
 browserTest('sign in', async browser => {
   const page = browser.initialPage
-  await page.goto(config.urlRoot(), {waitUntil: 'domcontentloaded'})
+  await page.goto(config.urlRoot(), {waitUntil: 'networkidle0'})
   await tu.impersonateUser(page, config.usernames[0])
   expect(await page.waitForSelector('[data-test-id="signed-in"]', {timeout: 4e3})).toBeDefined()
 })

--- a/e2ev2/tests/login.test.js
+++ b/e2ev2/tests/login.test.js
@@ -6,7 +6,7 @@ const browserTest = tu.browserTest(__filename)
 
 browserTest('sign in', async browser => {
   const page = browser.initialPage
-  await page.goto(config.urlRoot())
+  await page.goto(config.urlRoot(), {waitUtil: ['domcontentloaded']})
   await tu.impersonateUser(page, config.usernames[0])
   expect(await page.waitForSelector('[data-test-id="signed-in"]', {timeout: 4e3})).toBeDefined()
 })

--- a/e2ev2/tests/sanity.browser.test.js
+++ b/e2ev2/tests/sanity.browser.test.js
@@ -5,14 +5,14 @@ const browserTest = tu.browserTest(__filename)
 
 browserTest('page loads', async browser => {
   const page = browser.initialPage
-  await page.goto('https://example.com', {waitUntil: 'domcontentloaded'})
+  await page.goto('https://example.com', {waitUntil: 'networkidle0'})
   const h1 = await page.waitForSelector('h1')
   expect(await h1.evaluate(n => n.innerText)).toBe('Example Domain')
 })
 
 browserTest('view cookie policy page', async browser => {
   const page = browser.initialPage
-  await page.goto(config.urlRoot()+'/login', {waitUntil: 'domcontentloaded'})
+  await page.goto(config.urlRoot()+'/login', {waitUntil: 'networkidle0'})
   const cpLink = await page.waitForSelector('a[href="/cookie-policy"]')
   expect(cpLink).toBeDefined()
   // click and wait need to happen simultaneously to avoid a race
@@ -30,7 +30,7 @@ browserTest('view cookie policy page', async browser => {
 for (const p of ['/workspaces', '/profile']) {
   browserTest(`navigation to ${p} redirects to sign-in page`, async browser => {
     const page = browser.initialPage
-    await page.goto(config.urlRoot()+p, {waitUntil: 'domcontentloaded'})
+    await page.goto(config.urlRoot()+p, {waitUntil: 'networkidle0'})
     const button = await page.waitForSelector('[role="button"]')
     expect(await button.evaluate(n => n.textContent)).toBe('Sign In')
   })

--- a/e2ev2/tests/sanity.browser.test.js
+++ b/e2ev2/tests/sanity.browser.test.js
@@ -5,14 +5,14 @@ const browserTest = tu.browserTest(__filename)
 
 browserTest('page loads', async browser => {
   const page = browser.initialPage
-  await page.goto('https://example.com', {waitUtil: ['domcontentloaded']})
+  await page.goto('https://example.com', {waitUntil: 'domcontentloaded'})
   const h1 = await page.waitForSelector('h1')
   expect(await h1.evaluate(n => n.innerText)).toBe('Example Domain')
 })
 
 browserTest('view cookie policy page', async browser => {
   const page = browser.initialPage
-  await page.goto(config.urlRoot()+'/login', {waitUtil: ['domcontentloaded']})
+  await page.goto(config.urlRoot()+'/login', {waitUntil: 'domcontentloaded'})
   const cpLink = await page.waitForSelector('a[href="/cookie-policy"]')
   expect(cpLink).toBeDefined()
   // click and wait need to happen simultaneously to avoid a race
@@ -30,7 +30,7 @@ browserTest('view cookie policy page', async browser => {
 for (const p of ['/workspaces', '/profile']) {
   browserTest(`navigation to ${p} redirects to sign-in page`, async browser => {
     const page = browser.initialPage
-    await page.goto(config.urlRoot()+p, {waitUtil: ['domcontentloaded']})
+    await page.goto(config.urlRoot()+p, {waitUntil: 'domcontentloaded'})
     const button = await page.waitForSelector('[role="button"]')
     expect(await button.evaluate(n => n.textContent)).toBe('Sign In')
   })

--- a/e2ev2/tests/sanity.browser.test.js
+++ b/e2ev2/tests/sanity.browser.test.js
@@ -5,14 +5,14 @@ const browserTest = tu.browserTest(__filename)
 
 browserTest('page loads', async browser => {
   const page = browser.initialPage
-  await page.goto('https://example.com')
+  await page.goto('https://example.com', {waitUtil: ['domcontentloaded']})
   const h1 = await page.waitForSelector('h1')
   expect(await h1.evaluate(n => n.innerText)).toBe('Example Domain')
 })
 
 browserTest('view cookie policy page', async browser => {
   const page = browser.initialPage
-  await page.goto(config.urlRoot()+'/login')
+  await page.goto(config.urlRoot()+'/login', {waitUtil: ['domcontentloaded']})
   const cpLink = await page.waitForSelector('a[href="/cookie-policy"]')
   expect(cpLink).toBeDefined()
   // click and wait need to happen simultaneously to avoid a race
@@ -30,7 +30,7 @@ browserTest('view cookie policy page', async browser => {
 for (const p of ['/workspaces', '/profile']) {
   browserTest(`navigation to ${p} redirects to sign-in page`, async browser => {
     const page = browser.initialPage
-    await page.goto(config.urlRoot()+p)
+    await page.goto(config.urlRoot()+p, {waitUtil: ['domcontentloaded']})
     const button = await page.waitForSelector('[role="button"]')
     expect(await button.evaluate(n => n.textContent)).toBe('Sign In')
   })

--- a/e2ev2/tests/workspace-create.test.js
+++ b/e2ev2/tests/workspace-create.test.js
@@ -10,6 +10,7 @@ const workspaceCreationTimeoutMs = 30e3
 const workspaceDeletionTimeoutMs = 10e3
 browserTest('create a workspace', async browser => {
   const page = browser.initialPage
+  await page.goto(config.urlRoot(), {waitUtil: ['domcontentloaded']})
   await page.goto(config.urlRoot())
   await tu.impersonateUser(page, config.usernames[0])
   const createWorkspaceLink = await page.waitForSelector('clr-icon[shape="plus-circle"]')

--- a/e2ev2/tests/workspace-create.test.js
+++ b/e2ev2/tests/workspace-create.test.js
@@ -10,8 +10,7 @@ const workspaceCreationTimeoutMs = 30e3
 const workspaceDeletionTimeoutMs = 10e3
 browserTest('create a workspace', async browser => {
   const page = browser.initialPage
-  await page.goto(config.urlRoot(), {waitUtil: ['domcontentloaded']})
-  await page.goto(config.urlRoot())
+  await page.goto(config.urlRoot(), {waitUntil: 'domcontentloaded'})
   await tu.impersonateUser(page, config.usernames[0])
   const createWorkspaceLink = await page.waitForSelector('clr-icon[shape="plus-circle"]')
   await createWorkspaceLink.click()

--- a/e2ev2/tests/workspace-create.test.js
+++ b/e2ev2/tests/workspace-create.test.js
@@ -10,7 +10,7 @@ const workspaceCreationTimeoutMs = 30e3
 const workspaceDeletionTimeoutMs = 10e3
 browserTest('create a workspace', async browser => {
   const page = browser.initialPage
-  await page.goto(config.urlRoot(), {waitUntil: 'domcontentloaded'})
+  await page.goto(config.urlRoot(), {waitUntil: 'networkidle0'})
   await tu.impersonateUser(page, config.usernames[0])
   const createWorkspaceLink = await page.waitForSelector('clr-icon[shape="plus-circle"]')
   await createWorkspaceLink.click()


### PR DESCRIPTION
No ticket: no application code changes.

Waiting for the `networkidle0` event causes `page.goto` to fail when the page doesn't load. This is much clearer than having the timeout occur on a selector.