### PR TITLE
[risk=no][RW-8788] Fix nightly tests broken due to create-new-notebook xpath change

### DIFF
--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -1,8 +1,7 @@
 import CopyToWorkspaceModal from 'app/modal/copy-to-workspace-modal';
 import DataResourceCard from 'app/component/card/data-resource-card';
 import NewNotebookModal from 'app/modal/new-notebook-modal';
-import Link from 'app/element/link';
-import { Language, LinkText, MenuOption, ResourceCard } from 'app/text-labels';
+import { Language, MenuOption, ResourceCard } from 'app/text-labels';
 import { Page } from 'puppeteer';
 import { getPropValue } from 'utils/element-utils';
 import { waitForDocumentTitle, waitWhileLoading } from 'utils/waits-utils';
@@ -10,6 +9,7 @@ import NotebookPage from './notebook-page';
 import WorkspaceBase from './workspace-base';
 import { initializeRuntimeIfModalPresented } from 'utils/runtime-utils';
 import { logger } from 'libs/logger';
+import Link from 'app/element/link';
 
 const PageTitle = 'View Notebooks';
 
@@ -100,7 +100,8 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
   }
 
   createNewNotebookLink(): Link {
-    return Link.findByName(this.page, { normalizeSpace: LinkText.CreateNewNotebook });
+    const xpath = '//*[local-name()="svg" and @data-icon="circle-plus"]';
+    return new Link(this.page, xpath);
   }
 
   /**

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -1,6 +1,7 @@
 import CopyToWorkspaceModal from 'app/modal/copy-to-workspace-modal';
 import DataResourceCard from 'app/component/card/data-resource-card';
 import NewNotebookModal from 'app/modal/new-notebook-modal';
+import Link from 'app/element/link';
 import { Language, MenuOption, ResourceCard } from 'app/text-labels';
 import { Page } from 'puppeteer';
 import { getPropValue } from 'utils/element-utils';
@@ -9,7 +10,6 @@ import NotebookPage from './notebook-page';
 import WorkspaceBase from './workspace-base';
 import { initializeRuntimeIfModalPresented } from 'utils/runtime-utils';
 import { logger } from 'libs/logger';
-import Link from 'app/element/link';
 
 const PageTitle = 'View Notebooks';
 

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -80,7 +80,6 @@ export enum LinkText {
   CreateAnotherConceptSet = 'Create another Concept Set',
   CreateCohort = 'Create Cohort',
   CreateDataset = 'Create a Dataset',
-  CreateNewNotebook = 'New Notebook',
   CreateNewWorkspace = 'Create a New Workspace',
   CreateNotebook = 'Create Notebook',
   CreateReviewSets = 'Create Review Sets',
@@ -101,7 +100,6 @@ export enum LinkText {
   Edit = 'Edit',
   Export = 'Export',
   ExtractAndContinue = 'Extract & Continue',
-  Finish = 'Finish',
   FinishAndReview = 'Finish & Review',
   GetStarted = 'Get Started',
   GoToCopiedConceptSet = 'Go to Copied Concept Set',
@@ -130,7 +128,6 @@ export enum LinkText {
   SeeCodePreview = 'See Code Preview',
   StayHere = 'Stay Here',
   Submit = 'Submit',
-  Update = 'Update',
   Yes = 'Yes',
   YesDelete = 'YES, DELETE',
   YesLeave = 'Yes, Leave'


### PR DESCRIPTION
Tested locally by running `yarn test-nightly tests/nightly/admin/lock-workspace.spec.ts` with an `.env` file configured for the Test environment

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
