### PR TITLE
[risk=no][no ticket] Rename some "apps" API entities to "user apps"

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -19,7 +19,10 @@
       "gce": ["test-gce-docker-image"],
       "dataproc": ["test-dataproc-docker-image"]
     },
-    "gceVmZone": "us-central1-c"
+    "gceVmZone": "us-central1-c",
+    "userApps": {
+      "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
+    }
   },
   "billing": {
     "accountId": "013713-75CFF6-1751E5",
@@ -163,9 +166,6 @@
         "durationMinutes": 10
       }
     }]
-  },
-  "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   },
   "termsOfService": {
     "latestAouVersion": 1,

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -19,7 +19,10 @@
       "gce": [],
       "dataproc": []
     },
-    "gceVmZone": "us-central1-c"
+    "gceVmZone": "us-central1-c",
+    "userApps": {
+      "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
+    }
   },
   "billing": {
     "accountId": "013713-75CFF6-1751E5",
@@ -156,9 +159,6 @@
         "durationMinutes": 10
       }
     }]
-  },
-  "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   },
   "termsOfService": {
     "latestAouVersion": 1,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -19,7 +19,10 @@
       "gce": [],
       "dataproc": []
     },
-    "gceVmZone": "us-central1-a"
+    "gceVmZone": "us-central1-a",
+    "userApps": {
+      "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
+    }
   },
   "billing": {
     "accountId": "01DDC8-7ED304-6E46FE",
@@ -145,9 +148,6 @@
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50
-  },
-  "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   },
   "termsOfService": {
     "latestAouVersion": 1,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -19,7 +19,10 @@
       "gce": [],
       "dataproc": []
     },
-    "gceVmZone": "us-central1-a"
+    "gceVmZone": "us-central1-a",
+    "userApps": {
+      "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
+    }
   },
   "billing": {
     "accountId": "01DDC8-7ED304-6E46FE",
@@ -165,9 +168,6 @@
       "afterIncidentCount": 3,
       "disableUser": {}
     }]
-  },
-  "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   },
   "termsOfService": {
     "latestAouVersion": 1,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -19,7 +19,10 @@
       "gce": [],
       "dataproc": []
     },
-    "gceVmZone": "us-central1-a"
+    "gceVmZone": "us-central1-a",
+    "userApps": {
+      "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
+    }
   },
   "billing": {
     "accountId": "01DDC8-7ED304-6E46FE",
@@ -162,9 +165,6 @@
         "durationMinutes": 10
       }
     }]
-  },
-  "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   },
   "termsOfService": {
     "latestAouVersion": 1,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -19,7 +19,10 @@
       "gce": [],
       "dataproc": []
     },
-    "gceVmZone": "us-central1-a"
+    "gceVmZone": "us-central1-a",
+    "userApps": {
+      "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
+    }
   },
   "billing": {
     "accountId": "01DDC8-7ED304-6E46FE",
@@ -156,9 +159,6 @@
         "durationMinutes": 10
       }
     }]
-  },
-  "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   },
   "e2eTestUsers": {
     "testUserEmails": [

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -19,7 +19,10 @@
       "gce": [],
       "dataproc": []
     },
-    "gceVmZone": "us-central1-c"
+    "gceVmZone": "us-central1-c",
+    "userApps": {
+      "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
+    }
   },
   "billing": {
     "accountId": "013713-75CFF6-1751E5",
@@ -162,9 +165,6 @@
         "durationMinutes": 10
       }
     }]
-  },
-  "app": {
-    "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
   },
   "e2eTestUsers": {
     "testUserEmails": [

--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -7,10 +7,10 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.LeonardoApiHelper;
-import org.pmiops.workbench.model.App;
 import org.pmiops.workbench.model.CreateAppRequest;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.ListAppsResponse;
+import org.pmiops.workbench.model.UserAppEnvironment;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.workspaces.WorkspaceAuthService;
 import org.pmiops.workbench.workspaces.WorkspaceService;
@@ -64,7 +64,7 @@ public class AppsController implements AppsApiDelegate {
   }
 
   @Override
-  public ResponseEntity<App> getApp(String workspaceNamespace, String appName) {
+  public ResponseEntity<UserAppEnvironment> getApp(String workspaceNamespace, String appName) {
     DbWorkspace dbWorkspace = workspaceService.lookupWorkspaceByNamespace(workspaceNamespace);
     validateCanPerformApiAction(dbWorkspace);
 
@@ -74,7 +74,7 @@ public class AppsController implements AppsApiDelegate {
 
   @Override
   public ResponseEntity<EmptyResponse> updateApp(
-      String workspaceNamespace, String appName, App app) {
+      String workspaceNamespace, String appName, UserAppEnvironment app) {
     throw new UnsupportedOperationException("API not supported.");
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -89,13 +89,13 @@ public class AppsController implements AppsApiDelegate {
   }
 
   /**
-   * Validates user is allowed to perform APP action.
+   * Validates user is allowed to perform User App actions.
    *
-   * <p>App ACTION requires:
+   * <p>User App actions require:
    *
    * <ul>
-   *   <li>Feature is enabled
-   *   <li>User compute is not suspend due to security reason (e.g. egress alert)
+   *   <li>The User Apps feature is enabled (FF enableGkeApp)
+   *   <li>User compute is not suspended due to security reasons (e.g. egress alert)
    *   <li>User is OWNER or WRITER of the workspace
    * </ul>
    */

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -36,7 +36,6 @@ public class WorkbenchConfig {
   public RasConfig ras;
   public OfflineBatchConfig offlineBatch;
   public EgressAlertRemediationPolicy egressAlertRemediationPolicy;
-  public App app;
   public E2ETestUserConfig e2eTestUsers;
   public TermsOfServiceConfig termsOfService;
 
@@ -56,6 +55,7 @@ public class WorkbenchConfig {
     config.egressAlertRemediationPolicy = new EgressAlertRemediationPolicy();
     config.featureFlags = new FeatureFlagsConfig();
     config.firecloud = new FireCloudConfig();
+    config.firecloud.userApps = new UserApps();
     config.googleCloudStorageService = new GoogleCloudStorageServiceConfig();
     config.googleDirectoryService = new GoogleDirectoryServiceConfig();
     config.mandrill = new MandrillConfig();
@@ -68,7 +68,6 @@ public class WorkbenchConfig {
     config.wgsCohortExtraction = new WgsCohortExtractionConfig();
     config.zendesk = new ZendeskConfig();
     config.bucketAudit = new BucketAuditConfig();
-    config.app = new App();
     config.e2eTestUsers = new E2ETestUserConfig();
     config.termsOfService = new TermsOfServiceConfig();
     return config;
@@ -170,11 +169,18 @@ public class WorkbenchConfig {
 
     // The deployment area of the GCE VM. For example, us-east1-a or europe-west2-c
     public String gceVmZone;
+
+    public UserApps userApps;
   }
 
   public static class RuntimeImages {
     public List<String> gce;
     public List<String> dataproc;
+  }
+
+  public static class UserApps {
+    /** The descriptor path which defines RStudio application configuration. */
+    public String rStudioDescriptorPath;
   }
 
   public static class AuthConfig {
@@ -434,12 +440,6 @@ public class WorkbenchConfig {
     public List<String> notifyCcEmails;
     public boolean enableJiraTicketing;
     public List<Escalation> escalations;
-  }
-
-  /** Configs for managing APP in RW. */
-  public static class App {
-    /** The descriptor path which defines RStudio application configuration. */
-    public String rStudioDescriptorPath;
   }
 
   public static class E2ETestUserConfig {

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUser.java
@@ -42,8 +42,8 @@ public class DbUser {
 
   private static final String RUNTIME_NAME_PREFIX = "all-of-us-";
   private static final String PD_NAME_PREFIX = "all-of-us-pd-";
-  private static final String APP_NAME_PREFIX = "all-of-us-";
-  // The UUID for user managed resources. Currently, it is used by PD and APP.
+  private static final String USER_APP_NAME_PREFIX = "all-of-us-";
+  // The UUID for user managed resources. Currently, it is used by PD and User Apps.
   @VisibleForTesting static final int UUID_SUFFIX_SIZE = 4;
 
   // user "system account" fields besides those related to access modules
@@ -482,9 +482,9 @@ public class DbUser {
     return getUserPDNamePrefix() + "-" + randomStringForUserResource();
   }
 
-  /** Returns a name for the persistent disk used in APP to be created for this user. */
+  /** Returns a name for the persistent disk to be created for this user for a given AppType. */
   @Transient
-  public String generatePDNameForApp(AppType appType) {
+  public String generatePDNameForUserApps(AppType appType) {
     return getUserPDNamePrefix()
         + '-'
         + appType.toString().toLowerCase()
@@ -493,8 +493,8 @@ public class DbUser {
   }
 
   @Transient
-  public String generateAppName(AppType appType) {
-    return APP_NAME_PREFIX
+  public String generateUserAppName(AppType appType) {
+    return USER_APP_NAME_PREFIX
         + getUserId()
         + '-'
         + appType.toString().toLowerCase()

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
@@ -8,9 +8,9 @@ import org.pmiops.workbench.leonardo.model.LeonardoGetPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
-import org.pmiops.workbench.model.App;
 import org.pmiops.workbench.model.CreateAppRequest;
 import org.pmiops.workbench.model.Runtime;
+import org.pmiops.workbench.model.UserAppEnvironment;
 import org.pmiops.workbench.notebooks.model.StorageLink;
 
 /**
@@ -95,14 +95,14 @@ public interface LeonardoApiClient {
    * @param googleProjectId the GCP project the app belongs to
    * @param appName the name of the app
    */
-  App getAppByNameByProjectId(String googleProjectId, String appName);
+  UserAppEnvironment getAppByNameByProjectId(String googleProjectId, String appName);
 
   /**
-   * Lists all apps the user have permission on in the given workspace GCP project
+   * Lists all apps the user has permission on in the given workspace GCP project
    *
    * @param googleProjectId the GCP project the app belongs to
    */
-  List<App> listAppsInProject(String googleProjectId);
+  List<UserAppEnvironment> listAppsInProject(String googleProjectId);
 
   /**
    * Deletes a Leonardo app

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -50,11 +50,11 @@ import org.pmiops.workbench.leonardo.model.LeonardoRuntimeStatus;
 import org.pmiops.workbench.leonardo.model.LeonardoUpdateDiskRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoUpdateRuntimeRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoUserJupyterExtensionConfig;
-import org.pmiops.workbench.model.App;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.CreateAppRequest;
 import org.pmiops.workbench.model.Runtime;
 import org.pmiops.workbench.model.RuntimeConfigurationType;
+import org.pmiops.workbench.model.UserAppEnvironment;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.notebooks.NotebooksRetryHandler;
 import org.pmiops.workbench.notebooks.api.ProxyApi;
@@ -531,7 +531,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
                     appTypeToLabelValue(createAppRequest.getAppType())));
     // If no disk name in field name from request, that means creating new disk.
     if (Strings.isNullOrEmpty(diskRequest.getName())) {
-      diskRequest.setName(userProvider.get().generatePDNameForApp(appType));
+      diskRequest.setName(userProvider.get().generatePDNameForUserApps(appType));
     }
 
     leonardoCreateAppRequest
@@ -552,14 +552,14 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
         (context) -> {
           appsApi.createApp(
               dbWorkspace.getGoogleProject(),
-              userProvider.get().generateAppName(appType),
+              userProvider.get().generateUserAppName(appType),
               leonardoCreateAppRequest);
           return null;
         });
   }
 
   @Override
-  public App getAppByNameByProjectId(String googleProjectId, String appName) {
+  public UserAppEnvironment getAppByNameByProjectId(String googleProjectId, String appName) {
     AppsApi appsApi = appsApiProvider.get();
 
     LeonardoGetAppResponse leonardoGetAppResponse =
@@ -568,7 +568,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
   }
 
   @Override
-  public List<App> listAppsInProject(String googleProjectId) {
+  public List<UserAppEnvironment> listAppsInProject(String googleProjectId) {
     AppsApi appsApi = appsApiProvider.get();
     List<LeonardoListAppResponse> listAppResponses =
         leonardoRetryHandler.run(

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -545,7 +545,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
 
     if (appType.equals(AppType.RSTUDIO)) {
       leonardoCreateAppRequest.descriptorPath(
-          workbenchConfigProvider.get().app.rStudioDescriptorPath);
+          workbenchConfigProvider.get().firecloud.userApps.rStudioDescriptorPath);
     }
 
     leonardoRetryHandler.run(

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -34,7 +34,6 @@ import org.pmiops.workbench.leonardo.model.LeonardoRuntimeConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeConfig.CloudServiceEnum;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeImage;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeStatus;
-import org.pmiops.workbench.model.App;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.DataprocConfig;
 import org.pmiops.workbench.model.Disk;
@@ -49,6 +48,7 @@ import org.pmiops.workbench.model.Runtime;
 import org.pmiops.workbench.model.RuntimeConfigurationType;
 import org.pmiops.workbench.model.RuntimeError;
 import org.pmiops.workbench.model.RuntimeStatus;
+import org.pmiops.workbench.model.UserAppEnvironment;
 
 @Mapper(config = MapStructConfig.class)
 public interface LeonardoMapper {
@@ -205,18 +205,18 @@ public interface LeonardoMapper {
   @Mapping(target = "appName", source = "appName")
   @Mapping(target = "googleProject", source = "cloudContext.cloudResource")
   @Mapping(target = "autopauseThreshold", ignore = true)
-  App toApiApp(LeonardoGetAppResponse app);
+  UserAppEnvironment toApiApp(LeonardoGetAppResponse app);
 
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
   @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
   @Mapping(target = "appType", ignore = true)
   @Mapping(target = "autopauseThreshold", ignore = true)
   @Mapping(target = "googleProject", source = "cloudContext.cloudResource")
-  App toApiApp(LeonardoListAppResponse app);
+  UserAppEnvironment toApiApp(LeonardoListAppResponse app);
 
   @AfterMapping
   default void getAppAfterMapper(
-      @MappingTarget App app, LeonardoGetAppResponse leonardoGetAppResponse) {
+      @MappingTarget UserAppEnvironment app, LeonardoGetAppResponse leonardoGetAppResponse) {
     app.appName(leonardoGetAppResponse.getAppName())
         .googleProject(leonardoGetAppResponse.getCloudContext().getCloudResource());
     mapAppType(app, leonardoGetAppResponse.getAppName());
@@ -224,11 +224,11 @@ public interface LeonardoMapper {
 
   @AfterMapping
   default void listAppAfterMapper(
-      @MappingTarget App app, LeonardoListAppResponse leonardoListAppResponse) {
+      @MappingTarget UserAppEnvironment app, LeonardoListAppResponse leonardoListAppResponse) {
     mapAppType(app, leonardoListAppResponse.getAppName());
   }
 
-  default void mapAppType(App app, String appName) {
+  default void mapAppType(UserAppEnvironment app, String appName) {
     // App name format is all-of-us-{user-id}-{appType}.
     app.appType(AppType.fromValue(appName.substring(appName.lastIndexOf('-') + 1).toUpperCase()));
   }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -809,8 +809,8 @@ paths:
 
   "/v1/workspaces/{workspaceNamespace}/apps":
     get:
-      summary: List apps in workspace
-      description: List apps the caller has access to, in given workspaces
+      summary: List user apps in workspace
+      description: List user apps the caller has access to, in given workspaces
       operationId: listAppsInWorkspace
       tags:
         - apps
@@ -818,11 +818,11 @@ paths:
         - "$ref": "#/parameters/workspaceNamespace"
       responses:
         "200":
-          description: List of apps
+          description: List of user apps
           schema:
             "$ref": "#/definitions/ListAppsResponse"
         404:
-          description: No app exists for this user and workspace.
+          description: No user app exists for this user and workspace.
           schema:
             "$ref": "#/definitions/ErrorResponse"
         412:
@@ -830,9 +830,11 @@ paths:
           schema:
             "$ref": "#/definitions/ErrorResponse"
     post:
-      summary: Create a workspace APP.
+      summary: Create a user app in this workspace.
       description: |
-        Creates a new app request is received the current user in the given workspace. If a app already exists for the user in this billing project, a 409 conflict error is returned (even if the app is still initializing or is not in a ready state).
+        Creates a new user app for the current user in the given workspace. If a user app already 
+        exists for the user in this billing project, a 409 conflict error is returned (even if the 
+        app is still initializing or is not in a ready state).
       operationId: createApp
       tags:
         - apps
@@ -840,13 +842,13 @@ paths:
         - "$ref": "#/parameters/workspaceNamespace"
         - in: body
           name: app
-          description: APP definition
+          description: User App definition
           required: true
           schema:
             "$ref": "#/definitions/CreateAppRequest"
       responses:
         200:
-          description: App was created successfully
+          description: User App was created successfully
           schema:
             "$ref": "#/definitions/EmptyResponse"
         404:
@@ -854,7 +856,7 @@ paths:
           schema:
             "$ref": "#/definitions/ErrorResponse"
         409:
-          description: A app for this user and workspace already exists.
+          description: A user app for this user and workspace already exists.
           schema:
             "$ref": "#/definitions/EmptyResponse"
         412:
@@ -873,16 +875,16 @@ paths:
         - "$ref": "#/parameters/workspaceNamespace"
         - in: path
           name: appName
-          description: The name of app.
+          description: The name of the user app.
           required: true
           type: string
       responses:
         200:
-          description: The app for this user and workspace.
+          description: The user app for this user and workspace.
           schema:
-            "$ref": "#/definitions/App"
+            "$ref": "#/definitions/UserAppEnvironment"
         404:
-          description: No app exists for this user and workspace.
+          description: No user app exists for this user and workspace.
           schema:
             "$ref": "#/definitions/ErrorResponse"
         412:
@@ -890,8 +892,8 @@ paths:
           schema:
             "$ref": "#/definitions/ErrorResponse"
     patch:
-      summary: Updates the configuration of a app
-      description: In order to update the configuration of a app, it must first be running or paused
+      summary: Updates the configuration of a user app
+      description: In order to update the configuration of a user app, it must first be running or paused
       operationId: updateApp
       tags:
         - apps
@@ -899,16 +901,16 @@ paths:
         - "$ref": "#/parameters/workspaceNamespace"
         - in: path
           name: appName
-          description: The name of app.
+          description: The name of the user app.
           required: true
           type: string
         - in: body
           name: app
           schema:
-            "$ref": "#/definitions/App"
+            "$ref": "#/definitions/UserAppEnvironment"
       responses:
         202:
-          description: App update request accepted
+          description: User App update request accepted
           schema:
             "$ref": "#/definitions/EmptyResponse"
         400:
@@ -924,7 +926,7 @@ paths:
           schema:
             "$ref": "#/definitions/ErrorResponse"
     delete:
-      summary: Delete a workspace app.
+      summary: Delete a workspace user app.
       operationId: deleteApp
       tags:
         - apps
@@ -932,12 +934,12 @@ paths:
         - "$ref": "#/parameters/workspaceNamespace"
         - in: path
           name: appName
-          description: The name of app.
+          description: The name of the user app.
           required: true
           type: string
         - in: query
           name: deleteDisk
-          description: Whether or not disk should be deleted if the app is using persistent disk. Default to false if not specified
+          description: Whether or not the disk should be deleted if the user app is using a persistent disk. Default to false if not specified
           required: false
           type: boolean
           default: false
@@ -947,7 +949,7 @@ paths:
           schema:
             "$ref": "#/definitions/EmptyResponse"
         404:
-          description: No app exists for this user and workspace.
+          description: No user app exists for this user and workspace.
           schema:
             "$ref": "#/definitions/ErrorResponse"
         412:
@@ -4615,7 +4617,7 @@ definitions:
         description: G-Suite domain containing user accounts.
       projectId:
         type: string
-        description: The cloud project in which this app is running.
+        description: The GCP project environment in which this All of Us app is running.
       firecloudURL:
         type: string
         description: The Firecloud URL to use for REST requests.
@@ -6387,7 +6389,7 @@ definitions:
         description: timestamp for error in ISO 8601 format
 
   CreateAppRequest:
-    description: Create APP request body
+    description: Create User App request body
     properties:
       appType:
         "$ref": "#/definitions/AppType"
@@ -6403,22 +6405,22 @@ definitions:
         description: Persistent disk configuration
         "$ref": "#/definitions/PersistentDiskRequest"
 
-  App:
+  UserAppEnvironment:
     properties:
       googleProject:
         type: string
-        description: The Google Project used to create the app. Read only.
+        description: The Google Project used to create the user app. Read only.
       appName:
         type: string
-        description: The user-supplied name for the app. Read only.
+        description: The user-supplied name for the user app. Read only.
       appType:
         "$ref": "#/definitions/AppType"
       createdDate:
         type: string
-        description: The date and time the app was created, in ISO-8601 format. Read only.
+        description: The date and time the user app was created, in ISO-8601 format. Read only.
       status:
         "$ref": "#/definitions/AppStatus"
-        description: App status. Read only.
+        description: User App status. Read only.
       autopauseThreshold:
         type: integer
         description: The number of minutes of idle time to elapse before the cluster is
@@ -6432,20 +6434,20 @@ definitions:
         description: Read only. Map of service name to proxyUrl
       diskName:
         type: string
-        description: Read only. The name of the disk associated with this app
+        description: Read only. The name of the disk associated with this user app
       dateAccessed:
         type: string
         description: |
-          The date and time the runtime was last accessed, in ISO-8601 format.
+          The date and time the environment was last accessed, in ISO-8601 format.
           Date accessed is defined as the last time the runtime was created, modified, or accessed via the proxy.
       errors:
         type: array
-        description: The list of errors that were encountered on APP create, if any.
+        description: The list of errors that were encountered on user app creation, if any.
         items:
           $ref: "#/definitions/KubernetesError"
       labels:
         type: object
-        description: The labels of each app in the response whose key is in includeLabels in the request. Of type Map[String,String]
+        description: The labels of each user app in the response whose key is in includeLabels in the request. Of type Map[String,String]
 
   KubernetesError:
       description: a kubernetes app error
@@ -6738,7 +6740,7 @@ definitions:
   ListAppsResponse:
     type: array
     items:
-      "$ref": "#/definitions/App"
+      "$ref": "#/definitions/UserAppEnvironment"
 
   ListDisksResponse:
     type: array

--- a/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
@@ -130,6 +130,12 @@ public class AppsControllerTest {
   }
 
   @Test
+  public void testCanPerformAppActions() {
+    // does not throw
+    controller.validateCanPerformApiAction(testWorkspace);
+  }
+
+  @Test
   public void testCanPerformAppActions_featureNotEnabled() throws Exception {
     config.featureFlags.enableGkeApp = false;
     assertThrows(

--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -136,19 +136,19 @@ public class DisksControllerTest {
     // RStudio Disk: 3 are active, returns the newest one.
     LeonardoListPersistentDiskResponse oldRstudioDisk =
         newListPdResponse(
-            user.generatePDNameForApp(AppType.RSTUDIO),
+            user.generatePDNameForUserApps(AppType.RSTUDIO),
             LeonardoDiskStatus.READY,
             NOW.minusSeconds(100).toString(),
             AppType.RSTUDIO);
     LeonardoListPersistentDiskResponse newestRstudioDisk =
         newListPdResponse(
-            user.generatePDNameForApp(AppType.RSTUDIO),
+            user.generatePDNameForUserApps(AppType.RSTUDIO),
             LeonardoDiskStatus.READY,
             NOW.toString(),
             AppType.RSTUDIO);
     LeonardoListPersistentDiskResponse olderRstudioDisk =
         newListPdResponse(
-            user.generatePDNameForApp(AppType.RSTUDIO),
+            user.generatePDNameForUserApps(AppType.RSTUDIO),
             LeonardoDiskStatus.READY,
             NOW.minusSeconds(200).toString(),
             AppType.RSTUDIO);
@@ -179,13 +179,13 @@ public class DisksControllerTest {
     // Cromwell Disk: both are inactive, nothing to return.
     LeonardoListPersistentDiskResponse oldInactiveCromwellDisk =
         newListPdResponse(
-            user.generatePDNameForApp(AppType.CROMWELL),
+            user.generatePDNameForUserApps(AppType.CROMWELL),
             LeonardoDiskStatus.DELETING,
             NOW.minusMillis(100).toString(),
             AppType.CROMWELL);
     LeonardoListPersistentDiskResponse newerCromwellDisk =
         newListPdResponse(
-            user.generatePDNameForApp(AppType.CROMWELL),
+            user.generatePDNameForUserApps(AppType.CROMWELL),
             LeonardoDiskStatus.DELETED,
             NOW.toString(),
             AppType.CROMWELL);

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -127,7 +127,7 @@ public class LeonardoApiClientTest {
   @BeforeEach
   public void setUp() {
     config = WorkbenchConfig.createEmptyConfig();
-    config.app.rStudioDescriptorPath = RSTUDIO_DESCRIPTOR_PATH;
+    config.firecloud.userApps.rStudioDescriptorPath = RSTUDIO_DESCRIPTOR_PATH;
 
     user = new DbUser().setUsername(LOGGED_IN_USER_EMAIL).setUserId(123L);
 

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -33,12 +33,12 @@ import org.pmiops.workbench.leonardo.model.LeonardoCreateAppRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoDiskType;
 import org.pmiops.workbench.leonardo.model.LeonardoKubernetesRuntimeConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoPersistentDiskRequest;
-import org.pmiops.workbench.model.App;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.CreateAppRequest;
 import org.pmiops.workbench.model.DiskType;
 import org.pmiops.workbench.model.KubernetesRuntimeConfig;
 import org.pmiops.workbench.model.PersistentDiskRequest;
+import org.pmiops.workbench.model.UserAppEnvironment;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.notebooks.NotebooksRetryHandler;
 import org.pmiops.workbench.utils.TestMockFactory;
@@ -116,7 +116,7 @@ public class LeonardoApiClientTest {
   private static DbUser user = new DbUser();
 
   private DbWorkspace testWorkspace;
-  private App testApp;
+  private UserAppEnvironment testApp;
   private CreateAppRequest createAppRequest;
   private LeonardoKubernetesRuntimeConfig leonardoKubernetesRuntimeConfig;
   private LeonardoPersistentDiskRequest leonardoPersistentDiskRequest;
@@ -139,7 +139,7 @@ public class LeonardoApiClientTest {
     leonardoPersistentDiskRequest =
         new LeonardoPersistentDiskRequest().diskType(LeonardoDiskType.STANDARD).size(10);
     testApp =
-        new App()
+        new UserAppEnvironment()
             .appType(AppType.RSTUDIO)
             .googleProject(GOOGLE_PROJECT_ID)
             .kubernetesRuntimeConfig(kubernetesRuntimeConfig);

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -22,7 +22,6 @@ import org.pmiops.workbench.leonardo.model.LeonardoKubernetesRuntimeConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoListAppResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoPersistentDiskRequest;
-import org.pmiops.workbench.model.App;
 import org.pmiops.workbench.model.AppStatus;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.Disk;
@@ -31,6 +30,7 @@ import org.pmiops.workbench.model.DiskType;
 import org.pmiops.workbench.model.KubernetesError;
 import org.pmiops.workbench.model.KubernetesRuntimeConfig;
 import org.pmiops.workbench.model.PersistentDiskRequest;
+import org.pmiops.workbench.model.UserAppEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -45,7 +45,7 @@ public class LeonardoMapperTest {
   private static final String DISK_NAME = "disk name";
   private static final String GOOGLE_PROJECT = "google project";
 
-  private App app;
+  private UserAppEnvironment app;
   private KubernetesRuntimeConfig kubernetesRuntimeConfig;
   private LeonardoKubernetesRuntimeConfig leonardoKubernetesRuntimeConfig;
   private PersistentDiskRequest persistentDiskRequest;
@@ -84,7 +84,7 @@ public class LeonardoMapperTest {
     labels.put("label key 2", "label value 2");
 
     app =
-        new App()
+        new UserAppEnvironment()
             .createdDate("2022-10-10")
             .dateAccessed("2022-10-10")
             .kubernetesRuntimeConfig(kubernetesRuntimeConfig)


### PR DESCRIPTION
The use of "app" and "apps" in the API codebase does not always give enough context as to whether they refer to **system** apps (like the AoU app itself) or **user** apps, the new feature we're launching.  Add some clarifying text and rename some structures to show that they specifically refer to user apps

The main changes are
* WorkbenchConfig.App -> WorkbenchConfig.UserApps
* App -> UserAppEnvironment

This change is currently safe to make without worrying about the UI, because the UI does not yet use these structures.  Tested on Local->Local with no problems.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
