### PR TITLE
[RW-8188][risk=no]  Update Recent Accessed Table Styling

### DIFF
--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -30,7 +30,7 @@ import { userMetricsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { cond, reactStyles, withCdrVersions } from 'app/utils';
 import { getCdrVersion } from 'app/utils/cdr-versions';
-import { displayDateWithoutHours } from 'app/utils/dates';
+import { displayDate, displayDateWithoutHours } from 'app/utils/dates';
 import { getDisplayName, isNotebook } from 'app/utils/resources';
 
 const styles = reactStyles({
@@ -80,9 +80,13 @@ interface TableData {
   menu: JSX.Element;
   resourceType: JSX.Element;
   resourceName: JSX.Element;
+  resourceNameAsString: string;
   workspaceName: JSX.Element;
+  workspaceNameAsString: string;
   formattedLastModified: string;
+  lastModifiedDateAsString: string;
   cdrVersionName: string;
+  lastModifiedBy: string;
 }
 
 interface Props {
@@ -176,6 +180,7 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
                   {getDisplayName(r)}
                 </ResourceNavigation>
               ),
+              resourceNameAsString: getDisplayName(r),
               workspaceName: (
                 <WorkspaceNavigation
                   workspace={getWorkspace(r)}
@@ -183,10 +188,13 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
                   style={styles.navigation}
                 />
               ),
+              workspaceNameAsString: getWorkspace(r).name,
               formattedLastModified: displayDateWithoutHours(
                 r.lastModifiedEpochMillis
               ),
               cdrVersionName: getCdrVersionName(r),
+              lastModifiedBy: r.lastModifiedBy,
+              lastModifiedDateAsString: displayDate(r.lastModifiedEpochMillis),
             };
           })
       );
@@ -204,7 +212,7 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
       ),
     ],
     [
-      resources && wsMap && !loading,
+      resources && resources.length > 0 && wsMap && !loading,
       () => (
         <React.Fragment>
           <SmallHeader>Recently Accessed Items</SmallHeader>
@@ -213,8 +221,10 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
               value={tableData}
               scrollable={true}
               paginator={true}
+              sortMode='multiple'
               paginatorTemplate='CurrentPageReport'
               currentPageReportTemplate='Showing {totalRecords} most recent items'
+              style={{ width: '65rem', border: 'none' }}
             >
               <Column field='menu' style={styles.menu} />
               <Column
@@ -226,20 +236,31 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
                 field='resourceName'
                 header='Name'
                 style={styles.column}
+                sortField='resourceNameAsString'
+                sortable
               />
               <Column
                 field='workspaceName'
                 header='Workspace name'
-                style={styles.column}
-              />
-              <Column
-                field='formattedLastModified'
-                header='Last changed'
+                sortField='workspaceNameAsString'
+                sortable
                 style={styles.column}
               />
               <Column
                 field='cdrVersionName'
-                header='Dataset'
+                header='Dataset Version'
+                style={{ ...styles.column, width: '8rem' }}
+              />
+              <Column
+                field='formattedLastModified'
+                header='Last changed'
+                sortField='lastModifiedDateAsString'
+                sortable
+                style={{ ...styles.column, width: '6.5rem' }}
+              />
+              <Column
+                field='lastModifiedBy'
+                header='Last Modified By'
                 style={styles.column}
               />
             </DataTable>
@@ -247,6 +268,7 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
         </React.Fragment>
       ),
     ],
+    [resources && resources.length === 0, () => <div></div>],
     [loading, () => <SpinnerOverlay />]
   );
 });


### PR DESCRIPTION
When there are no recent resource:
<img width="1476" alt="Screen Shot 2022-10-05 at 4 13 41 PM" src="https://user-images.githubusercontent.com/34481816/194154277-97fec8a8-3f47-496c-9ebc-0b6939de79d0.png">

Updated recent resources table
<img width="1653" alt="Screen Shot 2022-10-05 at 4 16 58 PM" src="https://user-images.githubusercontent.com/34481816/194154957-43e47c02-52de-4a14-b81e-086c8c4036e4.png">


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
