### PR TITLE
[RW-8752][risk=no] Adding new API call survey autocomplete

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -72,8 +72,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
       String domain,
       String term,
       String type,
-      Boolean standard,
-      Integer limit) {
+      Boolean standard) {
     workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
     validateDomain(domain);
@@ -84,13 +83,11 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
           new CriteriaListResponse()
               .items(
                   cohortBuilderService.findCriteriaAutoCompleteV2(
-                      domain, term, ImmutableList.of(type), standard, limit)));
+                      domain, term, ImmutableList.of(type), standard)));
     } else {
       return ResponseEntity.ok(
           new CriteriaListResponse()
-              .items(
-                  cohortBuilderService.findCriteriaAutoComplete(
-                      domain, term, type, standard, limit)));
+              .items(cohortBuilderService.findCriteriaAutoComplete(domain, term, type, standard)));
     }
   }
 
@@ -110,7 +107,7 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
           new CriteriaListResponse()
               .items(
                   cohortBuilderService.findCriteriaAutoComplete(
-                      Domain.SURVEY.toString(), term, CriteriaType.PPI.toString(), false, null)));
+                      Domain.SURVEY.toString(), term, CriteriaType.PPI.toString(), false)));
     }
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -99,8 +99,8 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
       String workspaceNamespace, String workspaceId, String surveyName, String term) {
     workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
-    validateTerm(term);
     validateSurveyName(surveyName);
+    validateTerm(term);
     if (workbenchConfigProvider.get().featureFlags.enableDrugWildcardSearch) {
       return ResponseEntity.ok(
           new CriteriaListResponse()

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -262,7 +262,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomC
               + "and c1.conceptId in ( select c.conceptId "
               + "                      from DbCriteria c "
               + "                     where c.domainId = 'SURVEY' "
-              + "                       and match(c.fullText, concat(:term, '+[SURVEY_rank1]')) > 0) "
+              + "                       and match(c.fullText, concat(:term, '+[survey_rank1]')) > 0) "
               + "order by c1.count desc")
   Page<DbCriteria> findSurveyQuestionByTerm(@Param("term") String term, Pageable page);
 

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -60,6 +60,8 @@ public interface CohortBuilderService {
   List<Criteria> findCriteriaAutoCompleteV2(
       String domain, String term, List<String> types, Boolean standard, Integer limit);
 
+  List<Criteria> findSurveyAutoComplete(String surveyName, String term);
+
   List<Criteria> findCriteriaBy(String domain, String type, Boolean standard, Long parentId);
 
   CriteriaListWithCountResponse findCriteriaByDomain(

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -55,10 +55,10 @@ public interface CohortBuilderService {
   List<CriteriaAttribute> findCriteriaAttributeByConceptId(Long conceptId);
 
   List<Criteria> findCriteriaAutoComplete(
-      String domain, String term, String type, Boolean standard, Integer limit);
+      String domain, String term, String type, Boolean standard);
 
   List<Criteria> findCriteriaAutoCompleteV2(
-      String domain, String term, List<String> types, Boolean standard, Integer limit);
+      String domain, String term, List<String> types, Boolean standard);
 
   List<Criteria> findSurveyAutoComplete(String surveyName, String term);
 

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -273,6 +273,23 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   }
 
   @Override
+  public List<Criteria> findSurveyAutoComplete(String surveyName, String term) {
+    PageRequest pageRequest = PageRequest.of(0, DEFAULT_TREE_SEARCH_LIMIT);
+
+    SearchTerm searchTerm = new SearchTerm(term, mySQLStopWordsProvider.get().getStopWords());
+
+    Page<DbCriteria> dbCriteriaPage =
+        cbCriteriaDao.findSurveyQuestions(surveyName, searchTerm, pageRequest);
+
+    if (dbCriteriaPage == null) {
+      return ImmutableList.of();
+    }
+    return dbCriteriaPage.getContent().stream()
+        .map(cohortBuilderMapper::dbModelToClient)
+        .collect(Collectors.toList());
+  }
+
+  @Override
   public List<Criteria> findCriteriaBy(
       String domain, String type, Boolean standard, Long parentId) {
     List<DbCriteria> criteriaList;

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -222,9 +222,8 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
 
   @Override
   public List<Criteria> findCriteriaAutoComplete(
-      String domain, String term, String type, Boolean standard, Integer limit) {
-    PageRequest pageRequest =
-        PageRequest.of(0, Optional.ofNullable(limit).orElse(DEFAULT_TREE_SEARCH_LIMIT));
+      String domain, String term, String type, Boolean standard) {
+    PageRequest pageRequest = PageRequest.of(0, DEFAULT_TREE_SEARCH_LIMIT);
 
     List<DbCriteria> criteriaList =
         cbCriteriaDao.findCriteriaByDomainAndTypeAndStandardAndFullText(
@@ -246,9 +245,8 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
 
   @Override
   public List<Criteria> findCriteriaAutoCompleteV2(
-      String domain, String term, List<String> types, Boolean standard, Integer limit) {
-    PageRequest pageRequest =
-        PageRequest.of(0, Optional.ofNullable(limit).orElse(DEFAULT_TREE_SEARCH_LIMIT));
+      String domain, String term, List<String> types, Boolean standard) {
+    PageRequest pageRequest = PageRequest.of(0, DEFAULT_TREE_SEARCH_LIMIT);
 
     SearchTerm searchTerm = new SearchTerm(term, mySQLStopWordsProvider.get().getStopWords());
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3687,6 +3687,31 @@ paths:
           description: A collection of criteria
           schema:
             "$ref": "#/definitions/CriteriaListResponse"
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/survey/{surveyName}/{term}":
+    parameters:
+      - "$ref": "#/parameters/workspaceNamespace"
+      - "$ref": "#/parameters/workspaceId"
+    get:
+      tags:
+        - cohortBuilder
+      description: Returns matches on criteria table by code or name
+      operationId: findSurveyAutoComplete
+      parameters:
+        - in: path
+          name: surveyName
+          type: string
+          required: true
+          description: the specific survey to search
+        - in: path
+          name: term
+          type: string
+          required: true
+          description: the term to search for
+      responses:
+        200:
+          description: A collection of criteria
+          schema:
+            "$ref": "#/definitions/CriteriaListResponse"
   "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/drug":
     parameters:
       - "$ref": "#/parameters/workspaceNamespace"

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3677,11 +3677,6 @@ paths:
         type: string
         required: true
         description: the term to search for
-      - in: query
-        name: limit
-        type: integer
-        required: false
-        description: number of criteria matches to return
       responses:
         200:
           description: A collection of criteria

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import com.google.apphosting.api.DeadlineExceededException;
-import com.google.cloud.bigquery.*;
 import java.sql.Date;
 import java.time.LocalDate;
 import java.time.Period;
@@ -490,6 +489,89 @@ public class CohortBuilderControllerTest {
                 null,
                 null),
         "Bad Request: Please provide a valid type. blah is not valid.");
+  }
+
+  @Test
+  public void findSurveyAutoCompleteTheBasics() {
+    DbCriteria criteria =
+            DbCriteria.builder()
+                    .addDomainId(Domain.SURVEY.toString())
+                    .addType(CriteriaType.PPI.toString())
+                    .addSubtype("QUESTION")
+                    .addConceptId("1001")
+                    .addCount(0L)
+                    .addHierarchy(true)
+                    .addName("The Basics")
+                    .addStandard(true)
+                    .addFullText("LP12*[survey_rank1]")
+                    .build();
+    criteria = cbCriteriaDao.save(criteria);
+    //need to set the id in the path
+    criteria.setPath(String.valueOf(criteria.getId()));
+    criteria = cbCriteriaDao.save(criteria);
+
+    assertThat(
+            Objects.requireNonNull(
+                            controller
+                                    .findSurveyAutoComplete(
+                                            WORKSPACE_NAMESPACE,
+                                            WORKSPACE_ID,
+                                            "The Basics",
+                                            "LP12")
+                                    .getBody())
+                    .getItems()
+                    .get(0))
+            .isEqualTo(createResponseCriteria(criteria));
+  }
+
+  @Test
+  public void findSurveyAutoCompleteAllSurveys() {
+    DbCriteria criteria =
+            DbCriteria.builder()
+                    .addDomainId(Domain.SURVEY.toString())
+                    .addType(CriteriaType.PPI.toString())
+                    .addSubtype("QUESTION")
+                    .addConceptId("1001")
+                    .addCount(0L)
+                    .addHierarchy(true)
+                    .addName("The Basics")
+                    .addStandard(true)
+                    .addFullText("LP12*[survey_rank1]")
+                    .build();
+    criteria = cbCriteriaDao.save(criteria);
+    //need to set the id in the path
+    criteria.setPath(String.valueOf(criteria.getId()));
+    criteria = cbCriteriaDao.save(criteria);
+
+    assertThat(
+            Objects.requireNonNull(
+                            controller
+                                    .findSurveyAutoComplete(
+                                            WORKSPACE_NAMESPACE,
+                                            WORKSPACE_ID,
+                                            "All",
+                                            "LP12")
+                                    .getBody())
+                    .getItems()
+                    .get(0))
+            .isEqualTo(createResponseCriteria(criteria));
+  }
+
+  @Test
+  public void findSurveyAutoCompleteExceptions() {
+    assertThrows(
+            BadRequestException.class,
+            () ->
+                    controller.findSurveyAutoComplete(
+                            WORKSPACE_NAMESPACE, WORKSPACE_ID, null, "blah"),
+            "Bad Request: Please provide a valid surveyName. null is not valid.");
+
+    assertThrows(
+            BadRequestException.class,
+            () ->
+                    controller.findSurveyAutoComplete(
+                            WORKSPACE_NAMESPACE, WORKSPACE_ID, "All", null),
+            "Bad Request: Please provide a valid term. blah is not valid.");
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -10,7 +10,10 @@ import com.google.apphosting.api.DeadlineExceededException;
 import java.sql.Date;
 import java.time.LocalDate;
 import java.time.Period;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Provider;
@@ -392,8 +395,7 @@ public class CohortBuilderControllerTest {
                             Domain.MEASUREMENT.toString(),
                             "LP12",
                             CriteriaType.LOINC.toString(),
-                            true,
-                            null)
+                            true)
                         .getBody())
                 .getItems()
                 .get(0))
@@ -423,8 +425,7 @@ public class CohortBuilderControllerTest {
                             Domain.MEASUREMENT.toString(),
                             "LP12",
                             CriteriaType.LOINC.toString(),
-                            true,
-                            null)
+                            true)
                         .getBody())
                 .getItems()
                 .get(0))
@@ -453,8 +454,7 @@ public class CohortBuilderControllerTest {
                             Domain.CONDITION.toString(),
                             "LP12",
                             CriteriaType.SNOMED.toString(),
-                            true,
-                            null)
+                            true)
                         .getBody())
                 .getItems()
                 .get(0))
@@ -467,14 +467,14 @@ public class CohortBuilderControllerTest {
         BadRequestException.class,
         () ->
             controller.findCriteriaAutoComplete(
-                WORKSPACE_NAMESPACE, WORKSPACE_ID, null, "blah", null, null, null),
+                WORKSPACE_NAMESPACE, WORKSPACE_ID, null, "blah", null, null),
         "Bad Request: Please provide a valid domain. null is not valid.");
 
     assertThrows(
         BadRequestException.class,
         () ->
             controller.findCriteriaAutoComplete(
-                WORKSPACE_NAMESPACE, WORKSPACE_ID, null, "blah", null, null, null),
+                WORKSPACE_NAMESPACE, WORKSPACE_ID, null, "blah", null, null),
         "Bad Request: Please provide a valid domain. blah is not valid.");
 
     assertThrows(
@@ -486,7 +486,6 @@ public class CohortBuilderControllerTest {
                 Domain.CONDITION.toString(),
                 "blah",
                 "blah",
-                null,
                 null),
         "Bad Request: Please provide a valid type. blah is not valid.");
   }
@@ -494,84 +493,73 @@ public class CohortBuilderControllerTest {
   @Test
   public void findSurveyAutoCompleteTheBasics() {
     DbCriteria criteria =
-            DbCriteria.builder()
-                    .addDomainId(Domain.SURVEY.toString())
-                    .addType(CriteriaType.PPI.toString())
-                    .addSubtype("QUESTION")
-                    .addConceptId("1001")
-                    .addCount(0L)
-                    .addHierarchy(true)
-                    .addName("The Basics")
-                    .addStandard(true)
-                    .addFullText("LP12*[survey_rank1]")
-                    .build();
+        DbCriteria.builder()
+            .addDomainId(Domain.SURVEY.toString())
+            .addType(CriteriaType.PPI.toString())
+            .addSubtype("QUESTION")
+            .addConceptId("1001")
+            .addCount(0L)
+            .addHierarchy(true)
+            .addName("The Basics")
+            .addStandard(true)
+            .addFullText("LP12*[survey_rank1]")
+            .build();
     criteria = cbCriteriaDao.save(criteria);
-    //need to set the id in the path
+    // need to set the id in the path
     criteria.setPath(String.valueOf(criteria.getId()));
     criteria = cbCriteriaDao.save(criteria);
 
     assertThat(
             Objects.requireNonNull(
-                            controller
-                                    .findSurveyAutoComplete(
-                                            WORKSPACE_NAMESPACE,
-                                            WORKSPACE_ID,
-                                            "The Basics",
-                                            "LP12")
-                                    .getBody())
-                    .getItems()
-                    .get(0))
-            .isEqualTo(createResponseCriteria(criteria));
+                    controller
+                        .findSurveyAutoComplete(
+                            WORKSPACE_NAMESPACE, WORKSPACE_ID, "The Basics", "LP12")
+                        .getBody())
+                .getItems()
+                .get(0))
+        .isEqualTo(createResponseCriteria(criteria));
   }
 
   @Test
   public void findSurveyAutoCompleteAllSurveys() {
     DbCriteria criteria =
-            DbCriteria.builder()
-                    .addDomainId(Domain.SURVEY.toString())
-                    .addType(CriteriaType.PPI.toString())
-                    .addSubtype("QUESTION")
-                    .addConceptId("1001")
-                    .addCount(0L)
-                    .addHierarchy(true)
-                    .addName("The Basics")
-                    .addStandard(true)
-                    .addFullText("LP12*[survey_rank1]")
-                    .build();
+        DbCriteria.builder()
+            .addDomainId(Domain.SURVEY.toString())
+            .addType(CriteriaType.PPI.toString())
+            .addSubtype("QUESTION")
+            .addConceptId("1001")
+            .addCount(0L)
+            .addHierarchy(true)
+            .addName("The Basics")
+            .addStandard(true)
+            .addFullText("LP12*[survey_rank1]")
+            .build();
     criteria = cbCriteriaDao.save(criteria);
-    //need to set the id in the path
+    // need to set the id in the path
     criteria.setPath(String.valueOf(criteria.getId()));
     criteria = cbCriteriaDao.save(criteria);
 
     assertThat(
             Objects.requireNonNull(
-                            controller
-                                    .findSurveyAutoComplete(
-                                            WORKSPACE_NAMESPACE,
-                                            WORKSPACE_ID,
-                                            "All",
-                                            "LP12")
-                                    .getBody())
-                    .getItems()
-                    .get(0))
-            .isEqualTo(createResponseCriteria(criteria));
+                    controller
+                        .findSurveyAutoComplete(WORKSPACE_NAMESPACE, WORKSPACE_ID, "All", "LP12")
+                        .getBody())
+                .getItems()
+                .get(0))
+        .isEqualTo(createResponseCriteria(criteria));
   }
 
   @Test
   public void findSurveyAutoCompleteExceptions() {
     assertThrows(
-            BadRequestException.class,
-            () ->
-                    controller.findSurveyAutoComplete(
-                            WORKSPACE_NAMESPACE, WORKSPACE_ID, null, "blah"),
-            "Bad Request: Please provide a valid surveyName. null is not valid.");
+        BadRequestException.class,
+        () -> controller.findSurveyAutoComplete(WORKSPACE_NAMESPACE, WORKSPACE_ID, null, "blah"),
+        "Bad Request: Please provide a valid surveyName. null is not valid.");
 
     assertThrows(
-            BadRequestException.class,
-            () ->
-                    controller.findSurveyAutoComplete(
-                            WORKSPACE_NAMESPACE, WORKSPACE_ID, "All", null),
-            "Bad Request: Please provide a valid term. blah is not valid.");
+        BadRequestException.class,
+        () -> controller.findSurveyAutoComplete(WORKSPACE_NAMESPACE, WORKSPACE_ID, "All", null),
+        "Bad Request: Please provide a valid term. blah is not valid.");
   }
 
   @Test

--- a/ui/src/app/cohort-search/search-bar/search-bar.component.spec.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.spec.tsx
@@ -41,6 +41,7 @@ describe('SearchBar', () => {
       <SearchBar
         node={nodeStub}
         searchTerms={''}
+        selectedSurvey={''}
         setIngredients={() => {}}
         selectOption={() => {}}
         setInput={() => {}}

--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -195,6 +195,7 @@ interface Props {
   node: Criteria;
   searchTerms: string;
   setIngredients: Function;
+  selectedSurvey: string;
   selectOption: Function;
   setInput: Function;
 }
@@ -270,27 +271,40 @@ export class SearchBar extends React.Component<Props, State> {
     const {
       node: { domainId, isStandard, subtype, type },
       searchTerms,
+      selectedSurvey,
     } = this.props;
     AnalyticsTracker.CohortBuilder.SearchTerms(
       `${domainToTitle(domainId)} - '${searchTerms}'`
     );
     this.setState({ inputErrors: [], loading: true });
     const { id, namespace } = currentWorkspaceStore.getValue();
-    const apiCall =
-      domainId === Domain.DRUG.toString()
-        ? cohortBuilderApi().findDrugBrandOrIngredientByValue(
-            namespace,
-            id,
-            searchTerms
-          )
-        : cohortBuilderApi().findCriteriaAutoComplete(
-            namespace,
-            id,
-            domainId,
-            searchTerms,
-            type,
-            isStandard
-          );
+    let apiCall;
+    switch (domainId) {
+      case Domain.DRUG.toString():
+        apiCall = cohortBuilderApi().findDrugBrandOrIngredientByValue(
+          namespace,
+          id,
+          searchTerms
+        );
+        break;
+      case Domain.SURVEY.toString():
+        apiCall = cohortBuilderApi().findSurveyAutoComplete(
+          namespace,
+          id,
+          selectedSurvey,
+          searchTerms
+        );
+        break;
+      default:
+        apiCall = cohortBuilderApi().findCriteriaAutoComplete(
+          namespace,
+          id,
+          domainId,
+          searchTerms,
+          type,
+          isStandard
+        );
+    }
     apiCall.then(
       (resp) => {
         const optionNames: Array<string> = [];

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -433,6 +433,7 @@ export const CriteriaTree = fp.flow(
         searchTerms,
         select,
         selectedIds,
+        selectedSurvey,
         selectOption,
         setAttributes,
         setSearchTerms,
@@ -465,6 +466,7 @@ export const CriteriaTree = fp.flow(
             <SearchBar
               node={node}
               searchTerms={searchTerms}
+              selectedSurvey={selectedSurvey}
               selectOption={selectOption}
               setIngredients={(i) => this.setState({ ingredients: i })}
               setInput={(v) => setSearchTerms(v)}


### PR DESCRIPTION
Adding new API call survey autocomplete. This will allow for searching concepts in all surveys as well as an individual survey. 


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
