### PR TITLE
[DT-149][risk=no] Fix incorrect cross-domain message in dataset builder

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -889,7 +889,11 @@ export const DatasetPage = fp.flow(
       updatedSelectedDomainsWithConceptSetIds.delete(domainWithConceptSetId);
       values.items.forEach((domainWithDomainValues) => {
         const domain = reverseDomainEnum[domainWithDomainValues.domain];
-        if (domain !== domainWithConceptSetId.domain) {
+        if (
+          ![domain, Domain.PHYSICALMEASUREMENTCSS].includes(
+            domainWithConceptSetId.domain
+          )
+        ) {
           updatedCrossDomainConceptSetList.add(
             domainWithConceptSetId.conceptSetId
           );
@@ -972,7 +976,11 @@ export const DatasetPage = fp.flow(
         const domainWithConceptSetId = domainsWithConceptSetIds[index];
         values.items.forEach((domainWithDomainValues) => {
           const domain = reverseDomainEnum[domainWithDomainValues.domain];
-          if (domain !== domainWithConceptSetId.domain) {
+          if (
+            ![domain, Domain.PHYSICALMEASUREMENTCSS].includes(
+              domainWithConceptSetId.domain
+            )
+          ) {
             newCrossDomainConceptSetList.add(
               domainWithConceptSetId.conceptSetId
             );


### PR DESCRIPTION
![Screen Shot 2022-12-01 at 10 01 58 AM](https://user-images.githubusercontent.com/40036095/205103068-d525441e-3d53-428d-a721-b13a02ecf1d6.png)

![Screen Shot 2022-12-01 at 10 02 10 AM](https://user-images.githubusercontent.com/40036095/205103191-5863ba74-55b5-4577-885f-9c0668129a40.png)


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
