### PR TITLE
[RW-8860][risk=no]Bug incorrect results for code search

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -337,7 +337,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
     Page<DbCriteria> dbCriteriaPage =
         cbCriteriaDao.findCriteriaByDomainAndCodeAndStandardAndNotType(
             domain,
-            term.replaceAll("[()+\"*]", ""),
+            term,
             standard,
             CriteriaType.NONE.toString(),
             pageRequest);

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -336,11 +336,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
     // find a match on concept code
     Page<DbCriteria> dbCriteriaPage =
         cbCriteriaDao.findCriteriaByDomainAndCodeAndStandardAndNotType(
-            domain,
-            term,
-            standard,
-            CriteriaType.NONE.toString(),
-            pageRequest);
+            domain, term, standard, CriteriaType.NONE.toString(), pageRequest);
 
     // if no match is found on concept code then find match on full text index by term
     if (dbCriteriaPage.getContent().isEmpty() && !term.contains(".")) {

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -337,7 +337,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
     Page<DbCriteria> dbCriteriaPage =
         cbCriteriaDao.findCriteriaByDomainAndCodeAndStandardAndNotType(
             domain,
-            term.replaceAll("[()+\"*-]", ""),
+            term.replaceAll("[()+\"*]", ""),
             standard,
             CriteriaType.NONE.toString(),
             pageRequest);
@@ -387,7 +387,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
     // find a match on concept code
     Page<DbCriteria> dbCriteriaPage =
         cbCriteriaDao.findCriteriaByDomainAndCodeAndStandardAndNotType(
-            domain, term.replaceAll("[()+\"*-]", ""), standard, type, pageRequest);
+            domain, term.replaceAll("[()+\"*]", ""), standard, type, pageRequest);
 
     // if the modified search term is empty and endsWithTerms is empty return an empty result
     // this needs ot be here since word length of <3 are filtered and there are 2-concept codes

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -387,7 +387,7 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
     // find a match on concept code
     Page<DbCriteria> dbCriteriaPage =
         cbCriteriaDao.findCriteriaByDomainAndCodeAndStandardAndNotType(
-            domain, term.replaceAll("[()+\"*]", ""), standard, type, pageRequest);
+            domain, term, standard, type, pageRequest);
 
     // if the modified search term is empty and endsWithTerms is empty return an empty result
     // this needs ot be here since word length of <3 are filtered and there are 2-concept codes

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -833,20 +833,20 @@ public class CohortBuilderControllerTest {
     cbCriteriaDao.save(criteria);
 
     assertThat(
-        Objects.requireNonNull(
-                controller
-                    .findCriteriaByDomain(
-                        WORKSPACE_NAMESPACE,
-                        WORKSPACE_ID,
-                        Domain.CONDITION.name(),
-                        false,
-                        "12-1",
-                        null,
-                        false,
-                        null)
-                    .getBody())
-            .getItems()
-            .get(0))
+            Objects.requireNonNull(
+                    controller
+                        .findCriteriaByDomain(
+                            WORKSPACE_NAMESPACE,
+                            WORKSPACE_ID,
+                            Domain.CONDITION.name(),
+                            false,
+                            "12-1",
+                            null,
+                            false,
+                            null)
+                        .getBody())
+                .getItems()
+                .get(0))
         .isEqualTo(createResponseCriteria(criteria));
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -814,6 +814,43 @@ public class CohortBuilderControllerTest {
   }
 
   @Test
+  public void findCriteriaByDomainMatchesStandardCodeWithHyphen() {
+    DbCriteria criteria =
+        DbCriteria.builder()
+            .addCode("12-1")
+            .addCount(10L)
+            .addConceptId("123")
+            .addDomainId(Domain.CONDITION.toString())
+            .addGroup(Boolean.TRUE)
+            .addSelectable(Boolean.TRUE)
+            .addName("chol blah with hyphen in code")
+            .addParentId(0)
+            .addType(CriteriaType.LOINC.toString())
+            .addAttribute(Boolean.FALSE)
+            .addStandard(false)
+            .addFullText("[CONDITION_rank1]")
+            .build();
+    cbCriteriaDao.save(criteria);
+
+    assertThat(
+        Objects.requireNonNull(
+                controller
+                    .findCriteriaByDomain(
+                        WORKSPACE_NAMESPACE,
+                        WORKSPACE_ID,
+                        Domain.CONDITION.name(),
+                        false,
+                        "12-1",
+                        null,
+                        false,
+                        null)
+                    .getBody())
+            .getItems()
+            .get(0))
+        .isEqualTo(createResponseCriteria(criteria));
+  }
+
+  @Test
   public void findCriteriaByDomainMatchesSynonyms() {
     DbCriteria criteria =
         DbCriteria.builder()


### PR DESCRIPTION
Description:
---
- updated service call to not strip the '-' (hyphen) when doing a search by code
- added controller test for code with hyphen

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
