### PR TITLE
[no ticket][risk=no] promoting index build in preprod

### DIFF
--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -131,7 +131,7 @@
       "creationTime": "2022-01-01 00:00:00Z",
       "releaseNumber": 9,
       "numParticipants": 369297,
-      "cdrDbName": "r_2022q2_5",
+      "cdrDbName": "r_2022q2_6",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "registered"
@@ -147,7 +147,7 @@
       "creationTime": "2022-01-01 00:00:00Z",
       "releaseNumber": 10,
       "numParticipants": 372397,
-      "cdrDbName": "c_2022q2_6",
+      "cdrDbName": "c_2022q2_7",
       "hasFitbitData": true,
       "hasCopeSurveyData": true,
       "accessTier": "controlled",


### PR DESCRIPTION
Promoting index build in preprod. @chenchals Please be sure the publish the RT/CT BQ datasets in preprod with the release next week:

RT
db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-preprod --bq-dataset R2022Q2R2 --tier registered --table-prefixes cb_

CT
db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-preprod --bq-dataset C2022Q2R2 --tier controlled --table-prefixes cb_
