### PR TITLE
[No Ticket]risk:no] Added --project_id to back up tables - prevent circle failing when above quota

### DIFF
--- a/api/db-cdr/generate-cdr/build-backup-cb-ds-tables.sh
+++ b/api/db-cdr/generate-cdr/build-backup-cb-ds-tables.sh
@@ -54,7 +54,7 @@ ds_visit_occurrence
 function cpTableToBackupDataset(){
   echo "Copying $BQ_PROJECT:$BQ_DATASET.$1 to $OUTPUT_PROJECT:$BACKUP_DATASET.$1"
   # --force to overwrite if backup dataset exists
-  bq cp --force "$BQ_PROJECT:$BQ_DATASET.$1" "$OUTPUT_PROJECT:$BACKUP_DATASET.$1"
+  bq --project_id="$OUTPUT_PROJECT" cp --force "$BQ_PROJECT:$BQ_DATASET.$1" "$OUTPUT_PROJECT:$BACKUP_DATASET.$1"
 }
 
 for t in "${backup_tables[@]}"


### PR DESCRIPTION
Description:
---

- added --project_id to bq copy command for backing up tables. This should prevent from circle failing to create backup tables when above quota

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
