### PR TITLE
[DT-97][risk=no] Some cleanup of CDR indices build with new CDR version

### DIFF
--- a/api/db-cdr/generate-cdr/build-cb-criteria-missing-codes.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-missing-codes.sh
@@ -293,6 +293,120 @@ FROM
         GROUP BY 1,2,3,4
     ) x"
 
+echo "MEASUREMENT - add other source concepts"
+bq --quiet --project_id="$BQ_PROJECT" query --batch --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (
+      id
+      ,parent_id
+      ,domain_id
+      ,is_standard
+      ,type
+      ,concept_id
+      ,code
+      ,name
+      ,rollup_count
+      ,item_count
+      ,est_count
+      ,is_group
+      ,is_selectable
+      ,has_attribute
+      ,has_hierarchy
+      ,path
+    )
+SELECT
+    ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID
+    , -1
+    , 'MEASUREMENT'
+    , 0
+    , vocabulary_id
+    , concept_id
+    , concept_code
+    , concept_name
+    , 0
+    , cnt
+    , cnt
+    , 0
+    , 1
+    , 0
+    , 0
+    , CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+FROM
+    (
+        SELECT concept_name, vocabulary_id, concept_id, concept_code, count(DISTINCT person_id) cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.measurement\` a
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.measurement_concept_id = b.concept_id
+        WHERE standard_concept = 'S'
+            and domain_id = 'Measurement'
+            and vocabulary_id = 'CPT4'
+            and measurement_concept_id NOT IN
+                (
+                    SELECT concept_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                    WHERE domain_id = 'MEASUREMENT'
+                        and is_standard = 0
+                        and concept_id is not null
+                )
+        GROUP BY 1,2,3,4
+    ) x"
+
+echo "OBSERVATION - add other source concepts"
+bq --quiet --project_id="$BQ_PROJECT" query --batch --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+    (
+      id
+      ,parent_id
+      ,domain_id
+      ,is_standard
+      ,type
+      ,concept_id
+      ,code
+      ,name
+      ,rollup_count
+      ,item_count
+      ,est_count
+      ,is_group
+      ,is_selectable
+      ,has_attribute
+      ,has_hierarchy
+      ,path
+    )
+SELECT
+    ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as ID
+    , -1
+    , 'OBSERVATION'
+    , 0
+    , vocabulary_id
+    , concept_id
+    , concept_code
+    , concept_name
+    , 0
+    , cnt
+    , cnt
+    , 0
+    , 1
+    , 0
+    , 0
+    , CAST(ROW_NUMBER() OVER(order by vocabulary_id,concept_name) + (SELECT MAX(id) FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`) as STRING) as path
+FROM
+    (
+        SELECT concept_name, vocabulary_id, concept_id, concept_code, count(DISTINCT person_id) cnt
+        FROM \`$BQ_PROJECT.$BQ_DATASET.observation\` a
+        LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` b on a.observation_concept_id = b.concept_id
+        WHERE standard_concept = 'S'
+            and domain_id = 'Observation'
+            and vocabulary_id = 'CPT4'
+            and observation_concept_id NOT IN
+                (
+                    SELECT concept_id
+                    FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
+                    WHERE domain_id = 'OBSERVATION'
+                        and is_standard = 0
+                        and concept_id is not null
+                )
+        GROUP BY 1,2,3,4
+    ) x"
+
 echo "DRUG_EXPOSURE - add other standard concepts not in hierarchies"
 bq --quiet --project_id="$BQ_PROJECT" query --batch --nouse_legacy_sql \
 "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`

--- a/api/db-cdr/generate-cdr/build-search-all-events.sh
+++ b/api/db-cdr/generate-cdr/build-search-all-events.sh
@@ -100,7 +100,14 @@ JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = po.person_id
 JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = po.procedure_concept_id)
 LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = po.visit_occurrence_id)
 WHERE po.procedure_concept_id is not null
-    and po.procedure_concept_id != 0"
+    and po.procedure_concept_id != 0
+    and c.concept_id not in (
+          select concept_id
+          from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+          where domain_id = 'Procedure'
+          and vocabulary_id in ('CPT4', 'ICD9Proc', 'ICD10PCS')
+          and standard_concept = 'S'
+        )"
 
 ##############################################################
 # insert source measurement data into cb_search_all_events
@@ -198,7 +205,14 @@ JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = m.person_id
 JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = m.measurement_concept_id)
 LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = m.visit_occurrence_id)
 WHERE m.measurement_concept_id is not null
-    and m.measurement_concept_id != 0"
+    and m.measurement_concept_id != 0
+    and c.concept_id not in (
+              select concept_id
+              from \`$BQ_PROJECT.$BQ_DATASET.concept\`
+              where domain_id = 'Measurement'
+              and vocabulary_id in ('CPT4')
+              and standard_concept = 'S'
+            )"
 
 #####################################################################
 #   update standard diastolic pressure data into cb_search_all_events
@@ -357,7 +371,14 @@ JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = o.person_id
 JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = o.observation_concept_id)
 LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = o.visit_occurrence_id)
 WHERE o.observation_concept_id is not null
-    and o.observation_concept_id != 0"
+    and o.observation_concept_id != 0
+    and c.concept_id not in (
+              select concept_id
+              from \`$BQ_PROJECT.$BQ_DATASET..concept\`
+              where domain_id = 'Observation'
+              and vocabulary_id in ('CPT4')
+              and standard_concept = 'S'
+            )"
 
 ############################################################
 # insert standard device data into cb_search_all_events
@@ -382,29 +403,6 @@ LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrenc
 where c.standard_concept = 'S'
 and c.domain_id = 'Device'
 and de.device_concept_id != 0"
-
-#######################################################
-#   insert source drug data into cb_search_all_events
-#######################################################
-echo "Inserting drug data into cb_search_all_events"
-bq --quiet --project_id="$BQ_PROJECT" query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.cb_search_all_events\`
-    (person_id, entry_date, entry_datetime, is_standard, concept_id, domain, age_at_event, visit_concept_id, visit_occurrence_id)
-SELECT p.person_id,
-    d.drug_exposure_start_date as entry_date,
-    d.drug_exposure_start_datetime as entry_datetime,
-    0 as is_standard,
-    d.drug_source_concept_id as concept_id,
-    'Drug' as domain,
-    DATE_DIFF(d.drug_exposure_start_date,date(p.BIRTH_DATETIME), YEAR) - IF(EXTRACT(MONTH FROM date(p.BIRTH_DATETIME))*100 + EXTRACT(DAY FROM date(p.BIRTH_DATETIME)) > EXTRACT(MONTH FROM d.drug_exposure_start_date)*100 + EXTRACT(DAY FROM d.drug_exposure_start_date),1,0) as age_at_event,
-    vo.visit_concept_id,
-    vo.visit_occurrence_id
-FROM \`$BQ_PROJECT.$BQ_DATASET.drug_exposure\` d
-JOIN \`$BQ_PROJECT.$BQ_DATASET.person\` p on p.person_id = d.person_id
-JOIN \`$BQ_PROJECT.$BQ_DATASET.concept\` c on (c.concept_id = d.drug_source_concept_id)
-LEFT JOIN \`$BQ_PROJECT.$BQ_DATASET.visit_occurrence\` vo on (vo.visit_occurrence_id = d.visit_occurrence_id)
-WHERE d.drug_source_concept_id is not null
-    and d.drug_source_concept_id != 0"
 
 #########################################################
 #   insert standard drug data into cb_search_all_events


### PR DESCRIPTION
Some cleanup of CDR indices build with new CDR version

1. Removing all source drug concepts from BQ all events table. They are never searchable in the system.
2. Adding update for Measurement and Observation data that has fallen out of the CPT4 hierarchy
3. Removing CPT4, ICD9Proc, ICD10PCS standard Procedure data from BQ all events table. CPT4, ICD9Proc, ICD10PCS are only searchable in source Procedure
4. Removing CPT4 standard Measurement and Observation data from BQ all events table. CPT4 is only search from source Measurements/Observations