### PR TITLE
[RW-9027][risk=no] Add new user satisfaction survey modal

### DIFF
--- a/ui/src/app/components/multiple-choice-question.tsx
+++ b/ui/src/app/components/multiple-choice-question.tsx
@@ -22,7 +22,6 @@ const styles = reactStyles({
     color: colors.primary,
     fontSize: '18px',
     lineHeight: '1.25rem',
-    marginBottom: '0.5rem',
   },
 });
 
@@ -86,6 +85,7 @@ interface MultipleChoiceQuestionProps {
   selected: any | any[];
   onChange: (any) => void;
   style?: CSSProperties;
+  questionStyle?: CSSProperties;
   multiple?: boolean;
   horizontalOptions?: boolean;
   enableExpansionControls?: boolean;
@@ -106,6 +106,7 @@ export const MultipleChoiceQuestion = (props: MultipleChoiceQuestionProps) => {
     question,
     selected,
     style,
+    questionStyle,
   } = props;
 
   const handleQuestionChange = (
@@ -237,7 +238,7 @@ export const MultipleChoiceQuestion = (props: MultipleChoiceQuestionProps) => {
 
   return (
     <div style={{ ...styles.container, ...style }}>
-      <div style={{ ...styles.question }}>{question}</div>
+      <div style={{ ...styles.question, ...questionStyle }}>{question}</div>
       {multiple && (
         <div style={{ color: colors.primary }}>Select all that apply.</div>
       )}

--- a/ui/src/app/components/multiple-choice-question.tsx
+++ b/ui/src/app/components/multiple-choice-question.tsx
@@ -4,6 +4,7 @@ import { CSSProperties } from 'react';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { CheckBox, RadioButton } from 'app/components/inputs';
 import { TooltipTrigger } from 'app/components/popups';
+import { surveyStyles } from 'app/components/surveys';
 import colors from 'app/styles/colors';
 import { reactStyles, useId } from 'app/utils';
 
@@ -16,12 +17,6 @@ const styles = reactStyles({
   expansionButton: {
     fontSize: 12,
     textDecoration: 'underline',
-  },
-  question: {
-    fontWeight: 'bold',
-    color: colors.primary,
-    fontSize: '18px',
-    lineHeight: '1.25rem',
   },
 });
 
@@ -238,7 +233,9 @@ export const MultipleChoiceQuestion = (props: MultipleChoiceQuestionProps) => {
 
   return (
     <div style={{ ...styles.container, ...style }}>
-      <div style={{ ...styles.question, ...questionStyle }}>{question}</div>
+      <div style={{ ...surveyStyles.question, ...questionStyle }}>
+        {question}
+      </div>
       {multiple && (
         <div style={{ color: colors.primary }}>Select all that apply.</div>
       )}

--- a/ui/src/app/components/multiple-choice-question.tsx
+++ b/ui/src/app/components/multiple-choice-question.tsx
@@ -22,6 +22,7 @@ const styles = reactStyles({
     color: colors.primary,
     fontSize: '18px',
     lineHeight: '1.25rem',
+    marginBottom: '0.5rem',
   },
 });
 

--- a/ui/src/app/components/multiple-choice-question.tsx
+++ b/ui/src/app/components/multiple-choice-question.tsx
@@ -157,7 +157,7 @@ export const MultipleChoiceQuestion = (props: MultipleChoiceQuestionProps) => {
       value,
     } = option;
     return (
-      <FlexColumn style={subOptions && { width: '100%' }}>
+      <FlexColumn key={value} style={subOptions && { width: '100%' }}>
         <FlexRow style={{ alignItems: 'center' }}>
           <Option
             {...{ disabled, disabledText, label, multiple, value }}

--- a/ui/src/app/components/new-user-satisfaction-survey-modal.spec.tsx
+++ b/ui/src/app/components/new-user-satisfaction-survey-modal.spec.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+
+import {
+  CreateNewUserSatisfactionSurvey,
+  NewUserSatisfactionSurveySatisfaction,
+  SurveysApi,
+} from 'generated/fetch';
+
+import { ErrorMessage } from 'app/components/inputs';
+import {
+  registerApiClient,
+  surveysApi,
+} from 'app/services/swagger-fetch-clients';
+import { createNewUserSatisfactionSurveyStore } from 'app/utils/stores';
+
+import { SurveysApiStub } from 'testing/stubs/surveys-api-stub';
+
+import {
+  ADDITIONAL_INFO_MAX_CHARACTERS,
+  NewUserSatisfactionSurveyModal,
+} from './new-user-satisfaction-survey-modal';
+
+describe(NewUserSatisfactionSurveyModal.name, () => {
+  function setNewUserSatisfactionSurveyData<
+    T extends keyof CreateNewUserSatisfactionSurvey
+  >(attribute: T, value: CreateNewUserSatisfactionSurvey[T]) {
+    createNewUserSatisfactionSurveyStore.set({
+      newUserSatisfactionSurveyData: {
+        ...createNewUserSatisfactionSurveyStore.get()
+          .newUserSatisfactionSurveyData,
+        [attribute]: value,
+      },
+    });
+  }
+
+  function setValidNewUserSatisfactionSurveyData() {
+    setNewUserSatisfactionSurveyData(
+      'satisfaction',
+      NewUserSatisfactionSurveySatisfaction.VERYSATISFIED
+    );
+    setNewUserSatisfactionSurveyData('additionalInfo', '');
+  }
+
+  beforeEach(() => {
+    registerApiClient(SurveysApi, new SurveysApiStub());
+    setValidNewUserSatisfactionSurveyData();
+  });
+
+  function createShallowWrapper({
+    onCancel = () => {},
+    onSubmitSuccess = () => {},
+  } = {}) {
+    return shallow(
+      <NewUserSatisfactionSurveyModal
+        onCancel={onCancel}
+        onSubmitSuccess={onSubmitSuccess}
+      />
+    );
+  }
+
+  function findSubmitButton(wrapper: ShallowWrapper) {
+    return wrapper.find({ children: 'Submit' });
+  }
+
+  it('should disable the submit button until a satisfaction value is selected', () => {
+    setNewUserSatisfactionSurveyData('satisfaction', undefined);
+    expect(
+      findSubmitButton(createShallowWrapper()).prop('disabled')
+    ).toBeTruthy();
+
+    setNewUserSatisfactionSurveyData(
+      'satisfaction',
+      NewUserSatisfactionSurveySatisfaction.VERYSATISFIED
+    );
+    expect(
+      findSubmitButton(createShallowWrapper()).prop('disabled')
+    ).toBeFalsy();
+  });
+
+  it('should disable the submit button if additional info exceeds the max length', () => {
+    setNewUserSatisfactionSurveyData(
+      'additionalInfo',
+      'A'.repeat(ADDITIONAL_INFO_MAX_CHARACTERS + 1)
+    );
+    expect(
+      findSubmitButton(createShallowWrapper()).prop('disabled')
+    ).toBeTruthy();
+
+    setNewUserSatisfactionSurveyData(
+      'additionalInfo',
+      'A'.repeat(ADDITIONAL_INFO_MAX_CHARACTERS)
+    );
+    expect(
+      findSubmitButton(createShallowWrapper()).prop('disabled')
+    ).toBeFalsy();
+  });
+
+  it('should disable the submit button while awaiting submission response', async () => {
+    const wrapper = createShallowWrapper();
+    expect(findSubmitButton(wrapper).prop('disabled')).toBeFalsy();
+
+    const submitPromise = findSubmitButton(wrapper).prop('onClick')();
+    expect(findSubmitButton(wrapper).prop('disabled')).toBeTruthy();
+
+    await submitPromise;
+    expect(findSubmitButton(wrapper).prop('disabled')).toBeFalsy();
+  });
+
+  it('should display an error on API failure and remove it on API success', async () => {
+    const wrapper = createShallowWrapper();
+    expect(wrapper.find(ErrorMessage).exists()).toBeFalsy();
+
+    jest
+      .spyOn(surveysApi(), 'createNewUserSatisfactionSurvey')
+      .mockImplementationOnce(() => Promise.reject());
+    await findSubmitButton(wrapper).prop('onClick')();
+    expect(wrapper.find(ErrorMessage).exists()).toBeTruthy();
+
+    jest
+      .spyOn(surveysApi(), 'createNewUserSatisfactionSurvey')
+      .mockImplementationOnce(() => Promise.resolve(new Response()));
+    await findSubmitButton(wrapper).prop('onClick')();
+    expect(wrapper.find(ErrorMessage).exists()).toBeFalsy();
+  });
+});

--- a/ui/src/app/components/new-user-satisfaction-survey-modal.spec.tsx
+++ b/ui/src/app/components/new-user-satisfaction-survey-modal.spec.tsx
@@ -22,9 +22,12 @@ import {
 } from './new-user-satisfaction-survey-modal';
 
 describe(NewUserSatisfactionSurveyModal.name, () => {
-  function setNewUserSatisfactionSurveyData<
+  const setNewUserSatisfactionSurveyData = <
     T extends keyof CreateNewUserSatisfactionSurvey
-  >(attribute: T, value: CreateNewUserSatisfactionSurvey[T]) {
+  >(
+    attribute: T,
+    value: CreateNewUserSatisfactionSurvey[T]
+  ) => {
     createNewUserSatisfactionSurveyStore.set({
       newUserSatisfactionSurveyData: {
         ...createNewUserSatisfactionSurveyStore.get()
@@ -32,36 +35,36 @@ describe(NewUserSatisfactionSurveyModal.name, () => {
         [attribute]: value,
       },
     });
-  }
+  };
 
-  function setValidNewUserSatisfactionSurveyData() {
+  const setValidNewUserSatisfactionSurveyData = () => {
     setNewUserSatisfactionSurveyData(
       'satisfaction',
       NewUserSatisfactionSurveySatisfaction.VERYSATISFIED
     );
     setNewUserSatisfactionSurveyData('additionalInfo', '');
-  }
+  };
 
   beforeEach(() => {
     registerApiClient(SurveysApi, new SurveysApiStub());
     setValidNewUserSatisfactionSurveyData();
   });
 
-  function createShallowWrapper({
+  const createShallowWrapper = ({
     onCancel = () => {},
     onSubmitSuccess = () => {},
-  } = {}) {
+  } = {}) => {
     return shallow(
       <NewUserSatisfactionSurveyModal
         onCancel={onCancel}
         onSubmitSuccess={onSubmitSuccess}
       />
     );
-  }
+  };
 
-  function findSubmitButton(wrapper: ShallowWrapper) {
+  const findSubmitButton = (wrapper: ShallowWrapper) => {
     return wrapper.find({ children: 'Submit' });
-  }
+  };
 
   it('should disable the submit button until a satisfaction value is selected', () => {
     setNewUserSatisfactionSurveyData('satisfaction', undefined);

--- a/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
+++ b/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
@@ -48,10 +48,10 @@ export interface NewUserSatisfactionSurveyModalProps {
   onSubmitSuccess: () => void;
 }
 
-export function NewUserSatisfactionSurveyModal({
+export const NewUserSatisfactionSurveyModal = ({
   onCancel,
   onSubmitSuccess,
-}: NewUserSatisfactionSurveyModalProps) {
+}: NewUserSatisfactionSurveyModalProps) => {
   const { newUserSatisfactionSurveyData } = useStore(
     createNewUserSatisfactionSurveyStore
   );
@@ -141,4 +141,4 @@ export function NewUserSatisfactionSurveyModal({
       </FlexColumn>
     </Modal>
   );
-}
+};

--- a/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
+++ b/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import { useState } from 'react';
+
+import { NewUserSatisfactionSurveySatisfaction } from 'generated/fetch';
+
+import { Button } from 'app/components/buttons';
+import { FlexColumn, FlexRow } from 'app/components/flex';
+import {
+  ErrorMessage,
+  TextAreaWithLengthValidationMessage,
+} from 'app/components/inputs';
+import { Modal } from 'app/components/modals';
+import { MultipleChoiceQuestion } from 'app/components/multiple-choice-question';
+import { surveysApi } from 'app/services/swagger-fetch-clients';
+import colors from 'app/styles/colors';
+import {
+  createNewUserSatisfactionSurveyStore,
+  useStore,
+} from 'app/utils/stores';
+
+const orderedSatisfactionOptions = [
+  {
+    value: NewUserSatisfactionSurveySatisfaction.VERYUNSATISFIED,
+    label: 'Very unsatisfied',
+  },
+  {
+    value: NewUserSatisfactionSurveySatisfaction.UNSATISFIED,
+    label: 'Unsatisfied',
+  },
+  {
+    value: NewUserSatisfactionSurveySatisfaction.NEUTRAL,
+    label: 'Neutral',
+  },
+  {
+    value: NewUserSatisfactionSurveySatisfaction.SATISFIED,
+    label: 'Satisfied',
+  },
+  {
+    value: NewUserSatisfactionSurveySatisfaction.VERYSATISFIED,
+    label: 'Very satisfied',
+  },
+];
+
+export const ADDITIONAL_INFO_MAX_CHARACTERS = 500;
+
+export interface NewUserSatisfactionSurveyModalProps {
+  onCancel: () => void;
+  onSubmitSuccess: () => void;
+}
+
+export function NewUserSatisfactionSurveyModal({
+  onCancel,
+  onSubmitSuccess,
+}: NewUserSatisfactionSurveyModalProps) {
+  const { newUserSatisfactionSurveyData } = useStore(
+    createNewUserSatisfactionSurveyStore
+  );
+  const [submittingRequest, setSubmittingRequest] = useState(false);
+  const [error, setError] = useState(false);
+
+  return (
+    <Modal width={850} onRequestClose={onCancel}>
+      <FlexColumn style={{ gap: '0.5rem' }}>
+        <MultipleChoiceQuestion
+          question='How would you rate your overall satisfaction with the Researcher Workbench?'
+          options={orderedSatisfactionOptions}
+          selected={newUserSatisfactionSurveyData.satisfaction}
+          onChange={(satisfaction: NewUserSatisfactionSurveySatisfaction) => {
+            createNewUserSatisfactionSurveyStore.set({
+              newUserSatisfactionSurveyData: {
+                ...newUserSatisfactionSurveyData,
+                satisfaction: satisfaction,
+              },
+            });
+          }}
+        />
+        <label
+          htmlFor='new-user-satisfaction-survey-additional-info'
+          style={{
+            fontWeight: 'bold',
+            color: colors.primary,
+            fontSize: '18px',
+            lineHeight: '1.25rem',
+          }}
+        >
+          Please explain your selection. What were you expecting? What went
+          well? What didn't go well?
+        </label>
+
+        <TextAreaWithLengthValidationMessage
+          id='new-user-satisfaction-survey-additional-info'
+          onChange={(additionalInfo) => {
+            createNewUserSatisfactionSurveyStore.set({
+              newUserSatisfactionSurveyData: {
+                ...newUserSatisfactionSurveyData,
+                additionalInfo,
+              },
+            });
+          }}
+          initialText={newUserSatisfactionSurveyData.additionalInfo}
+          textBoxStyleOverrides={{ width: '100%' }}
+          heightOverride={{ height: '7rem' }}
+          maxCharacters={ADDITIONAL_INFO_MAX_CHARACTERS}
+        />
+        <FlexRow style={{ justifyContent: 'flex-end' }}>
+          {error && (
+            <ErrorMessage>
+              There was an error processing your request.
+            </ErrorMessage>
+          )}
+        </FlexRow>
+        <FlexRow style={{ justifyContent: 'flex-end', gap: '0.5rem' }}>
+          <Button type='secondary' onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            type='primary'
+            disabled={
+              newUserSatisfactionSurveyData.satisfaction === undefined ||
+              newUserSatisfactionSurveyData.additionalInfo.length > 500 ||
+              submittingRequest
+            }
+            onClick={async () => {
+              setSubmittingRequest(true);
+              try {
+                await surveysApi().createNewUserSatisfactionSurvey(
+                  newUserSatisfactionSurveyData
+                );
+                setError(false);
+                onSubmitSuccess();
+              } catch {
+                setError(true);
+              } finally {
+                setSubmittingRequest(false);
+              }
+            }}
+          >
+            Submit
+          </Button>
+        </FlexRow>
+      </FlexColumn>
+    </Modal>
+  );
+}

--- a/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
+++ b/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
@@ -73,6 +73,7 @@ export const NewUserSatisfactionSurveyModal = ({
               },
             });
           }}
+          questionStyle={{ marginBottom: '0.5rem' }}
         />
         <label
           htmlFor='new-user-satisfaction-survey-additional-info'

--- a/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
+++ b/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
@@ -11,6 +11,7 @@ import {
 } from 'app/components/inputs';
 import { Modal } from 'app/components/modals';
 import { MultipleChoiceQuestion } from 'app/components/multiple-choice-question';
+import { surveyStyles } from 'app/components/surveys';
 import { surveysApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
@@ -77,12 +78,7 @@ export const NewUserSatisfactionSurveyModal = ({
         />
         <label
           htmlFor='new-user-satisfaction-survey-additional-info'
-          style={{
-            fontWeight: 'bold',
-            color: colors.primary,
-            fontSize: '18px',
-            lineHeight: '1.25rem',
-          }}
+          style={surveyStyles.question}
         >
           Please explain your selection. What were you expecting? What went
           well? What didn't go well?

--- a/ui/src/app/components/surveys.tsx
+++ b/ui/src/app/components/surveys.tsx
@@ -1,0 +1,10 @@
+import colors from 'app/styles/colors';
+
+export const surveyStyles = {
+  question: {
+    fontWeight: 'bold',
+    color: colors.primary,
+    fontSize: '18px',
+    lineHeight: '1.25rem',
+  },
+};

--- a/ui/src/app/components/surveys.tsx
+++ b/ui/src/app/components/surveys.tsx
@@ -1,10 +1,11 @@
 import colors from 'app/styles/colors';
+import { reactStyles } from 'app/utils';
 
-export const surveyStyles = {
+export const surveyStyles = reactStyles({
   question: {
     fontWeight: 'bold',
     color: colors.primary,
     fontSize: '18px',
     lineHeight: '1.25rem',
   },
-};
+});

--- a/ui/src/app/services/swagger-fetch-clients.ts
+++ b/ui/src/app/services/swagger-fetch-clients.ts
@@ -41,6 +41,7 @@ import {
   RuntimeApi,
   StatusAlertApi,
   StatusApi,
+  SurveysApi,
   UserAdminApi,
   UserApi,
   UserMetricsApi,
@@ -123,6 +124,7 @@ export const userMetricsApi = bindCtor(UserMetricsApi);
 export const workspaceAdminApi = bindCtor(WorkspaceAdminApi);
 export const workspacesApi = bindCtor(WorkspacesApi);
 export const diskApi = bindCtor(DiskApi);
+export const surveysApi = bindCtor(SurveysApi);
 
 export const getApiBaseUrl = () => {
   if (cookiesEnabled()) {

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router';
 import {
   CdrVersionTier,
   ConfigResponse,
+  CreateNewUserSatisfactionSurvey,
   Disk,
   Profile,
   Runtime,
@@ -111,6 +112,18 @@ export const profileStore = atom<ProfileStore>({
       profile: p,
     }),
 });
+
+export interface CreateNewUserSatisfactionSurveyStore {
+  newUserSatisfactionSurveyData: CreateNewUserSatisfactionSurvey;
+}
+
+export const createNewUserSatisfactionSurveyStore =
+  atom<CreateNewUserSatisfactionSurveyStore>({
+    newUserSatisfactionSurveyData: {
+      satisfaction: undefined,
+      additionalInfo: '',
+    },
+  });
 
 export interface NotificationStore {
   title: string;

--- a/ui/src/testing/stubs/surveys-api-stub.ts
+++ b/ui/src/testing/stubs/surveys-api-stub.ts
@@ -1,0 +1,20 @@
+import { CreateNewUserSatisfactionSurvey, SurveysApi } from 'generated/fetch';
+
+import { stubNotImplementedError } from 'testing/stubs/stub-utils';
+
+export class SurveysApiStub extends SurveysApi {
+  constructor() {
+    super(undefined, undefined, (..._: any[]) => {
+      throw stubNotImplementedError;
+    });
+  }
+
+  createNewUserSatisfactionSurvey(
+    _newUserSatisfactionSurvey: CreateNewUserSatisfactionSurvey,
+    _options?: any
+  ) {
+    return new Promise<Response>((resolve, _) => {
+      resolve(new Response());
+    });
+  }
+}


### PR DESCRIPTION
Description:

Adds a new component to display the new user satisfaction survey.

This is _not_ user facing, yet. Two future stories will show this to users via a clicked-on notification and through an email link.

A test for the full success flow will be added as a small integration test once this is user-facing.

Since this is my first bigger front-end story, I would appreciate any structural suggestions.

Screenshot:
<img width="880" alt="image" src="https://user-images.githubusercontent.com/31020403/203415531-7dc11cc6-470e-4887-9f9b-1a8cc60571e7.png">

Screenshot - Error:
<img width="872" alt="image" src="https://user-images.githubusercontent.com/31020403/203415655-3caeffe6-7538-4805-9ee4-c2a2188ad064.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
