### PR TITLE
[DT-80][risk:no]Add is_cati flag for querying and updated BQ tests.

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -809,6 +809,13 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
         .operands(ImmutableList.of("2009-12-03"));
   }
 
+  private static Modifier catiModifier() {
+    return new Modifier()
+        .name(ModifierType.CATI)
+        .operator(Operator.EQUAL)
+        .operands(ImmutableList.of("1"));
+  }
+
   private static List<Attribute> wheelchairAttributes() {
     return ImmutableList.of(
         new Attribute()
@@ -2006,7 +2013,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
-  public void countSubjectsSurvey() {
+  public void countSubjectsSurveyAll() {
     // Survey
     CohortDefinition cohortDefinition =
         createCohortDefinition(
@@ -2015,7 +2022,18 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             new ArrayList<>());
     ResponseEntity<Long> response =
         controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition);
-    assertParticipants(response, 1);
+    assertParticipants(response, 2);
+  }
+
+  @Test
+  public void countSubjectsSurveyCatiModifier() {
+    CohortDefinition cohortDefinition =
+        createCohortDefinition(
+            Domain.SURVEY.toString(),
+            ImmutableList.of(survey().conceptId(1585899L)),
+            ImmutableList.of(catiModifier()));
+    assertParticipants(
+        controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
   }
 
   @Test
@@ -2076,13 +2094,28 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
-  public void countSubjectsQuestion() {
+  public void countSubjectsQuestionAll() {
     // Question
     SearchParameter ppiQuestion =
         survey().subtype(CriteriaSubType.QUESTION.toString()).conceptId(1585899L);
     CohortDefinition cohortDefinition =
         createCohortDefinition(
             ppiQuestion.getDomain(), ImmutableList.of(ppiQuestion), new ArrayList<>());
+    ResponseEntity<Long> response =
+        controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition);
+    assertParticipants(response, 2);
+  }
+
+  @Test
+  public void countSubjectsQuestionCatiModifier() {
+    // Question
+    SearchParameter ppiQuestion =
+        survey().subtype(CriteriaSubType.QUESTION.toString()).conceptId(1585899L);
+    CohortDefinition cohortDefinition =
+        createCohortDefinition(
+            ppiQuestion.getDomain(),
+            ImmutableList.of(ppiQuestion),
+            ImmutableList.of(catiModifier()));
     ResponseEntity<Long> response =
         controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition);
     assertParticipants(response, 1);

--- a/api/src/bigquerytest/resources/bigquery/cbdata/cb_search_all_events_data.json
+++ b/api/src/bigquerytest/resources/bigquery/cbdata/cb_search_all_events_data.json
@@ -359,6 +359,17 @@
     "is_standard": 0
   },
   {
+    "person_id": 2,
+    "entry_date": "2009-12-03",
+    "concept_id": 1585899,
+    "domain": "Observation",
+    "value_as_number": 7,
+    "value_as_concept_id": 7,
+    "value_source_concept_id": 7,
+    "is_standard": 0,
+    "is_cati": 1
+  },
+  {
     "person_id": 1,
     "entry_date": "2009-12-03",
     "concept_id": 3,

--- a/api/src/bigquerytest/resources/bigquery/schema/cb_search_all_events.json
+++ b/api/src/bigquerytest/resources/bigquery/schema/cb_search_all_events.json
@@ -73,5 +73,10 @@
     "mode": "NULLABLE",
     "name": "survey_version_concept_id",
     "type": "integer"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_cati",
+    "type": "integer"
   }
 ]


### PR DESCRIPTION
Description:
---
- Added CATI flag to API. 
- Added appropriate BQ tests
- Deployed API/UI locally and checked
---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
