### PR TITLE
[risk=low][RW-8473] Show support links in new CT workspaces

### DIFF
--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -56,10 +56,9 @@ const styles = reactStyles({
 });
 
 interface NotificationProps {
-  isNewCT: boolean;
   onCancel: () => void;
 }
-const MaybeNewCtNotification = (props: NotificationProps) => {
+const NewCtNotification = (props: NotificationProps) => {
   const dataPathsLink = (
     <StyledExternalLink
       href={`${zendeskBaseUrl()}/en-us/articles/4616869437204-Controlled-CDR-Directory`}
@@ -83,27 +82,25 @@ const MaybeNewCtNotification = (props: NotificationProps) => {
   );
 
   return (
-    props.isNewCT && (
-      <div style={styles.newCtNotification}>
-        <FlexRow>
-          <FlexColumn>
-            <div>
-              These resources will get you started using the genomic data.
-            </div>
-            <div>
-              {dataPathsLink} provides full genomic data paths, {dataFilesLink}{' '}
-              provides information about genomic data formatting, and{' '}
-              {cohortBuilderLink} describes how to build a cohort.
-            </div>
-          </FlexColumn>
-          <FontAwesomeIcon
-            icon={faXmark}
-            style={{ fontSize: '21px', marginLeft: '1em' }}
-            onClick={() => props.onCancel()}
-          />
-        </FlexRow>
-      </div>
-    )
+    <div style={styles.newCtNotification}>
+      <FlexRow>
+        <FlexColumn>
+          <div>
+            These resources will get you started using the genomic data.
+          </div>
+          <div>
+            {dataPathsLink} provides full genomic data paths, {dataFilesLink}{' '}
+            provides information about genomic data formatting, and{' '}
+            {cohortBuilderLink} describes how to build a cohort.
+          </div>
+        </FlexColumn>
+        <FontAwesomeIcon
+          icon={faXmark}
+          style={{ fontSize: '21px', marginLeft: '1em' }}
+          onClick={() => props.onCancel()}
+        />
+      </FlexRow>
+    </div>
   );
 };
 
@@ -214,10 +211,11 @@ export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
             {!routeData.minimizeChrome && (
               <WorkspaceNavBar tabPath={routeData.workspaceNavBarTab} />
             )}
-            <MaybeNewCtNotification
-              isNewCT={showNewCtNotification}
-              onCancel={() => setShowNewCtNotification(false)}
-            />
+            {showNewCtNotification && (
+              <NewCtNotification
+                onCancel={() => setShowNewCtNotification(false)}
+              />
+            )}
             <HelpSidebar pageKey={routeData.pageKey} />
             <div
               style={{

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -196,13 +196,13 @@ export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
     useEffect(() => {
       const isControlled =
         workspace?.accessTierShortName === AccessTierShortNames.Controlled;
-      const tenMinutesAgo = Date.now() - 1000 * 60 * 1000; // arbitrary notion of 'new' workspace
+      const tenMinutesAgo = Date.now() - 10 * 60 * 1000; // arbitrary notion of 'new' workspace
       const isNew = workspace?.creationTime > tenMinutesAgo;
       setShowNewCTNotification(isControlled && isNew);
     }, [workspace]);
 
     return (
-      <React.Fragment>
+      <>
         {workspace ? (
           <>
             {!routeData.minimizeChrome && (
@@ -235,7 +235,7 @@ export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
             <Spinner />
           </div>
         )}
-      </React.Fragment>
+      </>
     );
   }
 );

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -6,7 +6,7 @@ import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { StyledExternalLink } from 'app/components/buttons';
-import { FlexColumn, FlexRow } from 'app/components/flex';
+import { FlexRow } from 'app/components/flex';
 import { HelpSidebar } from 'app/components/help-sidebar';
 import { Spinner } from 'app/components/spinners';
 import { WorkspaceNavBar } from 'app/pages/workspace/workspace-nav-bar';
@@ -83,11 +83,11 @@ const NewCtNotification = (props: NotificationProps) => {
 
   return (
     <div style={styles.newCtNotification}>
-      <FlexRow>
-        <FlexColumn>
+      <FlexRow style={{ justifyContent: 'space-between' }}>
+        <div>
           These resources will get you started using the genomic data:{' '}
           {dataPathsLink}, {dataFilesLink}, and {cohortBuilderLink}.
-        </FlexColumn>
+        </div>
         <FontAwesomeIcon
           icon={faXmark}
           style={{ fontSize: '21px', marginLeft: '1em' }}

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -111,7 +111,7 @@ export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
     const params = useParams<MatchParams>();
     const { ns, wsid } = params;
 
-    const [showNewCTNotification, setShowNewCTNotification] = useState(false);
+    const [showNewCtNotification, setShowNewCtNotification] = useState(false);
 
     useEffect(() => {
       const updateStores = async (namespace) => {
@@ -198,7 +198,7 @@ export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
         workspace?.accessTierShortName === AccessTierShortNames.Controlled;
       const tenMinutesAgo = Date.now() - 10 * 60 * 1000; // arbitrary notion of 'new' workspace
       const isNew = workspace?.creationTime > tenMinutesAgo;
-      setShowNewCTNotification(isControlled && isNew);
+      setShowNewCtNotification(isControlled && isNew);
     }, [workspace]);
 
     return (
@@ -209,8 +209,8 @@ export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
               <WorkspaceNavBar tabPath={routeData.workspaceNavBarTab} />
             )}
             <MaybeNewCtNotification
-              isNewCT={showNewCTNotification}
-              onCancel={() => setShowNewCTNotification(false)}
+              isNewCT={showNewCtNotification}
+              onCancel={() => setShowNewCtNotification(false)}
             />
             <HelpSidebar pageKey={routeData.pageKey} />
             <div

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -34,6 +34,7 @@ import {
   runtimeStore,
   useStore,
 } from 'app/utils/stores';
+import { zendeskBaseUrl } from 'app/utils/zendesk';
 
 const styles = reactStyles({
   newCtNotification: {
@@ -59,21 +60,26 @@ interface NotificationProps {
   onCancel: () => void;
 }
 const MaybeNewCtNotification = (props: NotificationProps) => {
-  const dataPaths =
-    'https://aousupporthelp.zendesk.com/hc/en-us/articles/4616869437204-Controlled-CDR-Directory';
-  const dataFiles =
-    'https://aousupporthelp.zendesk.com/hc/en-us/articles/4614687617556-How-the-All-of-Us-Genomic-data-are-organized';
-  const cohortBuilder =
-    'https://aousupporthelp.zendesk.com/hc/en-us/articles/360039585591-Selecting-participants-using-the-Cohort-Builder-tool';
-
   const dataPathsLink = (
-    <StyledExternalLink href={dataPaths}>This resource</StyledExternalLink>
+    <StyledExternalLink
+      href={`${zendeskBaseUrl()}/hc/en-us/articles/4616869437204-Controlled-CDR-Directory`}
+    >
+      This resource
+    </StyledExternalLink>
   );
   const dataFilesLink = (
-    <StyledExternalLink href={dataFiles}>this resource</StyledExternalLink>
+    <StyledExternalLink
+      href={`${zendeskBaseUrl()}/hc/en-us/articles/4614687617556-How-the-All-of-Us-Genomic-data-are-organized`}
+    >
+      this resource
+    </StyledExternalLink>
   );
   const cohortBuilderLink = (
-    <StyledExternalLink href={cohortBuilder}>this resource</StyledExternalLink>
+    <StyledExternalLink
+      href={`${zendeskBaseUrl()}/hc/en-us/articles/360039585591-Selecting-participants-using-the-Cohort-Builder-tool`}
+    >
+      this resource
+    </StyledExternalLink>
   );
 
   return (

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -2,13 +2,19 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import * as fp from 'lodash/fp';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import { StyledExternalLink } from 'app/components/buttons';
+import { FlexColumn, FlexRow } from 'app/components/flex';
 import { HelpSidebar } from 'app/components/help-sidebar';
 import { Spinner } from 'app/components/spinners';
 import { WorkspaceNavBar } from 'app/pages/workspace/workspace-nav-bar';
 import { WorkspaceRoutes } from 'app/routing/workspace-app-routing';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
-import { withCurrentWorkspace } from 'app/utils';
+import colors, { colorWithWhiteness } from 'app/styles/colors';
+import { reactStyles, withCurrentWorkspace } from 'app/utils';
+import { AccessTierShortNames } from 'app/utils/access-tiers';
 import { reportError } from 'app/utils/errors';
 import {
   ExceededActionCountError,
@@ -29,6 +35,72 @@ import {
   useStore,
 } from 'app/utils/stores';
 
+const styles = reactStyles({
+  newCtNotification: {
+    padding: 16,
+    marginTop: 16,
+    marginLeft: '2rem',
+    width: 'calc(100% - 5rem)',
+    boxSizing: 'border-box',
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderRadius: '5px',
+    color: colors.primary,
+    fontFamily: 'Montserrat',
+    letterSpacing: 0,
+    lineHeight: '22px',
+    borderColor: colors.accent,
+    backgroundColor: colorWithWhiteness(colors.accent, 0.85),
+  },
+});
+
+interface NotificationProps {
+  isNewCT: boolean;
+  onCancel: () => void;
+}
+const MaybeNewCtNotification = (props: NotificationProps) => {
+  const dataPaths =
+    'https://aousupporthelp.zendesk.com/hc/en-us/articles/4616869437204-Controlled-CDR-Directory';
+  const dataFiles =
+    'https://aousupporthelp.zendesk.com/hc/en-us/articles/4614687617556-How-the-All-of-Us-Genomic-data-are-organized';
+  const cohortBuilder =
+    'https://aousupporthelp.zendesk.com/hc/en-us/articles/360039585591-Selecting-participants-using-the-Cohort-Builder-tool';
+
+  const dataPathsLink = (
+    <StyledExternalLink href={dataPaths}>This resource</StyledExternalLink>
+  );
+  const dataFilesLink = (
+    <StyledExternalLink href={dataFiles}>this resource</StyledExternalLink>
+  );
+  const cohortBuilderLink = (
+    <StyledExternalLink href={cohortBuilder}>this resource</StyledExternalLink>
+  );
+
+  return (
+    props.isNewCT && (
+      <div style={styles.newCtNotification}>
+        <FlexRow>
+          <FlexColumn>
+            <div>
+              These resources will get you started using the genomic data.
+            </div>
+            <div>
+              {dataPathsLink} provides full genomic data paths, {dataFilesLink}{' '}
+              provides information about genomic data formatting, and{' '}
+              {cohortBuilderLink} describes how to build a cohort.
+            </div>
+          </FlexColumn>
+          <FontAwesomeIcon
+            icon={faXmark}
+            style={{ fontSize: '21px', marginLeft: '1em' }}
+            onClick={() => props.onCancel()}
+          />
+        </FlexRow>
+      </div>
+    )
+  );
+};
+
 export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
   ({ workspace, hideSpinner }) => {
     useEffect(() => hideSpinner(), []);
@@ -38,6 +110,8 @@ export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
     const [pollAborter, setPollAborter] = useState(new AbortController());
     const params = useParams<MatchParams>();
     const { ns, wsid } = params;
+
+    const [showNewCTNotification, setShowNewCTNotification] = useState(false);
 
     useEffect(() => {
       const updateStores = async (namespace) => {
@@ -119,13 +193,25 @@ export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
       workspacesApi().updateRecentWorkspaces(ns, wsid);
     }, [ns, wsid]);
 
+    useEffect(() => {
+      const isControlled =
+        workspace?.accessTierShortName === AccessTierShortNames.Controlled;
+      const tenMinutesAgo = Date.now() - 1000 * 60 * 1000; // arbitrary notion of 'new' workspace
+      const isNew = workspace?.creationTime > tenMinutesAgo;
+      setShowNewCTNotification(isControlled && isNew);
+    }, [workspace]);
+
     return (
       <React.Fragment>
         {workspace ? (
-          <React.Fragment>
+          <>
             {!routeData.minimizeChrome && (
               <WorkspaceNavBar tabPath={routeData.workspaceNavBarTab} />
             )}
+            <MaybeNewCtNotification
+              isNewCT={showNewCTNotification}
+              onCancel={() => setShowNewCTNotification(false)}
+            />
             <HelpSidebar pageKey={routeData.pageKey} />
             <div
               style={{
@@ -135,7 +221,7 @@ export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
             >
               <WorkspaceRoutes />
             </div>
-          </React.Fragment>
+          </>
         ) : (
           <div
             style={{

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -61,6 +61,7 @@ interface NotificationProps {
 const NewCtNotification = (props: NotificationProps) => {
   const dataPathsLink = (
     <StyledExternalLink
+      target='_blank'
       href={`${zendeskBaseUrl()}/en-us/articles/4616869437204-Controlled-CDR-Directory`}
     >
       Genomic data paths
@@ -68,6 +69,7 @@ const NewCtNotification = (props: NotificationProps) => {
   );
   const dataFilesLink = (
     <StyledExternalLink
+      target='_blank'
       href={`${zendeskBaseUrl()}/en-us/articles/4614687617556-How-the-All-of-Us-Genomic-data-are-organized`}
     >
       genomic data formatting
@@ -75,6 +77,7 @@ const NewCtNotification = (props: NotificationProps) => {
   );
   const cohortBuilderLink = (
     <StyledExternalLink
+      target='_blank'
       href={`${zendeskBaseUrl()}/en-us/articles/360039585591-Selecting-participants-using-the-Cohort-Builder-tool`}
     >
       how to build a cohort

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -62,21 +62,21 @@ interface NotificationProps {
 const MaybeNewCtNotification = (props: NotificationProps) => {
   const dataPathsLink = (
     <StyledExternalLink
-      href={`${zendeskBaseUrl()}/hc/en-us/articles/4616869437204-Controlled-CDR-Directory`}
+      href={`${zendeskBaseUrl()}/en-us/articles/4616869437204-Controlled-CDR-Directory`}
     >
       This resource
     </StyledExternalLink>
   );
   const dataFilesLink = (
     <StyledExternalLink
-      href={`${zendeskBaseUrl()}/hc/en-us/articles/4614687617556-How-the-All-of-Us-Genomic-data-are-organized`}
+      href={`${zendeskBaseUrl()}/en-us/articles/4614687617556-How-the-All-of-Us-Genomic-data-are-organized`}
     >
       this resource
     </StyledExternalLink>
   );
   const cohortBuilderLink = (
     <StyledExternalLink
-      href={`${zendeskBaseUrl()}/hc/en-us/articles/360039585591-Selecting-participants-using-the-Cohort-Builder-tool`}
+      href={`${zendeskBaseUrl()}/en-us/articles/360039585591-Selecting-participants-using-the-Cohort-Builder-tool`}
     >
       this resource
     </StyledExternalLink>

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -63,21 +63,21 @@ const NewCtNotification = (props: NotificationProps) => {
     <StyledExternalLink
       href={`${zendeskBaseUrl()}/en-us/articles/4616869437204-Controlled-CDR-Directory`}
     >
-      This resource
+      Genomic data paths
     </StyledExternalLink>
   );
   const dataFilesLink = (
     <StyledExternalLink
       href={`${zendeskBaseUrl()}/en-us/articles/4614687617556-How-the-All-of-Us-Genomic-data-are-organized`}
     >
-      this resource
+      genomic data formatting
     </StyledExternalLink>
   );
   const cohortBuilderLink = (
     <StyledExternalLink
       href={`${zendeskBaseUrl()}/en-us/articles/360039585591-Selecting-participants-using-the-Cohort-Builder-tool`}
     >
-      this resource
+      how to build a cohort
     </StyledExternalLink>
   );
 
@@ -85,14 +85,8 @@ const NewCtNotification = (props: NotificationProps) => {
     <div style={styles.newCtNotification}>
       <FlexRow>
         <FlexColumn>
-          <div>
-            These resources will get you started using the genomic data.
-          </div>
-          <div>
-            {dataPathsLink} provides full genomic data paths, {dataFilesLink}{' '}
-            provides information about genomic data formatting, and{' '}
-            {cohortBuilderLink} describes how to build a cohort.
-          </div>
+          These resources will get you started using the genomic data:{' '}
+          {dataPathsLink}, {dataFilesLink}, and {cohortBuilderLink}.
         </FlexColumn>
         <FontAwesomeIcon
           icon={faXmark}

--- a/ui/src/app/utils/zendesk.ts
+++ b/ui/src/app/utils/zendesk.ts
@@ -37,6 +37,10 @@ export const zendeskWidgetKey = () => {
   return zendeskConfigs[environment.zendeskEnv].widgetKey;
 };
 
+export const zendeskBaseUrl = () => {
+  return zendeskConfigs[environment.zendeskEnv].baseUrl;
+};
+
 /**
  * A set of support URLs for the current environment. These need to be
  * parameterized per environment since the Zendesk support content IDs are not


### PR DESCRIPTION
When a CT workspace is "new" (here, 10 minutes old or less) display a notification with support links.  The user may dismiss this notification by clicking X

<img width="1355" alt="ct links" src="https://user-images.githubusercontent.com/2701406/193323043-759502ac-70d4-4e06-abbe-800f64d0d463.png">


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
