### PR TITLE
Fix: connect-to-db waits for the db to be ready

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -264,7 +264,7 @@ Common.register_command({
 def connect_to_db()
   common = Common.new
   common.status "Starting database if necessary..."
-  common.run_inline %W{docker-compose up -d db}
+  start_local_db_service()
   cmd = "MYSQL_PWD=root-notasecret mysql --database=workbench"
   common.run_inline %W{docker-compose exec db sh -c #{cmd}}
 end


### PR DESCRIPTION
If the database had not started (as is often the case for me after I've restarted the dev server), the connect-to-db script fails first invocation.

This commit uses the helper method that both starts the db and waits for it to be ready for connections before connecting.