### PR TITLE
[RW-8670][risk=no] Full Text Search - Add endsWith to findCriteriaAutoComplete call 

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -54,11 +54,19 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
     validateDomain(domain);
     validateType(type);
     validateTerm(term);
-    return ResponseEntity.ok(
-        new CriteriaListResponse()
-            .items(
-                cohortBuilderService.findCriteriaAutoComplete(
-                    domain, term, type, standard, limit)));
+    if (workbenchConfigProvider.get().featureFlags.enableDrugWildcardSearch) {
+      return ResponseEntity.ok(
+          new CriteriaListResponse()
+              .items(
+                  cohortBuilderService.findCriteriaAutoCompleteV2(
+                      domain, term, type, standard, limit)));
+    } else {
+      return ResponseEntity.ok(
+          new CriteriaListResponse()
+              .items(
+                  cohortBuilderService.findCriteriaAutoComplete(
+                      domain, term, type, standard, limit)));
+    }
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -189,7 +189,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomC
               + "and standard = :standard "
               + "and hierarchy=1 "
               + "and match(fullText, concat(:term, '+[', :domain, '_rank1]')) > 0 "
-              + "order by c.count desc")
+              + "order by c.count desc, name asc")
   List<DbCriteria> findCriteriaByDomainAndTypeAndStandardAndFullText(
       @Param("domain") String domain,
       @Param("type") String type,

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDao.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.cdr.dao;
 import java.util.List;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomCBCriteriaDao {
@@ -11,4 +12,15 @@ public interface CustomCBCriteriaDao {
 
   Page<DbCriteria> findCriteriaByDomainAndStandardAndTermAndNameEndsWith(
       String domain, Boolean standard, String term, List<String> endsWithList, Pageable page);
+
+  List<DbCriteria> findCriteriaByDomainAndTypeAndStandardAndNameEndsWith(
+      String domain, String type, Boolean standard, List<String> endsWithList, PageRequest page);
+
+  List<DbCriteria> findCriteriaByDomainAndTypeAndStandardAndTermAndNameEndsWith(
+      String domain,
+      String type,
+      Boolean standard,
+      String term,
+      List<String> endsWithTerms,
+      PageRequest pageRequest);
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
@@ -197,17 +197,6 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
   }
 
   @NotNull
-  private MapSqlParameterSource getMapSqlParameterSource(
-      String domain, Boolean standard, String term) {
-    MapSqlParameterSource parameters = new MapSqlParameterSource();
-    parameters.addValue("domain", domain).addValue("standard", standard);
-    if (term != null) {
-      parameters.addValue("term", term);
-    }
-    return parameters;
-  }
-
-  @NotNull
   private List<DbCriteria> queryForPaginatedList(
       Pageable page, QueryAndParameters queryAndParameters) {
     return namedParameterJdbcTemplate.query(

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.cdr.dao;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -17,6 +18,7 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -59,11 +61,36 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
           + "and (%s)\n"
           + "order by est_count desc, name asc\n";
 
+  private static final String AUTO_COMPLETE_ENDS_WITH_WITHOUT_TERM =
+      "select *\n"
+          + "from %s.cb_criteria\n"
+          + "where type = :type\n"
+          + "and standard = :standard\n"
+          + "and hierarchy = 1\n"
+          + "and match(full_text) against(concat('+[', :domain, '_rank1]') in boolean mode)\n"
+          + "and (%s)\n"
+          + "order by est_count desc, name asc\n";
+
+  private static final String AUTO_COMPLETE_ENDS_WITH_WITH_TERM =
+      "select *\n"
+          + "from %s.cb_criteria\n"
+          + "where type = :type\n"
+          + "and standard = :standard\n"
+          + "and hierarchy = 1\n"
+          + "and match(full_text) against(concat(:term, '+[', :domain, '_rank1]') in boolean mode)\n"
+          + "and (%s)\n"
+          + "order by est_count desc, name asc\n";
+
   private static final String DYNAMIC_SQL = "upper(name) like upper(%s)";
 
   private static final String LIMIT_OFFSET = "limit %s offset %s\n";
 
   private static final String OR = "\nor\n";
+
+  private static final String BIND_VAR_DOMAIN = "domain";
+  private static final String BIND_VAR_STANDARD = "standard";
+  private static final String BIND_VAR_TERM = "term";
+  private static final String BIND_VAR_TYPE = "type";
 
   @Autowired private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
@@ -72,8 +99,12 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
   @Override
   public Page<DbCriteria> findCriteriaByDomainAndStandardAndNameEndsWith(
       String domain, Boolean standard, List<String> endsWithList, Pageable page) {
+    Object[][] params = {
+      {BIND_VAR_DOMAIN, domain},
+      {BIND_VAR_STANDARD, standard}
+    };
     QueryAndParameters queryAndParameters =
-        generateQueryAndParameters(ENDS_WITH_WITHOUT_TERM, domain, standard, null, endsWithList);
+        generateQueryAndParameters(ENDS_WITH_WITHOUT_TERM, params, endsWithList);
     return new PageImpl<>(
         queryForPaginatedList(page, queryAndParameters),
         page,
@@ -83,23 +114,59 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
   @Override
   public Page<DbCriteria> findCriteriaByDomainAndStandardAndTermAndNameEndsWith(
       String domain, Boolean standard, String term, List<String> endsWithList, Pageable page) {
+    Object[][] params = {
+      {BIND_VAR_DOMAIN, domain},
+      {BIND_VAR_STANDARD, standard},
+      {BIND_VAR_TERM, term}
+    };
     QueryAndParameters queryAndParameters =
-        generateQueryAndParameters(ENDS_WITH_WITH_TERM, domain, standard, term, endsWithList);
+        generateQueryAndParameters(ENDS_WITH_WITH_TERM, params, endsWithList);
     return new PageImpl<>(
         queryForPaginatedList(page, queryAndParameters),
         page,
         Objects.requireNonNull(count(queryAndParameters)));
   }
 
-  protected QueryAndParameters generateQueryAndParameters(
-      String sql, String domain, Boolean standard, String term, List<String> endsWithList) {
-    MapSqlParameterSource parameters = new MapSqlParameterSource();
-    parameters.addValue("domain", domain).addValue("standard", standard);
-    if (term != null) {
-      parameters.addValue("term", term);
-    }
-    StringJoiner joiner = new StringJoiner(OR);
+  @Override
+  public List<DbCriteria> findCriteriaByDomainAndTypeAndStandardAndNameEndsWith(
+      String domain, String type, Boolean standard, List<String> endsWithList, PageRequest page) {
+    Object[][] params = {
+      {BIND_VAR_DOMAIN, domain}, {BIND_VAR_TYPE, type}, {BIND_VAR_STANDARD, standard}
+    };
+    QueryAndParameters queryAndParameters =
+        generateQueryAndParameters(AUTO_COMPLETE_ENDS_WITH_WITHOUT_TERM, params, endsWithList);
+    return new PageImpl<>(
+            queryForPaginatedList(page, queryAndParameters),
+            page,
+            Objects.requireNonNull(count(queryAndParameters)))
+        .getContent();
+  }
 
+  @Override
+  public List<DbCriteria> findCriteriaByDomainAndTypeAndStandardAndTermAndNameEndsWith(
+      String domain,
+      String type,
+      Boolean standard,
+      String term,
+      List<String> endsWithList,
+      PageRequest page) {
+    Object[][] params = {
+      {BIND_VAR_DOMAIN, domain},
+      {BIND_VAR_TYPE, type},
+      {BIND_VAR_STANDARD, standard},
+      {BIND_VAR_TERM, term}
+    };
+    QueryAndParameters queryAndParameters =
+        generateQueryAndParameters(AUTO_COMPLETE_ENDS_WITH_WITH_TERM, params, endsWithList);
+    return new PageImpl<>(
+            queryForPaginatedList(page, queryAndParameters),
+            page,
+            Objects.requireNonNull(count(queryAndParameters)))
+        .getContent();
+  }
+
+  protected QueryAndParameters generateQueryAndParameters(
+      String sql, Object[][] params, List<String> endsWithList) {
     long cdrVersionId = CdrVersionContext.getCdrVersion().getCdrVersionId();
     Optional<DbCdrVersion> cdrVersionOptional = cdrVersionDao.findById(cdrVersionId);
     DbCdrVersion dbCdrVersion =
@@ -108,6 +175,14 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
                 new BadRequestException(
                     String.format("CDR version with ID %s not found", cdrVersionId)));
 
+    MapSqlParameterSource parameters = new MapSqlParameterSource();
+    Arrays.stream(params)
+        .forEach(
+            param -> {
+              parameters.addValue(param[0].toString(), param[1]);
+            });
+
+    StringJoiner joiner = new StringJoiner(OR);
     IntStream.range(0, endsWithList.size())
         .forEach(
             idx -> {
@@ -119,6 +194,17 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
 
     return new QueryAndParameters(
         String.format(sql, dbCdrVersion.getCdrDbName(), joiner), parameters);
+  }
+
+  @NotNull
+  private MapSqlParameterSource getMapSqlParameterSource(
+      String domain, Boolean standard, String term) {
+    MapSqlParameterSource parameters = new MapSqlParameterSource();
+    parameters.addValue("domain", domain).addValue("standard", standard);
+    if (term != null) {
+      parameters.addValue("term", term);
+    }
+    return parameters;
   }
 
   @NotNull

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
@@ -65,8 +65,8 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
       "select *\n"
           + "from %s.cb_criteria\n"
           + "where type = :type\n"
-          + "and standard = :standard\n"
-          + "and hierarchy = 1\n"
+          + "and is_standard = :standard\n"
+          + "and has_hierarchy = 1\n"
           + "and match(full_text) against(concat('+[', :domain, '_rank1]') in boolean mode)\n"
           + "and (%s)\n"
           + "order by est_count desc, name asc\n";
@@ -75,8 +75,8 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
       "select *\n"
           + "from %s.cb_criteria\n"
           + "where type = :type\n"
-          + "and standard = :standard\n"
-          + "and hierarchy = 1\n"
+          + "and is_standard = :standard\n"
+          + "and has_hierarchy = 1\n"
           + "and match(full_text) against(concat(:term, '+[', :domain, '_rank1]') in boolean mode)\n"
           + "and (%s)\n"
           + "order by est_count desc, name asc\n";

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
@@ -45,52 +45,75 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
     }
   }
 
+  private static final String BIND_VAR_DOMAIN = "domain";
+  private static final String BIND_VAR_STANDARD = "standard";
+  private static final String BIND_VAR_TERM = "term";
+  private static final String BIND_VAR_TYPE = "type";
+
+  // SQL snips
+  private static final String DYNAMIC_SQL = "upper(name) like upper(%s)";
+  private static final String LIMIT_OFFSET = "limit %s offset %s\n";
+  private static final String OR = "\nor\n";
+
   private static final String ENDS_WITH_WITHOUT_TERM =
       "select *\n"
           + "from %s.cb_criteria\n"
-          + "where is_standard = :standard\n"
-          + "and match(full_text) against(concat('+[', :domain, '_rank1]') in boolean mode)\n"
+          + "where is_standard = :"
+          + BIND_VAR_STANDARD
+          + "\n"
+          + "and match(full_text) against(concat('+[', :"
+          + BIND_VAR_DOMAIN
+          + ", '_rank1]') in boolean mode)\n"
           + "and (%s)\n"
           + "order by est_count desc, name asc\n";
 
   private static final String ENDS_WITH_WITH_TERM =
       "select *\n"
           + "from %s.cb_criteria\n"
-          + "where is_standard = :standard\n"
-          + "and match(full_text) against(concat(:term, '+[', :domain, '_rank1]') in boolean mode)\n"
+          + "where is_standard = :"
+          + BIND_VAR_STANDARD
+          + "\n"
+          + "and match(full_text) against(concat(:"
+          + BIND_VAR_TERM
+          + ", '+[', :"
+          + BIND_VAR_DOMAIN
+          + ", '_rank1]') in boolean mode)\n"
           + "and (%s)\n"
           + "order by est_count desc, name asc\n";
 
   private static final String AUTO_COMPLETE_ENDS_WITH_WITHOUT_TERM =
       "select *\n"
           + "from %s.cb_criteria\n"
-          + "where type = :type\n"
-          + "and is_standard = :standard\n"
+          + "where type = :"
+          + BIND_VAR_TYPE
+          + "\n"
+          + "and is_standard = :"
+          + BIND_VAR_STANDARD
+          + "\n"
           + "and has_hierarchy = 1\n"
-          + "and match(full_text) against(concat('+[', :domain, '_rank1]') in boolean mode)\n"
+          + "and match(full_text) against(concat('+[', :"
+          + BIND_VAR_DOMAIN
+          + ", '_rank1]') in boolean mode)\n"
           + "and (%s)\n"
           + "order by est_count desc, name asc\n";
 
   private static final String AUTO_COMPLETE_ENDS_WITH_WITH_TERM =
       "select *\n"
           + "from %s.cb_criteria\n"
-          + "where type = :type\n"
-          + "and is_standard = :standard\n"
+          + "where type = :"
+          + BIND_VAR_TYPE
+          + "\n"
+          + "and is_standard = :"
+          + BIND_VAR_STANDARD
+          + "\n"
           + "and has_hierarchy = 1\n"
-          + "and match(full_text) against(concat(:term, '+[', :domain, '_rank1]') in boolean mode)\n"
+          + "and match(full_text) against(concat(:"
+          + BIND_VAR_TERM
+          + ", '+[', :"
+          + BIND_VAR_DOMAIN
+          + ", '_rank1]') in boolean mode)\n"
           + "and (%s)\n"
           + "order by est_count desc, name asc\n";
-
-  private static final String DYNAMIC_SQL = "upper(name) like upper(%s)";
-
-  private static final String LIMIT_OFFSET = "limit %s offset %s\n";
-
-  private static final String OR = "\nor\n";
-
-  private static final String BIND_VAR_DOMAIN = "domain";
-  private static final String BIND_VAR_STANDARD = "standard";
-  private static final String BIND_VAR_TERM = "term";
-  private static final String BIND_VAR_TYPE = "type";
 
   @Autowired private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
@@ -176,11 +199,7 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
                     String.format("CDR version with ID %s not found", cdrVersionId)));
 
     MapSqlParameterSource parameters = new MapSqlParameterSource();
-    Arrays.stream(params)
-        .forEach(
-            param -> {
-              parameters.addValue(param[0].toString(), param[1]);
-            });
+    Arrays.stream(params).forEach(param -> parameters.addValue(param[0].toString(), param[1]));
 
     StringJoiner joiner = new StringJoiner(OR);
     IntStream.range(0, endsWithList.size())

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -47,6 +47,9 @@ public interface CohortBuilderService {
   List<Criteria> findCriteriaAutoComplete(
       String domain, String term, String type, Boolean standard, Integer limit);
 
+  List<Criteria> findCriteriaAutoCompleteV2(
+      String domain, String term, String type, Boolean standard, Integer limit);
+
   List<Criteria> findCriteriaBy(String domain, String type, Boolean standard, Long parentId);
 
   CriteriaListWithCountResponse findCriteriaByDomain(

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -261,12 +261,12 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
     Map<String, String> parsedTerms = modifyTermMatchUseEndsWithTerms(term);
     String modifiedSearchTerm = parsedTerms.get(MODIFIED_TERMS);
     List<String> endsWithTerms = new ArrayList<>();
-    if (parsedTerms.get(ENDS_WITH_TERMS).length() > 0) {
+    if (!parsedTerms.get(ENDS_WITH_TERMS).isEmpty()) {
       endsWithTerms.addAll(Arrays.asList(parsedTerms.get(ENDS_WITH_TERMS).split(",")));
     }
 
     List<DbCriteria> criteriaList = new ArrayList<>();
-    if (endsWithTerms.isEmpty() && modifiedSearchTerm.length() > 0) {
+    if (endsWithTerms.isEmpty() && !modifiedSearchTerm.isEmpty()) {
       criteriaList =
           cbCriteriaDao.findCriteriaByDomainAndTypeAndStandardAndFullText(
               domain, type, standard, modifiedSearchTerm, pageRequest);
@@ -274,7 +274,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
       criteriaList =
           cbCriteriaDao.findCriteriaByDomainAndTypeAndStandardAndNameEndsWith(
               domain, type, standard, endsWithTerms, pageRequest);
-    } else if (!endsWithTerms.isEmpty() && modifiedSearchTerm.length() > 0) {
+    } else if (!endsWithTerms.isEmpty() && !modifiedSearchTerm.isEmpty()) {
       criteriaList =
           cbCriteriaDao.findCriteriaByDomainAndTypeAndStandardAndTermAndNameEndsWith(
               domain, type, standard, modifiedSearchTerm, endsWithTerms, pageRequest);


### PR DESCRIPTION
Description:

- Added endsWith term capability to full_text search for *findCriteriaAutoComplete* call


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
