### PR TITLE
[RW-8487][risk=no] Verify-genomic-properties-are-specified

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
@@ -171,7 +171,7 @@ public class UpdateCdrConfig {
           && StringUtils.isAnyEmpty(v.wgsFilterSetName, v.wgsBigqueryDataset)) {
         throw new IllegalArgumentException(
             String.format(
-                "Both wgsBigqueryDataset and wgsFilterSetName have to be defined. Current values are: wgsBigqueryDataset: %s / wgsFilterSetName: %s",
+                "If either of wgsBigqueryDataset and wgsFilterSetName is defined, the other has to be defined too. Current values are: wgsBigqueryDataset: %s / wgsFilterSetName: %s",
                 v.wgsBigqueryDataset, v.wgsFilterSetName));
       }
     }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/cdrconfig/UpdateCdrConfig.java
@@ -166,6 +166,14 @@ public class UpdateCdrConfig {
           cdrDefaultVersionPerTier.put(v.accessTier, v.cdrVersionId);
         }
       }
+
+      if (!StringUtils.isAllEmpty(v.wgsFilterSetName, v.wgsBigqueryDataset)
+          && StringUtils.isAnyEmpty(v.wgsFilterSetName, v.wgsBigqueryDataset)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Both wgsBigqueryDataset and wgsFilterSetName have to be defined. Current values are: wgsBigqueryDataset: %s / wgsFilterSetName: %s",
+                v.wgsBigqueryDataset, v.wgsFilterSetName));
+      }
     }
 
     accessTierShortNames.forEach(

--- a/api/tools/src/test/resources/cdrconfig/README.md
+++ b/api/tools/src/test/resources/cdrconfig/README.md
@@ -1,7 +1,9 @@
 # Test files for UpdateCdrConfig
 
 ## Validation tests: these files should all be rejected
+
 ### Access Tier
+
 Duplicate ID: duplicate_tier_id.json
 
 Duplicate Short Name: duplicate_tier_shortName.json
@@ -9,6 +11,7 @@ Duplicate Short Name: duplicate_tier_shortName.json
 Duplicate Display Name: duplicate_tier_displayName.json
 
 ### CDR Version
+
 CDR Version duplicate ID: duplicate_cdr_id.json
 
 CDR Version missing ID: missing_id_cdr.json
@@ -16,6 +19,7 @@ CDR Version missing ID: missing_id_cdr.json
 CDR Version archived default: archived_default_cdr.json
 
 ### Tier/CDR Integration
+
 CDR Version / Access Tier mismatch: cdr_tier_mismatch.json
 
 CDR Version has no Access Tier: cdr_no_tier.json
@@ -26,13 +30,20 @@ CDR Version multiple defaults in a tier: multi_default_in_tier.json
 
 CDR Version no default in a tier: no_default_in_tier.json
 
-## Tier migration test
-Confirm that it's possible to add Access Tiers concurrently with CDR Versions.
-It is not clear at present whether we have a use case for removing tiers.
-This will be a more involved process due to foreign key contraints.
+### Missing properties RW-8487
 
-At the time of initial creation of this tool (Jan 2021) we have a single tier: ID 1, short name 
-'registered', represented by `tier_migration_1.json`.  The second file `tier_migration_2.json` 
-adds a second tier and associated CDR Versions.  Removing the new tier by re-applying 
-`tier_migration_1.json` should be possible because there will be no resources referring to 
-this tier. 
+CDR has wgsBigqueryDataset but not wgsFilterSetName: cdr_wgsFilterSetName_not_defined.json
+
+CDR has wgsFilterSetName but not wgsBigqueryDataset: cdr_wgsBigqueryDataset_not_defined.json
+
+## Tier migration test
+
+Confirm that it's possible to add Access Tiers concurrently with CDR Versions. It is not clear at
+present whether we have a use case for removing tiers. This will be a more involved process due to
+foreign key contraints.
+
+At the time of initial creation of this tool (Jan 2021) we have a single tier: ID 1, short name
+'registered', represented by `tier_migration_1.json`. The second file `tier_migration_2.json`
+adds a second tier and associated CDR Versions. Removing the new tier by re-applying
+`tier_migration_1.json` should be possible because there will be no resources referring to this
+tier. 

--- a/api/tools/src/test/resources/cdrconfig/cdr_wgsBigqueryDataset_not_defined.json
+++ b/api/tools/src/test/resources/cdrconfig/cdr_wgsBigqueryDataset_not_defined.json
@@ -1,0 +1,35 @@
+{
+  "accessTiers": [
+    {
+      "accessTierId": 2,
+      "shortName": "controlled",
+      "displayName": "Controlled Tier",
+      "servicePerimeter": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test_2",
+      "authDomainName": "all-of-us-controlled-local",
+      "authDomainGroupEmail": "all-of-us-controlled-local@dev.test.firecloud.org",
+      "datasetsBucket": "gs://fc-aou-test-datasets-controlled/",
+      "enableUserWorkflows": true
+    }
+  ],
+  "cdrVersions": [
+    {
+      "cdrVersionId": 5,
+      "isDefault": true,
+      "accessTier": "controlled",
+      "name": "Synthetic Dataset in the Controlled Tier",
+      "bigqueryProject": "fc-aou-cdr-synth-test-2",
+      "bigqueryDataset": "test_R2019q4r3",
+      "wgsFilterSetName": "example",
+      "creationTime": "2020-08-26 00:09:51Z",
+      "releaseNumber": 3,
+      "numParticipants": 234525,
+      "cdrDbName": "cdr",
+      "hasFitbitData": true,
+      "hasCopeSurveyData": true,
+      "storageBasePath": "5",
+      "wgsCramManifestPath": "wgs/cram/manifest.csv",
+      "wgsVcfMergedStoragePath": "wgs/vcf/merged",
+      "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample"
+    }
+  ]
+}

--- a/api/tools/src/test/resources/cdrconfig/cdr_wgsFilterSetName_not_defined.json
+++ b/api/tools/src/test/resources/cdrconfig/cdr_wgsFilterSetName_not_defined.json
@@ -1,0 +1,35 @@
+{
+  "accessTiers": [
+    {
+      "accessTierId": 2,
+      "shortName": "controlled",
+      "displayName": "Controlled Tier",
+      "servicePerimeter": "accessPolicies/228353087260/servicePerimeters/terra_dev_aou_test_2",
+      "authDomainName": "all-of-us-controlled-local",
+      "authDomainGroupEmail": "all-of-us-controlled-local@dev.test.firecloud.org",
+      "datasetsBucket": "gs://fc-aou-test-datasets-controlled/",
+      "enableUserWorkflows": true
+    }
+  ],
+  "cdrVersions": [
+    {
+      "cdrVersionId": 5,
+      "isDefault": true,
+      "accessTier": "controlled",
+      "name": "Synthetic Dataset in the Controlled Tier",
+      "bigqueryProject": "fc-aou-cdr-synth-test-2",
+      "bigqueryDataset": "test_R2019q4r3",
+      "wgsBigqueryDataset": "1kg_wgs_2022q1",
+      "creationTime": "2020-08-26 00:09:51Z",
+      "releaseNumber": 3,
+      "numParticipants": 234525,
+      "cdrDbName": "cdr",
+      "hasFitbitData": true,
+      "hasCopeSurveyData": true,
+      "storageBasePath": "5",
+      "wgsCramManifestPath": "wgs/cram/manifest.csv",
+      "wgsVcfMergedStoragePath": "wgs/vcf/merged",
+      "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample"
+    }
+  ]
+}


### PR DESCRIPTION
Add a validation to ensure that both wgsBigqueryDataset and wgsFilterSetName are specified together if any one of them exists.

Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
