### PR TITLE
[no ticket][risk=no] Add workaround for e2e tests on M1 Macs

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,8 +15,16 @@ main ([example](https://app.circleci.com/pipelines/github/all-of-us/workbench/40
 * Clone github project: `git clone git@github.com:all-of-us/workbench.git`
 
 * Install required node libraries
-    - change to e2e dir `cd e2e`
-    - run cmd `yarn install`
+    - Change to e2e dir `cd e2e`
+    - (M1 Macs only) Manually install Chromium `brew install chromium --no-quarantine`
+    - (M1 Macs only) Add `export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true` to your `.bashrc` or equivalent. Then run `source ~/.bashrc`.
+    - Run command `yarn install`
+    - (M1 Macs only) Add the following alias to your `.bashrc`: `alias yarnm1e2e="find node_modules/puppeteer -name '*.js' | xargs sed -i '' \"s%/usr/bin/chromium-browser%\$(which chromium)%g\" && yarn"`. Then run `source ~/.bashrc`.
+      - If you are on an M1 Mac, use this alias every time you would otherwise use `yarn`
+      - Wait, what?
+        - Older puppeteer versions on M1 macs do not respect chromium path configurations 
+        - We can’t add symlinks to `/usr/bin` (the default location puppeteer looks) without disabling Mac security controls
+      - Alternatively, you could the run the above find/sed command every time you update node_modules and then run `yarn` normally.
 * Compile `yarn compile`
 
 ## Test Users


### PR DESCRIPTION
Older puppeteer versions do not support M1 Macs. This fix instructs the developer to manually install chromium and hotfix their vendored puppeteer package to point to their chromium installation.

I think this is the only way to fix the issue for our version of puppeteer.

**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
