### PR TITLE
[no-ticket][risk=no] Notebook test refactor

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import java.time.Clock;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
@@ -110,7 +111,7 @@ public class NotebooksServiceTest {
     MockNotebook(String path, String bucketName) {
       blob = mock(Blob.class);
       fileDetail = new FileDetail();
-      Set<String> workspaceUsersSet = new HashSet();
+      Set<String> workspaceUsersSet = new HashSet<>();
 
       String[] parts = path.split("/");
       String fileName = parts[parts.length - 1];

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -19,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import java.time.Clock;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
@@ -354,6 +354,12 @@ public class NotebooksServiceTest {
     verify(mockWorkspaceAuthService)
         .enforceWorkspaceAccessLevel(NAMESPACE_NAME, WORKSPACE_NAME, WorkspaceAccessLevel.WRITER);
     verify(mockLogsBasedMetricsService).recordEvent(EventMetric.NOTEBOOK_DELETE);
+    verify(mockCloudStorageClient).deleteBlob(BlobId.of(BUCKET_NAME, "notebooks/" + NOTEBOOK_NAME));
+    verify(mockUserRecentResourceService)
+        .deleteNotebookEntry(
+            eq(dbWorkspace.getWorkspaceId()),
+            anyLong(),
+            eq("gs://" + BUCKET_NAME + "/notebooks/" + NOTEBOOK_NAME));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -149,7 +149,7 @@ public class WorkspaceAdminServiceTest {
     UserMapper.class,
     UserService.class,
     WorkspaceAuthService.class,
-    WorkspaceService.class
+    WorkspaceService.class,
   })
   static class Configuration {
     @Bean
@@ -340,6 +340,7 @@ public class WorkspaceAdminServiceTest {
     when(mockCloudStorageClient.blobToFileDetail(any(), anyString(), anySet()))
         .thenReturn(
             expectedFiles.get(0), expectedFiles.get(1), expectedFiles.get(2), expectedFiles.get(3));
+
     final List<FileDetail> files = workspaceAdminService.listFiles(WORKSPACE_NAMESPACE);
     assertThat(files).containsExactlyElementsIn(expectedFiles);
   }


### PR DESCRIPTION
This is a rebased version of #6918.

Eric's original text from that PR:
---
Most of the existing functionality for notebooks shifted from the controller test to the service test.

The hashing tests stayed in the controller test, because the hashing logic is in the controller and not the service. Should we consider shifting this functionality to the service?

I wrote tests to test each of the controller functions. In the case of both the controller and service tests, I wrote the tests in such a way to ensure that only the logic of the class being tested was being used. All other functionality was stubbed.

In order to illustrate how the tests are changing, I made this diagram:
https://lucid.app/lucidchart/502dab38-d56b-4a26-a43a-093e8cea8fa5/edit?invitationId=inv_1557970f-fb2d-4d6e-a810-f6ec59c09dee#


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
