### PR TITLE
[risk=no][noTicket]Trim workspace Name on creation/updating workspace

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -70,6 +70,8 @@ function getSaveButtonDisableMsg(wrapper: AnyWrapper, attributeName: string) {
     .prop('disabled')[attributeName];
 }
 
+const WORKSPACE_NAME_TEXT = 'This is a text with space';
+
 describe('WorkspaceEdit', () => {
   let workspacesApi: WorkspacesApiStub;
   let userApi: UserApiStub;
@@ -1134,5 +1136,20 @@ describe('WorkspaceEdit', () => {
       'User Billing',
       'User Provided Billing Account',
     ]);
+  });
+  it('Should trim workspace name', async () => {
+    const wrapper = component();
+    let workspaceNameTextBox = wrapper
+      .find('[data-test-id="workspace-name"]')
+      .first();
+    workspaceNameTextBox.simulate('change', {
+      target: { value: '  ' + WORKSPACE_NAME_TEXT + '    ' },
+    });
+    expect(workspaceNameTextBox.prop('value')).not.toBe(WORKSPACE_NAME_TEXT);
+    workspaceNameTextBox.simulate('blur');
+    workspaceNameTextBox = wrapper
+      .find('[data-test-id="workspace-name"]')
+      .first();
+    expect(workspaceNameTextBox.prop('value')).toBe(WORKSPACE_NAME_TEXT);
   });
 });

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1492,6 +1492,9 @@ export const WorkspaceEdit = fp.flow(
                     autoFocus
                     placeholder='Workspace Name'
                     value={name}
+                    onBlur={(v) =>
+                      this.setState(fp.set(['workspace', 'name'], v.trim()))
+                    }
                     onChange={(v) =>
                       this.setState(fp.set(['workspace', 'name'], v))
                     }


### PR DESCRIPTION
Currently workbench allows spaces to be added to the start and end of workspace name string. This causes issues not only with sorting the workspace name but also storing unnecessary extra characters.

The reason why we added the trim functionality on blur and not onChange is because we want to let the user add a space in between two text eg: 'This is my workspace' is a valid workspace name. adding trim to onChange would have prevented user to add space after `This` forcing user to name it like `Thisismyworkspace`


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
