### PR TITLE
[RW-8851][risk=no] Fix survey autocomplete call

### DIFF
--- a/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
+++ b/e2e/tests/nightly/owner-copy-to-workspace.spec.ts
@@ -35,7 +35,7 @@ describe('Workspace owner can copy notebook', () => {
 
   /*Skipping the tests below as they will be moved to the new version of e2e test.
    * Story tracking this effort: https://precisionmedicineinitiative.atlassian.net/browse/RW-8763*/
-   
+
   test.skip(
     'Copy notebook to another Workspace when CDR versions match',
     async () => {

--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -291,7 +291,7 @@ export class SearchBar extends React.Component<Props, State> {
         apiCall = cohortBuilderApi().findSurveyAutoComplete(
           namespace,
           id,
-          selectedSurvey,
+          selectedSurvey || 'All surveys',
           searchTerms
         );
         break;


### PR DESCRIPTION
Fixes `Uncaught Error: Required parameter surveyName was null or undefined when calling findSurveyAutoComplete` error.