### PR TITLE
[RW-9067] [risk=no] Add url for user to view GCS bucket in GCP console

### DIFF
--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -256,7 +256,7 @@ export const WorkspaceAbout = fp.flow(
       return this.state.workspace
         ? 'https://console.cloud.google.com/storage/browser/' +
             this.state.workspace.googleBucketName +
-            ';project=' +
+            '?project=' +
             this.state.workspace.googleProject +
             '&authuser=' +
             this.props.profileState.profile.username

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -252,6 +252,17 @@ export const WorkspaceAbout = fp.flow(
         : '';
     }
 
+    get workspaceBucketUrl(): string {
+      return this.state.workspace
+        ? 'https://console.cloud.google.com/storage/browser/' +
+            this.state.workspace.googleBucketName +
+            ';project=' +
+            this.state.workspace.googleProject +
+            '&authuser=' +
+            this.props.profileState.profile.username
+        : '';
+    }
+
     async publishUnpublishWorkspace(publish: boolean) {
       const { workspace } = this.state;
       const { namespace, id } = workspace;
@@ -473,6 +484,16 @@ export const WorkspaceAbout = fp.flow(
                 </StyledExternalLink>
               </div>
             </TooltipTrigger>
+            <div>
+              <h3 style={{ marginBottom: '0.5rem' }}>File Management</h3>
+              <StyledExternalLink
+                data-test-id='workspace-bucket-url'
+                href={this.workspaceBucketUrl}
+                target='_blank'
+              >
+                Browse files in Google Cloud Platform
+              </StyledExternalLink>
+            </div>
           </div>
           {sharing && (
             <WorkspaceShare


### PR DESCRIPTION
Description:
![Screen Shot 2022-10-20 at 3 27 30 PM](https://user-images.githubusercontent.com/6351731/197040032-161cac36-43a5-4832-8435-920627937ca4.png)
After click:
![Screen Shot 2022-10-20 at 3 27 41 PM](https://user-images.githubusercontent.com/6351731/197040073-375645f6-4df7-45b3-9fbc-b5a0e150d979.png)

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
