### PR TITLE
[risk=no][no ticket] Centralize references to the AoU logo and include the env tag

### DIFF
--- a/ui/src/app/components/headers.tsx
+++ b/ui/src/app/components/headers.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { CSSProperties } from 'react';
 
 import { environment } from 'environments/environment';
 import colors from 'app/styles/colors';
@@ -76,10 +77,14 @@ export const SmallHeader = withStyle(styles.h4)('h4');
 export const ListPageHeader = withStyle(styles.listPageHeader)('h3');
 export const PageHeader = withStyle(styles.pageHeader)('h2');
 
-export const AouHeaderWithDisplayTag = () => (
+export const AouHeaderWithDisplayTag = (props: { style?: CSSProperties }) => (
   <div>
     <a href='/'>
-      <img style={styles.headerImage} src={logo} alt='all of us logo' />
+      <img
+        style={{ ...styles.headerImage, ...props.style }}
+        src={logo}
+        alt='all of us logo'
+      />
     </a>
     {environment.shouldShowDisplayTag && (
       <div style={styles.displayTag}>{environment.displayTag}</div>

--- a/ui/src/app/components/headers.tsx
+++ b/ui/src/app/components/headers.tsx
@@ -48,12 +48,29 @@ export const styles = reactStyles({
     fontSize: '28px',
     fontWeight: 400,
   },
-  headerImage: {
+  headerImageSignedIn: {
     height: '57px',
     width: '155px',
     marginLeft: '1rem',
   },
-  displayTag: {
+  headerImagePublic: {
+    height: '1.75rem',
+    marginLeft: '1rem',
+    marginTop: '1rem',
+  },
+  displayTagSignedIn: {
+    marginLeft: '1rem',
+    height: '12px',
+    width: '155px',
+    borderRadius: '2px',
+    backgroundColor: colors.primary,
+    color: colors.white,
+    fontFamily: 'Montserrat',
+    fontSize: '8px',
+    lineHeight: '12px',
+    textAlign: 'center',
+  },
+  displayTagPublic: {
     marginLeft: '1rem',
     height: '12px',
     width: '155px',
@@ -77,17 +94,30 @@ export const SmallHeader = withStyle(styles.h4)('h4');
 export const ListPageHeader = withStyle(styles.listPageHeader)('h3');
 export const PageHeader = withStyle(styles.pageHeader)('h2');
 
-export const AouHeaderWithDisplayTag = (props: { style?: CSSProperties }) => (
+const AouHeaderWithDisplayTag = (props: {
+  headerStyle: CSSProperties;
+  tagStyle: CSSProperties;
+}) => (
   <div>
     <a href='/'>
-      <img
-        style={{ ...styles.headerImage, ...props.style }}
-        src={logo}
-        alt='all of us logo'
-      />
+      <img style={props.headerStyle} src={logo} alt='all of us logo' />
     </a>
     {environment.shouldShowDisplayTag && (
-      <div style={styles.displayTag}>{environment.displayTag}</div>
+      <div style={props.tagStyle}>{environment.displayTag}</div>
     )}
   </div>
+);
+
+export const SignedInAouHeaderWithDisplayTag = () => (
+  <AouHeaderWithDisplayTag
+    headerStyle={styles.headerImageSignedIn}
+    tagStyle={styles.displayTagSignedIn}
+  />
+);
+
+export const PublicAouHeaderWithDisplayTag = () => (
+  <AouHeaderWithDisplayTag
+    headerStyle={styles.headerImagePublic}
+    tagStyle={styles.displayTagPublic}
+  />
 );

--- a/ui/src/app/components/headers.tsx
+++ b/ui/src/app/components/headers.tsx
@@ -1,7 +1,11 @@
-import colors from 'app/styles/colors';
-import { withStyle } from 'app/utils/index';
+import * as React from 'react';
 
-export const styles = {
+import { environment } from 'environments/environment';
+import colors from 'app/styles/colors';
+import { reactStyles, withStyle } from 'app/utils/index';
+import logo from 'assets/images/all-of-us-logo.svg';
+
+export const styles = reactStyles({
   h1: {
     color: colors.primary,
     fontWeight: 500,
@@ -43,7 +47,24 @@ export const styles = {
     fontSize: '28px',
     fontWeight: 400,
   },
-};
+  headerImage: {
+    height: '57px',
+    width: '155px',
+    marginLeft: '1rem',
+  },
+  displayTag: {
+    marginLeft: '1rem',
+    height: '12px',
+    width: '155px',
+    borderRadius: '2px',
+    backgroundColor: colors.primary,
+    color: colors.white,
+    fontFamily: 'Montserrat',
+    fontSize: '8px',
+    lineHeight: '12px',
+    textAlign: 'center',
+  },
+});
 
 export const BolderHeader = withStyle(styles.h1)('h1');
 export const BoldHeader = withStyle(styles.h2)('h2');
@@ -54,3 +75,14 @@ export const SemiBoldHeader = withStyle({ ...styles.h3, ...styles.semiBold })(
 export const SmallHeader = withStyle(styles.h4)('h4');
 export const ListPageHeader = withStyle(styles.listPageHeader)('h3');
 export const PageHeader = withStyle(styles.pageHeader)('h2');
+
+export const AouHeaderWithDisplayTag = () => (
+  <div>
+    <a href='/'>
+      <img style={styles.headerImage} src={logo} alt='all of us logo' />
+    </a>
+    {environment.shouldShowDisplayTag && (
+      <div style={styles.displayTag}>{environment.displayTag}</div>
+    )}
+  </div>
+);

--- a/ui/src/app/components/headers.tsx
+++ b/ui/src/app/components/headers.tsx
@@ -49,8 +49,8 @@ export const styles = reactStyles({
     fontWeight: 400,
   },
   headerImageSignedIn: {
-    height: '57px',
-    width: '155px',
+    height: 57,
+    width: 155,
     marginLeft: '1rem',
   },
   headerImagePublic: {
@@ -60,9 +60,9 @@ export const styles = reactStyles({
   },
   displayTagSignedIn: {
     marginLeft: '1rem',
-    height: '12px',
-    width: '155px',
-    borderRadius: '2px',
+    height: 12,
+    width: 155,
+    borderRadius: 2,
     backgroundColor: colors.primary,
     color: colors.white,
     fontFamily: 'Montserrat',
@@ -72,9 +72,9 @@ export const styles = reactStyles({
   },
   displayTagPublic: {
     marginLeft: '1rem',
-    height: '12px',
-    width: '155px',
-    borderRadius: '2px',
+    height: 12,
+    width: 135,
+    borderRadius: 2,
     backgroundColor: colors.primary,
     color: colors.white,
     fontFamily: 'Montserrat',

--- a/ui/src/app/components/public-layout.tsx
+++ b/ui/src/app/components/public-layout.tsx
@@ -26,7 +26,7 @@ export const PublicLayout = ({ contentStyle = {}, children }) => {
           borderBottom: `1px solid ${colorWithWhiteness(colors.dark, 0.7)}`,
         }}
       >
-        <AouHeaderWithDisplayTag />
+        <AouHeaderWithDisplayTag style={{ marginTop: '1rem' }} />
       </div>
       <div style={{ ...styles.content, ...contentStyle }}>{children}</div>
     </React.Fragment>

--- a/ui/src/app/components/public-layout.tsx
+++ b/ui/src/app/components/public-layout.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
 
-import { AouHeaderWithDisplayTag } from './headers';
+import { PublicAouHeaderWithDisplayTag } from './headers';
 
 const styles = reactStyles({
   content: {
@@ -26,7 +26,7 @@ export const PublicLayout = ({ contentStyle = {}, children }) => {
           borderBottom: `1px solid ${colorWithWhiteness(colors.dark, 0.7)}`,
         }}
       >
-        <AouHeaderWithDisplayTag style={{ marginTop: '1rem' }} />
+        <PublicAouHeaderWithDisplayTag />
       </div>
       <div style={{ ...styles.content, ...contentStyle }}>{children}</div>
     </React.Fragment>

--- a/ui/src/app/components/public-layout.tsx
+++ b/ui/src/app/components/public-layout.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
-import headerImage from 'assets/images/all-of-us-logo.svg';
+
+import { AouHeaderWithDisplayTag } from './headers';
 
 const styles = reactStyles({
   content: {
@@ -10,8 +11,6 @@ const styles = reactStyles({
     margin: '1rem',
   },
 });
-
-export const PUBLIC_HEADER_IMAGE = headerImage;
 
 /**
  * A layout component suitable for display public-facing content, such as static
@@ -27,12 +26,7 @@ export const PublicLayout = ({ contentStyle = {}, children }) => {
           borderBottom: `1px solid ${colorWithWhiteness(colors.dark, 0.7)}`,
         }}
       >
-        <a href='/'>
-          <img
-            style={{ height: '1.75rem', marginLeft: '1rem', marginTop: '1rem' }}
-            src={PUBLIC_HEADER_IMAGE}
-          />
-        </a>
+        <AouHeaderWithDisplayTag />
       </div>
       <div style={{ ...styles.content, ...contentStyle }}>{children}</div>
     </React.Fragment>

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -10,7 +10,7 @@ import { DemographicSurvey } from 'app/components/demographic-survey-v2';
 import { DemographicSurveyValidationMessage } from 'app/components/demographic-survey-v2-validation-message';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { Footer, FooterTypeEnum } from 'app/components/footer';
-import { AouHeaderWithDisplayTag } from 'app/components/headers';
+import { PublicAouHeaderWithDisplayTag } from 'app/components/headers';
 import { TooltipTrigger } from 'app/components/popups';
 import { TermsOfService } from 'app/components/terms-of-service';
 import {
@@ -305,7 +305,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
             backgroundImages
           )}
         >
-          <AouHeaderWithDisplayTag style={{ marginTop: '1rem' }} />
+          <PublicAouHeaderWithDisplayTag />
           {this.renderSignInStep(this.state.currentStep)}
         </FlexColumn>
         {this.renderNavigation(this.state.currentStep)}

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -10,8 +10,8 @@ import { DemographicSurvey } from 'app/components/demographic-survey-v2';
 import { DemographicSurveyValidationMessage } from 'app/components/demographic-survey-v2-validation-message';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { Footer, FooterTypeEnum } from 'app/components/footer';
+import { AouHeaderWithDisplayTag } from 'app/components/headers';
 import { TooltipTrigger } from 'app/components/popups';
-import { PUBLIC_HEADER_IMAGE } from 'app/components/public-layout';
 import { TermsOfService } from 'app/components/terms-of-service';
 import {
   withProfileErrorModal,
@@ -305,16 +305,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
             backgroundImages
           )}
         >
-          <div>
-            <img
-              style={{
-                height: '1.75rem',
-                marginLeft: '1rem',
-                marginTop: '1rem',
-              }}
-              src={PUBLIC_HEADER_IMAGE}
-            />
-          </div>
+          <AouHeaderWithDisplayTag />
           {this.renderSignInStep(this.state.currentStep)}
         </FlexColumn>
         {this.renderNavigation(this.state.currentStep)}

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -305,7 +305,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
             backgroundImages
           )}
         >
-          <AouHeaderWithDisplayTag />
+          <AouHeaderWithDisplayTag style={{ marginTop: '1rem' }} />
           {this.renderSignInStep(this.state.currentStep)}
         </FlexColumn>
         {this.renderNavigation(this.state.currentStep)}

--- a/ui/src/app/pages/signed-in/nav-bar.tsx
+++ b/ui/src/app/pages/signed-in/nav-bar.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { Breadcrumb } from 'app/components/breadcrumb';
 import { CTAvailableBannerMaybe } from 'app/components/ct-available-banner-maybe';
-import { AouHeaderWithDisplayTag } from 'app/components/headers';
+import { SignedInAouHeaderWithDisplayTag } from 'app/components/headers';
 import { ClrIcon } from 'app/components/icons';
 import { SideNav } from 'app/components/side-nav';
 import { StatusAlertBannerMaybe } from 'app/components/status-alert-banner-maybe';
@@ -106,7 +106,7 @@ export const NavBar = () => {
           }
         ></ClrIcon>
       </div>
-      <AouHeaderWithDisplayTag />
+      <SignedInAouHeaderWithDisplayTag />
       <Breadcrumb />
       <AccessRenewalNotificationMaybe />
       <StatusAlertBannerMaybe />

--- a/ui/src/app/pages/signed-in/nav-bar.tsx
+++ b/ui/src/app/pages/signed-in/nav-bar.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 
-import { environment } from 'environments/environment';
-import { CTAvailableBannerMaybe } from 'app//components/ct-available-banner-maybe';
 import { Breadcrumb } from 'app/components/breadcrumb';
+import { CTAvailableBannerMaybe } from 'app/components/ct-available-banner-maybe';
+import { AouHeaderWithDisplayTag } from 'app/components/headers';
 import { ClrIcon } from 'app/components/icons';
 import { SideNav } from 'app/components/side-nav';
 import { StatusAlertBannerMaybe } from 'app/components/status-alert-banner-maybe';
@@ -12,7 +12,6 @@ import { AccessRenewalNotificationMaybe } from 'app/pages/signed-in/access-renew
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
 import { profileStore, useStore } from 'app/utils/stores';
-import logo from 'assets/images/all-of-us-logo.svg';
 
 const styles = reactStyles({
   headerContainer: {
@@ -45,23 +44,6 @@ const styles = reactStyles({
   },
   sidenavIconHovering: {
     cursor: 'pointer',
-  },
-  headerImage: {
-    height: '57px',
-    width: '155px',
-    marginLeft: '1rem',
-  },
-  displayTag: {
-    marginLeft: '1rem',
-    height: '12px',
-    width: '155px',
-    borderRadius: '2px',
-    backgroundColor: colors.primary,
-    color: colors.white,
-    fontFamily: 'Montserrat',
-    fontSize: '8px',
-    lineHeight: '12px',
-    textAlign: 'center',
   },
 });
 
@@ -124,14 +106,7 @@ export const NavBar = () => {
           }
         ></ClrIcon>
       </div>
-      <div>
-        <a href={'/'}>
-          <img src={logo} style={styles.headerImage} />
-        </a>
-        {environment.shouldShowDisplayTag && (
-          <div style={styles.displayTag}>{environment.displayTag}</div>
-        )}
-      </div>
+      <AouHeaderWithDisplayTag />
       <Breadcrumb />
       <AccessRenewalNotificationMaybe />
       <StatusAlertBannerMaybe />

--- a/ui/src/app/routing/app-routing.tsx
+++ b/ui/src/app/routing/app-routing.tsx
@@ -9,7 +9,7 @@ import { Configuration } from 'generated/fetch';
 
 import { environment } from 'environments/environment';
 import { AppRoute, AppRouter, withRouteData } from 'app/components/app-router';
-import { AouHeaderWithDisplayTag } from 'app/components/headers';
+import { SignedInAouHeaderWithDisplayTag } from 'app/components/headers';
 import { NotificationModal } from 'app/components/modals';
 import { TermsOfService } from 'app/components/terms-of-service';
 import { withRoutingSpinner } from 'app/components/with-routing-spinner';
@@ -329,7 +329,7 @@ export const AppRoutingComponent: React.FunctionComponent<
                 fontFamily: 'Montserrat',
               }}
             >
-              <AouHeaderWithDisplayTag />
+              <SignedInAouHeaderWithDisplayTag />
               <div
                 style={{
                   fontSize: '20pt',

--- a/ui/src/app/routing/app-routing.tsx
+++ b/ui/src/app/routing/app-routing.tsx
@@ -9,6 +9,7 @@ import { Configuration } from 'generated/fetch';
 
 import { environment } from 'environments/environment';
 import { AppRoute, AppRouter, withRouteData } from 'app/components/app-router';
+import { AouHeaderWithDisplayTag } from 'app/components/headers';
 import { NotificationModal } from 'app/components/modals';
 import { TermsOfService } from 'app/components/terms-of-service';
 import { withRoutingSpinner } from 'app/components/with-routing-spinner';
@@ -48,7 +49,6 @@ import {
   stackdriverErrorReporterStore,
   useStore,
 } from 'app/utils/stores';
-import logo from 'assets/images/all-of-us-logo.svg';
 import { StackdriverErrorReporter } from 'stackdriver-errors-js';
 
 declare const gapi: any;
@@ -329,9 +329,7 @@ export const AppRoutingComponent: React.FunctionComponent<
                 fontFamily: 'Montserrat',
               }}
             >
-              <div>
-                <img alt='logo' src={logo} width='155px' />
-              </div>
+              <AouHeaderWithDisplayTag />
               <div
                 style={{
                   fontSize: '20pt',


### PR DESCRIPTION
I had some confusion about a "disabled" user which should not have been.  It took a long time to realize that the problem was that I was on Local->Test instead of Local->Local.  The Disabled User and Sign-In screens did not supply this information.  Now, all aou-logo screens inform the user which environment they're in (except when on Prod, matching existing behavior)

Signed-in screens: no change
Cookies Disabled screen: could not test

Sign-In
Before
<img width="402" alt="Sign in before" src="https://user-images.githubusercontent.com/2701406/195428541-945f9fac-0e49-45a6-93ed-d8c8db69c015.png">


After
<img width="408" alt="Sign in after" src="https://user-images.githubusercontent.com/2701406/195428362-082e6797-3ea6-4914-b323-5af390e22697.png">

User Disabled screen
Before
<img width="549" alt="Disabled before" src="https://user-images.githubusercontent.com/2701406/195429079-517da8ff-dd81-403a-af0b-8087b5c40e3e.png">

After
<img width="543" alt="Disabled after" src="https://user-images.githubusercontent.com/2701406/195429101-9271b136-69ad-4a1a-8eac-a29a6148220a.png">



<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
