### PR TITLE
[DT-195][risk=no] adding data browser arg to indexing build

### DIFF
--- a/api/db-cdr/generate-cdr/build-backup-cb-ds-tables.sh
+++ b/api/db-cdr/generate-cdr/build-backup-cb-ds-tables.sh
@@ -4,10 +4,17 @@
 
 set -e
 
-export BQ_PROJECT=$1  # project
-export BQ_DATASET=$2  # dataset
+export BQ_PROJECT=$1     # project
+export BQ_DATASET=$2     # dataset
 export OUTPUT_PROJECT=$3 # output project
 export OUTPUT_DATASET=$4 # output dataset
+export DATA_BROWSER=$5   # data browser build
+
+if [[ "$DATA_BROWSER" == true ]]
+then
+  echo "Building index for data browser. Skipping backup of cb and ds tables."
+  exit 0
+fi
 
 BACKUP_DATASET=${OUTPUT_DATASET}_backup
 

--- a/api/db-cdr/generate-cdr/build-cb-criteria-menu.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-menu.sh
@@ -4,8 +4,15 @@
 
 set -e
 
-export BQ_PROJECT=$1  # project
-export BQ_DATASET=$2  # dataset
+export BQ_PROJECT=$1   # project
+export BQ_DATASET=$2   # dataset
+export DATA_BROWSER=$3 # data browser build
+
+if [[ "$DATA_BROWSER" == true ]]
+then
+  echo "Building index for data browser. Skipping creation of the cb_criteria_menu table."
+  exit 0
+fi
 
 echo "Getting fitbit count"
 query="select count(*) as count from \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`

--- a/api/db-cdr/generate-cdr/build-cb-search-person.sh
+++ b/api/db-cdr/generate-cdr/build-cb-search-person.sh
@@ -6,6 +6,13 @@ set -e
 
 export BQ_PROJECT=$1                # CDR project
 export BQ_DATASET=$2                # CDR dataset
+export DATA_BROWSER=$3              # data browser build
+
+if [[ "$DATA_BROWSER" == true ]]
+then
+  echo "Building index for data browser. Skipping creation of the cb_search_person table."
+  exit 0
+fi
 
 ################################################
 # insert person data into cb_search_person

--- a/api/db-cdr/generate-cdr/build-cloudsql-tables.sh
+++ b/api/db-cdr/generate-cdr/build-cloudsql-tables.sh
@@ -4,10 +4,17 @@
 
 set -e
 
-export BQ_PROJECT=$1  # project
-export BQ_DATASET=$2  # dataset
+export BQ_PROJECT=$1     # project
+export BQ_DATASET=$2     # dataset
 export OUTPUT_PROJECT=$3 # output project
 export OUTPUT_DATASET=$4 # output dataset
+export DATA_BROWSER=$5   # data browser build
+
+if [[ "$DATA_BROWSER" == true ]]
+then
+  echo "Building index for data browser. Skipping creation of cloudsql tables."
+  exit 0
+fi
 
 # Check that bq_dataset exists and exit if not
 datasets=$(bq --project_id="$BQ_PROJECT" ls --max_results=1000)

--- a/api/db-cdr/generate-cdr/build-ds-linking.sh
+++ b/api/db-cdr/generate-cdr/build-ds-linking.sh
@@ -4,8 +4,15 @@
 
 set -e
 
-export BQ_PROJECT=$1  # project
-export BQ_DATASET=$2  # dataset
+export BQ_PROJECT=$1   # project
+export BQ_DATASET=$2   # dataset
+export DATA_BROWSER=$3 # data browser build
+
+if [[ "$DATA_BROWSER" == true ]]
+then
+  echo "Building index for data browser. Skipping creation of the ds_linking table."
+  exit 0
+fi
 
 # check if OMOP 5.3.1
 echo "ds-linking - checking $BQ_PROJECT:$BQ_DATASET.visit_detail table exists"

--- a/api/db-cdr/generate-cdr/build-ds-tables.sh
+++ b/api/db-cdr/generate-cdr/build-ds-tables.sh
@@ -4,8 +4,15 @@
 
 set -e
 
-export BQ_PROJECT=$1  # project
-export BQ_DATASET=$2  # dataset
+export BQ_PROJECT=$1   # project
+export BQ_DATASET=$2   # dataset
+export DATA_BROWSER=$3 # data browser build
+
+if [[ "$DATA_BROWSER" == true ]]
+then
+  echo "Building index for data browser. Skipping creation of the ds tables."
+  exit 0
+fi
 
 TABLE_LIST=$(bq ls -n 1000 "$BQ_PROJECT:$BQ_DATASET")
 if [[ "$TABLE_LIST" == *'visit_detail'* ]];

--- a/api/db-cdr/generate-cdr/build-review-all-events.sh
+++ b/api/db-cdr/generate-cdr/build-review-all-events.sh
@@ -4,8 +4,15 @@
 
 set -e
 
-export BQ_PROJECT=$1  # project
-export BQ_DATASET=$2  # dataset
+export BQ_PROJECT=$1   # project
+export BQ_DATASET=$2   # dataset
+export DATA_BROWSER=$3 # data browser build
+
+if [[ "$DATA_BROWSER" == true ]]
+then
+  echo "Building index for data browser. Skipping creation of the cb_review_all_events table."
+  exit 0
+fi
 
 #########################################
 # insert survey data into cb_review_survey #

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -540,7 +540,7 @@ def create_cdr_indices(cmd_name, *args)
   op.add_option(
     "--data-browser [data-browser]",
     ->(opts, v) { opts.data_browser = v},
-    "Is this run for data browser. Default is false"
+    "Generate for data browser. Optional - Default is false"
   )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.project and opts.bq_dataset and opts.cdr_version}
@@ -731,7 +731,7 @@ def build_search_all_events(cmd_name, *args)
   op.add_option(
     "--data-browser [data-browser]",
     ->(opts, v) { opts.data_browser = v},
-    "Is this run for data browser. Default is false"
+    "Generate for data browser. Optional - Default is false"
   )
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset }
   op.parse.validate
@@ -750,6 +750,7 @@ Common.register_command({
 
 def build_ds_linking(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
+  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -760,13 +761,18 @@ def build_ds_linking(cmd_name, *args)
       ->(opts, v) { opts.bq_dataset = v},
       "BQ dataset. Required."
   )
+  op.add_option(
+      "--data-browser [data-browser]",
+      ->(opts, v) { opts.data_browser = v},
+      "Generate for data browser. Optional - Default is false"
+  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-ds-linking.sh #{op.opts.bq_project} #{op.opts.bq_dataset}}
+    common.run_inline %W{./generate-cdr/build-ds-linking.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser}}
   end
 end
 
@@ -778,6 +784,7 @@ Common.register_command({
 
 def build_ds_tables(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
+  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -788,13 +795,18 @@ def build_ds_tables(cmd_name, *args)
       ->(opts, v) { opts.bq_dataset = v},
       "BQ dataset. Required."
   )
+  op.add_option(
+      "--data-browser [data-browser]",
+      ->(opts, v) { opts.data_browser = v},
+      "Generate for data browser. Optional - Default is false"
+  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-ds-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset}}
+    common.run_inline %W{./generate-cdr/build-ds-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser}}
   end
 end
 
@@ -806,6 +818,7 @@ Common.register_command({
 
 def build_review_all_events(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
+  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -816,13 +829,18 @@ def build_review_all_events(cmd_name, *args)
       ->(opts, v) { opts.bq_dataset = v},
       "BQ dataset. Required."
   )
+  op.add_option(
+      "--data-browser [data-browser]",
+      ->(opts, v) { opts.data_browser = v},
+      "Generate for data browser. Optional - Default is false"
+  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-review-all-events.sh #{op.opts.bq_project} #{op.opts.bq_dataset}}
+    common.run_inline %W{./generate-cdr/build-review-all-events.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser}}
   end
 end
 
@@ -834,6 +852,7 @@ Common.register_command({
 
 def build_cb_search_person(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
+  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -844,13 +863,18 @@ def build_cb_search_person(cmd_name, *args)
       ->(opts, v) { opts.bq_dataset = v},
       "BQ dataset. Required."
   )
+  op.add_option(
+      "--data-browser [data-browser]",
+      ->(opts, v) { opts.data_browser = v},
+      "Generate for data browser. Optional - Default is false"
+  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-cb-search-person.sh #{op.opts.bq_project} #{op.opts.bq_dataset}}
+    common.run_inline %W{./generate-cdr/build-cb-search-person.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser}}
   end
 end
 
@@ -890,6 +914,7 @@ Common.register_command({
 
 def build_cb_criteria_menu(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
+  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -900,13 +925,18 @@ def build_cb_criteria_menu(cmd_name, *args)
       ->(opts, v) { opts.bq_dataset = v},
       "BQ dataset. Required."
   )
+  op.add_option(
+      "--data-browser [data-browser]",
+      ->(opts, v) { opts.data_browser = v},
+      "Generate for data browser. Optional - Default is false"
+  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-cb-criteria-menu.sh #{op.opts.bq_project} #{op.opts.bq_dataset}}
+    common.run_inline %W{./generate-cdr/build-cb-criteria-menu.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser}}
   end
 end
 
@@ -918,6 +948,7 @@ Common.register_command({
 
 def build_cloudsql_tables(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
+  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -938,13 +969,18 @@ def build_cloudsql_tables(cmd_name, *args)
       ->(opts, v) { opts.output_dataset = v},
       "Output dataset. Required."
   )
+  op.add_option(
+      "--data-browser [data-browser]",
+      ->(opts, v) { opts.data_browser = v},
+      "Generate for data browser. Optional - Default is false"
+  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset and opts.output_project and opts.output_dataset}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-cloudsql-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.output_project} #{op.opts.output_dataset}}
+    common.run_inline %W{./generate-cdr/build-cloudsql-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.output_project} #{op.opts.output_dataset} #{op.opts.data_browser}}
   end
 end
 
@@ -956,6 +992,7 @@ Common.register_command({
 
 def build_backup_cb_ds_tables(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
+  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -976,13 +1013,18 @@ def build_backup_cb_ds_tables(cmd_name, *args)
       ->(opts, v) { opts.output_dataset = v},
       "Output dataset. Required."
   )
+  op.add_option(
+      "--data-browser [data-browser]",
+      ->(opts, v) { opts.data_browser = v},
+      "Generate for data browser. Optional - Default is false"
+  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset and opts.output_project and opts.output_dataset}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-backup-cb-ds-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.output_project} #{op.opts.output_dataset}}
+    common.run_inline %W{./generate-cdr/build-backup-cb-ds-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.output_project} #{op.opts.output_dataset} #{op.opts.data_browser}}
   end
 end
 


### PR DESCRIPTION
Exit immediately from the following shell scripts if the DATA_BROWSER arg is true.

- build-ds-linking
- build-ds-tables
- build-review-all-events
- build-cb-search-person
- build-cb-criteria-menu
- build-cloudsql-tables
- build-backup-cb-ds-tables