### PR TITLE
[risk=low][RW-9270] Continue deleting workspaces if one is not found

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -383,7 +383,7 @@ public class FireCloudServiceImpl implements FireCloudService {
 
   @Override
   public FirecloudWorkspaceResponse getWorkspaceAsService(
-      String workspaceNamespace, String firecloudName) throws WorkbenchException {
+      String workspaceNamespace, String firecloudName) {
     WorkspacesApi workspacesApi = serviceAccountWorkspaceApiProvider.get();
     return retryHandler.run(
         (context) ->
@@ -392,8 +392,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public FirecloudWorkspaceResponse getWorkspace(String workspaceNamespace, String firecloudName)
-      throws WorkbenchException {
+  public FirecloudWorkspaceResponse getWorkspace(String workspaceNamespace, String firecloudName) {
     WorkspacesApi workspacesApi = endUserWorkspacesApiProvider.get();
     return retryHandler.run(
         (context) ->
@@ -402,8 +401,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public Optional<FirecloudWorkspaceResponse> getWorkspace(DbWorkspace dbWorkspace)
-      throws WorkbenchException {
+  public Optional<FirecloudWorkspaceResponse> getWorkspace(DbWorkspace dbWorkspace) {
     try {
       final FirecloudWorkspaceResponse result =
           getWorkspace(dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
@@ -421,15 +419,14 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public List<FirecloudWorkspaceResponse> getWorkspaces() throws WorkbenchException {
+  public List<FirecloudWorkspaceResponse> getWorkspaces() {
     return retryHandler.run(
         (context) ->
             endUserWorkspacesApiProvider.get().listWorkspaces(FIRECLOUD_WORKSPACE_REQUIRED_FIELDS));
   }
 
   @Override
-  public void deleteWorkspace(String workspaceNamespace, String firecloudName)
-      throws WorkbenchException {
+  public void deleteWorkspace(String workspaceNamespace, String firecloudName) {
     WorkspacesApi workspacesApi = endUserWorkspacesApiProvider.get();
     retryHandler.run(
         (context) -> {
@@ -439,13 +436,13 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public FirecloudManagedGroupWithMembers getGroup(String groupName) throws WorkbenchException {
+  public FirecloudManagedGroupWithMembers getGroup(String groupName) {
     GroupsApi groupsApi = groupsApiProvider.get();
     return retryHandler.run((context) -> groupsApi.getGroup(groupName));
   }
 
   @Override
-  public FirecloudManagedGroupWithMembers createGroup(String groupName) throws WorkbenchException {
+  public FirecloudManagedGroupWithMembers createGroup(String groupName) {
     GroupsApi groupsApi = groupsApiProvider.get();
     return retryHandler.run((context) -> groupsApi.createGroup(groupName));
   }


### PR DESCRIPTION
The current version of `/v1/cron/deleteTestUserWorkspaces` will quit when it sees a 404 for a workspace that it intends to delete.  Because deleting many workspaces can take a long time, it's plausible that some workspaces will already be gone by the time it works through the list.

Now we catch `NotFoundException` and continue.

Tested locally by pausing local execution during a cron run and manually deleting one of the workspaces.  The cron run completed successfully, deleting the other workspaces.  

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
