### PR TITLE
[risk=low][RW-8651] Drop table user_recent_resources

### DIFF
--- a/api/db/changelog/db.changelog-202-drop-user-recent-resource.xml
+++ b/api/db/changelog/db.changelog-202-drop-user-recent-resource.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="thibault" id="changelog-202-drop-user-recent-resource">
+    <dropTable tableName="user_recent_resource"/>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -209,6 +209,7 @@
   <include file="changelog/db.changelog-199-update-demographic-survey-v2.xml"/>
   <include file="changelog/db.changelog-200-demographic-survey-v2-tweaks.xml"/>
   <include file="changelog/db.changelog-201-demographic-survey-v2-aian.xml"/>
+  <include file="changelog/db.changelog-202-drop-user-recent-resource.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceImpl.java
@@ -41,10 +41,8 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
   }
 
   /**
-   * Checks if notebook for given workspace and user is already in table user_recent_resource if
-   * yes, update the lastAccessDateTime only If no, check the number of resource entries for given
-   * user if it is above config userEntrycount, delete the row(s) with least lastAccessTime and add
-   * a new entry
+   * Create a Notebook recent-resource entry in the DB if none exists, reducing the table size to
+   * USER_ENTRY_COUNT per-user if necessary. Update the last accessed time if it does exist.
    */
   @Override
   public DbUserRecentlyModifiedResource updateNotebookEntry(
@@ -57,10 +55,8 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
   }
 
   /**
-   * Checks if cohort for given workspace and user is already in table user_recent_resource if yes,
-   * update the lastAccessDateTime only If no, check the number of resource entries for given user
-   * if it is above config userEntrycount, delete the row(s) with least lastAccessTime and add a new
-   * entry
+   * Create a Cohort recent-resource entry in the DB if none exists, reducing the table size to
+   * USER_ENTRY_COUNT per-user if necessary. Update the last accessed time if it does exist.
    */
   @Override
   public void updateCohortEntry(long workspaceId, long userId, long cohortId) {
@@ -71,6 +67,10 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
         String.valueOf(cohortId));
   }
 
+  /**
+   * Create a Concept Set recent-resource entry in the DB if none exists, reducing the table size to
+   * USER_ENTRY_COUNT per-user if necessary. Update the last accessed time if it does exist.
+   */
   @Override
   public void updateConceptSetEntry(long workspaceId, long userId, long conceptSetId) {
     updateUserRecentlyModifiedResourceEntry(
@@ -80,6 +80,10 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
         String.valueOf(conceptSetId));
   }
 
+  /**
+   * Create a Dataset recent-resource entry in the DB if none exists, reducing the table size to
+   * USER_ENTRY_COUNT per-user if necessary. Update the last accessed time if it does exist.
+   */
   @Override
   public void updateDataSetEntry(long workspaceId, long userId, long dataSetId) {
     updateUserRecentlyModifiedResourceEntry(
@@ -89,6 +93,10 @@ public class UserRecentResourceServiceImpl implements UserRecentResourceService 
         String.valueOf(dataSetId));
   }
 
+  /**
+   * Create a Cohort Review recent-resource entry in the DB if none exists, reducing the table size
+   * to USER_ENTRY_COUNT per-user if necessary. Update the last accessed time if it does exist.
+   */
   @Override
   public void updateCohortReviewEntry(long workspaceId, long userId, long cohortReviewId) {
     updateUserRecentlyModifiedResourceEntry(


### PR DESCRIPTION
A release has passed since we removed the last references to this table (#6857), so it's safe to delete now.

Tested locally with no problems.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
