### PR TITLE
[RW-8558][risk=no] Limit size of cohort definition 

### DIFF
--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -134,7 +134,7 @@ const styles = reactStyles({
 });
 
 // Limit the size of cohort definition to 1MB
-const COHORT_BYTE_LIMIT = 1000;
+const COHORT_BYTE_LIMIT = 1000000;
 
 interface Props extends NavigationProps, RouteComponentProps<MatchParams> {
   cohort: Cohort;
@@ -210,6 +210,7 @@ export const ListOverview = fp.flow(
 
     componentDidMount(): void {
       if (!this.definitionErrors) {
+        this.checkCohortSize();
         this.getTotalCount();
         // Prevents multiple count calls on initial cohort load
         setTimeout(() => this.setState({ initializing: false }), 100);
@@ -222,17 +223,21 @@ export const ListOverview = fp.flow(
         this.props.updateCount > prevProps.updateCount &&
         !this.definitionErrors
       ) {
-        this.setState({
-          cohortSizeError:
-            new Blob([JSON.stringify(mapRequest(this.props.searchRequest))])
-              .size > COHORT_BYTE_LIMIT,
-        });
+        this.checkCohortSize();
         this.getTotalCount();
       }
     }
 
     componentWillUnmount(): void {
       this.aborter.abort();
+    }
+
+    checkCohortSize() {
+      this.setState({
+        cohortSizeError:
+          new Blob([JSON.stringify(mapRequest(this.props.searchRequest))])
+            .size > COHORT_BYTE_LIMIT,
+      });
     }
 
     getTotalCount() {

--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -134,7 +134,7 @@ const styles = reactStyles({
 });
 
 // Limit the size of cohort definition to 1MB
-const COHORT_BYTE_LIMIT = 1000000;
+const COHORT_BYTE_LIMIT = 500;
 
 interface Props extends NavigationProps, RouteComponentProps<MatchParams> {
   cohort: Cohort;
@@ -608,9 +608,8 @@ export const ListOverview = fp.flow(
                 )}
                 {cohortSizeError && (
                   <TooltipTrigger
-                    content={
-                      'The size of your cohort exceeds the 1MB limit. Remove some criteria selections to continue.'
-                    }
+                    content={`The size of your cohort exceeds the 1MB limit. Please select Contact Us in the left hand navigation to report
+                      this issue.`}
                   >
                     <ClrIcon
                       style={{

--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -134,7 +134,7 @@ const styles = reactStyles({
 });
 
 // Limit the size of cohort definition to 1MB
-const COHORT_BYTE_LIMIT = 1000000;
+const COHORT_BYTE_LIMIT = 1000;
 
 interface Props extends NavigationProps, RouteComponentProps<MatchParams> {
   cohort: Cohort;
@@ -556,6 +556,7 @@ export const ListOverview = fp.flow(
         ageType,
         apiError,
         chartData,
+        cohortSizeError,
         currentGraphOptions,
         deleting,
         genderOrSexType,
@@ -699,7 +700,22 @@ export const ListOverview = fp.flow(
                 ) : loading ? (
                   <Spinner size={18} />
                 ) : (
-                  <span>{this.showTotalCount && total.toLocaleString()}</span>
+                  <React.Fragment>
+                    {cohortSizeError && (
+                      <TooltipTrigger
+                        content={
+                          'The size of your cohort exceeds the 1MB limit. Remove some criteria selections to continue.'
+                        }
+                      >
+                        <ClrIcon
+                          style={{ color: '#F57600', marginRight: '0.25rem' }}
+                          shape='warning-standard'
+                          size={18}
+                        />
+                      </TooltipTrigger>
+                    )}
+                    <span>{this.showTotalCount && total.toLocaleString()}</span>
+                  </React.Fragment>
                 )}
               </h2>
             </div>

--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -134,7 +134,7 @@ const styles = reactStyles({
 });
 
 // Limit the size of cohort definition to 1MB
-const COHORT_BYTE_LIMIT = 500;
+const COHORT_BYTE_LIMIT = 1000000;
 
 interface Props extends NavigationProps, RouteComponentProps<MatchParams> {
   cohort: Cohort;

--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -133,6 +133,9 @@ const styles = reactStyles({
   },
 });
 
+// Limit the size of cohort definition to 1MB
+const COHORT_BYTE_LIMIT = 1000000;
+
 interface Props extends NavigationProps, RouteComponentProps<MatchParams> {
   cohort: Cohort;
   cohortChanged: boolean;
@@ -150,6 +153,7 @@ interface State {
   apiCallCheck: number;
   apiError: boolean;
   chartData: any;
+  cohortSizeError: boolean;
   currentGraphOptions: {
     ageType: AgeType;
     genderOrSexType: GenderOrSexType;
@@ -185,6 +189,7 @@ export const ListOverview = fp.flow(
         apiCallCheck: 0,
         apiError: false,
         chartData: undefined,
+        cohortSizeError: false,
         currentGraphOptions: {
           ageType: AgeType.AGEATCDR,
           genderOrSexType: GenderOrSexType.GENDER,
@@ -217,6 +222,11 @@ export const ListOverview = fp.flow(
         this.props.updateCount > prevProps.updateCount &&
         !this.definitionErrors
       ) {
+        this.setState({
+          cohortSizeError:
+            new Blob([JSON.stringify(mapRequest(this.props.searchRequest))])
+              .size > COHORT_BYTE_LIMIT,
+        });
         this.getTotalCount();
       }
     }
@@ -517,8 +527,10 @@ export const ListOverview = fp.flow(
     }
 
     get disableSaveButton() {
-      const { loading, saving, total } = this.state;
-      return loading || saving || this.definitionErrors || !total;
+      const { cohortSizeError, loading, saving, total } = this.state;
+      return (
+        cohortSizeError || loading || saving || this.definitionErrors || !total
+      );
     }
 
     get disableRefreshButton() {

--- a/ui/src/app/cohort-search/overview/overview.component.tsx
+++ b/ui/src/app/cohort-search/overview/overview.component.tsx
@@ -601,6 +601,23 @@ export const ListOverview = fp.flow(
                     Create Cohort
                   </Button>
                 )}
+                {cohortSizeError && (
+                  <TooltipTrigger
+                    content={
+                      'The size of your cohort exceeds the 1MB limit. Remove some criteria selections to continue.'
+                    }
+                  >
+                    <ClrIcon
+                      style={{
+                        color: '#F57600',
+                        float: 'right',
+                        margin: '0.25rem 0.5rem 0 0',
+                      }}
+                      shape='warning-standard'
+                      size={24}
+                    />
+                  </TooltipTrigger>
+                )}
                 <TooltipTrigger content={<div>Export to notebook</div>}>
                   <Clickable
                     style={{ ...styles.actionIcon, ...styles.disabled }}
@@ -700,22 +717,7 @@ export const ListOverview = fp.flow(
                 ) : loading ? (
                   <Spinner size={18} />
                 ) : (
-                  <React.Fragment>
-                    {cohortSizeError && (
-                      <TooltipTrigger
-                        content={
-                          'The size of your cohort exceeds the 1MB limit. Remove some criteria selections to continue.'
-                        }
-                      >
-                        <ClrIcon
-                          style={{ color: '#F57600', marginRight: '0.25rem' }}
-                          shape='warning-standard'
-                          size={18}
-                        />
-                      </TooltipTrigger>
-                    )}
-                    <span>{this.showTotalCount && total.toLocaleString()}</span>
-                  </React.Fragment>
+                  <span>{this.showTotalCount && total.toLocaleString()}</span>
                 )}
               </h2>
             </div>


### PR DESCRIPTION
Limit size of cohorts to 1MB. If the limit is exceeded, we disable the save button and show an error icon with a tooltip
![Screen Shot 2022-08-03 at 9 34 53 PM](https://user-images.githubusercontent.com/40036095/183086912-a3759826-a64e-4529-9558-6cfb1d5b1377.png)


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
