### PR TITLE
[no ticket][risk=no] Compare instant instead of datatime string

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DisksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DisksController.java
@@ -134,7 +134,8 @@ public class DisksController implements DisksApiDelegate {
                 Collectors.toMap(
                     Disk::getAppType,
                     Function.identity(),
-                    BinaryOperator.maxBy(Comparator.comparing(Disk::getCreatedDate))));
+                    BinaryOperator.maxBy(
+                        Comparator.comparing((r) -> Instant.parse(r.getCreatedDate())))));
     recentDisks.addAll(appDisks.values());
     return recentDisks;
   }

--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -133,17 +133,26 @@ public class DisksControllerTest {
 
   @Test
   public void testListPD() throws ApiException {
-    // RStudio Disk: 2 are active, returns the newer one.
+    // RStudio Disk: 3 are active, returns the newest one.
     LeonardoListPersistentDiskResponse oldRstudioDisk =
         newListPdResponse(
-            "rstudio1", LeonardoDiskStatus.READY, NOW.minusMillis(100).toString(), AppType.RSTUDIO);
-    LeonardoListPersistentDiskResponse newerRstudioDisk =
+            "rstudio1",
+            LeonardoDiskStatus.READY,
+            NOW.minusSeconds(100).toString(),
+            AppType.RSTUDIO);
+    LeonardoListPersistentDiskResponse newestRstudioDisk =
         newListPdResponse("rstudio2", LeonardoDiskStatus.READY, NOW.toString(), AppType.RSTUDIO);
+    LeonardoListPersistentDiskResponse olderRstudioDisk =
+        newListPdResponse(
+            "rstudio3",
+            LeonardoDiskStatus.READY,
+            NOW.minusSeconds(200).toString(),
+            AppType.RSTUDIO);
     Disk expectedRStudioDisk =
         newDisk(
-            newerRstudioDisk.getName(),
+            newestRstudioDisk.getName(),
             DiskStatus.READY,
-            newerRstudioDisk.getAuditInfo().getCreatedDate(),
+            newestRstudioDisk.getAuditInfo().getCreatedDate(),
             AppType.RSTUDIO);
 
     // GCE Disk: 3 disks in total, 2 are active, newer one is inactive, returns the most recent
@@ -176,7 +185,8 @@ public class DisksControllerTest {
         .thenReturn(
             ImmutableList.of(
                 oldRstudioDisk,
-                newerRstudioDisk,
+                newestRstudioDisk,
+                olderRstudioDisk,
                 olderGceDisk,
                 oldGceDisk,
                 newerInactiveGceDisk,


### PR DESCRIPTION
Description:
Saw a test failure: https://output.circle-artifacts.com/output/job/b17bec21-5dcc-4114-ad3e-5e7d436169bc/artifacts/2/JunitTestResult/tests/test/classes/org.pmiops.workbench.api.DisksControllerTest.html
That might be caused by compare with ISO 8601 format directly. 
I guess the cause is when the generated timestamp happens to not having  mills. 
`2022-11-07T17:16:27Z` vs `2022-11-07T17:16:27.100Z`. 

Try to use instant see if that can fix this issue

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
