### PR TITLE
[DT-9][risk: no] Removed cohortReviewId from API and UI calls and updated test

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -628,10 +628,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void getVocabularies() {
-    VocabularyListResponse response =
-        controller
-            .getVocabularies(NAMESPACE, NAME, reviewWithoutEHRData.getCohortReviewId())
-            .getBody();
+    VocabularyListResponse response = controller.getVocabularies(NAMESPACE, NAME).getBody();
     List<Vocabulary> items = Objects.requireNonNull(response).getItems();
     assertThat(items.size()).isEqualTo(20);
     assertThat(items.get(0))

--- a/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortReviewController.java
@@ -459,7 +459,7 @@ public class CohortReviewController implements CohortReviewApiDelegate {
 
   @Override
   public ResponseEntity<VocabularyListResponse> getVocabularies(
-      String workspaceNamespace, String workspaceId, Long cohortReviewId) {
+      String workspaceNamespace, String workspaceId) {
     workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3427,11 +3427,10 @@ paths:
           description: ParticipantCohortAnnotation deletion request accepted
           schema:
             "$ref": "#/definitions/EmptyResponse"
-  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/vocabularies":
+  "/v1/workspaces/{workspaceNamespace}/{workspaceId}/review/vocabularies":
     parameters:
     - "$ref": "#/parameters/workspaceNamespace"
     - "$ref": "#/parameters/workspaceId"
-    - "$ref": "#/parameters/cohortReviewId"
     get:
       tags:
       - cohortReview

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -2236,10 +2236,7 @@ public class CohortReviewControllerTest {
     List<Vocabulary> actual =
         Objects.requireNonNull(
                 cohortReviewController
-                    .getVocabularies(
-                        workspace.getNamespace(),
-                        workspace.getId(),
-                        cohortReview.getCohortReviewId())
+                    .getVocabularies(workspace.getNamespace(), workspace.getId())
                     .getBody())
             .getItems();
 
@@ -2259,7 +2256,7 @@ public class CohortReviewControllerTest {
             ForbiddenException.class,
             () ->
                 cohortReviewController.getVocabularies(
-                    workspace.getNamespace(), workspace.getId(), cohortReview.getCohortReviewId()));
+                    workspace.getNamespace(), workspace.getId()));
 
     assertForbiddenException(exception);
   }

--- a/ui/src/app/pages/data/cohort-review/cohort-review-participants-table.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-participants-table.tsx
@@ -278,7 +278,7 @@ export const CohortReviewParticipantsTable = ({ cohortReview }) => {
           ({ cohortReview: review, queryResultSize }) => {
             currentCohortReviewStore.next(review);
             if (!vocabOptions.getValue()) {
-              getVocabOptions(ns, wsid, review.cohortReviewId);
+              getVocabOptions(ns, wsid);
             }
             setData(review.participantCohortStatuses.map(mapData));
             setTotalCount(queryResultSize);

--- a/ui/src/app/pages/data/cohort-review/detail-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-page.tsx
@@ -77,7 +77,7 @@ export const DetailPage = fp.flow(
         });
       }
       if (!vocabOptions.getValue()) {
-        getVocabOptions(namespace, id, cohortReview.cohortReviewId);
+        getVocabOptions(namespace, id);
       }
       this.updateParticipantStore();
       this.subscription = participantStore.subscribe((participant) =>

--- a/ui/src/app/services/review-state.service.ts
+++ b/ui/src/app/services/review-state.service.ts
@@ -122,13 +122,12 @@ export const reviewPaginationStore = new BehaviorSubject<any>(
 
 export function getVocabOptions(
   workspaceNamespace: string,
-  workspaceId: string,
-  cohortReviewId: number
+  workspaceId: string
 ) {
   const vocabFilters = { source: {}, standard: {} };
   try {
     cohortReviewApi()
-      .getVocabularies(workspaceNamespace, workspaceId, cohortReviewId)
+      .getVocabularies(workspaceNamespace, workspaceId)
       .then((response) => {
         response.items.forEach((item) => {
           const type = item.type.toLowerCase();


### PR DESCRIPTION
Description:
---
- Code Cleanup - remove cohortReviewId from API call - it's not used
- Updated API and UI

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
