### PR TITLE
[RW-9030][risk=low] Upload new user survey table data to the WRD

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryService.java
@@ -12,6 +12,7 @@ import org.pmiops.workbench.model.ReportingDatasetCohort;
 import org.pmiops.workbench.model.ReportingDatasetConceptSet;
 import org.pmiops.workbench.model.ReportingDatasetDomainIdValue;
 import org.pmiops.workbench.model.ReportingInstitution;
+import org.pmiops.workbench.model.ReportingNewUserSatisfactionSurvey;
 import org.pmiops.workbench.model.ReportingUser;
 import org.pmiops.workbench.model.ReportingWorkspace;
 import org.pmiops.workbench.model.ReportingWorkspaceFreeTierUsage;
@@ -55,6 +56,14 @@ public interface ReportingQueryService {
   }
 
   int getCohortsCount();
+
+  List<ReportingNewUserSatisfactionSurvey> getNewUserSatisfactionSurveys(long limit, long offset);
+
+  default Stream<List<ReportingNewUserSatisfactionSurvey>> getNewUserSatisfactionSurveysStream() {
+    return getStream(this::getNewUserSatisfactionSurveys);
+  }
+
+  int getNewUserSatisfactionSurveysCount();
 
   default <T> List<T> getBatchByIndex(BiFunction<Long, Long, List<T>> getter, long batchIndex) {
     final long offset = getQueryBatchSize() * batchIndex;
@@ -117,6 +126,11 @@ public interface ReportingQueryService {
 
   default Iterator<List<ReportingCohort>> getCohortsBatchIterator() {
     return getBatchIterator(this::getCohorts);
+  }
+
+  default Iterator<List<ReportingNewUserSatisfactionSurvey>>
+      getNewUserSatisfactionSurveyBatchIterator() {
+    return getBatchIterator(this::getNewUserSatisfactionSurveys);
   }
 
   /** Use the maximum batch to get in single batch */

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
@@ -9,6 +9,7 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.jdbc.ReportingQueryService;
 import org.pmiops.workbench.model.ReportingSnapshot;
 import org.pmiops.workbench.reporting.insertion.CohortColumnValueExtractor;
+import org.pmiops.workbench.reporting.insertion.NewUserSatisfactionSurveyColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.UserColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.WorkspaceColumnValueExtractor;
 import org.springframework.stereotype.Service;
@@ -37,7 +38,8 @@ public class ReportingServiceImpl implements ReportingService {
       ImmutableSet.of(
           CohortColumnValueExtractor.TABLE_NAME,
           WorkspaceColumnValueExtractor.TABLE_NAME,
-          UserColumnValueExtractor.TABLE_NAME);
+          UserColumnValueExtractor.TABLE_NAME,
+          NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME);
 
   public ReportingServiceImpl(
       ReportingQueryService reportingQueryService,
@@ -71,6 +73,10 @@ public class ReportingServiceImpl implements ReportingService {
     reportingQueryService
         .getCohortsStream()
         .forEach(b -> reportingUploadService.uploadBatchCohort(b, captureTimestamp));
+    reportingQueryService
+        .getNewUserSatisfactionSurveysStream()
+        .forEach(
+            b -> reportingUploadService.uploadBatchNewUserSatisfactionSurveys(b, captureTimestamp));
 
     // Third: Verify the count.
     boolean batchUploadSuccess =

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadService.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.reporting;
 
 import java.util.List;
 import org.pmiops.workbench.model.ReportingCohort;
+import org.pmiops.workbench.model.ReportingNewUserSatisfactionSurvey;
 import org.pmiops.workbench.model.ReportingSnapshot;
 import org.pmiops.workbench.model.ReportingUser;
 import org.pmiops.workbench.model.ReportingWorkspace;
@@ -19,6 +20,9 @@ public interface ReportingUploadService {
   void uploadBatchUser(List<ReportingUser> batch, long captureTimestamp);
 
   void uploadBatchCohort(List<ReportingCohort> batch, long captureTimestamp);
+
+  void uploadBatchNewUserSatisfactionSurveys(
+      List<ReportingNewUserSatisfactionSurvey> batch, long captureTimestamp);
 
   /** Uploads a record into VerifiedSnapshot table if upload result is verified. */
   void uploadVerifiedSnapshot(long captureTimestamp);

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
@@ -25,6 +25,7 @@ import org.pmiops.workbench.model.ReportingDatasetCohort;
 import org.pmiops.workbench.model.ReportingDatasetConceptSet;
 import org.pmiops.workbench.model.ReportingDatasetDomainIdValue;
 import org.pmiops.workbench.model.ReportingInstitution;
+import org.pmiops.workbench.model.ReportingNewUserSatisfactionSurvey;
 import org.pmiops.workbench.model.ReportingSnapshot;
 import org.pmiops.workbench.model.ReportingUser;
 import org.pmiops.workbench.model.ReportingWorkspace;
@@ -37,6 +38,7 @@ import org.pmiops.workbench.reporting.insertion.DatasetConceptSetColumnValueExtr
 import org.pmiops.workbench.reporting.insertion.DatasetDomainColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.InsertAllRequestPayloadTransformer;
 import org.pmiops.workbench.reporting.insertion.InstitutionColumnValueExtractor;
+import org.pmiops.workbench.reporting.insertion.NewUserSatisfactionSurveyColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.UserColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.WorkspaceColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.WorkspaceFreeTierUsageColumnValueExtractor;
@@ -64,6 +66,9 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
       workspaceFreeTierUsageRequestBuilder = WorkspaceFreeTierUsageColumnValueExtractor::values;
   private static final InsertAllRequestPayloadTransformer<ReportingDataset> datasetRequestBuilder =
       DatasetColumnValueExtractor::values;
+  private static final InsertAllRequestPayloadTransformer<ReportingNewUserSatisfactionSurvey>
+      newUserSatisfactionSurveyRequestBuilder =
+          NewUserSatisfactionSurveyColumnValueExtractor::values;
 
   /**
    * The verified–snapshot BigQuery name. It has no row other than the default snapshot_timestamp,
@@ -132,6 +137,17 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
     uploadBatchTable(
         cohortRequestBuilder.build(
             getTableId(CohortColumnValueExtractor.class), batch, getFixedValues(captureTimestamp)));
+  }
+
+  /** Batch uploads {@link ReportingNewUserSatisfactionSurvey}. */
+  @Override
+  public void uploadBatchNewUserSatisfactionSurveys(
+      List<ReportingNewUserSatisfactionSurvey> batch, long captureTimestamp) {
+    uploadBatchTable(
+        newUserSatisfactionSurveyRequestBuilder.build(
+            getTableId(NewUserSatisfactionSurveyColumnValueExtractor.class),
+            batch,
+            getFixedValues(captureTimestamp)));
   }
 
   /** Batch uploads a reporting table. */
@@ -247,6 +263,7 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
             reportingSnapshot.getWorkspaceFreeTierUsage(),
             fixedValues,
             batchSize));
+
     return resultBuilder.build().stream()
         .filter(r -> r.getRows().size() > 0)
         .collect(ImmutableList.toImmutableList());

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
@@ -26,6 +26,7 @@ import org.pmiops.workbench.reporting.insertion.DatasetColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.DatasetConceptSetColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.DatasetDomainColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.InstitutionColumnValueExtractor;
+import org.pmiops.workbench.reporting.insertion.NewUserSatisfactionSurveyColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.UserColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.WorkspaceColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.WorkspaceFreeTierUsageColumnValueExtractor;
@@ -111,6 +112,18 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
           CohortColumnValueExtractor.TABLE_NAME,
           (long) sourceCount,
           getActualRowCount(CohortColumnValueExtractor.TABLE_NAME, captureSnapshotTime),
+          sb)) {
+        detailsLogLevel = Level.WARNING;
+        verified = false;
+      }
+    }
+    if (batchTables.contains(NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME)) {
+      int sourceCount = reportingQueryService.getNewUserSatisfactionSurveysCount();
+      if (!verifyCount(
+          NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME,
+          (long) sourceCount,
+          getActualRowCount(
+              NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME, captureSnapshotTime),
           sb)) {
         detailsLogLevel = Level.WARNING;
         verified = false;

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/NewUserSatisfactionSurveyColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/NewUserSatisfactionSurveyColumnValueExtractor.java
@@ -1,0 +1,53 @@
+package org.pmiops.workbench.reporting.insertion;
+
+import static org.pmiops.workbench.cohortbuilder.util.QueryParameterValues.enumToString;
+import static org.pmiops.workbench.cohortbuilder.util.QueryParameterValues.toInsertRowString;
+
+import java.util.function.Function;
+import org.pmiops.workbench.model.ReportingNewUserSatisfactionSurvey;
+
+/*
+ * Column data and metadata convertors for BigQuery new_user_satisfaction_survey table in reporting
+ * dataset.
+ */
+public enum NewUserSatisfactionSurveyColumnValueExtractor
+    implements ColumnValueExtractor<ReportingNewUserSatisfactionSurvey> {
+  ID("id", ReportingNewUserSatisfactionSurvey::getId),
+  USER_ID("user_id", ReportingNewUserSatisfactionSurvey::getUserId),
+  CREATED(
+      "created",
+      newUserSatisfactionSurvey -> toInsertRowString(newUserSatisfactionSurvey.getCreated())),
+  MODIFIED(
+      "modified",
+      newUserSatisfactionSurvey -> toInsertRowString(newUserSatisfactionSurvey.getModified())),
+  SATISFACTION(
+      "satisfaction",
+      newUserSatisfactionSurvey -> enumToString(newUserSatisfactionSurvey.getSatisfaction())),
+  ADDITIONAL_INFO("additional_info", ReportingNewUserSatisfactionSurvey::getAdditionalInfo);
+
+  public static final String TABLE_NAME = "new_user_satisfaction_survey";
+  private final String parameterName;
+  private final Function<ReportingNewUserSatisfactionSurvey, Object> rowToInsertValueFunction;
+
+  NewUserSatisfactionSurveyColumnValueExtractor(
+      String parameterName,
+      Function<ReportingNewUserSatisfactionSurvey, Object> rowToInsertValueFunction) {
+    this.parameterName = parameterName;
+    this.rowToInsertValueFunction = rowToInsertValueFunction;
+  }
+
+  @Override
+  public String getBigQueryTableName() {
+    return TABLE_NAME;
+  }
+
+  @Override
+  public String getParameterName() {
+    return parameterName;
+  }
+
+  @Override
+  public Function<ReportingNewUserSatisfactionSurvey, Object> getRowToInsertValueFunction() {
+    return rowToInsertValueFunction;
+  }
+}

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9301,6 +9301,10 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/ReportingInstitution"
+      newUserSatisfactionSurveys:
+        type: array
+        items:
+          "$ref": "#/definitions/ReportingNewUserSatisfactionSurvey"
       workspaceFreeTierUsage:
         type: array
         items:
@@ -9814,6 +9818,30 @@ definitions:
       registeredTierRequirement:
         description: Institution tegisted tier requirement.
         "$ref": "#/definitions/InstitutionMembershipRequirement"
+  ReportingNewUserSatisfactionSurvey:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: ID of the survey response.
+      userId:
+        type: integer
+        format: int64
+        description: ID of the user who created the survey response.
+      created:
+        type: string
+        format: date-time
+        description: Time the survey response was created.
+      modified:
+        type: string
+        format: date-time
+        description: Time the survey response was last modified.
+      satisfaction:
+        "$ref": "#/definitions/NewUserSatisfactionSurveySatisfaction"
+      additionalInfo:
+        type: string
+        description: Additional information regarding the satisfaction score.
 
   ReportingDataset:
     x-aou-note: |-

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -10236,14 +10236,17 @@ definitions:
     type: object
     properties:
       satisfaction:
-        type: string
-        description: How satisfied the user is with the researcher workbench
-        enum:
-          - VERY_UNSATISFIED
-          - UNSATISFIED
-          - NEUTRAL
-          - SATISFIED
-          - VERY_SATISFIED
+        "$ref": "#/definitions/NewUserSatisfactionSurveySatisfaction"
       additionalInfo:
         type: string
         description: Additional information regarding their satisfaction score
+
+  NewUserSatisfactionSurveySatisfaction:
+    type: string
+    description: How satisfied the user is with the researcher workbench.
+    enum:
+      - VERY_UNSATISFIED
+      - UNSATISFIED
+      - NEUTRAL
+      - SATISFIED
+      - VERY_SATISFIED

--- a/api/src/test/java/org/pmiops/workbench/api/SurveysControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/SurveysControllerTest.java
@@ -15,7 +15,7 @@ import org.pmiops.workbench.db.model.DbNewUserSatisfactionSurvey.Satisfaction;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.CreateNewUserSatisfactionSurvey;
-import org.pmiops.workbench.model.CreateNewUserSatisfactionSurvey.SatisfactionEnum;
+import org.pmiops.workbench.model.NewUserSatisfactionSurveySatisfaction;
 import org.pmiops.workbench.survey.NewUserSatisfactionSurveyMapperImpl;
 import org.pmiops.workbench.survey.NewUserSatisfactionSurveyService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,7 +63,7 @@ public class SurveysControllerTest {
     final String additionalInfo = "Love it!";
     final CreateNewUserSatisfactionSurvey createNewUserSatisfactionSurvey =
         new CreateNewUserSatisfactionSurvey()
-            .satisfaction(SatisfactionEnum.VERY_SATISFIED)
+            .satisfaction(NewUserSatisfactionSurveySatisfaction.VERY_SATISFIED)
             .additionalInfo(additionalInfo);
     when(newUserSatisfactionSurveyService.eligibleToTakeSurvey(user)).thenReturn(true);
 
@@ -80,7 +80,7 @@ public class SurveysControllerTest {
   public void testCreateNewUserSatisfactionSurvey_failsIfUserIneligible() {
     final CreateNewUserSatisfactionSurvey createNewUserSatisfactionSurvey =
         new CreateNewUserSatisfactionSurvey()
-            .satisfaction(SatisfactionEnum.VERY_SATISFIED)
+            .satisfaction(NewUserSatisfactionSurveySatisfaction.VERY_SATISFIED)
             .additionalInfo("Love it!");
     when(newUserSatisfactionSurveyService.eligibleToTakeSurvey(user)).thenReturn(false);
 

--- a/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
@@ -13,15 +13,19 @@ import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbDataset;
+import org.pmiops.workbench.db.model.DbNewUserSatisfactionSurvey;
+import org.pmiops.workbench.db.model.DbNewUserSatisfactionSurvey.Satisfaction;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.BillingAccountType;
 import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.InstitutionMembershipRequirement;
+import org.pmiops.workbench.model.NewUserSatisfactionSurveySatisfaction;
 import org.pmiops.workbench.model.OrganizationType;
 import org.pmiops.workbench.model.ReportingCohort;
 import org.pmiops.workbench.model.ReportingDataset;
 import org.pmiops.workbench.model.ReportingInstitution;
+import org.pmiops.workbench.model.ReportingNewUserSatisfactionSurvey;
 import org.pmiops.workbench.model.ReportingSnapshot;
 import org.pmiops.workbench.model.ReportingWorkspace;
 import org.pmiops.workbench.model.ReportingWorkspaceFreeTierUsage;
@@ -106,6 +110,16 @@ public class ReportingTestUtils {
   public static final String DATASET__NAME = "foo_6";
   public static final Short DATASET__PRE_PACKAGED_CONCEPT_SET = 7;
   public static final Long DATASET__WORKSPACE_ID = 8L;
+
+  public static final Long NEW_USER_SATISFACTION_SURVEY__ID = 1L;
+  public static final Long NEW_USER_SATISFACTION_SURVEY__USER_ID = 2L;
+  public static final Timestamp NEW_USER_SATISFACTION_SURVEY__CREATED =
+      Timestamp.from(Instant.parse("2001-01-01T00:00:00.00Z"));
+  public static final Timestamp NEW_USER_SATISFACTION_SURVEY__MODIFIED =
+      Timestamp.from(Instant.parse("2002-01-01T00:00:00.00Z"));
+  public static final NewUserSatisfactionSurveySatisfaction
+      NEW_USER_SATISFACTION_SURVEY__SATISFACTION = NewUserSatisfactionSurveySatisfaction.NEUTRAL;
+  public static final String NEW_USER_SATISFACTION_SURVEY__ADDITIONAL_INFO = "It's ok.";
 
   public static ReportingWorkspace createDtoWorkspace() {
     return new ReportingWorkspace()
@@ -298,6 +312,23 @@ public class ReportingTestUtils {
     return dataset;
   }
 
+  public static ReportingNewUserSatisfactionSurvey createReportingNewUserSatisfactionSurvey() {
+    return new ReportingNewUserSatisfactionSurvey()
+        .id(NEW_USER_SATISFACTION_SURVEY__ID)
+        .userId(NEW_USER_SATISFACTION_SURVEY__USER_ID)
+        .created(offsetDateTimeUtc(NEW_USER_SATISFACTION_SURVEY__CREATED))
+        .modified(offsetDateTimeUtc(NEW_USER_SATISFACTION_SURVEY__MODIFIED))
+        .satisfaction(NEW_USER_SATISFACTION_SURVEY__SATISFACTION)
+        .additionalInfo(NEW_USER_SATISFACTION_SURVEY__ADDITIONAL_INFO);
+  }
+
+  public static DbNewUserSatisfactionSurvey createDbNewUserSatisfactionSurvey(DbUser user) {
+    return new DbNewUserSatisfactionSurvey()
+        .setUser(user)
+        .setSatisfaction(Satisfaction.SATISFIED)
+        .setAdditionalInfo("Love it!");
+  }
+
   public static ReportingSnapshot createEmptySnapshot() {
     return new ReportingSnapshot()
         .cohorts(new ArrayList<>())
@@ -306,6 +337,7 @@ public class ReportingTestUtils {
         .datasetDomainIdValues(new ArrayList<>())
         .datasetCohorts(new ArrayList<>())
         .institutions(new ArrayList<>())
-        .workspaceFreeTierUsage(new ArrayList<>());
+        .workspaceFreeTierUsage(new ArrayList<>())
+        .newUserSatisfactionSurveys(new ArrayList<>());
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/NewUserSatisfactionSurveyMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/NewUserSatisfactionSurveyMapperTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.db.model.DbNewUserSatisfactionSurvey;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.CreateNewUserSatisfactionSurvey;
-import org.pmiops.workbench.model.CreateNewUserSatisfactionSurvey.SatisfactionEnum;
+import org.pmiops.workbench.model.NewUserSatisfactionSurveySatisfaction;
 import org.pmiops.workbench.survey.NewUserSatisfactionSurveyMapper;
 import org.pmiops.workbench.survey.NewUserSatisfactionSurveyMapperImpl;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +25,8 @@ public class NewUserSatisfactionSurveyMapperTest {
 
     CreateNewUserSatisfactionSurvey createNewUserSatisfactionSurvey =
         new CreateNewUserSatisfactionSurvey();
-    createNewUserSatisfactionSurvey.setSatisfaction(SatisfactionEnum.SATISFIED);
+    createNewUserSatisfactionSurvey.setSatisfaction(
+        NewUserSatisfactionSurveySatisfaction.SATISFIED);
     createNewUserSatisfactionSurvey.setAdditionalInfo(additionalInfo);
     DbNewUserSatisfactionSurvey mappedDbNewUserSatisfactionSurvey =
         mapper.toDbNewUserSatisfactionSurvey(createNewUserSatisfactionSurvey, user);


### PR DESCRIPTION
Description:

Uploads data from the `new_user_satisfaction_survey` DB table to the `new_user_satisfaction_survey` BQ table added in [this PR](https://github.com/all-of-us/workbench-terraform-modules/pull/41).

Tested by running the `upload-snapshot-local.sh` script and verifying the data is in the local env table.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
