### PR TITLE
[DT-189][risk-no] Skip building prep_survey if one exists

### DIFF
--- a/api/db-cdr/generate-cdr/build-prep-survey.sh
+++ b/api/db-cdr/generate-cdr/build-prep-survey.sh
@@ -18,6 +18,20 @@ QUESTION_PARENT_ID=0
 ANSWER_PARENT_ID=0
 OUTPUT_FILE_NAME=$(echo "$FILE_NAME" | cut -d'_' -f 1 | xargs -I {} bash -c 'echo {}.csv')
 
+function check_prep_survey() {
+  echo "Getting prep_survey count"
+  query="select count(*) as count from \`$BQ_PROJECT.$BQ_DATASET.prep_survey\`"
+  prepSurveyCount=$(bq --quiet --project_id="$BQ_PROJECT" query --nouse_legacy_sql "$query" | tr -dc '0-9')
+
+  if [[ $prepSurveyCount > 0 ]];
+  then
+    echo "Skipping prep_survey table exists with row count [$prepSurveyCount]"
+    exit 0
+  else
+    echo "Creating prep_survey table"
+  fi
+}
+
 function simple_select() {
   # run this query to initializing our .bigqueryrc configuration file
   # otherwise this will corrupt the output of the first call to find_info()
@@ -149,6 +163,10 @@ function increment_question_parent_id() {
 function increment_answer_parent_id() {
   ANSWER_PARENT_ID=$(($1))
 }
+
+# check and exit if prep_survey table exists
+# else continue
+check_prep_survey
 
 # run this query to initializing our .bigqueryrc configuration file
 # otherwise this will corrupt the output of the first call to find_info()

--- a/api/db-cdr/generate-cdr/create-tables.sh
+++ b/api/db-cdr/generate-cdr/create-tables.sh
@@ -22,7 +22,7 @@ for filename in generate-cdr/bq-schemas/*.json;
 do
     json_name=${filename##*/}
     table_name=${json_name%.json}
-    if [[ "$table_name" != 'ds_procedure_occurrence_52' ]]
+    if [[ "$table_name" != 'ds_procedure_occurrence_52' || "$table_name" != 'prep_survey']]
     then
       echo "Deleting $table_name"
       bq --project_id="$BQ_PROJECT" rm -f "$BQ_DATASET.$table_name"
@@ -44,6 +44,10 @@ do
     then
       echo "Skipping cb_person"
       continue
+    elif [[ "$table_name" == 'prep_survey' && "$TABLE_LIST" != *"prep_survey"* ]]
+      then
+        echo "Creating $table_name"
+        bq --quiet --project_id="$BQ_PROJECT" mk --schema="$schema_path/$json_name" "$BQ_DATASET.$table_name"
     elif [[ "$table_name" == 'cb_search_all_events' ]]
     then
       echo "Creating $table_name"


### PR DESCRIPTION

Description:
---
Creating `prep-survey` takes significant amount of time and is unnecessary when running CDR indexing build multiple times for a giuve CDR, unless-survey-data- from curation changes or there is bug.
- updated cdr-indexing to skip building prep_survey table, if it exists in the dataset.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
