### PR TITLE
[DT-140][risk=no] Fix hidden/overlapping content in demographics lists

### DIFF
--- a/ui/src/app/cohort-search/cohort-search/cohort-search.component.tsx
+++ b/ui/src/app/cohort-search/cohort-search/cohort-search.component.tsx
@@ -449,10 +449,7 @@ export const CohortSearch = fp.flow(
                 }
               >
                 {domain === Domain.PERSON ? (
-                  <div
-                    data-test-id='demographics'
-                    style={{ flex: 1, overflow: 'auto' }}
-                  >
+                  <div data-test-id='demographics'>
                     <Demographics
                       criteriaType={type}
                       select={this.addSelection}

--- a/ui/src/app/cohort-search/demographics/demographics.component.tsx
+++ b/ui/src/app/cohort-search/demographics/demographics.component.tsx
@@ -44,7 +44,7 @@ const styles = reactStyles({
   countPreview: {
     backgroundColor: colorWithWhiteness(colors.secondary, 0.8),
     padding: '0.5rem',
-    margin: '0 2.5%',
+    margin: '0.5rem',
     width: '35%',
   },
   option: {
@@ -66,9 +66,9 @@ const styles = reactStyles({
   },
   selectList: {
     alignItems: 'center',
-    display: 'flex',
     marginRight: '1rem',
     maxHeight: '15rem',
+    overflow: 'auto',
     padding: '0.5rem 0 0 0.25rem',
   },
   slider: {
@@ -93,6 +93,18 @@ const ageNode = {
   type: CriteriaType.AGE,
   value: '',
 };
+// Forces scrollbar to be visible when the container has overlapping content
+const scrollbarCSS = `
+  .show-scrollbar::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 7px;
+  }
+  .show-scrollbar::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba(0, 0, 0, .5);
+    box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+  }
+`;
 
 const ageTypes = [
   { label: 'Current Age', type: AttrName.AGE },
@@ -448,7 +460,8 @@ export class Demographics extends React.Component<Props, State> {
     ) : (
       // List of selectable criteria used for Race, Ethnicity, Gender and Sex
       <React.Fragment>
-        <div style={styles.selectList}>
+        <style>{scrollbarCSS}</style>
+        <div className='show-scrollbar' style={styles.selectList}>
           <div style={{ margin: '0.25rem 0', overflow: 'auto', width: '100%' }}>
             {nodes.map((opt, o) => (
               <div key={o} style={styles.option}>


### PR DESCRIPTION
- Fixes issue where demographics lists in CB with more than 10 options start to overlap the parent container
- Add styles to force scrollbar to be visible when scrolling is necessary to see all options

Before:

https://user-images.githubusercontent.com/40036095/203242498-866ae0be-8c92-453e-8b37-f00d52c349b0.mov

After:

https://user-images.githubusercontent.com/40036095/203242551-e73e6080-fa01-4cd9-aefa-85a2a5976e10.mov

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
