### PR TITLE
[DT-13][risk=no] Clear input on return to concept homepage

### DIFF
--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -273,12 +273,8 @@ export const ConceptHomepage = fp.flow(
       this.state = {
         conceptDomainCards: [],
         conceptSurveysList: [],
-        currentInputString: props.cohortContext
-          ? props.cohortContext.searchTerms
-          : '',
-        currentSearchString: props.cohortContext
-          ? props.cohortContext.searchTerms
-          : '',
+        currentInputString: '',
+        currentSearchString: '',
         domainInfoError: false,
         showSearchError: false,
         surveyInfoError: false,
@@ -295,7 +291,6 @@ export const ConceptHomepage = fp.flow(
 
     async loadDomainsAndSurveys() {
       const {
-        cohortContext,
         workspace: { id, namespace },
       } = this.props;
       this.setState({
@@ -322,11 +317,7 @@ export const ConceptHomepage = fp.flow(
           console.error(e);
         });
       await Promise.all([getDomainCards, getSurveyInfo]);
-      if (cohortContext?.searchTerms) {
-        await this.updateCardCounts();
-      } else {
-        this.setState({ loadingConceptCounts: false });
-      }
+      this.setState({ loadingConceptCounts: false });
     }
 
     async updateCardCounts() {


### PR DESCRIPTION
Fixes issue on concept search homepage where the last search term remains in the search bar even after navigating away then returning.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
