### PR TITLE
[RW-8811][risk=no]   [P2] Demo Survey V2 is not recorded during account creation

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -244,6 +244,7 @@ public class ProfileController implements ProfileApiDelegate {
               addressMapper.addressToDbAddress(profile.getAddress()),
               demographicSurveyMapper.demographicSurveyToDbDemographicSurvey(
                   profile.getDemographicSurvey()),
+              demographicSurveyMapper.toDbDemographicSurveyV2(profile.getDemographicSurveyV2()),
               verifiedInstitutionalAffiliationMapper.modelToDbWithoutUser(
                   profile.getVerifiedInstitutionalAffiliation(), institutionService));
     } catch (Exception e) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -1,13 +1,10 @@
 package org.pmiops.workbench.db.dao;
 
 import com.google.api.services.oauth2.model.Userinfo;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
-import javax.annotation.Nonnull;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
+import org.pmiops.workbench.db.model.DbDemographicSurveyV2;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.NotFoundException;
@@ -15,6 +12,11 @@ import org.pmiops.workbench.model.AccessBypassRequest;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.Degree;
 import org.springframework.data.domain.Sort;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
 
 public interface UserService {
   int LATEST_AOU_TOS_VERSION = 1;
@@ -50,6 +52,7 @@ public interface UserService {
       List<Degree> degrees,
       DbAddress dbAddress,
       DbDemographicSurvey dbDemographicSurvey,
+      DbDemographicSurveyV2 dbDemographicSurveyv2,
       DbVerifiedInstitutionalAffiliation dbVerifiedAffiliation);
 
   // TODO(jaycarlton): Move compliance-related methods to a new UserComplianceService or similar

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -1,6 +1,10 @@
 package org.pmiops.workbench.db.dao;
 
 import com.google.api.services.oauth2.model.Userinfo;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
@@ -12,11 +16,6 @@ import org.pmiops.workbench.model.AccessBypassRequest;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.Degree;
 import org.springframework.data.domain.Sort;
-
-import javax.annotation.Nonnull;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
 
 public interface UserService {
   int LATEST_AOU_TOS_VERSION = 1;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -40,6 +40,7 @@ import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
+import org.pmiops.workbench.db.model.DbDemographicSurveyV2;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
@@ -346,6 +347,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
         null,
         null,
         null,
+        null,
         dbVerifiedAffiliation);
   }
 
@@ -361,6 +363,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       List<Degree> degrees,
       DbAddress dbAddress,
       DbDemographicSurvey dbDemographicSurvey,
+      DbDemographicSurveyV2 dbDemographicSurveyV2,
       DbVerifiedInstitutionalAffiliation dbVerifiedAffiliation) {
     DbUser dbUser = new DbUser();
     dbUser.setCreationNonce(Math.abs(random.nextLong()));
@@ -376,6 +379,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
       dbUser.setDegreesEnum(degrees);
     }
     dbUser.setDemographicSurvey(dbDemographicSurvey);
+    dbUser.setDemographicSurveyV2(dbDemographicSurveyV2);
 
     // For existing user that do not have address
     if (dbAddress != null) {
@@ -383,6 +387,9 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     }
     if (dbDemographicSurvey != null) {
       dbDemographicSurvey.setUser(dbUser);
+    }
+    if (dbDemographicSurveyV2 != null) {
+      dbDemographicSurveyV2.setUser(dbUser);
     }
 
     Timestamp now = clockNow();

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -404,7 +404,7 @@ public class DbUser {
   }
 
   @OneToOne(
-      cascade = CascadeType.MERGE,
+      cascade = CascadeType.ALL,
       orphanRemoval = true,
       fetch = FetchType.LAZY,
       mappedBy = "user")

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -282,10 +282,6 @@ public class ProfileService {
         demographicSurveyMapper.toDbDemographicSurveyV2(updatedProfile.getDemographicSurveyV2());
 
     if (newDemoSurvey != null) {
-      DbDemographicSurveyV2 existingSurvey = dbUser.getDemographicSurveyV2();
-      if (existingSurvey != null) {
-        newDemoSurvey.setId(existingSurvey.getId());
-      }
       dbUser.setDemographicSurveyV2(newDemoSurvey);
       // needed to trigger an RDR Export refresh for this Researcher
       dbUser.setLastModifiedTime(lastModifiedTime);

--- a/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
@@ -565,6 +565,42 @@ public class ProfileServiceTest {
   }
 
   @Test
+  public void updateProfile_with_existing_demo_survey_v2() {
+    DemographicSurveyV2 v2Survey =
+        new DemographicSurveyV2()
+            .ethnicCategories(
+                ImmutableList.of(
+                    EthnicCategory.ASIAN, EthnicCategory.ASIAN_CHINESE, EthnicCategory.WHITE))
+            .genderIdentities(ImmutableList.of(GenderIdentityV2.MAN, GenderIdentityV2.TRANS_MAN))
+            .sexualOrientations(ImmutableList.of(SexualOrientationV2.QUEER))
+            .sexAtBirth(SexAtBirthV2.PREFER_NOT_TO_ANSWER)
+            .yearOfBirthPreferNot(true)
+            .disabilityHearing(YesNoPreferNot.NO)
+            .disabilitySeeing(YesNoPreferNot.YES)
+            .education(EducationV2.DOCTORATE)
+            .disadvantaged(YesNoPreferNot.PREFER_NOT_TO_ANSWER);
+
+    Profile previousProfile = createValidProfile().demographicSurveyV2(v2Survey);
+    Profile updatedProfile =
+        createValidProfile().demographicSurveyV2(v2Survey).areaOfResearch("Some research");
+
+    DbUser targetUser =
+        userDao.save(new DbUser().setUserId(10).setGivenName("John").setFamilyName("Doe"));
+
+    when(mockUserService.updateUserWithRetries(any(), any(), any())).thenReturn(targetUser);
+
+    profileService.updateProfile(
+        targetUser, Agent.asUser(loggedInUser), updatedProfile, previousProfile);
+
+    TestMockFactory.assertEqualDemographicSurveys(
+        profileService.getProfile(targetUser).getDemographicSurveyV2(),
+        updatedProfile.getDemographicSurveyV2());
+
+    assertThat(profileService.getProfile(targetUser).getAreaOfResearch())
+        .isEqualTo("Some research");
+  }
+
+  @Test
   public void updateProfile_demo_survey_update_v2() {
     DemographicSurveyV2 v2Survey =
         new DemographicSurveyV2()


### PR DESCRIPTION
Description: This PR saves the demographic survey version 2 in Database when a new account is created. Along with that this PR uses a consistent definition to save demographic survey v2 object with the user object. The CASCADEType for demographicsurveyv2 was updated to type merge only because on updating  a profile of user who has submitted new version of demographic survey, was failing with the following error:

_org.hibernate.PersistentObjectException: detached entity passed to persist: org.pmiops.workbench.db.model.DbDemographicSurveyV2_

This is because the Save method accepts only transient objects. 
Definition of trainsient object: https://docs.jboss.org/hibernate/core/3.3/reference/en/html/objectstate.html

an object is transient if it has just been instantiated using the new operator, and it is not associated with a Hibernate Session. It has no persistent representation in the database and **no identifier value has been assigned**. 

Removing the setting of IDs helped solve this issue and now we can use CASCADETYPE.ALL rather just a small subset MERGE



<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
