### PR TITLE
[RW-9194][risk=no] Use account creation time instead of RT access time for survey eligibility

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/survey/NewUserSatisfactionSurveyServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/survey/NewUserSatisfactionSurveyServiceTest.java
@@ -1,27 +1,18 @@
 package org.pmiops.workbench.survey;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.pmiops.workbench.access.AccessTierService;
-import org.pmiops.workbench.db.dao.AccessTierDao;
-import org.pmiops.workbench.db.dao.UserAccessTierDao;
-import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbNewUserSatisfactionSurvey;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.db.model.DbUserAccessTier;
 import org.pmiops.workbench.test.FakeClock;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -29,10 +20,6 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 @SpringJUnitConfig
 class NewUserSatisfactionSurveyServiceTest {
   @Autowired private NewUserSatisfactionSurveyService newUserSatisfactionSurveyService;
-  @MockBean private AccessTierDao mockAccessTierDao;
-  @MockBean private UserAccessTierDao mockUserAccessTierDao;
-  @MockBean private AccessTierService mockAccessTierService;
-  private DbAccessTier registeredAccessTier;
 
   private static final Instant START_INSTANT = Instant.parse("2000-01-01T00:00:00.00Z");
   private static final FakeClock PROVIDED_CLOCK = new FakeClock(START_INSTANT);
@@ -49,20 +36,15 @@ class NewUserSatisfactionSurveyServiceTest {
 
   @BeforeEach
   public void setup() {
-    registeredAccessTier = TestMockFactory.createRegisteredTierForTests(mockAccessTierDao);
-    when(mockAccessTierService.getRegisteredTierOrThrow()).thenReturn(registeredAccessTier);
     PROVIDED_CLOCK.setInstant(START_INSTANT);
     user = new DbUser();
   }
 
-  // The user has RT access and the enabled date is within the eligibility window
+  // The user's creation date is within the eligibility window
   @Test
   public void testEligibleToTakeSurvey_eligible() {
     final Instant threeWeeksAgo = PROVIDED_CLOCK.instant().minus(3 * 7, ChronoUnit.DAYS);
-    DbUserAccessTier userAccessTier =
-        new DbUserAccessTier().setFirstEnabled(Timestamp.from(threeWeeksAgo));
-    when(mockUserAccessTierDao.getByUserAndAccessTier(user, registeredAccessTier))
-        .thenReturn(Optional.of(userAccessTier));
+    user.setCreationTime(Timestamp.from(threeWeeksAgo));
     assertThat(newUserSatisfactionSurveyService.eligibleToTakeSurvey(user)).isTrue();
   }
 
@@ -71,33 +53,19 @@ class NewUserSatisfactionSurveyServiceTest {
   public void testEligibleToTakeSurvey_takenSurveyIneligible() {
     final Instant instantWithinEligibilityWindow =
         PROVIDED_CLOCK.instant().minus(3 * 7, ChronoUnit.DAYS);
-    DbUserAccessTier userAccessTier =
-        new DbUserAccessTier().setFirstEnabled(Timestamp.from(instantWithinEligibilityWindow));
-    when(mockUserAccessTierDao.getByUserAndAccessTier(user, registeredAccessTier))
-        .thenReturn(Optional.of(userAccessTier));
+    user.setCreationTime(Timestamp.from(instantWithinEligibilityWindow));
 
     user.setNewUserSatisfactionSurvey(new DbNewUserSatisfactionSurvey());
 
     assertThat(newUserSatisfactionSurveyService.eligibleToTakeSurvey(user)).isFalse();
   }
 
-  // A user who has never gained RT access is ineligible
-  @Test
-  public void testEligibleToTakeSurvey_incompleteRTAccessStepsIneligible() {
-    when(mockUserAccessTierDao.getByUserAndAccessTier(user, registeredAccessTier))
-        .thenReturn(Optional.empty());
-    assertThat(newUserSatisfactionSurveyService.eligibleToTakeSurvey(user)).isFalse();
-  }
-
-  // A user with RT access for less than two weeks is ineligible
+  // A user created less than two weeks is ineligible
   @Test
   public void testEligibleToTakeSurvey_usersWithinTwoWeeksIneligible() {
     final Instant twoWeeksMinusOneDayAgo =
         PROVIDED_CLOCK.instant().minus((2 * 7) - 1, ChronoUnit.DAYS);
-    DbUserAccessTier userAccessTier =
-        new DbUserAccessTier().setFirstEnabled(Timestamp.from(twoWeeksMinusOneDayAgo));
-    when(mockUserAccessTierDao.getByUserAndAccessTier(user, registeredAccessTier))
-        .thenReturn(Optional.of(userAccessTier));
+    user.setCreationTime(Timestamp.from(twoWeeksMinusOneDayAgo));
     assertThat(newUserSatisfactionSurveyService.eligibleToTakeSurvey(user)).isFalse();
   }
 
@@ -106,10 +74,7 @@ class NewUserSatisfactionSurveyServiceTest {
   public void testEligibleToTakeSurvey_ineligibleAfterTwoMonths() {
     final Instant twoMonthsTwoWeeksOneDayAgo =
         PROVIDED_CLOCK.instant().minus(61 + (2 * 7) + 1, ChronoUnit.DAYS);
-    DbUserAccessTier userAccessTier =
-        new DbUserAccessTier().setFirstEnabled(Timestamp.from(twoMonthsTwoWeeksOneDayAgo));
-    when(mockUserAccessTierDao.getByUserAndAccessTier(user, registeredAccessTier))
-        .thenReturn(Optional.of(userAccessTier));
+    user.setCreationTime(Timestamp.from(twoMonthsTwoWeeksOneDayAgo));
     assertThat(newUserSatisfactionSurveyService.eligibleToTakeSurvey(user)).isFalse();
   }
 }


### PR DESCRIPTION
Description:

Use account creation time instead of RT access time for new user survey eligibility.

For reviewer: Should this use the user's `first_sign_in_time` instead? What state is a `user` in if they don't have a `first_sign_in_time`?

I did not test this locally as I think unit tests suffice. Let me know if that isn't the case.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
