### PR TITLE
[risk=low][RW-5847] use getExistingNotebooks/Names everywhere

### DIFF
--- a/ui/src/app/components/rename-modal.tsx
+++ b/ui/src/app/components/rename-modal.tsx
@@ -13,6 +13,7 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
+import { dropNotebookFileSuffix } from 'app/pages/analysis/util';
 import colors from 'app/styles/colors';
 import { reactStyles, summarizeErrors } from 'app/utils';
 import { nameValidationFormat, toDisplay } from 'app/utils/resources';
@@ -70,8 +71,17 @@ export class RenameModal extends React.Component<Props, States> {
       newName = this.props.nameFormat(newName);
     }
     const errors = validate(
-      { newName: newName?.trim() },
-      { newName: nameValidationFormat(existingNames, resourceType) }
+      // we expect the notebook name to lack the .ipynb suffix
+      // but we pass it through drop-suffix to also catch the case where the user has explicitly typed it in
+      {
+        newName:
+          resourceType === ResourceType.NOTEBOOK
+            ? dropNotebookFileSuffix(newName)
+            : newName?.trim(),
+      },
+      {
+        newName: nameValidationFormat(existingNames, resourceType),
+      }
     );
     return (
       <Modal loading={saving}>

--- a/ui/src/app/components/rename-modal.tsx
+++ b/ui/src/app/components/rename-modal.tsx
@@ -15,7 +15,7 @@ import {
 import { TooltipTrigger } from 'app/components/popups';
 import colors from 'app/styles/colors';
 import { reactStyles, summarizeErrors } from 'app/utils';
-import { toDisplay } from 'app/utils/resources';
+import { nameValidationFormat, toDisplay } from 'app/utils/resources';
 
 const styles = reactStyles({
   fieldHeader: {
@@ -25,44 +25,6 @@ const styles = reactStyles({
     display: 'block',
   },
 });
-
-/* Name validation for resources.
- *
- * Notebooks have characters that are disallowed. Specifically, Jupyter only disallows :/\
- * but Terra disallows a larger list of characters.  Those characters are listed in
- * `const notebookNameValidator` in this file:
- * https://github.com/DataBiosphere/terra-ui/blob/dev/src/components/notebook-utils.js#L42
- *
- * Other AoU resource types do not have the same name restriction and only block slashes.
- */
-export const nameValidationFormat = (
-  existingNames,
-  resourceType: ResourceType
-) =>
-  resourceType === ResourceType.NOTEBOOK
-    ? {
-        presence: { allowEmpty: false },
-        format: {
-          pattern: /^[^@#$%*+=?,[\]:;/\\]*$/,
-          message:
-            "can't contain these characters: @ # $ % * + = ? , [ ] : ; / \\ ",
-        },
-        exclusion: {
-          within: existingNames,
-          message: 'already exists',
-        },
-      }
-    : {
-        presence: { allowEmpty: false },
-        format: {
-          pattern: /^[^\/]*$/,
-          message: "can't contain a slash",
-        },
-        exclusion: {
-          within: existingNames,
-          message: 'already exists',
-        },
-      };
 
 interface Props {
   hideDescription?: boolean;

--- a/ui/src/app/pages/analysis/new-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-notebook-modal.tsx
@@ -32,13 +32,23 @@ interface Props {
 }
 
 export const NewNotebookModal = (props: Props) => {
+  const { onBack, onClose, workspace } = props;
+
   const [name, setName] = useState('');
   const [kernel, setKernel] = useState(Kernels.Python3);
   const [nameTouched, setNameTouched] = useState(false);
   const [existingNotebookNameList, setExistingNotebookNameList] = useState([]);
   const [navigate] = useNavigation();
 
-  const { onBack, onClose, workspace } = props;
+  useEffect(() => {
+    const { existingNameList } = props;
+    if (!!existingNameList) {
+      setExistingNotebookNameList(existingNameList);
+    } else {
+      getExistingNotebookNames(workspace).then(setExistingNotebookNameList);
+    }
+  }, [props.existingNameList]);
+
   const errors = validate(
     { name, kernel },
     {
@@ -49,17 +59,6 @@ export const NewNotebookModal = (props: Props) => {
       ),
     }
   );
-
-  useEffect(() => {
-    const { existingNameList } = props;
-    if (!!existingNameList) {
-      setExistingNotebookNameList(existingNameList);
-    } else {
-      getExistingNotebookNames(workspace).then((notebookList) => {
-        setExistingNotebookNameList(notebookList);
-      });
-    }
-  }, [props.existingNameList]);
 
   const create = () => {
     userMetricsApi().updateRecentResource(workspace.namespace, workspace.id, {

--- a/ui/src/app/pages/analysis/new-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-notebook-modal.tsx
@@ -14,13 +14,16 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
-import { nameValidationFormat } from 'app/components/rename-modal';
-import { getExistingNotebookNames } from 'app/pages/analysis/util';
+import {
+  dropNotebookFileSuffix,
+  getExistingNotebookNames,
+} from 'app/pages/analysis/util';
 import { userMetricsApi } from 'app/services/swagger-fetch-clients';
 import { summarizeErrors } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { useNavigation } from 'app/utils/navigation';
 import { Kernels } from 'app/utils/notebook-kernels';
+import { nameValidationFormat } from 'app/utils/resources';
 
 import { appendNotebookFileSuffix } from './util';
 
@@ -50,7 +53,9 @@ export const NewNotebookModal = (props: Props) => {
   }, [props.existingNameList]);
 
   const errors = validate(
-    { name, kernel },
+    // we expect the notebook name to lack the .ipynb suffix
+    // but we pass it through drop-suffix to also catch the case where the user has explicitly typed it in
+    { name: dropNotebookFileSuffix(name), kernel },
     {
       kernel: { presence: { allowEmpty: false } },
       name: nameValidationFormat(

--- a/ui/src/app/pages/analysis/notebook-list.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.tsx
@@ -15,11 +15,7 @@ import { ResourceList } from 'app/components/resource-list';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { NewNotebookModal } from 'app/pages/analysis/new-notebook-modal';
-import {
-  notebooksApi,
-  profileApi,
-  workspacesApi,
-} from 'app/services/swagger-fetch-clients';
+import { profileApi, workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { withCurrentWorkspace } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
@@ -28,7 +24,7 @@ import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
 
-import { dropNotebookFileSuffix } from './util';
+import { dropNotebookFileSuffix, getExistingNotebooks } from './util';
 
 const styles = {
   heading: {
@@ -150,19 +146,16 @@ export const NotebookList = withCurrentWorkspace()(
 
     private async loadNotebooks() {
       try {
-        const {
-          workspace: { namespace, id },
-        } = this.props;
+        const { workspace } = this.props;
         this.setState({ loading: true });
-        const notebookList = await notebooksApi().getNoteBookList(
-          namespace,
-          id
-        );
-        this.setState({ notebookList });
-        const notebookNameList = notebookList.map((fd) =>
-          dropNotebookFileSuffix(fd.name)
-        );
-        this.setState({ notebookNameList });
+        getExistingNotebooks(workspace).then((notebookList) => {
+          this.setState({
+            notebookList,
+            notebookNameList: notebookList.map((fd) =>
+              dropNotebookFileSuffix(fd.name)
+            ),
+          });
+        });
       } catch (error) {
         console.error(error);
       } finally {

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -25,7 +25,9 @@ export const getExistingNotebooks = (workspace): Promise<FileDetail[]> => {
   return notebooksApi().getNoteBookList(namespace, id);
 };
 
-export const getExistingNotebookNames = async (workspace): Promise<string[]> =>
-  (await getExistingNotebooks(workspace)).map((fd) =>
-    dropNotebookFileSuffix(fd.name)
-  );
+export const getExistingNotebookNames = async (
+  workspace
+): Promise<string[]> => {
+  const notebooks = await getExistingNotebooks(workspace);
+  return notebooks.map((fd) => dropNotebookFileSuffix(fd.name));
+};

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -6,7 +6,7 @@ const notebookExtension = '.ipynb';
 
 export function dropNotebookFileSuffix(filename: string) {
   if (filename?.endsWith(notebookExtension)) {
-    filename = filename.substring(0, filename.length - 6);
+    return filename.substring(0, filename.length - notebookExtension.length);
   }
 
   return filename;
@@ -14,7 +14,7 @@ export function dropNotebookFileSuffix(filename: string) {
 
 export function appendNotebookFileSuffix(filename: string) {
   if (filename && !filename.endsWith(notebookExtension)) {
-    filename = filename + notebookExtension;
+    return filename + notebookExtension;
   }
 
   return filename;

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -1,3 +1,5 @@
+import { FileDetail } from 'generated/fetch';
+
 import { notebooksApi } from 'app/services/swagger-fetch-clients';
 
 const notebookExtension = '.ipynb';
@@ -18,8 +20,12 @@ export function appendNotebookFileSuffix(filename: string) {
   return filename;
 }
 
-export const getExistingNotebookNames = async (workspace) => {
+export const getExistingNotebooks = (workspace): Promise<FileDetail[]> => {
   const { namespace, id } = workspace;
-  const notebook = await notebooksApi().getNoteBookList(namespace, id);
-  return notebook.map((fd) => dropNotebookFileSuffix(fd.name));
+  return notebooksApi().getNoteBookList(namespace, id);
 };
+
+export const getExistingNotebookNames = async (workspace): Promise<string[]> =>
+  (await getExistingNotebooks(workspace)).map((fd) =>
+    dropNotebookFileSuffix(fd.name)
+  );

--- a/ui/src/app/pages/data/concept/concept-add-modal.tsx
+++ b/ui/src/app/pages/data/concept/concept-add-modal.tsx
@@ -23,12 +23,12 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
-import { nameValidationFormat } from 'app/components/rename-modal';
 import { Spinner, SpinnerOverlay } from 'app/components/spinners';
 import { conceptSetsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { reactStyles, summarizeErrors, withCurrentWorkspace } from 'app/utils';
 import { conceptSetUpdating } from 'app/utils/navigation';
+import { nameValidationFormat } from 'app/utils/resources';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 const styles = reactStyles({

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -30,7 +30,6 @@ import {
 } from 'app/components/inputs';
 import { Modal, ModalFooter, ModalTitle } from 'app/components/modals';
 import { PopupTrigger, TooltipTrigger } from 'app/components/popups';
-import { nameValidationFormat } from 'app/components/rename-modal';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { EditComponentReact } from 'app/icons/edit';
@@ -54,6 +53,7 @@ import {
   NavigationProps,
   setSidebarActiveIconStore,
 } from 'app/utils/navigation';
+import { nameValidationFormat } from 'app/utils/resources';
 import { MatchParams } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -11,10 +11,6 @@ import {
   PrePackagedConceptSetEnum,
 } from 'generated/fetch';
 
-import {
-  appendNotebookFileSuffix,
-  dropNotebookFileSuffix,
-} from '../../analysis/util';
 import { Select } from 'app/components/inputs';
 import { Tooltip } from 'app/components/popups';
 import {

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -11,6 +11,10 @@ import {
   PrePackagedConceptSetEnum,
 } from 'generated/fetch';
 
+import {
+  appendNotebookFileSuffix,
+  dropNotebookFileSuffix,
+} from '../../analysis/util';
 import { Select } from 'app/components/inputs';
 import { Tooltip } from 'app/components/popups';
 import {
@@ -104,6 +108,35 @@ describe('ExportDatasetModal', () => {
     );
   });
 
+  it('should export to a new notebook if the user types in the file suffix', async () => {
+    const wrapper = mount(component(testProps));
+    const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
+    const notebookName = 'MyNotebook.ipynb';
+    const expectedNotebookName = notebookName;
+    const expectedDatasetRequest: DataSetRequest = {
+      dataSetId: dataset.id,
+      name: dataset.name,
+      domainValuePairs: dataset.domainValuePairs,
+    };
+
+    wrapper
+      .find('[data-test-id="notebook-name-input"]')
+      .first()
+      .simulate('change', { target: { value: notebookName } });
+    findExportButton(wrapper).simulate('click');
+    expect(exportSpy).toHaveBeenCalledWith(
+      workspace.namespace,
+      workspace.id,
+      expect.objectContaining({
+        dataSetRequest: expectedDatasetRequest,
+        newNotebook: true,
+        notebookName: expectedNotebookName,
+        kernelType: KernelTypeEnum.Python,
+        generateGenomicsAnalysisCode: false,
+      })
+    );
+  });
+
   it('should disable export if no name is provided', async () => {
     const wrapper = mount(component(testProps));
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
@@ -120,7 +153,7 @@ describe('ExportDatasetModal', () => {
     expect(wrapper.find(Tooltip).text()).toBe("Notebook name can't be blank");
   });
 
-  it('should disable export if a conflicting name is provided', async () => {
+  it('should disable export if a conflicting name is provided, without the suffix', async () => {
     const existingNotebookName = 'existing notebook.ipynb';
     notebooksApiStub.notebookList = [
       {
@@ -135,6 +168,31 @@ describe('ExportDatasetModal', () => {
       .first()
       .simulate('change', {
         target: { value: dropNotebookFileSuffix(existingNotebookName) },
+      });
+    await waitOneTickAndUpdate(wrapper);
+    findExportButton(wrapper).simulate('click');
+    expect(findExportButton(wrapper).props().disabled).toBeTruthy();
+
+    findExportButton(wrapper).simulate('mouseenter');
+    expect(wrapper.find(Tooltip).text()).toBe('Notebook name already exists');
+    expect(exportSpy).not.toHaveBeenCalled();
+  });
+
+  it('should disable export if a conflicting name is provided, including the suffix', async () => {
+    const existingNotebookName = 'existing notebook.ipynb';
+    notebooksApiStub.notebookList = [
+      {
+        name: existingNotebookName,
+      },
+    ];
+    const wrapper = mount(component(testProps));
+    const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
+
+    wrapper
+      .find('[data-test-id="notebook-name-input"]')
+      .first()
+      .simulate('change', {
+        target: { value: appendNotebookFileSuffix(existingNotebookName) },
       });
     await waitOneTickAndUpdate(wrapper);
     findExportButton(wrapper).simulate('click');

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -25,7 +25,10 @@ import {
 } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
 import { Spinner } from 'app/components/spinners';
-import { appendNotebookFileSuffix } from 'app/pages/analysis/util';
+import {
+  appendNotebookFileSuffix,
+  getExistingNotebookNames,
+} from 'app/pages/analysis/util';
 import { dataSetApi, notebooksApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { reactStyles, summarizeErrors, withCurrentWorkspace } from 'app/utils';
@@ -222,13 +225,8 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
   }
 
   useEffect(() => {
-    notebooksApi()
-      .getNoteBookList(workspace.namespace, workspace.id)
-      .then((notebooks) =>
-        setExistingNotebooks(
-          notebooks.map((fileDetail) => fileDetail.name.slice(0, -6))
-        )
-      )
+    getExistingNotebookNames(workspace)
+      .then(setExistingNotebooks)
       .catch(() => setExistingNotebooks([])); // If the request fails, at least let the user create new notebooks
   }, [workspace]);
 

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -68,7 +68,8 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
   );
   const [isExporting, setIsExporting] = useState(false);
   const [creatingNewNotebook, setCreatingNewNotebook] = useState(true);
-  const [notebookName, setNotebookName] = useState('');
+  const [notebookNameWithoutSuffix, setNotebookNameWithoutSuffix] =
+    useState('');
   const [codePreview, setCodePreview] = useState(null);
   const [loadingNotebook, setIsLoadingNotebook] = useState(false);
   const [errorMsg, setErrorMsg] = useState(null);
@@ -104,7 +105,7 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
       kernelType,
       genomicsAnalysisTool,
       generateGenomicsAnalysisCode: hasWgs(),
-      notebookName: appendNotebookFileSuffix(notebookName),
+      notebookName: appendNotebookFileSuffix(notebookNameWithoutSuffix),
       newNotebook: creatingNewNotebook,
     };
   }
@@ -123,7 +124,9 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
       // Open notebook in a new tab and return back to the Data tab
       const notebookUrl =
         `/workspaces/${workspace.namespace}/${workspace.id}/notebooks/preview/` +
-        appendNotebookFileSuffix(encodeURIComponentStrict(notebookName));
+        encodeURIComponentStrict(
+          appendNotebookFileSuffix(notebookNameWithoutSuffix)
+        );
       navigateByUrl(notebookUrl);
     } catch (e) {
       console.error(e);
@@ -179,7 +182,7 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
 
   function onNotebookSelect(value) {
     setCreatingNewNotebook(value === '');
-    setNotebookName(value);
+    setNotebookNameWithoutSuffix(value);
     setErrorMsg(null);
 
     if (value === '') {
@@ -238,7 +241,7 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
 
   const errors = {
     ...validate(
-      { notebookName },
+      { notebookName: notebookNameWithoutSuffix },
       {
         notebookName: {
           presence: { allowEmpty: false },
@@ -284,7 +287,7 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
           <ModalBody>
             <div style={{ marginTop: '1rem' }}>
               <Select
-                value={creatingNewNotebook ? '' : notebookName}
+                value={creatingNewNotebook ? '' : notebookNameWithoutSuffix}
                 data-test-id='select-notebook'
                 options={selectOptions}
                 onChange={(v) => onNotebookSelect(v)}
@@ -297,8 +300,8 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
                   Notebook Name
                 </SmallHeader>
                 <TextInput
-                  onChange={(v) => setNotebookName(v)}
-                  value={notebookName}
+                  onChange={(v) => setNotebookNameWithoutSuffix(v)}
+                  value={notebookNameWithoutSuffix}
                   data-test-id='notebook-name-input'
                 />
               </React.Fragment>

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -182,12 +182,12 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
     }
   }
 
-  function onNotebookSelect(value) {
-    setCreatingNewNotebook(value === '');
-    setNotebookNameWithoutSuffix(value);
+  function onNotebookSelect(nameWithoutSuffix) {
+    setCreatingNewNotebook(nameWithoutSuffix === '');
+    setNotebookNameWithoutSuffix(nameWithoutSuffix);
     setErrorMsg(null);
 
-    if (value === '') {
+    if (nameWithoutSuffix === '') {
       setCreatingNewNotebook(true);
     } else {
       setCreatingNewNotebook(false);
@@ -196,7 +196,7 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
         .getNotebookKernel(
           workspace.namespace,
           workspace.id,
-          appendNotebookFileSuffix(value)
+          appendNotebookFileSuffix(nameWithoutSuffix)
         )
         .then((resp) => setKernelType(resp.kernelType))
         .catch(() =>

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -248,7 +248,7 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
       { notebookName: dropNotebookFileSuffix(notebookNameWithoutSuffix) },
       {
         notebookName: nameValidationFormat(
-          existingNotebooks,
+          creatingNewNotebook ? existingNotebooks : [],
           ResourceType.NOTEBOOK
         ),
       }

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -124,7 +124,6 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
         workspace.id,
         createExportDatasetRequest()
       );
-      // Open notebook in a new tab and return back to the Data tab
       const notebookUrl =
         `/workspaces/${workspace.namespace}/${workspace.id}/notebooks/preview/` +
         encodeURIComponentStrict(

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -164,3 +164,41 @@ export function convertToResource(
     adminLocked,
   };
 }
+
+/* Name validation for resources.
+ *
+ * Notebooks have characters that are disallowed. Specifically, Jupyter only disallows :/\
+ * but Terra disallows a larger list of characters.  Those characters are listed in
+ * `const notebookNameValidator` in this file:
+ * https://github.com/DataBiosphere/terra-ui/blob/dev/src/components/notebook-utils.js#L42
+ *
+ * Other AoU resource types do not have the same name restriction and only block slashes.
+ */
+export const nameValidationFormat = (
+  existingNames,
+  resourceType: ResourceType
+) =>
+  resourceType === ResourceType.NOTEBOOK
+    ? {
+        presence: { allowEmpty: false },
+        format: {
+          pattern: /^[^@#$%*+=?,[\]:;/\\]*$/,
+          message:
+            "can't contain these characters: @ # $ % * + = ? , [ ] : ; / \\ ",
+        },
+        exclusion: {
+          within: existingNames,
+          message: 'already exists',
+        },
+      }
+    : {
+        presence: { allowEmpty: false },
+        format: {
+          pattern: /^[^\/]*$/,
+          message: "can't contain a slash",
+        },
+        exclusion: {
+          within: existingNames,
+          message: 'already exists',
+        },
+      };


### PR DESCRIPTION
Added in #7160 and applicable in several areas.

Also allow users to type in the full notebook name for export-dataset if they wish; and a few small refactorings.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
