### PR TITLE
[RW-8244][risk=no] Add tooltip to the preemptible workers setting

### DIFF
--- a/ui/src/app/pages/analysis/runtime-panel.tsx
+++ b/ui/src/app/pages/analysis/runtime-panel.tsx
@@ -22,7 +22,7 @@ import {
   StyledExternalLink,
 } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
-import { ClrIcon } from 'app/components/icons';
+import { ClrIcon, InfoIcon } from 'app/components/icons';
 import { CheckBox, RadioButton } from 'app/components/inputs';
 import { ErrorMessage, WarningMessage } from 'app/components/messages';
 import { TooltipTrigger } from 'app/components/popups';
@@ -1255,7 +1255,17 @@ const DataProcConfigSelector = ({
         </FlexRow>
         <FlexRow style={styles.labelAndInput}>
           <label style={styles.label} htmlFor='num-preemptible'>
-            Preemptible
+            Preemptible workers
+            <TooltipTrigger
+              content='Preemptible secondary workers can be added in addition to
+                primary workers. They are less expensive than primary workers
+                but may be removed from the cluster if they are required by
+                Google Cloud for other tasks. This may affect job stability'
+            >
+              <InfoIcon
+                style={{ marginLeft: '0.1rem', height: '18px', width: '18px' }}
+              />
+            </TooltipTrigger>
           </label>
           <InputNumber
             id='num-preemptible'


### PR DESCRIPTION
Description:

This PR adds a tooltip to the preemptible workers setting. It also updates the text “Preemptible” to “Preemptible workers.”

Before
![image](https://user-images.githubusercontent.com/31020403/189945678-69b0ba18-c927-474b-8a6d-a0e7ed3ccc3b.png)

After
![image](https://user-images.githubusercontent.com/31020403/189945614-63351230-c5d8-4950-8be7-366adf889ece.png)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
