### PR TITLE
[RW-8618][risk=no] Adding tooltip for new search operators

### DIFF
--- a/ui/src/app/cohort-search/cohort-criteria-menu.spec.tsx
+++ b/ui/src/app/cohort-search/cohort-criteria-menu.spec.tsx
@@ -8,7 +8,9 @@ import {
   registerApiClient,
 } from 'app/services/swagger-fetch-clients';
 import { currentWorkspaceStore } from 'app/utils/navigation';
+import { serverConfigStore } from 'app/utils/stores';
 
+import defaultServerConfig from 'testing/default-server-config';
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { CohortBuilderServiceStub } from 'testing/stubs/cohort-builder-service-stub';
 import { workspaceDataStub } from 'testing/stubs/workspaces';
@@ -27,6 +29,12 @@ describe('CohortCriteriaMenu', () => {
     currentWorkspaceStore.next({
       ...workspaceDataStub,
       cdrVersionId: '1',
+    });
+    serverConfigStore.set({
+      config: {
+        ...defaultServerConfig,
+        enableDrugWildcardSearch: false,
+      },
     });
   });
 

--- a/ui/src/app/cohort-search/cohort-criteria-menu.tsx
+++ b/ui/src/app/cohort-search/cohort-criteria-menu.tsx
@@ -299,7 +299,7 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
             <div style={styles.searchContainer}>
               <span style={styles.dropdownHeaderText}>
                 Search or browse all domains
-                {serverConfigStore.get().config.enableUniversalSearch && (
+                {serverConfigStore.get().config.enableDrugWildcardSearch && (
                   <TooltipTrigger side='top' content={searchTooltip}>
                     <ClrIcon
                       style={styles.infoIcon}

--- a/ui/src/app/cohort-search/cohort-criteria-menu.tsx
+++ b/ui/src/app/cohort-search/cohort-criteria-menu.tsx
@@ -5,10 +5,12 @@ const { useEffect, useRef, useState } = React;
 import { AlertDanger } from 'app/components/alert';
 import { ClrIcon } from 'app/components/icons';
 import { TextInput } from 'app/components/inputs';
+import { TooltipTrigger } from 'app/components/popups';
 import { Spinner } from 'app/components/spinners';
 import { cohortBuilderApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCurrentWorkspace } from 'app/utils';
+import { serverConfigStore } from 'app/utils/stores';
 
 const styles = reactStyles({
   cardBlock: {
@@ -155,7 +157,38 @@ const styles = reactStyles({
     textDecoration: 'none',
     width: '100%',
   },
+  infoIcon: {
+    color: colorWithWhiteness(colors.accent, 0.1),
+    marginLeft: '0.25rem',
+  },
 });
+
+const searchTooltip = (
+  <span>
+    The following special operators can be used to augment search terms:
+    <ul>
+      <li>
+        (*) is the wildcard operator. This operator can be used with a prefix or
+        suffix. For example: ceph* (starts with) or *statin (ends with - NOTE:
+        when searching for ends with it will only match with end of concept
+        name)
+      </li>
+      <li>
+        (-) indicates that this word must <b>not</b> be present. For example:
+        lung -cancer
+      </li>
+      <li>
+        (") a phrase that is enclosed within double quote (") characters matches
+        only rows that contain the phrase literally, as it was typed. For
+        example: "lung cancer"
+      </li>
+      <li>
+        These operators can be combined to produce more complex search
+        operations. For example: brain tum* -neoplasm
+      </li>
+    </ul>
+  </span>
+);
 
 export const CohortCriteriaMenu = withCurrentWorkspace()(
   ({ launchSearch, menuOptions, workspace, temporalGroup, isTemporal }) => {
@@ -266,6 +299,18 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
             <div style={styles.searchContainer}>
               <span style={styles.dropdownHeaderText}>
                 Search or browse all domains
+                {serverConfigStore.get().config.enableUniversalSearch && (
+                  <TooltipTrigger
+                    side='top'
+                    content={<div>{searchTooltip}</div>}
+                  >
+                    <ClrIcon
+                      style={styles.infoIcon}
+                      className='is-solid'
+                      shape='info-standard'
+                    />
+                  </TooltipTrigger>
+                )}
               </span>
               <div style={styles.searchBar}>
                 {domainCountsLoading ? (

--- a/ui/src/app/cohort-search/cohort-criteria-menu.tsx
+++ b/ui/src/app/cohort-search/cohort-criteria-menu.tsx
@@ -91,7 +91,7 @@ const styles = reactStyles({
     minHeight: '1.25rem',
     width: '15rem',
     borderRadius: '.125rem',
-    zIndex: 1000,
+    zIndex: 103,
   },
   dropdownHeader: {
     height: '1.75rem',
@@ -137,7 +137,7 @@ const styles = reactStyles({
     minHeight: '1.25rem',
     width: '10rem',
     borderRadius: '.125rem',
-    zIndex: 1000,
+    zIndex: 103,
   },
   subMenuIcon: {
     color: colors.secondary,
@@ -164,9 +164,9 @@ const styles = reactStyles({
 });
 
 const searchTooltip = (
-  <span>
+  <div style={{ marginLeft: '0.5rem' }}>
     The following special operators can be used to augment search terms:
-    <ul>
+    <ul style={{ listStylePosition: 'outside' }}>
       <li>
         (*) is the wildcard operator. This operator can be used with a prefix or
         suffix. For example: ceph* (starts with) or *statin (ends with - NOTE:
@@ -187,7 +187,7 @@ const searchTooltip = (
         operations. For example: brain tum* -neoplasm
       </li>
     </ul>
-  </span>
+  </div>
 );
 
 export const CohortCriteriaMenu = withCurrentWorkspace()(
@@ -300,10 +300,7 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
               <span style={styles.dropdownHeaderText}>
                 Search or browse all domains
                 {serverConfigStore.get().config.enableUniversalSearch && (
-                  <TooltipTrigger
-                    side='top'
-                    content={<div>{searchTooltip}</div>}
-                  >
+                  <TooltipTrigger side='top' content={searchTooltip}>
                     <ClrIcon
                       style={styles.infoIcon}
                       className='is-solid'

--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.tsx
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.spec.tsx
@@ -10,7 +10,9 @@ import {
   currentCohortSearchContextStore,
   currentWorkspaceStore,
 } from 'app/utils/navigation';
+import { serverConfigStore } from 'app/utils/stores';
 
+import defaultServerConfig from 'testing/default-server-config';
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import {
   CohortBuilderServiceStub,
@@ -48,6 +50,12 @@ describe('CohortSearch', () => {
   beforeEach(() => {
     currentWorkspaceStore.next(workspaceDataStub);
     registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
+    serverConfigStore.set({
+      config: {
+        ...defaultServerConfig,
+        enableDrugWildcardSearch: false,
+      },
+    });
   });
 
   it('should render', () => {

--- a/ui/src/app/cohort-search/list-search/list-search.component.spec.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.spec.tsx
@@ -4,13 +4,21 @@ import { shallow } from 'enzyme';
 import { CohortBuilderApi } from 'generated/fetch';
 
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
+import { serverConfigStore } from 'app/utils/stores';
 
+import defaultServerConfig from 'testing/default-server-config';
 import { CohortBuilderServiceStub } from 'testing/stubs/cohort-builder-service-stub';
 
 import { ListSearch } from './list-search.component';
 
 beforeEach(() => {
   registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
+  serverConfigStore.set({
+    config: {
+      ...defaultServerConfig,
+      enableDrugWildcardSearch: false,
+    },
+  });
 });
 
 describe('ListSearchComponent', () => {

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -271,9 +271,9 @@ const sourceStandardTooltip = (
   </span>
 );
 const searchTooltip = (
-  <span>
+  <div style={{ marginLeft: '0.5rem' }}>
     The following special operators can be used to augment search terms:
-    <ul>
+    <ul style={{ listStylePosition: 'outside' }}>
       <li>
         (*) is the wildcard operator. This operator can be used with a prefix or
         suffix. For example: ceph* (starts with) or *statin (ends with - NOTE:
@@ -294,7 +294,7 @@ const searchTooltip = (
         operations. For example: brain tum* -neoplasm
       </li>
     </ul>
-  </span>
+  </div>
 );
 
 interface Props {
@@ -920,7 +920,7 @@ export const ListSearch = fp.flow(
                 onKeyPress={this.handleInput}
               />
               {serverConfigStore.get().config.enableDrugWildcardSearch && (
-                <TooltipTrigger side='top' content={<div>{searchTooltip}</div>}>
+                <TooltipTrigger side='top' content={searchTooltip}>
                   <ClrIcon
                     style={styles.infoIcon}
                     className='is-solid'

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -50,6 +50,7 @@ import { WorkspaceData } from 'app/utils/workspace-data';
 const borderStyle = `1px solid ${colorWithWhiteness(colors.dark, 0.7)}`;
 const styles = reactStyles({
   searchContainer: {
+    float: 'left',
     width: '80%',
     padding: '0.4rem 0',
     zIndex: 10,
@@ -177,6 +178,7 @@ const styles = reactStyles({
   infoIcon: {
     color: colorWithWhiteness(colors.accent, 0.1),
     marginLeft: '0.25rem',
+    height: '100%',
   },
   clearSearchIcon: {
     color: colors.accent,
@@ -908,17 +910,40 @@ export const ListSearch = fp.flow(
               concepts before adding more.
             </div>
           )}
-          <div style={styles.searchContainer}>
-            <div style={styles.searchBar}>
-              <ClrIcon shape='search' size='18' />
-              <TextInput
-                data-test-id='list-search-input'
-                style={styles.searchInput}
-                value={searchTerms}
-                placeholder={this.textInputPlaceholder}
-                onChange={(e) => this.setState({ searchTerms: e })}
-                onKeyPress={this.handleInput}
-              />
+          <div style={{ display: 'flex' }}>
+            <div style={styles.searchContainer}>
+              <div style={styles.searchBar}>
+                <ClrIcon shape='search' size='18' />
+                <TextInput
+                  data-test-id='list-search-input'
+                  style={styles.searchInput}
+                  value={searchTerms}
+                  placeholder={this.textInputPlaceholder}
+                  onChange={(e) => this.setState({ searchTerms: e })}
+                  onKeyPress={this.handleInput}
+                />
+                {source === 'conceptSetDetails' && searching && (
+                  <Clickable
+                    style={styles.clearSearchIcon}
+                    onClick={() =>
+                      this.setState({
+                        data: concept,
+                        searching: false,
+                        searchTerms: '',
+                      })
+                    }
+                  >
+                    <ClrIcon size={24} shape='times-circle' />
+                  </Clickable>
+                )}
+              </div>
+              {inputErrors.map((error, e) => (
+                <AlertDanger key={e} style={styles.inputAlert}>
+                  <span data-test-id='input-error-alert'>{error}</span>
+                </AlertDanger>
+              ))}
+            </div>
+            <div style={{ float: 'right', width: '20%' }}>
               {serverConfigStore.get().config.enableUniversalSearch && (
                 <TooltipTrigger side='top' content={searchTooltip}>
                   <ClrIcon
@@ -928,26 +953,7 @@ export const ListSearch = fp.flow(
                   />
                 </TooltipTrigger>
               )}
-              {source === 'conceptSetDetails' && searching && (
-                <Clickable
-                  style={styles.clearSearchIcon}
-                  onClick={() =>
-                    this.setState({
-                      data: concept,
-                      searching: false,
-                      searchTerms: '',
-                    })
-                  }
-                >
-                  <ClrIcon size={24} shape='times-circle' />
-                </Clickable>
-              )}
             </div>
-            {inputErrors.map((error, e) => (
-              <AlertDanger key={e} style={styles.inputAlert}>
-                <span data-test-id='input-error-alert'>{error}</span>
-              </AlertDanger>
-            ))}
           </div>
           <div style={{ display: 'table', height: '100%', width: '100%' }}>
             <div style={styles.helpText}>

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -944,7 +944,7 @@ export const ListSearch = fp.flow(
               ))}
             </div>
             <div style={{ float: 'right', width: '20%' }}>
-              {serverConfigStore.get().config.enableUniversalSearch && (
+              {serverConfigStore.get().config.enableDrugWildcardSearch && (
                 <TooltipTrigger side='top' content={searchTooltip}>
                   <ClrIcon
                     style={styles.infoIcon}

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -44,6 +44,7 @@ import {
   currentCohortSearchContextStore,
   setSidebarActiveIconStore,
 } from 'app/utils/navigation';
+import { serverConfigStore } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 const borderStyle = `1px solid ${colorWithWhiteness(colors.dark, 0.7)}`;
@@ -271,23 +272,27 @@ const sourceStandardTooltip = (
 );
 const searchTooltip = (
   <span>
-    The following operators can be used when searching EHR data domains:
+    The following special operators can be used to augment search terms:
     <ul>
       <li>
-        (*) is the wildcard operator. Ex: ceph* (starts with) or *statin (ends
-        with - note: when searching for ends with it will only match with end of
-        concept name)
+        (*) is the wildcard operator. This operator can be used with a prefix or
+        suffix. For example: ceph* (starts with) or *statin (ends with - NOTE:
+        when searching for ends with it will only match with end of concept
+        name)
       </li>
       <li>
-        (-) indicates that this word must <b>not</b> be present. Ex: lung
-        -cancer
+        (-) indicates that this word must <b>not</b> be present. For example:
+        lung -cancer
       </li>
       <li>
         (") a phrase that is enclosed within double quote (") characters matches
-        only rows that contain the phrase literally, as it was typed. Ex: "lung
-        cancer"
+        only rows that contain the phrase literally, as it was typed. For
+        example: "lung cancer"
       </li>
-      <li>Combining operators Ex: brain tum* -neoplasm</li>
+      <li>
+        These operators can be combined to produce more complex search
+        operations. For example: brain tum* -neoplasm
+      </li>
     </ul>
   </span>
 );
@@ -914,7 +919,7 @@ export const ListSearch = fp.flow(
                 onChange={(e) => this.setState({ searchTerms: e })}
                 onKeyPress={this.handleInput}
               />
-              {serverConfigStore.get().config.enableUniversalSearch && (
+              {serverConfigStore.get().config.enableDrugWildcardSearch && (
                 <TooltipTrigger side='top' content={<div>{searchTooltip}</div>}>
                   <ClrIcon
                     style={styles.infoIcon}

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -61,7 +61,7 @@ const styles = reactStyles({
     backgroundColor: colorWithWhiteness(colors.secondary, 0.8),
   },
   searchInput: {
-    width: '90%',
+    width: '94%',
     height: '1.5rem',
     marginLeft: '0.25rem',
     padding: '0',
@@ -267,6 +267,28 @@ const sourceStandardTooltip = (
     recommend most users use the standardized items in defining their dataset.
     However, if you do not wish to rely on this standardization, you may select
     concepts as coded in the source data.
+  </span>
+);
+const searchTooltip = (
+  <span>
+    The following operators can be used when searching EHR data domains:
+    <ul>
+      <li>
+        (*) is the wildcard operator. Ex: ceph* (starts with) or *statin (ends
+        with - note: when searching for ends with it will only match with end of
+        concept name)
+      </li>
+      <li>
+        (-) indicates that this word must <b>not</b> be present. Ex: lung
+        -cancer
+      </li>
+      <li>
+        (") a phrase that is enclosed within double quote (") characters matches
+        only rows that contain the phrase literally, as it was typed. Ex: "lung
+        cancer"
+      </li>
+      <li>Combining operators Ex: brain tum* -neoplasm</li>
+    </ul>
   </span>
 );
 
@@ -892,6 +914,15 @@ export const ListSearch = fp.flow(
                 onChange={(e) => this.setState({ searchTerms: e })}
                 onKeyPress={this.handleInput}
               />
+              {serverConfigStore.get().config.enableUniversalSearch && (
+                <TooltipTrigger side='top' content={<div>{searchTooltip}</div>}>
+                  <ClrIcon
+                    style={styles.infoIcon}
+                    className='is-solid'
+                    shape='info-standard'
+                  />
+                </TooltipTrigger>
+              )}
               {source === 'conceptSetDetails' && searching && (
                 <Clickable
                   style={styles.clearSearchIcon}

--- a/ui/src/app/cohort-search/list-search/list-search.component.tsx
+++ b/ui/src/app/cohort-search/list-search/list-search.component.tsx
@@ -919,7 +919,7 @@ export const ListSearch = fp.flow(
                 onChange={(e) => this.setState({ searchTerms: e })}
                 onKeyPress={this.handleInput}
               />
-              {serverConfigStore.get().config.enableDrugWildcardSearch && (
+              {serverConfigStore.get().config.enableUniversalSearch && (
                 <TooltipTrigger side='top' content={searchTooltip}>
                   <ClrIcon
                     style={styles.infoIcon}

--- a/ui/src/app/cohort-search/search-bar/search-bar.component.spec.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.spec.tsx
@@ -4,7 +4,9 @@ import { shallow } from 'enzyme';
 import { CohortBuilderApi, Criteria } from 'generated/fetch';
 
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
+import { serverConfigStore } from 'app/utils/stores';
 
+import defaultServerConfig from 'testing/default-server-config';
 import { CohortBuilderServiceStub } from 'testing/stubs/cohort-builder-service-stub';
 
 import { SearchBar } from './search-bar.component';
@@ -27,6 +29,12 @@ const nodeStub = {
 describe('SearchBar', () => {
   beforeEach(() => {
     registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
+    serverConfigStore.set({
+      config: {
+        ...defaultServerConfig,
+        enableDrugWildcardSearch: false,
+      },
+    });
   });
   it('should render', () => {
     const wrapper = shallow(

--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -416,7 +416,7 @@ export class SearchBar extends React.Component<Props, State> {
           ))}
         </div>
         <div style={{ float: 'right' }}>
-          {serverConfigStore.get().config.enableUniversalSearch &&
+          {serverConfigStore.get().config.enableDrugWildcardSearch &&
             this.doesDomainIncludeToolTip() && (
               <TooltipTrigger side='top' content={searchTooltip}>
                 <ClrIcon

--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -22,8 +22,9 @@ import { serverConfigStore } from 'app/utils/stores';
 
 const styles = reactStyles({
   searchContainer: {
+    float: 'left',
     background: colors.white,
-    width: '100%',
+    width: '95%',
     zIndex: 10,
   },
   searchBar: {
@@ -80,6 +81,7 @@ const styles = reactStyles({
   infoIcon: {
     color: colorWithWhiteness(colors.accent, 0.1),
     marginLeft: '0.25rem',
+    height: '100%',
   },
 });
 
@@ -392,7 +394,7 @@ export class SearchBar extends React.Component<Props, State> {
         ? options[highlightedOption].name
         : this.props.searchTerms;
     return (
-      <div style={{ position: 'relative', width: '100%' }}>
+      <div style={{ display: 'flex', position: 'relative', width: '100%' }}>
         <div style={styles.searchContainer}>
           <div style={styles.searchBar}>
             {loading ? (
@@ -406,22 +408,24 @@ export class SearchBar extends React.Component<Props, State> {
               onChange={(e) => this.props.setInput(e)}
               onKeyDown={(e) => this.onKeyDown(e.key)}
             />
-            {serverConfigStore.get().config.enableUniversalSearch &&
-              this.doesDomainIncludeToolTip() && (
-                <TooltipTrigger side='top' content={searchTooltip}>
-                  <ClrIcon
-                    style={styles.infoIcon}
-                    className='is-solid'
-                    shape='info-standard'
-                  />
-                </TooltipTrigger>
-              )}
           </div>
           {inputErrors.map((error, e) => (
             <AlertDanger key={e} style={styles.inputAlert}>
               <span data-test-id='input-error-alert'>{error}</span>
             </AlertDanger>
           ))}
+        </div>
+        <div style={{ float: 'right' }}>
+          {serverConfigStore.get().config.enableUniversalSearch &&
+            this.doesDomainIncludeToolTip() && (
+              <TooltipTrigger side='top' content={searchTooltip}>
+                <ClrIcon
+                  style={styles.infoIcon}
+                  className='is-solid'
+                  shape='info-standard'
+                />
+              </TooltipTrigger>
+            )}
         </div>
         {options !== null && (
           <div ref={(el) => (this.dropdown = el)} style={styles.dropdownMenu}>

--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -84,9 +84,9 @@ const styles = reactStyles({
 });
 
 const searchTooltip = (
-  <span>
+  <div style={{ marginLeft: '0.5rem' }}>
     The following special operators can be used to augment search terms:
-    <ul>
+    <ul style={{ listStylePosition: 'outside' }}>
       <li>
         (*) is the wildcard operator. This operator can be used with a prefix or
         suffix. For example: ceph* (starts with) or *statin (ends with - NOTE:
@@ -107,7 +107,7 @@ const searchTooltip = (
         operations. For example: brain tum* -neoplasm
       </li>
     </ul>
-  </span>
+  </div>
 );
 
 const searchTrigger = 2;
@@ -400,7 +400,7 @@ export class SearchBar extends React.Component<Props, State> {
               onKeyDown={(e) => this.onKeyDown(e.key)}
             />
             {serverConfigStore.get().config.enableUniversalSearch && (
-              <TooltipTrigger side='top' content={<div>{searchTooltip}</div>}>
+              <TooltipTrigger side='top' content={searchTooltip}>
                 <ClrIcon
                   style={styles.infoIcon}
                   className='is-solid'

--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -18,6 +18,7 @@ import {
 } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { currentWorkspaceStore } from 'app/utils/navigation';
+import { serverConfigStore } from 'app/utils/stores';
 
 const styles = reactStyles({
   searchContainer: {
@@ -38,7 +39,7 @@ const styles = reactStyles({
     marginLeft: '0.25rem',
     outline: 'none',
     padding: '0',
-    width: '85%',
+    width: '94%',
   },
   dropdownMenu: {
     position: 'absolute',
@@ -76,7 +77,38 @@ const styles = reactStyles({
     padding: '0.2rem',
     width: '64.3%',
   },
+  infoIcon: {
+    color: colorWithWhiteness(colors.accent, 0.1),
+    marginLeft: '0.25rem',
+  },
 });
+
+const searchTooltip = (
+  <span>
+    The following special operators can be used to augment search terms:
+    <ul>
+      <li>
+        (*) is the wildcard operator. This operator can be used with a prefix or
+        suffix. For example: ceph* (starts with) or *statin (ends with - NOTE:
+        when searching for ends with it will only match with end of concept
+        name)
+      </li>
+      <li>
+        (-) indicates that this word must <b>not</b> be present. For example:
+        lung -cancer
+      </li>
+      <li>
+        (") a phrase that is enclosed within double quote (") characters matches
+        only rows that contain the phrase literally, as it was typed. For
+        example: "lung cancer"
+      </li>
+      <li>
+        These operators can be combined to produce more complex search
+        operations. For example: brain tum* -neoplasm
+      </li>
+    </ul>
+  </span>
+);
 
 const searchTrigger = 2;
 
@@ -367,6 +399,15 @@ export class SearchBar extends React.Component<Props, State> {
               onChange={(e) => this.props.setInput(e)}
               onKeyDown={(e) => this.onKeyDown(e.key)}
             />
+            {serverConfigStore.get().config.enableUniversalSearch && (
+              <TooltipTrigger side='top' content={<div>{searchTooltip}</div>}>
+                <ClrIcon
+                  style={styles.infoIcon}
+                  className='is-solid'
+                  shape='info-standard'
+                />
+              </TooltipTrigger>
+            )}
           </div>
           {inputErrors.map((error, e) => (
             <AlertDanger key={e} style={styles.inputAlert}>

--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -378,6 +378,13 @@ export class SearchBar extends React.Component<Props, State> {
     this.selectOption(options[highlightedOption]);
   }
 
+  doesDomainIncludeToolTip() {
+    return (
+      this.props.node.domainId !== Domain.VISIT.toString() &&
+      this.props.node.domainId !== Domain.PHYSICALMEASUREMENT.toString()
+    );
+  }
+
   render() {
     const { highlightedOption, inputErrors, loading, options } = this.state;
     const inputValue =
@@ -399,15 +406,16 @@ export class SearchBar extends React.Component<Props, State> {
               onChange={(e) => this.props.setInput(e)}
               onKeyDown={(e) => this.onKeyDown(e.key)}
             />
-            {serverConfigStore.get().config.enableUniversalSearch && (
-              <TooltipTrigger side='top' content={searchTooltip}>
-                <ClrIcon
-                  style={styles.infoIcon}
-                  className='is-solid'
-                  shape='info-standard'
-                />
-              </TooltipTrigger>
-            )}
+            {serverConfigStore.get().config.enableUniversalSearch &&
+              this.doesDomainIncludeToolTip() && (
+                <TooltipTrigger side='top' content={searchTooltip}>
+                  <ClrIcon
+                    style={styles.infoIcon}
+                    className='is-solid'
+                    shape='info-standard'
+                  />
+                </TooltipTrigger>
+              )}
           </div>
           {inputErrors.map((error, e) => (
             <AlertDanger key={e} style={styles.inputAlert}>

--- a/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
@@ -10,7 +10,9 @@ import {
 import { ConceptHomepage } from 'app/pages/data/concept/concept-homepage';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { currentWorkspaceStore } from 'app/utils/navigation';
+import { serverConfigStore } from 'app/utils/stores';
 
+import defaultServerConfig from 'testing/default-server-config';
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import {
   CohortBuilderServiceStub,
@@ -39,6 +41,12 @@ describe('ConceptHomepage', () => {
     registerApiClient(ConceptSetsApi, new ConceptSetsApiStub());
     registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     currentWorkspaceStore.next(workspaceDataStub);
+    serverConfigStore.set({
+      config: {
+        ...defaultServerConfig,
+        enableDrugWildcardSearch: false,
+      },
+    });
   });
 
   it('should render', () => {

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -66,9 +66,9 @@ const styles = reactStyles({
   },
   clearSearchIcon: {
     fill: colors.accent,
-    transform: 'translate(-1.5rem)',
     height: '1rem',
     width: '1rem',
+    marginLeft: '-1.5rem',
   },
   sectionHeader: {
     height: 24,

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -14,6 +14,7 @@ import { DomainCardBase } from 'app/components/card';
 import { FadeBox } from 'app/components/containers';
 import { ClrIcon } from 'app/components/icons';
 import { TextInput } from 'app/components/inputs';
+import { TooltipTrigger } from 'app/components/popups';
 import { Spinner, SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { cohortBuilderApi } from 'app/services/swagger-fetch-clients';
@@ -30,6 +31,7 @@ import {
   currentConceptStore,
   NavigationProps,
 } from 'app/utils/navigation';
+import { serverConfigStore } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 const styles = reactStyles({
@@ -100,7 +102,38 @@ const styles = reactStyles({
     padding: '0.2rem',
     width: '64.3%',
   },
+  infoIcon: {
+    color: colorWithWhiteness(colors.accent, 0.1),
+    marginLeft: '0.25rem',
+  },
 });
+
+const searchTooltip = (
+  <div style={{ marginLeft: '0.5rem' }}>
+    The following special operators can be used to augment search terms:
+    <ul style={{ listStylePosition: 'outside' }}>
+      <li>
+        (*) is the wildcard operator. This operator can be used with a prefix or
+        suffix. For example: ceph* (starts with) or *statin (ends with - NOTE:
+        when searching for ends with it will only match with end of concept
+        name)
+      </li>
+      <li>
+        (-) indicates that this word must <b>not</b> be present. For example:
+        lung -cancer
+      </li>
+      <li>
+        (") a phrase that is enclosed within double quote (") characters matches
+        only rows that contain the phrase literally, as it was typed. For
+        example: "lung cancer"
+      </li>
+      <li>
+        These operators can be combined to produce more complex search
+        operations. For example: brain tum* -neoplasm
+      </li>
+    </ul>
+  </div>
+);
 
 const DomainCard: React.FunctionComponent<{
   conceptDomainCard: ConceptDomainCard;
@@ -451,6 +484,15 @@ export const ConceptHomepage = fp.flow(
                     style={styles.clearSearchIcon}
                   />
                 </Clickable>
+              )}
+              {serverConfigStore.get().config.enableUniversalSearch && (
+                <TooltipTrigger side='top' content={searchTooltip}>
+                  <ClrIcon
+                    style={styles.infoIcon}
+                    className='is-solid'
+                    shape='info-standard'
+                  />
+                </TooltipTrigger>
               )}
             </div>
             {inputErrors.map((error, e) => (

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -485,7 +485,7 @@ export const ConceptHomepage = fp.flow(
                   />
                 </Clickable>
               )}
-              {serverConfigStore.get().config.enableUniversalSearch && (
+              {serverConfigStore.get().config.enableDrugWildcardSearch && (
                 <TooltipTrigger side='top' content={searchTooltip}>
                   <ClrIcon
                     style={styles.infoIcon}


### PR DESCRIPTION
Adding tooltip to the following UI components:

1. list-search.component.tsx 
![Screen Shot 2022-08-03 at 2 22 25 PM](https://user-images.githubusercontent.com/3904919/182692546-171aebfe-b7e4-40fa-b14d-6f832ded0708.png)
2. cohort-criteria-menu.tsx 
![Screen Shot 2022-08-03 at 2 22 56 PM](https://user-images.githubusercontent.com/3904919/182692808-7bea95b9-eb26-4eed-a900-89ba9e822bf1.png)
3. search-bar.component.tsx 
![Screen Shot 2022-08-03 at 2 23 13 PM](https://user-images.githubusercontent.com/3904919/182692852-aa163cd1-2a8d-4c5a-bf1d-87a155f4e9e7.png)
4. concept-homepage.tsx 
![Screen Shot 2022-08-03 at 2 23 28 PM](https://user-images.githubusercontent.com/3904919/182692886-d74e32b6-07b8-4fd2-8e9a-43c67b357cd7.png)
