### PR TITLE
[DT-189-5][risk=no] CDR indexing - Speedup build - prep_survey 

### DIFF
--- a/api/db-cdr/generate-cdr/create-tables.sh
+++ b/api/db-cdr/generate-cdr/create-tables.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-echo `bash -version`
+# #!/bin/bash
 # This script removes/creates all CDR indices specific tables.
 
 set -e
@@ -8,24 +8,41 @@ set -e
 export BQ_PROJECT=$1         # CDR project
 export BQ_DATASET=$2         # CDR dataset
 
-function createBasicTable(){
+function testCiBashAssociativeEnabled(){
+  echo `bash --version`
+
+  declare -A C_TABLES
+  C_TABLES["cb_search_all_events"]="concept_id"
+  C_TABLES["cb_review_survey"]="person_id"
+  C_TABLES["cb_search_person"]="person_id"
+  C_TABLES["cb_review_all_events"]="person_id,domain"
+
+  echo "Associative Array Keys: ${!C_TABLES[@]}"
+  echo "Associative Array Values: ${C_TABLES[@]}"
+  key="cb_review_survey"
+  echo "Value for key: $key = ${C_TABLES[$key]} "
+}
+# remove this after running once on Circle CI
+testCiBashAssociativeEnabled
+
+function deleteAndCreateTable(){
   local table_name=$1
-  echo "Creating $table_name"
-  bq --quiet --project_id="$BQ_PROJECT" mk --schema="$schema_path/$json_name" "$BQ_DATASET.$table_name"
+  # delete table - no error thrown if table does not exist
+  echo "Deleting $table_name"
+  bq --project_id="$BQ_PROJECT" rm -f "$BQ_DATASET.$table_name"
+  wait
+  # if number of arguments = 2, create a clustered table
+  if [[ $# -eq 2 ]]; then
+    local cluster_fields=$2
+    echo "Creating $table_name clustering_fields: $cluster_fields"
+    bq --quiet --project_id="$BQ_PROJECT" mk --schema="$schema_path/$json_name" --time_partitioning_type=DAY --clustering_fields "$cluster_fields" "$BQ_DATASET.$table_name"
+  else
+    # create a basic table
+    echo "Creating $table_name"
+    bq --quiet --project_id="$BQ_PROJECT" mk --schema="$schema_path/$json_name" "$BQ_DATASET.$table_name"
+  fi
   wait
 }
-
-function createClusteredTable(){
-  local table_name=$1
-  local cluster_fields=$2
-  echo "Creating $table_name clustering_fields $cluster_fields"
-  bq --quiet --project_id="$BQ_PROJECT" mk --schema="$schema_path/$json_name" --time_partitioning_type=DAY --clustering_fields "$cluster_fields" "$BQ_DATASET.$table_name"
-  wait
-}
-SKIP_TABLES=("cb_data_filter" "cb_person" "survey_module" "domain_card")
-CLUSTERED_TABLES=("cb_search_all_events" "cb_review_survey" "cb_search_person" "cb_review_all_events")
-
-TABLE_LIST=($(bq ls -n 1000 "$BQ_PROJECT:$BQ_DATASET" | tail -n +3 | cut -d " " -f 3 ))
 
 INCOMPATIBLE_DATASETS=("R2019Q4R3" "R2019Q4R4" "R2020Q4R3", "R2021Q3R5", "C2021Q2R1", "C2021Q3R6", "R2022Q2R2", "C2022Q2R2", "R2022Q2R6")
 
@@ -35,24 +52,36 @@ if [[ ${INCOMPATIBLE_DATASETS[@]} =~ $BQ_DATASET ]];
   exit 1
 fi
 
+TABLE_LIST=$(bq ls -n 1000 "$BQ_PROJECT:$BQ_DATASET" | tail -n +3 | cut -d " " -f 3 )
+
+SKIP_TABLES=("cb_data_filter" "cb_person" "survey_module" "domain_card")
+CLUSTERED_TABLES=("cb_search_all_events" "cb_review_survey" "cb_search_person" "cb_review_all_events")
+
 schema_path=generate-cdr/bq-schemas
 for filename in generate-cdr/bq-schemas/*.json;
 do
     json_name=${filename##*/}
     table_name=${json_name%.json}
+
     if [[ ${CLUSTERED_TABLES[@]} =~ "$table_name" ]]; then
       if [[ "$table_name" =~ cb_search_all_events ]]; then
-        createClusteredTable "$table_name" "concept_id"
+        deleteAndCreateTable "$table_name" "concept_id"
       elif [[ "$table_name" =~ cb_review_survey|cb_search_person ]]; then
-        createClusteredTable "$table_name" "person_id"
+        deleteAndCreateTable "$table_name" "person_id"
       elif [[ "$table_name" =~ cb_review_all_events ]]; then
-        createClusteredTable "$table_name" "person_id,domain"
+        deleteAndCreateTable "$table_name" "person_id,domain"
       fi
     elif [[ ${SKIP_TABLES[@]} =~ "$table_name"  ]]; then
       echo "Skipping table $table_name"
     elif [[ "$table_name" == 'ds_zip_code_socioeconomic' ]]; then
       if [[ "$TABLE_LIST" == *"zip3_ses_map"* ]]; then
-        createBasicTable "$table_name"
+        deleteAndCreateTable "$table_name"
+      fi
+    elif [[ "$table_name" == 'prep_survey' ]]; then
+      if [[ "$TABLE_LIST" != *"prep_survey"* ]]; then
+        deleteAndCreateTable "$table_name"
+      else
+        echo "Keeping existing prep_survey table"
       fi
     else
       createBasicTable "$table_name"


### PR DESCRIPTION
Description:
---
- CDR indices - For efficiency reason change the indexing build to pass over surveys if table already exists
- *Note* there is test code to check if CI bash has associative array feature enabled - Another PR will remove this test code


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
