### PR TITLE
[risk=no][no ticket] Fix linting to fix texts

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -98,10 +98,11 @@ public class NotebooksControllerTest {
     }
   }
 
-  class MockNotebook{
+  class MockNotebook {
     Blob blob;
     FileDetail fileDetail;
-    MockNotebook(String path, String bucketName){
+
+    MockNotebook(String path, String bucketName) {
       blob = mock(Blob.class);
       fileDetail = new FileDetail();
 
@@ -109,10 +110,8 @@ public class NotebooksControllerTest {
       String fileName = parts[parts.length - 1];
       fileDetail.setName(fileName);
 
-      when(blob.getName())
-          .thenReturn(path);
-      when(mockCloudStorageClient.blobToFileDetail(blob,bucketName)).thenReturn(fileDetail);
-
+      when(blob.getName()).thenReturn(path);
+      when(mockCloudStorageClient.blobToFileDetail(blob, bucketName)).thenReturn(fileDetail);
     }
   }
 
@@ -155,9 +154,11 @@ public class NotebooksControllerTest {
 
   @Test
   public void testNotebookFileList() {
-    MockNotebook notebook1 = new MockNotebook(NotebooksService.withNotebookExtension("notebooks/mockFile"),"bucket");
-    MockNotebook notebook2 = new MockNotebook("notebooks/mockFile.text","bucket");
-    MockNotebook notebook3 = new MockNotebook(NotebooksService.withNotebookExtension("notebooks/two words"),"bucket");
+    MockNotebook notebook1 =
+        new MockNotebook(NotebooksService.withNotebookExtension("notebooks/mockFile"), "bucket");
+    MockNotebook notebook2 = new MockNotebook("notebooks/mockFile.text", "bucket");
+    MockNotebook notebook3 =
+        new MockNotebook(NotebooksService.withNotebookExtension("notebooks/two words"), "bucket");
 
     when(mockCloudStorageClient.getBlobPageForPrefix("bucket", "notebooks"))
         .thenReturn(ImmutableList.of(notebook1.blob, notebook2.blob, notebook3.blob));
@@ -174,9 +175,7 @@ public class NotebooksControllerTest {
 
     assertThat(gotNames)
         .isEqualTo(
-            ImmutableList.of(
-                notebook1.fileDetail.getName(),
-                notebook3.fileDetail.getName()));
+            ImmutableList.of(notebook1.fileDetail.getName(), notebook3.fileDetail.getName()));
   }
 
   @Test
@@ -184,11 +183,17 @@ public class NotebooksControllerTest {
     DbWorkspace workspace = createWorkspace();
     stubGetWorkspace(workspace, WorkspaceAccessLevel.OWNER);
 
-    MockNotebook notebook1 = new MockNotebook(NotebooksService.withNotebookExtension("notebooks/extra/nope"),TestMockFactory.WORKSPACE_BUCKET_NAME);
-    MockNotebook notebook2 = new MockNotebook(NotebooksService.withNotebookExtension("notebooks/foo"),TestMockFactory.WORKSPACE_BUCKET_NAME);
+    MockNotebook notebook1 =
+        new MockNotebook(
+            NotebooksService.withNotebookExtension("notebooks/extra/nope"),
+            TestMockFactory.WORKSPACE_BUCKET_NAME);
+    MockNotebook notebook2 =
+        new MockNotebook(
+            NotebooksService.withNotebookExtension("notebooks/foo"),
+            TestMockFactory.WORKSPACE_BUCKET_NAME);
 
     when(mockCloudStorageClient.getBlobPageForPrefix(
-        TestMockFactory.WORKSPACE_BUCKET_NAME, "notebooks"))
+            TestMockFactory.WORKSPACE_BUCKET_NAME, "notebooks"))
         .thenReturn(ImmutableList.of(notebook1.blob, notebook2.blob));
     List<FileDetail> body =
         notebooksController
@@ -742,9 +747,9 @@ public class NotebooksControllerTest {
         .getMetadata(TestMockFactory.WORKSPACE_BUCKET_NAME, testNotebookPath);
 
     assertThat(
-        notebooksController
-            .getNotebookLockingMetadata(testWorkspaceNamespace, testWorkspaceName, testNotebook)
-            .getBody())
+            notebooksController
+                .getNotebookLockingMetadata(testWorkspaceNamespace, testWorkspaceName, testNotebook)
+                .getBody())
         .isEqualTo(expectedResponse);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/google/CloudStorageClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/google/CloudStorageClientTest.java
@@ -25,10 +25,7 @@ public class CloudStorageClientTest {
   @Autowired private CloudStorageClient cloudStorageClient;
 
   @TestConfiguration
-  @Import({
-    CloudStorageClientImpl.class
-  })
-
+  @Import({CloudStorageClientImpl.class})
   static class Configuration {
 
     @Bean
@@ -48,13 +45,12 @@ public class CloudStorageClientTest {
     when(notebookBlob.getName()).thenReturn(notebookPath);
     when(notebookBlob.getSize()).thenReturn(notebookSize);
     when(notebookBlob.getUpdateTime()).thenReturn(updateTime);
-    FileDetail actualFileDetail = cloudStorageClient.blobToFileDetail(notebookBlob,bucketName);
+    FileDetail actualFileDetail = cloudStorageClient.blobToFileDetail(notebookBlob, bucketName);
 
     assertThat(actualFileDetail.getName()).isEqualTo("nb1.ipynb");
-    assertThat(actualFileDetail.getPath()).isEqualTo("gs://"+bucketName+"/"+notebookBlob.getName());
+    assertThat(actualFileDetail.getPath())
+        .isEqualTo("gs://" + bucketName + "/" + notebookBlob.getName());
     assertThat(actualFileDetail.getLastModifiedTime()).isEqualTo(updateTime);
     assertThat(actualFileDetail.getSizeInBytes()).isEqualTo(notebookSize);
   }
-
-
 }


### PR DESCRIPTION
No actual changes.  Fixes the linting in #6912

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
