### PR TITLE
[RW-8669][risk=no] Add Fulltext endsWith search for ConceptSets

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -238,9 +238,13 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
     workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
     validateTerm(term);
-
-    return ResponseEntity.ok(
-        new CardCountResponse().items(cohortBuilderService.findDomainCounts(term)));
+    if (workbenchConfigProvider.get().featureFlags.enableDrugWildcardSearch) {
+      return ResponseEntity.ok(
+          new CardCountResponse().items(cohortBuilderService.findDomainCountsV2(term)));
+    } else {
+      return ResponseEntity.ok(
+          new CardCountResponse().items(cohortBuilderService.findDomainCounts(term)));
+    }
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDao.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.cdr.dao;
 
 import java.util.List;
+import org.pmiops.workbench.cdr.model.DbCardCount;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -23,4 +24,14 @@ public interface CustomCBCriteriaDao {
       String term,
       List<String> endsWithTerms,
       PageRequest pageRequest);
+
+  List<DbCardCount> findDomainCountsByDomainsAndStandardAndNameEndsWith(
+      List<String> domains, Boolean standard, List<String> endsWithList);
+
+  List<DbCardCount> findDomainCountsByDomainsAndStandardAndTermAndNameEndsWith(
+      List<String> domains, Boolean standard, String term, List<String> endsWithList);
+
+  List<DbCardCount> findSurveyCountsAndNameEndsWith(List<String> endsWithList);
+
+  List<DbCardCount> findSurveyCountsAndTermAndNameEndsWith(String term, List<String> endsWithList);
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
@@ -11,6 +11,7 @@ import java.util.stream.IntStream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.pmiops.workbench.cdr.CdrVersionContext;
+import org.pmiops.workbench.cdr.model.DbCardCount;
 import org.pmiops.workbench.cdr.model.DbCriteria;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
@@ -43,33 +44,47 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
     public MapSqlParameterSource getParameters() {
       return parameters;
     }
+
+    @Override
+    public String toString() {
+      return "QueryAndParameters{" + "query='" + query + '\'' + ", parameters=" + parameters + '}';
+    }
   }
 
+  private static final String SQL_DB_CDR_NAME = "DB_CDR_NAME";
+  private static final String SQL_ENDS_WITH = "SQL_ENDS_WITH";
   private static final String BIND_VAR_DOMAIN = "domain";
   private static final String BIND_VAR_STANDARD = "standard";
   private static final String BIND_VAR_TERM = "term";
   private static final String BIND_VAR_TYPE = "type";
+  private static final String BIND_VAR_IN_DOMAIN_LIST = "domains";
 
   // SQL snips
   private static final String DYNAMIC_SQL = "upper(name) like upper(%s)";
   private static final String LIMIT_OFFSET = "limit %s offset %s\n";
   private static final String OR = "\nor\n";
 
-  private static final String ENDS_WITH_WITHOUT_TERM =
+  private static final String CRITERIA_BY_DOMAIN_ENDS_WITH_NO_TERM =
       "select *\n"
-          + "from %s.cb_criteria\n"
+          + "from \n"
+          + SQL_DB_CDR_NAME
+          + ".cb_criteria\n"
           + "where is_standard = :"
           + BIND_VAR_STANDARD
           + "\n"
           + "and match(full_text) against(concat('+[', :"
           + BIND_VAR_DOMAIN
           + ", '_rank1]') in boolean mode)\n"
-          + "and (%s)\n"
+          + "and ("
+          + SQL_ENDS_WITH
+          + ")\n"
           + "order by est_count desc, name asc\n";
 
-  private static final String ENDS_WITH_WITH_TERM =
+  private static final String CRITERIA_BY_DOMAIN_ENDS_WITH_AND_TERM =
       "select *\n"
-          + "from %s.cb_criteria\n"
+          + "from \n"
+          + SQL_DB_CDR_NAME
+          + ".cb_criteria\n"
           + "where is_standard = :"
           + BIND_VAR_STANDARD
           + "\n"
@@ -78,12 +93,16 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
           + ", '+[', :"
           + BIND_VAR_DOMAIN
           + ", '_rank1]') in boolean mode)\n"
-          + "and (%s)\n"
+          + "and ("
+          + SQL_ENDS_WITH
+          + ")\n"
           + "order by est_count desc, name asc\n";
 
-  private static final String AUTO_COMPLETE_ENDS_WITH_WITHOUT_TERM =
+  private static final String AUTO_COMPLETE_ENDS_WITH_NO_TERM =
       "select *\n"
-          + "from %s.cb_criteria\n"
+          + "from \n"
+          + SQL_DB_CDR_NAME
+          + ".cb_criteria\n"
           + "where type = :"
           + BIND_VAR_TYPE
           + "\n"
@@ -94,12 +113,16 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
           + "and match(full_text) against(concat('+[', :"
           + BIND_VAR_DOMAIN
           + ", '_rank1]') in boolean mode)\n"
-          + "and (%s)\n"
+          + "and ("
+          + SQL_ENDS_WITH
+          + ")\n"
           + "order by est_count desc, name asc\n";
 
-  private static final String AUTO_COMPLETE_ENDS_WITH_WITH_TERM =
+  private static final String AUTO_COMPLETE_ENDS_WITH_AND_TERM =
       "select *\n"
-          + "from %s.cb_criteria\n"
+          + "from \n"
+          + SQL_DB_CDR_NAME
+          + ".cb_criteria\n"
           + "where type = :"
           + BIND_VAR_TYPE
           + "\n"
@@ -112,8 +135,111 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
           + ", '+[', :"
           + BIND_VAR_DOMAIN
           + ", '_rank1]') in boolean mode)\n"
-          + "and (%s)\n"
+          + "and ("
+          + SQL_ENDS_WITH
+          + ")\n"
           + "order by est_count desc, name asc\n";
+
+  private static final String DOMAIN_COUNTS_ENDS_WITH_AND_TERM =
+      "select \n"
+          + "upper(substring_index(substring_index(full_text, '[', -1), '_rank1', 1)) as domainId\n"
+          + ", upper(substring_index(substring_index(full_text, '[', -1), '_rank1', 1)) as name\n"
+          + ", count(*) as count\n"
+          + "from \n"
+          + SQL_DB_CDR_NAME
+          + ".cb_criteria\n"
+          + "where match(full_text) against(:"
+          + BIND_VAR_TERM
+          + " in boolean mode)\n"
+          + "and full_text like '%_rank1%'\n"
+          + "and is_standard = :"
+          + BIND_VAR_STANDARD
+          + "\n"
+          + "and domain_id in (:"
+          + BIND_VAR_IN_DOMAIN_LIST
+          + ")\n"
+          + "and ("
+          + SQL_ENDS_WITH
+          + ")\n"
+          + "group by 1 "
+          + "order by count desc";
+
+  private static final String DOMAIN_COUNTS_ENDS_WITH_NO_TERM =
+      "select \n"
+          + "upper(substring_index(substring_index(full_text, '[', -1), '_rank1', 1)) as domainId\n"
+          + ", upper(substring_index(substring_index(full_text, '[', -1), '_rank1', 1)) as name\n"
+          + ", count(*) as count\n"
+          + "from \n"
+          + SQL_DB_CDR_NAME
+          + ".cb_criteria\n"
+          + "where full_text like '%_rank1%'\n"
+          + "and is_standard = :"
+          + BIND_VAR_STANDARD
+          + "\n"
+          + "and domain_id in (:"
+          + BIND_VAR_IN_DOMAIN_LIST
+          + ")\n"
+          + "and ("
+          + SQL_ENDS_WITH
+          + ")\n"
+          + "group by 1 "
+          + "order by count desc";
+
+  private static final String SURVEY_COUNTS_ENDS_WITH_AND_TERM =
+      "select 'SURVEY' as domainId"
+          + ", name\n"
+          + ", count\n"
+          + "from \n"
+          + SQL_DB_CDR_NAME
+          + ".cb_criteria c \n"
+          + "join(\n"
+          + "select substring_index(path,'.',1) as survey_version_concept_id, count(*) as count\n"
+          + "from \n"
+          + SQL_DB_CDR_NAME
+          + ".cb_criteria\n"
+          + "where domain_id = 'SURVEY'\n"
+          + "and subtype = 'QUESTION'\n"
+          + "and concept_id in (select concept_id\n"
+          + "from \n"
+          + SQL_DB_CDR_NAME
+          + ".cb_criteria\n"
+          + "where domain_id = 'SURVEY' "
+          + "and match(full_text) against(concat(:"
+          + BIND_VAR_TERM
+          + ", '+[survey_rank1]') in boolean mode)\n"
+          + "and ("
+          + SQL_ENDS_WITH
+          + "))\n"
+          + "group by survey_version_concept_id"
+          + ") a on c.id = a.survey_version_concept_id "
+          + "order by count desc";
+
+  private static final String SURVEY_COUNTS_ENDS_WITH_NO_TERM =
+      "select 'SURVEY' as domainId"
+          + ", name\n"
+          + ", count\n"
+          + "from \n"
+          + SQL_DB_CDR_NAME
+          + ".cb_criteria c \n"
+          + "join(\n"
+          + "select substring_index(path,'.',1) as survey_version_concept_id, count(*) as count\n"
+          + "from \n"
+          + SQL_DB_CDR_NAME
+          + ".cb_criteria\n"
+          + "where domain_id = 'SURVEY'\n"
+          + "and subtype = 'QUESTION'\n"
+          + "and concept_id in (select concept_id\n"
+          + "from \n"
+          + SQL_DB_CDR_NAME
+          + ".cb_criteria\n"
+          + "where domain_id = 'SURVEY' "
+          + "and match(full_text) against('+[survey_rank1]' in boolean mode)\n"
+          + "and ("
+          + SQL_ENDS_WITH
+          + "))\n"
+          + "group by survey_version_concept_id"
+          + ") a on c.id = a.survey_version_concept_id "
+          + "order by count desc";
 
   @Autowired private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
@@ -127,7 +253,7 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
       {BIND_VAR_STANDARD, standard}
     };
     QueryAndParameters queryAndParameters =
-        generateQueryAndParameters(ENDS_WITH_WITHOUT_TERM, params, endsWithList);
+        generateQueryAndParameters(CRITERIA_BY_DOMAIN_ENDS_WITH_NO_TERM, params, endsWithList);
     return new PageImpl<>(
         queryForPaginatedList(page, queryAndParameters),
         page,
@@ -143,7 +269,7 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
       {BIND_VAR_TERM, term}
     };
     QueryAndParameters queryAndParameters =
-        generateQueryAndParameters(ENDS_WITH_WITH_TERM, params, endsWithList);
+        generateQueryAndParameters(CRITERIA_BY_DOMAIN_ENDS_WITH_AND_TERM, params, endsWithList);
     return new PageImpl<>(
         queryForPaginatedList(page, queryAndParameters),
         page,
@@ -157,7 +283,7 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
       {BIND_VAR_DOMAIN, domain}, {BIND_VAR_TYPE, type}, {BIND_VAR_STANDARD, standard}
     };
     QueryAndParameters queryAndParameters =
-        generateQueryAndParameters(AUTO_COMPLETE_ENDS_WITH_WITHOUT_TERM, params, endsWithList);
+        generateQueryAndParameters(AUTO_COMPLETE_ENDS_WITH_NO_TERM, params, endsWithList);
     return new PageImpl<>(
             queryForPaginatedList(page, queryAndParameters),
             page,
@@ -180,7 +306,7 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
       {BIND_VAR_TERM, term}
     };
     QueryAndParameters queryAndParameters =
-        generateQueryAndParameters(AUTO_COMPLETE_ENDS_WITH_WITH_TERM, params, endsWithList);
+        generateQueryAndParameters(AUTO_COMPLETE_ENDS_WITH_AND_TERM, params, endsWithList);
     return new PageImpl<>(
             queryForPaginatedList(page, queryAndParameters),
             page,
@@ -188,8 +314,43 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
         .getContent();
   }
 
+  @Override
+  public List<DbCardCount> findDomainCountsByDomainsAndStandardAndNameEndsWith(
+      List<String> domains, Boolean standard, List<String> endsWithList) {
+    Object[][] params = {{BIND_VAR_STANDARD, standard}, {BIND_VAR_IN_DOMAIN_LIST, domains}};
+    return queryForDbCardCountList(
+        generateQueryAndParameters(DOMAIN_COUNTS_ENDS_WITH_NO_TERM, params, endsWithList));
+  }
+
+  @Override
+  public List<DbCardCount> findDomainCountsByDomainsAndStandardAndTermAndNameEndsWith(
+      List<String> domains, Boolean standard, String term, List<String> endsWithList) {
+    Object[][] params = {
+      {BIND_VAR_STANDARD, standard},
+      {BIND_VAR_TERM, term},
+      {BIND_VAR_IN_DOMAIN_LIST, domains}
+    };
+    return queryForDbCardCountList(
+        generateQueryAndParameters(DOMAIN_COUNTS_ENDS_WITH_AND_TERM, params, endsWithList));
+  }
+
+  @Override
+  public List<DbCardCount> findSurveyCountsAndNameEndsWith(List<String> endsWithList) {
+    return queryForDbCardCountList(
+        generateQueryAndParameters(SURVEY_COUNTS_ENDS_WITH_NO_TERM, null, endsWithList));
+  }
+
+  @Override
+  public List<DbCardCount> findSurveyCountsAndTermAndNameEndsWith(
+      String term, List<String> endsWithList) {
+    Object[][] params = {{BIND_VAR_TERM, term}};
+    return queryForDbCardCountList(
+        generateQueryAndParameters(SURVEY_COUNTS_ENDS_WITH_AND_TERM, params, endsWithList));
+  }
+
   protected QueryAndParameters generateQueryAndParameters(
       String sql, Object[][] params, List<String> endsWithList) {
+
     long cdrVersionId = CdrVersionContext.getCdrVersion().getCdrVersionId();
     Optional<DbCdrVersion> cdrVersionOptional = cdrVersionDao.findById(cdrVersionId);
     DbCdrVersion dbCdrVersion =
@@ -199,20 +360,23 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
                     String.format("CDR version with ID %s not found", cdrVersionId)));
 
     MapSqlParameterSource parameters = new MapSqlParameterSource();
-    Arrays.stream(params).forEach(param -> parameters.addValue(param[0].toString(), param[1]));
-
+    if (params != null) {
+      Arrays.stream(params).forEach(param -> parameters.addValue(param[0].toString(), param[1]));
+    }
     StringJoiner joiner = new StringJoiner(OR);
     IntStream.range(0, endsWithList.size())
         .forEach(
             idx -> {
-              String endsWith = endsWithList.get(idx).replace("*", "%");
               String parameterName = "endsWith" + idx;
-              parameters.addValue(parameterName, endsWith);
+              parameters.addValue(parameterName, endsWithList.get(idx));
               joiner.add(String.format(DYNAMIC_SQL, ":" + parameterName));
             });
 
-    return new QueryAndParameters(
-        String.format(sql, dbCdrVersion.getCdrDbName(), joiner), parameters);
+    String tmpSql =
+        sql.replaceAll(SQL_DB_CDR_NAME, dbCdrVersion.getCdrDbName())
+            .replaceAll(SQL_ENDS_WITH, joiner.toString());
+
+    return new QueryAndParameters(tmpSql, parameters);
   }
 
   @NotNull
@@ -223,6 +387,16 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
             + String.format(LIMIT_OFFSET, page.getPageSize(), page.getOffset()),
         queryAndParameters.getParameters(),
         new DBCriteriaRowMapper());
+  }
+
+  @NotNull
+  private List<DbCardCount> queryForDbCardCountList(QueryAndParameters queryAndParameters) {
+    final List<DbCardCount> dbCardCountList =
+        namedParameterJdbcTemplate.query(
+            queryAndParameters.getQuery(),
+            queryAndParameters.getParameters(),
+            new DbCardCountRowMapper());
+    return dbCardCountList;
   }
 
   @Nullable
@@ -258,6 +432,43 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
           .addChildCount(rs.getLong("item_count"))
           .addSynonyms(rs.getString("display_synonyms"))
           .build();
+    }
+  }
+
+  private static class DbCardCountRowMapper implements RowMapper<DbCardCount> {
+
+    @Override
+    public DbCardCount mapRow(ResultSet rs, int rowNum) throws SQLException {
+      return new DbCardCountImpl(
+          rs.getString("domainId"), rs.getString("name"), rs.getLong("count"));
+    }
+  }
+
+  public static class DbCardCountImpl implements DbCardCount {
+
+    private String domainId;
+    private String name;
+    private long count;
+
+    public DbCardCountImpl(String domainId, String name, long count) {
+      this.domainId = domainId;
+      this.name = name;
+      this.count = count;
+    }
+
+    @Override
+    public String getDomainId() {
+      return domainId;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public Long getCount() {
+      return count;
     }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -69,6 +69,8 @@ public interface CohortBuilderService {
 
   List<CardCount> findDomainCounts(String term);
 
+  List<CardCount> findDomainCountsV2(String term);
+
   List<DomainCard> findDomainCards();
 
   List<Criteria> findDrugBrandOrIngredientByValue(String value, Integer limit);

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImplTest.java
@@ -9,7 +9,6 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import javax.inject.Provider;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +26,7 @@ import org.pmiops.workbench.cdr.dao.CriteriaMenuDao;
 import org.pmiops.workbench.cdr.dao.DomainCardDao;
 import org.pmiops.workbench.cdr.dao.PersonDao;
 import org.pmiops.workbench.cdr.dao.SurveyModuleDao;
+import org.pmiops.workbench.cohortbuilder.CohortBuilderServiceImpl.SearchTerm;
 import org.pmiops.workbench.cohortbuilder.mapper.CohortBuilderMapper;
 import org.pmiops.workbench.cohortbuilder.mapper.CohortBuilderMapperImpl;
 import org.pmiops.workbench.test.FakeClock;
@@ -91,8 +91,8 @@ class CohortBuilderServiceImplTest {
   @ParameterizedTest(name = "modifyTermMatchUseEndsWith: {0} {1}=>{2}")
   @MethodSource("getModifyTermMatchEndsWithParameters")
   void modifyTermMatchUseEndsWith(String testInput, String term, String expected) {
-    Map<String, String> actual = cohortBuilderService.modifyTermMatchUseEndsWithTerms(term);
-    assertWithMessage(testInput).that(actual.get("modifiedTerms")).isEqualTo(expected);
+    SearchTerm actual = cohortBuilderService.modifyTermMatchUseEndsWithTerms(term);
+    assertWithMessage(testInput).that(actual.getModifiedTerm()).isEqualTo(expected);
   }
 
   @ParameterizedTest(name = "modifyTermMatch: {0} {1}=>{2}")


### PR DESCRIPTION
Description:

- Implemented full text search ends with for concept search

![image](https://user-images.githubusercontent.com/4452480/182879331-1eee80b5-8e30-4029-9465-3e9cd2b699db.png)



---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
