### PR TITLE
[risk=low][RW-9077] Don't render recent-resources when workspaces are unavailable

### DIFF
--- a/ui/src/app/components/resource-list.spec.tsx
+++ b/ui/src/app/components/resource-list.spec.tsx
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import { WorkspaceResource } from 'generated/fetch';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
+import { stubResource } from 'testing/stubs/resources-stub';
 import { workspaceDataStub } from 'testing/stubs/workspaces';
 
 import { ResourceList } from './resource-list';
@@ -20,9 +21,8 @@ export const resourceTableColumns = (wrapper) =>
   resourceTable(wrapper).find('td');
 
 const COHORT_NAME = 'My Cohort';
-const COHORT: Partial<WorkspaceResource> = {
-  workspaceNamespace: workspaceDataStub.namespace,
-  workspaceFirecloudName: workspaceDataStub.id,
+const COHORT: WorkspaceResource = {
+  ...stubResource,
   cohort: {
     name: COHORT_NAME,
     criteria: 'something',

--- a/ui/src/app/components/resource-list.spec.tsx
+++ b/ui/src/app/components/resource-list.spec.tsx
@@ -69,7 +69,7 @@ describe('ResourceList', () => {
     );
   });
 
-  it("should render when a resource's workspace is not available", async () => {
+  it('should not render a resource when its workspace is not available', async () => {
     const wrapper = mount(
       <MemoryRouter>
         <ResourceList workspaces={[]} workspaceResources={[COHORT]} />

--- a/ui/src/app/components/resource-list.spec.tsx
+++ b/ui/src/app/components/resource-list.spec.tsx
@@ -9,8 +9,15 @@ import { workspaceDataStub } from 'testing/stubs/workspaces';
 
 import { ResourceList } from './resource-list';
 
-const RESOURCE_TYPE_COLUMN_NUMBER = 1;
-const NAME_COLUMN_NUMBER = 2;
+export const RESOURCE_TYPE_COLUMN_NUMBER = 1;
+export const NAME_COLUMN_NUMBER = 2;
+export const MODIFIED_DATE_COLUMN_NUMBER = 3;
+
+export const resourceTable = (wrapper) =>
+  wrapper.find('[data-test-id="resource-list"]').find('tbody');
+export const resourceTableRows = (wrapper) => resourceTable(wrapper).find('tr');
+export const resourceTableColumns = (wrapper) =>
+  resourceTable(wrapper).find('td');
 
 const COHORT_NAME = 'My Cohort';
 const COHORT: Partial<WorkspaceResource> = {
@@ -33,14 +40,13 @@ describe('ResourceList', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.exists()).toBeTruthy();
 
-    const Columns = wrapper
-      .find('[data-test-id="resource-list"]')
-      .find('tbody')
-      .find('td');
-
     // no resources are rendered
-    expect(Columns.at(RESOURCE_TYPE_COLUMN_NUMBER).exists()).toBeFalsy();
-    expect(Columns.at(NAME_COLUMN_NUMBER).exists()).toBeFalsy();
+    expect(
+      resourceTableColumns(wrapper).at(RESOURCE_TYPE_COLUMN_NUMBER).exists()
+    ).toBeFalsy();
+    expect(
+      resourceTableColumns(wrapper).at(NAME_COLUMN_NUMBER).exists()
+    ).toBeFalsy();
   });
 
   it('should render a cohort resource', async () => {
@@ -55,13 +61,12 @@ describe('ResourceList', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.exists()).toBeTruthy();
 
-    const Columns = wrapper
-      .find('[data-test-id="resource-list"]')
-      .find('tbody')
-      .find('td');
-
-    expect(Columns.at(RESOURCE_TYPE_COLUMN_NUMBER).text()).toBe('Cohort');
-    expect(Columns.at(NAME_COLUMN_NUMBER).text()).toBe(COHORT_NAME);
+    expect(
+      resourceTableColumns(wrapper).at(RESOURCE_TYPE_COLUMN_NUMBER).text()
+    ).toBe('Cohort');
+    expect(resourceTableColumns(wrapper).at(NAME_COLUMN_NUMBER).text()).toBe(
+      COHORT_NAME
+    );
   });
 
   it("should render when a resource's workspace is not available", async () => {
@@ -73,13 +78,12 @@ describe('ResourceList', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper.exists()).toBeTruthy();
 
-    const Columns = wrapper
-      .find('[data-test-id="resource-list"]')
-      .find('tbody')
-      .find('td');
-
     // the resource is not rendered, because its workspace is not available
-    expect(Columns.at(RESOURCE_TYPE_COLUMN_NUMBER).exists()).toBeFalsy();
-    expect(Columns.at(NAME_COLUMN_NUMBER).exists()).toBeFalsy();
+    expect(
+      resourceTableColumns(wrapper).at(RESOURCE_TYPE_COLUMN_NUMBER).exists()
+    ).toBeFalsy();
+    expect(
+      resourceTableColumns(wrapper).at(NAME_COLUMN_NUMBER).exists()
+    ).toBeFalsy();
   });
 });

--- a/ui/src/app/components/resource-list.spec.tsx
+++ b/ui/src/app/components/resource-list.spec.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { MemoryRouter } from 'react-router';
+import { mount } from 'enzyme';
+
+import { NotebooksApi, ProfileApi, WorkspacesApi } from 'generated/fetch';
+
+import { registerApiClient } from 'app/services/swagger-fetch-clients';
+import { displayDateWithoutHours } from 'app/utils/dates';
+import { currentWorkspaceStore } from 'app/utils/navigation';
+
+import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
+import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
+import { ProfileApiStub } from 'testing/stubs/profile-api-stub';
+import { workspaceDataStub } from 'testing/stubs/workspaces';
+import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
+
+import { NotebookList } from './notebook-list';
+
+const RESOURCE_TYPE_COLUMN_NUMBER = 1;
+const NOTEBOOK_NAME_COLUMN_NUMBER = 2;
+const MODIFIED_DATE_COLUMN_NUMBER = 3;
+
+const NOTEBOOK_HREF_LOCATION = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/notebooks/preview/mockFile.ipynb`;
+
+describe('NotebookList', () => {
+  beforeEach(() => {
+    registerApiClient(WorkspacesApi, new WorkspacesApiStub());
+    registerApiClient(NotebooksApi, new NotebooksApiStub());
+    registerApiClient(ProfileApi, new ProfileApiStub());
+  });
+
+  it('should render notebooks', async () => {
+    currentWorkspaceStore.next(workspaceDataStub);
+    const wrapper = mount(
+      <MemoryRouter>
+        <NotebookList hideSpinner={() => {}} />
+      </MemoryRouter>
+    );
+    await waitOneTickAndUpdate(wrapper);
+    const notebookTableColumns = wrapper
+      .find('[data-test-id="resource-list"]')
+      .find('tbody')
+      .find('td');
+
+    // Second Column of notebook table displays the type of resource: Notebook
+    expect(notebookTableColumns.at(RESOURCE_TYPE_COLUMN_NUMBER).text()).toMatch(
+      'Notebook'
+    );
+
+    // Third column of notebook table displays the notebook file name
+    expect(notebookTableColumns.at(NOTEBOOK_NAME_COLUMN_NUMBER).text()).toMatch(
+      NotebooksApiStub.stubNotebookList()[0].name.split('.ipynb')[0]
+    );
+
+    // Forth column of notebook table displays last modified time
+    expect(notebookTableColumns.at(MODIFIED_DATE_COLUMN_NUMBER).text()).toMatch(
+      displayDateWithoutHours(
+        NotebooksApiStub.stubNotebookList()[0].lastModifiedTime
+      )
+    );
+  });
+
+  it('should redirect to notebook playground mode when either resource type or name is clicked', async () => {
+    currentWorkspaceStore.next(workspaceDataStub);
+    const wrapper = mount(
+      <MemoryRouter>
+        <NotebookList hideSpinner={() => {}} />
+      </MemoryRouter>
+    );
+    await waitOneTickAndUpdate(wrapper);
+    const notebookTableColumns = wrapper
+      .find('[data-test-id="resource-list"]')
+      .find('tbody')
+      .find('td');
+
+    expect(
+      notebookTableColumns
+        .at(RESOURCE_TYPE_COLUMN_NUMBER)
+        .find('a')
+        .prop('href')
+    ).toBe(NOTEBOOK_HREF_LOCATION);
+
+    expect(
+      notebookTableColumns
+        .at(NOTEBOOK_NAME_COLUMN_NUMBER)
+        .find('a')
+        .prop('href')
+    ).toBe(NOTEBOOK_HREF_LOCATION);
+  });
+});

--- a/ui/src/app/components/resource-list.tsx
+++ b/ui/src/app/components/resource-list.tsx
@@ -23,6 +23,8 @@ import {
 } from 'app/components/resource-card';
 import colors from 'app/styles/colors';
 import { reactStyles, withCdrVersions } from 'app/utils';
+import { findCdrVersion } from 'app/utils/cdr-versions';
+import { ROWS_PER_PAGE_RESOURCE_TABLE } from 'app/utils/constants';
 import { displayDate, displayDateWithoutHours } from 'app/utils/dates';
 import {
   getDisplayName,
@@ -30,9 +32,6 @@ import {
   getTypeString,
   isNotebook,
 } from 'app/utils/resources';
-
-import { findCdrVersion } from './cdr-versions';
-import { ROWS_PER_PAGE_RESOURCE_TABLE } from './constants';
 
 const styles = reactStyles({
   column: {
@@ -104,7 +103,7 @@ interface Props {
   recentResourceSource?: boolean;
 }
 
-export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
+export const ResourceList = fp.flow(withCdrVersions())((props: Props) => {
   const [tableData, setTableData] = useState<TableData[]>();
 
   const reloadResources = async () => {

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -8,6 +8,7 @@ import {
   MODIFIED_DATE_COLUMN_NUMBER,
   NAME_COLUMN_NUMBER,
   RESOURCE_TYPE_COLUMN_NUMBER,
+  resourceTableColumns,
 } from 'app/components/resource-list.spec';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { displayDateWithoutHours } from 'app/utils/dates';
@@ -38,23 +39,21 @@ describe('NotebookList', () => {
       </MemoryRouter>
     );
     await waitOneTickAndUpdate(wrapper);
-    const notebookTableColumns = wrapper
-      .find('[data-test-id="resource-list"]')
-      .find('tbody')
-      .find('td');
 
     // Second Column of notebook table displays the type of resource: Notebook
-    expect(notebookTableColumns.at(RESOURCE_TYPE_COLUMN_NUMBER).text()).toMatch(
-      'Notebook'
-    );
+    expect(
+      resourceTableColumns(wrapper).at(RESOURCE_TYPE_COLUMN_NUMBER).text()
+    ).toMatch('Notebook');
 
     // Third column of notebook table displays the notebook file name
-    expect(notebookTableColumns.at(NAME_COLUMN_NUMBER).text()).toMatch(
+    expect(resourceTableColumns(wrapper).at(NAME_COLUMN_NUMBER).text()).toMatch(
       NotebooksApiStub.stubNotebookList()[0].name.split('.ipynb')[0]
     );
 
     // Forth column of notebook table displays last modified time
-    expect(notebookTableColumns.at(MODIFIED_DATE_COLUMN_NUMBER).text()).toMatch(
+    expect(
+      resourceTableColumns(wrapper).at(MODIFIED_DATE_COLUMN_NUMBER).text()
+    ).toMatch(
       displayDateWithoutHours(
         NotebooksApiStub.stubNotebookList()[0].lastModifiedTime
       )
@@ -69,20 +68,19 @@ describe('NotebookList', () => {
       </MemoryRouter>
     );
     await waitOneTickAndUpdate(wrapper);
-    const notebookTableColumns = wrapper
-      .find('[data-test-id="resource-list"]')
-      .find('tbody')
-      .find('td');
 
     expect(
-      notebookTableColumns
+      resourceTableColumns(wrapper)
         .at(RESOURCE_TYPE_COLUMN_NUMBER)
         .find('a')
         .prop('href')
     ).toBe(NOTEBOOK_HREF_LOCATION);
 
     expect(
-      notebookTableColumns.at(NAME_COLUMN_NUMBER).find('a').prop('href')
+      resourceTableColumns(wrapper)
+        .at(NAME_COLUMN_NUMBER)
+        .find('a')
+        .prop('href')
     ).toBe(NOTEBOOK_HREF_LOCATION);
   });
 });

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -4,6 +4,11 @@ import { mount } from 'enzyme';
 
 import { NotebooksApi, ProfileApi, WorkspacesApi } from 'generated/fetch';
 
+import {
+  MODIFIED_DATE_COLUMN_NUMBER,
+  NAME_COLUMN_NUMBER,
+  RESOURCE_TYPE_COLUMN_NUMBER,
+} from 'app/components/resource-list.spec';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
@@ -15,10 +20,6 @@ import { workspaceDataStub } from 'testing/stubs/workspaces';
 import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
 
 import { NotebookList } from './notebook-list';
-
-const RESOURCE_TYPE_COLUMN_NUMBER = 1;
-const NOTEBOOK_NAME_COLUMN_NUMBER = 2;
-const MODIFIED_DATE_COLUMN_NUMBER = 3;
 
 const NOTEBOOK_HREF_LOCATION = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/notebooks/preview/mockFile.ipynb`;
 
@@ -48,7 +49,7 @@ describe('NotebookList', () => {
     );
 
     // Third column of notebook table displays the notebook file name
-    expect(notebookTableColumns.at(NOTEBOOK_NAME_COLUMN_NUMBER).text()).toMatch(
+    expect(notebookTableColumns.at(NAME_COLUMN_NUMBER).text()).toMatch(
       NotebooksApiStub.stubNotebookList()[0].name.split('.ipynb')[0]
     );
 
@@ -81,10 +82,7 @@ describe('NotebookList', () => {
     ).toBe(NOTEBOOK_HREF_LOCATION);
 
     expect(
-      notebookTableColumns
-        .at(NOTEBOOK_NAME_COLUMN_NUMBER)
-        .find('a')
-        .prop('href')
+      notebookTableColumns.at(NAME_COLUMN_NUMBER).find('a').prop('href')
     ).toBe(NOTEBOOK_HREF_LOCATION);
   });
 });

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -20,8 +20,7 @@ const RESOURCE_TYPE_COLUMN_NUMBER = 1;
 const NOTEBOOK_NAME_COLUMN_NUMBER = 2;
 const MODIFIED_DATE_COLUMN_NUMBER = 3;
 
-const NOTEBOOK_HREF_LOCATION =
-  '/workspaces/defaultNamespace/1/notebooks/preview/mockFile.ipynb';
+const NOTEBOOK_HREF_LOCATION = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/notebooks/preview/mockFile.ipynb`;
 
 describe('NotebookList', () => {
   beforeEach(() => {

--- a/ui/src/app/pages/analysis/notebook-list.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.tsx
@@ -259,6 +259,7 @@ export const NotebookList = withCurrentWorkspace()(
                   {!loading && (
                     <ResourcesList
                       workspaceResources={this.getNotebookListAsResources()}
+                      workspaceMap={new Map([[workspace.namespace, workspace]])}
                       onUpdate={() => this.loadNotebooks()}
                     />
                   )}

--- a/ui/src/app/pages/analysis/notebook-list.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.tsx
@@ -258,8 +258,8 @@ export const NotebookList = withCurrentWorkspace()(
                   </FlexRow>
                   {!loading && (
                     <ResourcesList
+                      workspaces={[workspace]}
                       workspaceResources={this.getNotebookListAsResources()}
-                      workspaceMap={new Map([[workspace.namespace, workspace]])}
                       onUpdate={() => this.loadNotebooks()}
                     />
                   )}

--- a/ui/src/app/pages/analysis/notebook-list.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.tsx
@@ -11,6 +11,7 @@ import { FlexColumn, FlexRow } from 'app/components/flex';
 import { ListPageHeader } from 'app/components/headers';
 import { InfoIcon } from 'app/components/icons';
 import { TooltipTrigger } from 'app/components/popups';
+import { ResourceList } from 'app/components/resource-list';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { NewNotebookModal } from 'app/pages/analysis/new-notebook-modal';
@@ -22,7 +23,6 @@ import {
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { withCurrentWorkspace } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
-import { ResourcesList } from 'app/utils/resource-list';
 import { convertToResource } from 'app/utils/resources';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
 import { WorkspaceData } from 'app/utils/workspace-data';
@@ -257,7 +257,7 @@ export const NotebookList = withCurrentWorkspace()(
                     </div>
                   </FlexRow>
                   {!loading && (
-                    <ResourcesList
+                    <ResourceList
                       workspaces={[workspace]}
                       workspaceResources={this.getNotebookListAsResources()}
                       onUpdate={() => this.loadNotebooks()}

--- a/ui/src/app/pages/data/data-component.tsx
+++ b/ui/src/app/pages/data/data-component.tsx
@@ -301,8 +301,8 @@ export const DataComponent = withCurrentWorkspace()((props: Props) => {
         >
           {
             <ResourcesList
+              workspaces={[workspace]}
               workspaceResources={filteredList}
-              workspaceMap={new Map([[workspace.namespace, workspace]])}
               onUpdate={() => loadResources()}
             />
           }

--- a/ui/src/app/pages/data/data-component.tsx
+++ b/ui/src/app/pages/data/data-component.tsx
@@ -302,6 +302,7 @@ export const DataComponent = withCurrentWorkspace()((props: Props) => {
           {
             <ResourcesList
               workspaceResources={filteredList}
+              workspaceMap={new Map([[workspace.namespace, workspace]])}
               onUpdate={() => loadResources()}
             />
           }

--- a/ui/src/app/pages/data/data-component.tsx
+++ b/ui/src/app/pages/data/data-component.tsx
@@ -7,6 +7,7 @@ import { CardButton, TabButton } from 'app/components/buttons';
 import { FadeBox } from 'app/components/containers';
 import { ClrIcon } from 'app/components/icons';
 import { TooltipTrigger } from 'app/components/popups';
+import { ResourceList } from 'app/components/resource-list';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
@@ -14,7 +15,6 @@ import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { withCurrentWorkspace } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { useNavigation } from 'app/utils/navigation';
-import { ResourcesList } from 'app/utils/resource-list';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import cohortImg from 'assets/images/cohort-diagram.svg';
 import dataSetImg from 'assets/images/dataset-diagram.svg';
@@ -300,7 +300,7 @@ export const DataComponent = withCurrentWorkspace()((props: Props) => {
           }}
         >
           {
-            <ResourcesList
+            <ResourceList
               workspaces={[workspace]}
               workspaceResources={filteredList}
               onUpdate={() => loadResources()}

--- a/ui/src/app/pages/data/data-page.spec.tsx
+++ b/ui/src/app/pages/data/data-page.spec.tsx
@@ -10,6 +10,7 @@ import {
   WorkspacesApi,
 } from 'generated/fetch';
 
+import { resourceTableRows } from 'app/components/resource-list.spec';
 import { DataComponent } from 'app/pages/data/data-component';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { ROWS_PER_PAGE_RESOURCE_TABLE } from 'app/utils/constants';
@@ -49,13 +50,6 @@ describe('DataPage', () => {
         <DataComponent hideSpinner={() => {}} showSpinner={() => {}} />
       </MemoryRouter>
     );
-  };
-
-  const resourceTableRows = (wrapper) => {
-    return wrapper
-      .find('[data-test-id="resource-list"]')
-      .find('tbody')
-      .find('tr');
   };
 
   it('should render', async () => {

--- a/ui/src/app/pages/homepage/recent-resources.spec.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.spec.tsx
@@ -1,31 +1,71 @@
 import * as React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { mount } from 'enzyme';
 
-import { UserMetricsApi, WorkspacesApi } from 'generated/fetch';
+import { UserMetricsApi, WorkspaceAccessLevel } from 'generated/fetch';
 
+import {
+  MODIFIED_DATE_COLUMN_NUMBER,
+  NAME_COLUMN_NUMBER,
+  RESOURCE_TYPE_COLUMN_NUMBER,
+  resourceTableColumns,
+} from 'app/components/resource-list.spec';
 import { RecentResources } from 'app/pages/homepage/recent-resources';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
-import { currentWorkspaceStore } from 'app/utils/navigation';
 
-import { UserMetricsApiStub } from 'testing/stubs/user-metrics-api-stub';
-import { workspaceDataStub } from 'testing/stubs/workspaces';
-import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
+import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
+import {
+  UserMetricsApiStub,
+  userMetricsApiStubResources,
+} from 'testing/stubs/user-metrics-api-stub';
+import { workspaceStubs } from 'testing/stubs/workspaces';
 
 describe('RecentResourcesComponent', () => {
   beforeEach(() => {
-    registerApiClient(WorkspacesApi, new WorkspacesApiStub());
     registerApiClient(UserMetricsApi, new UserMetricsApiStub());
   });
 
-  it('should render outside of a workspace', () => {
-    currentWorkspaceStore.next(undefined);
-    const wrapper = mount(<RecentResources />);
+  it('should render resources in a workspace', async () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <RecentResources
+          workspaces={[
+            {
+              workspace: workspaceStubs[0],
+              accessLevel: WorkspaceAccessLevel.OWNER,
+            },
+          ]}
+        />
+      </MemoryRouter>
+    );
+    await waitOneTickAndUpdate(wrapper);
     expect(wrapper.exists()).toBeTruthy();
+
+    expect(
+      resourceTableColumns(wrapper).at(RESOURCE_TYPE_COLUMN_NUMBER).text()
+    ).toBe('Cohort');
+    expect(resourceTableColumns(wrapper).at(NAME_COLUMN_NUMBER).text()).toBe(
+      userMetricsApiStubResources[0].cohort.name
+    );
   });
 
-  it('should render in a workspace', () => {
-    currentWorkspaceStore.next(workspaceDataStub);
-    const wrapper = mount(<RecentResources />);
+  it('should not render resources when their workspace is not available', async () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <RecentResources workspaces={[]} />
+      </MemoryRouter>
+    );
+    await waitOneTickAndUpdate(wrapper);
     expect(wrapper.exists()).toBeTruthy();
+
+    expect(
+      resourceTableColumns(wrapper).at(RESOURCE_TYPE_COLUMN_NUMBER).exists()
+    ).toBeFalsy();
+    expect(
+      resourceTableColumns(wrapper).at(NAME_COLUMN_NUMBER).exists()
+    ).toBeFalsy();
+    expect(
+      resourceTableColumns(wrapper).at(MODIFIED_DATE_COLUMN_NUMBER).exists()
+    ).toBeFalsy();
   });
 });

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -25,7 +25,6 @@ interface Props {
 export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
   const [loading, setLoading] = useState(true);
   const [resources, setResources] = useState<WorkspaceResourceResponse>();
-  const [wsMap, setWorkspaceMap] = useState<Map<string, Workspace>>();
   const [apiLoadError, setApiLoadError] = useState<string>(null);
 
   const loadResources = async () => {
@@ -44,10 +43,6 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
   useEffect(() => {
     const { workspaces } = props;
     if (workspaces) {
-      const workspaceTuples = workspaces.map(
-        (r) => [r.workspace.namespace, r.workspace] as [string, Workspace]
-      );
-      setWorkspaceMap(new Map(workspaceTuples));
       loadResources();
     }
   }, [props.workspaces]);
@@ -63,7 +58,7 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
       ),
     ],
     [
-      resources && wsMap && !loading,
+      resources && !loading,
       () => (
         <React.Fragment>
           {resources.length > 0 && (
@@ -75,8 +70,8 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
           >
             <ResourcesList
               recentResourceSource
+              workspaces={props.workspaces.map((w) => w.workspace)}
               workspaceResources={resources}
-              workspaceMap={wsMap}
               onUpdate={loadResources}
             />
           </div>

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -4,7 +4,6 @@ import * as fp from 'lodash/fp';
 
 import {
   CdrVersionTiersResponse,
-  Workspace,
   WorkspaceResourceResponse,
   WorkspaceResponse,
 } from 'generated/fetch';

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -11,10 +11,10 @@ import {
 import { AlertWarning } from 'app/components/alert';
 import { SmallHeader } from 'app/components/headers';
 import { ClrIcon } from 'app/components/icons';
+import { ResourceList } from 'app/components/resource-list';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { userMetricsApi } from 'app/services/swagger-fetch-clients';
 import { cond, withCdrVersions } from 'app/utils';
-import { ResourcesList } from 'app/utils/resource-list';
 
 interface Props {
   cdrVersionTiersResponse: CdrVersionTiersResponse;
@@ -67,7 +67,7 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
             data-test-id='recent-resources-table'
             style={{ paddingTop: '1rem' }}
           >
-            <ResourcesList
+            <ResourceList
               recentResourceSource
               workspaces={props.workspaces.map((w) => w.workspace)}
               workspaceResources={resources}

--- a/ui/src/app/utils/resource-list.tsx
+++ b/ui/src/app/utils/resource-list.tsx
@@ -162,29 +162,27 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
           const workspace = workspaces.find(
             (w) => w.namespace === r.workspaceNamespace
           );
-          return (
-            // Don't return resources where we no longer have access to the workspace.
-            // For example: the owner has unshared the workspace, but a recent-resource entry remains.
-            workspace
-              ? [
-                  {
-                    resource: r,
-                    workspace,
-                    menu: renderResourceMenu(r),
-                    resourceType: getTypeString(r),
-                    resourceName: getDisplayName(r),
-                    formattedLastModified: displayDateWithoutHours(
-                      r.lastModifiedEpochMillis
-                    ),
-                    lastModifiedDateAsString: displayDate(
-                      r.lastModifiedEpochMillis
-                    ),
-                    cdrVersionName: getCdrVersionName(r),
-                    lastModifiedBy: r.lastModifiedBy,
-                  },
-                ]
-              : []
-          );
+          // Don't return resources where we no longer have access to the workspace.
+          // For example: the owner has unshared the workspace, but a recent-resource entry remains.
+          return workspace
+            ? [
+                {
+                  resource: r,
+                  workspace,
+                  menu: renderResourceMenu(r),
+                  resourceType: getTypeString(r),
+                  resourceName: getDisplayName(r),
+                  formattedLastModified: displayDateWithoutHours(
+                    r.lastModifiedEpochMillis
+                  ),
+                  lastModifiedDateAsString: displayDate(
+                    r.lastModifiedEpochMillis
+                  ),
+                  cdrVersionName: getCdrVersionName(r),
+                  lastModifiedBy: r.lastModifiedBy,
+                },
+              ]
+            : [];
         }, workspaceResources)
       );
     }

--- a/ui/src/app/utils/resource-list.tsx
+++ b/ui/src/app/utils/resource-list.tsx
@@ -99,7 +99,7 @@ interface Props {
   existingNameList: string[];
   workspaceResources: WorkspaceResource[];
   onUpdate: Function;
-  workspaceMap?: Map<string, Workspace>;
+  workspaceMap: Map<string, Workspace>;
   cdrVersionTiersResponse: CdrVersionTiersResponse;
   recentResourceSource?: boolean;
 }

--- a/ui/src/app/utils/resource-list.tsx
+++ b/ui/src/app/utils/resource-list.tsx
@@ -99,7 +99,7 @@ interface Props {
   existingNameList: string[];
   workspaceResources: WorkspaceResource[];
   onUpdate: Function;
-  workspaceMap: Map<string, Workspace>;
+  workspaces: Workspace[];
   cdrVersionTiersResponse: CdrVersionTiersResponse;
   recentResourceSource?: boolean;
 }
@@ -136,8 +136,7 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
   };
 
   const getWorkspace = (r: WorkspaceResource) => {
-    const { workspaceMap } = props;
-    return workspaceMap?.get(r.workspaceNamespace);
+    return props.workspaces.find((w) => w.namespace === r.workspaceNamespace);
   };
 
   const getCdrVersionName = (r: WorkspaceResource) => {
@@ -160,11 +159,13 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
   };
 
   useEffect(() => {
-    const { workspaceResources } = props;
+    const { workspaces, workspaceResources } = props;
     if (workspaceResources) {
       setTableData(
         fp.flatMap((r) => {
-          const workspace = getWorkspace(r);
+          const workspace = workspaces.find(
+            (w) => w.namespace === r.workspaceNamespace
+          );
           return (
             // Don't return resources where we no longer have access to the workspace.
             // For example: the owner has unshared the workspace, but a recent-resource entry remains.

--- a/ui/src/app/utils/resource-list.tsx
+++ b/ui/src/app/utils/resource-list.tsx
@@ -135,10 +135,6 @@ export const ResourcesList = fp.flow(withCdrVersions())((props: Props) => {
     });
   };
 
-  const getWorkspace = (r: WorkspaceResource) => {
-    return props.workspaces.find((w) => w.namespace === r.workspaceNamespace);
-  };
-
   const getCdrVersionName = (r: WorkspaceResource) => {
     const { cdrVersionTiersResponse } = props;
 

--- a/ui/src/testing/stubs/user-metrics-api-stub.ts
+++ b/ui/src/testing/stubs/user-metrics-api-stub.ts
@@ -2,8 +2,12 @@ import { UserMetricsApi } from 'generated/fetch';
 
 import { stubNotImplementedError } from 'testing/stubs/stub-utils';
 
+import { cohortStub } from './cohort-builder-service-stub';
 import { stubResource } from './resources-stub';
 
+export const userMetricsApiStubResources = [
+  { ...stubResource, cohort: cohortStub },
+];
 export class UserMetricsApiStub extends UserMetricsApi {
   constructor() {
     super(undefined, undefined, (..._: any[]) => {
@@ -12,6 +16,6 @@ export class UserMetricsApiStub extends UserMetricsApi {
   }
 
   getUserRecentResources() {
-    return Promise.resolve([stubResource]);
+    return Promise.resolve(userMetricsApiStubResources);
   }
 }


### PR DESCRIPTION
When a user has an entry in their recent-resources list but they don't have access to the resource's workspace, the current behavior is a blank screen!  Fix this by skipping such entries.

One way this might happen is if the workspace's owner unshares it with them.

We may also want to delete recent-resources on unshare, but this UI change will handle the general case of "can't see workspace" which could conceivably have other causes.

Also add some UI unit tests related to resources.

Tested locally.
 

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
