### PR TITLE
[DT-10][risk=no] Consolidate API calls that have many arguments

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.api;
 
 import com.google.apphosting.api.DeadlineExceededException;
-import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import java.util.Arrays;
 import java.util.Objects;
@@ -61,34 +60,22 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
 
   @Override
   public ResponseEntity<CriteriaListResponse> findCriteriaAutoComplete(
-      String workspaceNamespace,
-      String workspaceId,
-      String domain,
-      String term,
-      String type,
-      Boolean standard) {
+      String workspaceNamespace, String workspaceId, CriteriaSearchRequest criteriaSearchRequest) {
     workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
-    validateDomain(domain);
-    validateType(type);
-    validateTerm(term);
-    return ResponseEntity.ok(
-        new CriteriaListResponse()
-            .items(
-                cohortBuilderService.findCriteriaAutoComplete(
-                    domain, term, ImmutableList.of(type), standard)));
-  }
-
-  @Override
-  public ResponseEntity<CriteriaListResponse> findSurveyAutoComplete(
-      String workspaceNamespace, String workspaceId, String surveyName, String term) {
-    workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
-        workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
-    validateSurveyName(surveyName);
-    validateTerm(term);
-    return ResponseEntity.ok(
-        new CriteriaListResponse()
-            .items(cohortBuilderService.findSurveyAutoComplete(surveyName, term)));
+    validateDomain(criteriaSearchRequest.getDomain());
+    validateTerm(criteriaSearchRequest.getTerm());
+    if (Domain.SURVEY.equals(Domain.fromValue(criteriaSearchRequest.getDomain()))) {
+      validateSurveyName(criteriaSearchRequest.getSurveyName());
+      return ResponseEntity.ok(
+          new CriteriaListResponse()
+              .items(cohortBuilderService.findCriteriaAutoComplete(criteriaSearchRequest)));
+    } else {
+      validateType(criteriaSearchRequest.getType());
+      return ResponseEntity.ok(
+          new CriteriaListResponse()
+              .items(cohortBuilderService.findCriteriaAutoComplete(criteriaSearchRequest)));
+    }
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -67,15 +67,12 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
     validateTerm(criteriaSearchRequest.getTerm());
     if (Domain.SURVEY.equals(Domain.fromValue(criteriaSearchRequest.getDomain()))) {
       validateSurveyName(criteriaSearchRequest.getSurveyName());
-      return ResponseEntity.ok(
-          new CriteriaListResponse()
-              .items(cohortBuilderService.findCriteriaAutoComplete(criteriaSearchRequest)));
     } else {
       validateType(criteriaSearchRequest.getType());
-      return ResponseEntity.ok(
-          new CriteriaListResponse()
-              .items(cohortBuilderService.findCriteriaAutoComplete(criteriaSearchRequest)));
     }
+    return ResponseEntity.ok(
+        new CriteriaListResponse()
+            .items(cohortBuilderService.findCriteriaAutoComplete(criteriaSearchRequest)));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -33,10 +33,7 @@ public interface CohortBuilderService {
 
   List<CriteriaAttribute> findCriteriaAttributeByConceptId(Long conceptId);
 
-  List<Criteria> findCriteriaAutoComplete(
-      String domain, String term, List<String> types, Boolean standard);
-
-  List<Criteria> findSurveyAutoComplete(String surveyName, String term);
+  List<Criteria> findCriteriaAutoComplete(CriteriaSearchRequest criteriaSearchRequest);
 
   List<Criteria> findCriteriaBy(String domain, String type, Boolean standard, Long parentId);
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3763,62 +3763,24 @@ paths:
           description: A collection of criteria
           schema:
             "$ref": "#/definitions/CriteriaListResponse"
-  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/{domain}/search":
+  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/autocomplete":
     parameters:
       - "$ref": "#/parameters/workspaceNamespace"
       - "$ref": "#/parameters/workspaceId"
-    get:
+    post:
       tags:
       - cohortBuilder
-      description: Returns matches on criteria table by code or name
+      consumes:
+      - application/json
+      description: Returns matches on survey / criteria table by code or name
       operationId: findCriteriaAutoComplete
       parameters:
-      - in: path
-        name: domain
-        type: string
+      - in: body
+        name: request
         required: true
-        description: the specific domain of criteria to get
-      - in: query
-        name: type
-        type: string
-        required: false
-        description: the type of the criteria were search for
-      - in: query
-        name: standard
-        type: boolean
-        default: false
-        required: false
-        description: the type of the criteria were search for
-      - in: query
-        name: term
-        type: string
-        required: true
-        description: the term to search for
-      responses:
-        200:
-          description: A collection of criteria
-          schema:
-            "$ref": "#/definitions/CriteriaListResponse"
-  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/survey/{surveyName}/{term}":
-    parameters:
-      - "$ref": "#/parameters/workspaceNamespace"
-      - "$ref": "#/parameters/workspaceId"
-    get:
-      tags:
-        - cohortBuilder
-      description: Returns matches on criteria table by code or name
-      operationId: findSurveyAutoComplete
-      parameters:
-        - in: path
-          name: surveyName
-          type: string
-          required: true
-          description: the specific survey to search
-        - in: path
-          name: term
-          type: string
-          required: true
-          description: the term to search for
+        description: CriteriaSearchRequest body
+        schema:
+          "$ref": "#/definitions/CriteriaSearchRequest"
       responses:
         200:
           description: A collection of criteria
@@ -8288,12 +8250,15 @@ definitions:
         description: the term to search for
         type: string
       surveyName:
-        description: name for the survey to search
+        description: name for the survey to search for
         type: string
       removeDrugBrand:
         description: True - remove brand names from results
         type: boolean
         default: false
+      type:
+        description: the type of the criteria to search for
+        type: string
   CohortDefinition:
     description: 'The CohortDefinition describes the state of the Cohort Builder at any
       given moment. It contains two keys, `include` and `exclude`, each of which specifies

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -387,10 +387,11 @@ public class CohortBuilderControllerTest {
                         .findCriteriaAutoComplete(
                             WORKSPACE_NAMESPACE,
                             WORKSPACE_ID,
-                            Domain.MEASUREMENT.toString(),
-                            "LP12",
-                            CriteriaType.LOINC.toString(),
-                            true)
+                            new CriteriaSearchRequest()
+                                .domain(Domain.MEASUREMENT.toString())
+                                .term("LP12")
+                                .type(CriteriaType.LOINC.toString())
+                                .standard(true))
                         .getBody())
                 .getItems()
                 .get(0))
@@ -417,10 +418,11 @@ public class CohortBuilderControllerTest {
                         .findCriteriaAutoComplete(
                             WORKSPACE_NAMESPACE,
                             WORKSPACE_ID,
-                            Domain.MEASUREMENT.toString(),
-                            "LP12",
-                            CriteriaType.LOINC.toString(),
-                            true)
+                            new CriteriaSearchRequest()
+                                .domain(Domain.MEASUREMENT.toString())
+                                .term("LP12")
+                                .type(CriteriaType.LOINC.toString())
+                                .standard(true))
                         .getBody())
                 .getItems()
                 .get(0))
@@ -446,10 +448,11 @@ public class CohortBuilderControllerTest {
                         .findCriteriaAutoComplete(
                             WORKSPACE_NAMESPACE,
                             WORKSPACE_ID,
-                            Domain.CONDITION.toString(),
-                            "LP12",
-                            CriteriaType.SNOMED.toString(),
-                            true)
+                            new CriteriaSearchRequest()
+                                .domain(Domain.CONDITION.toString())
+                                .term("LP12")
+                                .type(CriteriaType.SNOMED.toString())
+                                .standard(true))
                         .getBody())
                 .getItems()
                 .get(0))
@@ -462,15 +465,11 @@ public class CohortBuilderControllerTest {
         BadRequestException.class,
         () ->
             controller.findCriteriaAutoComplete(
-                WORKSPACE_NAMESPACE, WORKSPACE_ID, null, "blah", null, null),
+                // null, "blah", null, null
+                WORKSPACE_NAMESPACE,
+                WORKSPACE_ID,
+                new CriteriaSearchRequest().domain(null).term("blah")),
         "Bad Request: Please provide a valid domain. null is not valid.");
-
-    assertThrows(
-        BadRequestException.class,
-        () ->
-            controller.findCriteriaAutoComplete(
-                WORKSPACE_NAMESPACE, WORKSPACE_ID, null, "blah", null, null),
-        "Bad Request: Please provide a valid domain. blah is not valid.");
 
     assertThrows(
         BadRequestException.class,
@@ -478,11 +477,23 @@ public class CohortBuilderControllerTest {
             controller.findCriteriaAutoComplete(
                 WORKSPACE_NAMESPACE,
                 WORKSPACE_ID,
-                Domain.CONDITION.toString(),
-                "blah",
-                "blah",
-                null),
+                new CriteriaSearchRequest()
+                    .domain(Domain.CONDITION.toString())
+                    .type("blah")
+                    .term("blah")),
         "Bad Request: Please provide a valid type. blah is not valid.");
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            controller.findCriteriaAutoComplete(
+                WORKSPACE_NAMESPACE,
+                WORKSPACE_ID,
+                new CriteriaSearchRequest()
+                    .domain(Domain.CONDITION.toString())
+                    .type(CriteriaType.SNOMED.toString())
+                    .term(null)),
+        "Bad Request: Please provide a valid search term. null is not valid.");
   }
 
   @Test
@@ -507,8 +518,13 @@ public class CohortBuilderControllerTest {
     assertThat(
             Objects.requireNonNull(
                     controller
-                        .findSurveyAutoComplete(
-                            WORKSPACE_NAMESPACE, WORKSPACE_ID, "The Basics", "LP12")
+                        .findCriteriaAutoComplete(
+                            WORKSPACE_NAMESPACE,
+                            WORKSPACE_ID,
+                            new CriteriaSearchRequest()
+                                .domain(Domain.SURVEY.toString())
+                                .surveyName("The Basics")
+                                .term("LP12"))
                         .getBody())
                 .getItems()
                 .get(0))
@@ -537,7 +553,13 @@ public class CohortBuilderControllerTest {
     assertThat(
             Objects.requireNonNull(
                     controller
-                        .findSurveyAutoComplete(WORKSPACE_NAMESPACE, WORKSPACE_ID, "All", "LP12")
+                        .findCriteriaAutoComplete(
+                            WORKSPACE_NAMESPACE,
+                            WORKSPACE_ID,
+                            new CriteriaSearchRequest()
+                                .domain(Domain.SURVEY.toString())
+                                .surveyName("All")
+                                .term("LP12"))
                         .getBody())
                 .getItems()
                 .get(0))
@@ -548,13 +570,21 @@ public class CohortBuilderControllerTest {
   public void findSurveyAutoCompleteExceptions() {
     assertThrows(
         BadRequestException.class,
-        () -> controller.findSurveyAutoComplete(WORKSPACE_NAMESPACE, WORKSPACE_ID, null, "blah"),
+        () ->
+            controller.findCriteriaAutoComplete(
+                WORKSPACE_NAMESPACE,
+                WORKSPACE_ID,
+                new CriteriaSearchRequest().domain(Domain.SURVEY.toString()).term("LP12")),
         "Bad Request: Please provide a valid surveyName. null is not valid.");
 
     assertThrows(
         BadRequestException.class,
-        () -> controller.findSurveyAutoComplete(WORKSPACE_NAMESPACE, WORKSPACE_ID, "All", null),
-        "Bad Request: Please provide a valid term. blah is not valid.");
+        () ->
+            controller.findCriteriaAutoComplete(
+                WORKSPACE_NAMESPACE,
+                WORKSPACE_ID,
+                new CriteriaSearchRequest().domain(Domain.SURVEY.toString()).surveyName("All")),
+        "Bad Request: Please provide a valid search term. null is not valid.");
   }
 
   @Test

--- a/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
+++ b/ui/src/app/cohort-search/search-bar/search-bar.component.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import * as fp from 'lodash/fp';
 
-import { Criteria, CriteriaType, Domain } from 'generated/fetch';
+import {
+  Criteria,
+  CriteriaSearchRequest,
+  CriteriaType,
+  Domain,
+} from 'generated/fetch';
 
 import { domainToTitle } from 'app/cohort-search/utils';
 import { AlertDanger } from 'app/components/alert';
@@ -287,21 +292,29 @@ export class SearchBar extends React.Component<Props, State> {
         );
         break;
       case Domain.SURVEY.toString():
-        apiCall = cohortBuilderApi().findSurveyAutoComplete(
-          namespace,
-          id,
-          selectedSurvey || 'All surveys',
-          searchTerms
-        );
-        break;
-      default:
+        const surveyRequest: CriteriaSearchRequest = {
+          domain: Domain.SURVEY.toString(),
+          surveyName: selectedSurvey || 'All surveys',
+          term: searchTerms,
+          standard: true,
+        };
         apiCall = cohortBuilderApi().findCriteriaAutoComplete(
           namespace,
           id,
-          domainId,
-          searchTerms,
-          type,
-          isStandard
+          surveyRequest
+        );
+        break;
+      default:
+        const request: CriteriaSearchRequest = {
+          domain: domainId,
+          term: searchTerms,
+          type: type,
+          standard: isStandard,
+        };
+        apiCall = cohortBuilderApi().findCriteriaAutoComplete(
+          namespace,
+          id,
+          request
         );
     }
     apiCall.then(


### PR DESCRIPTION
Description:
---
- Consolidated API calls that have many arguments. Merged the 2-calls below
  - `CohortBuilderController.findCriteriaAutoComplete`
  - `CohortBuilderController.findSurveyAutoComplete`
- Updated Swagger definition
- Updated API calls, 
- Updated UI calls 
- Updated API tests
- there were no explicit UI tests for these calls(?)
- Deployed app to local and verified autocomplete is working as expected

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
