### PR TITLE
[RW-8836][risk=no] Show root node for survey submenu selections

### DIFF
--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -221,6 +221,7 @@ export const CriteriaTree = fp.flow(
           domain,
           node: { id, isStandard, parentId, subtype, type },
           selectedSurvey,
+          source,
         } = this.props;
         this.setState({ loading: true });
         const {
@@ -295,15 +296,20 @@ export const CriteriaTree = fp.flow(
           });
           this.setState({ children });
         } else if (domain === Domain.SURVEY && selectedSurvey) {
-          // Temp: This should be handle in API
-          this.updatePpiSurveys(
-            rootNodes,
-            rootNodes.items.filter((child) => child.name === selectedSurvey)
-          );
-        } else if (
-          domain === Domain.SURVEY &&
-          this.props.source === 'conceptSetDetails'
-        ) {
+          if (source === 'cohort' && selectedSurvey !== 'All Surveys') {
+            this.setState({
+              children: rootNodes.items.filter(
+                (child) => child.name === selectedSurvey
+              ),
+            });
+          } else {
+            // Temp: This should be handle in API
+            this.updatePpiSurveys(
+              rootNodes,
+              rootNodes.items.filter((child) => child.name === selectedSurvey)
+            );
+          }
+        } else if (domain === Domain.SURVEY && source === 'conceptSetDetails') {
           this.updatePpiSurveys(
             rootNodes,
             rootNodes.items.filter((child) => child.id === parentId)


### PR DESCRIPTION
Include the top level survey node after selecting a survey from the criteria submenu

https://user-images.githubusercontent.com/40036095/189800741-9486e23e-5b0a-4431-8391-31b64ba2462e.mov

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
