### PR TITLE
[RW-8891][RW-8892][risk=no] Fix issues when deleting selected or last cohort review

### DIFF
--- a/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
@@ -179,9 +179,15 @@ export const CohortReviewPage = fp.flow(
     if (cohortReviewResponse.items.length > 0) {
       let selectedReview = cohortReviewResponse.items[0];
       if (crid) {
-        selectedReview = cohortReviewResponse.items.find(
+        const reviewIndex = cohortReviewResponse.items.findIndex(
           (cr) => cr.cohortReviewId === +crid
         );
+        if (reviewIndex > -1) {
+          selectedReview = cohortReviewResponse.items[reviewIndex];
+        } else {
+          // Review with id from url doesn't exist, use the first review from the response
+          updateUrlWithCohortReviewId(selectedReview.cohortReviewId);
+        }
       } else {
         updateUrlWithCohortReviewId(selectedReview.cohortReviewId);
       }

--- a/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
@@ -159,10 +159,12 @@ export const CohortReviewPage = fp.flow(
       });
   };
 
-  // sets the cohort review id as a url param
-  const updateUrlWithCohortReviewId = (cohortReviewId: number) =>
+  // sets the cohort review id as a url param or removes it if no id is passed
+  const updateUrlWithCohortReviewId = (cohortReviewId?: number) =>
     history.push(
-      `/workspaces/${ns}/${wsid}/data/cohorts/${cid}/reviews/${cohortReviewId}`
+      `/workspaces/${ns}/${wsid}/data/cohorts/${cid}/reviews/${
+        cohortReviewId || ''
+      }`
     );
 
   const loadCohortAndReviews = async () => {
@@ -195,6 +197,15 @@ export const CohortReviewPage = fp.flow(
       setActiveReview(selectedReview);
       getParticipantData(selectedReview.cohortReviewId);
     } else {
+      // no reviews exist for this cohort
+      if (activeReview) {
+        // clear charts in overview section
+        setActiveReview(undefined);
+      }
+      if (crid) {
+        // remove crid param from url
+        updateUrlWithCohortReviewId();
+      }
       hideSpinner();
     }
     setLoading(false);


### PR DESCRIPTION
Fixes 2 issues that can occur when deleting a cohort review:
- Deleting the currently selected review results in an error that causes an infinite spinner
- After deleting the last review in the list, the charts in the overview section still show with the deleted review' data

https://user-images.githubusercontent.com/40036095/191336809-56848b70-907f-4c03-b67f-f9ce141e2991.mov

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
