### PR TITLE
[risk=no][RW-8701] fix nightly tests broken due to FontAwesome change

### DIFF
--- a/e2e/app/component/bypass-modules.ts
+++ b/e2e/app/component/bypass-modules.ts
@@ -75,15 +75,9 @@ export default class BypassPopup extends BaseMenu {
     }
   }
 
-  // click the checkmark on the bypass-popup to save the bypass access
-  async clickCheckmarkBypass(): Promise<void> {
-    const xpath = `${this.getXpath()}//*[local-name()='svg' and @data-icon='check']`;
-    await new Checkbox(this.page, xpath).click();
-  }
-
   // click the cancel icon to close the bypass-popup
   async clickCancelBypass(): Promise<void> {
-    const xpath = `${this.getXpath()}//*[local-name()='svg' and @data-icon='times']`;
+    const xpath = `${this.getXpath()}//*[local-name()='svg' and @data-icon='xmark']`;
     await new Checkbox(this.page, xpath).click();
   }
 }

--- a/e2e/app/page/data-access/module.ts
+++ b/e2e/app/page/data-access/module.ts
@@ -20,7 +20,7 @@ export default class Module extends Container {
   }
 
   async getCheckIcon(): Promise<ElementHandle> {
-    return this.page.waitForXPath(`${this.rootXpath}//*[local-name()="svg" and @data-icon="check-circle"]`, {
+    return this.page.waitForXPath(`${this.rootXpath}//*[local-name()="svg" and @data-icon="circle-check"]`, {
       visible: true
     });
   }

--- a/e2e/app/sidebar/genomic-extractions-sidebar.ts
+++ b/e2e/app/sidebar/genomic-extractions-sidebar.ts
@@ -62,7 +62,7 @@ export default class GenomicExtractionsSidebar extends BaseSidebar {
 
   private async getStatusSuccessXpath(datasetName: string): Promise<string> {
     const statusCell = await this.getStatusCell(datasetName);
-    return statusCell.getXpath() + '/*[.//*[@data-icon="check-circle" and @role="img"]]';
+    return statusCell.getXpath() + '/*[.//*[@data-icon="circle-check" and @role="img"]]';
   }
 
   private async getStatusCell(datasetName: string): Promise<Cell> {


### PR DESCRIPTION
Tested locally by running `yarn test-nightly tests/nightly/admin/user-admin-table.spec.ts` with an `.env` file configured for the Test environment

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
