### PR TITLE
[DT-73][risk=no] Fix attributes for survey concept

### DIFF
--- a/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
+++ b/ui/src/app/cohort-search/tree-node/tree-node.component.tsx
@@ -330,7 +330,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
     event.stopPropagation();
     const {
       node,
-      node: { conceptId, domainId, group, parentId, subtype, value },
+      node: { domainId, group, parentId, subtype, value },
       select,
       selectedIds,
       source,
@@ -357,15 +357,11 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
         if (question) {
           name = `${question.name} - ${name}`;
         }
-        const attribute =
-          conceptId === 1585747
-            ? {
-                name: AttrName.NUM,
-                operator: Operator.EQUAL,
-                operands: [value],
-              }
-            : { name: AttrName.CAT, operator: Operator.IN, operands: [value] };
-        attributes.push(attribute);
+        attributes.push({
+          name: AttrName.CAT,
+          operator: Operator.IN,
+          operands: [value],
+        });
       }
       const param = {
         ...(node as Object),


### PR DESCRIPTION
Remove hardcoded condition causing wrong type of attribute sent for survey with `conceptId` of 1585747

Before:
![Screen Shot 2022-10-10 at 11 12 56 AM](https://user-images.githubusercontent.com/40036095/194911456-27f4bf67-9021-43c6-b970-16901c075f5e.png)

After:
![Screen Shot 2022-10-10 at 11 13 04 AM](https://user-images.githubusercontent.com/40036095/194911485-2a738feb-dc10-4dd3-8d26-f0b5d6286fcd.png)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
