### PR TITLE
[risk=low][RW-8705] Set OLD/MIGRATED workspaces to DELETED

### DIFF
--- a/api/db/changelog/db.changelog-203-delete-old-billing-migration-workspaces.xml
+++ b/api/db/changelog/db.changelog-203-delete-old-billing-migration-workspaces.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="thibault" id="changelog-203-delete-old-billing-migration-workspaces">
+    <!--
+      Delete the last remaining ACTIVE workspaces with BillingMigrationStatus other than 1 (NEW)
+      which designates One Project Per Workspace (1PPW) - which has been true for all new workspaces
+      created since 2019.
+
+      https://precisionmedicineinitiative.atlassian.net/browse/RW-8705
+
+      There are 31 of these in Test, and none in any other environment, according to
+      SELECT COUNT(*) FROM workspace
+      WHERE active_status = 0 /* ACTIVE */ AND billing_migration_status != 1 /* NEW */ ;
+
+      We are unable to delete these by our usual means, because the user which created them no
+      longer exists - perhaps why these were not migrated originally.  This also does not delete
+      their associated resources, but we are addressing such cases as part of a more general
+      cleanup in https://precisionmedicineinitiative.atlassian.net/browse/RW-8018
+
+
+      See also:
+
+      A previous attempt at cleanup
+      * https://github.com/all-of-us/workbench/pull/6162
+      * https://precisionmedicineinitiative.atlassian.net/browse/RW-5492
+
+      A fix for a typo in the above accidental change (changelog-190-billing-migration-bug-backfill)
+      * https://precisionmedicineinitiative.atlassian.net/browse/RW-7906
+      * https://github.com/all-of-us/workbench/pull/6336
+
+     -->
+    <sql>
+      UPDATE workspace
+        SET active_status = 1 /* DELETED */
+        WHERE active_status = 0 /* ACTIVE */ AND billing_migration_status != 1 /* NEW */ ;
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -210,6 +210,7 @@
   <include file="changelog/db.changelog-200-demographic-survey-v2-tweaks.xml"/>
   <include file="changelog/db.changelog-201-demographic-survey-v2-aian.xml"/>
   <include file="changelog/db.changelog-202-drop-user-recent-resource.xml"/>
+  <include file="changelog/db.changelog-203-delete-old-billing-migration-workspaces.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`


### PR DESCRIPTION
The presence of workspaces with the combination of (OLD BillingMigrationStatus, ACTIVE ActiveStatus) is complicating the logic of FreeTierBillingCron (see #6882, #6911, and #6922).

We had believed the migration of all ACTIVE workspaces to the NEW BillingMigrationStatus to be complete years ago, but we apparently missed a few: 31 in Test, none elsewhere.  None of these workspaces seem to be of value and they violate the assumption of 1PPW that we have relied on for a long time now.  Let's delete them.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
