### PR TITLE
[risk=no][no ticket] rm deprecated unsafeSelfBypassAccessRequirement

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
@@ -90,19 +90,6 @@ public class UserAdminController implements UserAdminApiDelegate {
   }
 
   @Override
-  @Deprecated // unsafeSelfBypassAccessRequirements() handles all modules at once
-  public ResponseEntity<EmptyResponse> unsafeSelfBypassAccessRequirement(
-      AccessBypassRequest request) {
-    if (!workbenchConfigProvider.get().access.unsafeAllowSelfBypass) {
-      throw new ForbiddenException("Self bypass is disallowed in this environment.");
-    }
-    final DbUser user = userProvider.get();
-    accessModuleService.updateBypassTime(user.getUserId(), request);
-    userService.updateUserAccessTiers(user, Agent.asUser(user));
-    return ResponseEntity.ok(new EmptyResponse());
-  }
-
-  @Override
   public ResponseEntity<EmptyResponse> unsafeSelfBypassAccessRequirements() {
     if (!workbenchConfigProvider.get().access.unsafeAllowSelfBypass) {
       throw new ForbiddenException("Self bypass is disallowed in this environment.");

--- a/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
@@ -14,7 +14,6 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.ForbiddenException;
-import org.pmiops.workbench.model.AccessBypassRequest;
 import org.pmiops.workbench.model.AccountPropertyUpdate;
 import org.pmiops.workbench.model.AdminUserListResponse;
 import org.pmiops.workbench.model.Authority;

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1519,36 +1519,6 @@ paths:
           description: Internal Error
           schema:
             "$ref": "#/definitions/ErrorResponse"
-  "/v1/admin/unsafe-self-bypass-access-requirement":
-    post:
-      tags:
-      - userAdmin
-      consumes:
-      - application/json
-      description: >
-        DEPRECATED.  Use unsafeSelfBypassAccessRequirements to bypass all modules at once.
-        Updates the given user to bypass the request access requirement.
-      parameters:
-      - in: body
-        name: request
-        schema:
-          "$ref": "#/definitions/AccessBypassRequest"
-        description: 'Whether the requirement should be bypassed or not. Defaults
-          to true, so an empty body  will cause the requirement to be bypassed.'
-      operationId: unsafeSelfBypassAccessRequirement
-      responses:
-        200:
-          description: success
-          schema:
-            "$ref": "#/definitions/EmptyResponse"
-        403:
-          description: Self bypass is disallowed in this environment
-          schema:
-            "$ref": "#/definitions/ErrorResponse"
-        400:
-          description: No module exists with name submitted
-          schema:
-            "$ref": "#/definitions/ErrorResponse"
   "/v1/admin/unsafe-self-bypass-access-requirements":
     post:
       tags:

--- a/api/src/test/java/org/pmiops/workbench/api/AdminAuthorityTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AdminAuthorityTest.java
@@ -59,7 +59,6 @@ public class AdminAuthorityTest {
           // logEgressEvent requires an API key secret; it's a webhook which cannot use authority
           "logEgressEvent",
           // Not technically an admin endpoint, but only enabled in lower environments
-          "unsafeSelfBypassAccessRequirement",
           "unsafeSelfBypassAccessRequirements");
 
   /**


### PR DESCRIPTION
Because #7095 has been released, we can now remove the endpoint.

Tested locally.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
