### PR TITLE
[DT-174][risk=no] Fix rename function for excludes groups

### DIFF
--- a/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
+++ b/e2e/tests/conceptsets/conceptset-edit-rename.spec.ts
@@ -59,7 +59,7 @@ describe('Editing and rename Concept Set', () => {
     criteriaSearch = await procedures.clickSelectConceptButton();
 
     // Search in Procedures domain
-    procedureName = 'Screening mammography';
+    procedureName = 'cancer screening';
     await criteriaSearch.searchCriteria(procedureName);
 
     // Select first row. Its name cell should match the search words.

--- a/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
+++ b/ui/src/app/cohort-search/search-group-list/search-group-list.component.tsx
@@ -214,9 +214,10 @@ const SearchGroupList = fp.flow(withCurrentWorkspace())(
             <div key={g} data-test-id={`${role}-search-group`}>
               <SearchGroup
                 group={group}
-                index={g + index}
-                setSearchContext={setSearchContext}
+                groupIndex={g + index}
                 role={role}
+                roleIndex={g}
+                setSearchContext={setSearchContext}
                 updated={updated}
                 updateRequest={updateRequest}
               />

--- a/ui/src/app/cohort-search/search-group/search-group.component.tsx
+++ b/ui/src/app/cohort-search/search-group/search-group.component.tsx
@@ -195,9 +195,10 @@ function initItem(id: string, type: string, tempGroup: number) {
 
 interface Props {
   group: any;
-  index: number;
-  setSearchContext: (context: any) => void;
+  groupIndex: number;
   role: keyof CohortDefinition;
+  roleIndex: number;
+  setSearchContext: (context: any) => void;
   updated: number;
   updateRequest: Function;
   workspace: WorkspaceData;
@@ -391,9 +392,9 @@ export const SearchGroup = withCurrentWorkspace()(
     }
 
     rename(newName: string) {
-      const { group, index, role } = this.props;
+      const { group, roleIndex, role } = this.props;
       const searchRequest = searchRequestStore.getValue();
-      searchRequest[role][index] = { ...group, name: newName };
+      searchRequest[role][roleIndex] = { ...group, name: newName };
       searchRequestStore.next(searchRequest);
       this.setState({ renaming: false });
     }
@@ -566,7 +567,7 @@ export const SearchGroup = withCurrentWorkspace()(
     render() {
       const {
         group: { id, items, mention, name, status, temporal, time, timeValue },
-        index,
+        groupIndex,
         setSearchContext,
         role,
       } = this.props;
@@ -580,7 +581,7 @@ export const SearchGroup = withCurrentWorkspace()(
         overlayStyle,
         renaming,
       } = this.state;
-      const groupName = !!name ? name : `Group ${index + 1}`;
+      const groupName = !!name ? name : `Group ${groupIndex + 1}`;
       const showGroupCount =
         !loading &&
         !error &&


### PR DESCRIPTION
Separates the column index (`roleIndex`) from the overall group index (`groupIndex`) to prevent duplicate groups when renaming a group in the excludes column.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
