### PR TITLE
[DT-52][risk=no] Fix cohort selections for nightly genomics test

### DIFF
--- a/e2e/tests/nightly/genomic-extraction-to-vcf.spec.ts
+++ b/e2e/tests/nightly/genomic-extraction-to-vcf.spec.ts
@@ -54,9 +54,9 @@ describe('Genomics Extraction Test', () => {
     let totalCount = await cohortBuildPage.getTotalCount();
     expect(group1Count).toEqual(totalCount);
 
-    // Group 2: Include Demographics Age. range: 20 - 21 to have smallest number of participants.
-    const minAge = 20;
-    const maxAge = 21;
+    // Group 2: Include Demographics Age. range: 21 - 22 to have smallest number of participants.
+    const minAge = 21;
+    const maxAge = 22;
     const group2 = cohortBuildPage.findIncludeParticipantsGroup('Group 2');
     await group2.includeAge(minAge, maxAge, AgeSelectionRadioButton.CurrentAge);
 


### PR DESCRIPTION
Update the age range selection to get a non-zero count.

Before (20-21 age range)
![Screen Shot 2022-09-26 at 10 09 48 AM](https://user-images.githubusercontent.com/40036095/192314565-2c09f639-dda1-4c67-af05-340be2f78f56.png)

After (21-22 age range)
![Screen Shot 2022-09-26 at 10 10 22 AM](https://user-images.githubusercontent.com/40036095/192314640-abc460a2-bb35-43ab-b815-7593572eeab7.png)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
