### PR TITLE
[RW-9114][risk=no] Don't update RDR DB table when export fails in the middle

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -183,7 +183,11 @@ public class RdrExportServiceImpl implements RdrExportService {
         // data already from a backfill, we'd still want to resend any normal modifications, if any,
         // in order to trigger this review process.
         if (!backfill) {
-          updateDbRdrExport(RdrEntity.WORKSPACE, workspaceIds);
+          updateDbRdrExport(
+              RdrEntity.WORKSPACE,
+              rdrWorkspacesList.stream()
+                  .map(r -> Long.valueOf(r.getWorkspaceId()))
+                  .collect(Collectors.toList()));
         }
       }
       log.info(

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.inject.Provider;
 import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -168,6 +169,7 @@ public class RdrExportServiceImpl implements RdrExportService {
   public void exportWorkspaces(List<Long> workspaceIds, boolean backfill) {
     List<RdrWorkspace> rdrWorkspacesList;
     try {
+      // toRdrWorkspace may fail and will return null, skip failures and continue.
       rdrWorkspacesList =
           workspaceIds.stream()
               .map(
@@ -178,21 +180,27 @@ public class RdrExportServiceImpl implements RdrExportService {
       if (!rdrWorkspacesList.isEmpty()) {
         rdrApiProvider.get().exportWorkspaces(rdrWorkspacesList, backfill);
 
+        List<Long> workspaceIdsToUpload =
+            rdrWorkspacesList.stream()
+                .map(r -> Long.valueOf(r.getWorkspaceId()))
+                .collect(Collectors.toList());
+
         // Skip the RDR export table updates on backfills. A normal export may trigger manual review
         // from the RDR, where-as a backfill does not. Therefore, even if the RDR has the latest
         // data already from a backfill, we'd still want to resend any normal modifications, if any,
         // in order to trigger this review process.
         if (!backfill) {
-          updateDbRdrExport(
-              RdrEntity.WORKSPACE,
-              rdrWorkspacesList.stream()
-                  .map(r -> Long.valueOf(r.getWorkspaceId()))
-                  .collect(Collectors.toList()));
+          updateDbRdrExport(RdrEntity.WORKSPACE, workspaceIdsToUpload);
         }
+        log.info(
+            String.format(
+                "Successfully exported workspace count: %d, total count %d",
+                workspaceIdsToUpload.size(), workspaceIds.size()));
+        log.info(
+            String.format(
+                "successfully exported workspace data for workspace IDs: %s",
+                workspaceIdsToUpload));
       }
-      log.info(
-          String.format(
-              "successfully exported workspace data for workspace IDs: %s", workspaceIds));
     } catch (ApiException ex) {
       log.severe(
           String.format(
@@ -214,6 +222,7 @@ public class RdrExportServiceImpl implements RdrExportService {
         : researcher.demographicSurveyV2(null);
   }
 
+  @Nullable
   private RdrWorkspace toRdrWorkspace(DbWorkspace dbWorkspace) {
     RdrWorkspace rdrWorkspace = rdrMapper.toRdrWorkspace(dbWorkspace);
     setExcludeFromPublicDirectory(dbWorkspace.getCreator(), rdrWorkspace);

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -321,8 +321,9 @@ public class RdrExportServiceImplTest {
 
   @Test
   public void exportWorkspace_firecloudCallFail_skipUpdateRdrEntity() throws ApiException {
-    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName())).thenThrow(
-        WorkbenchException.class);
+    when(mockWorkspaceService.getFirecloudUserRoles(
+            workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+        .thenThrow(WorkbenchException.class);
 
     rdrExportService.exportWorkspaces(ImmutableList.of(workspace.getWorkspaceId()), NO_BACKFILL);
     assertThat(rdrExportDao.findAll()).hasSize(0);

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -325,8 +325,12 @@ public class RdrExportServiceImplTest {
             workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
         .thenThrow(WorkbenchException.class);
 
-    rdrExportService.exportWorkspaces(ImmutableList.of(workspace.getWorkspaceId()), NO_BACKFILL);
-    assertThat(rdrExportDao.findAll()).hasSize(0);
+    // workspace.getWorkspaceId() fails, so skip that export. There should be only one workspace
+    // exported
+    rdrExportService.exportWorkspaces(
+        ImmutableList.of(workspace.getWorkspaceId(), creatorWorkspace.getWorkspaceId()),
+        NO_BACKFILL);
+    assertThat(rdrExportDao.findAll()).hasSize(1);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -39,6 +39,7 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.Degree;
 import org.pmiops.workbench.model.InstitutionalRole;
@@ -316,6 +317,15 @@ public class RdrExportServiceImplTest {
     assertThat(rdrExportDao.findAll()).hasSize(1);
 
     verify(mockRdrApi).exportWorkspaces(ImmutableList.of(rdrWorkspace), NO_BACKFILL);
+  }
+
+  @Test
+  public void exportWorkspace_firecloudCallFail_skipUpdateRdrEntity() throws ApiException {
+    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName())).thenThrow(
+        WorkbenchException.class);
+
+    rdrExportService.exportWorkspaces(ImmutableList.of(workspace.getWorkspaceId()), NO_BACKFILL);
+    assertThat(rdrExportDao.findAll()).hasSize(0);
   }
 
   @Test


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
