### PR TITLE
[risk=no] Fix failing cohort e2e tests

### DIFF
--- a/e2e/app/page/cohort-participants-group.ts
+++ b/e2e/app/page/cohort-participants-group.ts
@@ -524,7 +524,7 @@ export default class CohortParticipantsGroup {
     const enterTextAndSearch = async (searchString: string): Promise<boolean> => {
       const responsePromise = this.page.waitForResponse(
         (response) => {
-          return response.url().includes('/criteria/') && response.request().method() === 'GET';
+          return response.url().includes('/criteria/') && response.request().method() === 'POST';
         },
         { timeout: 60000 }
       );


### PR DESCRIPTION
Change expected api call from `GET` to `POST`
FYI @dmohs @chavanr2019 