### PR TITLE
[risk=low][no ticket] Notebooks API: add tests and refactor

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
@@ -97,10 +97,11 @@ public class NotebooksController implements NotebooksApiDelegate {
 
   @Override
   public ResponseEntity<FileDetail> cloneNotebook(
-      String workspace, String workspaceName, String notebookName) {
+      String workspace, String workspaceName, String notebookNameWithExtension) {
     FileDetail fileDetail;
     try {
-      fileDetail = notebooksService.cloneNotebook(workspace, workspaceName, notebookName);
+      fileDetail =
+          notebooksService.cloneNotebook(workspace, workspaceName, notebookNameWithExtension);
     } catch (BlobAlreadyExistsException e) {
       throw new BadRequestException("File already exists at copy destination");
     }

--- a/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
@@ -59,36 +59,36 @@ public class NotebooksController implements NotebooksApiDelegate {
   public ResponseEntity<FileDetail> copyNotebook(
       String fromWorkspaceNamespace,
       String fromWorkspaceId,
-      String fromNotebookName,
+      String fromNotebookNameWithExtension,
       CopyRequest copyRequest) {
     return ResponseEntity.ok(
-        copyNotebookImpl(fromWorkspaceNamespace, fromWorkspaceId, fromNotebookName, copyRequest));
+        copyNotebookImpl(
+            fromWorkspaceNamespace, fromWorkspaceId, fromNotebookNameWithExtension, copyRequest));
   }
 
   private FileDetail copyNotebookImpl(
       String fromWorkspaceNamespace,
       String fromWorkspaceId,
-      String fromNotebookName,
+      String fromNotebookNameWithExtension,
       CopyRequest copyRequest) {
     FileDetail fileDetail;
     try {
       // Checks the new name extension to match the original from file type, add extension if
       // needed.
       // TODO(yonghao): Remove withNotebookExtension after UI start setting extension.
-      String newName =
-          isRMarkdownNotebook(fromNotebookName)
+      String newNameWithExtension =
+          isRMarkdownNotebook(fromNotebookNameWithExtension)
               ? NotebookUtils.withRMarkdownExtension(copyRequest.getNewName())
               : NotebookUtils.withJupyterNotebookExtension(copyRequest.getNewName());
 
-      // TODO(yonghao): Remove withNotebookExtension after UI start setting extension.
       fileDetail =
           notebooksService.copyNotebook(
               fromWorkspaceNamespace,
               fromWorkspaceId,
-              NotebookUtils.withJupyterNotebookExtension(fromNotebookName),
+              fromNotebookNameWithExtension,
               copyRequest.getToWorkspaceNamespace(),
               copyRequest.getToWorkspaceName(),
-              newName);
+              newNameWithExtension);
     } catch (BlobAlreadyExistsException e) {
       throw new ConflictException("File already exists at copy destination");
     }

--- a/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
@@ -174,7 +174,7 @@ public class NotebooksController implements NotebooksApiDelegate {
     // throws NotFoundException if the notebook is not in GCS
     // returns null if found but no user-metadata
     Map<String, String> metadata =
-        cloudStorageClient.getMetadata(bucketName, "notebooks/" + notebookName);
+        cloudStorageClient.getMetadata(bucketName, NotebookUtils.withNotebookPath(notebookName));
 
     if (metadata != null) {
       String lockExpirationTime = metadata.get("lockExpiresAt");

--- a/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
@@ -77,15 +77,15 @@ public class NotebooksController implements NotebooksApiDelegate {
       // TODO(yonghao): Remove withNotebookExtension after UI start setting extension.
       String newName =
           isRMarkdownNotebook(fromNotebookName)
-              ? NotebooksService.withRMarkdownExtension(copyRequest.getNewName())
-              : NotebooksService.withJupyterNotebookExtension(copyRequest.getNewName());
+              ? NotebookUtils.withRMarkdownExtension(copyRequest.getNewName())
+              : NotebookUtils.withJupyterNotebookExtension(copyRequest.getNewName());
 
       // TODO(yonghao): Remove withNotebookExtension after UI start setting extension.
       fileDetail =
           notebooksService.copyNotebook(
               fromWorkspaceNamespace,
               fromWorkspaceId,
-              NotebooksService.withJupyterNotebookExtension(fromNotebookName),
+              NotebookUtils.withJupyterNotebookExtension(fromNotebookName),
               copyRequest.getToWorkspaceNamespace(),
               copyRequest.getToWorkspaceName(),
               newName);

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -67,9 +67,10 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
   @Override
   @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
   public ResponseEntity<ReadOnlyNotebookResponse> adminReadOnlyNotebook(
-      String workspaceNamespace, String notebookName, AccessReason accessReason) {
+      String workspaceNamespace, String notebookNameWithFileExtension, AccessReason accessReason) {
     final String notebookHtml =
-        workspaceAdminService.getReadOnlyNotebook(workspaceNamespace, notebookName, accessReason);
+        workspaceAdminService.getReadOnlyNotebook(
+            workspaceNamespace, notebookNameWithFileExtension, accessReason);
     return ResponseEntity.ok(new ReadOnlyNotebookResponse().html(notebookHtml));
   }
 

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -44,6 +44,7 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceDetails;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceIngest;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceRequestClone;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
+import org.pmiops.workbench.notebooks.NotebookUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.retry.RetryException;
@@ -351,8 +352,8 @@ public class FireCloudServiceImpl implements FireCloudService {
             .namespace(toWorkspaceNamespace)
             .name(toFirecloudName)
             // We copy only the notebooks/ subdirectory as a heuristic to avoid unintentionally
-            // propagating copies of large data files elswhere in the bucket.
-            .copyFilesWithPrefix("notebooks/")
+            // propagating copies of large data files elsewhere in the bucket.
+            .copyFilesWithPrefix(NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY + "/")
             .authorizationDomain(
                 ImmutableList.of(new FirecloudManagedGroupRef().membersGroupName(authDomainName)))
             .bucketLocation(configProvider.get().firecloud.workspaceBucketLocation);

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
@@ -33,6 +33,18 @@ public class NotebookUtils {
     return nameWithFileExtension.endsWith(R_MARKDOWN_NOTEBOOK_EXTENSION);
   }
 
+  public static String withJupyterNotebookExtension(String notebookName) {
+    return notebookName.endsWith(JUPYTER_NOTEBOOK_EXTENSION)
+        ? notebookName
+        : notebookName.concat(JUPYTER_NOTEBOOK_EXTENSION);
+  }
+
+  public static String withRMarkdownExtension(String notebookName) {
+    return notebookName.endsWith(R_MARKDOWN_NOTEBOOK_EXTENSION)
+        ? notebookName
+        : notebookName.concat(R_MARKDOWN_NOTEBOOK_EXTENSION);
+  }
+
   public static String withNotebookPath(String notebookName) {
     return NOTEBOOKS_WORKSPACE_DIRECTORY + "/" + notebookName;
   }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
@@ -32,4 +32,8 @@ public class NotebookUtils {
   public static boolean isRMarkdownNotebook(String nameWithFileExtension) {
     return nameWithFileExtension.endsWith(R_MARKDOWN_NOTEBOOK_EXTENSION);
   }
+
+  public static String withNotebookPath(String notebookName) {
+    return NOTEBOOKS_WORKSPACE_DIRECTORY + "/" + notebookName;
+  }
 }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
@@ -23,17 +23,21 @@ public interface NotebooksService {
   FileDetail copyNotebook(
       String fromWorkspaceNamespace,
       String fromWorkspaceName,
-      String fromNotebookName,
+      String fromNotebookNameWithExtension,
       String toWorkspaceNamespace,
       String toWorkspaceName,
-      String newNotebookName);
+      String newNotebookNameWithExtension);
 
-  FileDetail cloneNotebook(String workspaceNamespace, String workspaceName, String notebookName);
+  FileDetail cloneNotebook(
+      String workspaceNamespace, String workspaceName, String notebookNameWithExtension);
 
   void deleteNotebook(String workspaceNamespace, String workspaceName, String notebookName);
 
   FileDetail renameNotebook(
-      String workspaceNamespace, String workspaceName, String notebookName, String newName);
+      String workspaceNamespace,
+      String workspaceName,
+      String originalNameWithExtension,
+      String newNameWithExtension);
 
   JSONObject getNotebookContents(String bucketName, String notebookName);
 

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
@@ -1,8 +1,5 @@
 package org.pmiops.workbench.notebooks;
 
-import static org.pmiops.workbench.notebooks.NotebookUtils.JUPYTER_NOTEBOOK_EXTENSION;
-import static org.pmiops.workbench.notebooks.NotebookUtils.R_MARKDOWN_NOTEBOOK_EXTENSION;
-
 import com.google.cloud.storage.Blob;
 import java.util.List;
 import org.json.JSONObject;
@@ -10,17 +7,6 @@ import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.KernelTypeEnum;
 
 public interface NotebooksService {
-  static String withJupyterNotebookExtension(String notebookName) {
-    return notebookName.endsWith(JUPYTER_NOTEBOOK_EXTENSION)
-        ? notebookName
-        : notebookName.concat(JUPYTER_NOTEBOOK_EXTENSION);
-  }
-
-  static String withRMarkdownExtension(String notebookName) {
-    return notebookName.endsWith(R_MARKDOWN_NOTEBOOK_EXTENSION)
-        ? notebookName
-        : notebookName.concat(R_MARKDOWN_NOTEBOOK_EXTENSION);
-  }
 
   List<FileDetail> getNotebooks(String workspaceNamespace, String workspaceName);
 

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -139,10 +139,10 @@ public class NotebooksServiceImpl implements NotebooksService {
   public FileDetail copyNotebook(
       String fromWorkspaceNamespace,
       String fromWorkspaceFirecloudName,
-      String fromNotebookName,
+      String fromNotebookNameWithExtension,
       String toWorkspaceNamespace,
       String toWorkspaceFirecloudName,
-      String newNotebookName) {
+      String newNotebookNameWithExtension) {
     workspaceAuthService.enforceWorkspaceAccessLevel(
         fromWorkspaceNamespace, fromWorkspaceFirecloudName, WorkspaceAccessLevel.READER);
     workspaceAuthService.enforceWorkspaceAccessLevel(
@@ -165,9 +165,11 @@ public class NotebooksServiceImpl implements NotebooksService {
     }
 
     GoogleCloudLocators fromNotebookLocators =
-        getNotebookLocators(fromWorkspaceNamespace, fromWorkspaceFirecloudName, fromNotebookName);
+        getNotebookLocators(
+            fromWorkspaceNamespace, fromWorkspaceFirecloudName, fromNotebookNameWithExtension);
     GoogleCloudLocators newNotebookLocators =
-        getNotebookLocators(toWorkspaceNamespace, toWorkspaceFirecloudName, newNotebookName);
+        getNotebookLocators(
+            toWorkspaceNamespace, toWorkspaceFirecloudName, newNotebookNameWithExtension);
 
     if (!cloudStorageClient
         .getExistingBlobIdsIn(Collections.singletonList(newNotebookLocators.blobId))
@@ -177,7 +179,7 @@ public class NotebooksServiceImpl implements NotebooksService {
     cloudStorageClient.copyBlob(fromNotebookLocators.blobId, newNotebookLocators.blobId);
 
     FileDetail fileDetail = new FileDetail();
-    fileDetail.setName(newNotebookName);
+    fileDetail.setName(newNotebookNameWithExtension);
     fileDetail.setPath(newNotebookLocators.fullPath);
     Timestamp now = new Timestamp(clock.instant().toEpochMilli());
     fileDetail.setLastModifiedTime(now.getTime());
@@ -189,13 +191,13 @@ public class NotebooksServiceImpl implements NotebooksService {
 
   @Override
   public FileDetail cloneNotebook(
-      String workspaceNamespace, String workspaceName, String fromNotebookName) {
-    String newName = "Duplicate of " + fromNotebookName;
+      String workspaceNamespace, String workspaceName, String fromNotebookNameWithExtension) {
+    String newName = "Duplicate of " + fromNotebookNameWithExtension;
     final FileDetail copiedNotebookFileDetail =
         copyNotebook(
             workspaceNamespace,
             workspaceName,
-            fromNotebookName,
+            fromNotebookNameWithExtension,
             workspaceNamespace,
             workspaceName,
             newName);
@@ -220,16 +222,19 @@ public class NotebooksServiceImpl implements NotebooksService {
 
   @Override
   public FileDetail renameNotebook(
-      String workspaceNamespace, String workspaceName, String originalName, String newName) {
+      String workspaceNamespace,
+      String workspaceName,
+      String originalNameWithExtension,
+      String newNameWithExtension) {
     FileDetail fileDetail =
         copyNotebook(
             workspaceNamespace,
             workspaceName,
-            originalName,
+            originalNameWithExtension,
             workspaceNamespace,
             workspaceName,
-            newName);
-    deleteNotebook(workspaceNamespace, workspaceName, originalName);
+            newNameWithExtension);
+    deleteNotebook(workspaceNamespace, workspaceName, originalNameWithExtension);
 
     return fileDetail;
   }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -278,7 +278,7 @@ public class NotebooksServiceImpl implements NotebooksService {
         cloudStorageClient.getBlob(
             bucketName,
             NotebookUtils.withNotebookPath(
-                NotebooksService.withJupyterNotebookExtension(notebookName)));
+                NotebookUtils.withJupyterNotebookExtension(notebookName)));
     if (blob.getSize() >= MAX_NOTEBOOK_READ_SIZE_BYTES) {
       throw new FailedPreconditionException(
           String.format(
@@ -298,7 +298,7 @@ public class NotebooksServiceImpl implements NotebooksService {
     cloudStorageClient.writeFile(
         bucketName,
         NotebookUtils.withNotebookPath(
-            NotebooksService.withJupyterNotebookExtension(notebookNameWithFileExtension)),
+            NotebookUtils.withJupyterNotebookExtension(notebookNameWithFileExtension)),
         notebookContents.toString().getBytes(StandardCharsets.UTF_8));
     logsBasedMetricService.recordEvent(EventMetric.NOTEBOOK_SAVE);
   }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -191,16 +191,16 @@ public class NotebooksServiceImpl implements NotebooksService {
 
   @Override
   public FileDetail cloneNotebook(
-      String workspaceNamespace, String workspaceName, String fromNotebookNameWithExtension) {
-    String newName = "Duplicate of " + fromNotebookNameWithExtension;
+      String workspaceNamespace, String workspaceName, String notebookNameWithExtension) {
+    String newNameWithExtension = "Duplicate of " + notebookNameWithExtension;
     final FileDetail copiedNotebookFileDetail =
         copyNotebook(
             workspaceNamespace,
             workspaceName,
-            fromNotebookNameWithExtension,
+            notebookNameWithExtension,
             workspaceNamespace,
             workspaceName,
-            newName);
+            newNameWithExtension);
     logsBasedMetricService.recordEvent(EventMetric.NOTEBOOK_CLONE);
     return copiedNotebookFileDetail;
   }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -277,7 +277,8 @@ public class NotebooksServiceImpl implements NotebooksService {
     Blob blob =
         cloudStorageClient.getBlob(
             bucketName,
-            "notebooks/".concat(NotebooksService.withJupyterNotebookExtension(notebookName)));
+            NotebookUtils.withNotebookPath(
+                NotebooksService.withJupyterNotebookExtension(notebookName)));
     if (blob.getSize() >= MAX_NOTEBOOK_READ_SIZE_BYTES) {
       throw new FailedPreconditionException(
           String.format(
@@ -296,7 +297,8 @@ public class NotebooksServiceImpl implements NotebooksService {
     }
     cloudStorageClient.writeFile(
         bucketName,
-        "notebooks/" + NotebooksService.withJupyterNotebookExtension(notebookNameWithFileExtension),
+        NotebookUtils.withNotebookPath(
+            NotebooksService.withJupyterNotebookExtension(notebookNameWithFileExtension)),
         notebookContents.toString().getBytes(StandardCharsets.UTF_8));
     logsBasedMetricService.recordEvent(EventMetric.NOTEBOOK_SAVE);
   }
@@ -349,7 +351,7 @@ public class NotebooksServiceImpl implements NotebooksService {
             .getWorkspace(workspaceNamespace, firecloudName)
             .getWorkspace()
             .getBucketName();
-    String blobPath = NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY + "/" + notebookName;
+    String blobPath = NotebookUtils.withNotebookPath(notebookName);
     String pathStart = "gs://" + bucket + "/";
     String fullPath = pathStart + blobPath;
     BlobId blobId = BlobId.of(bucket, blobPath);

--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -278,13 +278,11 @@ public class NotebooksControllerTest {
     String workspaceName = "workspace";
     MockNotebook notebook1 =
         new MockNotebook(
-            NotebookUtils.withNotebookPath(
-                NotebooksService.withJupyterNotebookExtension("mockFile")),
+            NotebookUtils.withNotebookPath(NotebookUtils.withJupyterNotebookExtension("mockFile")),
             "bucket");
     MockNotebook notebook2 =
         new MockNotebook(
-            NotebookUtils.withNotebookPath(
-                NotebooksService.withJupyterNotebookExtension("two words")),
+            NotebookUtils.withNotebookPath(NotebookUtils.withJupyterNotebookExtension("two words")),
             "bucket");
 
     when(mockNotebookService.getNotebooks(anyString(), anyString()))
@@ -567,7 +565,7 @@ public class NotebooksControllerTest {
 
     final String testWorkspaceNamespace = "test-ns";
     final String testWorkspaceName = "test-ws";
-    final String testNotebook = NotebooksService.withJupyterNotebookExtension("test-notebook");
+    final String testNotebook = NotebookUtils.withJupyterNotebookExtension("test-notebook");
 
     FirecloudWorkspaceDetails fcWorkspace =
         TestMockFactory.createFirecloudWorkspace(

--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -5,11 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.storage.Blob;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
@@ -18,7 +16,6 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +44,7 @@ import org.pmiops.workbench.monitoring.LogsBasedMetricServiceFakeImpl;
 import org.pmiops.workbench.notebooks.NotebookLockingUtils;
 import org.pmiops.workbench.notebooks.NotebookUtils;
 import org.pmiops.workbench.notebooks.NotebooksService;
+import org.pmiops.workbench.utils.MockNotebook;
 import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.workspaces.WorkspaceAuthService;
 import org.pmiops.workbench.workspaces.resources.UserRecentResourceService;
@@ -82,24 +80,6 @@ public class NotebooksControllerTest {
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     DbUser user() {
       return currentUser;
-    }
-  }
-
-  class MockNotebook {
-    Blob blob;
-    FileDetail fileDetail;
-
-    MockNotebook(String path, String bucketName) {
-      blob = mock(Blob.class);
-      fileDetail = new FileDetail();
-
-      String[] parts = path.split("/");
-      String fileName = parts[parts.length - 1];
-      fileDetail.setName(fileName);
-
-      when(blob.getName()).thenReturn(path);
-      when(mockCloudStorageClient.blobToFileDetail(blob, bucketName, mock(Set.class)))
-          .thenReturn(fileDetail);
     }
   }
 
@@ -277,13 +257,9 @@ public class NotebooksControllerTest {
     String workspaceNamespace = "project";
     String workspaceName = "workspace";
     MockNotebook notebook1 =
-        new MockNotebook(
-            NotebookUtils.withNotebookPath(NotebookUtils.withJupyterNotebookExtension("mockFile")),
-            "bucket");
+        MockNotebook.mockWithPathAndJupyterExtension("mockFile", "bucket", mockCloudStorageClient);
     MockNotebook notebook2 =
-        new MockNotebook(
-            NotebookUtils.withNotebookPath(NotebookUtils.withJupyterNotebookExtension("two words")),
-            "bucket");
+        MockNotebook.mockWithPathAndJupyterExtension("two words", "bucket", mockCloudStorageClient);
 
     when(mockNotebookService.getNotebooks(anyString(), anyString()))
         .thenReturn(ImmutableList.of(notebook1.fileDetail, notebook2.fileDetail));

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -49,6 +49,7 @@ import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.RecentResourceRequest;
 import org.pmiops.workbench.model.WorkspaceResource;
 import org.pmiops.workbench.model.WorkspaceResourceResponse;
+import org.pmiops.workbench.notebooks.NotebookUtils;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
@@ -354,7 +355,8 @@ public class UserMetricsControllerTest {
         .thenReturn(
             ImmutableList.of(dbUserRecentlyModifiedResource1, dbUserRecentlyModifiedResource2));
     when(mockCloudStorageClient.getExistingBlobIdsIn(anyList()))
-        .thenReturn(ImmutableSet.of(BlobId.of("bkt", "notebooks/notebook.ipynb")));
+        .thenReturn(
+            ImmutableSet.of(BlobId.of("bkt", NotebookUtils.withNotebookPath("notebook.ipynb"))));
 
     WorkspaceResourceResponse recentResources =
         userMetricsController.getUserRecentResources().getBody();

--- a/api/src/test/java/org/pmiops/workbench/google/CloudStorageClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/google/CloudStorageClientTest.java
@@ -11,6 +11,7 @@ import java.time.ZoneId;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.model.FileDetail;
+import org.pmiops.workbench.notebooks.NotebookUtils;
 import org.pmiops.workbench.test.FakeClock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -37,7 +38,7 @@ public class CloudStorageClientTest {
 
   @Test
   public void testBlobToFileDetail() {
-    String notebookPath = "notebooks/nb1.ipynb";
+    String notebookPath = NotebookUtils.withNotebookPath("nb1.ipynb");
     Long notebookSize = 500l;
     Long updateTime = Instant.now().getEpochSecond();
     String bucketName = "bucket";

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -452,15 +452,13 @@ public class NotebooksServiceTest {
   public void testGetNotebooks() {
     MockNotebook notebook1 =
         new MockNotebook(
-            NotebookUtils.withNotebookPath(
-                NotebooksService.withJupyterNotebookExtension("mockFile")),
+            NotebookUtils.withNotebookPath(NotebookUtils.withJupyterNotebookExtension("mockFile")),
             BUCKET_NAME);
     MockNotebook notebook2 =
         new MockNotebook(NotebookUtils.withNotebookPath("mockFile.text"), BUCKET_NAME);
     MockNotebook notebook3 =
         new MockNotebook(
-            NotebookUtils.withNotebookPath(
-                NotebooksService.withJupyterNotebookExtension("two words")),
+            NotebookUtils.withNotebookPath(NotebookUtils.withJupyterNotebookExtension("two words")),
             BUCKET_NAME);
 
     when(mockCloudStorageClient.getBlobPageForPrefix(BUCKET_NAME, "notebooks"))
@@ -537,9 +535,9 @@ public class NotebooksServiceTest {
         BUCKET_NAME,
         WorkspaceAccessLevel.OWNER);
     when(mockBlob1.getName())
-        .thenReturn(NotebooksService.withJupyterNotebookExtension("notebooks/extra/nope"));
+        .thenReturn(NotebookUtils.withJupyterNotebookExtension("notebooks/extra/nope"));
     when(mockBlob2.getName())
-        .thenReturn(NotebooksService.withJupyterNotebookExtension("notebooks/foo"));
+        .thenReturn(NotebookUtils.withJupyterNotebookExtension("notebooks/foo"));
     when(mockCloudStorageClient.getBlobPageForPrefix(BUCKET_NAME, "notebooks"))
         .thenReturn(ImmutableList.of(mockBlob1, mockBlob2));
     when(mockCloudStorageClient.blobToFileDetail(mockBlob1, BUCKET_NAME, workspaceUsersSet))
@@ -555,7 +553,7 @@ public class NotebooksServiceTest {
     List<String> gotNames = body.stream().map(FileDetail::getName).collect(Collectors.toList());
 
     assertThat(gotNames)
-        .isEqualTo(ImmutableList.of(NotebooksService.withJupyterNotebookExtension("foo")));
+        .isEqualTo(ImmutableList.of(NotebookUtils.withJupyterNotebookExtension("foo")));
   }
 
   @Test
@@ -652,8 +650,8 @@ public class NotebooksServiceTest {
         notebooksService.renameNotebook(
             NAMESPACE_NAME,
             WORKSPACE_NAME,
-            NotebooksService.withJupyterNotebookExtension("oldName"),
-            NotebooksService.withJupyterNotebookExtension("newName"));
+            NotebookUtils.withJupyterNotebookExtension("oldName"),
+            NotebookUtils.withJupyterNotebookExtension("newName"));
 
     verify(mockCloudStorageClient).deleteBlob(any());
     verify(mockUserRecentResourceService).deleteNotebookEntry(anyLong(), anyLong(), anyString());

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -194,6 +194,14 @@ public class NotebooksServiceTest {
   }
 
   @Test
+  public void testAdminGetReadOnlyHtml_requiresFileSuffix() {
+    Assertions.assertThrows(
+        NotImplementedException.class,
+        () ->
+            notebooksService.adminGetReadOnlyHtml(NAMESPACE_NAME, WORKSPACE_NAME, "notebookName"));
+  }
+
+  @Test
   public void testCloneNotebook() {
     stubGetWorkspace(NAMESPACE_NAME, WORKSPACE_NAME, BUCKET_NAME, WorkspaceAccessLevel.OWNER);
     doReturn(dbWorkspace).when(workspaceDao).getRequired(anyString(), anyString());
@@ -218,7 +226,7 @@ public class NotebooksServiceTest {
     String fromBucket = "FROM_BUCKET";
     String toWorkspaceNamespace = "toWorkspaceNamespace";
     String toWorkspaceFirecloudName = "toWorkspaceFirecloudName";
-    String newNotebookName = "newNotebookName";
+    String newNotebookName = "newNotebookName.ipynb";
     String toBucket = "TO_BUCKET";
     HashSet<BlobId> existingBlobIds = new HashSet<>();
 
@@ -665,7 +673,16 @@ public class NotebooksServiceTest {
   }
 
   @Test
-  public void testGetNotebookKernel_notSupported() {
+  public void testSaveNotebook_notSupportedWithoutSuffix() {
+    Assertions.assertThrows(
+        NotImplementedException.class,
+        () ->
+            notebooksService.saveNotebook(
+                BUCKET_NAME, "test", new JSONObject().put("who", "I'm a notebook!")));
+  }
+
+  @Test
+  public void testSaveNotebook_rmdNotSupported() {
     Assertions.assertThrows(
         NotImplementedException.class,
         () ->

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -49,6 +49,7 @@ import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.monitoring.LogsBasedMetricService;
 import org.pmiops.workbench.monitoring.views.EventMetric;
 import org.pmiops.workbench.test.FakeClock;
+import org.pmiops.workbench.utils.MockNotebook;
 import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.workspaces.WorkspaceAuthService;
 import org.pmiops.workbench.workspaces.resources.UserRecentResourceService;
@@ -103,25 +104,6 @@ public class NotebooksServiceTest {
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     DbUser getDbUser() {
       return dbUser;
-    }
-  }
-
-  class MockNotebook {
-    Blob blob;
-    FileDetail fileDetail;
-
-    MockNotebook(String path, String bucketName) {
-      blob = mock(Blob.class);
-      fileDetail = new FileDetail();
-      Set<String> workspaceUsersSet = new HashSet();
-
-      String[] parts = path.split("/");
-      String fileName = parts[parts.length - 1];
-      fileDetail.setName(fileName);
-
-      when(blob.getName()).thenReturn(path);
-      when(mockCloudStorageClient.blobToFileDetail(blob, bucketName, workspaceUsersSet))
-          .thenReturn(fileDetail);
     }
   }
 
@@ -451,15 +433,13 @@ public class NotebooksServiceTest {
   @Test
   public void testGetNotebooks() {
     MockNotebook notebook1 =
-        new MockNotebook(
-            NotebookUtils.withNotebookPath(NotebookUtils.withJupyterNotebookExtension("mockFile")),
-            BUCKET_NAME);
+        MockNotebook.mockWithPathAndJupyterExtension(
+            "mockFile", BUCKET_NAME, mockCloudStorageClient);
     MockNotebook notebook2 =
-        new MockNotebook(NotebookUtils.withNotebookPath("mockFile.text"), BUCKET_NAME);
+        MockNotebook.mockWithPath("mockFile.text", BUCKET_NAME, mockCloudStorageClient);
     MockNotebook notebook3 =
-        new MockNotebook(
-            NotebookUtils.withNotebookPath(NotebookUtils.withJupyterNotebookExtension("two words")),
-            BUCKET_NAME);
+        MockNotebook.mockWithPathAndJupyterExtension(
+            "two words", BUCKET_NAME, mockCloudStorageClient);
 
     when(mockCloudStorageClient.getBlobPageForPrefix(
             BUCKET_NAME, NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY))

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -444,11 +444,16 @@ public class NotebooksServiceTest {
   public void testGetNotebooks() {
     MockNotebook notebook1 =
         new MockNotebook(
-            NotebooksService.withJupyterNotebookExtension("notebooks/mockFile"), BUCKET_NAME);
-    MockNotebook notebook2 = new MockNotebook("notebooks/mockFile.text", BUCKET_NAME);
+            NotebookUtils.withNotebookPath(
+                NotebooksService.withJupyterNotebookExtension("mockFile")),
+            BUCKET_NAME);
+    MockNotebook notebook2 =
+        new MockNotebook(NotebookUtils.withNotebookPath("mockFile.text"), BUCKET_NAME);
     MockNotebook notebook3 =
         new MockNotebook(
-            NotebooksService.withJupyterNotebookExtension("notebooks/two words"), BUCKET_NAME);
+            NotebookUtils.withNotebookPath(
+                NotebooksService.withJupyterNotebookExtension("two words")),
+            BUCKET_NAME);
 
     when(mockCloudStorageClient.getBlobPageForPrefix(BUCKET_NAME, "notebooks"))
         .thenReturn(ImmutableList.of(notebook1.blob, notebook2.blob, notebook3.blob));
@@ -487,9 +492,9 @@ public class NotebooksServiceTest {
         dbWorkspace.getFirecloudName(),
         BUCKET_NAME,
         WorkspaceAccessLevel.OWNER);
-    when(mockBlob1.getName()).thenReturn("notebooks/f1.ipynb");
-    when(mockBlob2.getName()).thenReturn("notebooks/f2.rmd");
-    when(mockBlob3.getName()).thenReturn("notebooks/f3.random");
+    when(mockBlob1.getName()).thenReturn(NotebookUtils.withNotebookPath("f1.ipynb"));
+    when(mockBlob2.getName()).thenReturn(NotebookUtils.withNotebookPath("f2.rmd"));
+    when(mockBlob3.getName()).thenReturn(NotebookUtils.withNotebookPath("f3.random"));
     when(mockCloudStorageClient.getBlobPageForPrefix(BUCKET_NAME, "notebooks"))
         .thenReturn(ImmutableList.of(mockBlob1, mockBlob2, mockBlob3));
     when(mockCloudStorageClient.blobToFileDetail(mockBlob1, BUCKET_NAME, workspaceUsersSet))
@@ -621,7 +626,7 @@ public class NotebooksServiceTest {
 
   @Test
   public void testIsNotebookBlob_negative() {
-    when(mockBlob.getName()).thenReturn("notebooks/test.txt");
+    when(mockBlob.getName()).thenReturn(NotebookUtils.withNotebookPath("test.txt"));
     assertThat(notebooksService.isNotebookBlob(mockBlob)).isEqualTo(false);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -461,7 +461,8 @@ public class NotebooksServiceTest {
             NotebookUtils.withNotebookPath(NotebookUtils.withJupyterNotebookExtension("two words")),
             BUCKET_NAME);
 
-    when(mockCloudStorageClient.getBlobPageForPrefix(BUCKET_NAME, "notebooks"))
+    when(mockCloudStorageClient.getBlobPageForPrefix(
+            BUCKET_NAME, NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY))
         .thenReturn(ImmutableList.of(notebook1.blob, notebook2.blob, notebook3.blob));
     stubGetWorkspace(NAMESPACE_NAME, WORKSPACE_NAME, BUCKET_NAME, WorkspaceAccessLevel.OWNER);
 
@@ -501,7 +502,8 @@ public class NotebooksServiceTest {
     when(mockBlob1.getName()).thenReturn(NotebookUtils.withNotebookPath("f1.ipynb"));
     when(mockBlob2.getName()).thenReturn(NotebookUtils.withNotebookPath("f2.rmd"));
     when(mockBlob3.getName()).thenReturn(NotebookUtils.withNotebookPath("f3.random"));
-    when(mockCloudStorageClient.getBlobPageForPrefix(BUCKET_NAME, "notebooks"))
+    when(mockCloudStorageClient.getBlobPageForPrefix(
+            BUCKET_NAME, NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY))
         .thenReturn(ImmutableList.of(mockBlob1, mockBlob2, mockBlob3));
     when(mockCloudStorageClient.blobToFileDetail(mockBlob1, BUCKET_NAME, workspaceUsersSet))
         .thenReturn(fileDetail1);
@@ -535,10 +537,14 @@ public class NotebooksServiceTest {
         BUCKET_NAME,
         WorkspaceAccessLevel.OWNER);
     when(mockBlob1.getName())
-        .thenReturn(NotebookUtils.withJupyterNotebookExtension("notebooks/extra/nope"));
+        .thenReturn(
+            NotebookUtils.withNotebookPath(
+                NotebookUtils.withJupyterNotebookExtension("extra/nope")));
     when(mockBlob2.getName())
-        .thenReturn(NotebookUtils.withJupyterNotebookExtension("notebooks/foo"));
-    when(mockCloudStorageClient.getBlobPageForPrefix(BUCKET_NAME, "notebooks"))
+        .thenReturn(
+            NotebookUtils.withNotebookPath(NotebookUtils.withJupyterNotebookExtension("foo")));
+    when(mockCloudStorageClient.getBlobPageForPrefix(
+            BUCKET_NAME, NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY))
         .thenReturn(ImmutableList.of(mockBlob1, mockBlob2));
     when(mockCloudStorageClient.blobToFileDetail(mockBlob1, BUCKET_NAME, workspaceUsersSet))
         .thenReturn(fileDetail1);

--- a/api/src/test/java/org/pmiops/workbench/utils/MockNotebook.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/MockNotebook.java
@@ -1,0 +1,42 @@
+package org.pmiops.workbench.utils;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.storage.Blob;
+import java.util.HashSet;
+import java.util.Set;
+import org.pmiops.workbench.google.CloudStorageClient;
+import org.pmiops.workbench.model.FileDetail;
+import org.pmiops.workbench.notebooks.NotebookUtils;
+
+public class MockNotebook {
+  public Blob blob;
+  public FileDetail fileDetail;
+
+  public MockNotebook(String path, String bucketName, CloudStorageClient mockCloudStorageClient) {
+    blob = mock(Blob.class);
+    fileDetail = new FileDetail();
+    Set<String> workspaceUsersSet = new HashSet<>();
+
+    String[] parts = path.split("/");
+    String fileName = parts[parts.length - 1];
+    fileDetail.setName(fileName);
+
+    when(blob.getName()).thenReturn(path);
+    when(mockCloudStorageClient.blobToFileDetail(blob, bucketName, workspaceUsersSet))
+        .thenReturn(fileDetail);
+  }
+
+  public static MockNotebook mockWithPath(
+      String filename, String bucketName, CloudStorageClient mockCloudStorageClient) {
+    return new MockNotebook(
+        NotebookUtils.withNotebookPath(filename), bucketName, mockCloudStorageClient);
+  }
+
+  public static MockNotebook mockWithPathAndJupyterExtension(
+      String filename, String bucketName, CloudStorageClient mockCloudStorageClient) {
+    return mockWithPath(
+        NotebookUtils.withJupyterNotebookExtension(filename), bucketName, mockCloudStorageClient);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -71,6 +71,7 @@ import org.pmiops.workbench.model.ListRuntimeResponse;
 import org.pmiops.workbench.model.TimeSeriesPoint;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAdminView;
+import org.pmiops.workbench.notebooks.NotebookUtils;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
@@ -308,10 +309,11 @@ public class WorkspaceAdminServiceTest {
   public void testlistFiles() {
     final List<Blob> blobs =
         ImmutableList.of(
-            mockBlob("bucket", "notebooks/test.ipynb", 1000L),
-            mockBlob("bucket", "notebooks/test2.ipynb", 2000L),
-            mockBlob("bucket", "notebooks/scratch.txt", 123L),
-            mockBlob("bucket", "notebooks/hidden/sneaky.ipynb", 1000L * 1000L));
+            mockBlob("bucket", NotebookUtils.withNotebookPath("notebooks/test.ipynb"), 1000L),
+            mockBlob("bucket", NotebookUtils.withNotebookPath("test2.ipynb"), 2000L),
+            mockBlob("bucket", NotebookUtils.withNotebookPath("scratch.txt"), 123L),
+            mockBlob(
+                "bucket", NotebookUtils.withNotebookPath("hidden/sneaky.ipynb"), 1000L * 1000L));
     when(mockCloudStorageClient.getBlobPage("bucket")).thenReturn(blobs);
 
     final List<FileDetail> expectedFiles =

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -309,7 +309,7 @@ public class WorkspaceAdminServiceTest {
   public void testlistFiles() {
     final List<Blob> blobs =
         ImmutableList.of(
-            mockBlob("bucket", NotebookUtils.withNotebookPath("notebooks/test.ipynb"), 1000L),
+            mockBlob("bucket", NotebookUtils.withNotebookPath("test.ipynb"), 1000L),
             mockBlob("bucket", NotebookUtils.withNotebookPath("test2.ipynb"), 2000L),
             mockBlob("bucket", NotebookUtils.withNotebookPath("scratch.txt"), 123L),
             mockBlob(

--- a/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/resources/UserRecentResourceServiceTest.java
@@ -28,6 +28,7 @@ import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource.DbUserRecentlyModifiedResourceType;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.Domain;
+import org.pmiops.workbench.notebooks.NotebookUtils;
 import org.pmiops.workbench.test.FakeClock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -262,7 +263,9 @@ public class UserRecentResourceServiceTest {
     CLOCK.increment(2000);
 
     userRecentResourceService.updateNotebookEntry(
-        newWorkspace.getWorkspaceId(), user.getUserId(), "notebooks");
+        newWorkspace.getWorkspaceId(),
+        user.getUserId(),
+        NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY);
     userRecentResourceService.updateCohortEntry(
         newWorkspace.getWorkspaceId(), user.getUserId(), cohort.getCohortId());
 


### PR DESCRIPTION
Follow-up to #7166 and #7196
* add API tests to show new cases where notebook file extensions are required
* add some .rmd tests
* rename some API method params to be more explicit about requiring extensions
* remove a hard-coded with-jupyter extension which is no longer needed
* NotebookUtils.withNotebookPath()
* other small refactoring

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
