### PR TITLE
[DT-127][risk=no] Temporarily filter survey conduct content

### DIFF
--- a/ui/src/app/cohort-search/attributes-page/attributes-page.component.tsx
+++ b/ui/src/app/cohort-search/attributes-page/attributes-page.component.tsx
@@ -470,10 +470,14 @@ export const AttributesPage = fp.flow(
           loading: false,
         });
       } else {
-        options.unshift({
-          label: optionUtil.ANY.display,
-          value: AttrName[AttrName.ANY],
-        });
+        if (
+          !options.find((option) => option.value === AttrName.ANY.toString())
+        ) {
+          options.unshift({
+            label: optionUtil.ANY.display,
+            value: AttrName[AttrName.ANY],
+          });
+        }
         this.setState(
           { formValid: true, isCOPEOrMinuteSurvey: false, options },
           () => this.getAttributes()

--- a/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
+++ b/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
@@ -6,6 +6,7 @@ import {
   CohortDefinition,
   CriteriaMenu,
   Domain,
+  Workspace,
 } from 'generated/fetch';
 
 import { CohortCriteriaMenu } from 'app/cohort-search/cohort-criteria-menu';
@@ -25,6 +26,7 @@ import { reactStyles, withCdrVersions, withCurrentWorkspace } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { getCdrVersion } from 'app/utils/cdr-versions';
 import { currentWorkspaceStore } from 'app/utils/navigation';
+import { cdrVersionStore } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { Subscription } from 'rxjs/Subscription';
 
@@ -103,6 +105,14 @@ function mapMenuItem(item: CriteriaMenu) {
   };
 }
 
+export const notSynthAndHasSurveyConductData = (workspace: Workspace) => {
+  const { hasSurveyConductData, name } = getCdrVersion(
+    workspace,
+    cdrVersionStore.get() as CdrVersionTiersResponse
+  );
+  return !name.includes('Synthetic') && hasSurveyConductData;
+};
+
 interface Props {
   groups: Array<any>;
   setSearchContext: (context: any) => void;
@@ -156,7 +166,6 @@ const SearchGroupList = fp.flow(
 
     getMenuOptions() {
       const {
-        cdrVersionTiersResponse,
         workspace,
         workspace: { cdrVersionId, id, namespace },
       } = this.props;
@@ -175,8 +184,7 @@ const SearchGroupList = fp.flow(
                 );
                 const filterSurveyConductData =
                   option.domain === Domain.SURVEY.toString() &&
-                  getCdrVersion(workspace, cdrVersionTiersResponse)
-                    .hasSurveyConductData;
+                  notSynthAndHasSurveyConductData(workspace);
                 // Survey items to hide if hasSurveyConductData cdr flag is enabled
                 const surveyConductMenuItems = [
                   'Personal Medical History',

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -284,7 +284,7 @@ export const CriteriaTree = fp.flow(
         }
         const filterSurveyConductData =
           domain === Domain.SURVEY &&
-          !getCdrVersion(workspace, cdrVersionTiersResponse)
+          getCdrVersion(workspace, cdrVersionTiersResponse)
             .hasSurveyConductData;
         // Surveys to hide if hasSurveyConductData cdr flag is enabled
         const surveyConductConceptIds = [1740639, 43529712, 43528698];

--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -10,6 +10,7 @@ import {
 } from 'generated/fetch';
 
 import { SearchBar } from 'app/cohort-search/search-bar/search-bar.component';
+import { notSynthAndHasSurveyConductData } from 'app/cohort-search/search-group-list/search-group-list.component';
 import { ppiSurveys } from 'app/cohort-search/search-state.service';
 import { TreeNode } from 'app/cohort-search/tree-node/tree-node.component';
 import { ClrIcon } from 'app/components/icons';
@@ -218,7 +219,6 @@ export const CriteriaTree = fp.flow(
     async loadRootNodes() {
       try {
         const {
-          cdrVersionTiersResponse,
           domain,
           node: { id, isStandard, parentId, subtype, type },
           selectedSurvey,
@@ -284,8 +284,7 @@ export const CriteriaTree = fp.flow(
         }
         const filterSurveyConductData =
           domain === Domain.SURVEY &&
-          getCdrVersion(workspace, cdrVersionTiersResponse)
-            .hasSurveyConductData;
+          notSynthAndHasSurveyConductData(workspace);
         // Surveys to hide if hasSurveyConductData cdr flag is enabled
         const surveyConductConceptIds = [1740639, 43529712, 43528698];
         // TODO Remove condition and filter after fix for survey conduct data in new dataset is complete

--- a/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.spec.tsx
@@ -10,8 +10,10 @@ import {
 import { ConceptHomepage } from 'app/pages/data/concept/concept-homepage';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { currentWorkspaceStore } from 'app/utils/navigation';
+import { cdrVersionStore } from 'app/utils/stores';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
+import { cdrVersionTiersResponse } from 'testing/stubs/cdr-versions-api-stub';
 import {
   CohortBuilderServiceStub,
   DomainStubVariables,
@@ -39,6 +41,7 @@ describe('ConceptHomepage', () => {
     registerApiClient(ConceptSetsApi, new ConceptSetsApiStub());
     registerApiClient(CohortBuilderApi, new CohortBuilderServiceStub());
     currentWorkspaceStore.next(workspaceDataStub);
+    cdrVersionStore.set(cdrVersionTiersResponse);
   });
 
   it('should render', () => {

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -9,6 +9,7 @@ import {
   SurveyModule,
 } from 'generated/fetch';
 
+import { notSynthAndHasSurveyConductData } from 'app/cohort-search/search-group-list/search-group-list.component';
 import { AlertClose, AlertDanger } from 'app/components/alert';
 import { Clickable } from 'app/components/buttons';
 import { DomainCardBase } from 'app/components/card';
@@ -322,14 +323,10 @@ export const ConceptHomepage = fp.flow(
       const getSurveyInfo = cohortBuilderApi()
         .findSurveyModules(namespace, id)
         .then((surveysInfo) => {
-          const { hasSurveyConductData } = getCdrVersion(
-            workspace,
-            cdrVersionTiersResponse
-          );
           // Surveys to hide if hasSurveyConductData cdr flag is enabled
           const surveyConductConceptIds = [1740639, 43529712, 43528698];
           // TODO Remove condition and filter after fix for survey conduct data in new dataset is complete
-          const surveysList = hasSurveyConductData
+          const surveysList = notSynthAndHasSurveyConductData(workspace)
             ? surveysInfo.items.filter(
                 ({ conceptId }) => !surveyConductConceptIds.includes(conceptId)
               )

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -29,7 +29,6 @@ import {
   withCurrentConcept,
   withCurrentWorkspace,
 } from 'app/utils';
-import { getCdrVersion } from 'app/utils/cdr-versions';
 import {
   currentCohortSearchContextStore,
   currentConceptStore,
@@ -301,7 +300,6 @@ export const ConceptHomepage = fp.flow(
 
     async loadDomainsAndSurveys() {
       const {
-        cdrVersionTiersResponse,
         cohortContext,
         workspace,
         workspace: { id, namespace },


### PR DESCRIPTION
Hide all content for `Personal Medical History`, `Family History` and `Personal and Family Health History` surveys until the tools have been updated to handle the new cdr.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
