### PR TITLE
[RW-8884][risk=no] Use correct definition for cohort snapshots

### DIFF
--- a/ui/src/app/pages/data/cohort-review/cohort-definition.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-definition.component.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import {
-  Cohort,
+  CohortDefinition,
   Criteria,
   CriteriaType,
   Domain,
@@ -100,7 +100,7 @@ const modifierOperatorDisplay = (operator: Operator) => {
 };
 
 interface Props extends RouteComponentProps<MatchParams> {
-  cohort: Cohort;
+  cohortDefinition: CohortDefinition;
 }
 
 interface State {
@@ -128,14 +128,11 @@ export const CohortDefinitionComponent = withRouter(
     }
 
     mapDefinition() {
-      const {
-        cohort: { criteria },
-      } = this.props;
-      const def = JSON.parse(criteria);
+      const { cohortDefinition } = this.props;
       const definition = ['includes', 'excludes'].reduce((acc, role) => {
-        if (def[role].length) {
+        if (cohortDefinition[role].length) {
           const roleObj = { role, groups: [] };
-          def[role].forEach((group) => {
+          cohortDefinition[role].forEach((group) => {
             roleObj.groups.push(this.mapGroup(group));
           });
           acc.push(roleObj);

--- a/ui/src/app/pages/data/cohort-review/query-report.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/query-report.component.tsx
@@ -432,10 +432,19 @@ export const QueryReport = fp.flow(
                       {outdatedDefinition && (
                         <div style={styles.queryHeader}>
                           Cohort Snapshot{' '}
-                          <img
-                            src={outdated}
-                            title='Outdated Cohort Definition'
-                          />
+                          <span
+                            style={{
+                              color: colors.warning,
+                              fontSize: '14px',
+                              fontWeight: 'normal',
+                            }}
+                          >
+                            <img
+                              src={outdated}
+                              title='Outdated Cohort Definition'
+                            />{' '}
+                            Outdated
+                          </span>
                         </div>
                       )}
                       <div style={styles.row}>

--- a/ui/src/app/pages/data/cohort-review/query-report.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/query-report.component.tsx
@@ -312,7 +312,7 @@ export const QueryReport = fp.flow(
                   'YYYY-MM-DD'
                 ),
               });
-              request = JSON.parse(cohort.criteria);
+              request = JSON.parse(cohortResponse.criteria);
             }
             this.setState({ cohortLoading: false });
           });


### PR DESCRIPTION
- Fix issue on Cohort Description page where we were using the current cohort definition instead of the cohort snapshot
- Add text so the user knows data from the snapshot is being displayed
![Screen Shot 2022-09-20 at 9 02 16 AM](https://user-images.githubusercontent.com/40036095/191278659-304c3bbb-2ec6-498f-8f80-ed2edec79d36.png)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
