### PR TITLE
[DO NOT MERGE] run the nightly tests on this PR inistead of the usual workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -787,7 +787,6 @@ jobs:
 workflows:
   build-test-deploy:
    jobs:
-     - api-bigquery-test
      - puppeteer-env-setup
      - puppeteer-generate-access-tokens:
           env_name: "test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -786,44 +786,18 @@ jobs:
 
 workflows:
   build-test-deploy:
-    jobs:
-      # Always run basic test/lint/compilation (open PRs, main branch merge)
-      # Note: by default tags are not picked up.
-      - api-local-test
-      - api-unit-test
-      - ui-unit-test
-      - api-bigquery-test
-      - api-integration-test
-      - api-test-coverage:
-          requires:
-          - api-unit-test
-      # Deploy to "test" on main branch merges
-      - api-deploy-to-test:
-          <<: *filter-main-branch
-          requires:
-            - api-unit-test
-      - ui-deploy-to-test:
-          <<: *filter-main-branch
-          requires:
-            - ui-unit-test
-      # Deploy local UI server connected to "test" API server. Run Puppeteer tests for PR commits only
-      - puppeteer-env-setup
-      - puppeteer-generate-access-tokens:
-          env_name: "local"
-      - puppeteer-test:
-          <<: *filter-pr-branch
-          env_name: "local"
-          parallel_num: 5
-          optional_steps:
-            - halt-puppeteer-check
-          requires:
-            - puppeteer-env-setup
-            - puppeteer-generate-access-tokens
-      # On main branch merges, run Puppeteer tests after ui and api deployed to "test" env successfully
-      - puppeteer-test:
-          parallel_num: 5
+   jobs:
+     - api-bigquery-test
+     - puppeteer-env-setup
+     - puppeteer-generate-access-tokens:
           env_name: "test"
-          <<: *filter-main-branch
+     - puppeteer-test:
+          parallel_num: 4
+          test_mode: "nightly-integration"
+          optional_steps:
+            - puppeteer-access-test-user-setup
+          # genomic-extraction-to-vcf.spec takes long time to run.
+          no_output_timeout: 90m
           requires:
             - puppeteer-env-setup
             - puppeteer-generate-access-tokens


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
