### PR TITLE
[risk=low][RW-9007] Add 2 UI environment flags for Cromwell MVP

### DIFF
--- a/ui/src/app/components/apps-panel.spec.tsx
+++ b/ui/src/app/components/apps-panel.spec.tsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 
 import { NotebooksApi, RuntimeApi, RuntimeStatus } from 'generated/fetch';
 
+import { environment } from 'environments/environment';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 import { isVisible } from 'app/utils/runtime-utils';
@@ -33,9 +34,8 @@ describe('AppsPanel', () => {
   let runtimeStub: RuntimeApiStub;
   beforeEach(() => {
     currentWorkspaceStore.next(workspaceDataStub);
-    serverConfigStore.set({
-      config: { ...defaultServerConfig, enableGkeApp: true },
-    });
+    serverConfigStore.set({ config: defaultServerConfig });
+    environment.showAppsPanel = true;
     runtimeStub = new RuntimeApiStub();
     registerApiClient(RuntimeApi, runtimeStub);
     registerApiClient(NotebooksApi, new NotebooksApiStub());

--- a/ui/src/app/components/help-sidebar-icons.tsx
+++ b/ui/src/app/components/help-sidebar-icons.tsx
@@ -22,6 +22,7 @@ import {
   TerraJobStatus,
 } from 'generated/fetch';
 
+import { environment } from 'environments/environment';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { DEFAULT, reactStyles, switchCase } from 'app/utils';
 import { getCdrVersion } from 'app/utils/cdr-versions';
@@ -115,13 +116,13 @@ const displayRuntimeStatusIcon = (
   icon: IconConfig,
   workspaceNamespace: string
 ) => {
-  const { enableGkeApp } = serverConfigStore.get().config;
+  const { showAppsPanel } = environment;
 
   const jupyterAssets = appAssets.find(
     (aa) => aa.appType === UIAppType.JUPYTER
   );
 
-  const containerStyle: CSSProperties = enableGkeApp
+  const containerStyle: CSSProperties = showAppsPanel
     ? {
         height: '100%',
         alignItems: 'center',
@@ -133,11 +134,11 @@ const displayRuntimeStatusIcon = (
         alignItems: 'center',
         justifyContent: 'space-around',
       };
-  const iconStyle: CSSProperties = enableGkeApp
+  const iconStyle: CSSProperties = showAppsPanel
     ? { width: '36px', position: 'absolute' }
     : { width: '22px', position: 'absolute' };
 
-  const iconSrc = enableGkeApp ? jupyterAssets.icon : thunderstorm;
+  const iconSrc = showAppsPanel ? jupyterAssets.icon : thunderstorm;
 
   // We always want to show the thunderstorm or Jupyter icon.
   // For most runtime statuses (Deleting and Unknown currently excepted), we will show a small
@@ -546,8 +547,8 @@ export const HelpSidebarIcons = (props: HelpSidebarIconsProps) => {
     criteria,
   } = props;
   const { loadingError } = useStore(runtimeStore);
-  const { enableGkeApp, enableGenomicExtraction } =
-    serverConfigStore.get().config;
+  const { enableGenomicExtraction } = serverConfigStore.get().config;
+  const { showAppsPanel } = environment;
   const defaultIcons: SidebarIconId[] = [
     'criteria',
     'concept',
@@ -561,7 +562,7 @@ export const HelpSidebarIcons = (props: HelpSidebarIconsProps) => {
   );
 
   if (
-    enableGkeApp &&
+    showAppsPanel &&
     WorkspacePermissionsUtil.canWrite(workspace.accessLevel)
   ) {
     keys.push('apps');

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -15,6 +15,7 @@ import {
   WorkspacesApi,
 } from 'generated/fetch';
 
+import { environment } from 'environments/environment';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
@@ -310,34 +311,26 @@ describe('HelpSidebar', () => {
     ).toBe(0);
   });
 
-  it('should display apps icon for writable workspaces when enableGkeApp is true', async () => {
+  it('should display apps icon for writable workspaces when showAppsPanel is true', async () => {
     currentWorkspaceStore.next({
       ...currentWorkspaceStore.value,
       accessLevel: WorkspaceAccessLevel.WRITER,
     });
-    serverConfigStore.set({
-      config: {
-        ...defaultServerConfig,
-        enableGkeApp: true,
-      },
-    });
+    serverConfigStore.set({ config: defaultServerConfig });
+    environment.showAppsPanel = true;
     const wrapper = await component();
     expect(
       wrapper.find({ 'data-test-id': 'help-sidebar-icon-apps' }).length
     ).toBe(1);
   });
 
-  it('should not display apps icon for writable workspaces when enableGkeApp is false', async () => {
+  it('should not display apps icon for writable workspaces when showAppsPanel is false', async () => {
     currentWorkspaceStore.next({
       ...currentWorkspaceStore.value,
       accessLevel: WorkspaceAccessLevel.WRITER,
     });
-    serverConfigStore.set({
-      config: {
-        ...defaultServerConfig,
-        enableGkeApp: false,
-      },
-    });
+    serverConfigStore.set({ config: defaultServerConfig });
+    environment.showAppsPanel = false;
     const wrapper = await component();
     expect(
       wrapper.find({ 'data-test-id': 'help-sidebar-icon-apps' }).length

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -5,6 +5,7 @@ import * as fp from 'lodash/fp';
 
 import { CdrVersionTiersResponse, Workspace } from 'generated/fetch';
 
+import { environment } from 'environments/environment';
 import { Clickable } from 'app/components/buttons';
 import { FlexRow } from 'app/components/flex';
 import { ClrIcon } from 'app/components/icons';
@@ -171,7 +172,7 @@ export const WorkspaceNavBar = fp.flow(
   const { ns, wsid } = useParams<MatchParams>();
 
   useEffect(() => {
-    if (serverConfigStore.get().config.enableGkeApp && tabs.length === 3) {
+    if (environment.showNewAnalysisTab && tabs.length === 3) {
       tabs.push({ name: 'Analysis (New)', link: 'apps' });
     }
   }, []);

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -1,5 +1,6 @@
 import { AccessModule, Profile } from 'generated/fetch';
 
+import { environment } from 'environments/environment';
 import { Guard } from 'app/components/app-router';
 import { cond } from 'app/utils';
 import {
@@ -18,7 +19,7 @@ import {
   hasAuthorityForAction,
 } from 'app/utils/authorities';
 import { currentWorkspaceStore } from 'app/utils/navigation';
-import { authStore, profileStore, serverConfigStore } from 'app/utils/stores';
+import { authStore, profileStore } from 'app/utils/stores';
 
 import { AuthorityMissing } from './authority-missing';
 
@@ -93,7 +94,7 @@ export const adminLockedGuard = (ns: string, wsid: string): Guard => {
 // new analysis page, if the flag is off
 export const tempAppsAnalysisGuard = (ns: string, wsid: string): Guard => {
   return {
-    allowed: (): boolean => serverConfigStore.get().config.enableGkeApp,
+    allowed: (): boolean => environment.showNewAnalysisTab,
     redirectPath: `/workspaces/${ns}/${wsid}/data`,
   };
 };

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -56,17 +56,24 @@ export interface EnvironmentBase {
   enableCaptcha: boolean;
   // Captcha site key registered with the domain
   captchaSiteKey: string;
-  // Enable workbench footer on the signed in pages
-  enableFooter: boolean;
-  // Enable redirect to v2 demographic survey if not submitted by user
-  enableDemographicSurveyV2Redirect: boolean;
 
+  // Environment flags: UI-specific feature flags
+  //
   // WARNING: Please think *very* carefully before adding a new environment flag here! Instead
   // of this file, prefer storing feature flags in the server-side WorkbenchConfig and passing them
   // to the UI via ConfigController and serverConfigStore.
   //
   // The UI environment config should be restricted to truly UI-specific environment variables, such
   // as server API endpoints and client IDs.
+
+  // Enable workbench footer on the signed in pages
+  enableFooter: boolean;
+  // Enable redirect to v2 demographic survey if not submitted by user
+  enableDemographicSurveyV2Redirect: boolean;
+  // Show the AppsPanel component to enable the use of User Apps in the UI
+  showAppsPanel: boolean;
+  // Show the new Analysis Tab in the UI
+  showNewAnalysisTab: boolean;
 }
 
 export interface Environment extends EnvironmentBase {

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -24,4 +24,6 @@ export const environment: Environment = {
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: false,
+  showAppsPanel: true,
+  showNewAnalysisTab: true,
 };

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -23,4 +23,6 @@ export const environment: Environment = {
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: false,
+  showAppsPanel: false,
+  showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.preprod.ts
+++ b/ui/src/environments/environment.preprod.ts
@@ -22,4 +22,6 @@ export const environment: Environment = {
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: true,
+  showAppsPanel: false,
+  showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -22,4 +22,6 @@ export const environment: Environment = {
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: true,
+  showAppsPanel: false,
+  showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -22,4 +22,6 @@ export const environment: Environment = {
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: false,
+  showAppsPanel: false,
+  showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -22,4 +22,6 @@ export const environment: Environment = {
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: false,
+  showAppsPanel: false,
+  showNewAnalysisTab: false,
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -26,4 +26,6 @@ export const testEnvironmentBase: EnvironmentBase = {
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: false,
+  showAppsPanel: true,
+  showNewAnalysisTab: true,
 };

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -83,7 +83,6 @@ const defaultServerConfig: ConfigResponse = {
   freeTierBillingAccountId: 'freetier',
   accessModules: defaultAccessModuleConfig,
   currentDuccVersions: [3, 4],
-  enableGkeApp: false,
 };
 
 export default defaultServerConfig;


### PR DESCRIPTION
Replace the use of the API/UI FF enableGkeApp in the UI with 2 new environment flags gating specific UI features:
* showAppsPanel for the Apps Panel
* showNewAnalysisTab for the new analysis tab

This will allow us to launch the Apps Panel for the Cromwell MVP without needing to also launch the new analysis tab.

Tested locally: both new flags work as expected, and they can be turned on and off independently.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
