### PR TITLE
[RW-8877][risk=no] fine tuning full text search

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -109,9 +109,9 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomC
   default List<DbCardCount> findDomainCounts(
       SearchTerm searchTerm, Boolean standard, List<String> domainNames) {
     if (searchTerm.hasModifiedTermOnly()) {
-      StringBuilder stringBuilder = new StringBuilder(searchTerm.getModifiedTerm());
-      domainNames.forEach(d -> stringBuilder.append(" [" + d + "_rank1]"));
-      return findDomainCountsByTermAndStandardAndDomains(stringBuilder.toString(), standard);
+      StringBuilder termBuilder = new StringBuilder(searchTerm.getModifiedTerm());
+      domainNames.forEach(d -> termBuilder.append(" [" + d + "_rank1]"));
+      return findDomainCountsByTermAndStandardAndDomains(termBuilder.toString(), standard);
     } else if (searchTerm.hasEndsWithOnly()) {
       return findDomainCountsByNameEndsWithAndStandardAndDomains(
           searchTerm.getEndsWithTerms(), standard, domainNames);

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -410,7 +410,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomC
               + "and concept_id in ( select concept_id "
               + "from cb_criteria "
               + "where domain_id = 'SURVEY' "
-              + "and match(full_text) against(concat(:term, '+[survey_rank1]') in boolean mode)) "
+              + "and match(full_text) against(:term in boolean mode)) "
               + "group by survey_version_concept_id"
               + ") a on c.id = a.survey_version_concept_id "
               + "order by count desc",

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -111,8 +111,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomC
     if (searchTerm.hasModifiedTermOnly()) {
       StringBuilder stringBuilder = new StringBuilder(searchTerm.getModifiedTerm());
       domainNames.forEach(d -> stringBuilder.append(" [" + d + "_rank1]"));
-      return findDomainCountsByTermAndStandardAndDomains(
-          stringBuilder.toString(), standard);
+      return findDomainCountsByTermAndStandardAndDomains(stringBuilder.toString(), standard);
     } else if (searchTerm.hasEndsWithOnly()) {
       return findDomainCountsByNameEndsWithAndStandardAndDomains(
           searchTerm.getEndsWithTerms(), standard, domainNames);
@@ -376,8 +375,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomC
               + "order by count desc",
       nativeQuery = true)
   List<DbCardCount> findDomainCountsByTermAndStandardAndDomains(
-      @Param("term") String term,
-      @Param("standard") Boolean standard);
+      @Param("term") String term, @Param("standard") Boolean standard);
 
   @Query(
       value =

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
@@ -433,11 +433,11 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
   @Override
   public List<DbCardCount> findDomainCountsByTermAndNameEndsWithAndStandardAndDomains(
       String term, List<String> endsWithList, Boolean standard, List<String> domains) {
-    StringBuilder stringBuilder = new StringBuilder(term);
-    domains.forEach(d -> stringBuilder.append(" [" + d + "_rank1]"));
+    StringBuilder termBuilder = new StringBuilder(term);
+    domains.forEach(d -> termBuilder.append(" [" + d + "_rank1]"));
     Object[][] params = {
       {BIND_VAR_STANDARD, standard},
-      {BIND_VAR_TERM, stringBuilder.toString()}
+      {BIND_VAR_TERM, termBuilder.toString()}
     };
     return queryForDbCardCountList(
         generateQueryAndParameters(DOMAIN_COUNTS_TERM_ENDS_WITH, params, endsWithList));

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CustomCBCriteriaDaoImpl.java
@@ -179,11 +179,9 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
           + "where match(full_text) against(:"
           + BIND_VAR_TERM
           + " in boolean mode)\n"
-          + "and full_text like '%_rank1%'\n"
           + "and is_standard = :"
           + BIND_VAR_STANDARD
           + "\n"
-          + DOMAIN_ID_IN_DOMAINS
           + "and ("
           + SQL_ENDS_WITH
           + ") \n"
@@ -435,10 +433,11 @@ public class CustomCBCriteriaDaoImpl implements CustomCBCriteriaDao {
   @Override
   public List<DbCardCount> findDomainCountsByTermAndNameEndsWithAndStandardAndDomains(
       String term, List<String> endsWithList, Boolean standard, List<String> domains) {
+    StringBuilder stringBuilder = new StringBuilder(term);
+    domains.forEach(d -> stringBuilder.append(" [" + d + "_rank1]"));
     Object[][] params = {
       {BIND_VAR_STANDARD, standard},
-      {BIND_VAR_TERM, term},
-      {VAR_IN_DOMAINS, domains}
+      {BIND_VAR_TERM, stringBuilder.toString()}
     };
     return queryForDbCardCountList(
         generateQueryAndParameters(DOMAIN_COUNTS_TERM_ENDS_WITH, params, endsWithList));

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -557,9 +557,11 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
     strDomains.removeAll(
         cardCounts.stream().map(DbCardCount::getDomainId).collect(Collectors.toList()));
     // modify search term and call
+    StringBuilder stringBuilder = new StringBuilder(modifyTermMatch(term));
+    domains.forEach(d -> stringBuilder.append(" [" + d + "_rank1]"));
     cardCounts.addAll(
         cbCriteriaDao.findDomainCountsByTermAndStandardAndDomains(
-            modifyTermMatch(term), standard, strDomains));
+            stringBuilder.toString(), standard));
 
     return cardCounts.stream()
         .filter(cardCount -> cardCount.getCount() > 0)

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchTerm.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchTerm.java
@@ -29,11 +29,7 @@ public class SearchTerm {
 
   public String getCodeTerm() {
     // could just be a static method
-    if (term.startsWith("-")) {
-      return term.substring(1).replaceAll("[()+\"*]", "");
-    } else {
       return term.replaceAll("[()+\"*]", "");
-    }
   }
 
   public String getModifiedTerm() {

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchTerm.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchTerm.java
@@ -29,7 +29,7 @@ public class SearchTerm {
 
   public String getCodeTerm() {
     // could just be a static method
-      return term.replaceAll("[()+\"*]", "");
+    return term.replaceAll("[()+\"*]", "");
   }
 
   public String getModifiedTerm() {

--- a/api/src/test/java/org/pmiops/workbench/cohortbuilder/SearchTermTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortbuilder/SearchTermTest.java
@@ -74,13 +74,13 @@ class SearchTermTest {
     return Stream.of(
         Arguments.of("Search term: ", "12-5", "12-5"),
         Arguments.of("Search term: ", "+12-5", "12-5"),
-        Arguments.of("Search term: ", "-12-5", "12-5"),
+        Arguments.of("Search term: ", "-12-5", "-12-5"),
         Arguments.of("Search term: ", "*12-5", "12-5"),
         Arguments.of("Search term: ", "+12-5*", "12-5"),
-        Arguments.of("Search term: ", "-12-5*", "12-5"),
+        Arguments.of("Search term: ", "-12-5*", "-12-5"),
         Arguments.of("Search term: ", "*12-5*", "12-5"),
         Arguments.of("Search term: ", "+12-5*", "12-5"),
-        Arguments.of("Search term: ", "-12-5*", "12-5"));
+        Arguments.of("Search term: ", "-12-5*", "-12-5"));
   }
 
   @ParameterizedTest(name = "checkEndsWithTerms: {0} {1}=>{2}")


### PR DESCRIPTION
Fine tuning full text search:

1. When using universal search for term `-12-55`, it's returning results for surveys and it should not be.
![Screen Shot 2022-09-15 at 3 27 52 PM](https://user-images.githubusercontent.com/3904919/190502547-9b952b7f-3797-412f-91ed-ffa7dcb99035.png)
2. When using universal search for term '*ing -upper', it's only returning survey data. we should have matching data for conditions, procedures, observations and measurements.
![Screen Shot 2022-09-15 at 3 32 45 PM](https://user-images.githubusercontent.com/3904919/190503664-5a30b560-1a86-40c0-b693-4a0bfdacd0b9.png)
3. When searching codes with '-12', it returns results that match which is the opposite of the minus operator(should remove terms).
![Screen Shot 2022-09-15 at 3 37 31 PM](https://user-images.githubusercontent.com/3904919/190504193-d9e8ef20-f671-41e2-835d-91c5f07981b0.png)
