### PR TITLE
[RW-9028][risk=no] Add notification for new user satisfaction survey

### DIFF
--- a/api-proxy/handlers/|v1|profile.get.mjs
+++ b/api-proxy/handlers/|v1|profile.get.mjs
@@ -147,7 +147,9 @@ const body = JSON.stringify(
     education: 'PREFER_NOT_TO_ANSWER',
     disadvantaged: 'PREFER_NOT_TO_ANSWER',
     surveyComments: 'asdfg'
-  }
+  },
+  newUserSatisfactionSurveyEligibility: true,
+  newUserSatisfactionSurveyEligibilityEndTime: "2023-01-10T14:38:10Z"
 }
 )
 

--- a/api-proxy/handlers/|v1|surveys|newUserSatisfactionSurvey.post.mjs
+++ b/api-proxy/handlers/|v1|surveys|newUserSatisfactionSurvey.post.mjs
@@ -1,0 +1,26 @@
+const matchReq = req =>
+  req.url.pathname === '/v1/surveys/newUserSatisfactionSurvey'
+  && req.url.search === ''
+  && req.method === 'POST'
+
+const body = JSON.stringify(
+  {
+    satisfaction: "VERY_SATISFIED",
+    additionalInfo: "I love the workbench!"
+  }
+)
+
+const headers = {
+  'access-control-allow-credentials': 'true',
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, HEAD, POST, PUT, DELETE, PATCH, TRACE, OPTIONS',
+  'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, Authorization',
+  'content-type': 'application/json'
+}
+
+const handleReq = (req, res) => {
+  if (!matchReq(req)) { return }
+  Object.keys(headers).forEach(h => res.setHeader(h, headers[h]))
+  res.status(200).mwrite(body).mend()
+}
+export default handleReq

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.profile;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -48,7 +49,8 @@ public interface ProfileMapper {
       List<String> accessTierShortNames,
       List<UserTierEligibility> tierEligibilities,
       ProfileAccessModules accessModules,
-      boolean newUserSatisfactionSurveyEligibility);
+      boolean newUserSatisfactionSurveyEligibility,
+      Instant newUserSatisfactionSurveyEligibilityEndTime);
 
   List<AdminTableUser> adminViewToModel(List<DbAdminTableUser> adminTableUsers);
 

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.profile;
 import com.google.common.annotations.VisibleForTesting;
 import java.sql.Timestamp;
 import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
@@ -142,6 +143,8 @@ public class ProfileService {
 
     final boolean newUserSatisfactionSurveyEligibility =
         newUserSatisfactionSurveyService.eligibleToTakeSurvey(user);
+    final Instant newUserSatisfactionSurveyEligibilityEndTime =
+        newUserSatisfactionSurveyService.eligibilityWindowEnd(user);
 
     return profileMapper.toModel(
         user,
@@ -152,7 +155,8 @@ public class ProfileService {
         accessTierShortNames,
         userTierEligibilities,
         accessModules,
-        newUserSatisfactionSurveyEligibility);
+        newUserSatisfactionSurveyEligibility,
+        newUserSatisfactionSurveyEligibilityEndTime);
   }
 
   public void validateAffiliation(Profile profile) {

--- a/api/src/main/java/org/pmiops/workbench/survey/NewUserSatisfactionSurveyService.java
+++ b/api/src/main/java/org/pmiops/workbench/survey/NewUserSatisfactionSurveyService.java
@@ -1,7 +1,10 @@
 package org.pmiops.workbench.survey;
 
+import java.time.Instant;
 import org.pmiops.workbench.db.model.DbUser;
 
 public interface NewUserSatisfactionSurveyService {
   boolean eligibleToTakeSurvey(DbUser user);
+
+  Instant eligibilityWindowEnd(DbUser user);
 }

--- a/api/src/main/java/org/pmiops/workbench/survey/NewUserSatisfactionSurveyServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/survey/NewUserSatisfactionSurveyServiceImpl.java
@@ -22,13 +22,18 @@ public class NewUserSatisfactionSurveyServiceImpl implements NewUserSatisfaction
       return false;
     }
 
+    final Instant now = clock.instant();
+    return now.isAfter(eligibilityWindowStart(user)) && now.isBefore(eligibilityWindowEnd(user));
+  }
+
+  private Instant eligibilityWindowStart(DbUser user) {
     final Instant createdTime = user.getCreationTime().toInstant();
 
-    final Instant windowStart = createdTime.plus(2 * 7, ChronoUnit.DAYS);
-    final Instant windowEnd = windowStart.plus(61, ChronoUnit.DAYS);
+    return createdTime.plus(2 * 7, ChronoUnit.DAYS);
+  }
 
-    final Instant now = clock.instant();
-
-    return now.isAfter(windowStart) && now.isBefore(windowEnd);
+  @Override
+  public Instant eligibilityWindowEnd(DbUser user) {
+    return eligibilityWindowStart(user).plus(61, ChronoUnit.DAYS);
   }
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6114,6 +6114,9 @@ definitions:
         $ref: '#/definitions/DemographicSurveyV2'
       newUserSatisfactionSurveyEligibility:
         type: boolean
+      newUserSatisfactionSurveyEligibilityEndTime:
+        type: string
+        description: Timestamp indicating when the user is ineligible to take the new user survey in ISO 8601 format
 
   AccessModuleStatus:
     type: object

--- a/api/src/test/java/org/pmiops/workbench/survey/NewUserSatisfactionSurveyServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/survey/NewUserSatisfactionSurveyServiceTest.java
@@ -77,4 +77,13 @@ class NewUserSatisfactionSurveyServiceTest {
     user.setCreationTime(Timestamp.from(twoMonthsTwoWeeksOneDayAgo));
     assertThat(newUserSatisfactionSurveyService.eligibleToTakeSurvey(user)).isFalse();
   }
+
+  @Test
+  public void testEligibilityWindowEnd() {
+    user.setCreationTime(Timestamp.from(PROVIDED_CLOCK.instant()));
+    final Instant twoMonthsTwoWeeksFromNow =
+        PROVIDED_CLOCK.instant().plus(61 + (2 * 7), ChronoUnit.DAYS);
+    assertThat(newUserSatisfactionSurveyService.eligibilityWindowEnd(user))
+        .isEqualTo(twoMonthsTwoWeeksFromNow);
+  }
 }

--- a/e2ev2/tests/new-user-satisfaction-survey.test.js
+++ b/e2ev2/tests/new-user-satisfaction-survey.test.js
@@ -1,0 +1,35 @@
+const config = require('../src/config')
+const tu = require('../src/test-utils')
+
+const browserTest = tu.browserTest(__filename)
+
+browserTest('take the new user satisfaction survey via the relevant notification', async browser => {
+  const page = browser.initialPage
+  await tu.useApiProxy(page)
+  await tu.fakeSignIn(page)
+  await page.goto(config.urlRoot(), {waitUntil: 'networkidle0'})
+
+  const surveyNotification = await page.waitForSelector('[data-test-id="new-user-satisfaction-survey-notification"]');
+  const launchSurveyButton = await surveyNotification.waitForSelector('[role="button"]');
+  await launchSurveyButton.click();
+
+  let surveyModal = await page.waitForSelector('[data-test-id="new-user-satisfaction-survey-modal"]');
+
+  const verySatisfiedButton = await surveyModal.waitForSelector('[value="VERY_SATISFIED"]');
+  await verySatisfiedButton.click();
+
+  const additionalInfoInput = await surveyModal.waitForSelector('#new-user-satisfaction-survey-additional-info');
+  await additionalInfoInput.type('I love the workbench!');
+
+  const submitButton = await surveyModal.waitForSelector('[role="button"]:nth-of-type(2)');
+  await submitButton.click();
+
+  // wait for the submit request to succeed
+  await new Promise((r) => setTimeout(r, 100));
+
+  surveyModal = await page.$('[data-test-id="new-user-satisfaction-survey-modal"]');
+  expect(surveyModal).toBeNull();
+
+  // todo: Verify the notification goes away. Not possible without a different /profile handler that sets newUserSatisfactionSurveyEligibility to false.
+}, 10e3);
+

--- a/e2ev2/tests/new-user-satisfaction-survey.test.js
+++ b/e2ev2/tests/new-user-satisfaction-survey.test.js
@@ -15,10 +15,10 @@ browserTest('take the new user satisfaction survey via the relevant notification
   let surveyModal = await page.waitForSelector('[aria-modal="true"]');
   await surveyModal.waitForSelector('[value="VERY_SATISFIED"]').then(b => b.click());
   await surveyModal.waitForSelector('#new-user-satisfaction-survey-additional-info').then(i => i.type('I love the workbench!'));
-  await surveyModal.waitForSelector('[aria-label="submit"]').then(b => b.click());
+  const submitButton = await surveyModal.waitForSelector('[aria-label="submit"]');
 
-  // wait for the submit request to succeed
-  await new Promise((r) => setTimeout(r, 100));
+  const [submitEvent] = await tu.promiseWindowEvent(page, 'new-user-satisfaction-survey-submitted');
+  await Promise.all([submitEvent, submitButton.click()]);
 
   surveyModal = await page.$('[aria-modal="true"]');
   expect(surveyModal).toBeNull();

--- a/e2ev2/tests/new-user-satisfaction-survey.test.js
+++ b/e2ev2/tests/new-user-satisfaction-survey.test.js
@@ -20,8 +20,8 @@ browserTest('take the new user satisfaction survey via the relevant notification
   const [submitEvent] = await tu.promiseWindowEvent(page, 'new-user-satisfaction-survey-submitted');
   await Promise.all([submitEvent, submitButton.click()]);
 
-  surveyModal = await page.$('[aria-modal="true"]');
-  expect(surveyModal).toBeNull();
+  // Ideally, we would check that `surveyModal` is now hidden, but as far as I know puppeteer does not offer a way to check that
+  await page.waitForSelector('[aria-modal="true"]', { hidden: true });
 
   // todo: Verify the notification goes away. Not possible without a different /profile handler that sets newUserSatisfactionSurveyEligibility to false.
 }, 10e3);

--- a/e2ev2/tests/new-user-satisfaction-survey.test.js
+++ b/e2ev2/tests/new-user-satisfaction-survey.test.js
@@ -10,19 +10,12 @@ browserTest('take the new user satisfaction survey via the relevant notification
   await page.goto(config.urlRoot(), {waitUntil: 'networkidle0'})
 
   const surveyNotification = await page.waitForSelector('[data-test-id="new-user-satisfaction-survey-notification"]');
-  const launchSurveyButton = await surveyNotification.waitForSelector('[aria-label="take satisfaction survey"]');
-  await launchSurveyButton.click();
+  await surveyNotification.waitForSelector('[aria-label="take satisfaction survey"]').then(b => b.click());
 
   let surveyModal = await page.waitForSelector('[aria-modal="true"]');
-
-  const verySatisfiedButton = await surveyModal.waitForSelector('[value="VERY_SATISFIED"]');
-  await verySatisfiedButton.click();
-
-  const additionalInfoInput = await surveyModal.waitForSelector('#new-user-satisfaction-survey-additional-info');
-  await additionalInfoInput.type('I love the workbench!');
-
-  const submitButton = await surveyModal.waitForSelector('[aria-label="submit"]');
-  await submitButton.click();
+  await surveyModal.waitForSelector('[value="VERY_SATISFIED"]').then(b => b.click());
+  await surveyModal.waitForSelector('#new-user-satisfaction-survey-additional-info').then(i => i.type('I love the workbench!'));
+  await surveyModal.waitForSelector('[aria-label="submit"]').then(b => b.click());
 
   // wait for the submit request to succeed
   await new Promise((r) => setTimeout(r, 100));

--- a/e2ev2/tests/new-user-satisfaction-survey.test.js
+++ b/e2ev2/tests/new-user-satisfaction-survey.test.js
@@ -10,10 +10,10 @@ browserTest('take the new user satisfaction survey via the relevant notification
   await page.goto(config.urlRoot(), {waitUntil: 'networkidle0'})
 
   const surveyNotification = await page.waitForSelector('[data-test-id="new-user-satisfaction-survey-notification"]');
-  const launchSurveyButton = await surveyNotification.waitForSelector('[role="button"]');
+  const launchSurveyButton = await surveyNotification.waitForSelector('[aria-label="take satisfaction survey"]');
   await launchSurveyButton.click();
 
-  let surveyModal = await page.waitForSelector('[data-test-id="new-user-satisfaction-survey-modal"]');
+  let surveyModal = await page.waitForSelector('[aria-modal="true"]');
 
   const verySatisfiedButton = await surveyModal.waitForSelector('[value="VERY_SATISFIED"]');
   await verySatisfiedButton.click();
@@ -21,13 +21,13 @@ browserTest('take the new user satisfaction survey via the relevant notification
   const additionalInfoInput = await surveyModal.waitForSelector('#new-user-satisfaction-survey-additional-info');
   await additionalInfoInput.type('I love the workbench!');
 
-  const submitButton = await surveyModal.waitForSelector('[role="button"]:nth-of-type(2)');
+  const submitButton = await surveyModal.waitForSelector('[aria-label="submit"]');
   await submitButton.click();
 
   // wait for the submit request to succeed
   await new Promise((r) => setTimeout(r, 100));
 
-  surveyModal = await page.$('[data-test-id="new-user-satisfaction-survey-modal"]');
+  surveyModal = await page.$('[aria-modal="true"]');
   expect(surveyModal).toBeNull();
 
   // todo: Verify the notification goes away. Not possible without a different /profile handler that sets newUserSatisfactionSurveyEligibility to false.

--- a/ui/src/app/components/new-user-satisfaction-survey-banner-maybe.tsx
+++ b/ui/src/app/components/new-user-satisfaction-survey-banner-maybe.tsx
@@ -29,6 +29,7 @@ export const NewUserSatisfactionSurveyBannerMaybe = () => {
           buttonText='Take Survey'
           buttonOnClick={() => setShowModal(true)}
           bannerTextWidth='20rem'
+          buttonAriaLabel='take satisfaction survey'
         />
       )}
       {showModal && (

--- a/ui/src/app/components/new-user-satisfaction-survey-banner-maybe.tsx
+++ b/ui/src/app/components/new-user-satisfaction-survey-banner-maybe.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { useState } from 'react';
+
+import { NewUserSatisfactionSurveyModal } from 'app/components/new-user-satisfaction-survey-modal';
+import { NotificationBanner } from 'app/components/notification-banner';
+import { profileStore, useStore } from 'app/utils/stores';
+import moment from 'moment';
+
+export const NewUserSatisfactionSurveyBannerMaybe = () => {
+  const { profile, reload } = useStore(profileStore);
+  const [showModal, setShowModal] = useState(false);
+
+  const eligibilityEnd = moment(
+    profile.newUserSatisfactionSurveyEligibilityEndTime
+  ).format('M/D/YY');
+
+  return (
+    <>
+      {profile.newUserSatisfactionSurveyEligibility && (
+        <NotificationBanner
+          dataTestId='new-user-satisfaction-survey-notification'
+          text={
+            <span>
+              Please take 2 minutes to rate your satisfaction with the{' '}
+              <i>All of Us</i> Researcher Workbench. Please complete the survey
+              by {eligibilityEnd}.
+            </span>
+          }
+          buttonText='Take Survey'
+          buttonOnClick={() => setShowModal(true)}
+          bannerTextWidth='20rem'
+        />
+      )}
+      {showModal && (
+        <NewUserSatisfactionSurveyModal
+          onCancel={() => setShowModal(false)}
+          onSubmitSuccess={() => {
+            setShowModal(false);
+            reload();
+          }}
+        />
+      )}
+    </>
+  );
+};

--- a/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
+++ b/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
@@ -80,7 +80,7 @@ export const NewUserSatisfactionSurveyModal = ({
   );
 
   return (
-    <Modal width={850} onRequestClose={onCancel}>
+    <Modal width={850} onRequestClose={onCancel} data={{'test-id': 'new-user-satisfaction-survey-modal'}}>
       <FlexColumn style={{ gap: '0.5rem' }}>
         <MultipleChoiceQuestion
           question='How would you rate your overall satisfaction with the Researcher Workbench?'

--- a/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
+++ b/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
@@ -159,6 +159,9 @@ export const NewUserSatisfactionSurveyModal = ({
                   );
                   setSubmittingRequest(false);
                   setError(false);
+                  window.dispatchEvent(
+                    new Event('new-user-satisfaction-survey-submitted')
+                  );
                   onSubmitSuccess();
                 } catch {
                   setSubmittingRequest(false);

--- a/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
+++ b/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
@@ -156,12 +156,12 @@ export const NewUserSatisfactionSurveyModal = ({
                   await surveysApi().createNewUserSatisfactionSurvey(
                     newUserSatisfactionSurveyData
                   );
+                  setSubmittingRequest(false);
                   setError(false);
                   onSubmitSuccess();
                 } catch {
-                  setError(true);
-                } finally {
                   setSubmittingRequest(false);
+                  setError(true);
                 }
               }}
             >

--- a/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
+++ b/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
@@ -80,7 +80,11 @@ export const NewUserSatisfactionSurveyModal = ({
   );
 
   return (
-    <Modal width={850} onRequestClose={onCancel} data={{'test-id': 'new-user-satisfaction-survey-modal'}}>
+    <Modal
+      width={850}
+      onRequestClose={onCancel}
+      data={{ 'test-id': 'new-user-satisfaction-survey-modal' }}
+    >
       <FlexColumn style={{ gap: '0.5rem' }}>
         <MultipleChoiceQuestion
           question='How would you rate your overall satisfaction with the Researcher Workbench?'

--- a/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
+++ b/ui/src/app/components/new-user-satisfaction-survey-modal.tsx
@@ -80,11 +80,7 @@ export const NewUserSatisfactionSurveyModal = ({
   );
 
   return (
-    <Modal
-      width={850}
-      onRequestClose={onCancel}
-      data={{ 'test-id': 'new-user-satisfaction-survey-modal' }}
-    >
+    <Modal width={850} onRequestClose={onCancel}>
       <FlexColumn style={{ gap: '0.5rem' }}>
         <MultipleChoiceQuestion
           question='How would you rate your overall satisfaction with the Researcher Workbench?'
@@ -131,7 +127,7 @@ export const NewUserSatisfactionSurveyModal = ({
           )}
         </FlexRow>
         <FlexRow style={{ justifyContent: 'flex-end', gap: '0.5rem' }}>
-          <Button type='secondary' onClick={onCancel}>
+          <Button type='secondary' onClick={onCancel} aria-label='cancel'>
             Cancel
           </Button>
           <TooltipTrigger
@@ -153,6 +149,7 @@ export const NewUserSatisfactionSurveyModal = ({
           >
             <Button
               type='primary'
+              aria-label='submit'
               disabled={!!validationErrors || submittingRequest}
               onClick={async () => {
                 setSubmittingRequest(true);

--- a/ui/src/app/components/notification-banner.spec.tsx
+++ b/ui/src/app/components/notification-banner.spec.tsx
@@ -14,6 +14,7 @@ describe('NotificationBanner', () => {
           buttonText='BLAH'
           buttonPath='yahoo.com'
           buttonDisabled={true}
+          bannerTextWidth='177px'
         />
       </MemoryRouter>
     );

--- a/ui/src/app/components/notification-banner.tsx
+++ b/ui/src/app/components/notification-banner.tsx
@@ -72,6 +72,7 @@ interface NotificationProps {
   buttonStyle?: CSSProperties;
   buttonOnClick?: () => void;
   bannerTextWidth: CSSProperties['width'];
+  buttonAriaLabel?: string;
 }
 
 export const NotificationBanner = ({
@@ -85,6 +86,7 @@ export const NotificationBanner = ({
   textStyle,
   buttonStyle,
   buttonOnClick,
+  buttonAriaLabel,
   bannerTextWidth,
 }: NotificationProps) => {
   return (
@@ -100,6 +102,7 @@ export const NotificationBanner = ({
           path={buttonPath}
           disabled={buttonDisabled}
           onClick={buttonOnClick}
+          aria-label={buttonAriaLabel}
         >
           <div style={styles.buttonText}>{buttonText}</div>
         </ButtonWithLocationState>
@@ -110,6 +113,7 @@ export const NotificationBanner = ({
           path={buttonPath}
           disabled={buttonDisabled}
           onClick={buttonOnClick}
+          aria-label={buttonAriaLabel}
         >
           <div style={styles.buttonText}>{buttonText}</div>
         </Button>

--- a/ui/src/app/components/notification-banner.tsx
+++ b/ui/src/app/components/notification-banner.tsx
@@ -12,13 +12,15 @@ const styles = reactStyles({
   box: {
     boxSizing: 'border-box',
     height: '56.5px',
-    width: '380.5px',
     border: '0.5px solid rgba(38,34,98,0.5)',
     borderRadius: '5px',
     backgroundColor: colorWithWhiteness(colors.warning, 0.9),
     alignItems: 'center',
     justifyContent: 'center',
     marginLeft: 'auto',
+    gap: '24.5px',
+    paddingLeft: '24.5px',
+    paddingRight: '24.5px',
   },
   icon: {
     height: '25px',
@@ -28,19 +30,16 @@ const styles = reactStyles({
     fontSize: '25px',
     letterSpacing: 0,
     lineHeight: '25px',
-    marginLeft: 'auto',
     alignItems: 'center',
   },
   text: {
     height: '40px',
-    width: '177px',
     color: colors.primary,
     fontFamily: 'Montserrat',
     fontSize: '14px',
     fontWeight: 600,
     letterSpacing: 0,
     lineHeight: '20px',
-    marginLeft: 'auto',
   },
   button: {
     boxSizing: 'border-box',
@@ -48,8 +47,6 @@ const styles = reactStyles({
     width: '102px',
     border: '0.8px solid #216FB4',
     borderRadius: '1.6px',
-    marginLeft: 'auto',
-    marginRight: 'auto',
   },
   buttonText: {
     height: '20px',
@@ -73,6 +70,7 @@ interface NotificationProps {
   boxStyle?: CSSProperties;
   textStyle?: CSSProperties;
   buttonStyle?: CSSProperties;
+  bannerTextWidth: CSSProperties['width'];
 }
 
 export const NotificationBanner = ({
@@ -85,11 +83,14 @@ export const NotificationBanner = ({
   boxStyle,
   textStyle,
   buttonStyle,
+  bannerTextWidth,
 }: NotificationProps) => {
   return (
     <FlexRow data-test-id={dataTestId} style={{ ...styles.box, ...boxStyle }}>
       <AlarmExclamation style={styles.icon} />
-      <div style={{ ...styles.text, ...textStyle }}>{text}</div>
+      <div style={{ ...styles.text, ...textStyle, width: bannerTextWidth }}>
+        {text}
+      </div>
       {useLocationLink ? (
         <ButtonWithLocationState
           type='primary'

--- a/ui/src/app/components/notification-banner.tsx
+++ b/ui/src/app/components/notification-banner.tsx
@@ -64,12 +64,13 @@ interface NotificationProps {
   dataTestId: string;
   text: string | JSX.Element;
   buttonText: string;
-  buttonPath: string;
-  buttonDisabled: boolean;
+  buttonPath?: string;
+  buttonDisabled?: boolean;
   useLocationLink?: boolean;
   boxStyle?: CSSProperties;
   textStyle?: CSSProperties;
   buttonStyle?: CSSProperties;
+  buttonOnClick?: () => void;
   bannerTextWidth: CSSProperties['width'];
 }
 
@@ -83,6 +84,7 @@ export const NotificationBanner = ({
   boxStyle,
   textStyle,
   buttonStyle,
+  buttonOnClick,
   bannerTextWidth,
 }: NotificationProps) => {
   return (
@@ -97,6 +99,7 @@ export const NotificationBanner = ({
           style={{ ...styles.button, ...buttonStyle }}
           path={buttonPath}
           disabled={buttonDisabled}
+          onClick={buttonOnClick}
         >
           <div style={styles.buttonText}>{buttonText}</div>
         </ButtonWithLocationState>
@@ -106,6 +109,7 @@ export const NotificationBanner = ({
           style={styles.button}
           path={buttonPath}
           disabled={buttonDisabled}
+          onClick={buttonOnClick}
         >
           <div style={styles.buttonText}>{buttonText}</div>
         </Button>

--- a/ui/src/app/components/take-demographic-survey-v2.tsx
+++ b/ui/src/app/components/take-demographic-survey-v2.tsx
@@ -11,12 +11,6 @@ import {
 import { profileStore, useStore } from 'app/utils/stores';
 
 const styles = reactStyles({
-  bannerText: {
-    width: '26rem',
-  },
-  bannerBox: {
-    width: '36rem',
-  },
   bannerButton: {
     width: '120px',
     alignSelf: 'center',
@@ -53,13 +47,12 @@ export const TakeDemographicSurveyV2BannerMaybe = () => {
         text={
           deadlineReached ? notificationTextAfterDeadline : notificationText
         }
-        boxStyle={styles.bannerBox}
-        textStyle={styles.bannerText}
         useLocationLink={true}
         buttonStyle={styles.bannerButton}
         buttonText='Take Survey'
         buttonPath={DEMOGRAPHIC_SURVEY_V2_PATH}
         buttonDisabled={location.pathname === DEMOGRAPHIC_SURVEY_V2_PATH}
+        bannerTextWidth='26rem'
       />
     )
   );

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -30,6 +30,7 @@ export const AccessRenewalNotificationMaybe = () => {
       buttonText='Get Started'
       buttonPath={ACCESS_RENEWAL_PATH}
       buttonDisabled={fullPagePath === ACCESS_RENEWAL_PATH}
+      bannerTextWidth='177px'
     />
   ) : null;
 };

--- a/ui/src/app/pages/signed-in/nav-bar.tsx
+++ b/ui/src/app/pages/signed-in/nav-bar.tsx
@@ -5,6 +5,7 @@ import { Breadcrumb } from 'app/components/breadcrumb';
 import { CTAvailableBannerMaybe } from 'app/components/ct-available-banner-maybe';
 import { SignedInAouHeaderWithDisplayTag } from 'app/components/headers';
 import { ClrIcon } from 'app/components/icons';
+import { NewUserSatisfactionSurveyBannerMaybe } from 'app/components/new-user-satisfaction-survey-banner-maybe';
 import { SideNav } from 'app/components/side-nav';
 import { StatusAlertBannerMaybe } from 'app/components/status-alert-banner-maybe';
 import { TakeDemographicSurveyV2BannerMaybe } from 'app/components/take-demographic-survey-v2';
@@ -111,6 +112,7 @@ export const NavBar = () => {
       <AccessRenewalNotificationMaybe />
       <StatusAlertBannerMaybe />
       <TakeDemographicSurveyV2BannerMaybe />
+      <NewUserSatisfactionSurveyBannerMaybe />
       <CTAvailableBannerMaybe />
       {showSideNav && (
         <SideNav


### PR DESCRIPTION
Description:

Adds a notification for the new user satisfaction survey.

This is the first user-facing satisfaction survey change. I will wait to merge this alongside the related [email story](https://precisionmedicineinitiative.atlassian.net/browse/RW-9029) so they release at the same time.

Demo video:

https://user-images.githubusercontent.com/31020403/206270652-f69fcf74-1bf7-41c3-b9c5-9bd20b0fc398.mov

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
