### PR TITLE
[RW-8766][risk=no] Disable submenu for universal search results

### DIFF
--- a/ui/src/app/cohort-search/cohort-criteria-menu.tsx
+++ b/ui/src/app/cohort-search/cohort-criteria-menu.tsx
@@ -229,14 +229,14 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
     };
 
     const categoryHasResults = (index: number) => {
-      return (
-        domainCounts === null ||
-        domainCounts.some((domainCount) =>
-          menuOptions[index].some(
-            (menuOption) => domainCount.domain === menuOption.domain
-          )
+      return domainCounts?.some((domainCount) =>
+        menuOptions[index].some(
+          (menuOption) => domainCount.domain === menuOption.domain
         )
       );
+    };
+    const showMenuItem = (index: number) => {
+      return domainCounts === null || categoryHasResults(index);
     };
 
     const closeAndClearMenu = () => {
@@ -373,7 +373,7 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                     )
                     .map((category, index) => (
                       <ul key={index}>
-                        {categoryHasResults(index) && (
+                        {showMenuItem(index) && (
                           <li
                             style={styles.dropdownHeader}
                             className='menuitem-header'
@@ -424,7 +424,10 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                                 key={m}
                                 style={styles.dropdownLink}
                                 onClick={() => {
-                                  if (!menuItem.group) {
+                                  if (
+                                    !menuItem.group ||
+                                    categoryHasResults(index)
+                                  ) {
                                     onMenuItemClick(menuItem);
                                   }
                                 }}
@@ -442,7 +445,7 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                                   </span>
                                 )}
                               </a>
-                              {menuItem.group && (
+                              {menuItem.group && !categoryHasResults(index) && (
                                 <React.Fragment>
                                   <i
                                     style={styles.subMenuIcon}


### PR DESCRIPTION
Prevents the submenu from rendering when there are search results for that item:

https://user-images.githubusercontent.com/40036095/186523673-38d34a3e-107d-4d2a-9932-05272893eb16.mov

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
