### PR TITLE
[risk=no][no ticket] use drop/appendNotebookFileSuffix where appropriate

### DIFF
--- a/ui/src/app/pages/analysis/new-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-notebook-modal.tsx
@@ -21,6 +21,8 @@ import { AnalyticsTracker } from 'app/utils/analytics';
 import { useNavigation } from 'app/utils/navigation';
 import { Kernels } from 'app/utils/notebook-kernels';
 
+import { appendNotebookFileSuffix } from './util';
+
 interface Props {
   onClose: Function;
   workspace: Workspace;
@@ -44,7 +46,7 @@ export const NewNotebookModal = (props: Props) => {
 
   const save = () => {
     userMetricsApi().updateRecentResource(workspace.namespace, workspace.id, {
-      notebookName: `${name}.ipynb`,
+      notebookName: appendNotebookFileSuffix(name),
     });
     navigate(
       [

--- a/ui/src/app/pages/analysis/notebook-list.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.tsx
@@ -28,6 +28,8 @@ import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
 
+import { dropNotebookFileSuffix } from './util';
+
 const styles = {
   heading: {
     color: colors.primary,
@@ -158,7 +160,7 @@ export const NotebookList = withCurrentWorkspace()(
         );
         this.setState({ notebookList });
         const notebookNameList = notebookList.map((fd) =>
-          fd.name.slice(0, -'.ipynb'.length)
+          dropNotebookFileSuffix(fd.name)
         );
         this.setState({ notebookNameList });
       } catch (error) {

--- a/ui/src/app/pages/analysis/notebook-resource-card.tsx
+++ b/ui/src/app/pages/analysis/notebook-resource-card.tsx
@@ -26,7 +26,10 @@ import {
   withSpinnerOverlay,
   WithSpinnerOverlayProps,
 } from 'app/components/with-spinner-overlay';
-import { dropNotebookFileSuffix } from 'app/pages/analysis/util';
+import {
+  appendNotebookFileSuffix,
+  dropNotebookFileSuffix,
+} from 'app/pages/analysis/util';
 import { notebooksApi } from 'app/services/swagger-fetch-clients';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { getDisplayName, getType } from 'app/utils/resources';
@@ -113,10 +116,6 @@ export const NotebookResourceCard = fp.flow(
       ];
     }
 
-    fullNotebookName(name) {
-      return !name || /^.+\.ipynb$/.test(name) ? name : `${name}.ipynb`;
-    }
-
     renameNotebook(newName) {
       const { resource } = this.props;
       return notebooksApi()
@@ -125,7 +124,7 @@ export const NotebookResourceCard = fp.flow(
           resource.workspaceFirecloudName,
           {
             name: resource.notebook.name,
-            newName: this.fullNotebookName(newName),
+            newName: appendNotebookFileSuffix(newName),
           }
         )
         .then(() => this.props.onUpdate())
@@ -211,7 +210,7 @@ export const NotebookResourceCard = fp.flow(
               onCancel={() => this.setState({ showRenameModal: false })}
               hideDescription={true}
               oldName={getDisplayName(resource)}
-              nameFormat={(name) => this.fullNotebookName(name)}
+              nameFormat={(name) => appendNotebookFileSuffix(name)}
               existingNames={this.props.existingNameList}
             />
           )}

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -1,7 +1,7 @@
 const notebookExtension = '.ipynb';
 
 export function dropNotebookFileSuffix(filename: string) {
-  if (filename.endsWith(notebookExtension)) {
+  if (filename?.endsWith(notebookExtension)) {
     filename = filename.substring(0, filename.length - 6);
   }
 
@@ -9,7 +9,7 @@ export function dropNotebookFileSuffix(filename: string) {
 }
 
 export function appendNotebookFileSuffix(filename: string) {
-  if (!filename.endsWith(notebookExtension)) {
+  if (filename && !filename.endsWith(notebookExtension)) {
     filename = filename + notebookExtension;
   }
 


### PR DESCRIPTION
Minor UI cleanup.

Tested by creating a new notebook, renaming it using the snowman menu, executing cells in the notebook, using the Jupyter file manager, and observing that the homepage and the Analysis page show new and old notebooks correctly.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
