### PR TITLE
[risk=low][no ticket] Bump dependencycheck because previous versions are broken

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -48,7 +48,7 @@ plugins {
     // are overridden with forked templates within this repo; they will likely need to be re-copied from
     // the newer release version and have AoU-specific modifications re-applied.
     id 'org.hidetake.swagger.generator' version '2.18.2'
-    id 'org.owasp.dependencycheck' version '6.0.1'
+    id 'org.owasp.dependencycheck' version '7.4.4'
     id 'org.springframework.boot' version '2.3.12.RELEASE'
 }
 


### PR DESCRIPTION
We run this tool as part of the release process.  Previous versions are broken: https://github.com/jeremylong/DependencyCheck/issues/5224

Bumping to latest allows us to run the tool successfully.

Test by running this locally: `./gradlew dependencyCheckAnalyze`

`main` fails with:
```
> Task :dependencyCheckAnalyze
Verifying dependencies for project api
Checking for updates and analyzing dependencies for vulnerabilities
org.owasp.dependencycheck.data.nvdcve.DatabaseException: Error updating 'CVE-2020-36569'
org.owasp.dependencycheck.data.update.exception.UpdateException: org.owasp.dependencycheck.data.nvdcve.DatabaseException: Error updating 'CVE-2020-36569'
        at org.owasp.dependencycheck.data.update.nvd.ProcessTask.processFiles(ProcessTask.java:156)
        at org.owasp.dependencycheck.data.update.nvd.ProcessTask.call(ProcessTask.java:113)
        at org.owasp.dependencycheck.data.update.nvd.ProcessTask.call(ProcessTask.java:40)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
Caused by: org.owasp.dependencycheck.data.nvdcve.DatabaseException: Error updating 'CVE-2020-36569'
        at org.owasp.dependencycheck.data.nvdcve.CveDB.updateVulnerability(CveDB.java:846)
        at org.owasp.dependencycheck.data.update.nvd.NvdCveParser.parse(NvdCveParser.java:101)
        at org.owasp.dependencycheck.data.update.nvd.ProcessTask.importJSON(ProcessTask.java:139)
        at org.owasp.dependencycheck.data.update.nvd.ProcessTask.processFiles(ProcessTask.java:152)
        ... 6 more
Caused by: org.h2.jdbc.JdbcBatchUpdateException: Value too long for column """VERSIONENDEXCLUDING"" VARCHAR(50) SELECTIVITY 1": "'0.0.0-20160722212129-ac0cc4484ad4_before_v0.0.0-20200131131040-063a3fb69896' (75)"; SQL statement:
INSERT INTO software (cveid, cpeEntryId, versionEndExcluding, versionEndIncluding, versionStartExcluding, versionStartIncluding, vulnerable) VALUES (?, ?, ?, ?, ?, ?, ?) [22001-199]
        at org.h2.jdbc.JdbcPreparedStatement.executeBatch(JdbcPreparedStatement.java:1298)
        at org.owasp.dependencycheck.data.nvdcve.CveDB.executeBatch(CveDB.java:1267)
        at org.owasp.dependencycheck.data.nvdcve.CveDB.updateVulnerabilityInsertSoftware(CveDB.java:1118)
        at org.owasp.dependencycheck.data.nvdcve.CveDB.updateVulnerability(CveDB.java:840)
        ... 9 more
Unable to update 1 or more Cached Web DataSource, using local data instead. Results may not include recent vulnerabilities.
Unable to continue dependency-check analysis.

> Task :dependencyCheckAnalyze FAILED
```

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
