### PR TITLE
[RW-8941][risk=low]: Reworks APPs api to follow rest best practice

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -7,6 +7,7 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.LeonardoApiHelper;
 import org.pmiops.workbench.model.App;
+import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.ListAppsResponse;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
@@ -17,7 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class AppController implements AppApiDelegate {
+public class AppsController implements AppsApiDelegate {
   private final LeonardoApiClient leonardoApiClient;
   private final Provider<DbUser> userProvider;
   private final WorkspaceAuthService workspaceAuthService;
@@ -26,7 +27,7 @@ public class AppController implements AppApiDelegate {
   private final LeonardoApiHelper leonardoApiHelper;
 
   @Autowired
-  public AppController(
+  public AppsController(
       LeonardoApiClient leonardoApiClient,
       Provider<DbUser> userProvider,
       WorkspaceAuthService workspaceAuthService,
@@ -60,22 +61,22 @@ public class AppController implements AppApiDelegate {
   }
 
   @Override
-  public ResponseEntity<EmptyResponse> deleteApp(String workspaceNamespace, Boolean deleteDisk) {
+  public ResponseEntity<EmptyResponse> deleteApp(String workspaceNamespace, String appName, Boolean deleteDisk) {
     throw new UnsupportedOperationException("API not supported.");
   }
 
   @Override
-  public ResponseEntity<App> getApp(String workspaceNamespace) {
+  public ResponseEntity<App> getApp(String workspaceNamespace, String appName) {
     throw new UnsupportedOperationException("API not supported.");
   }
 
   @Override
-  public ResponseEntity<EmptyResponse> updateApp(String workspaceNamespace, App app) {
+  public ResponseEntity<EmptyResponse> updateApp(String workspaceNamespace, String appName, App app) {
     throw new UnsupportedOperationException("API not supported.");
   }
 
   @Override
-  public ResponseEntity<ListAppsResponse> listApp() {
+  public ResponseEntity<ListAppsResponse> listAppsInWorkspace(String workspaceNamespace) {
     throw new UnsupportedOperationException("API not supported.");
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -7,7 +7,6 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.LeonardoApiHelper;
 import org.pmiops.workbench.model.App;
-import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.ListAppsResponse;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
@@ -61,7 +60,8 @@ public class AppsController implements AppsApiDelegate {
   }
 
   @Override
-  public ResponseEntity<EmptyResponse> deleteApp(String workspaceNamespace, String appName, Boolean deleteDisk) {
+  public ResponseEntity<EmptyResponse> deleteApp(
+      String workspaceNamespace, String appName, Boolean deleteDisk) {
     throw new UnsupportedOperationException("API not supported.");
   }
 
@@ -71,7 +71,8 @@ public class AppsController implements AppsApiDelegate {
   }
 
   @Override
-  public ResponseEntity<EmptyResponse> updateApp(String workspaceNamespace, String appName, App app) {
+  public ResponseEntity<EmptyResponse> updateApp(
+      String workspaceNamespace, String appName, App app) {
     throw new UnsupportedOperationException("API not supported.");
   }
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -807,20 +807,20 @@ paths:
           schema:
             "$ref": "#/definitions/ErrorResponse"
 
-  "/v1/apps/{workspaceNamespace}":
+  "/v1/workspaces/{workspaceNamespace}/apps":
     get:
-      summary: Get the user's app by type.
-      description: "Returns the current user's app by type."
-      operationId: getApp
+      summary: List apps in workspace
+      description: List apps the caller has access to, in given workspaces
+      operationId: listAppsInWorkspace
       tags:
-        - app
+        - apps
       parameters:
         - "$ref": "#/parameters/workspaceNamespace"
       responses:
-        200:
-          description: The app for this user and workspace.
+        "200":
+          description: List of apps
           schema:
-            "$ref": "#/definitions/App"
+            "$ref": "#/definitions/ListAppsResponse"
         404:
           description: No app exists for this user and workspace.
           schema:
@@ -833,10 +833,9 @@ paths:
       summary: Create a workspace APP.
       description: |
         Creates a new app request is received the current user in the given workspace. If a app already exists for the user in this billing project, a 409 conflict error is returned (even if the app is still initializing or is not in a ready state).
-        TODO(RW-3697): Custom app creation params should be added as a body param here.
       operationId: createApp
       tags:
-        - app
+        - apps
       parameters:
         - "$ref": "#/parameters/workspaceNamespace"
         - in: body
@@ -862,14 +861,47 @@ paths:
           description: Compute is temporarily suspended for security reasons.
           schema:
             "$ref": "#/definitions/ErrorResponse"
+
+  "/workspaces/{workspaceNamespace}/apps/{appName}":
+    get:
+      summary: Get the user's app by name in a workspace.
+      description: "Returns the current user's app by name in a workspace if exists."
+      operationId: getApp
+      tags:
+        - apps
+      parameters:
+        - "$ref": "#/parameters/workspaceNamespace"
+        - in: path
+          name: appName
+          description: The name of app.
+          required: true
+          type: string
+      responses:
+        200:
+          description: The app for this user and workspace.
+          schema:
+            "$ref": "#/definitions/App"
+        404:
+          description: No app exists for this user and workspace.
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
+        412:
+          description: Compute is temporarily suspended for security reasons.
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
     patch:
       summary: Updates the configuration of a app
       description: In order to update the configuration of a app, it must first be running or paused
       operationId: updateApp
       tags:
-        - app
+        - apps
       parameters:
         - "$ref": "#/parameters/workspaceNamespace"
+        - in: path
+          name: appName
+          description: The name of app.
+          required: true
+          type: string
         - in: body
           name: app
           schema:
@@ -895,9 +927,14 @@ paths:
       summary: Delete a workspace app.
       operationId: deleteApp
       tags:
-        - app
+        - apps
       parameters:
         - "$ref": "#/parameters/workspaceNamespace"
+        - in: path
+          name: appName
+          description: The name of app.
+          required: true
+          type: string
         - in: query
           name: deleteDisk
           description: Whether or not disk should be deleted if the app is using persistent disk. Default to false if not specified
@@ -917,18 +954,6 @@ paths:
           description: Compute is temporarily suspended for security reasons.
           schema:
             "$ref": "#/definitions/ErrorResponse"
-  "/v1/apps/":
-    get:
-      tags:
-        - app
-      summary: List apps
-      description: List apps the caller has access to, in all workspaces
-      operationId: listApp
-      responses:
-        "200":
-          description: List of apps
-          schema:
-            "$ref": "#/definitions/ListAppsResponse"
 
   "/v1/disks/{workspaceNamespace}":
     get:

--- a/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
@@ -33,10 +33,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 
 @DataJpaTest
-public class AppControllerTest {
+public class AppsControllerTest {
   @TestConfiguration
   @Import({
-    AppController.class,
+    AppsController.class,
     FakeClockConfiguration.class,
     LeonardoApiHelper.class,
   })
@@ -55,7 +55,7 @@ public class AppControllerTest {
     }
   }
 
-  @Autowired private AppController controller;
+  @Autowired private AppsController controller;
 
   @MockBean LeonardoApiClient mockLeonardoApiClient;
   @MockBean WorkspaceAuthService mockWorkspaceAuthService;


### PR DESCRIPTION
Description:

1. APP -> APPS
2. /workspaces/{workspaceNamespace}/apps because of [nest collections](https://restfulapi.net/resource-naming/#:~:text=1.2.%20Collection%20and%20Sub%2Dcollection%20Resources).
3. Create and List are moved to  /workspaces/{workspaceNamespace}/apps
4. GET DELETE and UPDATE in /workspaces/{workspaceNamespace}/apps/{appName}

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
