### PR TITLE
[DT-189-7][risk=no] CDR indexing build - to build or not to build prep_survey

### DIFF
--- a/api/db-cdr/generate-cdr/build-prep-survey.sh
+++ b/api/db-cdr/generate-cdr/build-prep-survey.sh
@@ -20,15 +20,12 @@ OUTPUT_FILE_NAME=$(echo "$FILE_NAME" | cut -d'_' -f 1 | xargs -I {} bash -c 'ech
 
 function check_prep_survey() {
   echo "Checking prep_survey count"
-  query="select count(*) as count from \`$BQ_PROJECT.$BQ_DATASET.prep_survey\`"
-  results=$(bq --quiet --project_id="all-of-us-ehr-dev" query --nouse_legacy_sql "$query")
-  prepSurveyCount=0
-  if [[ "$results" == *"count"* ]]; then
-    prepSurveyCount=$(echo "$prepSurveyCount" | tr -dc '0-9')
-  fi
+  query="select row_count from \`$BQ_PROJECT.$BQ_DATASET.prep_create_tables_list\` where table_name = 'prep_survey'"
+  prepSurveyCount=$(bq --quiet --project_id="all-of-us-ehr-dev" query --nouse_legacy_sql "$query"| tr -dc '0-9')
+
   if [[ $prepSurveyCount > 0 ]];
   then
-    echo "Table prep_survey exists with row count [$prepSurveyCount]. Skipping creating prep_survey table"
+    echo "Table prep_survey has row count [$prepSurveyCount]. Skipping creating prep_survey table"
     exit 0
   else
     echo "Creating prep_survey table"

--- a/api/db-cdr/generate-cdr/build-prep-survey.sh
+++ b/api/db-cdr/generate-cdr/build-prep-survey.sh
@@ -21,8 +21,11 @@ OUTPUT_FILE_NAME=$(echo "$FILE_NAME" | cut -d'_' -f 1 | xargs -I {} bash -c 'ech
 function check_prep_survey() {
   echo "Checking prep_survey count"
   query="select count(*) as count from \`$BQ_PROJECT.$BQ_DATASET.prep_survey\`"
-  prepSurveyCount=$(bq --quiet --project_id="$BQ_PROJECT" query --nouse_legacy_sql "$query" | tr -dc '0-9')
-
+  results=$(bq --quiet --project_id="all-of-us-ehr-dev" query --nouse_legacy_sql "$query")
+  prepSurveyCount=0
+  if [[ "$results" == *"count"* ]]; then
+    prepSurveyCount=$(echo "$prepSurveyCount" | tr -dc '0-9')
+  fi
   if [[ $prepSurveyCount > 0 ]];
   then
     echo "Table prep_survey exists with row count [$prepSurveyCount]. Skipping creating prep_survey table"

--- a/api/db-cdr/generate-cdr/create-tables.sh
+++ b/api/db-cdr/generate-cdr/create-tables.sh
@@ -10,23 +10,6 @@ set -e
 export BQ_PROJECT=$1         # CDR project
 export BQ_DATASET=$2         # CDR dataset
 
-function testCiBashAssociativeEnabled(){
-  echo `bash --version`
-
-  declare -A C_TABLES
-  C_TABLES["cb_search_all_events"]="concept_id"
-  C_TABLES["cb_review_survey"]="person_id"
-  C_TABLES["cb_search_person"]="person_id"
-  C_TABLES["cb_review_all_events"]="person_id,domain"
-
-  echo "Associative Array Keys: ${!C_TABLES[@]}"
-  echo "Associative Array Values: ${C_TABLES[@]}"
-  key="cb_review_survey"
-  echo "Value for key: $key = ${C_TABLES[$key]} "
-}
-# remove this after running once on Circle CI
-testCiBashAssociativeEnabled
-
 function deleteAndCreateTable(){
   local table_name=$1
   # delete table - no error thrown if table does not exist

--- a/api/db-cdr/generate-cdr/create-tables.sh
+++ b/api/db-cdr/generate-cdr/create-tables.sh
@@ -29,7 +29,7 @@ function deleteAndCreateTable(){
     bq --quiet --project_id="$BQ_PROJECT" mk --schema="$schema_path/$json_name" "$BQ_DATASET.$table_name"
   fi
   wait
-  updateRowCounts $table_name
+  updateRowCounts "$table_name"
 }
 
 function createTableForRowCounts(){

--- a/api/db-cdr/generate-cdr/create-tables.sh
+++ b/api/db-cdr/generate-cdr/create-tables.sh
@@ -58,6 +58,9 @@ if [[ ${INCOMPATIBLE_DATASETS[@]} =~ $BQ_DATASET ]];
   exit 1
 fi
 
+# now that we can run cdr-indexing build - create a temp table to keep track of newly created/retained tables
+createTableForRowCounts
+
 TABLE_LIST=$(bq ls -n 1000 "$BQ_PROJECT:$BQ_DATASET" | tail -n +3 | cut -d " " -f 3 )
 
 SKIP_TABLES=("cb_data_filter" "cb_person" "survey_module" "domain_card")

--- a/api/db-cdr/generate-cdr/create-tables.sh
+++ b/api/db-cdr/generate-cdr/create-tables.sh
@@ -89,7 +89,8 @@ do
       if [[ "$TABLE_LIST" != *"prep_survey"* ]]; then
         deleteAndCreateTable "$table_name"
       else
-        echo "Keeping existing prep_survey table"
+        echo "Keeping existing prep_survey table and updating row count"
+        updateRowCounts "$table_name"
       fi
     else
       deleteAndCreateTable "$table_name"


### PR DESCRIPTION
Description:
---
- CDR indices - For efficiency reason change the indexing build to pass over surveys if table already exists
- fix getting prepSurveyCounts 

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
