### PR TITLE
refactor syncEraCommonsStatus into something that can be migrated

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/AccessSyncService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessSyncService.java
@@ -54,4 +54,6 @@ public interface AccessSyncService {
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException;
 
   DbUser syncDuccVersionStatus(DbUser targetUser, Agent agent);
+
+  DbUser syncEraCommonsStatus();
 }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -365,7 +365,7 @@ public class ProfileController implements ProfileApiDelegate {
 
   @Override
   public ResponseEntity<Profile> syncEraCommonsStatus() {
-    userService.syncEraCommonsStatus();
+    accessSyncService.syncEraCommonsStatus();
     return getProfileResponse(userProvider.get());
   }
 
@@ -517,7 +517,7 @@ public class ProfileController implements ProfileApiDelegate {
 
     shibbolethService.updateShibbolethToken(token.getJwt());
 
-    userService.syncEraCommonsStatus();
+    accessSyncService.syncEraCommonsStatus();
     return getProfileResponse(userProvider.get());
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -95,9 +95,6 @@ public interface UserService {
    */
   Set<DbUser> findActiveUsersByUsernames(List<String> usernames);
 
-  // TODO migrate to AccessTierSyncService
-  DbUser syncEraCommonsStatus();
-
   Optional<DbUser> getByUsername(String username);
 
   // same as the above, but throw NotFoundException if not found

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -19,6 +19,7 @@ import javax.annotation.Nonnull;
 import javax.inject.Provider;
 import javax.mail.MessagingException;
 import org.hibernate.exception.GenericJDBCException;
+import org.jetbrains.annotations.Nullable;
 import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessSyncService;
 import org.pmiops.workbench.access.AccessTierService;
@@ -465,62 +466,40 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   public Set<DbUser> findActiveUsersByUsernames(List<String> usernames) {
     return userDao.findUserByUsernameInAndDisabledFalse(usernames);
   }
-  /**
-   * Updates the given user's eraCommons-related fields with the NihStatus object returned from FC.
-   *
-   * <p>This method saves the updated user object to the database and returns it.
-   */
-  private DbUser setEraCommonsStatus(DbUser targetUser, FirecloudNihStatus nihStatus, Agent agent) {
+
+  @Nullable
+  private Timestamp calculateEraCompletion(
+      DbUser user, FirecloudNihStatus nihStatus, Timestamp nihLinkExpireTime) {
+    Timestamp eraCommonsCompletionTime =
+        accessModuleService
+            .getAccessModuleStatus(user, DbAccessModuleName.ERA_COMMONS)
+            .map(AccessModuleStatus::getCompletionEpochMillis)
+            .map(Timestamp::new)
+            .orElse(null);
+
     Timestamp now = clockNow();
 
-    return updateUserWithRetries(
-        user -> {
-          if (nihStatus != null) {
-            Timestamp eraCommonsCompletionTime =
-                accessModuleService
-                    .getAccessModuleStatus(user, DbAccessModuleName.ERA_COMMONS)
-                    .map(AccessModuleStatus::getCompletionEpochMillis)
-                    .map(Timestamp::new)
-                    .orElse(null);
+    // NihStatus should never come back from firecloud with an empty linked username.
+    // If that is the case, there is an error with FC, because we should get a 404
+    // in that case. Leaving the null checking in for code safety reasons
 
-            Timestamp nihLinkExpireTime =
-                Timestamp.from(Instant.ofEpochSecond(nihStatus.getLinkExpireTime()));
+    if (nihStatus.getLinkedNihUsername() == null) {
+      // If FireCloud says we have no NIH link, always clear the completion time.
+      eraCommonsCompletionTime = null;
+    } else if (!nihLinkExpireTime.equals(user.getEraCommonsLinkExpireTime())) {
+      // If the link expiration time has changed, we treat this as a "new" completion of the
+      // access requirement.
+      eraCommonsCompletionTime = now;
+    } else if (nihStatus.getLinkedNihUsername() != null
+        && !nihStatus.getLinkedNihUsername().equals(user.getEraCommonsLinkedNihUsername())) {
+      // If the linked username has changed, we treat this as a new completion time.
+      eraCommonsCompletionTime = now;
+    } else if (eraCommonsCompletionTime == null) {
+      // If the user hasn't previously completed this access requirement, set the time to now.
+      eraCommonsCompletionTime = now;
+    }
 
-            // NihStatus should never come back from firecloud with an empty linked username.
-            // If that is the case, there is an error with FC, because we should get a 404
-            // in that case. Leaving the null checking in for code safety reasons
-
-            if (nihStatus.getLinkedNihUsername() == null) {
-              // If FireCloud says we have no NIH link, always clear the completion time.
-              eraCommonsCompletionTime = null;
-            } else if (!nihLinkExpireTime.equals(user.getEraCommonsLinkExpireTime())) {
-              // If the link expiration time has changed, we treat this as a "new" completion of the
-              // access requirement.
-              eraCommonsCompletionTime = now;
-            } else if (nihStatus.getLinkedNihUsername() != null
-                && !nihStatus
-                    .getLinkedNihUsername()
-                    .equals(user.getEraCommonsLinkedNihUsername())) {
-              // If the linked username has changed, we treat this as a new completion time.
-              eraCommonsCompletionTime = now;
-            } else if (eraCommonsCompletionTime == null) {
-              // If the user hasn't yet completed this access requirement, set the time to now.
-              eraCommonsCompletionTime = now;
-            }
-
-            user.setEraCommonsLinkedNihUsername(nihStatus.getLinkedNihUsername());
-            user.setEraCommonsLinkExpireTime(nihLinkExpireTime);
-            accessModuleService.updateCompletionTime(
-                user, DbAccessModuleName.ERA_COMMONS, eraCommonsCompletionTime);
-          } else {
-            user.setEraCommonsLinkedNihUsername(null);
-            user.setEraCommonsLinkExpireTime(null);
-            accessModuleService.updateCompletionTime(user, DbAccessModuleName.ERA_COMMONS, null);
-          }
-          return user;
-        },
-        targetUser,
-        agent);
+    return eraCommonsCompletionTime;
   }
 
   /** Syncs the eraCommons access module status for the current user. */
@@ -528,7 +507,23 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   public DbUser syncEraCommonsStatus() {
     DbUser user = userProvider.get();
     FirecloudNihStatus nihStatus = fireCloudService.getNihStatus();
-    return setEraCommonsStatus(user, nihStatus, Agent.asUser(user));
+    if (nihStatus == null) {
+      accessModuleService.updateCompletionTime(user, DbAccessModuleName.ERA_COMMONS, null);
+      return userDao.save(
+          user.setEraCommonsLinkedNihUsername(null).setEraCommonsLinkExpireTime(null));
+    } else {
+      Timestamp nihLinkExpireTime =
+          Timestamp.from(Instant.ofEpochSecond(nihStatus.getLinkExpireTime()));
+      Timestamp eraCommonsCompletionTime =
+          calculateEraCompletion(user, nihStatus, nihLinkExpireTime);
+
+      accessModuleService.updateCompletionTime(
+          user, DbAccessModuleName.ERA_COMMONS, eraCommonsCompletionTime);
+
+      return userDao.save(
+          user.setEraCommonsLinkedNihUsername(nihStatus.getLinkedNihUsername())
+              .setEraCommonsLinkExpireTime(nihLinkExpireTime));
+    }
   }
 
   @Override

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -17,7 +16,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-import java.util.function.Supplier;
 import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,7 +35,6 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.mail.MailService;
@@ -154,79 +151,6 @@ public class UserServiceTest {
 
   private void tick() {
     fakeClock.increment(CLOCK_INCREMENT_MILLIS);
-  }
-
-  @Test
-  public void testSyncEraCommonsStatus() {
-    FirecloudNihStatus nihStatus = new FirecloudNihStatus();
-    nihStatus.setLinkedNihUsername("nih-user");
-    // FireCloud stores the NIH status in seconds, not msecs.
-    final long FC_LINK_EXPIRATION_SECONDS = START_INSTANT.toEpochMilli() / 1000;
-    nihStatus.setLinkExpireTime(FC_LINK_EXPIRATION_SECONDS);
-
-    when(mockFireCloudService.getNihStatus()).thenReturn(nihStatus);
-
-    userService.syncEraCommonsStatus();
-
-    DbUser user = userDao.findUserByUsername(USERNAME);
-    assertModuleCompletionEqual(
-        DbAccessModuleName.ERA_COMMONS, user, Timestamp.from(START_INSTANT));
-
-    assertThat(user.getEraCommonsLinkExpireTime()).isEqualTo(Timestamp.from(START_INSTANT));
-    assertThat(user.getEraCommonsLinkedNihUsername()).isEqualTo("nih-user");
-
-    // Completion timestamp should not change when the method is called again.
-    tick();
-    userService.syncEraCommonsStatus();
-
-    assertModuleCompletionEqual(
-        DbAccessModuleName.ERA_COMMONS, user, Timestamp.from(START_INSTANT));
-  }
-
-  @Test
-  public void testClearsEraCommonsStatus() {
-    // Put the test user in a state where eRA commons is completed.
-    DbUser testUser = userDao.findUserByUsername(USERNAME);
-    testUser.setEraCommonsLinkedNihUsername("nih-user");
-    testUser = userDao.save(testUser);
-
-    accessModuleService.updateCompletionTime(
-        testUser, DbAccessModuleName.ERA_COMMONS, Timestamp.from(START_INSTANT));
-
-    userService.syncEraCommonsStatus();
-
-    DbUser retrievedUser = userDao.findUserByUsername(USERNAME);
-    assertModuleCompletionEqual(DbAccessModuleName.ERA_COMMONS, retrievedUser, null);
-  }
-
-  @Test
-  public void testSyncEraCommonsStatus_lastModified() {
-    // User starts without eRA commons.
-    Supplier<Timestamp> getLastModified =
-        () -> userDao.findUserByUsername(USERNAME).getLastModifiedTime();
-    Timestamp modifiedTime0 = getLastModified.get();
-
-    when(mockFireCloudService.getNihStatus())
-        .thenReturn(
-            new FirecloudNihStatus()
-                .linkedNihUsername("nih-user")
-                // FireCloud stores the NIH status in seconds, not msecs.
-                .linkExpireTime(START_INSTANT.toEpochMilli() / 1000));
-
-    tick();
-    userService.syncEraCommonsStatus();
-    Timestamp modifiedTime1 = getLastModified.get();
-    assertWithMessage(
-            "modified time should change when eRA commons status changes, want %s < %s",
-            modifiedTime0, modifiedTime1)
-        .that(modifiedTime0.before(modifiedTime1))
-        .isTrue();
-
-    userService.syncEraCommonsStatus();
-    assertWithMessage(
-            "modified time should not change on sync, if eRA commons status doesn't change")
-        .that(modifiedTime1)
-        .isEqualTo(getLastModified.get());
   }
 
   @Test


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
