### PR TITLE
[RW-9101][RW-9104][RW-9103][risk=no]: Support list/clone/rename/delete/copy rmd files

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
@@ -10,6 +10,7 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.BlobAlreadyExistsException;
 import org.pmiops.workbench.exceptions.ConflictException;
+import org.pmiops.workbench.exceptions.NotImplementedException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.model.CopyRequest;
@@ -21,6 +22,7 @@ import org.pmiops.workbench.model.NotebookRename;
 import org.pmiops.workbench.model.ReadOnlyNotebookResponse;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.notebooks.NotebookLockingUtils;
+import org.pmiops.workbench.notebooks.NotebookUtils;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.workspaces.WorkspaceAuthService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,6 +100,10 @@ public class NotebooksController implements NotebooksApiDelegate {
   @Override
   public ResponseEntity<ReadOnlyNotebookResponse> readOnlyNotebook(
       String workspaceNamespace, String workspaceName, String notebookName) {
+    if(!NotebookUtils.isJupyterNotebook(notebookName)) {
+      throw new NotImplementedException(String.format("%s type of file is not implemented yet", notebookName));
+    }
+
     ReadOnlyNotebookResponse response =
         new ReadOnlyNotebookResponse()
             .html(
@@ -123,6 +129,10 @@ public class NotebooksController implements NotebooksApiDelegate {
   @Override
   public ResponseEntity<KernelTypeResponse> getNotebookKernel(
       String workspace, String workspaceName, String notebookName) {
+    if(!NotebookUtils.isJupyterNotebook(notebookName)) {
+      throw new BadRequestException(String.format("%s is not a Jupyter notebook file", notebookName));
+    }
+
     workspaceAuthService.enforceWorkspaceAccessLevel(
         workspace, workspaceName, WorkspaceAccessLevel.READER);
 

--- a/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
@@ -74,10 +74,10 @@ public class NotebooksController implements NotebooksApiDelegate {
           notebooksService.copyNotebook(
               fromWorkspaceNamespace,
               fromWorkspaceId,
-              NotebooksService.withNotebookExtension(fromNotebookName),
+              fromNotebookName,
               copyRequest.getToWorkspaceNamespace(),
               copyRequest.getToWorkspaceName(),
-              NotebooksService.withNotebookExtension(copyRequest.getNewName()));
+              copyRequest.getNewName());
     } catch (BlobAlreadyExistsException e) {
       throw new ConflictException("File already exists at copy destination");
     }

--- a/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
@@ -70,14 +70,15 @@ public class NotebooksController implements NotebooksApiDelegate {
       CopyRequest copyRequest) {
     FileDetail fileDetail;
     try {
+      // TODO(yonghao): Remove withNotebookExtension after UI start setting extension.
       fileDetail =
           notebooksService.copyNotebook(
               fromWorkspaceNamespace,
               fromWorkspaceId,
-              fromNotebookName,
+              NotebooksService.withNotebookExtension(fromNotebookName),
               copyRequest.getToWorkspaceNamespace(),
               copyRequest.getToWorkspaceName(),
-              copyRequest.getNewName());
+              NotebooksService.withNotebookExtension(copyRequest.getNewName()));
     } catch (BlobAlreadyExistsException e) {
       throw new ConflictException("File already exists at copy destination");
     }

--- a/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
@@ -100,8 +100,9 @@ public class NotebooksController implements NotebooksApiDelegate {
   @Override
   public ResponseEntity<ReadOnlyNotebookResponse> readOnlyNotebook(
       String workspaceNamespace, String workspaceName, String notebookName) {
-    if(!NotebookUtils.isJupyterNotebook(notebookName)) {
-      throw new NotImplementedException(String.format("%s type of file is not implemented yet", notebookName));
+    if (!NotebookUtils.isJupyterNotebook(notebookName)) {
+      throw new NotImplementedException(
+          String.format("%s type of file is not implemented yet", notebookName));
     }
 
     ReadOnlyNotebookResponse response =
@@ -129,8 +130,9 @@ public class NotebooksController implements NotebooksApiDelegate {
   @Override
   public ResponseEntity<KernelTypeResponse> getNotebookKernel(
       String workspace, String workspaceName, String notebookName) {
-    if(!NotebookUtils.isJupyterNotebook(notebookName)) {
-      throw new BadRequestException(String.format("%s is not a Jupyter notebook file", notebookName));
+    if (!NotebookUtils.isJupyterNotebook(notebookName)) {
+      throw new BadRequestException(
+          String.format("%s is not a Jupyter notebook file", notebookName));
     }
 
     workspaceAuthService.enforceWorkspaceAccessLevel(

--- a/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.api;
 
+import static org.pmiops.workbench.notebooks.NotebookUtils.isRMarkdownNotebook;
+
 import java.time.Clock;
 import java.util.List;
 import java.util.Map;
@@ -70,15 +72,22 @@ public class NotebooksController implements NotebooksApiDelegate {
       CopyRequest copyRequest) {
     FileDetail fileDetail;
     try {
+      // Checks the new name extension to match the original from file type, add extension if
+      // needed.
       // TODO(yonghao): Remove withNotebookExtension after UI start setting extension.
+      String newName =
+          isRMarkdownNotebook(fromNotebookName)
+              ? NotebooksService.withRMarkdownExtension(copyRequest.getNewName())
+              : NotebooksService.withJupyterNotebookExtension(copyRequest.getNewName());
+
       fileDetail =
           notebooksService.copyNotebook(
               fromWorkspaceNamespace,
               fromWorkspaceId,
-              NotebooksService.withNotebookExtension(fromNotebookName),
+              NotebooksService.withJupyterNotebookExtension(fromNotebookName),
               copyRequest.getToWorkspaceNamespace(),
               copyRequest.getToWorkspaceName(),
-              NotebooksService.withNotebookExtension(copyRequest.getNewName()));
+              newName);
     } catch (BlobAlreadyExistsException e) {
       throw new ConflictException("File already exists at copy destination");
     }

--- a/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
@@ -80,6 +80,7 @@ public class NotebooksController implements NotebooksApiDelegate {
               ? NotebooksService.withRMarkdownExtension(copyRequest.getNewName())
               : NotebooksService.withJupyterNotebookExtension(copyRequest.getNewName());
 
+      // TODO(yonghao): Remove withNotebookExtension after UI start setting extension.
       fileDetail =
           notebooksService.copyNotebook(
               fromWorkspaceNamespace,

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
@@ -8,6 +8,7 @@ public class NotebookUtils {
 
   public static String NOTEBOOKS_WORKSPACE_DIRECTORY = "notebooks";
   public static String JUPYTER_NOTEBOOK_EXTENSION = ".ipynb";
+  public static String R_MARKDOWN_NOTEBOOK_EXTENSION = ".rmd";
 
   // Pattern matches directory and the file type, e.g. notebooks/file.ipynb
   public static final Pattern JUPYTER_NOTEBOOK_WITH_DIRECTORY_PATTERN =
@@ -26,5 +27,9 @@ public class NotebookUtils {
 
   public static boolean isJupyterNotebook(String name) {
     return name.endsWith(JUPYTER_NOTEBOOK_EXTENSION);
+  }
+
+  public static boolean isRMarkdownNotebook(String name) {
+    return name.endsWith(R_MARKDOWN_NOTEBOOK_EXTENSION);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
@@ -4,7 +4,7 @@ import java.util.regex.Pattern;
 
 /** Notebook files operation utils */
 public class NotebookUtils {
-  private NotebookUtils{}
+  private NotebookUtils() {}
 
   public static String NOTEBOOKS_WORKSPACE_DIRECTORY = "notebooks";
   public static String NOTEBOOK_EXTENSION = ".ipynb";

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
@@ -1,0 +1,24 @@
+package org.pmiops.workbench.notebooks;
+
+import java.util.regex.Pattern;
+
+/** Notebook files operation utils */
+public class NotebookUtils {
+  private NotebookUtils{}
+
+  public static String NOTEBOOKS_WORKSPACE_DIRECTORY = "notebooks";
+  public static String NOTEBOOK_EXTENSION = ".ipynb";
+
+  public static final Pattern JUPYTER_NOTEBOOK_PATTERN =
+      Pattern.compile(NOTEBOOKS_WORKSPACE_DIRECTORY + "/[^/]+(\\.(?i)(ipynb))$");
+  public static final Pattern R_MARKDOWN_NOTEBOOK_PATTERN =
+      Pattern.compile(NOTEBOOKS_WORKSPACE_DIRECTORY + "/[^/]+(\\.(?i)(rmd))$");
+
+  public static boolean isJupyterNotebook(String name) {
+    return JUPYTER_NOTEBOOK_PATTERN.matcher(name).matches();
+  }
+
+  public static boolean isRMarkDownNotebook(String name) {
+    return R_MARKDOWN_NOTEBOOK_PATTERN.matcher(name).matches();
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
@@ -7,18 +7,24 @@ public class NotebookUtils {
   private NotebookUtils() {}
 
   public static String NOTEBOOKS_WORKSPACE_DIRECTORY = "notebooks";
-  public static String NOTEBOOK_EXTENSION = ".ipynb";
+  public static String JUPYTER_NOTEBOOK_EXTENSION = ".ipynb";
 
-  public static final Pattern JUPYTER_NOTEBOOK_PATTERN =
+  // Pattern matches directory and the file type, e.g. notebooks/file.ipynb
+  public static final Pattern JUPYTER_NOTEBOOK_WITH_DIRECTORY_PATTERN =
       Pattern.compile(NOTEBOOKS_WORKSPACE_DIRECTORY + "/[^/]+(\\.(?i)(ipynb))$");
-  public static final Pattern R_MARKDOWN_NOTEBOOK_PATTERN =
+  // Pattern matches directory and the file type, e.g. notebooks/file.rmd
+  public static final Pattern R_MARKDOWN_NOTEBOOK_WITH_DIRECTORY_PATTERN =
       Pattern.compile(NOTEBOOKS_WORKSPACE_DIRECTORY + "/[^/]+(\\.(?i)(rmd))$");
 
-  public static boolean isJupyterNotebook(String name) {
-    return JUPYTER_NOTEBOOK_PATTERN.matcher(name).matches();
+  public static boolean isJupyterNotebookWithDirectory(String name) {
+    return JUPYTER_NOTEBOOK_WITH_DIRECTORY_PATTERN.matcher(name).matches();
   }
 
-  public static boolean isRMarkDownNotebook(String name) {
-    return R_MARKDOWN_NOTEBOOK_PATTERN.matcher(name).matches();
+  public static boolean isRMarkDownNotebookWithDirectory(String name) {
+    return R_MARKDOWN_NOTEBOOK_WITH_DIRECTORY_PATTERN.matcher(name).matches();
+  }
+
+  public static boolean isJupyterNotebook(String name) {
+    return name.endsWith(JUPYTER_NOTEBOOK_EXTENSION);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.notebooks;
 
-import static org.pmiops.workbench.notebooks.NotebookUtils.NOTEBOOK_EXTENSION;
+import static org.pmiops.workbench.notebooks.NotebookUtils.JUPYTER_NOTEBOOK_EXTENSION;
 
 import com.google.cloud.storage.Blob;
 import java.util.List;
@@ -11,9 +11,9 @@ import org.pmiops.workbench.model.KernelTypeEnum;
 public interface NotebooksService {
 
   static String withNotebookExtension(String notebookName) {
-    return notebookName.endsWith(NOTEBOOK_EXTENSION)
+    return notebookName.endsWith(JUPYTER_NOTEBOOK_EXTENSION)
         ? notebookName
-        : notebookName.concat(NOTEBOOK_EXTENSION);
+        : notebookName.concat(JUPYTER_NOTEBOOK_EXTENSION);
   }
 
   List<FileDetail> getNotebooks(String workspaceNamespace, String workspaceName);

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.notebooks;
 
+import static org.pmiops.workbench.notebooks.NotebookUtils.NOTEBOOK_EXTENSION;
+
 import com.google.cloud.storage.Blob;
 import java.util.List;
 import org.json.JSONObject;
@@ -7,9 +9,6 @@ import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.KernelTypeEnum;
 
 public interface NotebooksService {
-
-  String NOTEBOOKS_WORKSPACE_DIRECTORY = "notebooks";
-  String NOTEBOOK_EXTENSION = ".ipynb";
 
   static String withNotebookExtension(String notebookName) {
     return notebookName.endsWith(NOTEBOOK_EXTENSION)

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.notebooks;
 
 import static org.pmiops.workbench.notebooks.NotebookUtils.JUPYTER_NOTEBOOK_EXTENSION;
+import static org.pmiops.workbench.notebooks.NotebookUtils.R_MARKDOWN_NOTEBOOK_EXTENSION;
 
 import com.google.cloud.storage.Blob;
 import java.util.List;
@@ -9,11 +10,16 @@ import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.KernelTypeEnum;
 
 public interface NotebooksService {
-
-  static String withNotebookExtension(String notebookName) {
+  static String withJupyterNotebookExtension(String notebookName) {
     return notebookName.endsWith(JUPYTER_NOTEBOOK_EXTENSION)
         ? notebookName
         : notebookName.concat(JUPYTER_NOTEBOOK_EXTENSION);
+  }
+
+  static String withRMarkdownExtension(String notebookName) {
+    return notebookName.endsWith(R_MARKDOWN_NOTEBOOK_EXTENSION)
+        ? notebookName
+        : notebookName.concat(R_MARKDOWN_NOTEBOOK_EXTENSION);
   }
 
   List<FileDetail> getNotebooks(String workspaceNamespace, String workspaceName);

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -276,7 +276,8 @@ public class NotebooksServiceImpl implements NotebooksService {
   private Blob getBlobWithSizeConstraint(String bucketName, String notebookName) {
     Blob blob =
         cloudStorageClient.getBlob(
-            bucketName, "notebooks/".concat(NotebooksService.withNotebookExtension(notebookName)));
+            bucketName,
+            "notebooks/".concat(NotebooksService.withJupyterNotebookExtension(notebookName)));
     if (blob.getSize() >= MAX_NOTEBOOK_READ_SIZE_BYTES) {
       throw new FailedPreconditionException(
           String.format(
@@ -293,7 +294,7 @@ public class NotebooksServiceImpl implements NotebooksService {
     }
     cloudStorageClient.writeFile(
         bucketName,
-        "notebooks/" + NotebooksService.withNotebookExtension(notebookName),
+        "notebooks/" + NotebooksService.withJupyterNotebookExtension(notebookName),
         notebookContents.toString().getBytes(StandardCharsets.UTF_8));
     logsBasedMetricService.recordEvent(EventMetric.NOTEBOOK_SAVE);
   }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -130,8 +130,9 @@ public class NotebooksServiceImpl implements NotebooksService {
 
   @Override
   public boolean isNotebookBlob(Blob blob) {
-    return NotebookUtils.isJupyterNotebook(blob.getName())
-        || NotebookUtils.isRMarkDownNotebook(blob.getName());
+    // Blobs have notebooks/ directory
+    return NotebookUtils.isJupyterNotebookWithDirectory(blob.getName())
+        || NotebookUtils.isRMarkDownNotebookWithDirectory(blob.getName());
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -121,8 +121,8 @@ public class NotebooksServiceImpl implements NotebooksService {
       String bucketName, String workspaceNamespace, String workspaceName) {
     Set<String> workspaceUsers =
         workspaceAuthService.getFirecloudWorkspaceAcls(workspaceNamespace, workspaceName).keySet();
-    return cloudStorageClient.getBlobPageForPrefix(bucketName, NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY)
-        .stream()
+    return cloudStorageClient
+        .getBlobPageForPrefix(bucketName, NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY).stream()
         .filter(this::isNotebookBlob)
         .map(blob -> cloudStorageClient.blobToFileDetail(blob, bucketName, workspaceUsers))
         .collect(Collectors.toList());
@@ -130,7 +130,8 @@ public class NotebooksServiceImpl implements NotebooksService {
 
   @Override
   public boolean isNotebookBlob(Blob blob) {
-    return NotebookUtils.isJupyterNotebook(blob.getName()) || NotebookUtils.isRMarkDownNotebook(blob.getName());
+    return NotebookUtils.isJupyterNotebook(blob.getName())
+        || NotebookUtils.isRMarkDownNotebook(blob.getName());
   }
 
   @Override
@@ -286,8 +287,9 @@ public class NotebooksServiceImpl implements NotebooksService {
 
   @Override
   public void saveNotebook(String bucketName, String notebookName, JSONObject notebookContents) {
-    if(!NotebookUtils.isJupyterNotebook(notebookName)) {
-      throw new NotImplementedException(String.format("%s type of file is not implemented yet", notebookName));
+    if (!NotebookUtils.isJupyterNotebook(notebookName)) {
+      throw new NotImplementedException(
+          String.format("%s type of file is not implemented yet", notebookName));
     }
     cloudStorageClient.writeFile(
         bucketName,
@@ -321,8 +323,9 @@ public class NotebooksServiceImpl implements NotebooksService {
   @Override
   public String adminGetReadOnlyHtml(
       String workspaceNamespace, String workspaceName, String notebookName) {
-    if(!NotebookUtils.isJupyterNotebook(notebookName)) {
-      throw new NotImplementedException(String.format("%s type of file is not implemented yet", notebookName));
+    if (!NotebookUtils.isJupyterNotebook(notebookName)) {
+      throw new NotImplementedException(
+          String.format("%s type of file is not implemented yet", notebookName));
     }
 
     String bucketName =

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -148,7 +148,6 @@ public class NotebooksServiceImpl implements NotebooksService {
     workspaceAuthService.enforceWorkspaceAccessLevel(
         toWorkspaceNamespace, toWorkspaceFirecloudName, WorkspaceAccessLevel.WRITER);
     workspaceAuthService.validateActiveBilling(toWorkspaceNamespace, toWorkspaceFirecloudName);
-    newNotebookName = NotebooksService.withNotebookExtension(newNotebookName);
 
     final DbWorkspace fromWorkspace =
         workspaceDao.getRequired(fromWorkspaceNamespace, fromWorkspaceFirecloudName);
@@ -229,7 +228,7 @@ public class NotebooksServiceImpl implements NotebooksService {
             originalName,
             workspaceNamespace,
             workspaceName,
-            NotebooksService.withNotebookExtension(newName));
+            newName);
     deleteNotebook(workspaceNamespace, workspaceName, originalName);
 
     return fileDetail;
@@ -290,7 +289,7 @@ public class NotebooksServiceImpl implements NotebooksService {
   public void saveNotebook(String bucketName, String notebookName, JSONObject notebookContents) {
     if (!NotebookUtils.isJupyterNotebook(notebookName)) {
       throw new NotImplementedException(
-          String.format("%s type of file is not implemented yet", notebookName));
+          String.format("%s is a type of file that is not yet supported", notebookName));
     }
     cloudStorageClient.writeFile(
         bucketName,
@@ -326,7 +325,7 @@ public class NotebooksServiceImpl implements NotebooksService {
       String workspaceNamespace, String workspaceName, String notebookName) {
     if (!NotebookUtils.isJupyterNotebook(notebookName)) {
       throw new NotImplementedException(
-          String.format("%s type of file is not implemented yet", notebookName));
+          String.format("%s is a type of file that is not yet supported", notebookName));
     }
 
     String bucketName =

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -62,6 +62,7 @@ import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceAdminView;
 import org.pmiops.workbench.model.WorkspaceAuditLogQueryResponse;
 import org.pmiops.workbench.model.WorkspaceUserAdminView;
+import org.pmiops.workbench.notebooks.NotebookUtils;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
 import org.pmiops.workbench.utils.mappers.UserMapper;
@@ -406,7 +407,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
   private int getNonNotebookFileCount(String bucketName) {
     return (int)
         cloudStorageClient
-            .getBlobPageForPrefix(bucketName, NotebooksService.NOTEBOOKS_WORKSPACE_DIRECTORY)
+            .getBlobPageForPrefix(bucketName, NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY)
             .stream()
             .filter(((Predicate<Blob>) notebooksService::isNotebookBlob).negate())
             .count();

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -407,8 +407,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
   private int getNonNotebookFileCount(String bucketName) {
     return (int)
         cloudStorageClient
-            .getBlobPageForPrefix(bucketName, NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY)
-            .stream()
+            .getBlobPageForPrefix(bucketName, NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY).stream()
             .filter(((Predicate<Blob>) notebooksService::isNotebookBlob).negate())
             .count();
   }

--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -281,6 +281,15 @@ public class NotebooksControllerTest {
   }
 
   @Test
+  public void testGetNotebookKernel_notSupported() {
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            notebooksController.getNotebookKernel(
+                FROM_WORKSPACE_NAMESPACE, FROM_WORKSPACE_NAME, "file.rmd"));
+  }
+
+  @Test
   public void testGetNotebookLockingMetadata() {
     final String lastLockedUser = LOGGED_IN_USER_EMAIL;
     final Long lockExpirationTime = Instant.now().plus(Duration.ofMinutes(1)).toEpochMilli();

--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -192,6 +192,41 @@ public class NotebooksControllerTest {
   }
 
   @Test
+  public void testCopyNotebook_rmd_withNoExtensionName() {
+    String toWorkspaceNamespace = "fromProject";
+    String toWorkspaceName = "fromWorkspace_001";
+    String newName = "toName";
+    String toPath = "/path/to/" + newName;
+    long toLastModifiedTime = Instant.now().toEpochMilli();
+    CopyRequest copyRequest = new CopyRequest();
+    FileDetail expectedFileDetail = createFileDetail(newName + ".rmd", toPath, toLastModifiedTime);
+    copyRequest.setNewName(newName);
+    copyRequest.setToWorkspaceNamespace(toWorkspaceNamespace);
+    copyRequest.setToWorkspaceName(toWorkspaceName);
+
+    when(mockNotebookService.copyNotebook(
+            anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(expectedFileDetail);
+
+    FileDetail actualFileDetail =
+        notebooksController
+            .copyNotebook(FROM_WORKSPACE_NAMESPACE, FROM_WORKSPACE_NAME, "test.rmd", copyRequest)
+            .getBody();
+
+    // Note the fromNotebooName will change after stop setting extension for notebookName.
+    verify(mockNotebookService)
+        .copyNotebook(
+            FROM_WORKSPACE_NAMESPACE,
+            FROM_WORKSPACE_NAME,
+            "test.rmd.ipynb",
+            toWorkspaceNamespace,
+            toWorkspaceName,
+            newName + ".rmd");
+
+    assertThat(actualFileDetail).isEqualTo(expectedFileDetail);
+  }
+
+  @Test
   public void testCopyNotebook_alreadyExists() {
     String toWorkspaceNamespace = "fromProject";
     String toWorkspaceName = "fromWorkspace_001";
@@ -240,9 +275,11 @@ public class NotebooksControllerTest {
     String workspaceNamespace = "project";
     String workspaceName = "workspace";
     MockNotebook notebook1 =
-        new MockNotebook(NotebooksService.withNotebookExtension("notebooks/mockFile"), "bucket");
+        new MockNotebook(
+            NotebooksService.withJupyterNotebookExtension("notebooks/mockFile"), "bucket");
     MockNotebook notebook2 =
-        new MockNotebook(NotebooksService.withNotebookExtension("notebooks/two words"), "bucket");
+        new MockNotebook(
+            NotebooksService.withJupyterNotebookExtension("notebooks/two words"), "bucket");
 
     when(mockNotebookService.getNotebooks(anyString(), anyString()))
         .thenReturn(ImmutableList.of(notebook1.fileDetail, notebook2.fileDetail));
@@ -506,7 +543,7 @@ public class NotebooksControllerTest {
 
     final String testWorkspaceNamespace = "test-ns";
     final String testWorkspaceName = "test-ws";
-    final String testNotebook = NotebooksService.withNotebookExtension("test-notebook");
+    final String testNotebook = NotebooksService.withJupyterNotebookExtension("test-notebook");
 
     FirecloudWorkspaceDetails fcWorkspace =
         TestMockFactory.createFirecloudWorkspace(

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -258,7 +258,7 @@ public class NotebooksServiceTest {
 
     FileDetail expectedFileDetail =
         new FileDetail()
-            .name(newNotebookName + ".ipynb")
+            .name(newNotebookName)
             .path("gs://" + toBucket + "/notebooks/" + newNotebookName);
     assertThat(actualFileDetail.getName()).isEqualTo(expectedFileDetail.getName());
     assertThat(actualFileDetail.getPath()).isEqualTo(expectedFileDetail.getPath());

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -218,7 +218,7 @@ public class NotebooksServiceTest {
     String fromBucket = "FROM_BUCKET";
     String toWorkspaceNamespace = "toWorkspaceNamespace";
     String toWorkspaceFirecloudName = "toWorkspaceFirecloudName";
-    String newNotebookName = "newNotebookName.ipynb";
+    String newNotebookName = "newNotebookName";
     String toBucket = "TO_BUCKET";
     HashSet<BlobId> existingBlobIds = new HashSet<>();
 
@@ -259,7 +259,7 @@ public class NotebooksServiceTest {
     FileDetail expectedFileDetail =
         new FileDetail()
             .name(newNotebookName + ".ipynb")
-            .path("gs://" + toBucket + "/notebooks/" + newNotebookName + ".ipynb");
+            .path("gs://" + toBucket + "/notebooks/" + newNotebookName);
     assertThat(actualFileDetail.getName()).isEqualTo(expectedFileDetail.getName());
     assertThat(actualFileDetail.getPath()).isEqualTo(expectedFileDetail.getPath());
     assertThat(actualFileDetail.getSizeInBytes()).isEqualTo(expectedFileDetail.getSizeInBytes());

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -218,7 +218,7 @@ public class NotebooksServiceTest {
     String fromBucket = "FROM_BUCKET";
     String toWorkspaceNamespace = "toWorkspaceNamespace";
     String toWorkspaceFirecloudName = "toWorkspaceFirecloudName";
-    String newNotebookName = "newNotebookName";
+    String newNotebookName = "newNotebookName.ipynb";
     String toBucket = "TO_BUCKET";
     HashSet<BlobId> existingBlobIds = new HashSet<>();
 

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -443,11 +443,12 @@ public class NotebooksServiceTest {
   @Test
   public void testGetNotebooks() {
     MockNotebook notebook1 =
-        new MockNotebook(NotebooksService.withNotebookExtension("notebooks/mockFile"), BUCKET_NAME);
+        new MockNotebook(
+            NotebooksService.withJupyterNotebookExtension("notebooks/mockFile"), BUCKET_NAME);
     MockNotebook notebook2 = new MockNotebook("notebooks/mockFile.text", BUCKET_NAME);
     MockNotebook notebook3 =
         new MockNotebook(
-            NotebooksService.withNotebookExtension("notebooks/two words"), BUCKET_NAME);
+            NotebooksService.withJupyterNotebookExtension("notebooks/two words"), BUCKET_NAME);
 
     when(mockCloudStorageClient.getBlobPageForPrefix(BUCKET_NAME, "notebooks"))
         .thenReturn(ImmutableList.of(notebook1.blob, notebook2.blob, notebook3.blob));
@@ -523,8 +524,9 @@ public class NotebooksServiceTest {
         BUCKET_NAME,
         WorkspaceAccessLevel.OWNER);
     when(mockBlob1.getName())
-        .thenReturn(NotebooksService.withNotebookExtension("notebooks/extra/nope"));
-    when(mockBlob2.getName()).thenReturn(NotebooksService.withNotebookExtension("notebooks/foo"));
+        .thenReturn(NotebooksService.withJupyterNotebookExtension("notebooks/extra/nope"));
+    when(mockBlob2.getName())
+        .thenReturn(NotebooksService.withJupyterNotebookExtension("notebooks/foo"));
     when(mockCloudStorageClient.getBlobPageForPrefix(BUCKET_NAME, "notebooks"))
         .thenReturn(ImmutableList.of(mockBlob1, mockBlob2));
     when(mockCloudStorageClient.blobToFileDetail(mockBlob1, BUCKET_NAME, workspaceUsersSet))
@@ -539,7 +541,8 @@ public class NotebooksServiceTest {
             dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
     List<String> gotNames = body.stream().map(FileDetail::getName).collect(Collectors.toList());
 
-    assertThat(gotNames).isEqualTo(ImmutableList.of(NotebooksService.withNotebookExtension("foo")));
+    assertThat(gotNames)
+        .isEqualTo(ImmutableList.of(NotebooksService.withJupyterNotebookExtension("foo")));
   }
 
   @Test
@@ -636,8 +639,8 @@ public class NotebooksServiceTest {
         notebooksService.renameNotebook(
             NAMESPACE_NAME,
             WORKSPACE_NAME,
-            NotebooksService.withNotebookExtension("oldName"),
-            NotebooksService.withNotebookExtension("newName"));
+            NotebooksService.withJupyterNotebookExtension("oldName"),
+            NotebooksService.withJupyterNotebookExtension("newName"));
 
     verify(mockCloudStorageClient).deleteBlob(any());
     verify(mockUserRecentResourceService).deleteNotebookEntry(anyLong(), anyLong(), anyString());

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -214,7 +214,7 @@ public class NotebooksServiceTest {
   public void testCopyNotebook() {
     String fromWorkspaceNamespace = "fromWorkspaceNamespace";
     String fromWorkspaceFirecloudName = "fromWorkspaceFirecloudName";
-    String fromNotebookName = "fromNotebookName";
+    String fromNotebookName = "fromNotebookName.ipynb";
     String fromBucket = "FROM_BUCKET";
     String toWorkspaceNamespace = "toWorkspaceNamespace";
     String toWorkspaceFirecloudName = "toWorkspaceFirecloudName";
@@ -647,24 +647,6 @@ public class NotebooksServiceTest {
     verify(mockWorkspaceAuthService, times(2))
         .enforceWorkspaceAccessLevel(NAMESPACE_NAME, WORKSPACE_NAME, WorkspaceAccessLevel.WRITER);
     verify(mockWorkspaceAuthService).validateActiveBilling(NAMESPACE_NAME, WORKSPACE_NAME);
-    assertThat(actualResult.getName()).isEqualTo("newName.ipynb");
-    assertThat(actualResult.getPath())
-        .isEqualTo("gs://" + BUCKET_NAME + "/notebooks/newName.ipynb");
-  }
-
-  @Test
-  public void testRenameNotebook_withOutExtension() {
-
-    when(mockWorkspaceAuthService.enforceWorkspaceAccessLevel(anyString(), anyString(), any()))
-        .thenReturn(WorkspaceAccessLevel.OWNER);
-
-    when(workspaceDao.getRequired(anyString(), anyString())).thenReturn(dbWorkspace);
-
-    stubGetWorkspace(NAMESPACE_NAME, WORKSPACE_NAME, BUCKET_NAME, WorkspaceAccessLevel.OWNER);
-
-    FileDetail actualResult =
-        notebooksService.renameNotebook(NAMESPACE_NAME, WORKSPACE_NAME, "oldName", "newName");
-
     assertThat(actualResult.getName()).isEqualTo("newName.ipynb");
     assertThat(actualResult.getPath())
         .isEqualTo("gs://" + BUCKET_NAME + "/notebooks/newName.ipynb");

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -38,6 +38,7 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.BlobAlreadyExistsException;
 import org.pmiops.workbench.exceptions.FailedPreconditionException;
+import org.pmiops.workbench.exceptions.NotImplementedException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceDetails;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
@@ -63,7 +64,7 @@ import org.springframework.context.annotation.Scope;
 @DataJpaTest
 public class NotebooksServiceTest {
   private static final String BUCKET_NAME = "BUCKET_NAME";
-  private static final String NOTEBOOK_NAME = "my first notebook";
+  private static final String NOTEBOOK_NAME = "my first notebook.ipynb";
   private static final String NAMESPACE_NAME = "namespace_name";
   private static final String WORKSPACE_NAME = "workspace_name";
   private static final String PREVIOUS_NOTEBOOK = "previous notebook";
@@ -188,7 +189,7 @@ public class NotebooksServiceTest {
     when(mockBlob.getSize()).thenReturn(1l);
     when(mockBlob.getContent()).thenReturn(new byte[10]);
     String actualResult =
-        notebooksService.adminGetReadOnlyHtml(NAMESPACE_NAME, WORKSPACE_NAME, "notebookName");
+        notebooksService.adminGetReadOnlyHtml(NAMESPACE_NAME, WORKSPACE_NAME, "notebookName.ipynb");
     assertThat(actualResult).isEqualTo(htmlDocument);
   }
 
@@ -489,7 +490,7 @@ public class NotebooksServiceTest {
     when(mockBlob2.getName()).thenReturn("notebooks/f2.rmd");
     when(mockBlob3.getName()).thenReturn("notebooks/f3.random");
     when(mockCloudStorageClient.getBlobPageForPrefix(BUCKET_NAME, "notebooks"))
-        .thenReturn(ImmutableList.of(mockBlob1, mockBlob2));
+        .thenReturn(ImmutableList.of(mockBlob1, mockBlob2, mockBlob3));
     when(mockCloudStorageClient.blobToFileDetail(mockBlob1, BUCKET_NAME, workspaceUsersSet))
         .thenReturn(fileDetail1);
     when(mockCloudStorageClient.blobToFileDetail(mockBlob2, BUCKET_NAME, workspaceUsersSet))
@@ -498,7 +499,7 @@ public class NotebooksServiceTest {
         .thenReturn(fileDetail3);
     when(fileDetail1.getName()).thenReturn("f1.ipynb");
     when(fileDetail2.getName()).thenReturn("f2.rmd");
-    when(fileDetail2.getName()).thenReturn("f3.random");
+    when(fileDetail3.getName()).thenReturn("f3.random");
 
     List<FileDetail> body =
         notebooksService.getNotebooks(
@@ -676,7 +677,7 @@ public class NotebooksServiceTest {
   @Test
   public void testGetNotebookKernel_notSupported() {
     Assertions.assertThrows(
-        BadRequestException.class,
+        NotImplementedException.class,
         () ->
             notebooksService.saveNotebook(
                 BUCKET_NAME, "test.rmd", new JSONObject().put("who", "I'm a notebook!")));

--- a/ui/src/app/pages/analysis/notebook-resource-card.tsx
+++ b/ui/src/app/pages/analysis/notebook-resource-card.tsx
@@ -26,7 +26,6 @@ import {
   withSpinnerOverlay,
   WithSpinnerOverlayProps,
 } from 'app/components/with-spinner-overlay';
-import { dropNotebookFileSuffix } from 'app/pages/analysis/util';
 import { notebooksApi } from 'app/services/swagger-fetch-clients';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { getDisplayName, getType } from 'app/utils/resources';

--- a/ui/src/app/pages/analysis/notebook-resource-card.tsx
+++ b/ui/src/app/pages/analysis/notebook-resource-card.tsx
@@ -176,7 +176,7 @@ export const NotebookResourceCard = fp.flow(
       return notebooksApi().copyNotebook(
         this.props.resource.workspaceNamespace,
         this.props.resource.workspaceFirecloudName,
-        dropNotebookFileSuffix(this.props.resource.notebook.name),
+        this.props.resource.notebook.name,
         copyRequest
       );
     }


### PR DESCRIPTION
Description:

- List RMD files is supported by checking rmd pattern macher
- Clone/Delete/Copy/Rename are supported without anychanges. 
- Get kernel type is not supported for rmd file
- Convert RMD file to HTLM is to be implemented. 
- Note, I can not test it because I can not create rmd files in gcs bucket and open with RStudio yet.  

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
