### PR TITLE
[risk=no][RW-9324] Logic and endpoint for sending Terra-ToS email reminders

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -169,6 +169,6 @@
   },
   "termsOfService": {
     "latestAouVersion": 1,
-    "latestTerraTosTimestamp": "2023-01-01T00:00:00Z"
+    "latestTerraTosTimestamp": "1985-10-26T01:22:33Z"
   }
 }

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -166,5 +166,9 @@
   },
   "app": {
     "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
+  },
+  "termsOfService": {
+    "latestAouVersion": 1,
+    "latestTerraTosTimestamp": "2023-01-01T00:00:00Z"
   }
 }

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -159,5 +159,9 @@
   },
   "app": {
     "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
+  },
+  "termsOfService": {
+    "latestAouVersion": 1,
+    "latestTerraTosTimestamp": "2023-01-01T00:00:00Z"
   }
 }

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -162,6 +162,6 @@
   },
   "termsOfService": {
     "latestAouVersion": 1,
-    "latestTerraTosTimestamp": "2023-01-01T00:00:00Z"
+    "latestTerraTosTimestamp": "1985-10-26T01:22:33Z"
   }
 }

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -148,5 +148,9 @@
   },
   "app": {
     "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
+  },
+  "termsOfService": {
+    "latestAouVersion": 1,
+    "latestTerraTosTimestamp": "2024-12-31T12:34:56Z"
   }
 }

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -151,6 +151,6 @@
   },
   "termsOfService": {
     "latestAouVersion": 1,
-    "latestTerraTosTimestamp": "2024-12-31T12:34:56Z"
+    "latestTerraTosTimestamp": "2030-12-31T12:34:56Z"
   }
 }

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -168,5 +168,9 @@
   },
   "app": {
     "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
+  },
+  "termsOfService": {
+    "latestAouVersion": 1,
+    "latestTerraTosTimestamp": "2024-12-31T12:34:56Z"
   }
 }

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -171,6 +171,6 @@
   },
   "termsOfService": {
     "latestAouVersion": 1,
-    "latestTerraTosTimestamp": "2024-12-31T12:34:56Z"
+    "latestTerraTosTimestamp": "2030-12-31T12:34:56Z"
   }
 }

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -168,6 +168,6 @@
   },
   "termsOfService": {
     "latestAouVersion": 1,
-    "latestTerraTosTimestamp": "2024-12-31T12:34:56Z"
+    "latestTerraTosTimestamp": "2030-12-31T12:34:56Z"
   }
 }

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -165,5 +165,9 @@
   },
   "app": {
     "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
+  },
+  "termsOfService": {
+    "latestAouVersion": 1,
+    "latestTerraTosTimestamp": "2024-12-31T12:34:56Z"
   }
 }

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -170,5 +170,9 @@
       "puppeteer-egress-1@staging.fake-research-aou.org",
       "puppetcitester4@staging.fake-research-aou.org"
     ]
+  },
+  "termsOfService": {
+    "latestAouVersion": 1,
+    "latestTerraTosTimestamp": "2024-12-31T12:34:56Z"
   }
 }

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -173,6 +173,6 @@
   },
   "termsOfService": {
     "latestAouVersion": 1,
-    "latestTerraTosTimestamp": "2024-12-31T12:34:56Z"
+    "latestTerraTosTimestamp": "2030-12-31T12:34:56Z"
   }
 }

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -176,5 +176,9 @@
       "puppeteer-egress-1@fake-research-aou.org",
       "puppeteer-tester-3@fake-research-aou.org"
     ]
+  },
+  "termsOfService": {
+    "latestAouVersion": 1,
+    "latestTerraTosTimestamp": "2023-01-01T00:00:00Z"
   }
 }

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -179,6 +179,6 @@
   },
   "termsOfService": {
     "latestAouVersion": 1,
-    "latestTerraTosTimestamp": "2023-01-01T00:00:00Z"
+    "latestTerraTosTimestamp": "1985-10-26T01:22:33Z"
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
@@ -22,6 +22,7 @@ import org.pmiops.workbench.model.BatchSyncAccessRequest;
 import org.pmiops.workbench.model.BatchSyncAccessResponse;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.Profile;
+import org.pmiops.workbench.model.TerraTosReminderEmailsResponse;
 import org.pmiops.workbench.model.UserAuditLogQueryResponse;
 import org.pmiops.workbench.profile.ProfileService;
 import org.springframework.http.ResponseEntity;
@@ -119,5 +120,12 @@ public class UserAdminController implements UserAdminApiDelegate {
                     userService.findUsersByUsernames(request.getUsernames()).stream()
                         .map(DbUser::getUserId)
                         .collect(Collectors.toList()))));
+  }
+
+  @Override
+  @AuthorityRequired({Authority.COMMUNICATIONS_ADMIN})
+  public ResponseEntity<TerraTosReminderEmailsResponse> sendTerraTosReminderEmails() {
+    return ResponseEntity.ok(
+        new TerraTosReminderEmailsResponse());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.api;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -23,6 +24,7 @@ import org.pmiops.workbench.model.BatchSyncAccessResponse;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.Profile;
 import org.pmiops.workbench.model.TerraTosReminderEmailsResponse;
+import org.pmiops.workbench.model.TerraTosReminderEmailsResponseUsers;
 import org.pmiops.workbench.model.UserAuditLogQueryResponse;
 import org.pmiops.workbench.profile.ProfileService;
 import org.springframework.http.ResponseEntity;
@@ -125,7 +127,16 @@ public class UserAdminController implements UserAdminApiDelegate {
   @Override
   @AuthorityRequired({Authority.COMMUNICATIONS_ADMIN})
   public ResponseEntity<TerraTosReminderEmailsResponse> sendTerraTosReminderEmails() {
+    List<DbUser> emailsSent = userService.sendTerraTosReminderEmails();
+
     return ResponseEntity.ok(
-        new TerraTosReminderEmailsResponse());
+        new TerraTosReminderEmailsResponse()
+            .users(emailsSent.stream().map(this::toResponse).collect(Collectors.toList())));
+  }
+
+  private TerraTosReminderEmailsResponseUsers toResponse(DbUser user) {
+    return new TerraTosReminderEmailsResponseUsers()
+        .contactEmail(user.getContactEmail())
+        .username(user.getUsername());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -38,6 +38,7 @@ public class WorkbenchConfig {
   public EgressAlertRemediationPolicy egressAlertRemediationPolicy;
   public App app;
   public E2ETestUserConfig e2eTestUsers;
+  public TermsOfServiceConfig termsOfService;
 
   /** Creates a config with non-null-but-empty member variables, for use in testing. */
   public static WorkbenchConfig createEmptyConfig() {
@@ -69,6 +70,7 @@ public class WorkbenchConfig {
     config.bucketAudit = new BucketAuditConfig();
     config.app = new App();
     config.e2eTestUsers = new E2ETestUserConfig();
+    config.termsOfService = new TermsOfServiceConfig();
     return config;
   }
 
@@ -442,5 +444,15 @@ public class WorkbenchConfig {
 
   public static class E2ETestUserConfig {
     public List<String> testUserEmails;
+  }
+
+  // Configs for AoU and Terra Terms of Service
+  public static class TermsOfServiceConfig {
+    // which All of Us Terms of Service is considered current
+    public int latestAouVersion;
+
+    // When the current version of the Terra Terms of Service was released,
+    // in ISO 8601 string format
+    public String latestTerraTosTimestamp;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -159,4 +159,6 @@ public interface UserService {
 
   /** Send reminder emails to all registered users who have not signed the latest Terra ToS */
   List<DbUser> sendTerraTosReminderEmails();
+
+  boolean shouldSendTerraTosReminderEmail(long userId);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -158,4 +158,6 @@ public interface UserService {
 
   /** Signs a user out of all web and device sessions and reset their sign-in cookies. */
   void signOut(DbUser user);
+
+  List<DbUser> sendTerraTosReminderEmails();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
 import com.google.api.services.oauth2.model.Userinfo;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -160,5 +161,6 @@ public interface UserService {
   /** Send reminder emails to all registered users who have not signed the latest Terra ToS */
   List<DbUser> sendTerraTosReminderEmails();
 
+  @VisibleForTesting
   boolean shouldSendTerraTosReminderEmail(long userId);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -18,8 +18,6 @@ import org.pmiops.workbench.model.Degree;
 import org.springframework.data.domain.Sort;
 
 public interface UserService {
-  int LATEST_AOU_TOS_VERSION = 1;
-
   /**
    * Updates a user record with a modifier function.
    *
@@ -159,5 +157,6 @@ public interface UserService {
   /** Signs a user out of all web and device sessions and reset their sign-in cookies. */
   void signOut(DbUser user);
 
+  /** Send reminder emails to all registered users who have not signed the latest Terra ToS */
   List<DbUser> sendTerraTosReminderEmails();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -840,7 +840,8 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     boolean userIsCompliant =
         userTermsOfServiceDao
             .findFirstByUserIdOrderByTosVersionDesc(userId)
-            .map(tos -> tos.getTerraAgreementTime().after(latestTerraTosTime))
+            .flatMap(dbTos -> Optional.ofNullable(dbTos.getTerraAgreementTime()))
+            .map(userAgreementTime -> userAgreementTime.after(latestTerraTosTime))
             .orElse(false);
 
     // send emails to noncompliant users

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -831,7 +831,8 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     return usersToRemind;
   }
 
-  private boolean shouldSendTerraTosReminderEmail(long userId) {
+  @Override
+  public boolean shouldSendTerraTosReminderEmail(long userId) {
     Timestamp latestTerraTosTime =
         Timestamp.from(Instant.parse(configProvider.get().termsOfService.latestTerraTosTimestamp));
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -819,6 +819,11 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     directoryService.signOut(user.getUsername());
   }
 
+  @Override
+  public List<DbUser> sendTerraTosReminderEmails() {
+    return accessTierService.getAllRegisteredTierUsers();
+  }
+
   /**
    * Return the user's registered tier access expiration time, for the purpose of sending an access
    * renewal reminder or expiration email.

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -825,7 +825,8 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
             .filter(u -> shouldSendTerraTosReminderEmail(u.getUserId()))
             .collect(Collectors.toList());
 
-    usersToRemind.forEach(this::sendTerraTosReminderEmail);
+    // TODO
+    // usersToRemind.forEach(this::sendTerraTosReminderEmail);
 
     return usersToRemind;
   }
@@ -845,9 +846,6 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     // send emails to noncompliant users
     return !userIsCompliant;
   }
-
-  // STUB METHOD until we have an email ready
-  private void sendTerraTosReminderEmail(DbUser user) {}
 
   /**
    * Return the user's registered tier access expiration time, for the purpose of sending an access

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -77,6 +77,7 @@ public class DbUser {
   private List<Short> degrees;
   private String areaOfResearch;
   private DbDemographicSurvey demographicSurvey;
+  private DbDemographicSurveyV2 demographicSurveyV2;
   private DbAddress address;
 
   // Access module fields go here. See http://broad.io/aou-access-modules for docs.
@@ -85,7 +86,6 @@ public class DbUser {
   private Timestamp eraCommonsLinkExpireTime;
   private String rasLinkLoginGovUsername;
   private DbUserCodeOfConductAgreement duccAgreement;
-  private DbDemographicSurveyV2 demographicSurveyV2;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1673,6 +1673,25 @@ paths:
           description: User doesn't have the ACCESS_CONTROL_ADMIN authority
           schema:
             "$ref": "#/definitions/ErrorResponse"
+  "/v1/admin/users/sendTerraTosReminderEmails":
+    post:
+      tags:
+        - userAdmin
+      consumes:
+        - application/json
+      description: >
+        Send emails to currently-registered users who have not yet agreed to the most recent
+        version of Terra's Terms of Service. Requires COMMUNICATIONS_ADMIN Authority.
+      operationId: sendTerraTosReminderEmails
+      responses:
+        200:
+          description: 'A response containing the emails of the users who were notified'
+          schema:
+            "$ref": "#/definitions/TerraTosReminderEmailsResponse"
+        403:
+          description: User doesn't have the COMMUNICATIONS_ADMIN authority
+          schema:
+            "$ref": "#/definitions/ErrorResponse"
   "/v1/admin/workspaces/{workspaceNamespace}/locked":
     parameters:
       - "$ref": "#/parameters/workspaceNamespace"
@@ -9878,7 +9897,7 @@ definitions:
           A unique string identifier used in the API to map a user affiliation to an institution. (Database
           identifiers are not typically exposed in the workbench API).
       registeredTierRequirement:
-        description: Institution tegisted tier requirement.
+        description: Institution registered tier requirement.
         "$ref": "#/definitions/InstitutionMembershipRequirement"
   ReportingNewUserSatisfactionSurvey:
     type: object
@@ -10349,3 +10368,16 @@ definitions:
       - NEUTRAL
       - SATISFIED
       - VERY_SATISFIED
+
+  TerraTosReminderEmailsResponse:
+    type: object
+    properties:
+      users:
+        type: array
+        items:
+          type: object
+          properties:
+            username:
+              type: string
+            contactEmail:
+              type: string

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.pmiops.workbench.db.dao.UserService.LATEST_AOU_TOS_VERSION;
 
 import com.google.api.services.directory.model.User;
 import com.google.common.collect.ImmutableList;
@@ -282,7 +281,7 @@ public class ProfileControllerTest extends BaseControllerTest {
             .zipCode(ZIP_CODE));
 
     createAccountRequest = new CreateAccountRequest();
-    createAccountRequest.setTermsOfServiceVersion(LATEST_AOU_TOS_VERSION);
+    createAccountRequest.setTermsOfServiceVersion(config.termsOfService.latestAouVersion);
     createAccountRequest.setProfile(profile);
     createAccountRequest.setCaptchaVerificationToken(CAPTCHA_TOKEN);
 
@@ -414,18 +413,19 @@ public class ProfileControllerTest extends BaseControllerTest {
 
   @Test
   public void testCreateAccount_withTosVersion() {
-    createAccountRequest.setTermsOfServiceVersion(LATEST_AOU_TOS_VERSION);
+    createAccountRequest.setTermsOfServiceVersion(config.termsOfService.latestAouVersion);
     createAccountAndDbUserWithAffiliation();
 
     final DbUser dbUser = userDao.findUserByUsername(FULL_USER_NAME);
     final List<DbUserTermsOfService> tosRows = Lists.newArrayList(userTermsOfServiceDao.findAll());
     assertThat(tosRows.size()).isEqualTo(1);
-    assertThat(tosRows.get(0).getTosVersion()).isEqualTo(LATEST_AOU_TOS_VERSION);
+    assertThat(tosRows.get(0).getTosVersion()).isEqualTo(config.termsOfService.latestAouVersion);
     assertThat(tosRows.get(0).getUserId()).isEqualTo(dbUser.getUserId());
     assertThat(tosRows.get(0).getAouAgreementTime()).isNotNull();
     assertThat(tosRows.get(0).getTerraAgreementTime()).isNull();
     Profile profile = profileService.getProfile(dbUser);
-    assertThat(profile.getLatestTermsOfServiceVersion()).isEqualTo(LATEST_AOU_TOS_VERSION);
+    assertThat(profile.getLatestTermsOfServiceVersion())
+        .isEqualTo(config.termsOfService.latestAouVersion);
   }
 
   @Test
@@ -433,7 +433,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertThrows(
         BadRequestException.class,
         () -> {
-          createAccountRequest.setTermsOfServiceVersion(LATEST_AOU_TOS_VERSION - 1);
+          createAccountRequest.setTermsOfServiceVersion(config.termsOfService.latestAouVersion - 1);
           createAccountAndDbUserWithAffiliation();
         });
   }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -152,6 +152,8 @@ public class UserServiceTest {
     providedWorkbenchConfig.access.enableComplianceTraining = true;
     providedWorkbenchConfig.access.enableEraCommons = true;
     providedWorkbenchConfig.termsOfService.latestAouVersion = 5; // arbitrary
+    providedWorkbenchConfig.termsOfService.latestTerraTosTimestamp =
+        "2001-01-01T12:34:56Z"; // arbitrary
 
     // key UserService logic depends on the existence of the Registered Tier
     registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
@@ -653,6 +655,65 @@ public class UserServiceTest {
     String username = "test@@appspot.gserviceaccount.com";
     userService.createServiceAccountUser(username);
     assertThat(userDao.findUserByUsername(username)).isNotNull();
+  }
+
+  @Test
+  public void testShouldSendTerraTosReminderEmail_missingToS() {
+    long userId = userDao.findUserByUsername(USERNAME).getUserId();
+    assertThat(userTermsOfServiceDao.findFirstByUserIdOrderByTosVersionDesc(userId)).isEmpty();
+
+    assertThat(userService.shouldSendTerraTosReminderEmail(userId)).isTrue();
+  }
+
+  @Test
+  public void testShouldSendTerraTosReminderEmail_missingTerraToS() {
+    long userId = userDao.findUserByUsername(USERNAME).getUserId();
+    DbUserTermsOfService tos =
+        userTermsOfServiceDao.save(
+            new DbUserTermsOfService()
+                .setUserId(userId)
+                .setAouAgreementTime(Timestamp.from(fakeClock.instant())));
+    assertThat(tos.getTerraAgreementTime()).isNull();
+
+    assertThat(userService.shouldSendTerraTosReminderEmail(userId)).isTrue();
+  }
+
+  @Test
+  public void testShouldSendTerraTosReminderEmail_oldTerraToS() {
+    Timestamp latestTerraTos =
+        Timestamp.from(
+            Instant.parse(providedWorkbenchConfig.termsOfService.latestTerraTosTimestamp));
+    Timestamp tooOldTime = Timestamp.from(Instant.parse("1999-01-01T12:34:56Z"));
+    // sanity-check that the test is valid
+    assertThat(tooOldTime.getTime()).isLessThan(latestTerraTos.getTime());
+
+    long userId = userDao.findUserByUsername(USERNAME).getUserId();
+    userTermsOfServiceDao.save(
+        new DbUserTermsOfService()
+            .setUserId(userId)
+            .setAouAgreementTime(Timestamp.from(fakeClock.instant()))
+            .setTerraAgreementTime(tooOldTime));
+
+    assertThat(userService.shouldSendTerraTosReminderEmail(userId)).isTrue();
+  }
+
+  @Test
+  public void testShouldSendTerraTosReminderEmail_recentTerraToS() {
+    Timestamp latestTerraTos =
+        Timestamp.from(
+            Instant.parse(providedWorkbenchConfig.termsOfService.latestTerraTosTimestamp));
+    Timestamp newerTime = Timestamp.from(Instant.parse("2023-01-01T12:34:56Z"));
+    // sanity-check that the test is valid
+    assertThat(newerTime.getTime()).isGreaterThan(latestTerraTos.getTime());
+
+    long userId = userDao.findUserByUsername(USERNAME).getUserId();
+    userTermsOfServiceDao.save(
+        new DbUserTermsOfService()
+            .setUserId(userId)
+            .setAouAgreementTime(Timestamp.from(fakeClock.instant()))
+            .setTerraAgreementTime(newerTime));
+
+    assertThat(userService.shouldSendTerraTosReminderEmail(userId)).isFalse();
   }
 
   private void assertModuleCompletionEqual(


### PR DESCRIPTION
Does not actually send emails - that is stubbed out until the email is ready.  This PR is safe to merge without it, so I'll follow up with a new PR at that time.

Submitted for early review because we have a quickly approaching deadline.

A better approach would be to check the user's actually-accepted Terra ToS version.  That would be a bit more involved, and may make sense as a next step:
* Sam has a new endpoint `termsOfServiceDetails`: https://github.com/broadinstitute/sam/pull/935
* Calling this using impersonation for every registered-tier user would give us the most authoritative list about who's compliant and who isn't
* Going forward we can use this endpoint in normal user flows to populate the AoU DB for the next time we'll need this information

This PR assumes we won't have time for that before we need to send these emails.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
