### PR TITLE
[DT-65][risk=no] Fix validation when renaming resources

### DIFF
--- a/ui/src/app/components/create-modal.tsx
+++ b/ui/src/app/components/create-modal.tsx
@@ -74,7 +74,7 @@ export const CreateModal = ({
   const onSave = async () => {
     setSaving(true);
     setSaveErrorMsg('');
-    save(name, description)
+    save(name.trim(), description)
       .then(() => close())
       .catch((e) => {
         setSaveErrorMsg(

--- a/ui/src/app/components/rename-modal.tsx
+++ b/ui/src/app/components/rename-modal.tsx
@@ -108,7 +108,7 @@ export class RenameModal extends React.Component<Props, States> {
       newName = this.props.nameFormat(newName);
     }
     const errors = validate(
-      { newName: newName.trim() },
+      { newName: newName?.trim() },
       { newName: nameValidationFormat(existingNames, resourceType) }
     );
     return (

--- a/ui/src/app/components/rename-modal.tsx
+++ b/ui/src/app/components/rename-modal.tsx
@@ -94,7 +94,10 @@ export class RenameModal extends React.Component<Props, States> {
 
   onRename() {
     this.setState({ saving: true });
-    this.props.onRename(this.state.newName, this.state.resourceDescription);
+    this.props.onRename(
+      this.state.newName.trim(),
+      this.state.resourceDescription
+    );
   }
 
   render() {
@@ -105,7 +108,7 @@ export class RenameModal extends React.Component<Props, States> {
       newName = this.props.nameFormat(newName);
     }
     const errors = validate(
-      { newName: newName },
+      { newName: newName.trim() },
       { newName: nameValidationFormat(existingNames, resourceType) }
     );
     return (

--- a/ui/src/app/pages/data/cohort-review/create-cohort-review-modal.tsx
+++ b/ui/src/app/pages/data/cohort-review/create-cohort-review-modal.tsx
@@ -89,7 +89,10 @@ export const CreateCohortReviewModal = ({
     },
   };
 
-  const errors = validate({ reviewName, numberOfParticipants }, validators);
+  const errors = validate(
+    { reviewName: reviewName?.trim(), numberOfParticipants },
+    validators
+  );
 
   const createDisabled = !reviewName || !numberOfParticipants || errors;
 
@@ -97,7 +100,7 @@ export const CreateCohortReviewModal = ({
     setCreating(true);
     setCreateError(false);
     const request = {
-      name: reviewName,
+      name: reviewName.trim(),
       size: parseInt(numberOfParticipants, 10),
     };
 

--- a/ui/src/app/pages/data/concept/concept-add-modal.tsx
+++ b/ui/src/app/pages/data/concept/concept-add-modal.tsx
@@ -258,7 +258,7 @@ export const ConceptAddModal = withCurrentWorkspace()(
         selectedConceptsInDomain,
       } = this.state;
       const errors = validate(
-        { name: name.trim() },
+        { name: name?.trim() },
         {
           name: nameValidationFormat(
             conceptSets.map((concept: ConceptSet) => concept.name),

--- a/ui/src/app/pages/data/concept/concept-add-modal.tsx
+++ b/ui/src/app/pages/data/concept/concept-add-modal.tsx
@@ -8,6 +8,7 @@ import {
   CreateConceptSetRequest,
   Criteria,
   Domain,
+  ResourceType,
   UpdateConceptSetRequest,
 } from 'generated/fetch';
 
@@ -22,6 +23,7 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
+import { nameValidationFormat } from 'app/components/rename-modal';
 import { Spinner, SpinnerOverlay } from 'app/components/spinners';
 import { conceptSetsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
@@ -179,7 +181,7 @@ export const ConceptAddModal = withCurrentWorkspace()(
         }
       } else {
         const conceptSet: ConceptSet = {
-          name,
+          name: name.trim(),
           description: newSetDescription,
           domain,
           criteriums: [],
@@ -256,15 +258,12 @@ export const ConceptAddModal = withCurrentWorkspace()(
         selectedConceptsInDomain,
       } = this.state;
       const errors = validate(
-        { name },
+        { name: name.trim() },
         {
-          name: {
-            presence: { allowEmpty: false },
-            exclusion: {
-              within: conceptSets.map((concept: ConceptSet) => concept.name),
-              message: 'already exists',
-            },
-          },
+          name: nameValidationFormat(
+            conceptSets.map((concept: ConceptSet) => concept.name),
+            ResourceType.CONCEPTSET
+          ),
         }
       );
 

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -442,7 +442,7 @@ export const ConceptSearch = fp.flow(
         showMoreDescription,
       } = this.state;
       const errors = validate(
-        { editDescription, editName: editName.trim() },
+        { editDescription, editName: editName?.trim() },
         {
           editName: nameValidationFormat(
             existingNames,

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -26,9 +26,11 @@ import { FlexColumn, FlexRow } from 'app/components/flex';
 import {
   TextAreaWithLengthValidationMessage,
   TextInput,
+  ValidationError,
 } from 'app/components/inputs';
 import { Modal, ModalFooter, ModalTitle } from 'app/components/modals';
 import { PopupTrigger, TooltipTrigger } from 'app/components/popups';
+import { nameValidationFormat } from 'app/components/rename-modal';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { EditComponentReact } from 'app/icons/edit';
@@ -40,6 +42,7 @@ import { conceptSetsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
   reactStyles,
+  summarizeErrors,
   withCurrentCohortSearchContext,
   withCurrentConcept,
   withCurrentWorkspace,
@@ -162,6 +165,7 @@ interface State {
   editSaving: boolean;
   error: boolean;
   errorMessage: string;
+  existingNames: string[];
   loading: boolean;
   showMoreDescription: boolean;
   // Show if trying to navigate away with unsaved changes
@@ -190,6 +194,7 @@ export const ConceptSearch = fp.flow(
         editSaving: false,
         error: false,
         errorMessage: '',
+        existingNames: [],
         deleting: false,
         loading: false,
         showMoreDescription: false,
@@ -296,7 +301,7 @@ export const ConceptSearch = fp.flow(
         this.setState({ editSaving: true });
         await conceptSetsApi().updateConceptSet(ns, wsid, +csid, {
           ...conceptSet,
-          name: editName,
+          name: editName.trim(),
           description: editDescription,
         });
         await this.getConceptSet();
@@ -328,6 +333,20 @@ export const ConceptSearch = fp.flow(
       return !!this.state.conceptSet && this.state.conceptSet.criteriums
         ? this.state.conceptSet.criteriums.length
         : 0;
+    }
+
+    onEditOpen() {
+      const { ns, wsid, csid } = this.props.match.params;
+      conceptSetsApi()
+        .getConceptSetsInWorkspace(ns, wsid)
+        .then((conceptSets) => {
+          this.setState({
+            editing: true,
+            existingNames: conceptSets.items
+              .filter((conceptSet) => conceptSet.id !== +csid)
+              .map((conceptSet) => conceptSet.name),
+          });
+        });
     }
 
     get displayDomainName() {
@@ -387,7 +406,7 @@ export const ConceptSearch = fp.flow(
     tooltipContent(errors) {
       return !!errors ? (
         <ul>
-          {errors.editName && <li>Name cannot be blank</li>}
+          {errors.editName && <li>{errors.editName}</li>}
           {errors.editDescription && (
             <li>Description cannot exceed 1000 characters</li>
           )}
@@ -417,14 +436,18 @@ export const ConceptSearch = fp.flow(
         error,
         errorMessage,
         editSaving,
+        existingNames,
         deleting,
         loading,
         showMoreDescription,
       } = this.state;
       const errors = validate(
-        { editDescription, editName },
+        { editDescription, editName: editName.trim() },
         {
-          editName: { presence: { allowEmpty: false } },
+          editName: nameValidationFormat(
+            existingNames,
+            ResourceType.CONCEPTSET
+          ),
           editDescription: { length: { maximum: 1000 } },
         }
       );
@@ -455,7 +478,7 @@ export const ConceptSearch = fp.flow(
                             accessLevel
                           )}
                           onDelete={() => this.setState({ deleting: true })}
-                          onEdit={() => this.setState({ editing: true })}
+                          onEdit={() => this.onEditOpen()}
                           onCopy={() => this.setState({ copying: true })}
                         />
                         <div style={styles.conceptSetMetadataWrapper}>
@@ -469,6 +492,9 @@ export const ConceptSearch = fp.flow(
                                 data-test-id='edit-name'
                                 onChange={(v) => this.setState({ editName: v })}
                               />
+                              <ValidationError>
+                                {summarizeErrors(errors?.editName)}
+                              </ValidationError>
                               <TextAreaWithLengthValidationMessage
                                 initialText={editDescription}
                                 id='edit-description'
@@ -524,9 +550,7 @@ export const ConceptSearch = fp.flow(
                                   }
                                   style={{ marginLeft: '.5rem' }}
                                   data-test-id='edit-concept-set'
-                                  onClick={() =>
-                                    this.setState({ editing: true })
-                                  }
+                                  onClick={() => this.onEditOpen()}
                                 >
                                   <EditComponentReact
                                     enableHoverEffect={true}


### PR DESCRIPTION
- Trim whitespace from new names before validating to prevent duplicate names for resources
Before:
![Screen Shot 2022-10-11 at 3 15 02 PM](https://user-images.githubusercontent.com/40036095/195190982-7ce01aba-a9dc-4a7f-be13-e8f8845c2097.png)
After:
![Screen Shot 2022-10-11 at 3 15 37 PM](https://user-images.githubusercontent.com/40036095/195191032-b10987f5-2c8e-4802-a919-4c51c05855c3.png)
- Add missing name validation to concept set edit page
![Screen Shot 2022-10-11 at 3 13 39 PM](https://user-images.githubusercontent.com/40036095/195191173-175b6289-6f12-496e-8cf0-cedc5764cd66.png)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
