### PR TITLE
[RW-8479] [risk=low] Use different dataset for dataproc and gce

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
+++ b/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
@@ -147,14 +147,14 @@ public class EgressLogService {
   }
 
   private String getDatasetId(Optional<SumologicEgressEvent> sumologicEgressEvent) {
-    // If getGceEgressMib is not null, we see this egress triggered by GCE, otherwise, it's
+    // If getGceEgressMib is more than zero, we see this egress triggered by GCE, otherwise, it's
     // Dataproc.
     // TODO(yonghao): Revisit this logic and probably make an enum once we understand what does GKE
     // sumologic event looks like.
     boolean isGce =
         sumologicEgressEvent
             .map(SumologicEgressEvent::getGceEgressMib)
-            .map(d -> d == 0)
+            .map(d -> d > 0)
             .orElse(false);
     return isGce
         ? workbenchConfigProvider.get().firecloud.workspaceLogsProject + GCE_LOG_LOCATION

--- a/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
+++ b/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
@@ -48,8 +48,13 @@ public class EgressLogService {
           new EgressTerraRuntimeLogPattern("File downloads", "%download%"),
           new EgressTerraRuntimeLogPattern("Errors", "%error%"));
 
+  private static final String GCE_LOG_LOCATION = "WorkspaceRuntimeLogs.cos_containers";
+  private static final String DATAPROC_LOG_LOCATION = "WorkspaceRuntimeLogs.jupyter";
+
+
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final BigQueryService bigQueryService;
+
 
   @Autowired
   public EgressLogService(

--- a/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
+++ b/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
@@ -12,6 +12,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -72,6 +73,9 @@ public class EgressLogService {
     Instant endTime = event.getCreationTime().toInstant();
     Optional<SumologicEgressEvent> maybeSumologicEvent =
         maybeParseSumologicEvent(event.getSumologicEvent());
+    if (!maybeSumologicEvent.isPresent()) {
+      return new ArrayList<>();
+    }
     Instant startTime =
         maybeSumologicEvent
             .map(SumologicEgressEvent::getTimeWindowStart)

--- a/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
+++ b/api/src/main/java/org/pmiops/workbench/exfiltration/EgressLogService.java
@@ -173,13 +173,12 @@ public class EgressLogService {
         QueryJobConfiguration.newBuilder(
                 String.format(
                     "SELECT timestamp, jsonPayload.message AS message"
-                        + " FROM "
-                        + datasetId
+                        + " FROM %s"
                         + " WHERE resource.labels.project_id = @project_id"
                         + "  AND timestamp BETWEEN @start_time AND @end_time"
                         + "  AND jsonPayload.message LIKE @log_pattern"
                         + " ORDER BY timestamp DESC",
-                    workbenchConfigProvider.get().firecloud.workspaceLogsProject))
+                    datasetId))
             .setNamedParameters(
                 ImmutableMap.<String, QueryParameterValue>builder()
                     .putAll(baseParams)


### PR DESCRIPTION
Description:
We use different log locations for GCE and dataproc.

1. GCE: WorkspaceRuntimeLogs.cos_containers
2. Dataproc: WorkspaceRuntimeLogs.jupyter

This PR dynamically set the file location based on whether it is dataproc or GCE
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
