### PR TITLE
DT-64 fix sql to remove duplicate entries

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortQueryBuilder.java
@@ -21,7 +21,7 @@ public class CohortQueryBuilder extends QueryBuilder {
           + "WHERE ";
 
   private static final String RANDOM_SQL_TEMPLATE =
-      "SELECT RAND() as x, *\n"
+      "SELECT RAND() as x, person_id, race_concept_id, gender_concept_id, ethnicity_concept_id, sex_at_birth_concept_id, birth_datetime, deceased\n"
           + "FROM (SELECT person.person_id, race_concept_id, gender_concept_id, ethnicity_concept_id, sex_at_birth_concept_id, birth_datetime, CASE WHEN death.person_id IS NULL THEN false ELSE true END as deceased\n"
           + "FROM `${projectId}.${dataSetId}.person` person\n"
           + "LEFT JOIN `${projectId}.${dataSetId}.death` death ON (person.person_id = death.person_id)\n"

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortQueryBuilder.java
@@ -21,10 +21,12 @@ public class CohortQueryBuilder extends QueryBuilder {
           + "WHERE ";
 
   private static final String RANDOM_SQL_TEMPLATE =
-      "SELECT RAND() as x, person.person_id, race_concept_id, gender_concept_id, ethnicity_concept_id, sex_at_birth_concept_id, birth_datetime, CASE WHEN death.person_id IS NULL THEN false ELSE true END as deceased\n"
+      "SELECT RAND() as x, *\n"
+          + "FROM (SELECT person.person_id, race_concept_id, gender_concept_id, ethnicity_concept_id, sex_at_birth_concept_id, birth_datetime, CASE WHEN death.person_id IS NULL THEN false ELSE true END as deceased\n"
           + "FROM `${projectId}.${dataSetId}.person` person\n"
           + "LEFT JOIN `${projectId}.${dataSetId}.death` death ON (person.person_id = death.person_id)\n"
-          + "WHERE person.person_id IN (${innerSql})";
+          + "WHERE person.person_id IN (${innerSql})\n"
+          + "GROUP BY person_id, race_concept_id, gender_concept_id, ethnicity_concept_id, sex_at_birth_concept_id, birth_datetime, deceased)\n";
 
   private static final String RANDOM_SQL_ORDER_BY = "ORDER BY x\nLIMIT";
 


### PR DESCRIPTION
Update BigQuery SQL that produces random participants for cohort review. The death table happens to have duplicate rows. This is not expected, so we will full proof the code by doing a group by to remove the duplicates. This code change will fix the problem in both RT and CT CDRs.

![Screen Shot 2022-09-29 at 10 07 54 AM](https://user-images.githubusercontent.com/3904919/193082354-971b1914-f9e8-476d-a2fd-5f3fa08abe2b.png)
