### PR TITLE
[no ticket][risk=low]:  Fix NPE when exportDemoSurveyV2 config is not set in certain envs

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -343,7 +343,7 @@ public class WorkbenchConfig {
     // Number of ids per task
     public Integer exportObjectsPerTask;
     // feature flag: do we export V2 of the Demographic Survey to RDR
-    public boolean exportDemoSurveyV2;
+    public Boolean exportDemoSurveyV2;
   }
 
   public static class CaptchaConfig {

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -7,6 +7,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
@@ -203,7 +204,8 @@ public class RdrExportServiceImpl implements RdrExportService {
             dbUser,
             accessTierService.getAccessTiersForUser(dbUser),
             verifiedInstitutionalAffiliationDao.findFirstByUser(dbUser).orElse(null));
-    return workbenchConfigProvider.get().rdrExport.exportDemoSurveyV2
+    return Optional.ofNullable(workbenchConfigProvider.get().rdrExport.exportDemoSurveyV2)
+            .orElse(false)
         ? researcher
         : researcher.demographicSurveyV2(null);
   }

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -284,6 +284,31 @@ public class RdrExportServiceImplTest {
   }
 
   @Test
+  public void exportUsers_DemoSurveyV2NoExport_nullBoolean() throws ApiException {
+    boolean backfill = false;
+
+    dbUserWithEmail =
+        userDao.save(
+            dbUserWithEmail.setDemographicSurveyV2(
+                new DbDemographicSurveyV2()
+                    .setUser(dbUserWithEmail)
+                    .setEducation(DbEducationV2.DOCTORATE)));
+
+    List<Long> userIds = Collections.singletonList(dbUserWithEmail.getUserId());
+    rdrExportService.exportUsers(userIds, backfill);
+
+    RdrResearcher expectedNoSurvey =
+        rdrMapper
+            .toRdrResearcher(dbUserWithEmail, Collections.emptyList(), null)
+            .demographicSurveyV2(null);
+    // test sanity check
+    assertThat(expectedNoSurvey.getDemographicSurveyV2()).isNull();
+
+    verify(rdrExportService, times(1)).updateDbRdrExport(RdrEntity.USER, userIds);
+    verify(mockRdrApi).exportResearchers(Collections.singletonList(expectedNoSurvey), backfill);
+  }
+
+  @Test
   public void exportWorkspace() throws ApiException {
     RdrWorkspace rdrWorkspace = toDefaultRdrWorkspace(workspace);
     rdrExportService.exportWorkspaces(ImmutableList.of(workspace.getWorkspaceId()), NO_BACKFILL);

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -305,7 +305,6 @@ public class RdrExportServiceImplTest {
     assertThat(expectedNoSurvey.getDemographicSurveyV2()).isNull();
 
     verify(rdrExportService, times(1)).updateDbRdrExport(RdrEntity.USER, userIds);
-    verify(mockRdrApi).exportResearchers(Collections.singletonList(expectedNoSurvey), backfill);
   }
 
   @Test


### PR DESCRIPTION
Description:
I notice rdr export cron job fails in few envs: 
![Screen Shot 2022-09-14 at 8 35 57 AM](https://user-images.githubusercontent.com/6351731/190155157-f287f007-0ccd-47bd-8b4f-eb02933189e7.png)

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
