### PR TITLE
[DT-75][risk=no] Send attribute with PFHH survey selections

### DIFF
--- a/ui/src/app/cohort-search/tree/tree.component.tsx
+++ b/ui/src/app/cohort-search/tree/tree.component.tsx
@@ -190,14 +190,9 @@ export const CriteriaTree = fp.flow(
       const { concept, domain, selectedIds, source } = this.props;
       if (source === 'conceptSetDetails') {
         if (prevProps.concept !== concept) {
-          const { cdrVersionId } = currentWorkspaceStore.getValue();
           this.setState({ children: concept, loading: false });
           if (domain === Domain.SURVEY) {
-            const rootSurveys = ppiSurveys.getValue();
-            if (!rootSurveys[cdrVersionId]) {
-              rootSurveys[cdrVersionId] = concept;
-              ppiSurveys.next(rootSurveys);
-            }
+            this.setPPISurveys(concept);
           }
         }
       }
@@ -226,11 +221,7 @@ export const CriteriaTree = fp.flow(
           workspace,
         } = this.props;
         this.setState({ loading: true });
-        const {
-          cdrVersionId,
-          id: workspaceId,
-          namespace,
-        } = currentWorkspaceStore.getValue();
+        const { id: workspaceId, namespace } = currentWorkspaceStore.getValue();
         const criteriaType =
           domain === Domain.DRUG ? CriteriaType.ATC.toString() : type;
         const promises = [
@@ -315,6 +306,7 @@ export const CriteriaTree = fp.flow(
                 (child) => child.name === selectedSurvey
               ),
             });
+            this.setPPISurveys(rootNodes);
           } else {
             // Temp: This should be handle in API
             this.updatePpiSurveys(
@@ -338,11 +330,7 @@ export const CriteriaTree = fp.flow(
                 : rootNodes,
           });
           if (domain === Domain.SURVEY) {
-            const rootSurveys = ppiSurveys.getValue();
-            if (!rootSurveys[cdrVersionId]) {
-              rootSurveys[cdrVersionId] = rootNodes;
-              ppiSurveys.next(rootSurveys);
-            }
+            this.setPPISurveys(rootNodes);
           }
         }
       } catch (error) {
@@ -350,6 +338,15 @@ export const CriteriaTree = fp.flow(
         this.setState({ error: true });
       } finally {
         this.setState({ loading: false });
+      }
+    }
+
+    setPPISurveys(rootSurveyList: Criteria[]) {
+      const { cdrVersionId } = currentWorkspaceStore.getValue();
+      const rootSurveys = ppiSurveys.getValue();
+      if (!rootSurveys[cdrVersionId]) {
+        rootSurveys[cdrVersionId] = rootSurveyList;
+        ppiSurveys.next(rootSurveys);
       }
     }
 
@@ -367,7 +364,7 @@ export const CriteriaTree = fp.flow(
       const {
         node: { domainId, isStandard, type },
       } = this.props;
-      const { cdrVersionId, id, namespace } = currentWorkspaceStore.getValue();
+      const { id, namespace } = currentWorkspaceStore.getValue();
       if (selectedSurveyChild && selectedSurveyChild.length > 0) {
         cohortBuilderApi()
           .findCriteriaBy(
@@ -383,11 +380,7 @@ export const CriteriaTree = fp.flow(
           );
       } else {
         this.setState({ children: resp });
-        const rootSurveys = ppiSurveys.getValue();
-        if (!rootSurveys[cdrVersionId]) {
-          rootSurveys[cdrVersionId] = resp;
-          ppiSurveys.next(rootSurveys);
-        }
+        this.setPPISurveys(resp);
       }
     }
 


### PR DESCRIPTION
Add `PERSONALFAMILYHEALTHHISTORY` attribute to selections made from the Personal and Family Health History survey

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
