### PR TITLE
[RW-8692][risk=no] Skip test as notebook format as changed

### DIFF
--- a/e2e/tests/nightly/dataproc-to-gce.spec.ts
+++ b/e2e/tests/nightly/dataproc-to-gce.spec.ts
@@ -15,7 +15,7 @@ describe('Updating runtime compute type', () => {
 
   const workspaceName = makeRandomName('e2eDataprocToGceTest');
 
-  test('Switch from dataproc to GCE', async () => {
+  test.skip('Switch from dataproc to GCE', async () => {
     await findOrCreateWorkspace(page, {
       workspaceName,
       cdrVersion: config.CONTROLLED_TIER_CDR_VERSION_NAME,

--- a/e2e/tests/nightly/dataproc-to-gce.spec.ts
+++ b/e2e/tests/nightly/dataproc-to-gce.spec.ts
@@ -15,6 +15,8 @@ describe('Updating runtime compute type', () => {
 
   const workspaceName = makeRandomName('e2eDataprocToGceTest');
 
+  /*Skipping the test below as they will be moved to the new version of e2e test.
+   * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
   test.skip('Switch from dataproc to GCE', async () => {
     await findOrCreateWorkspace(page, {
       workspaceName,

--- a/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
@@ -33,7 +33,7 @@ describe('Workspace owner can copy notebook', () => {
   const destinationDefaultCdrWorkspace = 'e2eNightlyOwnerCopyNotebookDestinationWorkspace';
   const destinationOldCdrWorkspace = 'e2eNightlyOwnerCopyNotebookDestinationOldCdrWorkspace';
 
-  test(
+  test.skip(
     'Copy notebook to another Workspace when CDR versions match',
     async () => {
       await createCustomCdrVersionWorkspace(defaultCdrWorkspace, config.DEFAULT_CDR_VERSION_NAME);
@@ -45,7 +45,7 @@ describe('Workspace owner can copy notebook', () => {
     30 * 60 * 1000
   );
 
-  test(
+  test.skip(
     'Copy notebook to another Workspace when CDR versions differ',
     async () => {
       // reuse same source workspace for all tests, but always create new destination workspace.

--- a/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
@@ -33,6 +33,9 @@ describe('Workspace owner can copy notebook', () => {
   const destinationDefaultCdrWorkspace = 'e2eNightlyOwnerCopyNotebookDestinationWorkspace';
   const destinationOldCdrWorkspace = 'e2eNightlyOwnerCopyNotebookDestinationOldCdrWorkspace';
 
+  /*Skipping the tests below as they will be moved to the new version of e2e test.
+   * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
+   
   test.skip(
     'Copy notebook to another Workspace when CDR versions match',
     async () => {


### PR DESCRIPTION
These tests are failing since the notebook format has changed from cards to table. We will be re-writting the test in e2e version 2, so skipping it for now (Jira ticket tracking the effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763)
---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
