### PR TITLE
[DT-118][risk-no] change generated BQ SQL for any concept set that contains questions from PFHH survey

### DIFF
--- a/api/src/bigquerytest/resources/bigquery/cbdata/ds_survey_data.json
+++ b/api/src/bigquerytest/resources/bigquery/cbdata/ds_survey_data.json
@@ -7,5 +7,14 @@
     "QUESTION": "Question",
     "ANSWER_CONCEPT_ID": 1,
     "ANSWER": "NO"
+  },
+  {
+    "PERSON_ID": "1",
+    "SURVEY_DATETIME": "2020-01-31 00:00:00 UTC",
+    "SURVEY": "The Basics",
+    "QUESTION_CONCEPT_ID": 43530446,
+    "QUESTION": "Question",
+    "ANSWER_CONCEPT_ID": 1385558,
+    "ANSWER": "NO"
   }
 ]

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -440,6 +440,40 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomC
       nativeQuery = true)
   List<DbCriteria> findVersionedSurveys();
 
+  @Query(
+      value =
+          "select distinct concept_id "
+              + "from cb_criteria c "
+              + "join ( "
+              + "      select cast(id as char) as id "
+              + "      from cb_criteria "
+              + "      where concept_id in (1740639) "
+              + "      and domain_id = 'SURVEY' "
+              + "      ) a on (c.path like CONCAT('%', a.id, '.%')) "
+              + "where domain_id = 'SURVEY' "
+              + "and type = 'PPI' "
+              + "and subtype = 'QUESTION' "
+              + "and concept_id in (:conceptIds)",
+      nativeQuery = true)
+  List<Long> findPFHHSurveyQuestionIds(@Param("conceptIds") List<Long> conceptIds);
+
+  @Query(
+      value =
+          "select distinct cast(value as signed) "
+              + "from cb_criteria c "
+              + "join ( "
+              + "      select cast(id as char) as id "
+              + "      from cb_criteria "
+              + "      where concept_id in (1740639) "
+              + "      and domain_id = 'SURVEY' "
+              + "      ) a on (c.path like CONCAT('%', a.id, '.%')) "
+              + "where domain_id = 'SURVEY' "
+              + "and type = 'PPI' "
+              + "and subtype = 'ANSWER' "
+              + "and concept_id in (:conceptIds)",
+      nativeQuery = true)
+  List<Long> findPFHHSurveyAnswerIds(@Param("conceptIds") List<Long> conceptIds);
+
   @Query(value = "SELECT * FROM INFORMATION_SCHEMA.INNODB_FT_DEFAULT_STOPWORD", nativeQuery = true)
   List<String> findMySQLStopWords();
 

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -74,4 +74,8 @@ public interface CohortBuilderService {
       Long questionConceptId, Long answerConceptId);
 
   List<Criteria> findVersionedSurveys();
+
+  List<Long> findPFHHSurveyQuestionIds(List<Long> conceptIds);
+
+  List<Long> findPFHHSurveyAnswerIds(List<Long> conceptIds);
 }

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -568,6 +568,16 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
         .collect(Collectors.toList());
   }
 
+  @Override
+  public List<Long> findPFHHSurveyQuestionIds(List<Long> conceptIds) {
+    return cbCriteriaDao.findPFHHSurveyQuestionIds(conceptIds);
+  }
+
+  @Override
+  public List<Long> findPFHHSurveyAnswerIds(List<Long> conceptIds) {
+    return cbCriteriaDao.findPFHHSurveyAnswerIds(conceptIds);
+  }
+
   private CriteriaListWithCountResponse getTopCountsSearchWithStandard(
       CriteriaSearchRequest request, PageRequest pageRequest) {
     Page<DbCriteria> dbCriteriaPage;

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -31,6 +31,9 @@ public class CBCriteriaDaoTest {
   @Autowired private CBCriteriaDao cbCriteriaDao;
   @Autowired private JdbcTemplate jdbcTemplate;
   private DbCriteria surveyCriteria;
+  private DbCriteria pfhhSurveyQuestion;
+
+  private DbCriteria pfhhSurveyAnswer;
   private DbCriteria sourceCriteria;
   private DbCriteria standardCriteria;
   private DbCriteria icd9Criteria;
@@ -75,6 +78,61 @@ public class CBCriteriaDaoTest {
             .addPath(String.valueOf(surveyCriteria.getId()))
             .addFullText("term[survey_rank1]")
             .build());
+    // adding pfhh survey module
+    DbCriteria pfhhSurveyModule =
+        cbCriteriaDao.save(
+            DbCriteria.builder()
+                .addDomainId(Domain.SURVEY.toString())
+                .addType(CriteriaType.PPI.toString())
+                .addSubtype(CriteriaSubType.SURVEY.toString())
+                .addGroup(true)
+                .addConceptId("1740639")
+                .addStandard(false)
+                .addSelectable(true)
+                .addName("Personal and Family Health History")
+                .build());
+    // adding pfhh survey module path
+    pfhhSurveyModule.setPath(String.valueOf(pfhhSurveyModule.getId()));
+    cbCriteriaDao.save(pfhhSurveyModule);
+    // adding pfhh survey question
+    pfhhSurveyQuestion =
+        cbCriteriaDao.save(
+            DbCriteria.builder()
+                .addDomainId(Domain.SURVEY.toString())
+                .addType(CriteriaType.PPI.toString())
+                .addSubtype(CriteriaSubType.QUESTION.toString())
+                .addGroup(true)
+                .addConceptId("43530446")
+                .addStandard(false)
+                .addSelectable(true)
+                .addName("Question")
+                .build());
+    // setting the correct path on pfhh question
+    pfhhSurveyQuestion.setPath(pfhhSurveyModule.getId() + "." + pfhhSurveyQuestion.getId());
+    pfhhSurveyQuestion = cbCriteriaDao.save(pfhhSurveyQuestion);
+    // adding a pfhh survey answer
+    pfhhSurveyAnswer =
+        cbCriteriaDao.save(
+            DbCriteria.builder()
+                .addDomainId(Domain.SURVEY.toString())
+                .addType(CriteriaType.PPI.toString())
+                .addSubtype(CriteriaSubType.ANSWER.toString())
+                .addGroup(false)
+                .addConceptId("43530446")
+                .addStandard(false)
+                .addSelectable(true)
+                .addName("Answer")
+                .addValue("1385558")
+                .build());
+    // setting the correct path on pfhh answer
+    pfhhSurveyAnswer.setPath(
+        pfhhSurveyModule.getId()
+            + "."
+            + pfhhSurveyQuestion.getId()
+            + "."
+            + pfhhSurveyAnswer.getId());
+    cbCriteriaDao.save(pfhhSurveyAnswer);
+
     sourceCriteria =
         cbCriteriaDao.save(
             DbCriteria.builder()
@@ -490,5 +548,20 @@ public class CBCriteriaDaoTest {
     assertThat(dbCriteria).hasSize(1);
     assertThat(dbCriteria).containsExactly(versionedSurvey);
     jdbcTemplate.execute("drop table cb_survey_version");
+  }
+
+  @Test
+  public void findPFHHSurveyQuestionIds() {
+    List<Long> pfhhSurveyQuestionIds =
+        cbCriteriaDao.findPFHHSurveyQuestionIds(ImmutableList.of(43530446L));
+    assertThat(Long.parseLong(pfhhSurveyQuestion.getConceptId()))
+        .isEqualTo(pfhhSurveyQuestionIds.get(0));
+  }
+
+  @Test
+  public void findPFHHSurveyAnswerIds() {
+    List<Long> pfhhSurveyAnswerIds =
+        cbCriteriaDao.findPFHHSurveyAnswerIds(ImmutableList.of(43530446L));
+    assertThat(Long.parseLong(pfhhSurveyAnswer.getValue())).isEqualTo(pfhhSurveyAnswerIds.get(0));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
@@ -738,7 +738,7 @@ public class DataSetServiceTest {
 
   @Test
   public void test_getExtractionDirectory_datasetDoesNotExist() {
-    assertThat(dataSetServiceImpl.getExtractionDirectory(123l).isPresent()).isFalse();
+    assertThat(dataSetServiceImpl.getExtractionDirectory(123L).isPresent()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
change generated BQ SQL for any concept set that contains questions from PFHH survey


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
