### PR TITLE
[risk=low][RW-9210] Use full notebook filenames

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
@@ -110,16 +110,17 @@ public class NotebooksController implements NotebooksApiDelegate {
 
   @Override
   public ResponseEntity<ReadOnlyNotebookResponse> readOnlyNotebook(
-      String workspaceNamespace, String workspaceName, String notebookName) {
-    if (!NotebookUtils.isJupyterNotebook(notebookName)) {
+      String workspaceNamespace, String workspaceName, String notebookNameWithFileExtension) {
+    if (!NotebookUtils.isJupyterNotebook(notebookNameWithFileExtension)) {
       throw new NotImplementedException(
-          String.format("%s type of file is not implemented yet", notebookName));
+          String.format("%s type of file is not implemented yet", notebookNameWithFileExtension));
     }
 
     ReadOnlyNotebookResponse response =
         new ReadOnlyNotebookResponse()
             .html(
-                notebooksService.getReadOnlyHtml(workspaceNamespace, workspaceName, notebookName));
+                notebooksService.getReadOnlyHtml(
+                    workspaceNamespace, workspaceName, notebookNameWithFileExtension));
     return ResponseEntity.ok(response);
   }
 
@@ -140,10 +141,10 @@ public class NotebooksController implements NotebooksApiDelegate {
 
   @Override
   public ResponseEntity<KernelTypeResponse> getNotebookKernel(
-      String workspace, String workspaceName, String notebookName) {
-    if (!NotebookUtils.isJupyterNotebook(notebookName)) {
+      String workspace, String workspaceName, String notebookNameWithFileExtension) {
+    if (!NotebookUtils.isJupyterNotebook(notebookNameWithFileExtension)) {
       throw new BadRequestException(
-          String.format("%s is not a Jupyter notebook file", notebookName));
+          String.format("%s is not a Jupyter notebook file", notebookNameWithFileExtension));
     }
 
     workspaceAuthService.enforceWorkspaceAccessLevel(
@@ -152,7 +153,8 @@ public class NotebooksController implements NotebooksApiDelegate {
     return ResponseEntity.ok(
         new KernelTypeResponse()
             .kernelType(
-                notebooksService.getNotebookKernel(workspace, workspaceName, notebookName)));
+                notebooksService.getNotebookKernel(
+                    workspace, workspaceName, notebookNameWithFileExtension)));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
@@ -17,19 +17,19 @@ public class NotebookUtils {
   public static final Pattern R_MARKDOWN_NOTEBOOK_WITH_DIRECTORY_PATTERN =
       Pattern.compile(NOTEBOOKS_WORKSPACE_DIRECTORY + "/[^/]+(\\.(?i)(rmd))$");
 
-  public static boolean isJupyterNotebookWithDirectory(String name) {
-    return JUPYTER_NOTEBOOK_WITH_DIRECTORY_PATTERN.matcher(name).matches();
+  public static boolean isJupyterNotebookWithDirectory(String nameWithFileExtension) {
+    return JUPYTER_NOTEBOOK_WITH_DIRECTORY_PATTERN.matcher(nameWithFileExtension).matches();
   }
 
-  public static boolean isRMarkDownNotebookWithDirectory(String name) {
-    return R_MARKDOWN_NOTEBOOK_WITH_DIRECTORY_PATTERN.matcher(name).matches();
+  public static boolean isRMarkDownNotebookWithDirectory(String nameWithFileExtension) {
+    return R_MARKDOWN_NOTEBOOK_WITH_DIRECTORY_PATTERN.matcher(nameWithFileExtension).matches();
   }
 
-  public static boolean isJupyterNotebook(String name) {
-    return name.endsWith(JUPYTER_NOTEBOOK_EXTENSION);
+  public static boolean isJupyterNotebook(String nameWithFileExtension) {
+    return nameWithFileExtension.endsWith(JUPYTER_NOTEBOOK_EXTENSION);
   }
 
-  public static boolean isRMarkdownNotebook(String name) {
-    return name.endsWith(R_MARKDOWN_NOTEBOOK_EXTENSION);
+  public static boolean isRMarkdownNotebook(String nameWithFileExtension) {
+    return nameWithFileExtension.endsWith(R_MARKDOWN_NOTEBOOK_EXTENSION);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
@@ -56,11 +56,13 @@ public interface NotebooksService {
   KernelTypeEnum getNotebookKernel(
       String workspaceNamespace, String workspaceName, String notebookName);
 
-  void saveNotebook(String bucketName, String notebookName, JSONObject notebookContents);
+  void saveNotebook(
+      String bucketName, String notebookNameWithFileExtension, JSONObject notebookContents);
 
   public String convertNotebookToHtml(byte[] notebook);
 
   String getReadOnlyHtml(String workspaceNamespace, String workspaceName, String notebookName);
 
-  String adminGetReadOnlyHtml(String workspaceNamespace, String workspaceName, String notebookName);
+  String adminGetReadOnlyHtml(
+      String workspaceNamespace, String workspaceName, String notebookNameWithFileExtension);
 }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -287,14 +287,16 @@ public class NotebooksServiceImpl implements NotebooksService {
   }
 
   @Override
-  public void saveNotebook(String bucketName, String notebookName, JSONObject notebookContents) {
-    if (!NotebookUtils.isJupyterNotebook(notebookName)) {
+  public void saveNotebook(
+      String bucketName, String notebookNameWithFileExtension, JSONObject notebookContents) {
+    if (!NotebookUtils.isJupyterNotebook(notebookNameWithFileExtension)) {
       throw new NotImplementedException(
-          String.format("%s is a type of file that is not yet supported", notebookName));
+          String.format(
+              "%s is a type of file that is not yet supported", notebookNameWithFileExtension));
     }
     cloudStorageClient.writeFile(
         bucketName,
-        "notebooks/" + NotebooksService.withJupyterNotebookExtension(notebookName),
+        "notebooks/" + NotebooksService.withJupyterNotebookExtension(notebookNameWithFileExtension),
         notebookContents.toString().getBytes(StandardCharsets.UTF_8));
     logsBasedMetricService.recordEvent(EventMetric.NOTEBOOK_SAVE);
   }
@@ -323,10 +325,11 @@ public class NotebooksServiceImpl implements NotebooksService {
 
   @Override
   public String adminGetReadOnlyHtml(
-      String workspaceNamespace, String workspaceName, String notebookName) {
-    if (!NotebookUtils.isJupyterNotebook(notebookName)) {
+      String workspaceNamespace, String workspaceName, String notebookNameWithFileExtension) {
+    if (!NotebookUtils.isJupyterNotebook(notebookNameWithFileExtension)) {
       throw new NotImplementedException(
-          String.format("%s is a type of file that is not yet supported", notebookName));
+          String.format(
+              "%s is a type of file that is not yet supported", notebookNameWithFileExtension));
     }
 
     String bucketName =
@@ -335,7 +338,7 @@ public class NotebooksServiceImpl implements NotebooksService {
             .getWorkspace()
             .getBucketName();
 
-    Blob blob = getBlobWithSizeConstraint(bucketName, notebookName);
+    Blob blob = getBlobWithSizeConstraint(bucketName, notebookNameWithFileExtension);
     return convertNotebookToHtml(blob.getContent());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -315,7 +315,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
 
   @Override
   public String getReadOnlyNotebook(
-      String workspaceNamespace, String notebookName, AccessReason accessReason) {
+      String workspaceNamespace, String notebookNameWithFileExtension, AccessReason accessReason) {
     if (StringUtils.isBlank(accessReason.getReason())) {
       throw new BadRequestException("Notebook viewing access reason is required");
     }
@@ -323,8 +323,9 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     final String workspaceName =
         getWorkspaceByNamespaceOrThrow(workspaceNamespace).getFirecloudName();
     adminAuditor.fireViewNotebookAction(
-        workspaceNamespace, workspaceName, notebookName, accessReason);
-    return notebooksService.adminGetReadOnlyHtml(workspaceNamespace, workspaceName, notebookName);
+        workspaceNamespace, workspaceName, notebookNameWithFileExtension, accessReason);
+    return notebooksService.adminGetReadOnlyHtml(
+        workspaceNamespace, workspaceName, notebookNameWithFileExtension);
   }
 
   // NOTE: may be an undercount since we only retrieve the first Page of Storage List results

--- a/ui/src/app/pages/admin/admin-notebook-view.tsx
+++ b/ui/src/app/pages/admin/admin-notebook-view.tsx
@@ -6,7 +6,6 @@ import { useQuery } from 'app/components/app-router';
 import { StyledRouterLink } from 'app/components/buttons';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
-import { appendNotebookFileSuffix } from 'app/pages/analysis/util';
 import { workspaceAdminApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
@@ -46,12 +45,12 @@ const styles = reactStyles({
 
 interface Props {
   workspaceNamespace: string;
-  notebookName: string;
+  notebookNameWithSuffix: string;
   accessReason: string;
 }
 
 const AdminNotebookViewComponent = (props: Props) => {
-  const { workspaceNamespace, notebookName, accessReason } = props;
+  const { workspaceNamespace, notebookNameWithSuffix, accessReason } = props;
   const [notebookHtml, setHtml] = useState('');
   const [workspaceName, setWorkspaceName] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
@@ -67,7 +66,8 @@ const AdminNotebookViewComponent = (props: Props) => {
     );
     return (
       <div style={styles.heading}>
-        Viewing {notebookName} in {link} for reason:<div>{accessReason}</div>
+        Viewing {notebookNameWithSuffix} in {link} for reason:
+        <div>{accessReason}</div>
       </div>
     );
   };
@@ -105,17 +105,13 @@ const AdminNotebookViewComponent = (props: Props) => {
     }
 
     workspaceAdminApi()
-      .adminReadOnlyNotebook(
-        workspaceNamespace,
-        appendNotebookFileSuffix(notebookName),
-        {
-          reason: accessReason,
-        }
-      )
+      .adminReadOnlyNotebook(workspaceNamespace, notebookNameWithSuffix, {
+        reason: accessReason,
+      })
       .then((response) => setHtml(response.html))
       .catch((e) => {
         if (e.status === 404) {
-          setErrorMessage(`Notebook ${notebookName} was not found`);
+          setErrorMessage(`Notebook ${notebookNameWithSuffix} was not found`);
         } else if (e.status === 412) {
           setErrorMessage('Notebook is too large to display in preview mode');
         } else {
@@ -140,11 +136,11 @@ const AdminNotebookView = (spinnerProps: WithSpinnerOverlayProps) => {
   const { ns, nbName } = useParams<MatchParams>();
   const accessReason = useQuery().get('accessReason');
 
-  // react-router does not handling decoding of URL parameters, they must be decoded here.
+  // react-router does not handle decoding of URL parameters, they must be decoded here.
   return (
     <AdminNotebookViewComponent
       workspaceNamespace={ns}
-      notebookName={decodeURIComponent(nbName)}
+      notebookNameWithSuffix={decodeURIComponent(nbName)}
       accessReason={accessReason}
     />
   );

--- a/ui/src/app/pages/admin/admin-notebook-view.tsx
+++ b/ui/src/app/pages/admin/admin-notebook-view.tsx
@@ -6,6 +6,7 @@ import { useQuery } from 'app/components/app-router';
 import { StyledRouterLink } from 'app/components/buttons';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
+import { appendNotebookFileSuffix } from 'app/pages/analysis/util';
 import { workspaceAdminApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
@@ -104,9 +105,13 @@ const AdminNotebookViewComponent = (props: Props) => {
     }
 
     workspaceAdminApi()
-      .adminReadOnlyNotebook(workspaceNamespace, notebookName, {
-        reason: accessReason,
-      })
+      .adminReadOnlyNotebook(
+        workspaceNamespace,
+        appendNotebookFileSuffix(notebookName),
+        {
+          reason: accessReason,
+        }
+      )
       .then((response) => setHtml(response.html))
       .catch((e) => {
         if (e.status === 404) {

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -44,7 +44,6 @@ import {
   NotebookFrameError,
   SecuritySuspendedMessage,
 } from './notebook-frame-error';
-import { appendNotebookFileSuffix } from './util';
 
 const styles = reactStyles({
   navBar: {
@@ -178,7 +177,7 @@ export const InteractiveNotebook = fp.flow(
         const { html } = await notebooksApi().readOnlyNotebook(
           ns,
           wsid,
-          appendNotebookFileSuffix(nbName)
+          nbName
         );
         this.setState({ html: html });
       } catch (e) {

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -44,6 +44,7 @@ import {
   NotebookFrameError,
   SecuritySuspendedMessage,
 } from './notebook-frame-error';
+import { appendNotebookFileSuffix } from './util';
 
 const styles = reactStyles({
   navBar: {
@@ -177,7 +178,7 @@ export const InteractiveNotebook = fp.flow(
         const { html } = await notebooksApi().readOnlyNotebook(
           ns,
           wsid,
-          nbName
+          appendNotebookFileSuffix(nbName)
         );
         this.setState({ html: html });
       } catch (e) {

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -101,7 +101,7 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
       kernelType,
       genomicsAnalysisTool,
       generateGenomicsAnalysisCode: hasWgs(),
-      notebookName,
+      notebookName: appendNotebookFileSuffix(notebookName),
       newNotebook: creatingNewNotebook,
     };
   }
@@ -185,7 +185,11 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
       setCreatingNewNotebook(false);
       setIsLoadingNotebook(true);
       notebooksApi()
-        .getNotebookKernel(workspace.namespace, workspace.id, value)
+        .getNotebookKernel(
+          workspace.namespace,
+          workspace.id,
+          appendNotebookFileSuffix(value)
+        )
         .then((resp) => setKernelType(resp.kernelType))
         .catch(() =>
           setErrorMsg(


### PR DESCRIPTION
After #7166 some endpoints now require full notebook names (including .ipynb) which broke some key RW features.

I *think* I have identified all such endpoints and have modified their calls from the RW UI to ensure that the full names are used.  Additionally I renamed some API parameters to be more explicit about this new requirement

TODO: API and UI tests
**But we need this hotfix ASAP so I am inclined to add those in another PR**

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
