### PR TITLE
[RW-8758][risk=low]  Puppeteer test failing due to Researcher Demographic Survey

### DIFF
--- a/ui/src/app/pages/signed-in/signed-in.tsx
+++ b/ui/src/app/pages/signed-in/signed-in.tsx
@@ -123,6 +123,8 @@ export const SignedIn = (spinnerProps: WithSpinnerOverlayProps) => {
 
   const { enableUpdatedDemographicSurvey } = serverConfigStore.get().config;
 
+  const {enableDemographicSurveyV2Redirect} = environment;
+
   // DEMOGRAPHIC_SURVEY_SESSION_KEY is set in session when the user selects Maybe Later Button on
   // Demographic Survey Page and is cleared out on signOut.
   // So, if this key exist, it means user should not be redirected to demographic survey page.
@@ -159,6 +161,7 @@ export const SignedIn = (spinnerProps: WithSpinnerOverlayProps) => {
               }
             >
               {enableUpdatedDemographicSurvey &&
+              enableDemographicSurveyV2Redirect &&
               pastSurveyDueDate &&
               !profileState.profile.demographicSurveyV2 &&
               !hasDismissedDemographicSurvey ? (

--- a/ui/src/app/pages/signed-in/signed-in.tsx
+++ b/ui/src/app/pages/signed-in/signed-in.tsx
@@ -123,7 +123,7 @@ export const SignedIn = (spinnerProps: WithSpinnerOverlayProps) => {
 
   const { enableUpdatedDemographicSurvey } = serverConfigStore.get().config;
 
-  const {enableDemographicSurveyV2Redirect} = environment;
+  const { enableDemographicSurveyV2Redirect } = environment;
 
   // DEMOGRAPHIC_SURVEY_SESSION_KEY is set in session when the user selects Maybe Later Button on
   // Demographic Survey Page and is cleared out on signOut.

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -58,6 +58,8 @@ export interface EnvironmentBase {
   captchaSiteKey: string;
   // Enable workbench footer on the signed in pages
   enableFooter: boolean;
+  // Enable redirect to v2 demographic survey if not submitted by user
+  enableDemographicSurveyV2Redirect: boolean;
 
   // WARNING: Please think *very* carefully before adding a new environment flag here! Instead
   // of this file, prefer storing feature flags in the server-side WorkbenchConfig and passing them

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -23,4 +23,5 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
+  enableDemographicSurveyV2Redirect: false,
 };

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -22,4 +22,5 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
+  enableDemographicSurveyV2Redirect: false,
 };

--- a/ui/src/environments/environment.preprod.ts
+++ b/ui/src/environments/environment.preprod.ts
@@ -21,4 +21,5 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
+  enableDemographicSurveyV2Redirect: true,
 };

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -21,4 +21,5 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
+  enableDemographicSurveyV2Redirect: true,
 };

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -21,4 +21,5 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
+  enableDemographicSurveyV2Redirect: false,
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -21,4 +21,5 @@ export const environment: Environment = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
+  enableDemographicSurveyV2Redirect: false,
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -25,4 +25,5 @@ export const testEnvironmentBase: EnvironmentBase = {
   enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
+  enableDemographicSurveyV2Redirect: false,
 };


### PR DESCRIPTION
… and prod

We have a lot of test failures just because all the users are being redirected to demographic survey page. As per a conversation with Moira, i have disabled the redirect on all environments except PRe prod and prod for now


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
