### PR TITLE
[no ticket][risk=no] bumping cloud cdr

### DIFF
--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -131,7 +131,7 @@
       "creationTime": "2022-01-01 00:00:00Z",
       "releaseNumber": 9,
       "numParticipants": 369297,
-      "cdrDbName": "r_2022q2_4",
+      "cdrDbName": "r_2022q2_5",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"
@@ -147,7 +147,7 @@
       "creationTime": "2022-01-01 00:00:00Z",
       "releaseNumber": 10,
       "numParticipants": 372397,
-      "cdrDbName": "c_2022q2_5",
+      "cdrDbName": "c_2022q2_6",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "controlled",


### PR DESCRIPTION
We had to rebuild the cloud sql search indexes for RT and CT CDR. @evrii I'm tagging you as the reviewer since you are the release eng next week. You will need to run publish commands for both RT and CT in preprod. Commands are below(they should be run from the api directory). We also have entries in the release playbook that explain this as well.

RT
db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-preprod --bq-dataset R2022Q2R2 --tier registered --table-prefixes cb_

CT
db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-preprod --bq-dataset C2022Q2R2 --tier controlled --table-prefixes cb_
