### PR TITLE
[no ticket][risk=no] fixing drug index

### DIFF
--- a/api/db-cdr/generate-cdr/build-cb-criteria-missing-codes.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-missing-codes.sh
@@ -368,7 +368,7 @@ WHERE ancestor_concept_id in
         SELECT DISTINCT concept_id
         FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
         WHERE domain_id = 'DRUG'
-            and type = 'RXNORM'
+            and type in ('CVX', 'HCPCS', 'RxNorm Extension')
             and is_group = 0
             and is_selectable = 1
     )


### PR DESCRIPTION
fixing drug index - the script should load all drugs of the following types into the cb_criteria_ancestor table:

1. CVX
2. HCPCS
3. RxNorm Extension
