### PR TITLE
[no-ticket][risk=no] Move blobToFileDetail from interface to service

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageClient.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageClient.java
@@ -54,13 +54,5 @@ public interface CloudStorageClient {
 
   String getCaptchaServerKey();
 
-  default FileDetail blobToFileDetail(Blob blob, String bucketName) {
-    String[] parts = blob.getName().split("/");
-    FileDetail fileDetail = new FileDetail();
-    fileDetail.setName(parts[parts.length - 1]);
-    fileDetail.setPath("gs://" + bucketName + "/" + blob.getName());
-    fileDetail.setLastModifiedTime(blob.getUpdateTime());
-    fileDetail.setSizeInBytes(blob.getSize());
-    return fileDetail;
-  }
+  FileDetail blobToFileDetail(Blob blob, String bucketName);
 }

--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageClientImpl.java
@@ -17,6 +17,7 @@ import javax.inject.Provider;
 import org.json.JSONObject;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.model.FileDetail;
 
 public class CloudStorageClientImpl implements CloudStorageClient {
 
@@ -143,5 +144,17 @@ public class CloudStorageClientImpl implements CloudStorageClient {
   @Override
   public String getCaptchaServerKey() {
     return getCredentialsBucketString("captcha-server-key.txt");
+  }
+
+  @Override
+  public FileDetail blobToFileDetail(Blob blob, String bucketName) {
+    String[] parts = blob.getName().split("/");
+    FileDetail fileDetail = new FileDetail();
+    fileDetail.setName(parts[parts.length - 1]);
+    fileDetail.setPath("gs://" + bucketName + "/" + blob.getName());
+    fileDetail.setLastModifiedTime(blob.getUpdateTime());
+    fileDetail.setSizeInBytes(blob.getSize());
+
+    return fileDetail;
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.db.dao.AccessTierDao;
@@ -185,32 +184,19 @@ public class NotebooksControllerTest {
     DbWorkspace workspace = createWorkspace();
     stubGetWorkspace(workspace, WorkspaceAccessLevel.OWNER);
 
-    FileDetail fileDetail1 = new FileDetail();
-    FileDetail fileDetail2 = new FileDetail();
-    Blob mockBlob1 = mock(Blob.class);
-    Blob mockBlob2 = mock(Blob.class);
-
-
-    fileDetail1.setName("nope.ipynb");
-    when(mockBlob1.getName())
-        .thenReturn(NotebooksService.withNotebookExtension("notebooks/extra/nope"));
-    when(mockCloudStorageClient.blobToFileDetail(mockBlob1,TestMockFactory.WORKSPACE_BUCKET_NAME)).thenReturn(fileDetail1);
-
-
-    fileDetail2.setName("foo.ipynb");
-    when(mockBlob2.getName()).thenReturn(NotebooksService.withNotebookExtension("notebooks/foo"));
-    when(mockCloudStorageClient.blobToFileDetail(mockBlob2,TestMockFactory.WORKSPACE_BUCKET_NAME)).thenReturn(fileDetail2);
+    Notebook notebook1 = new Notebook(NotebooksService.withNotebookExtension("notebooks/extra/nope"),TestMockFactory.WORKSPACE_BUCKET_NAME);
+    Notebook notebook2 = new Notebook(NotebooksService.withNotebookExtension("notebooks/foo"),TestMockFactory.WORKSPACE_BUCKET_NAME);
 
     when(mockCloudStorageClient.getBlobPageForPrefix(
         TestMockFactory.WORKSPACE_BUCKET_NAME, "notebooks"))
-        .thenReturn(ImmutableList.of(mockBlob1, mockBlob2));
+        .thenReturn(ImmutableList.of(notebook1.blob, notebook2.blob));
     List<FileDetail> body =
         notebooksController
             .getNoteBookList(workspace.getWorkspaceNamespace(), workspace.getFirecloudName())
             .getBody();
 
     List<String> gotNames = body.stream().map(FileDetail::getName).collect(Collectors.toList());
-    assertThat(gotNames).isEqualTo(ImmutableList.of(NotebooksService.withNotebookExtension("foo")));
+    assertThat(gotNames).isEqualTo(ImmutableList.of(notebook2.fileDetail.getName()));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -127,9 +127,6 @@ public class NotebooksControllerTest {
     cdrVersion.setCdrDbName("");
     cdrVersion.setAccessTier(TestMockFactory.createRegisteredTierForTests(accessTierDao));
     cdrVersion = cdrVersionDao.save(cdrVersion);
-
-    // required to enable the use of default method blobToFileDetail()
-//    when(mockCloudStorageClient.blobToFileDetail(any(), anyString())).thenCallRealMethod();
   }
 
   @AfterEach

--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.db.dao.AccessTierDao;
@@ -113,6 +114,9 @@ public class NotebooksControllerTest {
   @Autowired private UserDao userDao;
   @Autowired private NotebooksController notebooksController;
 
+  @Mock
+  private NotebooksService mockNotebookService;
+
   @BeforeEach
   public void setUp() {
     currentUser = createUser(LOGGED_IN_USER_EMAIL);
@@ -125,7 +129,7 @@ public class NotebooksControllerTest {
     cdrVersion = cdrVersionDao.save(cdrVersion);
 
     // required to enable the use of default method blobToFileDetail()
-    when(mockCloudStorageClient.blobToFileDetail(any(), anyString())).thenCallRealMethod();
+//    when(mockCloudStorageClient.blobToFileDetail(any(), anyString())).thenCallRealMethod();
   }
 
   @AfterEach
@@ -145,6 +149,12 @@ public class NotebooksControllerTest {
     Blob mockBlob1 = mock(Blob.class);
     Blob mockBlob2 = mock(Blob.class);
     Blob mockBlob3 = mock(Blob.class);
+    FileDetail fileDetail1 = new FileDetail();
+    FileDetail fileDetail2 = new FileDetail();
+    FileDetail fileDetail3 = new FileDetail();
+    fileDetail1.setName("mockFile.ipynb");
+    fileDetail2.setName("mockFile.text");
+    fileDetail3.setName("two words.ipynb");
     when(mockBlob1.getName())
         .thenReturn(NotebooksService.withNotebookExtension("notebooks/mockFile"));
     when(mockBlob2.getName()).thenReturn("notebooks/mockFile.text");
@@ -152,6 +162,10 @@ public class NotebooksControllerTest {
         .thenReturn(NotebooksService.withNotebookExtension("notebooks/two words"));
     when(mockCloudStorageClient.getBlobPageForPrefix("bucket", "notebooks"))
         .thenReturn(ImmutableList.of(mockBlob1, mockBlob2, mockBlob3));
+
+    when(mockCloudStorageClient.blobToFileDetail(mockBlob1,"bucket")).thenReturn(fileDetail1);
+    when(mockCloudStorageClient.blobToFileDetail(mockBlob2,"bucket")).thenReturn(fileDetail2);
+    when(mockCloudStorageClient.blobToFileDetail(mockBlob3,"bucket")).thenReturn(fileDetail3);
 
     // Will return 1 entry as only python files in notebook folder are return
     List<String> gotNames =
@@ -170,6 +184,10 @@ public class NotebooksControllerTest {
     DbWorkspace workspace = createWorkspace();
     stubGetWorkspace(workspace, WorkspaceAccessLevel.OWNER);
 
+    FileDetail file1 = new FileDetail();
+    FileDetail file2 = new FileDetail();
+    file1.setName("nope.ipynb");
+    file2.setName("foo.ipynb");
     Blob mockBlob1 = mock(Blob.class);
     Blob mockBlob2 = mock(Blob.class);
     when(mockBlob1.getName())
@@ -178,6 +196,10 @@ public class NotebooksControllerTest {
     when(mockCloudStorageClient.getBlobPageForPrefix(
             TestMockFactory.WORKSPACE_BUCKET_NAME, "notebooks"))
         .thenReturn(ImmutableList.of(mockBlob1, mockBlob2));
+
+
+    when(mockCloudStorageClient.blobToFileDetail(mockBlob1,TestMockFactory.WORKSPACE_BUCKET_NAME)).thenReturn(file1);
+    when(mockCloudStorageClient.blobToFileDetail(mockBlob2,TestMockFactory.WORKSPACE_BUCKET_NAME)).thenReturn(file2);
 
     List<FileDetail> body =
         notebooksController

--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -181,10 +181,10 @@ public class NotebooksControllerTest {
     DbWorkspace workspace = createWorkspace();
     stubGetWorkspace(workspace, WorkspaceAccessLevel.OWNER);
 
-    FileDetail file1 = new FileDetail();
-    FileDetail file2 = new FileDetail();
-    file1.setName("nope.ipynb");
-    file2.setName("foo.ipynb");
+    FileDetail fileDetail1 = new FileDetail();
+    FileDetail fileDetail2 = new FileDetail();
+    fileDetail1.setName("nope.ipynb");
+    fileDetail2.setName("foo.ipynb");
     Blob mockBlob1 = mock(Blob.class);
     Blob mockBlob2 = mock(Blob.class);
     when(mockBlob1.getName())
@@ -195,8 +195,8 @@ public class NotebooksControllerTest {
         .thenReturn(ImmutableList.of(mockBlob1, mockBlob2));
 
 
-    when(mockCloudStorageClient.blobToFileDetail(mockBlob1,TestMockFactory.WORKSPACE_BUCKET_NAME)).thenReturn(file1);
-    when(mockCloudStorageClient.blobToFileDetail(mockBlob2,TestMockFactory.WORKSPACE_BUCKET_NAME)).thenReturn(file2);
+    when(mockCloudStorageClient.blobToFileDetail(mockBlob1,TestMockFactory.WORKSPACE_BUCKET_NAME)).thenReturn(fileDetail1);
+    when(mockCloudStorageClient.blobToFileDetail(mockBlob2,TestMockFactory.WORKSPACE_BUCKET_NAME)).thenReturn(fileDetail2);
 
     List<FileDetail> body =
         notebooksController

--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -98,10 +98,10 @@ public class NotebooksControllerTest {
     }
   }
 
-  class Notebook{
+  class MockNotebook{
     Blob blob;
     FileDetail fileDetail;
-    Notebook(String path, String bucketName){
+    MockNotebook(String path, String bucketName){
       blob = mock(Blob.class);
       fileDetail = new FileDetail();
 
@@ -155,9 +155,9 @@ public class NotebooksControllerTest {
 
   @Test
   public void testNotebookFileList() {
-    Notebook notebook1 = new Notebook(NotebooksService.withNotebookExtension("notebooks/mockFile"),"bucket");
-    Notebook notebook2 = new Notebook("notebooks/mockFile.text","bucket");
-    Notebook notebook3 = new Notebook(NotebooksService.withNotebookExtension("notebooks/two words"),"bucket");
+    MockNotebook notebook1 = new MockNotebook(NotebooksService.withNotebookExtension("notebooks/mockFile"),"bucket");
+    MockNotebook notebook2 = new MockNotebook("notebooks/mockFile.text","bucket");
+    MockNotebook notebook3 = new MockNotebook(NotebooksService.withNotebookExtension("notebooks/two words"),"bucket");
 
     when(mockCloudStorageClient.getBlobPageForPrefix("bucket", "notebooks"))
         .thenReturn(ImmutableList.of(notebook1.blob, notebook2.blob, notebook3.blob));
@@ -184,8 +184,8 @@ public class NotebooksControllerTest {
     DbWorkspace workspace = createWorkspace();
     stubGetWorkspace(workspace, WorkspaceAccessLevel.OWNER);
 
-    Notebook notebook1 = new Notebook(NotebooksService.withNotebookExtension("notebooks/extra/nope"),TestMockFactory.WORKSPACE_BUCKET_NAME);
-    Notebook notebook2 = new Notebook(NotebooksService.withNotebookExtension("notebooks/foo"),TestMockFactory.WORKSPACE_BUCKET_NAME);
+    MockNotebook notebook1 = new MockNotebook(NotebooksService.withNotebookExtension("notebooks/extra/nope"),TestMockFactory.WORKSPACE_BUCKET_NAME);
+    MockNotebook notebook2 = new MockNotebook(NotebooksService.withNotebookExtension("notebooks/foo"),TestMockFactory.WORKSPACE_BUCKET_NAME);
 
     when(mockCloudStorageClient.getBlobPageForPrefix(
         TestMockFactory.WORKSPACE_BUCKET_NAME, "notebooks"))

--- a/api/src/test/java/org/pmiops/workbench/google/CloudStorageClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/google/CloudStorageClientTest.java
@@ -1,0 +1,60 @@
+package org.pmiops.workbench.google;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.storage.Blob;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+import org.pmiops.workbench.model.FileDetail;
+import org.pmiops.workbench.test.FakeClock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+public class CloudStorageClientTest {
+
+  private static final FakeClock CLOCK = new FakeClock(Instant.now(), ZoneId.systemDefault());
+
+  @Autowired private CloudStorageClient cloudStorageClient;
+
+  @TestConfiguration
+  @Import({
+    CloudStorageClientImpl.class
+  })
+
+  static class Configuration {
+
+    @Bean
+    Clock clock() {
+      return CLOCK;
+    }
+  }
+
+  @Test
+  public void getExtractionJobs() {
+    String notebookPath = "notebooks/nb1.ipynb";
+    Long notebookSize = 500l;
+    Long updateTime = Instant.now().getEpochSecond();
+    String bucketName = "bucket";
+
+    Blob notebookBlob = mock(Blob.class);
+    when(notebookBlob.getName()).thenReturn(notebookPath);
+    when(notebookBlob.getSize()).thenReturn(notebookSize);
+    when(notebookBlob.getUpdateTime()).thenReturn(updateTime);
+    FileDetail actualFileDetail = cloudStorageClient.blobToFileDetail(notebookBlob,bucketName);
+
+    assertThat(actualFileDetail.getName()).isEqualTo("nb1.ipynb");
+    assertThat(actualFileDetail.getPath()).isEqualTo("gs://"+bucketName+"/"+notebookBlob.getName());
+    assertThat(actualFileDetail.getLastModifiedTime()).isEqualTo(updateTime);
+    assertThat(actualFileDetail.getSizeInBytes()).isEqualTo(notebookSize);
+  }
+
+
+}

--- a/api/src/test/java/org/pmiops/workbench/google/CloudStorageClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/google/CloudStorageClientTest.java
@@ -38,7 +38,7 @@ public class CloudStorageClientTest {
   }
 
   @Test
-  public void getExtractionJobs() {
+  public void testBlobToFileDetail() {
     String notebookPath = "notebooks/nb1.ipynb";
     Long notebookSize = 500l;
     Long updateTime = Instant.now().getEpochSecond();

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.workspaceadmin;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -170,8 +171,8 @@ public class WorkspaceAdminServiceTest {
     when(mockFirecloudService.getGroup(anyString()))
         .thenReturn(new FirecloudManagedGroupWithMembers().groupEmail("test@firecloud.org"));
 
-    // required to enable the use of default method blobToFileDetail()
-    when(mockCloudStorageClient.blobToFileDetail(any(), anyString())).thenCallRealMethod();
+//    // required to enable the use of default method blobToFileDetail()
+//    when(mockCloudStorageClient.blobToFileDetail(any(), anyString())).thenCallRealMethod();
 
     testLeoRuntime =
         new LeonardoGetRuntimeResponse()
@@ -324,6 +325,9 @@ public class WorkspaceAdminServiceTest {
                 .sizeInBytes(1000L * 1000L)
                 .lastModifiedTime(dummyTime));
 
+    when(mockCloudStorageClient.blobToFileDetail(any(), anyString()))
+        .thenReturn(
+            expectedFiles.get(0), expectedFiles.get(1), expectedFiles.get(2), expectedFiles.get(3));
     final List<FileDetail> files = workspaceAdminService.listFiles(WORKSPACE_NAMESPACE);
     assertThat(files).containsExactlyElementsIn(expectedFiles);
   }

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -2,7 +2,6 @@ package org.pmiops.workbench.workspaceadmin;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -171,9 +171,6 @@ public class WorkspaceAdminServiceTest {
     when(mockFirecloudService.getGroup(anyString()))
         .thenReturn(new FirecloudManagedGroupWithMembers().groupEmail("test@firecloud.org"));
 
-//    // required to enable the use of default method blobToFileDetail()
-//    when(mockCloudStorageClient.blobToFileDetail(any(), anyString())).thenCallRealMethod();
-
     testLeoRuntime =
         new LeonardoGetRuntimeResponse()
             .runtimeName(RUNTIME_NAME)


### PR DESCRIPTION
Description:
Moved blobToFileDetail from interface to service. Updated tests accordingly.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
