### PR TITLE
[risk=low][no ticket] Sort first-sign-in correctly in UserAdminTable

### DIFF
--- a/ui/src/app/pages/admin/user/admin-user-table.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-table.tsx
@@ -24,7 +24,6 @@ import {
   AuthorityGuardedAction,
   hasAuthorityForAction,
 } from 'app/utils/authorities';
-import { sortableDateString } from 'app/utils/dates';
 import { getAdminUrl } from 'app/utils/institutions';
 import moment from 'moment';
 
@@ -98,8 +97,8 @@ interface DataTableFields {
   enabled: JSX.Element;
   dataAccess: JSX.Element;
   bypass: JSX.Element;
-  firstSignInTime: string;
-  sortableFirstSignInTime: string;
+  firstSignInTime: number;
+  firstSignInTimeText: string;
 }
 
 interface Props extends WithSpinnerOverlayProps {
@@ -241,10 +240,10 @@ export const AdminUserTable = withUserProfile()(
             />
           ),
 
-          firstSignInTime: this.formattedTimestampOrEmptyString(
+          firstSignInTime: user.firstSignInTime,
+          firstSignInTimeText: this.formattedTimestampOrEmptyString(
             user.firstSignInTime
           ),
-          sortableFirstSignInTime: sortableDateString(user.firstSignInTime),
         }))
         .sort((f1: DataTableFields, f2: DataTableFields) =>
           f1.nameText.localeCompare(f2.nameText)
@@ -334,8 +333,8 @@ export const AdminUserTable = withUserProfile()(
                 })}
                 {buildColumn({
                   header: 'First Sign-in',
-                  field: 'firstSignInTime',
-                  sortField: 'sortableFirstSignInTime',
+                  field: 'firstSignInTimeText',
+                  sortField: 'firstSignInTime',
                   filterable: false,
                   headerWidth: 180,
                 })}

--- a/ui/src/app/pages/admin/user/admin-user-table.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-table.tsx
@@ -24,6 +24,7 @@ import {
   AuthorityGuardedAction,
   hasAuthorityForAction,
 } from 'app/utils/authorities';
+import { displayDate, sortableDateString } from 'app/utils/dates';
 import { getAdminUrl } from 'app/utils/institutions';
 import moment from 'moment';
 
@@ -98,6 +99,7 @@ interface DataTableFields {
   dataAccess: JSX.Element;
   bypass: JSX.Element;
   firstSignInTime: string;
+  sortableFirstSignInTime: string;
 }
 
 interface Props extends WithSpinnerOverlayProps {
@@ -242,6 +244,7 @@ export const AdminUserTable = withUserProfile()(
           firstSignInTime: this.formattedTimestampOrEmptyString(
             user.firstSignInTime
           ),
+          sortableFirstSignInTime: sortableDateString(user.firstSignInTime),
         }))
         .sort((f1: DataTableFields, f2: DataTableFields) =>
           f1.nameText.localeCompare(f2.nameText)
@@ -332,7 +335,7 @@ export const AdminUserTable = withUserProfile()(
                 {buildColumn({
                   header: 'First Sign-in',
                   field: 'firstSignInTime',
-                  sortField: 'firstSignInTime',
+                  sortField: 'sortableFirstSignInTime',
                   filterable: false,
                   headerWidth: 180,
                 })}

--- a/ui/src/app/pages/admin/user/admin-user-table.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-table.tsx
@@ -24,7 +24,7 @@ import {
   AuthorityGuardedAction,
   hasAuthorityForAction,
 } from 'app/utils/authorities';
-import { displayDate, sortableDateString } from 'app/utils/dates';
+import { sortableDateString } from 'app/utils/dates';
 import { getAdminUrl } from 'app/utils/institutions';
 import moment from 'moment';
 

--- a/ui/src/app/utils/dates.tsx
+++ b/ui/src/app/utils/dates.tsx
@@ -50,10 +50,3 @@ export function isDateValid(date: Date): boolean {
     !isNaN(date.valueOf())
   );
 }
-
-export function sortableDateString(
-  timeInEpochMillis: number | undefined
-): string {
-  const date = new Date(timeInEpochMillis);
-  return isDateValid(date) ? date.toISOString() : '';
-}

--- a/ui/src/app/utils/dates.tsx
+++ b/ui/src/app/utils/dates.tsx
@@ -50,3 +50,10 @@ export function isDateValid(date: Date): boolean {
     !isNaN(date.valueOf())
   );
 }
+
+export function sortableDateString(
+  timeInEpochMillis: number | undefined
+): string {
+  const date = new Date(timeInEpochMillis);
+  return isDateValid(date) ? date.toISOString() : '';
+}


### PR DESCRIPTION
Was sorting by the output text string, which was month-first:
<img width="216" alt="bad sort" src="https://user-images.githubusercontent.com/2701406/194358042-fe1fa7bd-6eb6-494a-adb2-dc684123c3e8.png">

Now sorts correctly by using the epoch date instead of text
<img width="210" alt="good sort" src="https://user-images.githubusercontent.com/2701406/194358182-62f7a744-9050-4e39-8b2f-0cf5164c2194.png">


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
