### PR TITLE
[No-Ticket][risk:no] updated fitbit Sleep and survey conduct flags for RT and CT

### DIFF
--- a/api/config/cdr_config_local.json
+++ b/api/config/cdr_config_local.json
@@ -57,8 +57,9 @@
       "releaseNumber": 3,
       "numParticipants": 234525,
       "cdrDbName": "cdr",
-      "hasFitbitData": true,
+      "hasFitbitSleepData": true,
       "hasCopeSurveyData": true,
+      "hasSurveyConductData": true,
       "accessTier": "registered"
     },
     {
@@ -89,7 +90,9 @@
       "numParticipants": 234525,
       "cdrDbName": "cdr",
       "hasFitbitData": true,
+      "hasFitbitSleepData": true,
       "hasCopeSurveyData": true,
+      "hasSurveyConductData": true,
       "storageBasePath": "5",
       "wgsCramManifestPath": "wgs/cram/manifest.csv",
       "wgsVcfMergedStoragePath": "wgs/vcf/merged",

--- a/api/config/cdr_config_local.json
+++ b/api/config/cdr_config_local.json
@@ -57,6 +57,7 @@
       "releaseNumber": 3,
       "numParticipants": 234525,
       "cdrDbName": "cdr",
+      "hasFitbitData": true,
       "hasFitbitSleepData": true,
       "hasCopeSurveyData": true,
       "hasSurveyConductData": true,


### PR DESCRIPTION
Description:
- updated fitbit sleep and survey conduct flag for `cdr_config_local.json`
- updated `ds_linking.csv` in [all-of-us-cb-test-csv](https://console.cloud.google.com/storage/browser/all-of-us-cb-test-csv) for fitbit sleep  tables
- ran local data migrations and testing  with API/UI deployment

**fitbit_sleep_daily_summary:**
![image](https://user-images.githubusercontent.com/4452480/200350954-5e079558-bf4d-4bae-ad41-53347c94a9be.png)

**fitbit_sleep_level:**
![image](https://user-images.githubusercontent.com/4452480/200351157-097832ba-8d46-41f1-a66f-52d75a603252.png)


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
