### PR TITLE
[risk=low][RW-6988][RW-8627] rm deprecated getWorkspaceResources()

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -61,7 +61,6 @@ import org.pmiops.workbench.model.WorkspaceBillingUsageResponse;
 import org.pmiops.workbench.model.WorkspaceCreatorFreeCreditsRemainingResponse;
 import org.pmiops.workbench.model.WorkspaceOperation;
 import org.pmiops.workbench.model.WorkspaceResourceResponse;
-import org.pmiops.workbench.model.WorkspaceResourcesRequest;
 import org.pmiops.workbench.model.WorkspaceResponse;
 import org.pmiops.workbench.model.WorkspaceResponseListResponse;
 import org.pmiops.workbench.model.WorkspaceUserRolesResponse;
@@ -868,12 +867,6 @@ public class WorkspacesController implements WorkspacesApiDelegate {
         workspaceMapper.toApiRecentWorkspace(dbWorkspace, workspaceAccessLevel);
     recentWorkspaceResponse.add(recentWorkspace);
     return ResponseEntity.ok(recentWorkspaceResponse);
-  }
-
-  @Override
-  public ResponseEntity<WorkspaceResourceResponse> getWorkspaceResources(
-      String ns, String id, WorkspaceResourcesRequest wrr) {
-    return getWorkspaceResourcesImpl(ns, id, wrr.getTypesToFetch());
   }
 
   @Override

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1024,27 +1024,6 @@ paths:
           schema:
             "$ref": "#/definitions/Workspace"
 
-  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/resources":
-    parameters:
-      - "$ref": "#/parameters/workspaceNamespace"
-      - "$ref": "#/parameters/workspaceId"
-    post:
-      parameters:
-        - in: body
-          name: resourceTypesToFetch
-          description: Types of workspace resources to fetch. Currently only supports
-            Cohorts, Cohort Reviews, Concept Sets, and Datasets
-          schema:
-            "$ref": "#/definitions/WorkspaceResourcesRequest"
-      tags:
-      - workspaces
-      description: Gets a user defined selection of objects contained within a workspace
-      operationId: getWorkspaceResources
-      responses:
-        200:
-          description: OK
-          schema:
-            "$ref": "#/definitions/WorkspaceResourceResponse"
   "/v2/workspaces/{workspaceNamespace}/{workspaceId}/resources":
     parameters:
       - "$ref": "#/parameters/workspaceNamespace"
@@ -6467,13 +6446,6 @@ definitions:
         description: 'Pagination token that can be used in a subsequent calls to retrieve
           more results. If not set, there are no more results to retrieve.'
         type: string
-  WorkspaceResourcesRequest:
-    type: object
-    properties:
-      typesToFetch:
-        type: array
-        items:
-          "$ref": "#/definitions/ResourceType"
   WorkspaceResourceResponse:
     type: array
     items:

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -164,7 +164,6 @@ import org.pmiops.workbench.model.WorkspaceOperation;
 import org.pmiops.workbench.model.WorkspaceOperationStatus;
 import org.pmiops.workbench.model.WorkspaceResource;
 import org.pmiops.workbench.model.WorkspaceResourceResponse;
-import org.pmiops.workbench.model.WorkspaceResourcesRequest;
 import org.pmiops.workbench.model.WorkspaceResponseListResponse;
 import org.pmiops.workbench.model.WorkspaceUserRolesResponse;
 import org.pmiops.workbench.monitoring.LogsBasedMetricServiceFakeImpl;
@@ -3381,20 +3380,19 @@ public class WorkspacesControllerTest {
                             new DomainValuePair().value("VALUE").domain(Domain.CONDITION))))
             .getBody();
 
-    WorkspaceResourcesRequest workspaceResourcesRequest = new WorkspaceResourcesRequest();
-    workspaceResourcesRequest.setTypesToFetch(
+    List<String> typesToFetch =
         ImmutableList.of(
-            ResourceType.COHORT,
-            ResourceType.COHORT_REVIEW,
-            ResourceType.CONCEPT_SET,
-            ResourceType.DATASET));
+            ResourceType.COHORT.toString(),
+            ResourceType.COHORT_REVIEW.toString(),
+            ResourceType.CONCEPT_SET.toString(),
+            ResourceType.DATASET.toString());
 
     WorkspaceResourceResponse workspaceResourceResponse =
         workspacesController
-            .getWorkspaceResources(
-                workspace.getNamespace(), workspace.getId(), workspaceResourcesRequest)
+            .getWorkspaceResourcesV2(workspace.getNamespace(), workspace.getId(), typesToFetch)
             .getBody();
-    assertThat(workspaceResourceResponse.size()).isEqualTo(4);
+    assertThat(workspaceResourceResponse).hasSize(4);
+
     List<Cohort> cohorts =
         workspaceResourceResponse.stream()
             .map(WorkspaceResource::getCohort)


### PR DESCRIPTION
We do not refer to it anywhere after #6858 and a release has passed since it has merged.  Safe to remove the endpoint now.

Tested locally - I am able to access workspace resources as expected.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
