### PR TITLE
[risk=no][RW-8242] Rename the wrapper-based withErrorModal

### DIFF
--- a/ui/src/app/components/demographic-survey-v2-validation-message.tsx
+++ b/ui/src/app/components/demographic-survey-v2-validation-message.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as fp from 'lodash/fp';
 
-import { withProfileErrorModal } from 'app/components/with-error-modal';
+import { withProfileErrorModal } from 'app/components/with-error-modal-wrapper';
 
 import {
   possiblePreferNotToAnswerErrors,

--- a/ui/src/app/components/demographic-survey-v2.tsx
+++ b/ui/src/app/components/demographic-survey-v2.tsx
@@ -14,7 +14,7 @@ import {
 } from 'generated/fetch';
 
 import { FlexColumn, FlexRow } from 'app/components/flex';
-import { withProfileErrorModal } from 'app/components/with-error-modal';
+import { withProfileErrorModal } from 'app/components/with-error-modal-wrapper';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
 import {

--- a/ui/src/app/components/demographic-survey.tsx
+++ b/ui/src/app/components/demographic-survey.tsx
@@ -27,7 +27,7 @@ import { AouTitle } from 'app/components/text-wrappers';
 import {
   withProfileErrorModal,
   WithProfileErrorModalProps,
-} from 'app/components/with-error-modal';
+} from 'app/components/with-error-modal-wrapper';
 import { AccountCreationOptions } from 'app/pages/login/account-creation/account-creation-options';
 import {
   DropDownSection,

--- a/ui/src/app/components/with-error-modal-wrapper.tsx
+++ b/ui/src/app/components/with-error-modal-wrapper.tsx
@@ -15,7 +15,7 @@ export interface WithErrorModalProps {
   showErrorModal: (title: string, body: string) => void;
 }
 
-export const withErrorModal = () => {
+export const withErrorModalWrapper = () => {
   return (WrappedComponent) => {
     return class ErrorModalWrapper extends React.Component<any, State> {
       constructor(props) {
@@ -76,7 +76,7 @@ export const withProfileErrorWrapper = (WrappedComponent) => {
     </React.Fragment>
   );
 
-  const ProfileErrorWrapper = ({ showErrorModal, ...props }) => {
+  return ({ showErrorModal, ...props }) => {
     return (
       <WrappedComponent
         showProfileErrorModal={(message) =>
@@ -86,11 +86,9 @@ export const withProfileErrorWrapper = (WrappedComponent) => {
       />
     );
   };
-
-  return ProfileErrorWrapper;
 };
 
 export const withProfileErrorModal = fp.flow(
   withProfileErrorWrapper,
-  withErrorModal()
+  withErrorModalWrapper()
 );

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -13,7 +13,7 @@ import { ExclamationTriangle } from 'app/components/icons';
 import { withErrorModal } from 'app/components/modals';
 import { SupportMailto } from 'app/components/support';
 import { AoU } from 'app/components/text-wrappers';
-import { withProfileErrorModal } from 'app/components/with-error-modal';
+import { withProfileErrorModal } from 'app/components/with-error-modal-wrapper';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { profileApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';

--- a/ui/src/app/pages/analysis/notebook-resource-card.tsx
+++ b/ui/src/app/pages/analysis/notebook-resource-card.tsx
@@ -19,9 +19,9 @@ import {
   WithConfirmDeleteModalProps,
 } from 'app/components/with-confirm-delete-modal';
 import {
-  withErrorModal,
   WithErrorModalProps,
-} from 'app/components/with-error-modal';
+  withErrorModalWrapper,
+} from 'app/components/with-error-modal-wrapper';
 import {
   withSpinnerOverlay,
   WithSpinnerOverlayProps,
@@ -49,7 +49,7 @@ interface State {
 }
 
 export const NotebookResourceCard = fp.flow(
-  withErrorModal(),
+  withErrorModalWrapper(),
   withConfirmDeleteModal(),
   withSpinnerOverlay()
 )(

--- a/ui/src/app/pages/data/cohort-review/cohort-review-resource-card.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-resource-card.tsx
@@ -18,9 +18,9 @@ import {
   WithConfirmDeleteModalProps,
 } from 'app/components/with-confirm-delete-modal';
 import {
-  withErrorModal,
   WithErrorModalProps,
-} from 'app/components/with-error-modal';
+  withErrorModalWrapper,
+} from 'app/components/with-error-modal-wrapper';
 import {
   withSpinnerOverlay,
   WithSpinnerOverlayProps,
@@ -43,7 +43,7 @@ interface State {
 }
 
 export const CohortReviewResourceCard = fp.flow(
-  withErrorModal(),
+  withErrorModalWrapper(),
   withConfirmDeleteModal(),
   withSpinnerOverlay()
 )(

--- a/ui/src/app/pages/data/cohort/cohort-resource-card.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-resource-card.tsx
@@ -19,9 +19,9 @@ import {
   WithConfirmDeleteModalProps,
 } from 'app/components/with-confirm-delete-modal';
 import {
-  withErrorModal,
   WithErrorModalProps,
-} from 'app/components/with-error-modal';
+  withErrorModalWrapper,
+} from 'app/components/with-error-modal-wrapper';
 import {
   withSpinnerOverlay,
   WithSpinnerOverlayProps,
@@ -54,7 +54,7 @@ interface State {
 }
 
 export const CohortResourceCard = fp.flow(
-  withErrorModal(),
+  withErrorModalWrapper(),
   withConfirmDeleteModal(),
   withSpinnerOverlay(),
   withNavigation

--- a/ui/src/app/pages/data/concept/concept-set-resource-card.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-resource-card.tsx
@@ -20,9 +20,9 @@ import {
   WithConfirmDeleteModalProps,
 } from 'app/components/with-confirm-delete-modal';
 import {
-  withErrorModal,
   WithErrorModalProps,
-} from 'app/components/with-error-modal';
+  withErrorModalWrapper,
+} from 'app/components/with-error-modal-wrapper';
 import {
   withSpinnerOverlay,
   WithSpinnerOverlayProps,
@@ -52,7 +52,7 @@ interface State {
 }
 
 export const ConceptSetResourceCard = fp.flow(
-  withErrorModal(),
+  withErrorModalWrapper(),
   withConfirmDeleteModal(),
   withSpinnerOverlay()
 )(

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -39,9 +39,9 @@ import { CheckBox } from 'app/components/inputs';
 import { TooltipTrigger } from 'app/components/popups';
 import { Spinner, SpinnerOverlay } from 'app/components/spinners';
 import {
-  withErrorModal,
   WithErrorModalProps,
-} from 'app/components/with-error-modal';
+  withErrorModalWrapper,
+} from 'app/components/with-error-modal-wrapper';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { CircleWithText } from 'app/icons/circleWithText';
 import { ExportDatasetModal } from 'app/pages/data/data-set/export-dataset-modal';
@@ -786,7 +786,7 @@ export const DatasetPage = fp.flow(
   withUserProfile(),
   withCurrentWorkspace(),
   withCdrVersions(),
-  withErrorModal(),
+  withErrorModalWrapper(),
   withRouter
 )(
   ({

--- a/ui/src/app/pages/data/data-set/dataset-resource-card.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-resource-card.tsx
@@ -19,9 +19,9 @@ import {
   WithConfirmDeleteModalProps,
 } from 'app/components/with-confirm-delete-modal';
 import {
-  withErrorModal,
   WithErrorModalProps,
-} from 'app/components/with-error-modal';
+  withErrorModalWrapper,
+} from 'app/components/with-error-modal-wrapper';
 import {
   withSpinnerOverlay,
   WithSpinnerOverlayProps,
@@ -56,7 +56,7 @@ interface State {
 }
 
 export const DatasetResourceCard = fp.flow(
-  withErrorModal(),
+  withErrorModalWrapper(),
   withConfirmDeleteModal(),
   withSpinnerOverlay(),
   withNavigation

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -16,7 +16,7 @@ import { TermsOfService } from 'app/components/terms-of-service';
 import {
   withProfileErrorModal,
   WithProfileErrorModalProps,
-} from 'app/components/with-error-modal';
+} from 'app/components/with-error-modal-wrapper';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { AccountCreation } from 'app/pages/login/account-creation/account-creation';
 import { AccountCreationInstitution } from 'app/pages/login/account-creation/account-creation-institution';

--- a/ui/src/app/pages/profile/profile-component.tsx
+++ b/ui/src/app/pages/profile/profile-component.tsx
@@ -28,7 +28,7 @@ import { SpinnerOverlay } from 'app/components/spinners';
 import {
   withProfileErrorModal,
   WithProfileErrorModalProps,
-} from 'app/components/with-error-modal';
+} from 'app/components/with-error-modal-wrapper';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { AccountCreationOptions } from 'app/pages/login/account-creation/account-creation-options';
 import { styles } from 'app/pages/profile/profile-styles';

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -208,6 +208,7 @@ export const WorkspaceAbout = fp.flow(
 
     loadUserRoles(workspace: WorkspaceData) {
       this.setState({ workspaceUserRoles: [] });
+
       workspacesApi()
         .getFirecloudWorkspaceUserRoles(workspace.namespace, workspace.id)
         .then((resp) => {


### PR DESCRIPTION
We have two things named `withErrorModal` with the same general purpose!  Longer term, we should remove one.

But here's an immediate improvement: rename one of them.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
