### PR TITLE
[risk=low][RW-9323] Convert deleteTestUserWorkspaces to Task Queues

### DIFF
--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -161,6 +161,7 @@
     }]
   },
   "e2eTestUsers": {
+    "workspaceDeletionBatchSize": 15,
     "testUserEmails": [
       "puppeteer-tester-1@staging.fake-research-aou.org",
       "puppeteer-writer-1@staging.fake-research-aou.org",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -167,6 +167,7 @@
     }]
   },
   "e2eTestUsers": {
+    "workspaceDeletionBatchSize": 15,
     "testUserEmails": [
       "puppeteer-tester-7@fake-research-aou.org",
       "puppeteer-writer-1@fake-research-aou.org",

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskWorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskWorkspacesController.java
@@ -1,0 +1,48 @@
+package org.pmiops.workbench.api;
+
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceService;
+import org.pmiops.workbench.model.DeleteTestUserWorkspacesRequest;
+import org.pmiops.workbench.model.TestUserWorkspace;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CloudTaskWorkspacesController implements CloudTaskWorkspacesApiDelegate {
+  private static final Logger LOGGER =
+      Logger.getLogger(CloudTaskWorkspacesController.class.getName());
+
+  private final ImpersonatedWorkspaceService impersonatedWorkspaceService;
+
+  @Autowired
+  public CloudTaskWorkspacesController(ImpersonatedWorkspaceService impersonatedWorkspaceService) {
+    this.impersonatedWorkspaceService = impersonatedWorkspaceService;
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteTestUserWorkspaces(DeleteTestUserWorkspacesRequest request) {
+    LOGGER.info(String.format("Deleting a batch of %d workspaces...", request.size()));
+    request.stream()
+        .collect(Collectors.groupingBy(TestUserWorkspace::getUsername, Collectors.counting()))
+        .forEach(
+            (user, count) -> LOGGER.info(String.format("%d owned by test user %s", count, user)));
+
+    request.forEach(
+        workspace -> {
+          try {
+            impersonatedWorkspaceService.deleteWorkspace(
+                workspace.getUsername(), workspace.getWsNamespace(), workspace.getWsFirecloudId());
+          } catch (NotFoundException e) {
+            LOGGER.info(
+                String.format(
+                    "Workspace %s/%s was not found - may have been concurrently deleted",
+                    workspace.getWsNamespace(), workspace.getWsFirecloudId()));
+          }
+        });
+
+    return ResponseEntity.ok().build();
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineTestUsersController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineTestUsersController.java
@@ -5,6 +5,7 @@ import static org.pmiops.workbench.firecloud.IntegrationTestUsers.COMPLIANT_USER
 import java.util.List;
 import java.util.logging.Logger;
 import javax.inject.Provider;
+import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.impersonation.ImpersonatedUserService;
@@ -22,15 +23,17 @@ public class OfflineTestUsersController implements OfflineTestUsersApiDelegate {
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final ImpersonatedUserService impersonatedUserService;
   private final ImpersonatedWorkspaceService impersonatedWorkspaceService;
+  private final TaskQueueService taskQueueService;
 
   @Autowired
   public OfflineTestUsersController(
       Provider<WorkbenchConfig> workbenchConfigProvider,
       ImpersonatedUserService impersonatedUserService,
-      ImpersonatedWorkspaceService impersonatedWorkspaceService) {
+      ImpersonatedWorkspaceService impersonatedWorkspaceService,TaskQueueService taskQueueService) {
     this.workbenchConfigProvider = workbenchConfigProvider;
     this.impersonatedUserService = impersonatedUserService;
     this.impersonatedWorkspaceService = impersonatedWorkspaceService;
+    this.taskQueueService = taskQueueService;
   }
 
   @Override
@@ -75,6 +78,9 @@ public class OfflineTestUsersController implements OfflineTestUsersApiDelegate {
     if (testUserConf == null) {
       LOGGER.info("This environment does not have a test user config block.  Exiting.");
     } else {
+
+      taskQueueService.groupAndPushDeleteTestWorkspaceTasks();
+
       testUserConf.testUserEmails.forEach(this::deleteAllOwnedWorkspaces);
     }
 

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineTestUsersController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineTestUsersController.java
@@ -4,12 +4,14 @@ import static org.pmiops.workbench.firecloud.IntegrationTestUsers.COMPLIANT_USER
 
 import java.util.List;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.inject.Provider;
 import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.impersonation.ImpersonatedUserService;
 import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceService;
+import org.pmiops.workbench.model.TestUserWorkspace;
 import org.pmiops.workbench.model.WorkspaceResponse;
 import org.pmiops.workbench.utils.UserUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +31,8 @@ public class OfflineTestUsersController implements OfflineTestUsersApiDelegate {
   public OfflineTestUsersController(
       Provider<WorkbenchConfig> workbenchConfigProvider,
       ImpersonatedUserService impersonatedUserService,
-      ImpersonatedWorkspaceService impersonatedWorkspaceService,TaskQueueService taskQueueService) {
+      ImpersonatedWorkspaceService impersonatedWorkspaceService,
+      TaskQueueService taskQueueService) {
     this.workbenchConfigProvider = workbenchConfigProvider;
     this.impersonatedUserService = impersonatedUserService;
     this.impersonatedWorkspaceService = impersonatedWorkspaceService;
@@ -78,36 +81,28 @@ public class OfflineTestUsersController implements OfflineTestUsersApiDelegate {
     if (testUserConf == null) {
       LOGGER.info("This environment does not have a test user config block.  Exiting.");
     } else {
-
-      taskQueueService.groupAndPushDeleteTestWorkspaceTasks();
-
-      testUserConf.testUserEmails.forEach(this::deleteAllOwnedWorkspaces);
+      taskQueueService.groupAndPushDeleteTestWorkspaceTasks(
+          testUserConf.testUserEmails.stream()
+              .flatMap(this::enumerateWorkspaces)
+              .collect(Collectors.toList()));
     }
 
     return ResponseEntity.ok().build();
   }
 
-  private void deleteAllOwnedWorkspaces(String username) {
+  private Stream<TestUserWorkspace> enumerateWorkspaces(String username) {
     List<WorkspaceResponse> workspaces = impersonatedWorkspaceService.getOwnedWorkspaces(username);
     LOGGER.info(
         String.format(
-            "Test user %s currently owns %d workspaces; deleting.", username, workspaces.size()));
+            "Test user %s currently owns %d workspaces; queueing for deletion",
+            username, workspaces.size()));
 
-    workspaces.forEach(
-        workspace -> {
-          try {
-            impersonatedWorkspaceService.deleteWorkspace(username, workspace.getWorkspace());
-          } catch (NotFoundException e) {
-            LOGGER.info(
-                String.format(
-                    "Workspace %s/%s was not found - may have been concurrently deleted",
-                    workspace.getWorkspace().getNamespace(), workspace.getWorkspace().getId()));
-          }
-        });
-
-    workspaces = impersonatedWorkspaceService.getOwnedWorkspaces(username);
-    LOGGER.info(
-        String.format(
-            "After deletions, test user %s now owns %d workspaces", username, workspaces.size()));
+    return workspaces.stream()
+        .map(
+            ws ->
+                new TestUserWorkspace()
+                    .username(username)
+                    .wsNamespace(ws.getWorkspace().getNamespace())
+                    .wsFirecloudId(ws.getWorkspace().getId()));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -16,7 +16,6 @@ import java.util.logging.Logger;
 import javax.inject.Provider;
 import org.pmiops.workbench.auth.UserAuthentication;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.config.WorkbenchConfig.E2ETestUserConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.RdrExportConfig;
 import org.pmiops.workbench.config.WorkbenchLocationConfigService;
 import org.pmiops.workbench.exceptions.BadRequestException;
@@ -139,11 +138,17 @@ public class TaskQueueService {
     return tasknames;
   }
 
-  public List<String> groupAndPushDeleteTestWorkspaceTasks(List<TestUserWorkspace> workspacesToDelete) {
-    int batchSize = Optional.ofNullable(workbenchConfigProvider.get().e2eTestUsers).map(conf -> conf.workspaceDeletionBatchSize).orElseThrow(
-        () -> new BadRequestException("Deletion of e2e test user workspaces is not enabled in this environment")
-    );
-    List<List<TestUserWorkspace>> groups = CloudTasksUtils.partitionList(workspacesToDelete, batchSize);
+  public List<String> groupAndPushDeleteTestWorkspaceTasks(
+      List<TestUserWorkspace> workspacesToDelete) {
+    int batchSize =
+        Optional.ofNullable(workbenchConfigProvider.get().e2eTestUsers)
+            .map(conf -> conf.workspaceDeletionBatchSize)
+            .orElseThrow(
+                () ->
+                    new BadRequestException(
+                        "Deletion of e2e test user workspaces is not enabled in this environment"));
+    List<List<TestUserWorkspace>> groups =
+        CloudTasksUtils.partitionList(workspacesToDelete, batchSize);
     List<String> tasknames = new ArrayList<>();
     for (List<TestUserWorkspace> group : groups) {
       tasknames.add(

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -134,7 +134,7 @@ public class TaskQueueService {
                 createAndPushTask(
                     DELETE_TEST_WORKSPACES_QUEUE_NAME,
                     DELETE_TEST_WORKSPACES_PATH,
-                    new DeleteTestUserWorkspacesRequest().addAll(group)));
+                    group));
   }
 
   public void pushEgressEventTask(Long eventId) {

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -91,18 +91,18 @@ public class TaskQueueService {
     String path = backfill ? pathBase + "?backfill=true" : pathBase;
 
     CloudTasksUtils.partitionList(ids, rdrConfig.exportObjectsPerTask)
-        .forEach(group -> createAndPushTask(rdrConfig.queueName, path, group));
+        .forEach(batch -> createAndPushTask(rdrConfig.queueName, path, batch));
   }
 
   public void groupAndPushAuditProjectsTasks(List<Long> userIds) {
     WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
     CloudTasksUtils.partitionList(userIds, workbenchConfig.offlineBatch.usersPerAuditTask)
         .forEach(
-            group ->
+            batch ->
                 createAndPushTask(
                     AUDIT_PROJECTS_QUEUE_NAME,
                     AUDIT_PROJECTS_PATH,
-                    new AuditProjectAccessRequest().userIds(group)));
+                    new AuditProjectAccessRequest().userIds(batch)));
   }
 
   public List<String> groupAndPushSynchronizeAccessTasks(List<Long> userIds) {
@@ -111,11 +111,11 @@ public class TaskQueueService {
             userIds, workbenchConfig.offlineBatch.usersPerSynchronizeAccessTask)
         .stream()
         .map(
-            group ->
+            batch ->
                 createAndPushTask(
                     SYNCHRONIZE_ACCESS_QUEUE_NAME,
                     SYNCHRONIZE_ACCESS_PATH,
-                    new SynchronizeUserAccessRequest().userIds(group)))
+                    new SynchronizeUserAccessRequest().userIds(batch)))
         .collect(Collectors.toList());
   }
 
@@ -129,9 +129,9 @@ public class TaskQueueService {
                         "Deletion of e2e test user workspaces is not enabled in this environment"));
     CloudTasksUtils.partitionList(workspacesToDelete, batchSize)
         .forEach(
-            group ->
+            batch ->
                 createAndPushTask(
-                    DELETE_TEST_WORKSPACES_QUEUE_NAME, DELETE_TEST_WORKSPACES_PATH, group));
+                    DELETE_TEST_WORKSPACES_QUEUE_NAME, DELETE_TEST_WORKSPACES_PATH, batch));
   }
 
   public void pushEgressEventTask(Long eventId) {

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -21,7 +21,6 @@ import org.pmiops.workbench.config.WorkbenchLocationConfigService;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.AuditProjectAccessRequest;
 import org.pmiops.workbench.model.CreateWorkspaceTaskRequest;
-import org.pmiops.workbench.model.DeleteTestUserWorkspacesRequest;
 import org.pmiops.workbench.model.DuplicateWorkspaceTaskRequest;
 import org.pmiops.workbench.model.ProcessEgressEventRequest;
 import org.pmiops.workbench.model.SynchronizeUserAccessRequest;
@@ -132,9 +131,7 @@ public class TaskQueueService {
         .forEach(
             group ->
                 createAndPushTask(
-                    DELETE_TEST_WORKSPACES_QUEUE_NAME,
-                    DELETE_TEST_WORKSPACES_PATH,
-                    group));
+                    DELETE_TEST_WORKSPACES_QUEUE_NAME, DELETE_TEST_WORKSPACES_PATH, group));
   }
 
   public void pushEgressEventTask(Long eventId) {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -443,6 +443,7 @@ public class WorkbenchConfig {
   }
 
   public static class E2ETestUserConfig {
+    public int workspaceDeletionBatchSize;
     public List<String> testUserEmails;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceService.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.impersonation;
 
 import java.util.List;
-import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceResponse;
 
 /**

--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceService.java
@@ -13,5 +13,5 @@ import org.pmiops.workbench.model.WorkspaceResponse;
 public interface ImpersonatedWorkspaceService {
   List<WorkspaceResponse> getOwnedWorkspaces(String username);
 
-  void deleteWorkspace(String username, Workspace workspace);
+  void deleteWorkspace(String username, String wsNamespace, String wsId);
 }

--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
@@ -68,10 +68,8 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
   }
 
   @Override
-  public void deleteWorkspace(String username, Workspace workspace) {
+  public void deleteWorkspace(String username, String wsNamespace, String wsId) {
     final DbUser dbUser = userDao.findUserByUsername(username);
-    final String wsNamespace = workspace.getNamespace();
-    final String wsId = workspace.getId();
 
     // also confirms that the workspace exists in the DB
     DbWorkspace dbWorkspace = workspaceDao.getRequired(wsNamespace, wsId);

--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
@@ -11,7 +11,6 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.pmiops.workbench.model.WorkspaceResponse;

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3149,6 +3149,25 @@ paths:
       responses:
         200:
           description: 'Workspace created'
+  "/v1/cloudTask/deleteTestUserWorkspaces":
+    post:
+      tags:
+        - cloudTaskWorkspaces
+        - cloudTask
+      description: Deletes the requestd test user workspaces.
+      operationId: deleteTestUserWorkspaces
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: request
+          required: true
+          description: Workspace duplication task to process.
+          schema:
+            "$ref": "#/definitions/DeleteTestUserWorkspaceRequest"
+      responses:
+        200:
+          description: 'Workspaces deleted'
   "/v1/institutions":
     x-aou-note: Institution endpoints, for Verified Institutional Affiliation
     get:
@@ -9023,6 +9042,28 @@ definitions:
         description: 'Egress event ID to be processed'
         type: integer
         format: int64
+
+  DeleteTestUserWorkspacesRequest:
+    type: array
+    items:
+      "$ref": "#/definitions/TestUserWorkspace"
+
+  TestUserWorkspace:
+    type: object
+    required:
+      - username
+      - wsNamespace
+      - wsFirecloudId
+    properties:
+      username:
+        description: 'Test username (email address including GSuite)'
+        type: string
+      wsNamespace:
+        description: 'Workspace Namespace'
+        type: string
+      wsFirecloudId:
+        description: 'Firecloud ID for the Workspace'
+        type: string
 
   CreateWorkspaceTaskRequest:
     type: object

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3164,7 +3164,7 @@ paths:
           required: true
           description: Workspace duplication task to process.
           schema:
-            "$ref": "#/definitions/DeleteTestUserWorkspaceRequest"
+            "$ref": "#/definitions/DeleteTestUserWorkspacesRequest"
       responses:
         200:
           description: 'Workspaces deleted'

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3155,7 +3155,7 @@ paths:
       tags:
         - cloudTaskWorkspaces
         - cloudTask
-      description: Deletes the requestd test user workspaces.
+      description: Deletes the requested test user workspaces.
       operationId: deleteTestUserWorkspaces
       consumes:
         - application/json
@@ -3163,7 +3163,7 @@ paths:
         - in: body
           name: request
           required: true
-          description: Workspace duplication task to process.
+          description: Batch of workspace deletions to process.
           schema:
             "$ref": "#/definitions/DeleteTestUserWorkspacesRequest"
       responses:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -3151,6 +3151,7 @@ paths:
           description: 'Workspace created'
   "/v1/cloudTask/deleteTestUserWorkspaces":
     post:
+      security: []
       tags:
         - cloudTaskWorkspaces
         - cloudTask


### PR DESCRIPTION
Cron deleteTestUserWorkspaces was not able to complete in the 10-minute deadline, so hand off the work to a Task Queue endpoint.

It takes roughly 10 sec to delete a workspace, so the original endpoint is failing after ~ 60 workspace deletions.  This PR splits them into 15-workspace batches, for a healthy margin of error.

Wiki entry about Task Queues [here](https://github.com/all-of-us/workbench/wiki/Using-Task-Queues-when-endpoints-take-too-long-to-complete).

Tested locally, using our simulated Local queueing system.  Queue monitoring/alerting to follow.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
