### PR TITLE
[risk=no][RW-9007] inline the appspanel apps to avoid re-mounting

### DIFF
--- a/ui/src/app/components/apps-panel.tsx
+++ b/ui/src/app/components/apps-panel.tsx
@@ -92,59 +92,52 @@ export const AppsPanel = (props: {
     !appStates.find((s) => s.appType === appType)?.shouldExpandByDefault;
   const showAvailableSection = appsToDisplay.some(showInAvailableSection);
 
-  const ActiveApps = (sectionProps: { showCloseButtonHere: boolean }) => (
-    <FlexColumn>
-      <FlexRow>
-        <h3 style={styles.header}>Active applications</h3>
-        {sectionProps.showCloseButtonHere && (
-          <CloseButton {...{ onClose }} style={styles.closeButton} />
-        )}
-      </FlexRow>
-      {appsToDisplay.map(
-        (appType) =>
-          showInActiveSection(appType) && (
-            <ExpandedApp {...{ ...props, appType }} key={appType} />
-          )
-      )}
-    </FlexColumn>
-  );
-
-  const AvailableApps = (sectionProps: { showCloseButtonHere: boolean }) => (
-    <FlexColumn>
-      <FlexRow>
-        <h3 style={styles.header}>Launch other applications</h3>
-        {sectionProps.showCloseButtonHere && (
-          <CloseButton {...{ onClose }} style={styles.closeButton} />
-        )}
-      </FlexRow>
-      {appsToDisplay.map(
-        (appType) =>
-          showInAvailableSection(appType) &&
-          (userExpandedApps.includes(appType) ? (
-            <ExpandedApp {...{ ...props, appType }} key={appType} />
-          ) : (
-            <UnexpandedApp
-              {...{ appType }}
-              key={appType}
-              onClick={() =>
-                appStates.find((s) => s.appType === appType)?.expandable &&
-                addToExpandedApps(appType)
-              }
-            />
-          ))
-      )}
-    </FlexColumn>
-  );
-
   return props.workspace.billingStatus === BillingStatus.INACTIVE ? (
     <DisabledPanel />
   ) : (
     <div>
       {showActiveSection && (
-        <ActiveApps showCloseButtonHere={showActiveSection} />
+        <FlexColumn>
+          <FlexRow>
+            <h3 style={styles.header}>Active applications</h3>
+            <CloseButton {...{ onClose }} style={styles.closeButton} />
+          </FlexRow>
+          {appsToDisplay.map(
+            (appType) =>
+              showInActiveSection(appType) && (
+                <ExpandedApp {...{ ...props, appType }} key={appType} />
+              )
+          )}
+        </FlexColumn>
       )}
       {showAvailableSection && (
-        <AvailableApps showCloseButtonHere={!showActiveSection} />
+        <FlexColumn>
+          <FlexRow>
+            <h3 style={styles.header}>Launch other applications</h3>
+            {
+              // only show the close button in the Available section if there is no Active section
+              !showActiveSection && (
+                <CloseButton {...{ onClose }} style={styles.closeButton} />
+              )
+            }
+          </FlexRow>
+          {appsToDisplay.map(
+            (appType) =>
+              showInAvailableSection(appType) &&
+              (userExpandedApps.includes(appType) ? (
+                <ExpandedApp {...{ ...props, appType }} key={appType} />
+              ) : (
+                <UnexpandedApp
+                  {...{ appType }}
+                  key={appType}
+                  onClick={() =>
+                    appStates.find((s) => s.appType === appType)?.expandable &&
+                    addToExpandedApps(appType)
+                  }
+                />
+              ))
+          )}
+        </FlexColumn>
       )}
     </div>
   );


### PR DESCRIPTION
I'm still not 100% on why this makes a difference, but it does: because ActiveApps and AvailableApps were defined in the render function of AppsPanel, they would re-mount more often than necessary.  Inlining these components resolves that problem.

The best way to observe the effect here is via the Network tab in React Dev Tools, when the Apps Panel is experiencing a transition change for Jupyter (e.g. Pausing a Running runtime).

Before this change, there are repeated calls to check the runtime status (as expected) but also calls to check the disks and the list of notebooks (unexpected - these are called by subcomponents which should be be changing).

After this change, the only repeated calls are those to check the runtime status.




<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
