### PR TITLE
[DT-122][risk=no] Removed processing for personal medical history and family  health history

### DIFF
--- a/api/db-cdr/generate-cdr/stage-redcap-files.py
+++ b/api/db-cdr/generate-cdr/stage-redcap-files.py
@@ -15,7 +15,6 @@ from os.path import isfile, join
 surveys = ['ENGLISHBasics_DataDictionary',
            'ENGLISHLifestyle_DataDictionary',
            'ENGLISHOverallHealth_DataDictionary',
-           'ENGLISHPersonalMedicalHistory_DataDictionary',
            'ENGLISHHealthCareAccessUtiliza_DataDictionary',
            'ENGLISHNewYearMinuteSurveyOnCO_DataDictionary',
            'ENGLISHSocialDeterminantsOfHea_DataDictionary',
@@ -137,9 +136,6 @@ def main():
         blob.upload_from_filename(home_dir + "/" + f)
 
     # These files are static and never change moving forward
-    bucket.copy_blob(bucket.blob('redcap/familyhealthhistory_staged.csv'),
-                     bucket,
-                     dataset + '/cdr_csv_files/familyhealthhistory_staged.csv')
     bucket.copy_blob(bucket.blob('redcap/cope_staged.csv'),
                      bucket,
                      dataset + '/cdr_csv_files/cope_staged.csv')


### PR DESCRIPTION
Description:
---
- Removed Personal medical history and family health history processing
- Updated cdr-indexing build jobs [PR#64](https://github.com/all-of-us/cdr-indices/pull/64)

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
