### PR TITLE
[RW-8722][risk=high]  Cannot disable users who have taken the updated demographic survey

### DIFF
--- a/api/db/changelog/db.changelog-204-demographic-survey-fk-constraint.xml
+++ b/api/db/changelog/db.changelog-204-demographic-survey-fk-constraint.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
     <changeSet author="nsaxena" id="db.changelog-204-demographic-survey-fk-constraint">
-        <!-- Following FK Constraint does not have onDeletew CASCADE properties (check changelog 196) which made it difficult to update profile -->
+        <!-- Following FK Constraint does not have onDelete CASCADE properties (check changelog 196) which made it difficult to update profile -->
         <dropForeignKeyConstraint baseTableName="demographic_survey_v2_ethnic_category" constraintName="fk_demographic_survey_v2_ethnic_category"/>
         <dropForeignKeyConstraint baseTableName="demographic_survey_v2_gender_identity" constraintName="fk_demographic_survey_v2_gender_identity"/>
         <dropForeignKeyConstraint baseTableName="demographic_survey_v2_sexual_orientation" constraintName="fk_demographic_survey_v2_sexual_orientation"/>

--- a/api/db/changelog/db.changelog-204-demographic-survey-fk-constraint.xml
+++ b/api/db/changelog/db.changelog-204-demographic-survey-fk-constraint.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+    <changeSet author="nsaxena" id="db.changelog-204-demographic-survey-fk-constraint">
+        <!-- Following FK Constraint does not have onDeletew CASCADE properties (check changelog 196) which made it difficult to update profile -->
+        <dropForeignKeyConstraint baseTableName="demographic_survey_v2_ethnic_category" constraintName="fk_demographic_survey_v2_ethnic_category"/>
+        <dropForeignKeyConstraint baseTableName="demographic_survey_v2_gender_identity" constraintName="fk_demographic_survey_v2_gender_identity"/>
+        <dropForeignKeyConstraint baseTableName="demographic_survey_v2_sexual_orientation" constraintName="fk_demographic_survey_v2_sexual_orientation"/>
+
+        <addForeignKeyConstraint baseColumnNames="demographic_survey_v2_id"
+                                 baseTableName="demographic_survey_v2_ethnic_category"
+                                 constraintName="fk_demographic_survey_v2_ethnic"
+                                 referencedColumnNames="demographic_survey_v2_id"
+                                 referencedTableName="demographic_survey_v2" onDelete="CASCADE"/>
+        <addForeignKeyConstraint baseColumnNames="demographic_survey_v2_id"
+                                 baseTableName="demographic_survey_v2_gender_identity"
+                                 constraintName="fk_demographic_survey_v2_gender_identity"
+                                 referencedColumnNames="demographic_survey_v2_id"
+                                 referencedTableName="demographic_survey_v2" onDelete="CASCADE"/>
+        <addForeignKeyConstraint baseColumnNames="demographic_survey_v2_id"
+                                 baseTableName="demographic_survey_v2_sexual_orientation"
+                                 constraintName="fk_demographic_survey_v2_sexual_orientation"
+                                 referencedColumnNames="demographic_survey_v2_id"
+                                 referencedTableName="demographic_survey_v2" onDelete="CASCADE"/>                         
+    </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -211,6 +211,7 @@
   <include file="changelog/db.changelog-201-demographic-survey-v2-aian.xml"/>
   <include file="changelog/db.changelog-202-drop-user-recent-resource.xml"/>
   <include file="changelog/db.changelog-203-delete-old-billing-migration-workspaces.xml"/>
+  <include file="changelog/db.changelog-204-demographic-survey-fk-constraint.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -404,7 +404,7 @@ public class DbUser {
   }
 
   @OneToOne(
-      cascade = CascadeType.ALL,
+      cascade = CascadeType.MERGE,
       orphanRemoval = true,
       fetch = FetchType.LAZY,
       mappedBy = "user")


### PR DESCRIPTION
**Problem**:   We were not able to update user profile

**Why**: This happened because when the DbUser object was being saved, it was trying to update the already existing  DbDemographicSurveyV2 as well, which caused issues: 
_'detached entity passed to persist: org.pmiops.workbench.db.model.DbDemographicSurveyV2 '

**Solution** :
The DbUser was using CASCADE.persist to save the linked DbDemographicSurveyV2. However since the object already exist in DB, it was failing, using CASCADE.MERGE solved it as it automatically merged the DbDemographicSurveyV2 object.
(ref: https://stackoverflow.com/questions/13370221/persistentobjectexception-detached-entity-passed-to-persist-thrown-by-jpa-and-h)

- Using CASCADE.MERGE , however started showing  the following error:

_'Cannot delete demographic_survey_race' or other child tables for demographic_survey_

To solve that i updated the FK constraint of all demographic survey child tables to include onDelete= cascade

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
