### PR TITLE
[RW-8941][RW-8925][risk=no]: Implement GET and LIST app endpoints

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -165,6 +165,6 @@
     }]
   },
   "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/81d3a9a1ad9f106da5ffb987f7cb040748b41d19\/apps\/rstudio\/app.yaml"
+    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   }
 }

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -158,6 +158,6 @@
     }]
   },
   "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/81d3a9a1ad9f106da5ffb987f7cb040748b41d19\/apps\/rstudio\/app.yaml"
+    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   }
 }

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -147,6 +147,6 @@
     "usersPerSynchronizeAccessTask": 50
   },
   "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/81d3a9a1ad9f106da5ffb987f7cb040748b41d19\/apps\/rstudio\/app.yaml"
+    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   }
 }

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -167,6 +167,6 @@
     }]
   },
   "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/81d3a9a1ad9f106da5ffb987f7cb040748b41d19\/apps\/rstudio\/app.yaml"
+    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   }
 }

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -164,6 +164,6 @@
     }]
   },
   "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/81d3a9a1ad9f106da5ffb987f7cb040748b41d19\/apps\/rstudio\/app.yaml"
+    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   }
 }

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -158,6 +158,6 @@
     }]
   },
   "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/81d3a9a1ad9f106da5ffb987f7cb040748b41d19\/apps\/rstudio\/app.yaml"
+    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   }
 }

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -164,6 +164,6 @@
     }]
   },
   "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/81d3a9a1ad9f106da5ffb987f7cb040748b41d19\/apps\/rstudio\/app.yaml"
+    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -78,6 +78,8 @@ public class AppsController implements AppsApiDelegate {
 
   @Override
   public ResponseEntity<ListAppsResponse> listAppsInWorkspace(String workspaceNamespace) {
-    throw new UnsupportedOperationException("API not supported.");
+    if (!workbenchConfigProvider.get().featureFlags.enableGkeApp) {
+      throw new UnsupportedOperationException("API not supported.");
+    }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -82,6 +82,5 @@ public class AppsController implements AppsApiDelegate {
     if (!workbenchConfigProvider.get().featureFlags.enableGkeApp) {
       throw new UnsupportedOperationException("API not supported.");
     }
-    List<LeonardoListAppResponse>
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -7,6 +7,7 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.LeonardoApiHelper;
 import org.pmiops.workbench.model.App;
+import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.ListAppsResponse;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
@@ -17,7 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class AppController implements AppApiDelegate {
+public class AppsController implements AppsApiDelegate {
   private final LeonardoApiClient leonardoApiClient;
   private final Provider<DbUser> userProvider;
   private final WorkspaceAuthService workspaceAuthService;
@@ -26,7 +27,7 @@ public class AppController implements AppApiDelegate {
   private final LeonardoApiHelper leonardoApiHelper;
 
   @Autowired
-  public AppController(
+  public AppsController(
       LeonardoApiClient leonardoApiClient,
       Provider<DbUser> userProvider,
       WorkspaceAuthService workspaceAuthService,
@@ -60,22 +61,22 @@ public class AppController implements AppApiDelegate {
   }
 
   @Override
-  public ResponseEntity<EmptyResponse> deleteApp(String workspaceNamespace, Boolean deleteDisk) {
+  public ResponseEntity<EmptyResponse> deleteApp(String workspaceNamespace, String appName, Boolean deleteDisk) {
     throw new UnsupportedOperationException("API not supported.");
   }
 
   @Override
-  public ResponseEntity<App> getApp(String workspaceNamespace) {
+  public ResponseEntity<App> getApp(String workspaceNamespace, String appName) {
     throw new UnsupportedOperationException("API not supported.");
   }
 
   @Override
-  public ResponseEntity<EmptyResponse> updateApp(String workspaceNamespace, App app) {
+  public ResponseEntity<EmptyResponse> updateApp(String workspaceNamespace, String appName, App app) {
     throw new UnsupportedOperationException("API not supported.");
   }
 
   @Override
-  public ResponseEntity<ListAppsResponse> listApp() {
+  public ResponseEntity<ListAppsResponse> listAppsInWorkspace(String workspaceNamespace) {
     throw new UnsupportedOperationException("API not supported.");
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -47,6 +47,7 @@ public class AppsController implements AppsApiDelegate {
   public ResponseEntity<EmptyResponse> createApp(
       String workspaceNamespace, CreateAppRequest createAppRequest) {
     DbWorkspace dbWorkspace = workspaceService.lookupWorkspaceByNamespace(workspaceNamespace);
+    workspaceAuthService.validateActiveBilling(workspaceNamespace, dbWorkspace.getFirecloudName());
     validateCanPerformApiAction(dbWorkspace);
 
     leonardoApiClient.createApp(createAppRequest, dbWorkspace);
@@ -85,7 +86,7 @@ public class AppsController implements AppsApiDelegate {
   }
 
   /**
-   * Validates user is allowed to perform acc action.
+   * Validates user is allowed to perform APP action.
    *
    * <p>App ACTION requires:
    *
@@ -107,6 +108,5 @@ public class AppsController implements AppsApiDelegate {
     String firecloudWorkspaceName = dbWorkspace.getFirecloudName();
     workspaceAuthService.enforceWorkspaceAccessLevel(
         workspaceNamespace, firecloudWorkspaceName, WorkspaceAccessLevel.WRITER);
-    workspaceAuthService.validateActiveBilling(workspaceNamespace, firecloudWorkspaceName);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -7,7 +7,6 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.LeonardoApiHelper;
 import org.pmiops.workbench.model.App;
-import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.ListAppsResponse;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
@@ -61,7 +60,8 @@ public class AppsController implements AppsApiDelegate {
   }
 
   @Override
-  public ResponseEntity<EmptyResponse> deleteApp(String workspaceNamespace, String appName, Boolean deleteDisk) {
+  public ResponseEntity<EmptyResponse> deleteApp(
+      String workspaceNamespace, String appName, Boolean deleteDisk) {
     throw new UnsupportedOperationException("API not supported.");
   }
 
@@ -71,7 +71,8 @@ public class AppsController implements AppsApiDelegate {
   }
 
   @Override
-  public ResponseEntity<EmptyResponse> updateApp(String workspaceNamespace, String appName, App app) {
+  public ResponseEntity<EmptyResponse> updateApp(
+      String workspaceNamespace, String appName, App app) {
     throw new UnsupportedOperationException("API not supported.");
   }
 

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
@@ -1,13 +1,16 @@
 package org.pmiops.workbench.leonardo;
 
+import java.net.CacheRequest;
 import java.util.List;
 import java.util.Map;
+import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.leonardo.model.LeonardoGetPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.model.App;
+import org.pmiops.workbench.model.CreateAppRequest;
 import org.pmiops.workbench.model.Runtime;
 import org.pmiops.workbench.notebooks.model.StorageLink;
 
@@ -81,12 +84,26 @@ public interface LeonardoApiClient {
   /**
    * Creates Leonardo app owned by the current authenticated user.
    *
-   * @param app the details for the app to create
-   * @param workspaceNamespace the workspace namespace to identify a workspace.
-   * @param workspaceFirecloudName the firecloudName of the workspace this app is associated with
+   * @param createAppRequest the details for the app to create
+   * @param dbWorkspace the workspace to create App within.
    */
-  void createApp(App app, String workspaceNamespace, String workspaceFirecloudName)
+  void createApp(CreateAppRequest createAppRequest, DbWorkspace dbWorkspace)
       throws WorkbenchException;
+
+  /**
+   * Gets Leonardo app owned by app name and workspace GCP project
+   *
+   * @param googleProjectId the GCP project if of the workpsace for the app to create
+   * @param appName the name of the app
+   */
+  App getAppByNameByProjectId(String googleProjectId, String appName);
+
+  /**
+   * Lists all apps the user have permission on in the given workspace GCP project
+   *
+   * @param googleProjectId the GCP project if of the workpsace for the app to create
+   */
+  List<App> listAppsInProject(String googleProjectId);
 
   /** @return true if Leonardo service is okay, false otherwise. */
   boolean getLeonardoStatus();

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
@@ -92,7 +92,7 @@ public interface LeonardoApiClient {
   /**
    * Gets Leonardo app owned by app name and workspace GCP project
    *
-   * @param googleProjectId the GCP project if of the workpsace for the app to create
+   * @param googleProjectId the GCP project the app belongs to
    * @param appName the name of the app
    */
   App getAppByNameByProjectId(String googleProjectId, String appName);
@@ -100,7 +100,7 @@ public interface LeonardoApiClient {
   /**
    * Lists all apps the user have permission on in the given workspace GCP project
    *
-   * @param googleProjectId the GCP project if of the workpsace for the app to create
+   * @param googleProjectId the GCP project the app belongs to
    */
   List<App> listAppsInProject(String googleProjectId);
 

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.leonardo;
 
-import java.net.CacheRequest;
 import java.util.List;
 import java.util.Map;
 import org.pmiops.workbench.db.model.DbWorkspace;

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -37,6 +37,7 @@ import org.pmiops.workbench.leonardo.model.LeonardoCreateAppRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoCreateRuntimeRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoGetPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
+import org.pmiops.workbench.leonardo.model.LeonardoListAppResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoMachineConfig;
@@ -532,6 +533,15 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
               createAppRequest);
           return null;
         });
+  }
+
+  public List<App> listAppsInWorkspace(App app, String workspaceNamespace, String workspaceFirecloudName) {
+    AppsApi appsApi = appsApiProvider.get();
+    DbWorkspace workspace = workspaceDao.getRequired(workspaceNamespace, workspaceFirecloudName);
+    List<LeonardoListAppResponse> listAppResponses = leonardoRetryHandler.run(
+        (context) -> appsApi.listAppByProject(app.getGoogleProject(), /* labels= */ null, /* includeDeleted= */false,  /* includeLabels= */null));
+
+    listAppResponses.
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -505,26 +505,26 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
   public void createApp(CreateAppRequest createAppRequest, DbWorkspace dbWorkspace)
       throws WorkbenchException {
     AppsApi appsApi = appsApiProvider.get();
-    App app = createAppRequest.getApp();
     LeonardoCreateAppRequest leonardoCreateAppRequest = new LeonardoCreateAppRequest();
     Map<String, String> appLabels =
         new ImmutableMap.Builder<String, String>()
             .put(LeonardoMapper.LEONARDO_LABEL_AOU, "true")
             .put(LeonardoMapper.LEONARDO_LABEL_CREATED_BY, userProvider.get().getUsername())
-            .put(LeonardoMapper.LEONARDO_LABEL_APP_TYPE, app.getAppType().toString())
+            .put(LeonardoMapper.LEONARDO_LABEL_APP_TYPE, createAppRequest.getAppType().toString())
             .build();
 
     leonardoCreateAppRequest
-        .appType(leonardoMapper.toLeonardoAppType(app.getAppType()))
+        .appType(leonardoMapper.toLeonardoAppType(createAppRequest.getAppType()))
         .kubernetesRuntimeConfig(
-            leonardoMapper.toLeonardoKubernetesRuntimeConfig(app.getKubernetesRuntimeConfig()))
+            leonardoMapper.toLeonardoKubernetesRuntimeConfig(
+                createAppRequest.getKubernetesRuntimeConfig()))
         .diskConfig(
             leonardoMapper.toLeonardoPersistentDiskRequest(
                 createAppRequest.getPersistentDiskRequest()))
         .customEnvironmentVariables(getBaseEnvironmentVariables(dbWorkspace))
         .labels(appLabels);
 
-    if (app.getAppType().equals(AppType.RSTUDIO)) {
+    if (createAppRequest.getAppType().equals(AppType.RSTUDIO)) {
       leonardoCreateAppRequest.descriptorPath(
           workbenchConfigProvider.get().app.rStudioDescriptorPath);
     }
@@ -532,8 +532,8 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
     leonardoRetryHandler.run(
         (context) -> {
           appsApi.createApp(
-              app.getGoogleProject(),
-              userProvider.get().getAppName(app.getAppType()),
+              dbWorkspace.getGoogleProject(),
+              userProvider.get().getAppName(createAppRequest.getAppType()),
               leonardoCreateAppRequest);
           return null;
         });

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -518,12 +518,15 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
         .appType(leonardoMapper.toLeonardoAppType(app.getAppType()))
         .kubernetesRuntimeConfig(
             leonardoMapper.toLeonardoKubernetesRuntimeConfig(app.getKubernetesRuntimeConfig()))
-        .diskConfig(leonardoMapper.toLeonardoPersistentDiskRequest(createAppRequest.getPersistentDiskRequest()))
+        .diskConfig(
+            leonardoMapper.toLeonardoPersistentDiskRequest(
+                createAppRequest.getPersistentDiskRequest()))
         .customEnvironmentVariables(getBaseEnvironmentVariables(dbWorkspace))
         .labels(appLabels);
 
     if (app.getAppType().equals(AppType.RSTUDIO)) {
-      leonardoCreateAppRequest.descriptorPath(workbenchConfigProvider.get().app.rStudioDescriptorPath);
+      leonardoCreateAppRequest.descriptorPath(
+          workbenchConfigProvider.get().app.rStudioDescriptorPath);
     }
 
     leonardoRetryHandler.run(
@@ -540,16 +543,22 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
   public App getAppByNameByProjectId(String googleProjectId, String appName) {
     AppsApi appsApi = appsApiProvider.get();
 
-    LeonardoGetAppResponse leonardoGetAppResponse = leonardoRetryHandler.run(
-        (context) -> appsApi.getApp(googleProjectId, appName));
+    LeonardoGetAppResponse leonardoGetAppResponse =
+        leonardoRetryHandler.run((context) -> appsApi.getApp(googleProjectId, appName));
     return leonardoMapper.toApiApp(leonardoGetAppResponse);
   }
 
   @Override
   public List<App> listAppsInProject(String googleProjectId) {
     AppsApi appsApi = appsApiProvider.get();
-    List<LeonardoListAppResponse> listAppResponses = leonardoRetryHandler.run(
-        (context) -> appsApi.listAppByProject(googleProjectId, /* labels= */ null, /* includeDeleted= */false,  /* includeLabels= */null));
+    List<LeonardoListAppResponse> listAppResponses =
+        leonardoRetryHandler.run(
+            (context) ->
+                appsApi.listAppByProject(
+                    googleProjectId,
+                    /* labels= */ null,
+                    /* includeDeleted= */ false,
+                    /* includeLabels= */ null));
 
     return listAppResponses.stream().map(leonardoMapper::toApiApp).collect(Collectors.toList());
   }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -168,7 +168,7 @@ public interface LeonardoMapper {
   @Mapping(target = "dateAccessed", source = "app.auditInfo.dateAccessed")
   @Mapping(target = "appType", ignore = true)
   @Mapping(target = "appName", source = "appName")
-  @Mapping(target = "googleProject", source = "googleProject")
+  @Mapping(target = "googleProject", source = "cloudContext")
   @Mapping(target = "autopauseThreshold", ignore = true)
   App toApiApp(LeonardoGetAppResponse app);
 
@@ -176,6 +176,7 @@ public interface LeonardoMapper {
   @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
   @Mapping(target = "appType", ignore = true)
   @Mapping(target = "autopauseThreshold", ignore = true)
+  @Mapping(target = "googleProject", source = "cloudContext")
   App toApiApp(LeonardoListAppResponse app);
 
   @AfterMapping

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -168,7 +168,7 @@ public interface LeonardoMapper {
   @Mapping(target = "dateAccessed", source = "app.auditInfo.dateAccessed")
   @Mapping(target = "appType", ignore = true)
   @Mapping(target = "appName", source = "appName")
-  @Mapping(target = "googleProject", source = "cloudContext")
+  @Mapping(target = "googleProject", source = "cloudContext.cloudResource")
   @Mapping(target = "autopauseThreshold", ignore = true)
   App toApiApp(LeonardoGetAppResponse app);
 
@@ -176,14 +176,14 @@ public interface LeonardoMapper {
   @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
   @Mapping(target = "appType", ignore = true)
   @Mapping(target = "autopauseThreshold", ignore = true)
-  @Mapping(target = "googleProject", source = "cloudContext")
+  @Mapping(target = "googleProject", source = "cloudContext.cloudResource")
   App toApiApp(LeonardoListAppResponse app);
 
   @AfterMapping
   default void getAppAfterMapper(
       @MappingTarget App app, LeonardoGetAppResponse leonardoGetAppResponse) {
     app.appName(leonardoGetAppResponse.getAppName())
-        .googleProject(leonardoGetAppResponse.getGoogleProject());
+        .googleProject(leonardoGetAppResponse.getCloudContext().getCloudResource());
     mapAppType(app, leonardoGetAppResponse.getAppName());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -4,12 +4,9 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.gson.Gson;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.mapstruct.AfterMapping;
-import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -41,7 +38,6 @@ import org.pmiops.workbench.model.DiskStatus;
 import org.pmiops.workbench.model.GceConfig;
 import org.pmiops.workbench.model.GceWithPdConfig;
 import org.pmiops.workbench.model.KubernetesRuntimeConfig;
-import org.pmiops.workbench.model.ListAppsResponse;
 import org.pmiops.workbench.model.ListRuntimeResponse;
 import org.pmiops.workbench.model.PersistentDiskRequest;
 import org.pmiops.workbench.model.Runtime;
@@ -176,7 +172,6 @@ public interface LeonardoMapper {
   @Mapping(target = "autopauseThreshold", ignore = true)
   App toApiApp(LeonardoGetAppResponse app);
 
-
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
   @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
   @Mapping(target = "appType", ignore = true)
@@ -186,7 +181,8 @@ public interface LeonardoMapper {
   @AfterMapping
   default void getAppAfterMapper(
       @MappingTarget App app, LeonardoGetAppResponse leonardoGetAppResponse) {
-    app.appName(leonardoGetAppResponse.getAppName()).googleProject(leonardoGetAppResponse.getGoogleProject());
+    app.appName(leonardoGetAppResponse.getAppName())
+        .googleProject(leonardoGetAppResponse.getGoogleProject());
     mapAppType(app, leonardoGetAppResponse.getAppName());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -171,8 +171,8 @@ public interface LeonardoMapper {
       LeonardoListAppResponse leonardoListAppResponse);
 
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
-  @Mapping(target = "toolDockerImage", source = "appImages")
-  @Mapping(target = "configurationType", ignore = true)
+  @Mapping(target = "createdDate", source = "diskName")
+  @Mapping(target = "kubernetesRuntimeConfig", ignore = true)
   @Mapping(target = "gceConfig", ignore = true)
   @Mapping(target = "gceWithPdConfig", ignore = true)
   @Mapping(target = "dataprocConfig", ignore = true)

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -17,8 +17,10 @@ import org.pmiops.workbench.leonardo.model.LeonardoDiskConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoDiskStatus;
 import org.pmiops.workbench.leonardo.model.LeonardoGceConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoGceWithPdConfig;
+import org.pmiops.workbench.leonardo.model.LeonardoGetAppResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoKubernetesRuntimeConfig;
+import org.pmiops.workbench.leonardo.model.LeonardoListAppResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoMachineConfig;
@@ -27,6 +29,7 @@ import org.pmiops.workbench.leonardo.model.LeonardoRuntimeConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeConfig.CloudServiceEnum;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeImage;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeStatus;
+import org.pmiops.workbench.model.App;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.DataprocConfig;
 import org.pmiops.workbench.model.Disk;
@@ -35,6 +38,7 @@ import org.pmiops.workbench.model.DiskStatus;
 import org.pmiops.workbench.model.GceConfig;
 import org.pmiops.workbench.model.GceWithPdConfig;
 import org.pmiops.workbench.model.KubernetesRuntimeConfig;
+import org.pmiops.workbench.model.ListAppsResponse;
 import org.pmiops.workbench.model.ListRuntimeResponse;
 import org.pmiops.workbench.model.PersistentDiskRequest;
 import org.pmiops.workbench.model.Runtime;
@@ -161,6 +165,49 @@ public interface LeonardoMapper {
         leonardoListRuntimeResponse.getDiskConfig());
   }
 
+  @Mapping(target = "createdDate", source = "auditInfo.createdDate")
+  @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
+  ListAppsResponse toApiListAppResponse(
+      LeonardoListAppResponse leonardoListAppResponse);
+
+  @Mapping(target = "createdDate", source = "auditInfo.createdDate")
+  @Mapping(target = "toolDockerImage", source = "appImages")
+  @Mapping(target = "configurationType", ignore = true)
+  @Mapping(target = "gceConfig", ignore = true)
+  @Mapping(target = "gceWithPdConfig", ignore = true)
+  @Mapping(target = "dataprocConfig", ignore = true)
+  App toApiApp(LeonardoGetAppResponse app);
+
+  @Mapping(target = "createdDate", source = "auditInfo.createdDate")
+  @Mapping(target = "autopauseThreshold", ignore = true)
+  @Mapping(target = "toolDockerImage", ignore = true)
+  @Mapping(target = "configurationType", ignore = true)
+  @Mapping(target = "gceConfig", ignore = true)
+  @Mapping(target = "gceWithPdConfig", ignore = true)
+  @Mapping(target = "dataprocConfig", ignore = true)
+  @Mapping(target = "errors", ignore = true)
+  App toApiApp(LeonardoListAppResponse app);
+
+  @AfterMapping
+  default void getAppAfterMapper(
+      @MappingTarget App app, LeonardoGetAppResponse leonardoGetAppResponse) {
+    mapLabels(app, leonardoGetAppResponse.getLabels());
+    mapAppConfig(
+        app,
+        leonardoGetAppResponse.getAppConfig(),
+        leonardoGetAppResponse.getDiskConfig());
+  }
+
+  @AfterMapping
+  default void listAppAfterMapper(
+      @MappingTarget App app, LeonardoListAppResponse leonardoListAppResponse) {
+    mapLabels(app, leonardoListAppResponse.getLabels());
+    mapAppConfig(
+        app,
+        leonardoListAppResponse.getAppConfig(),
+        leonardoListAppResponse.getDiskConfig());
+  }
+  
   KubernetesRuntimeConfig toKubernetesRuntimeConfig(
       LeonardoKubernetesRuntimeConfig leonardoKubernetesRuntimeConfig);
 

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -3026,9 +3026,9 @@ components:
         appName:
           type: string
           description: the name of the app
-        googleProject:
+        cloudContext:
           type: string
-          description: Deprecated. The project this app is associated with
+          description: Google project this app is associated with if the app is created in GCP; Azure's tenantId/subscriptionId/managedResourceGroupId if the app is created in Azure
         kubernetesRuntimeConfig:
           $ref: '#/components/schemas/KubernetesRuntimeConfig'
         errors:

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -1891,6 +1891,11 @@ components:
       enum:
         - pd-standard
         - pd-ssd
+    CloudProvider:
+      type: string
+      enum:
+        - GCP
+        - AZURE
     RuntimeStatus:
       type: string
       enum:
@@ -3027,8 +3032,7 @@ components:
           type: string
           description: the name of the app
         cloudContext:
-          type: string
-          description: Google project this app is associated with if the app is created in GCP; Azure's tenantId/subscriptionId/managedResourceGroupId if the app is created in Azure
+          $ref: '#/components/schemas/CloudContext'
         kubernetesRuntimeConfig:
           $ref: '#/components/schemas/KubernetesRuntimeConfig'
         errors:
@@ -3067,8 +3071,7 @@ components:
           type: string
           description: Deprecated. The project this app is associated with
         cloudContext:
-          type: string
-          description: Google project this app is associated with if the app is created in GCP; Azure's tenantId/subscriptionId/managedResourceGroupId if the app is created in Azure
+          $ref: '#/components/schemas/CloudContext'
         kubernetesRuntimeConfig:
           $ref: '#/components/schemas/KubernetesRuntimeConfig'
         errors:
@@ -3094,6 +3097,19 @@ components:
         labels:
           type: object
           description: The labels of each app in the response whose key is in includeLabels in the request. Of type Map[String,String]
+
+    CloudContext:
+      description: Cloud platform which holds context for a workspace.
+      type: object
+      required:
+        - cloudProvider
+        - cloudResource
+      properties:
+        cloudProvider:
+          $ref: '#/components/schemas/CloudProvider'
+        cloudResource:
+          type: string
+          description: Cloud resource name. Google project if cloud provider is GCP OR Azure's tenantId/subscriptionId/managedResourceGroupId if in Azure
 
     KubernetesRuntimeConfig:
       description: configuration for a kubernetes app runtime

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -3023,6 +3023,12 @@ components:
         - auditInfo
       type: object
       properties:
+        appName:
+          type: string
+          description: the name of the app
+        googleProject:
+          type: string
+          description: Deprecated. The project this app is associated with
         kubernetesRuntimeConfig:
           $ref: '#/components/schemas/KubernetesRuntimeConfig'
         errors:
@@ -3045,6 +3051,9 @@ components:
           $ref: "#/components/schemas/AuditInfo"
         appType:
           $ref: '#/components/schemas/AppType'
+        labels:
+          type: object
+          description: The labels of each app in the response whose key is in includeLabels in the request. Of type Map[String,String]
 
     ListAppResponse:
       description: the configuration of an app

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -843,7 +843,7 @@ paths:
           description: APP definition
           required: true
           schema:
-            "$ref": "#/definitions/App"
+            "$ref": "#/definitions/CreateAppRequest"
       responses:
         200:
           description: App was created successfully
@@ -6208,6 +6208,15 @@ definitions:
         type: string
         description: timestamp for error in ISO 8601 format
 
+  CreateAppRequest:
+    description: Create APP request body
+    properties:
+      app:
+        $ref: "#/definitions/App"
+      persistentDiskRequest:
+        description: Persistent disk configuration
+        "$ref": "#/definitions/PersistentDiskRequest"
+
   App:
     properties:
       googleProject:
@@ -6232,9 +6241,12 @@ definitions:
       kubernetesRuntimeConfig:
         description: kubernetesRuntimeConfig will be returned
         "$ref": "#/definitions/KubernetesRuntimeConfig"
-      persistentDiskRequest:
-        description: Persistent disk configuration
-        "$ref": "#/definitions/PersistentDiskRequest"
+      proxyUrls:
+        type: object
+        description: Read only. Map of service name to proxyUrl
+      diskName:
+        type: string
+        description: Read only. The name of the disk associated with this app
       errors:
         type: array
         description: The list of errors that were encountered on APP create, if any.

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6247,11 +6247,19 @@ definitions:
       diskName:
         type: string
         description: Read only. The name of the disk associated with this app
+      dateAccessed:
+        type: string
+        description: |
+          The date and time the runtime was last accessed, in ISO-8601 format.
+          Date accessed is defined as the last time the runtime was created, modified, or accessed via the proxy.
       errors:
         type: array
         description: The list of errors that were encountered on APP create, if any.
         items:
           $ref: "#/definitions/KubernetesError"
+      labels:
+        type: object
+        description: The labels of each app in the response whose key is in includeLabels in the request. Of type Map[String,String]
 
   KubernetesError:
       description: a kubernetes app error

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -862,7 +862,7 @@ paths:
           schema:
             "$ref": "#/definitions/ErrorResponse"
 
-  "/workspaces/{workspaceNamespace}/apps/{appName}":
+  "/v1/workspaces/{workspaceNamespace}/apps/{appName}":
     get:
       summary: Get the user's app by name in a workspace.
       description: "Returns the current user's app by name in a workspace if exists."
@@ -6211,8 +6211,16 @@ definitions:
   CreateAppRequest:
     description: Create APP request body
     properties:
-      app:
-        $ref: "#/definitions/App"
+      appType:
+        "$ref": "#/definitions/AppType"
+      autopauseThreshold:
+        type: integer
+        description: The number of minutes of idle time to elapse before the cluster is
+          autopaused. If autopause is set to false, this value is disregarded.
+          A value of 0 is equivalent to autopause being turned off.
+      kubernetesRuntimeConfig:
+        description: kubernetesRuntimeConfig will be returned
+        "$ref": "#/definitions/KubernetesRuntimeConfig"
       persistentDiskRequest:
         description: Persistent disk configuration
         "$ref": "#/definitions/PersistentDiskRequest"

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -807,20 +807,20 @@ paths:
           schema:
             "$ref": "#/definitions/ErrorResponse"
 
-  "/v1/apps/{workspaceNamespace}":
+  "/v1/workspaces/{workspaceNamespace}/apps":
     get:
-      summary: Get the user's app by type.
-      description: "Returns the current user's app by type."
-      operationId: getApp
+      summary: List apps in workspace
+      description: List apps the caller has access to, in given workspaces
+      operationId: listAppsInWorkspace
       tags:
-        - app
+        - apps
       parameters:
         - "$ref": "#/parameters/workspaceNamespace"
       responses:
-        200:
-          description: The app for this user and workspace.
+        "200":
+          description: List of apps
           schema:
-            "$ref": "#/definitions/App"
+            "$ref": "#/definitions/ListAppsResponse"
         404:
           description: No app exists for this user and workspace.
           schema:
@@ -833,10 +833,9 @@ paths:
       summary: Create a workspace APP.
       description: |
         Creates a new app request is received the current user in the given workspace. If a app already exists for the user in this billing project, a 409 conflict error is returned (even if the app is still initializing or is not in a ready state).
-        TODO(RW-3697): Custom app creation params should be added as a body param here.
       operationId: createApp
       tags:
-        - app
+        - apps
       parameters:
         - "$ref": "#/parameters/workspaceNamespace"
         - in: body
@@ -862,14 +861,47 @@ paths:
           description: Compute is temporarily suspended for security reasons.
           schema:
             "$ref": "#/definitions/ErrorResponse"
+
+  "/workspaces/{workspaceNamespace}/apps/{appName}":
+    get:
+      summary: Get the user's app by name in a workspace.
+      description: "Returns the current user's app by name in a workspace if exists."
+      operationId: getApp
+      tags:
+        - apps
+      parameters:
+        - "$ref": "#/parameters/workspaceNamespace"
+        - in: path
+          name: appName
+          description: The name of app.
+          required: true
+          type: string
+      responses:
+        200:
+          description: The app for this user and workspace.
+          schema:
+            "$ref": "#/definitions/App"
+        404:
+          description: No app exists for this user and workspace.
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
+        412:
+          description: Compute is temporarily suspended for security reasons.
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
     patch:
       summary: Updates the configuration of a app
       description: In order to update the configuration of a app, it must first be running or paused
       operationId: updateApp
       tags:
-        - app
+        - apps
       parameters:
         - "$ref": "#/parameters/workspaceNamespace"
+        - in: path
+          name: appName
+          description: The name of app.
+          required: true
+          type: string
         - in: body
           name: app
           schema:
@@ -895,9 +927,14 @@ paths:
       summary: Delete a workspace app.
       operationId: deleteApp
       tags:
-        - app
+        - apps
       parameters:
         - "$ref": "#/parameters/workspaceNamespace"
+        - in: path
+          name: appName
+          description: The name of app.
+          required: true
+          type: string
         - in: query
           name: deleteDisk
           description: Whether or not disk should be deleted if the app is using persistent disk. Default to false if not specified
@@ -917,18 +954,6 @@ paths:
           description: Compute is temporarily suspended for security reasons.
           schema:
             "$ref": "#/definitions/ErrorResponse"
-  "/v1/apps/":
-    get:
-      tags:
-        - app
-      summary: List apps
-      description: List apps the caller has access to, in all workspaces
-      operationId: listApp
-      responses:
-        "200":
-          description: List of apps
-          schema:
-            "$ref": "#/definitions/ListAppsResponse"
 
   "/v1/disks/{workspaceNamespace}":
     get:

--- a/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
@@ -75,9 +75,9 @@ public class AppsControllerTest {
   private static final String WORKSPACE_ID = "myfirstworkspace";
 
   private static WorkbenchConfig config = new WorkbenchConfig();
-  private static DbUser user = new DbUser();
   private static DbWorkspace testWorkspace;
   private CreateAppRequest createAppRequest;
+  private DbUser user = new DbUser();
   private App testApp;
 
   @BeforeEach

--- a/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
@@ -97,43 +97,6 @@ public class AppsControllerTest {
   }
 
   @Test
-  public void testCreateAppFail_featureNotEnabled() throws Exception {
-    config.featureFlags.enableGkeApp = false;
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> controller.createApp(WORKSPACE_NS, createAppRequest));
-  }
-
-  @Test
-  public void testCreateAppFail_securitySuspended() throws ApiException {
-    user.setComputeSecuritySuspendedUntil(
-        Timestamp.from(FakeClockConfiguration.NOW.toInstant().plus(Duration.ofMinutes(5))));
-    assertThrows(
-        FailedPreconditionException.class,
-        () -> controller.createApp(WORKSPACE_NS, createAppRequest));
-  }
-
-  @Test
-  public void testCreateAppFail_noWorkspacePermission() throws ApiException {
-    doThrow(ForbiddenException.class)
-        .when(mockWorkspaceAuthService)
-        .enforceWorkspaceAccessLevel(WORKSPACE_NS, WORKSPACE_ID, WorkspaceAccessLevel.WRITER);
-
-    assertThrows(
-        ForbiddenException.class, () -> controller.createApp(WORKSPACE_NS, createAppRequest));
-  }
-
-  @Test
-  public void testCreateAppFail_validateActiveBilling() {
-    doThrow(ForbiddenException.class)
-        .when(mockWorkspaceAuthService)
-        .validateActiveBilling(WORKSPACE_NS, WORKSPACE_ID);
-
-    assertThrows(
-        ForbiddenException.class, () -> controller.createApp(WORKSPACE_NS, createAppRequest));
-  }
-
-  @Test
   public void testGetAppSuccess() throws Exception {
     controller.getApp(WORKSPACE_NS, APP_NAME);
     verify(mockLeonardoApiClient).getAppByNameByProjectId(GOOGLE_PROJECT_ID, APP_NAME);
@@ -143,5 +106,42 @@ public class AppsControllerTest {
   public void testListAppSuccess() throws Exception {
     controller.listAppsInWorkspace(WORKSPACE_NS);
     verify(mockLeonardoApiClient).listAppsInProject(GOOGLE_PROJECT_ID);
+  }
+
+  @Test
+  public void testCanPerformAppActions_featureNotEnabled() throws Exception {
+    config.featureFlags.enableGkeApp = false;
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> controller.validateCanPerformApiAction(testWorkspace));
+  }
+
+  @Test
+  public void testCanPerformAppActions_securitySuspended() throws ApiException {
+    user.setComputeSecuritySuspendedUntil(
+        Timestamp.from(FakeClockConfiguration.NOW.toInstant().plus(Duration.ofMinutes(5))));
+    assertThrows(
+        FailedPreconditionException.class,
+        () -> controller.validateCanPerformApiAction(testWorkspace));
+  }
+
+  @Test
+  public void testCanPerformAppActions_noWorkspacePermission() throws ApiException {
+    doThrow(ForbiddenException.class)
+        .when(mockWorkspaceAuthService)
+        .enforceWorkspaceAccessLevel(WORKSPACE_NS, WORKSPACE_ID, WorkspaceAccessLevel.WRITER);
+
+    assertThrows(
+        ForbiddenException.class, () -> controller.validateCanPerformApiAction(testWorkspace));
+  }
+
+  @Test
+  public void testCanPerformAppActions_validateActiveBilling() {
+    doThrow(ForbiddenException.class)
+        .when(mockWorkspaceAuthService)
+        .validateActiveBilling(WORKSPACE_NS, WORKSPACE_ID);
+
+    assertThrows(
+        ForbiddenException.class, () -> controller.validateCanPerformApiAction(testWorkspace));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
@@ -32,8 +32,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
 @DataJpaTest
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 public class AppsControllerTest {
   @TestConfiguration
   @Import({

--- a/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
@@ -34,9 +34,12 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 public class AppsControllerTest {
   @TestConfiguration
   @Import({

--- a/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
@@ -33,10 +33,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 
 @DataJpaTest
-public class AppControllerTest {
+public class AppsControllerTest {
   @TestConfiguration
   @Import({
-    AppController.class,
+    AppsController.class,
     FakeClockConfiguration.class,
     LeonardoApiHelper.class,
   })
@@ -55,7 +55,7 @@ public class AppControllerTest {
     }
   }
 
-  @Autowired private AppController controller;
+  @Autowired private AppsController controller;
 
   @MockBean LeonardoApiClient mockLeonardoApiClient;
   @MockBean WorkspaceAuthService mockWorkspaceAuthService;

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -143,7 +143,10 @@ public class LeonardoApiClientTest {
             .googleProject(GOOGLE_PROJECT_ID)
             .kubernetesRuntimeConfig(kubernetesRuntimeConfig);
     createAppRequest =
-        new CreateAppRequest().app(testApp).persistentDiskRequest(persistentDiskRequest);
+        new CreateAppRequest()
+            .appType(AppType.RSTUDIO)
+            .kubernetesRuntimeConfig(kubernetesRuntimeConfig)
+            .persistentDiskRequest(persistentDiskRequest);
 
     DbCdrVersion cdrVersion =
         new DbCdrVersion()
@@ -212,7 +215,7 @@ public class LeonardoApiClientTest {
   @Test
   public void testListAppSuccess() throws Exception {
     leonardoApiClient.listAppsInProject(GOOGLE_PROJECT_ID);
-    verify(userAppsApi).listAppByProject(GOOGLE_PROJECT_ID, null, null, null);
+    verify(userAppsApi).listAppByProject(GOOGLE_PROJECT_ID, null, false, null);
   }
 
   private void stubGetFcWorkspace(WorkspaceAccessLevel accessLevel) {

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import org.checkerframework.checker.units.qual.C;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -143,8 +142,8 @@ public class LeonardoApiClientTest {
             .appType(AppType.RSTUDIO)
             .googleProject(GOOGLE_PROJECT_ID)
             .kubernetesRuntimeConfig(kubernetesRuntimeConfig);
-    createAppRequest = new CreateAppRequest().app(testApp)
-            .persistentDiskRequest(persistentDiskRequest);
+    createAppRequest =
+        new CreateAppRequest().app(testApp).persistentDiskRequest(persistentDiskRequest);
 
     DbCdrVersion cdrVersion =
         new DbCdrVersion()
@@ -159,7 +158,7 @@ public class LeonardoApiClientTest {
                     .setDatasetsBucket(CDR_BUCKET))
             .setStorageBasePath(CDR_STORAGE_BASE_PATH)
             .setWgsCramManifestPath(WGS_PATH);
-     testWorkspace =
+    testWorkspace =
         new DbWorkspace()
             .setWorkspaceNamespace(WORKSPACE_NS)
             .setGoogleProject(GOOGLE_PROJECT_ID)
@@ -181,7 +180,7 @@ public class LeonardoApiClientTest {
   }
 
   @Test
-  public void testCreateAppSuccess_success() throws Exception {
+  public void testCreateAppSuccess() throws Exception {
     stubGetFcWorkspace(WorkspaceAccessLevel.OWNER);
     leonardoApiClient.createApp(createAppRequest, testWorkspace);
     verify(userAppsApi)
@@ -202,6 +201,18 @@ public class LeonardoApiClientTest {
             .customEnvironmentVariables(customEnvironmentVariables);
 
     assertThat(createAppRequest).isEqualTo(expectedAppRequest);
+  }
+
+  @Test
+  public void testGetAppSuccess() throws Exception {
+    leonardoApiClient.getAppByNameByProjectId(GOOGLE_PROJECT_ID, getAppName(AppType.RSTUDIO));
+    verify(userAppsApi).getApp(GOOGLE_PROJECT_ID, getAppName(AppType.RSTUDIO));
+  }
+
+  @Test
+  public void testListAppSuccess() throws Exception {
+    leonardoApiClient.listAppsInProject(GOOGLE_PROJECT_ID);
+    verify(userAppsApi).listAppByProject(GOOGLE_PROJECT_ID, null, null, null);
   }
 
   private void stubGetFcWorkspace(WorkspaceAccessLevel accessLevel) {

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import org.checkerframework.checker.units.qual.C;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -34,6 +35,7 @@ import org.pmiops.workbench.leonardo.model.LeonardoKubernetesRuntimeConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoPersistentDiskRequest;
 import org.pmiops.workbench.model.App;
 import org.pmiops.workbench.model.AppType;
+import org.pmiops.workbench.model.CreateAppRequest;
 import org.pmiops.workbench.model.DiskType;
 import org.pmiops.workbench.model.KubernetesRuntimeConfig;
 import org.pmiops.workbench.model.PersistentDiskRequest;
@@ -113,7 +115,9 @@ public class LeonardoApiClientTest {
   private static WorkbenchConfig config = new WorkbenchConfig();
   private static DbUser user = new DbUser();
 
+  private DbWorkspace testWorkspace;
   private App testApp;
+  private CreateAppRequest createAppRequest;
   private LeonardoKubernetesRuntimeConfig leonardoKubernetesRuntimeConfig;
   private LeonardoPersistentDiskRequest leonardoPersistentDiskRequest;
   private Map<String, String> appLabels = new HashMap<>();
@@ -138,7 +142,8 @@ public class LeonardoApiClientTest {
         new App()
             .appType(AppType.RSTUDIO)
             .googleProject(GOOGLE_PROJECT_ID)
-            .kubernetesRuntimeConfig(kubernetesRuntimeConfig)
+            .kubernetesRuntimeConfig(kubernetesRuntimeConfig);
+    createAppRequest = new CreateAppRequest().app(testApp)
             .persistentDiskRequest(persistentDiskRequest);
 
     DbCdrVersion cdrVersion =
@@ -154,7 +159,7 @@ public class LeonardoApiClientTest {
                     .setDatasetsBucket(CDR_BUCKET))
             .setStorageBasePath(CDR_STORAGE_BASE_PATH)
             .setWgsCramManifestPath(WGS_PATH);
-    DbWorkspace testWorkspace =
+     testWorkspace =
         new DbWorkspace()
             .setWorkspaceNamespace(WORKSPACE_NS)
             .setGoogleProject(GOOGLE_PROJECT_ID)
@@ -178,7 +183,7 @@ public class LeonardoApiClientTest {
   @Test
   public void testCreateAppSuccess_success() throws Exception {
     stubGetFcWorkspace(WorkspaceAccessLevel.OWNER);
-    leonardoApiClient.createApp(testApp, WORKSPACE_NS, WORKSPACE_NAME);
+    leonardoApiClient.createApp(createAppRequest, testWorkspace);
     verify(userAppsApi)
         .createApp(
             eq(GOOGLE_PROJECT_ID),

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.checkerframework.checker.units.qual.A;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.leonardo.model.LeonardoAppStatus;
@@ -59,22 +58,38 @@ public class LeonardoMapperTest {
     persistentDiskRequest = new PersistentDiskRequest().diskType(DiskType.STANDARD).size(10);
     leonardoPersistentDiskRequest =
         new LeonardoPersistentDiskRequest().diskType(LeonardoDiskType.STANDARD).size(10);
-    leonardoAuditInfo = new LeonardoAuditInfo().createdDate("2022-10-10").creator("bob@gmail.com").dateAccessed("2022-10-10");
+    leonardoAuditInfo =
+        new LeonardoAuditInfo()
+            .createdDate("2022-10-10")
+            .creator("bob@gmail.com")
+            .dateAccessed("2022-10-10");
 
     kubernetesErrors.add(new KubernetesError().errorMessage("error1").googleErrorCode(404));
     kubernetesErrors.add(new KubernetesError().errorMessage("error2").googleErrorCode(401));
-    leonardoKubernetesErrors.add(new LeonardoKubernetesError().errorMessage("error1").googleErrorCode(404));
-    leonardoKubernetesErrors.add(new LeonardoKubernetesError().errorMessage("error2").googleErrorCode(401));
+    leonardoKubernetesErrors.add(
+        new LeonardoKubernetesError().errorMessage("error1").googleErrorCode(404));
+    leonardoKubernetesErrors.add(
+        new LeonardoKubernetesError().errorMessage("error2").googleErrorCode(401));
 
     proxyUrls.put("cromwell", "cromwell url");
     proxyUrls.put("rstudio", "rstudio url");
     labels.put("label key 1", "label value 1");
     labels.put("label key 2", "label value 2");
 
-    app = new App().createdDate("2022-10-10").dateAccessed("2022-10-10").kubernetesRuntimeConfig(kubernetesRuntimeConfig)
-        .googleProject("google project").appType(AppType.CROMWELL).errors(kubernetesErrors).proxyUrls(proxyUrls).diskName(DISK_NAME)
-        .appName(APP_NAME).status(AppStatus.RUNNING).googleProject(GOOGLE_PROJECT)
-        .labels(labels);
+    app =
+        new App()
+            .createdDate("2022-10-10")
+            .dateAccessed("2022-10-10")
+            .kubernetesRuntimeConfig(kubernetesRuntimeConfig)
+            .googleProject("google project")
+            .appType(AppType.CROMWELL)
+            .errors(kubernetesErrors)
+            .proxyUrls(proxyUrls)
+            .diskName(DISK_NAME)
+            .appName(APP_NAME)
+            .status(AppStatus.RUNNING)
+            .googleProject(GOOGLE_PROJECT)
+            .labels(labels);
   }
 
   @Test
@@ -107,22 +122,37 @@ public class LeonardoMapperTest {
     assertThat(mapper.toLeonardoAppType(AppType.CROMWELL)).isEqualTo(LeonardoAppType.CROMWELL);
   }
 
-
   @Test
   public void testToAppFromGetResponse() {
-    LeonardoGetAppResponse getAppResponse = new LeonardoGetAppResponse().appType(LeonardoAppType.CROMWELL)
-            .status(LeonardoAppStatus.RUNNING).auditInfo(leonardoAuditInfo).diskName(DISK_NAME)
-        .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig).appName(APP_NAME).googleProject(GOOGLE_PROJECT)
-            .errors(leonardoKubernetesErrors).proxyUrls(proxyUrls).labels(labels);
+    LeonardoGetAppResponse getAppResponse =
+        new LeonardoGetAppResponse()
+            .appType(LeonardoAppType.CROMWELL)
+            .status(LeonardoAppStatus.RUNNING)
+            .auditInfo(leonardoAuditInfo)
+            .diskName(DISK_NAME)
+            .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig)
+            .appName(APP_NAME)
+            .googleProject(GOOGLE_PROJECT)
+            .errors(leonardoKubernetesErrors)
+            .proxyUrls(proxyUrls)
+            .labels(labels);
     assertThat(mapper.toApiApp(getAppResponse)).isEqualTo(app);
   }
 
   @Test
   public void testToAppFromListResponse() {
-    LeonardoListAppResponse listAppResponse = new LeonardoListAppResponse().appType(LeonardoAppType.CROMWELL)
-        .status(LeonardoAppStatus.RUNNING).auditInfo(leonardoAuditInfo).diskName(DISK_NAME)
-        .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig)
-        .errors(leonardoKubernetesErrors).proxyUrls(proxyUrls).labels(labels).appName(APP_NAME).googleProject(GOOGLE_PROJECT);
+    LeonardoListAppResponse listAppResponse =
+        new LeonardoListAppResponse()
+            .appType(LeonardoAppType.CROMWELL)
+            .status(LeonardoAppStatus.RUNNING)
+            .auditInfo(leonardoAuditInfo)
+            .diskName(DISK_NAME)
+            .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig)
+            .errors(leonardoKubernetesErrors)
+            .proxyUrls(proxyUrls)
+            .labels(labels)
+            .appName(APP_NAME)
+            .googleProject(GOOGLE_PROJECT);
     assertThat(mapper.toApiApp(listAppResponse)).isEqualTo(app);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -2,14 +2,27 @@ package org.pmiops.workbench.utils.mappers;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.checkerframework.checker.units.qual.A;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.pmiops.workbench.leonardo.model.LeonardoAppStatus;
 import org.pmiops.workbench.leonardo.model.LeonardoAppType;
+import org.pmiops.workbench.leonardo.model.LeonardoAuditInfo;
 import org.pmiops.workbench.leonardo.model.LeonardoDiskType;
+import org.pmiops.workbench.leonardo.model.LeonardoGetAppResponse;
+import org.pmiops.workbench.leonardo.model.LeonardoKubernetesError;
 import org.pmiops.workbench.leonardo.model.LeonardoKubernetesRuntimeConfig;
+import org.pmiops.workbench.leonardo.model.LeonardoListAppResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoPersistentDiskRequest;
+import org.pmiops.workbench.model.App;
+import org.pmiops.workbench.model.AppStatus;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.DiskType;
+import org.pmiops.workbench.model.KubernetesError;
 import org.pmiops.workbench.model.KubernetesRuntimeConfig;
 import org.pmiops.workbench.model.PersistentDiskRequest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,11 +35,20 @@ public class LeonardoMapperTest {
   @Autowired private LeonardoMapper mapper;
 
   private static final String MACHINE_TYPE = "n1-standard-1";
+  private static final String APP_NAME = "all-of-us-123-cromwell";
+  private static final String DISK_NAME = "disk name";
+  private static final String GOOGLE_PROJECT = "google project";
 
+  private App app;
   private KubernetesRuntimeConfig kubernetesRuntimeConfig;
   private LeonardoKubernetesRuntimeConfig leonardoKubernetesRuntimeConfig;
   private PersistentDiskRequest persistentDiskRequest;
   private LeonardoPersistentDiskRequest leonardoPersistentDiskRequest;
+  private LeonardoAuditInfo leonardoAuditInfo;
+  private List<KubernetesError> kubernetesErrors = new ArrayList<>();
+  private List<LeonardoKubernetesError> leonardoKubernetesErrors = new ArrayList<>();
+  private Map<String, String> proxyUrls = new HashMap<>();
+  private Map<String, String> labels = new HashMap<>();
 
   @BeforeEach
   public void setUp() {
@@ -37,6 +59,22 @@ public class LeonardoMapperTest {
     persistentDiskRequest = new PersistentDiskRequest().diskType(DiskType.STANDARD).size(10);
     leonardoPersistentDiskRequest =
         new LeonardoPersistentDiskRequest().diskType(LeonardoDiskType.STANDARD).size(10);
+    leonardoAuditInfo = new LeonardoAuditInfo().createdDate("2022-10-10").creator("bob@gmail.com").dateAccessed("2022-10-10");
+
+    kubernetesErrors.add(new KubernetesError().errorMessage("error1").googleErrorCode(404));
+    kubernetesErrors.add(new KubernetesError().errorMessage("error2").googleErrorCode(401));
+    leonardoKubernetesErrors.add(new LeonardoKubernetesError().errorMessage("error1").googleErrorCode(404));
+    leonardoKubernetesErrors.add(new LeonardoKubernetesError().errorMessage("error2").googleErrorCode(401));
+
+    proxyUrls.put("cromwell", "cromwell url");
+    proxyUrls.put("rstudio", "rstudio url");
+    labels.put("label key 1", "label value 1");
+    labels.put("label key 2", "label value 2");
+
+    app = new App().createdDate("2022-10-10").dateAccessed("2022-10-10").kubernetesRuntimeConfig(kubernetesRuntimeConfig)
+        .googleProject("google project").appType(AppType.CROMWELL).errors(kubernetesErrors).proxyUrls(proxyUrls).diskName(DISK_NAME)
+        .appName(APP_NAME).status(AppStatus.RUNNING).googleProject(GOOGLE_PROJECT)
+        .labels(labels);
   }
 
   @Test
@@ -67,5 +105,24 @@ public class LeonardoMapperTest {
   public void testToLeonardoAppType() {
     assertThat(mapper.toLeonardoAppType(AppType.RSTUDIO)).isEqualTo(LeonardoAppType.CUSTOM);
     assertThat(mapper.toLeonardoAppType(AppType.CROMWELL)).isEqualTo(LeonardoAppType.CROMWELL);
+  }
+
+
+  @Test
+  public void testToAppFromGetResponse() {
+    LeonardoGetAppResponse getAppResponse = new LeonardoGetAppResponse().appType(LeonardoAppType.CROMWELL)
+            .status(LeonardoAppStatus.RUNNING).auditInfo(leonardoAuditInfo).diskName(DISK_NAME)
+        .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig).appName(APP_NAME).googleProject(GOOGLE_PROJECT)
+            .errors(leonardoKubernetesErrors).proxyUrls(proxyUrls).labels(labels);
+    assertThat(mapper.toApiApp(getAppResponse)).isEqualTo(app);
+  }
+
+  @Test
+  public void testToAppFromListResponse() {
+    LeonardoListAppResponse listAppResponse = new LeonardoListAppResponse().appType(LeonardoAppType.CROMWELL)
+        .status(LeonardoAppStatus.RUNNING).auditInfo(leonardoAuditInfo).diskName(DISK_NAME)
+        .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig)
+        .errors(leonardoKubernetesErrors).proxyUrls(proxyUrls).labels(labels).appName(APP_NAME).googleProject(GOOGLE_PROJECT);
+    assertThat(mapper.toApiApp(listAppResponse)).isEqualTo(app);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -132,9 +132,9 @@ public class LeonardoMapperTest {
             .diskName(DISK_NAME)
             .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig)
             .appName(APP_NAME)
-            .googleProject(GOOGLE_PROJECT)
             .errors(leonardoKubernetesErrors)
             .proxyUrls(proxyUrls)
+            .cloudContext(GOOGLE_PROJECT)
             .labels(labels);
     assertThat(mapper.toApiApp(getAppResponse)).isEqualTo(app);
   }
@@ -152,7 +152,8 @@ public class LeonardoMapperTest {
             .proxyUrls(proxyUrls)
             .labels(labels)
             .appName(APP_NAME)
-            .googleProject(GOOGLE_PROJECT);
+            .googleProject(GOOGLE_PROJECT)
+            .cloudContext(GOOGLE_PROJECT);
     assertThat(mapper.toApiApp(listAppResponse)).isEqualTo(app);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.leonardo.model.LeonardoAppStatus;
 import org.pmiops.workbench.leonardo.model.LeonardoAppType;
 import org.pmiops.workbench.leonardo.model.LeonardoAuditInfo;
+import org.pmiops.workbench.leonardo.model.LeonardoCloudContext;
 import org.pmiops.workbench.leonardo.model.LeonardoDiskType;
 import org.pmiops.workbench.leonardo.model.LeonardoGetAppResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoKubernetesError;
@@ -134,7 +135,7 @@ public class LeonardoMapperTest {
             .appName(APP_NAME)
             .errors(leonardoKubernetesErrors)
             .proxyUrls(proxyUrls)
-            .cloudContext(GOOGLE_PROJECT)
+            .cloudContext(new LeonardoCloudContext().cloudResource(GOOGLE_PROJECT))
             .labels(labels);
     assertThat(mapper.toApiApp(getAppResponse)).isEqualTo(app);
   }
@@ -153,7 +154,7 @@ public class LeonardoMapperTest {
             .labels(labels)
             .appName(APP_NAME)
             .googleProject(GOOGLE_PROJECT)
-            .cloudContext(GOOGLE_PROJECT);
+            .cloudContext(new LeonardoCloudContext().cloudResource(GOOGLE_PROJECT));
     assertThat(mapper.toApiApp(listAppResponse)).isEqualTo(app);
   }
 }


### PR DESCRIPTION
Description:
I am working on a Terra side change to modify GET/LIST interface a bit. 
https://github.com/DataBiosphere/leonardo/pull/2911
This API may not work until that PR deployed

This PR also update CreateAppRequest, Leonardo interface, use new RStudio descriptor path
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
