### PR TITLE
[RW-8942][risk=no] Implement delete app endpoint

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -94,7 +94,6 @@ public class AppsController implements AppsApiDelegate {
    *   <li>Feature is enabled
    *   <li>User compute is not suspend due to security reason (e.g. egress alert)
    *   <li>User is OWNER or WRITER of the workspace
-   *   <li>Workspace has valid billing.
    * </ul>
    */
   @VisibleForTesting

--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -57,7 +57,10 @@ public class AppsController implements AppsApiDelegate {
   @Override
   public ResponseEntity<EmptyResponse> deleteApp(
       String workspaceNamespace, String appName, Boolean deleteDisk) {
-    throw new UnsupportedOperationException("API not supported.");
+    DbWorkspace dbWorkspace = workspaceService.lookupWorkspaceByNamespace(workspaceNamespace);
+    validateCanPerformApiAction(dbWorkspace);
+    leonardoApiClient.deleteApp(appName, dbWorkspace, deleteDisk);
+    return ResponseEntity.ok(new EmptyResponse());
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
@@ -104,6 +104,16 @@ public interface LeonardoApiClient {
    */
   List<App> listAppsInProject(String googleProjectId);
 
+  /**
+   * Deletes a Leonardo app
+   *
+   * @param appName the name of the app
+   * @param dbWorkspace the workspace to delete the app in
+   * @param deleteDisk whether the app's persistent disk should also be deleted
+   */
+  void deleteApp(String appName, DbWorkspace dbWorkspace, boolean deleteDisk)
+      throws WorkbenchException;
+
   /** @return true if Leonardo service is okay, false otherwise. */
   boolean getLeonardoStatus();
 }

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -564,6 +564,18 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
   }
 
   @Override
+  public void deleteApp(String appName, DbWorkspace dbWorkspace, boolean deleteDisk)
+      throws WorkbenchException {
+    AppsApi appsApi = appsApiProvider.get();
+
+    leonardoRetryHandler.run(
+        (context) -> {
+          appsApi.deleteApp(dbWorkspace.getGoogleProject(), appName, deleteDisk);
+          return null;
+        });
+  }
+
+  @Override
   public boolean getLeonardoStatus() {
     try {
       serviceInfoApiProvider.get().getSystemStatus();

--- a/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
@@ -123,6 +123,13 @@ public class AppsControllerTest {
   }
 
   @Test
+  public void testDeleteAppSuccess() {
+    boolean deleteDisk = true;
+    controller.deleteApp(WORKSPACE_NS, APP_NAME, deleteDisk);
+    verify(mockLeonardoApiClient).deleteApp(APP_NAME, testWorkspace, deleteDisk);
+  }
+
+  @Test
   public void testCanPerformAppActions_featureNotEnabled() throws Exception {
     config.featureFlags.enableGkeApp = false;
     assertThrows(

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -218,6 +218,14 @@ public class LeonardoApiClientTest {
     verify(userAppsApi).listAppByProject(GOOGLE_PROJECT_ID, null, false, null);
   }
 
+  @Test
+  public void testDeleteAppSuccess() throws Exception {
+    String appName = "app-name";
+    boolean deleteDisk = true;
+    leonardoApiClient.deleteApp(appName, testWorkspace, deleteDisk);
+    verify(userAppsApi).deleteApp(GOOGLE_PROJECT_ID, appName, deleteDisk);
+  }
+
   private void stubGetFcWorkspace(WorkspaceAccessLevel accessLevel) {
     FirecloudWorkspaceDetails fcWorkspaceDetail =
         new FirecloudWorkspaceDetails()


### PR DESCRIPTION
Description:

Implements the endpoint for deleting Leo apps.

This was verified locally by manually sending `curl` requests.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
