### PR TITLE
[RW-8681][risk=no] API changes to add Login.gov access to reporting output

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -197,6 +197,8 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "  u.disabled,\n"
                 + "  uame.era_commons_bypass_time,\n"
                 + "  uame.era_commons_completion_time,\n"
+                + "  uaml.ras_login_gov_bypass_time,\n"
+                + "  uaml.ras_login_gov_completion_time,\n"
                 + "  u.family_name,\n"
                 // temporary solution for RW-6566
                 + "  uat.first_enabled AS first_registration_completion_time,\n"
@@ -294,6 +296,14 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "  ) uame ON u.user_id = uame.user_id "
                 + "  LEFT OUTER JOIN ( "
                 + "    SELECT uam.user_id, "
+                + "      uam.bypass_time AS ras_login_gov_bypass_time, "
+                + "      uam.completion_time AS ras_login_gov_completion_time "
+                + "    FROM user_access_module uam "
+                + "    JOIN access_module am ON am.access_module_id=uam.access_module_id "
+                + "    WHERE am.name = 'RAS_LOGIN_GOV' "
+                + "  ) uaml ON u.user_id = uaml.user_id "
+                + "  LEFT OUTER JOIN ( "
+                + "    SELECT uam.user_id, "
                 + "      uam.bypass_time AS two_factor_auth_bypass_time, "
                 + "      uam.completion_time AS two_factor_auth_completion_time "
                 + "    FROM user_access_module uam "
@@ -339,6 +349,10 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 .eraCommonsBypassTime(offsetDateTimeUtc(rs.getTimestamp("era_commons_bypass_time")))
                 .eraCommonsCompletionTime(
                     offsetDateTimeUtc(rs.getTimestamp("era_commons_completion_time")))
+                .rasLoginGovBypassTime(
+                    offsetDateTimeUtc(rs.getTimestamp("ras_login_gov_bypass_time")))
+                .rasLoginGovCompletionTime(
+                    offsetDateTimeUtc(rs.getTimestamp("ras_login_gov_completion_time")))
                 .familyName(rs.getString("family_name"))
                 .firstRegistrationCompletionTime(
                     offsetDateTimeUtc(rs.getTimestamp("first_registration_completion_time")))

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
@@ -34,6 +34,10 @@ public enum UserColumnValueExtractor implements ColumnValueExtractor<ReportingUs
       "era_commons_bypass_time", u -> toInsertRowString(u.getEraCommonsBypassTime())),
   ERA_COMMONS_COMPLETION_TIME(
       "era_commons_completion_time", u -> toInsertRowString(u.getEraCommonsCompletionTime())),
+  RAS_LOGIN_GOV_BYPASS_TIME(
+      "ras_login_gov_bypass_time", u -> toInsertRowString(u.getRasLoginGovBypassTime())),
+  RAS_LOGIN_GOV_COMPLETION_TIME(
+      "ras_login_gov_completion_time", u -> toInsertRowString(u.getRasLoginGovCompletionTime())),
   FAMILY_NAME("family_name", ReportingUser::getFamilyName),
   FIRST_REGISTRATION_COMPLETION_TIME(
       "first_registration_completion_time",

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9332,6 +9332,15 @@ definitions:
       professionalUrl:
         type: string
         description: User's URL at primary place of work.
+      rasLoginGovBypassTime:
+        type: string
+        format: date-time
+        description: Time an administrator bypassed the RAS Login.gov requirement
+          for this user.
+      rasLoginGovCompletionTime:
+        type: string
+        format: date-time
+        description: Time user completed the RAS Login.gov account link.
       twoFactorAuthBypassTime:
         type: string
         format: date-time

--- a/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
@@ -11,6 +11,8 @@ import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__INSTITUTIONAL_ROLE_ENUM;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__INSTITUTIONAL_ROLE_OTHER_TEXT;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__INSTITUTION_ID;
+import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__RAS_LOGIN_GOV_BYPASS_TIME;
+import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__RAS_LOGIN_GOV_COMPLETION_TIME;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__TWO_FACTOR_AUTH_BYPASS_TIME;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__TWO_FACTOR_AUTH_COMPLETION_TIME;
 
@@ -124,6 +126,7 @@ public class ReportingQueryServiceTest {
   private DbAccessModule twoFactorAuthModule;
   private DbAccessModule rtTrainingModule;
   private DbAccessModule eRACommonsModule;
+  private DbAccessModule rasLoginGovModule;
   private DbAccessModule duccModule;
 
   @BeforeEach
@@ -136,6 +139,7 @@ public class ReportingQueryServiceTest {
     rtTrainingModule =
         accessModuleDao.findOneByName(DbAccessModuleName.RT_COMPLIANCE_TRAINING).get();
     eRACommonsModule = accessModuleDao.findOneByName(DbAccessModuleName.ERA_COMMONS).get();
+    rasLoginGovModule = accessModuleDao.findOneByName(DbAccessModuleName.RAS_LOGIN_GOV).get();
     duccModule = accessModuleDao.findOneByName(DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
   }
 
@@ -502,6 +506,11 @@ public class ReportingQueryServiceTest {
           USER__COMPLIANCE_TRAINING_COMPLETION_TIME);
       addUserAccessModule(
           user, eRACommonsModule, USER__ERA_COMMONS_BYPASS_TIME, USER__ERA_COMMONS_COMPLETION_TIME);
+      addUserAccessModule(
+          user,
+          rasLoginGovModule,
+          USER__RAS_LOGIN_GOV_BYPASS_TIME,
+          USER__RAS_LOGIN_GOV_COMPLETION_TIME);
       addUserAccessModule(
           user,
           duccModule,

--- a/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
@@ -68,6 +68,10 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
       Timestamp.from(Instant.parse("2015-05-19T00:00:00.00Z"));
   public static final Timestamp USER__ERA_COMMONS_COMPLETION_TIME =
       Timestamp.from(Instant.parse("2015-05-20T00:00:00.00Z"));
+  public static final Timestamp USER__RAS_LOGIN_GOV_BYPASS_TIME =
+      Timestamp.from(Instant.parse("2015-05-21T00:00:00.00Z"));
+  public static final Timestamp USER__RAS_LOGIN_GOV_COMPLETION_TIME =
+      Timestamp.from(Instant.parse("2015-05-22T00:00:00.00Z"));
   public static final String USER__FAMILY_NAME = "foo_16";
   public static final Timestamp USER__FIRST_SIGN_IN_TIME =
       Timestamp.from(Instant.parse("2015-05-23T00:00:00.00Z"));


### PR DESCRIPTION
Description:

Updates API to add Login.gov access to reporting output.

Dependent on applying https://github.com/all-of-us/workbench-devops/pull/104.

I tested this in the "local" terraform environment using the process outlined in https://github.com/all-of-us/workbench/wiki/Workbench-Reporting-Dataset-(WRD)#testing.

From the checklist below:
> If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers

Are there any consumers besides the BQ table I need to update for this change?

> If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests

1. Does this checklist item refer to _all_ tests or only (suspected) _relevant_ tests?
2. As far as I can tell no E2E tests are relevant here, do you think that's the case?
3. Why aren't these tests covered by CCI? I thought only nightly tests were skipped.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
