### PR TITLE
[DT-138][risk=no] updating BQ SQL generator to include long read wgs data

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -668,10 +668,10 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   private static SearchParameter longReadWholeGenomeVariant() {
     return new SearchParameter()
-            .domain(Domain.LR_WHOLE_GENOME_VARIANT.toString())
-            .group(false)
-            .standard(false)
-            .ancestorData(false);
+        .domain(Domain.LR_WHOLE_GENOME_VARIANT.toString())
+        .group(false)
+        .standard(false)
+        .ancestorData(false);
   }
 
   private static SearchParameter survey() {
@@ -1485,12 +1485,12 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   @Test
   public void countParticipantsLongReadWholeGenomeVariant() {
     CohortDefinition cohortDefinition =
-            createCohortDefinition(
-                    Domain.LR_WHOLE_GENOME_VARIANT.toString(),
-                    ImmutableList.of(longReadWholeGenomeVariant()),
-                    new ArrayList<>());
+        createCohortDefinition(
+            Domain.LR_WHOLE_GENOME_VARIANT.toString(),
+            ImmutableList.of(longReadWholeGenomeVariant()),
+            new ArrayList<>());
     assertParticipants(
-            controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
+        controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
   }
 
   @Test

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -666,6 +666,14 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
         .ancestorData(false);
   }
 
+  private static SearchParameter longReadWholeGenomeVariant() {
+    return new SearchParameter()
+            .domain(Domain.LR_WHOLE_GENOME_VARIANT.toString())
+            .group(false)
+            .standard(false)
+            .ancestorData(false);
+  }
+
   private static SearchParameter survey() {
     return new SearchParameter()
         .domain(Domain.SURVEY.toString())
@@ -1472,6 +1480,17 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             new ArrayList<>());
     assertParticipants(
         controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
+  }
+
+  @Test
+  public void countParticipantsLongReadWholeGenomeVariant() {
+    CohortDefinition cohortDefinition =
+            createCohortDefinition(
+                    Domain.LR_WHOLE_GENOME_VARIANT.toString(),
+                    ImmutableList.of(longReadWholeGenomeVariant()),
+                    new ArrayList<>());
+    assertParticipants(
+            controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
   }
 
   @Test

--- a/api/src/bigquerytest/resources/bigquery/cbdata/cb_search_person_data.json
+++ b/api/src/bigquerytest/resources/bigquery/cbdata/cb_search_person_data.json
@@ -12,7 +12,8 @@
     "has_physical_measurement_data": 1,
     "has_ppi_survey_data": 1,
     "has_fitbit": 1,
-    "has_whole_genome_variant": 1
+    "has_whole_genome_variant": 1,
+    "has_lr_whole_genome_variant": 1
   },
   {
     "person_id": 2,

--- a/api/src/bigquerytest/resources/bigquery/schema/cb_search_person.json
+++ b/api/src/bigquerytest/resources/bigquery/schema/cb_search_person.json
@@ -63,5 +63,10 @@
     "type": "integer",
     "name": "has_whole_genome_variant",
     "mode": "nullable"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "has_lr_whole_genome_variant",
+    "type": "INTEGER"
   }
 ]

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
@@ -69,7 +69,9 @@ public final class SearchGroupItemQueryBuilder {
           Domain.PHYSICAL_MEASUREMENT,
           "has_physical_measurement_data",
           Domain.ARRAY_DATA,
-          "has_array_data");
+          "has_array_data",
+          Domain.LR_WHOLE_GENOME_VARIANT,
+          "has_lr_whole_genome_variant");
 
   // sql parts to help construct BigQuery sql statements
   private static final String OR = " OR ";
@@ -783,6 +785,7 @@ public final class SearchGroupItemQueryBuilder {
     Domain domain = Domain.fromValue(searchGroupItem.getType());
     return Domain.FITBIT.equals(domain)
         || Domain.WHOLE_GENOME_VARIANT.equals(domain)
+        || Domain.LR_WHOLE_GENOME_VARIANT.equals(domain)
         || Domain.ARRAY_DATA.equals(domain)
         || (searchGroupItem.getSearchParameters().size() == 1
             && searchGroupItem.getSearchParameters().stream()


### PR DESCRIPTION
updating BQ SQL generator to include long read wgs data


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
