### PR TITLE
[RW-8687][risk=no] Add survey submenu to CB criteria menu

### DIFF
--- a/ui/src/app/cohort-search/cohort-criteria-menu.tsx
+++ b/ui/src/app/cohort-search/cohort-criteria-menu.tsx
@@ -393,6 +393,7 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                           )
                           .map((menuItem, m) => (
                             <li
+                              key={m}
                               style={{
                                 ...styles.dropdownItem,
                                 ...(hoverId === `${index}-${m}`

--- a/ui/src/app/cohort-search/cohort-criteria-menu.tsx
+++ b/ui/src/app/cohort-search/cohort-criteria-menu.tsx
@@ -135,7 +135,7 @@ const styles = reactStyles({
     border: `1px solid ${colorWithWhiteness(colors.black, 0.8)}`,
     boxShadow: '0 1px 0.125rem hsla(0,0%,45%,.25)',
     minHeight: '1.25rem',
-    width: '10rem',
+    width: '15rem',
     borderRadius: '.125rem',
     zIndex: 103,
   },
@@ -447,7 +447,7 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                                     style={styles.subMenuIcon}
                                     className='pi pi-sort-down'
                                   />
-                                  {subMenuOpen && (
+                                  {hoverId === `${index}-${m}` && subMenuOpen && (
                                     <ul style={styles.subMenu}>
                                       {menuItem.children?.map(
                                         (subMenuItem, s) => (

--- a/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
+++ b/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
@@ -85,7 +85,7 @@ const styles = reactStyles({
 });
 
 function mapMenuItem(item: CriteriaMenu) {
-  const { category, domainId, group, id, name, sortOrder, type } = item;
+  const { category, domainId, group, id, name, parentId, sortOrder, type } = item;
   return {
     category,
     children: null,
@@ -93,6 +93,9 @@ function mapMenuItem(item: CriteriaMenu) {
     group,
     id,
     name,
+    selectedSurvey: domainId === Domain.SURVEY.toString() && parentId !== 0
+      ? name
+      : null,
     sortOrder,
     standard: domainId === Domain.VISIT.toString() ? true : null,
     type,
@@ -181,7 +184,7 @@ const SearchGroupList = fp.flow(
 
     launchSearch(criteria: any, searchTerms?: string) {
       const { role } = this.props;
-      const { domain, type, standard } = criteria;
+      const { domain, selectedSurvey, type, standard } = criteria;
       // If domain is PERSON, list the type as well as the domain in the label
       const label = `Add ${
         role === 'includes' ? 'Include' : 'Exclude'
@@ -201,6 +204,7 @@ const SearchGroupList = fp.flow(
         standard,
         role,
         groupId,
+        selectedSurvey,
       };
       this.props.setSearchContext(context);
     }

--- a/ui/src/app/cohort-search/search-group/search-group.component.tsx
+++ b/ui/src/app/cohort-search/search-group/search-group.component.tsx
@@ -413,7 +413,7 @@ export const SearchGroup = withCurrentWorkspace()(
 
     launchSearch(criteria: any, temporalGroup: number, searchTerms?: string) {
       const { group, setSearchContext, role } = this.props;
-      const { domain, type, standard } = criteria;
+      const { domain, selectedSurvey, type, standard } = criteria;
       // If domain is PERSON, list the type as well as the domain in the label
       const label = `Add ${
         role === 'includes' ? 'Include' : 'Exclude'
@@ -433,6 +433,7 @@ export const SearchGroup = withCurrentWorkspace()(
         role,
         groupId,
         temporalGroup,
+        selectedSurvey,
       };
       setSearchContext(context);
     }


### PR DESCRIPTION
Add submenu for individual surveys to the main criteria menu in cohort builder.
![Screen Shot 2022-08-09 at 2 32 24 PM](https://user-images.githubusercontent.com/40036095/183746021-77279dfa-fd7a-46fe-ae38-f27263dcde14.png)

Top option will be to show all surveys:
![Screen Shot 2022-08-09 at 2 32 45 PM](https://user-images.githubusercontent.com/40036095/183746108-003a03d5-c173-4785-8992-f2485339526f.png)

Or a single survey can be selected:
![Screen Shot 2022-08-09 at 2 32 58 PM](https://user-images.githubusercontent.com/40036095/183746178-d9a28c53-b56e-4ee5-b52e-5e68706a418e.png)

*Note: Currently will need to run `./project.rb run-local-data-migrations` and deploy local api to test the new menu

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
