### PR TITLE
[RW-8880][risk=no] Fix hidden tooltip in CB autocomplete

### DIFF
--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -58,7 +58,7 @@ const styles = reactStyles({
     overflowY: 'auto',
     width: '100%',
     borderRadius: '.125rem',
-    zIndex: 1000,
+    zIndex: 105,
   },
   dropdownItem: {
     height: '1rem',

--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -405,7 +405,7 @@ export class SearchBar extends React.Component<Props, State> {
     const { highlightedOption, inputErrors, loading, options } = this.state;
     const inputValue =
       highlightedOption !== null
-        ? options[highlightedOption].name
+        ? options?.[highlightedOption].name
         : this.props.searchTerms;
     return (
       <div style={{ display: 'flex', position: 'relative', width: '100%' }}>

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -537,26 +537,29 @@ export function validateInputForMySQL(
     inputErrors.add('There is an unclosed " in the search string');
   }
   // check each endsWith term - terms that start with *
-  searchString.trim().split(' ').forEach((word) => {
-    // consecutive special chars
-    if (word.match(/[+*-]{2,}/)) {
-      inputErrors.add(
-        `Search term [${word}] cannot contain consecutive special characters `
-      );
-    }
-    if (word.match(/^\*.*\*$/)) {
-      inputErrors.add(
-        `Search term [${word}] cannot start and end in wild character '*'`
-      );
-    }
-    // length of every word without the special chars mut be >= searchTrigger
-    // for hyphenated word there will be at least 2 letters, if hyphen is removed
-    if (word.replace(/[+*"'-]/g, '').length < searchTrigger) {
-      inputErrors.add(
-        `Search term [${word}] length must be at least ${searchTrigger} characters without special characters`
-      );
-    }
-  });
+  searchString
+    .trim()
+    .split(' ')
+    .forEach((word) => {
+      // consecutive special chars
+      if (word.match(/[+*-]{2,}/)) {
+        inputErrors.add(
+          `Search term [${word}] cannot contain consecutive special characters `
+        );
+      }
+      if (word.match(/^\*.*\*$/)) {
+        inputErrors.add(
+          `Search term [${word}] cannot start and end in wild character '*'`
+        );
+      }
+      // length of every word without the special chars mut be >= searchTrigger
+      // for hyphenated word there will be at least 2 letters, if hyphen is removed
+      if (word.replace(/[+*"'-]/g, '').length < searchTrigger) {
+        inputErrors.add(
+          `Search term [${word}] length must be at least ${searchTrigger} characters without special characters`
+        );
+      }
+    });
   return Array.from(inputErrors);
 }
 

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -537,7 +537,7 @@ export function validateInputForMySQL(
     inputErrors.add('There is an unclosed " in the search string');
   }
   // check each endsWith term - terms that start with *
-  searchString.split(' ').forEach((word) => {
+  searchString.trim().split(' ').forEach((word) => {
     // consecutive special chars
     if (word.match(/[+*-]{2,}/)) {
       inputErrors.add(


### PR DESCRIPTION
Fix issue where full text tooltip is hidden behind the autocomplete dropdown.

Before:
<img width="1149" alt="Screen Shot 2022-09-16 at 9 27 38 AM" src="https://user-images.githubusercontent.com/40036095/190663599-654307e7-eaf4-440e-b46e-ed2dbbffde4d.png">

After:
<img width="1140" alt="Screen Shot 2022-09-16 at 9 27 18 AM" src="https://user-images.githubusercontent.com/40036095/190663774-ac28d2d8-ee98-4413-bce8-5adf8f792da8.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
