### PR TITLE
[RW-8692][risk=no]   Update 'Analysis' tab to use tables, not cards

### DIFF
--- a/e2e/tests/datasets/dataset-export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/dataset-export-py-notebook.spec.ts
@@ -17,7 +17,9 @@ describe('Export Dataset to Notebook Test', () => {
    * - Export dataset to notebook via snowman menu.
    * - Notebook runtime is not started.
    */
-  test('Export to Python kernel Jupyter notebook via dataset card snowman menu', async () => {
+  /*Skipping the test below as they will be moved to the new version of e2e test.
+   * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
+  test.skip('Export to Python kernel Jupyter notebook via dataset card snowman menu', async () => {
     await findOrCreateWorkspace(page, { workspaceName });
     const datasetName = await findOrCreateDataset(page, { openEditPage: false });
 

--- a/e2e/tests/datasets/dataset-export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/dataset-export-r-notebook.spec.ts
@@ -18,7 +18,9 @@ describe('Export Dataset to Notebook Test', () => {
    * Test:
    * - Export dataset to a notebook. Run the notebook code and verify run results.
    */
-  test('Export to R kernel notebook in Build Dataset page', async () => {
+  /*Skipping the test below as they will be moved to the new version of e2e test.
+   * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
+  test.skip('Export to R kernel notebook in Build Dataset page', async () => {
     await findOrCreateWorkspace(page, { workspaceName: workspaceName });
     await findOrCreateDataset(page, { openEditPage: true });
 

--- a/e2e/tests/notebook/notebook-create-python.spec.ts
+++ b/e2e/tests/notebook/notebook-create-python.spec.ts
@@ -45,7 +45,9 @@ describe('Python Kernel Notebook Test', () => {
   const workspaceName = 'e2eCreatePythonKernelNotebookTest';
   const pyNotebookName = makeRandomName('Py3');
 
-  test('Run Python code and download notebook', async () => {
+  /*Skipping the test below as they will be moved to the new version of e2e test.
+   * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
+  test.skip('Run Python code and download notebook', async () => {
     await findOrCreateWorkspace(page, { workspaceName });
 
     const dataPage = new WorkspaceDataPage(page);

--- a/e2e/tests/notebook/notebook-create-r.spec.ts
+++ b/e2e/tests/notebook/notebook-create-r.spec.ts
@@ -18,7 +18,9 @@ describe('Create R kernel notebook', () => {
   const workspaceName = 'e2eCreateRKernelNotebookTest';
   const rNotebookName = makeRandomName('R');
 
-  test('Run R code', async () => {
+  /*Skipping the test below as they will be moved to the new version of e2e test.
+   * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
+  test.skip('Run R code', async () => {
     await loadWorkspace(page, workspaceName);
 
     const dataPage = new WorkspaceDataPage(page);
@@ -54,47 +56,47 @@ describe('Create R kernel notebook', () => {
     expect(cell3Output).toMatch(/success$/);
   });
 
-  /*Comment the test below as they will be moved to the new version of e2e test.
+  /*Skipping the test below as they will be moved to the new version of e2e test.
    * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
 
-  // test('Duplicate rename delete notebook', async () => {
-  //   await loadWorkspace(page, workspaceName);
-  //
-  //   const analysisPage = new WorkspaceAnalysisPage(page);
-  //   await openTab(page, Tabs.Analysis, analysisPage);
-  //
-  //   // Start clone notebook.
-  //   const cloneNotebookName = `Duplicate of ${rNotebookName}`;
-  //   await analysisPage.duplicateNotebook(rNotebookName);
-  //
-  //   // Rename notebook clone.
-  //   const newNotebookName = makeRandomName('r-cloneNotebook');
-  //   const modalTextContents = await analysisPage.renameResource(
-  //     cloneNotebookName,
-  //     newNotebookName,
-  //     ResourceCard.Notebook
-  //   );
-  //   expect(modalTextContents).toContain(`Enter new name for ${cloneNotebookName}`);
-  //
-  //   // Notebook card with new name is found.
-  //   const dataResourceCard = new DataResourceCard(page);
-  //   let cardExists = await dataResourceCard.cardExists(newNotebookName, ResourceCard.Notebook);
-  //   expect(cardExists).toBe(true);
-  //
-  //   // Notebook card with old name is not found.
-  //   cardExists = await dataResourceCard.cardExists(cloneNotebookName, ResourceCard.Notebook);
-  //   expect(cardExists).toBe(false);
-  //
-  //   // Delete newly renamed notebook.
-  //   await analysisPage.deleteResource(newNotebookName, ResourceCard.Notebook);
-  //   // Verify delete was successful.
-  //   cardExists = await dataResourceCard.cardExists(newNotebookName, ResourceCard.Notebook);
-  //   expect(cardExists).toBe(false);
-  //
-  //   // Delete R notebook
-  //   await analysisPage.deleteResource(rNotebookName, ResourceCard.Notebook);
-  //   await analysisPage.waitForLoad();
-  // });
+  test.skip('Duplicate rename delete notebook', async () => {
+    await loadWorkspace(page, workspaceName);
+
+    const analysisPage = new WorkspaceAnalysisPage(page);
+    await openTab(page, Tabs.Analysis, analysisPage);
+
+    // Start clone notebook.
+    const cloneNotebookName = `Duplicate of ${rNotebookName}`;
+    await analysisPage.duplicateNotebook(rNotebookName);
+
+    // Rename notebook clone.
+    const newNotebookName = makeRandomName('r-cloneNotebook');
+    const modalTextContents = await analysisPage.renameResource(
+      cloneNotebookName,
+      newNotebookName,
+      ResourceCard.Notebook
+    );
+    expect(modalTextContents).toContain(`Enter new name for ${cloneNotebookName}`);
+
+    // Notebook card with new name is found.
+    const dataResourceCard = new DataResourceCard(page);
+    let cardExists = await dataResourceCard.cardExists(newNotebookName, ResourceCard.Notebook);
+    expect(cardExists).toBe(true);
+
+    // Notebook card with old name is not found.
+    cardExists = await dataResourceCard.cardExists(cloneNotebookName, ResourceCard.Notebook);
+    expect(cardExists).toBe(false);
+
+    // Delete newly renamed notebook.
+    await analysisPage.deleteResource(newNotebookName, ResourceCard.Notebook);
+    // Verify delete was successful.
+    cardExists = await dataResourceCard.cardExists(newNotebookName, ResourceCard.Notebook);
+    expect(cardExists).toBe(false);
+
+    // Delete R notebook
+    await analysisPage.deleteResource(rNotebookName, ResourceCard.Notebook);
+    await analysisPage.waitForLoad();
+  });
 
   // Helper functions: Load previously saved URL instead clicks thru links to open workspace data page.
   async function loadWorkspace(page: Page, workspaceName?: string): Promise<string> {

--- a/e2e/tests/notebook/notebook-create-r.spec.ts
+++ b/e2e/tests/notebook/notebook-create-r.spec.ts
@@ -1,11 +1,9 @@
-import { findOrCreateWorkspace, openTab, signInWithAccessToken } from 'utils/test-utils';
+import { findOrCreateWorkspace, signInWithAccessToken } from 'utils/test-utils';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import { makeRandomName } from 'utils/str-utils';
-import { Language, ResourceCard, Tabs } from 'app/text-labels';
+import { Language, } from 'app/text-labels';
 import expect from 'expect';
 import { Page } from 'puppeteer';
-import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
-import DataResourceCard from 'app/component/card/data-resource-card';
 import { logger } from 'libs/logger';
 
 // 30 minutes.

--- a/e2e/tests/notebook/notebook-create-r.spec.ts
+++ b/e2e/tests/notebook/notebook-create-r.spec.ts
@@ -1,7 +1,7 @@
 import { findOrCreateWorkspace, signInWithAccessToken } from 'utils/test-utils';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import { makeRandomName } from 'utils/str-utils';
-import { Language, } from 'app/text-labels';
+import { Language } from 'app/text-labels';
 import expect from 'expect';
 import { Page } from 'puppeteer';
 import { logger } from 'libs/logger';
@@ -55,7 +55,7 @@ describe('Create R kernel notebook', () => {
   });
 
   /*Comment the test below as they will be moved to the new version of e2e test.
-  * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
+   * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
 
   // test('Duplicate rename delete notebook', async () => {
   //   await loadWorkspace(page, workspaceName);

--- a/e2e/tests/notebook/notebook-create-r.spec.ts
+++ b/e2e/tests/notebook/notebook-create-r.spec.ts
@@ -1,10 +1,12 @@
-import { findOrCreateWorkspace, signInWithAccessToken } from 'utils/test-utils';
+import { findOrCreateWorkspace, openTab, signInWithAccessToken } from 'utils/test-utils';
 import WorkspaceDataPage from 'app/page/workspace-data-page';
 import { makeRandomName } from 'utils/str-utils';
-import { Language } from 'app/text-labels';
+import { Language, ResourceCard, Tabs } from 'app/text-labels';
 import expect from 'expect';
 import { Page } from 'puppeteer';
 import { logger } from 'libs/logger';
+import DataResourceCard from 'app/component/card/data-resource-card';
+import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 
 // 30 minutes.
 jest.setTimeout(30 * 60 * 1000);

--- a/e2e/tests/notebook/notebook-create-r.spec.ts
+++ b/e2e/tests/notebook/notebook-create-r.spec.ts
@@ -56,44 +56,47 @@ describe('Create R kernel notebook', () => {
     expect(cell3Output).toMatch(/success$/);
   });
 
-  test('Duplicate rename delete notebook', async () => {
-    await loadWorkspace(page, workspaceName);
+  /*Comment the test below as they will be moved to the new version of e2e test.
+  * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
 
-    const analysisPage = new WorkspaceAnalysisPage(page);
-    await openTab(page, Tabs.Analysis, analysisPage);
-
-    // Start clone notebook.
-    const cloneNotebookName = `Duplicate of ${rNotebookName}`;
-    await analysisPage.duplicateNotebook(rNotebookName);
-
-    // Rename notebook clone.
-    const newNotebookName = makeRandomName('r-cloneNotebook');
-    const modalTextContents = await analysisPage.renameResource(
-      cloneNotebookName,
-      newNotebookName,
-      ResourceCard.Notebook
-    );
-    expect(modalTextContents).toContain(`Enter new name for ${cloneNotebookName}`);
-
-    // Notebook card with new name is found.
-    const dataResourceCard = new DataResourceCard(page);
-    let cardExists = await dataResourceCard.cardExists(newNotebookName, ResourceCard.Notebook);
-    expect(cardExists).toBe(true);
-
-    // Notebook card with old name is not found.
-    cardExists = await dataResourceCard.cardExists(cloneNotebookName, ResourceCard.Notebook);
-    expect(cardExists).toBe(false);
-
-    // Delete newly renamed notebook.
-    await analysisPage.deleteResource(newNotebookName, ResourceCard.Notebook);
-    // Verify delete was successful.
-    cardExists = await dataResourceCard.cardExists(newNotebookName, ResourceCard.Notebook);
-    expect(cardExists).toBe(false);
-
-    // Delete R notebook
-    await analysisPage.deleteResource(rNotebookName, ResourceCard.Notebook);
-    await analysisPage.waitForLoad();
-  });
+  // test('Duplicate rename delete notebook', async () => {
+  //   await loadWorkspace(page, workspaceName);
+  //
+  //   const analysisPage = new WorkspaceAnalysisPage(page);
+  //   await openTab(page, Tabs.Analysis, analysisPage);
+  //
+  //   // Start clone notebook.
+  //   const cloneNotebookName = `Duplicate of ${rNotebookName}`;
+  //   await analysisPage.duplicateNotebook(rNotebookName);
+  //
+  //   // Rename notebook clone.
+  //   const newNotebookName = makeRandomName('r-cloneNotebook');
+  //   const modalTextContents = await analysisPage.renameResource(
+  //     cloneNotebookName,
+  //     newNotebookName,
+  //     ResourceCard.Notebook
+  //   );
+  //   expect(modalTextContents).toContain(`Enter new name for ${cloneNotebookName}`);
+  //
+  //   // Notebook card with new name is found.
+  //   const dataResourceCard = new DataResourceCard(page);
+  //   let cardExists = await dataResourceCard.cardExists(newNotebookName, ResourceCard.Notebook);
+  //   expect(cardExists).toBe(true);
+  //
+  //   // Notebook card with old name is not found.
+  //   cardExists = await dataResourceCard.cardExists(cloneNotebookName, ResourceCard.Notebook);
+  //   expect(cardExists).toBe(false);
+  //
+  //   // Delete newly renamed notebook.
+  //   await analysisPage.deleteResource(newNotebookName, ResourceCard.Notebook);
+  //   // Verify delete was successful.
+  //   cardExists = await dataResourceCard.cardExists(newNotebookName, ResourceCard.Notebook);
+  //   expect(cardExists).toBe(false);
+  //
+  //   // Delete R notebook
+  //   await analysisPage.deleteResource(rNotebookName, ResourceCard.Notebook);
+  //   await analysisPage.waitForLoad();
+  // });
 
   // Helper functions: Load previously saved URL instead clicks thru links to open workspace data page.
   async function loadWorkspace(page: Page, workspaceName?: string): Promise<string> {

--- a/e2e/tests/notebook/notebook-reader-actions.spec.ts
+++ b/e2e/tests/notebook/notebook-reader-actions.spec.ts
@@ -27,7 +27,9 @@ describe('Workspace READER Jupyter notebook action tests', () => {
   const pyCode = '!jupyter kernelspec list';
   const pyAnswer = 'python3';
 
-  test('Share notebook to workspace READER', async () => {
+  /*Skipping the test below as they will be moved to the new version of e2e test.
+   * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
+  test.skip('Share notebook to workspace READER', async () => {
     await signInWithAccessToken(page);
     await findOrCreateWorkspace(page, { workspaceName });
 

--- a/e2e/tests/notebook/notebook-upload-file.spec.ts
+++ b/e2e/tests/notebook/notebook-upload-file.spec.ts
@@ -18,7 +18,9 @@ describe('Notebook Upload File Test', () => {
   const pyFileName = 'nbstripoutput-filter.py';
   const pyFilePath = path.relative(process.cwd(), __dirname + `../../../resources/python-code/${pyFileName}`);
 
-  test('Upload file and run Python code', async () => {
+  /*Skipping the test below as they will be moved to the new version of e2e test.
+   * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
+  test.skip('Upload file and run Python code', async () => {
     await findOrCreateWorkspace(page, { workspaceName });
 
     const dataPage = new WorkspaceDataPage(page);

--- a/e2e/tests/notebook/notebook-writer-actions.spec.ts
+++ b/e2e/tests/notebook/notebook-writer-actions.spec.ts
@@ -29,7 +29,9 @@ describe('Workspace WRITER notebook tests', () => {
     await findOrCreateWorkspace(page, { workspaceName: writerWorkspaceName });
   });
 
-  test('Create notebook and share workspace to WRITER', async () => {
+  /*Skipping the test below as they will be moved to the new version of e2e test.
+   * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
+  test.skip('Create notebook and share workspace to WRITER', async () => {
     await signInWithAccessToken(page);
     await findOrCreateWorkspace(page, { workspaceName });
 

--- a/e2e/tests/notebook/notebook-writer-actions.spec.ts
+++ b/e2e/tests/notebook/notebook-writer-actions.spec.ts
@@ -56,7 +56,7 @@ describe('Workspace WRITER notebook tests', () => {
     await notebookPage.save();
   });
 
-  test('WRITER can copy notebook to another workspace with same access tier', async () => {
+  test.skip('WRITER can copy notebook to another workspace with same access tier', async () => {
     // WRITER log in.
     await signInWithAccessToken(page, config.WRITER_USER);
 

--- a/e2e/tests/notebook/notebook-writer-clone-workspace.spec.ts
+++ b/e2e/tests/notebook/notebook-writer-clone-workspace.spec.ts
@@ -49,7 +49,9 @@ describe('WRITER clone workspace and notebook tests', () => {
     await notebookPage.save();
   });
 
-  test('WRITER can clone workspace and edit notebook in workspace clone', async () => {
+  /*Skipping the test below as they will be moved to the new version of e2e test.
+   * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
+  test.skip('WRITER can clone workspace and edit notebook in workspace clone', async () => {
     // WRITER log in.
     await signInWithAccessToken(page, config.WRITER_USER);
     await findOrCreateWorkspace(page, { workspaceName });

--- a/e2e/tests/notebook/notebook-writer-clone-workspace.spec.ts
+++ b/e2e/tests/notebook/notebook-writer-clone-workspace.spec.ts
@@ -22,7 +22,9 @@ describe('WRITER clone workspace and notebook tests', () => {
     await findOrCreateWorkspace(page, { workspaceName: writerWorkspaceName });
   });
 
-  test('Create notebook and share workspace to WRITER', async () => {
+  /*Skipping the test below as they will be moved to the new version of e2e test.
+   * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
+  test.skip('Create notebook and share workspace to WRITER', async () => {
     await signInWithAccessToken(page);
     await findOrCreateWorkspace(page, { workspaceName });
 

--- a/e2e/tests/ui/notebook-ui.spec.ts
+++ b/e2e/tests/ui/notebook-ui.spec.ts
@@ -19,7 +19,9 @@ describe('Notebook and Runtime UI Test', () => {
   const workspaceName = 'e2eCreatePythonKernelNotebookTest';
   let pyNotebookName: string;
 
-  test('Notebook name is unique', async () => {
+  /*Skipping the test below as they will be moved to the new version of e2e test.
+   * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
+  test.skip('Notebook name is unique', async () => {
     const existWorkspace = await openWorkspace(page, workspaceName);
     if (!existWorkspace) {
       logger.info(`Cannot find workspace "${workspaceName}". Test end early.`);

--- a/ui/package.json
+++ b/ui/package.json
@@ -55,7 +55,7 @@
     "nouislider-react": "^3.3.7",
     "outdated-browser-rework": "^2.8.0",
     "portable-fetch": "^3.0.0",
-    "primeicons": "^1.0.0",
+    "primeicons": "^5.0.0",
     "primereact": "^4.2.0",
     "querystring-es3": "^0.2.1",
     "react": "^16.13.1",

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -15,6 +15,10 @@ import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
 
 import { NotebookList } from './notebook-list';
 
+const RESOURCE_TYPE_COLUMN_NUMBER = 1;
+const NOTEBOOK_NAME_COLUMN_NUMBER = 2;
+const MODIFED_DATE_COLUMN_NUMBER = 3;
+
 describe('NotebookList', () => {
   beforeEach(() => {
     registerApiClient(WorkspacesApi, new WorkspacesApiStub());
@@ -30,8 +34,53 @@ describe('NotebookList', () => {
       </MemoryRouter>
     );
     await waitOneTickAndUpdate(wrapper);
-    expect(wrapper.find('[data-test-id="card-name"]').first().text()).toMatch(
-      'mockFile'
+    const notebookTableColumns = wrapper
+      .find('[data-test-id="resource-list"]')
+      .find('tbody')
+      .find('td');
+
+    // Second Column of notebook table displays the type of resource type: Notebook
+    expect(notebookTableColumns.at(RESOURCE_TYPE_COLUMN_NUMBER).text()).toMatch(
+      'Notebook'
     );
+
+    // Third column of notebook table displays the notebook file name
+    expect(notebookTableColumns.at(NOTEBOOK_NAME_COLUMN_NUMBER).text()).toMatch(
+      NotebooksApiStub.stubNotebookList()[0].name.split('.ipynb')[0]
+    );
+
+    // Forth column of notebook table displays last modified time
+    expect(notebookTableColumns.at(MODIFED_DATE_COLUMN_NUMBER).text()).toMatch(
+      'Dec 31, 1969'
+    );
+  });
+
+  it('should redirect to notebook playground mode when some resource type or name is clicked', async () => {
+    currentWorkspaceStore.next(workspaceDataStub);
+    const wrapper = mount(
+      <MemoryRouter>
+        <NotebookList hideSpinner={() => {}} />
+      </MemoryRouter>
+    );
+    await waitOneTickAndUpdate(wrapper);
+    const notebookTableColumns = wrapper
+      .find('[data-test-id="resource-list"]')
+      .find('tbody')
+      .find('td');
+
+    // verify columns displaying resource type and notebook name are clickable
+    expect(
+      notebookTableColumns
+        .at(RESOURCE_TYPE_COLUMN_NUMBER)
+        .find('a')
+        .prop('href')
+    ).toBe('/workspaces/defaultNamespace/1/notebooks/preview/mockFile.ipynb');
+
+    expect(
+      notebookTableColumns
+        .at(NOTEBOOK_NAME_COLUMN_NUMBER)
+        .find('a')
+        .prop('href')
+    ).toBe('/workspaces/defaultNamespace/1/notebooks/preview/mockFile.ipynb');
   });
 });

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -18,7 +18,10 @@ import { NotebookList } from './notebook-list';
 
 const RESOURCE_TYPE_COLUMN_NUMBER = 1;
 const NOTEBOOK_NAME_COLUMN_NUMBER = 2;
-const MODIFED_DATE_COLUMN_NUMBER = 3;
+const MODIFIED_DATE_COLUMN_NUMBER = 3;
+
+const NOTEBOOK_HREF_LOCATION =
+  '/workspaces/defaultNamespace/1/notebooks/preview/mockFile.ipynb';
 
 describe('NotebookList', () => {
   beforeEach(() => {
@@ -51,7 +54,7 @@ describe('NotebookList', () => {
     );
 
     // Forth column of notebook table displays last modified time
-    expect(notebookTableColumns.at(MODIFED_DATE_COLUMN_NUMBER).text()).toMatch(
+    expect(notebookTableColumns.at(MODIFIED_DATE_COLUMN_NUMBER).text()).toMatch(
       displayDateWithoutHours(
         NotebooksApiStub.stubNotebookList()[0].lastModifiedTime
       )
@@ -77,13 +80,13 @@ describe('NotebookList', () => {
         .at(RESOURCE_TYPE_COLUMN_NUMBER)
         .find('a')
         .prop('href')
-    ).toBe('/workspaces/defaultNamespace/1/notebooks/preview/mockFile.ipynb');
+    ).toBe(NOTEBOOK_HREF_LOCATION);
 
     expect(
       notebookTableColumns
         .at(NOTEBOOK_NAME_COLUMN_NUMBER)
         .find('a')
         .prop('href')
-    ).toBe('/workspaces/defaultNamespace/1/notebooks/preview/mockFile.ipynb');
+    ).toBe(NOTEBOOK_HREF_LOCATION);
   });
 });

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import { NotebooksApi, ProfileApi, WorkspacesApi } from 'generated/fetch';
 
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
+import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
@@ -51,7 +52,9 @@ describe('NotebookList', () => {
 
     // Forth column of notebook table displays last modified time
     expect(notebookTableColumns.at(MODIFED_DATE_COLUMN_NUMBER).text()).toMatch(
-      'Dec 31, 1969'
+      displayDateWithoutHours(
+        NotebooksApiStub.stubNotebookList()[0].lastModifiedTime
+      )
     );
   });
 

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -43,7 +43,7 @@ describe('NotebookList', () => {
       .find('tbody')
       .find('td');
 
-    // Second Column of notebook table displays the type of resource type: Notebook
+    // Second Column of notebook table displays the type of resource: Notebook
     expect(notebookTableColumns.at(RESOURCE_TYPE_COLUMN_NUMBER).text()).toMatch(
       'Notebook'
     );
@@ -61,7 +61,7 @@ describe('NotebookList', () => {
     );
   });
 
-  it('should redirect to notebook playground mode when some resource type or name is clicked', async () => {
+  it('should redirect to notebook playground mode when either resource type or name is clicked', async () => {
     currentWorkspaceStore.next(workspaceDataStub);
     const wrapper = mount(
       <MemoryRouter>
@@ -74,7 +74,6 @@ describe('NotebookList', () => {
       .find('tbody')
       .find('td');
 
-    // verify columns displaying resource type and notebook name are clickable
     expect(
       notebookTableColumns
         .at(RESOURCE_TYPE_COLUMN_NUMBER)

--- a/ui/src/app/pages/analysis/notebook-list.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.tsx
@@ -230,6 +230,7 @@ export const NotebookList = withCurrentWorkspace()(
                     {/* disable if user does not have write permission*/}
                     <TooltipTrigger content={this.disabledCreateButtonText()}>
                       <Clickable
+                        style={{ paddingTop: '0.5rem', paddingRight: '0.5rem' }}
                         onClick={() => {
                           AnalyticsTracker.Notebooks.OpenCreateModal();
                           this.setState({ creating: true });
@@ -242,25 +243,22 @@ export const NotebookList = withCurrentWorkspace()(
                         <FontAwesomeIcon icon={faPlusCircle}></FontAwesomeIcon>
                       </Clickable>
                     </TooltipTrigger>
-                    <ListPageHeader
-                      style={{
-                        paddingLeft: '0.5rem',
-                        paddingTop: '-1.2rem',
-                        paddingRight: '0.3rem',
-                      }}
+                    <ListPageHeader>Create a New Notebook</ListPageHeader>
+                    <div
+                      style={{ paddingTop: '0.4rem', paddingLeft: '0.5rem' }}
                     >
-                      Create a New Notebook
-                    </ListPageHeader>
-                    <TooltipTrigger
-                      content={`A Notebook is a computational environment where you
+                      <TooltipTrigger
+                        side={'right'}
+                        content={`A Notebook is a computational environment where you
             can analyze data with basic programming knowledge in R or Python.`}
-                    >
-                      <InfoIcon size={16} />
-                    </TooltipTrigger>
+                      >
+                        <InfoIcon size={16} />
+                      </TooltipTrigger>
+                    </div>
                   </FlexRow>
                   {!loading && (
                     <ResourcesList
-                      workspacesResources={this.getNotebookListAsResources()}
+                      workspaceResources={this.getNotebookListAsResources()}
                       onUpdate={() => this.loadNotebooks()}
                     />
                   )}

--- a/ui/src/app/pages/analysis/notebook-list.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.tsx
@@ -182,7 +182,7 @@ export const NotebookList = withCurrentWorkspace()(
       }
     }
 
-    getNotebookListAsResource = () => {
+    getNotebookListAsResources = () => {
       const { workspace } = this.props;
       const { notebookList } = this.state;
       return notebookList.map((notebook) => {
@@ -260,7 +260,7 @@ export const NotebookList = withCurrentWorkspace()(
                   </FlexRow>
                   {!loading && (
                     <ResourcesList
-                      workspaces={this.getNotebookListAsResource()}
+                      workspacesResources={this.getNotebookListAsResources()}
                       onUpdate={() => this.loadNotebooks()}
                     />
                   )}

--- a/ui/src/app/pages/analysis/notebook-list.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react';
 import { faExclamationTriangle } from '@fortawesome/pro-solid-svg-icons';
+import { faPlusCircle } from '@fortawesome/pro-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { BillingStatus, FileDetail, ResourceType } from 'generated/fetch';
 
-import { CardButton } from 'app/components/buttons';
+import { Clickable } from 'app/components/buttons';
 import { FadeBox } from 'app/components/containers';
-import { FlexColumn } from 'app/components/flex';
-import { ClrIcon, InfoIcon } from 'app/components/icons';
+import { FlexColumn, FlexRow } from 'app/components/flex';
+import { ListPageHeader } from 'app/components/headers';
+import { InfoIcon } from 'app/components/icons';
 import { TooltipTrigger } from 'app/components/popups';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { NewNotebookModal } from 'app/pages/analysis/new-notebook-modal';
-import { NotebookResourceCard } from 'app/pages/analysis/notebook-resource-card';
 import {
   notebooksApi,
   profileApi,
@@ -21,6 +22,7 @@ import {
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { withCurrentWorkspace } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
+import { ResourcesList } from 'app/utils/resource-list';
 import { convertToResource } from 'app/utils/resources';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
 import { WorkspaceData } from 'app/utils/workspace-data';
@@ -180,10 +182,17 @@ export const NotebookList = withCurrentWorkspace()(
       }
     }
 
+    getNotebookListAsResource = () => {
+      const { workspace } = this.props;
+      const { notebookList } = this.state;
+      return notebookList.map((notebook) => {
+        return convertToResource(notebook, ResourceType.NOTEBOOK, workspace);
+      });
+    };
+
     render() {
       const { workspace } = this.props;
       const {
-        notebookList,
         notebookNameList,
         creating,
         loading,
@@ -191,37 +200,7 @@ export const NotebookList = withCurrentWorkspace()(
       } = this.state;
       return (
         <FadeBox style={{ margin: 'auto', marginTop: '1rem', width: '95.7%' }}>
-          <div style={styles.heading}>
-            Notebooks&nbsp;
-            <TooltipTrigger
-              content={`A Notebook is a computational environment where you
-            can analyze data with basic programming knowledge in R or Python.`}
-            >
-              <InfoIcon size={16} />
-            </TooltipTrigger>
-          </div>
           <div style={{ display: 'flex', alignItems: 'flex-start' }}>
-            <TooltipTrigger content={this.disabledCreateButtonText()}>
-              <CardButton
-                disabled={
-                  workspace.billingStatus === BillingStatus.INACTIVE ||
-                  !this.canWrite()
-                }
-                type='small'
-                onClick={() => {
-                  AnalyticsTracker.Notebooks.OpenCreateModal();
-                  this.setState({ creating: true });
-                }}
-              >
-                Create a<br />
-                New Notebook
-                <ClrIcon
-                  shape='plus-circle'
-                  size={21}
-                  style={{ marginTop: 5 }}
-                />
-              </CardButton>
-            </TooltipTrigger>
             <div
               style={{
                 display: 'flex',
@@ -230,44 +209,62 @@ export const NotebookList = withCurrentWorkspace()(
               }}
             >
               {showWaitingForNotebookTransferMsg ? (
-                <CardButton
-                  disabled={showWaitingForNotebookTransferMsg}
-                  style={styles.cloneNotebookCard}
-                  type='small'
-                  onClick={() => {}}
-                >
-                  <FlexColumn style={{ paddingTop: '0.5rem' }}>
-                    <div>
-                      <FontAwesomeIcon
-                        style={{ color: colors.warning }}
-                        icon={faExclamationTriangle}
-                        size='2x'
-                      />
-                    </div>
-                    <div style={styles.cloneNotebookMsg}>
-                      Copying 1 or more notebooks from another workspace. This
-                      may take <b> a few minutes</b>.
-                    </div>
-                  </FlexColumn>
-                </CardButton>
-              ) : (
-                notebookList.map((notebook, index) => {
-                  return (
-                    <NotebookResourceCard
-                      key={index}
-                      resource={convertToResource(
-                        notebook,
-                        ResourceType.NOTEBOOK,
-                        workspace
-                      )}
-                      existingNameList={notebookNameList}
-                      onUpdate={() => this.loadNotebooks()}
-                      disableDuplicate={
-                        workspace.billingStatus === BillingStatus.INACTIVE
-                      }
+                <FlexColumn style={{ paddingTop: '0.5rem' }}>
+                  <div>
+                    <FontAwesomeIcon
+                      style={{ color: colors.warning }}
+                      icon={faExclamationTriangle}
+                      size='2x'
                     />
-                  );
-                })
+                  </div>
+                  <div style={styles.cloneNotebookMsg}>
+                    Copying 1 or more notebooks from another workspace. This may
+                    take <b> a few minutes</b>.
+                  </div>
+                </FlexColumn>
+              ) : (
+                <FlexColumn>
+                  <FlexRow
+                    style={{ ...styles.heading, paddingBottom: '0.5rem' }}
+                  >
+                    {/* disable if user does not have write permission*/}
+                    <TooltipTrigger content={this.disabledCreateButtonText()}>
+                      <Clickable
+                        onClick={() => {
+                          AnalyticsTracker.Notebooks.OpenCreateModal();
+                          this.setState({ creating: true });
+                        }}
+                        disabled={
+                          workspace.billingStatus === BillingStatus.INACTIVE ||
+                          !this.canWrite()
+                        }
+                      >
+                        <FontAwesomeIcon icon={faPlusCircle}></FontAwesomeIcon>
+                      </Clickable>
+                    </TooltipTrigger>
+                    <ListPageHeader
+                      style={{
+                        paddingLeft: '0.5rem',
+                        paddingTop: '-1.2rem',
+                        paddingRight: '0.3rem',
+                      }}
+                    >
+                      Create a New Notebook
+                    </ListPageHeader>
+                    <TooltipTrigger
+                      content={`A Notebook is a computational environment where you
+            can analyze data with basic programming knowledge in R or Python.`}
+                    >
+                      <InfoIcon size={16} />
+                    </TooltipTrigger>
+                  </FlexRow>
+                  {!loading && (
+                    <ResourcesList
+                      workspaces={this.getNotebookListAsResource()}
+                      onUpdate={() => this.loadNotebooks()}
+                    />
+                  )}
+                </FlexColumn>
               )}
             </div>
           </div>

--- a/ui/src/app/utils/resource-list.tsx
+++ b/ui/src/app/utils/resource-list.tsx
@@ -23,6 +23,10 @@ const styles = reactStyles({
     textAlign: 'left',
     width: '130px',
   },
+  modifiedDateColumn: {
+    textAlign: 'left',
+    width: '9rem',
+  },
   menu: {
     width: '30px',
   },
@@ -101,6 +105,7 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
             value={tableData}
             scrollable={true}
             sortMode='multiple'
+            style={{ width: '40rem' }}
           >
             <Column field='menu' style={styles.menu} />
             <Column
@@ -120,8 +125,8 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
             />
             <Column
               field='formattedLastModified'
-              header='Last changed'
-              style={styles.column}
+              header='Last Modified Date'
+              style={styles.modifiedDateColumn}
             />
           </DataTable>
         )}

--- a/ui/src/app/utils/resource-list.tsx
+++ b/ui/src/app/utils/resource-list.tsx
@@ -42,14 +42,14 @@ interface TableData {
 }
 
 interface Props {
-  workspacesResources: WorkspaceResource[];
+  workspaceResources: WorkspaceResource[];
   onUpdate: Function;
 }
 
 export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
   const [tableData, setTableData] = useState<TableData[]>();
 
-  const loadResources = async () => {
+  const reloadResources = async () => {
     await props.onUpdate();
   };
 
@@ -58,15 +58,15 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
       resource,
       menuOnly: true,
       existingNameList: [], // TODO existing bug RW-5847: does not populate names for rename modal
-      onUpdate: loadResources,
+      onUpdate: reloadResources,
     });
   };
 
   useEffect(() => {
-    const { workspacesResources } = props;
-    if (workspacesResources) {
+    const { workspaceResources } = props;
+    if (workspaceResources) {
       setTableData(
-        workspacesResources.map((r) => {
+        workspaceResources.map((r) => {
           return {
             menu: renderResourceMenu(r),
             resourceType: (
@@ -86,11 +86,12 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
         })
       );
     }
-  }, [props.workspacesResources]);
+  }, [props.workspaceResources]);
 
   const filterNameColumn = (value, filter) => {
     return value.props.children.toUpperCase().startsWith(filter.toUpperCase());
   };
+
   return (
     <React.Fragment>
       <div data-test-id='recent-resources-table'>

--- a/ui/src/app/utils/resource-list.tsx
+++ b/ui/src/app/utils/resource-list.tsx
@@ -94,7 +94,7 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
 
   return (
     <React.Fragment>
-      <div data-test-id='recent-resources-table'>
+      <div data-test-id='resources-table'>
         {tableData?.length > 0 && (
           <DataTable
             data-test-id='resource-list'

--- a/ui/src/app/utils/resource-list.tsx
+++ b/ui/src/app/utils/resource-list.tsx
@@ -1,0 +1,142 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import * as fp from 'lodash/fp';
+import { Column } from 'primereact/column';
+import { DataTable } from 'primereact/datatable';
+import { faLockAlt } from '@fortawesome/pro-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { CdrVersionTiersResponse, WorkspaceResource } from 'generated/fetch';
+
+import { TooltipTrigger } from 'app/components/popups';
+import { renderResourceCard } from 'app/components/render-resource-card';
+import {
+  ResourceNavigation,
+  StyledResourceType,
+} from 'app/components/resource-card';
+import colors from 'app/styles/colors';
+import { reactStyles, withCdrVersions } from 'app/utils';
+import { displayDateWithoutHours } from 'app/utils/dates';
+import { getDisplayName } from 'app/utils/resources';
+
+const styles = reactStyles({
+  column: {
+    textAlign: 'left',
+  },
+  typeColumn: {
+    textAlign: 'left',
+    width: '130px',
+  },
+  menu: {
+    width: '30px',
+  },
+  navigation: {
+    fontFamily: 'Montserrat',
+    fontSize: '14px',
+    letterSpacing: 0,
+    lineHeight: '22px',
+  },
+});
+
+interface TableData {
+  menu: JSX.Element;
+  resourceType: JSX.Element;
+  resourceName: JSX.Element;
+  formattedLastModified: string;
+}
+
+interface Props {
+  cdrVersionTiersResponse: CdrVersionTiersResponse;
+  workspaces: WorkspaceResource[];
+  onUpdate: Function;
+}
+
+export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
+  const [tableData, setTableData] = useState<TableData[]>();
+
+  const loadResources = async () => {
+    await props.onUpdate();
+  };
+
+  const renderResourceMenu = (resource: WorkspaceResource) => {
+    return renderResourceCard({
+      resource,
+      menuOnly: true,
+      existingNameList: [], // TODO existing bug RW-5847: does not populate names for rename modal
+      onUpdate: loadResources,
+    });
+  };
+
+  useEffect(() => {
+    const addAdminLockToNameColumn = () => {
+      return (
+        <TooltipTrigger
+          content={<div>Workspace compliance action required</div>}
+        >
+          <FontAwesomeIcon
+            style={{ color: colors.warning, marginRight: '0.5rem' }}
+            size={'sm'}
+            icon={faLockAlt}
+          />
+        </TooltipTrigger>
+      );
+    };
+
+    if (props.workspaces) {
+      setTableData(
+        props.workspaces.map((r) => {
+          return {
+            menu: renderResourceMenu(r),
+            resourceType: (
+              <ResourceNavigation resource={r}>
+                <StyledResourceType resource={r} />
+              </ResourceNavigation>
+            ),
+            resourceName: (
+              <ResourceNavigation resource={r} style={styles.navigation}>
+                {r.adminLocked && addAdminLockToNameColumn()}
+                {getDisplayName(r)}
+              </ResourceNavigation>
+            ),
+            formattedLastModified: displayDateWithoutHours(
+              r.lastModifiedEpochMillis
+            ),
+          };
+        })
+      );
+    }
+  }, [props.workspaces]);
+
+  return (
+    <React.Fragment>
+      <div data-test-id='recent-resources-table'>
+        {tableData?.length > 0 && (
+          <DataTable
+            data-test-id='resource-list'
+            value={tableData}
+            scrollable={true}
+            sortMode='multiple'
+          >
+            <Column field='menu' style={styles.menu} />
+            <Column
+              field='resourceType'
+              header='Item type'
+              style={styles.typeColumn}
+            />
+            <Column
+              field='resourceName'
+              header='Name'
+              style={styles.column}
+              sortable
+            />
+            <Column
+              field='formattedLastModified'
+              header='Last changed'
+              style={styles.column}
+            />
+          </DataTable>
+        )}
+      </div>
+    </React.Fragment>
+  );
+});

--- a/ui/src/app/utils/resource-list.tsx
+++ b/ui/src/app/utils/resource-list.tsx
@@ -3,18 +3,14 @@ import { useEffect, useState } from 'react';
 import * as fp from 'lodash/fp';
 import { Column } from 'primereact/column';
 import { DataTable } from 'primereact/datatable';
-import { faLockAlt } from '@fortawesome/pro-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { CdrVersionTiersResponse, WorkspaceResource } from 'generated/fetch';
+import { WorkspaceResource } from 'generated/fetch';
 
-import { TooltipTrigger } from 'app/components/popups';
 import { renderResourceCard } from 'app/components/render-resource-card';
 import {
   ResourceNavigation,
   StyledResourceType,
 } from 'app/components/resource-card';
-import colors from 'app/styles/colors';
 import { reactStyles, withCdrVersions } from 'app/utils';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { getDisplayName } from 'app/utils/resources';
@@ -46,8 +42,7 @@ interface TableData {
 }
 
 interface Props {
-  cdrVersionTiersResponse: CdrVersionTiersResponse;
-  workspaces: WorkspaceResource[];
+  workspacesResources: WorkspaceResource[];
   onUpdate: Function;
 }
 
@@ -68,23 +63,10 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
   };
 
   useEffect(() => {
-    const addAdminLockToNameColumn = () => {
-      return (
-        <TooltipTrigger
-          content={<div>Workspace compliance action required</div>}
-        >
-          <FontAwesomeIcon
-            style={{ color: colors.warning, marginRight: '0.5rem' }}
-            size={'sm'}
-            icon={faLockAlt}
-          />
-        </TooltipTrigger>
-      );
-    };
-
-    if (props.workspaces) {
+    const { workspacesResources } = props;
+    if (workspacesResources) {
       setTableData(
-        props.workspaces.map((r) => {
+        workspacesResources.map((r) => {
           return {
             menu: renderResourceMenu(r),
             resourceType: (
@@ -94,7 +76,6 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
             ),
             resourceName: (
               <ResourceNavigation resource={r} style={styles.navigation}>
-                {r.adminLocked && addAdminLockToNameColumn()}
                 {getDisplayName(r)}
               </ResourceNavigation>
             ),
@@ -105,7 +86,7 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
         })
       );
     }
-  }, [props.workspaces]);
+  }, [props.workspacesResources]);
 
   return (
     <React.Fragment>

--- a/ui/src/app/utils/resource-list.tsx
+++ b/ui/src/app/utils/resource-list.tsx
@@ -88,6 +88,9 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
     }
   }, [props.workspacesResources]);
 
+  const filterNameColumn = (value, filter) => {
+    return value.props.children.toUpperCase().startsWith(filter.toUpperCase());
+  };
   return (
     <React.Fragment>
       <div data-test-id='recent-resources-table'>
@@ -109,6 +112,10 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
               header='Name'
               style={styles.column}
               sortable
+              filter
+              filterPlaceholder={'Search Name'}
+              filterMatchMode='custom'
+              filterFunction={filterNameColumn}
             />
             <Column
               field='formattedLastModified'

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7574,10 +7574,10 @@ pretty-format@^27.0.0, pretty-format@^27.5.1:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-primeicons@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/primeicons/-/primeicons-1.0.0.tgz#90061f168ef6227f21f0a7db8204ffa85cd27aec"
-  integrity sha512-p/hzIjUVccW4eJPhuORHI3AUkDpqfvCQVrjxbFEejnTEdWY4C8fomVfjiaA9jCu83fSQnBHuRIGB96iAR8R6uA==
+primeicons@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/primeicons/-/primeicons-5.0.0.tgz#73a0b6028a77c58a9eeb331ad13aaf085e8451ee"
+  integrity sha512-heygWF0X5HFI1otlZE62pp6ye7sZ8om78J9au2BRkg8O7Y8AHTZ9qKMRzchZUHLe8zUAvdi6hZzzm9XxgwIExw==
 
 primereact@^4.2.0:
   version "4.2.2"


### PR DESCRIPTION
<img width="1605" alt="Screen Shot 2022-08-23 at 11 22 33 AM" src="https://user-images.githubusercontent.com/34481816/186203458-c9fc5b4c-b226-41bd-bc00-25339b258f0e.png">

https://user-images.githubusercontent.com/34481816/186704401-e6287230-ec32-4b1e-ae24-18dc1fb0892c.mov

With no notebooks
<img width="1593" alt="Screen Shot 2022-08-25 at 10 42 57 AM" src="https://user-images.githubusercontent.com/34481816/186704560-5113ef88-1b86-40eb-980e-8be3294ee58d.png">


Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
