### PR TITLE
[risk=low][no ticket] remove 3 env flags we no longer need

### DIFF
--- a/ui/src/app/components/copy-snippet-modal.tsx
+++ b/ui/src/app/components/copy-snippet-modal.tsx
@@ -31,7 +31,6 @@ export const CopySnippetModal = ({ title, copyText, closeFunction }: Props) => {
           type='secondaryLight'
           style={{ paddingLeft: '0' }}
           onClick={() => {
-            // @ts-ignore: Unreachable code error. TODO: We can remove this once TS is upgraded to >= 3.4
             navigator.clipboard.writeText(copyText);
             setIsCopied(true);
 

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -288,9 +288,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
   // TODO: Move Previous, Next, and Submit buttons out of each of the
   // steps and into this component
   render() {
-    const showFooter =
-      environment.enableFooter &&
-      this.state.currentStep !== SignInStep.TERMS_OF_SERVICE;
+    const showFooter = this.state.currentStep !== SignInStep.TERMS_OF_SERVICE;
     const backgroundImages = StepToImageConfig.get(this.state.currentStep);
     return (
       <FlexColumn

--- a/ui/src/app/pages/signed-in/signed-in.tsx
+++ b/ui/src/app/pages/signed-in/signed-in.tsx
@@ -172,9 +172,7 @@ export const SignedInImpl = (spinnerProps: WithSpinnerOverlayProps) => {
             </div>
           )}
       </FlexRow>
-      {!hideFooter && environment.enableFooter && (
-        <Footer type={FooterTypeEnum.Workbench} />
-      )}
+      {!hideFooter && <Footer type={FooterTypeEnum.Workbench} />}
       <InactivityMonitor />
       <ZendeskWidget />
     </FlexColumn>

--- a/ui/src/app/pages/signed-in/signed-in.tsx
+++ b/ui/src/app/pages/signed-in/signed-in.tsx
@@ -164,7 +164,7 @@ export const SignedInImpl = (spinnerProps: WithSpinnerOverlayProps) => {
               !profileState.profile.demographicSurveyV2 &&
               !hasDismissedDemographicSurvey ? (
                 <DemographicSurveyPage
-                  routeData={{ title: 'Demographic Page' }}
+                  routeData={{ title: 'Demographic Survey' }}
                 />
               ) : (
                 <SignedInRoutes />

--- a/ui/src/app/pages/signed-in/signed-in.tsx
+++ b/ui/src/app/pages/signed-in/signed-in.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import * as fp from 'lodash/fp';
 
-import { environment } from 'environments/environment';
 import { withRouteData } from 'app/components/app-router';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { Footer, FooterTypeEnum } from 'app/components/footer';
@@ -122,8 +121,6 @@ export const SignedInImpl = (spinnerProps: WithSpinnerOverlayProps) => {
     checkStoresLoaded();
   }, [profileState, tiers]);
 
-  const { enableDemographicSurveyV2Redirect } = environment;
-
   // DEMOGRAPHIC_SURVEY_SESSION_KEY is set in session when the user selects Maybe Later Button on
   // Demographic Survey Page and is cleared out on signOut.
   // So, if this key exist, it means user should not be redirected to demographic survey page.
@@ -159,8 +156,7 @@ export const SignedInImpl = (spinnerProps: WithSpinnerOverlayProps) => {
                   : styles.appContainer
               }
             >
-              {enableDemographicSurveyV2Redirect &&
-              pastSurveyDueDate &&
+              {pastSurveyDueDate &&
               !profileState.profile.demographicSurveyV2 &&
               !hasDismissedDemographicSurvey ? (
                 <DemographicSurveyPage

--- a/ui/src/app/pages/workspace/workspace-library.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-library.spec.tsx
@@ -30,16 +30,10 @@ describe('WorkspaceLibrary', () => {
   let publishedWorkspaceStubs = [];
   let PHENOTYPE_LIBRARY_WORKSPACES;
   let TUTORIAL_WORKSPACE;
-  let PUBLISHED_WORKSPACE;
 
-  const suffixes = [
-    ' Phenotype Library',
-    ' Tutorial Workspace',
-    ' Published Workspace',
-  ];
+  const suffixes = [' Phenotype Library', ' Tutorial Workspace'];
 
   const props = {
-    enablePublishedWorkspaces: true,
     hideSpinner: () => {},
     showSpinner: () => {},
   };
@@ -76,7 +70,6 @@ describe('WorkspaceLibrary', () => {
 
     PHENOTYPE_LIBRARY_WORKSPACES = publishedWorkspaceStubs[0];
     TUTORIAL_WORKSPACE = publishedWorkspaceStubs[1];
-    PUBLISHED_WORKSPACE = publishedWorkspaceStubs[2];
   });
 
   it('renders', () => {
@@ -121,21 +114,6 @@ describe('WorkspaceLibrary', () => {
       .find('[data-test-id="workspace-card-name"]')
       .map((c) => c.text());
     expect(cardNameList.length).toBe(0);
-  });
-
-  it('should display published workspaces', async () => {
-    registerApiClient(
-      WorkspacesApi,
-      new WorkspacesApiStub(publishedWorkspaceStubs)
-    );
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    wrapper.find('[data-test-id="Published Workspaces"]').simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-    const cardNameList = wrapper
-      .find('[data-test-id="workspace-card-name"]')
-      .map((c) => c.text());
-    expect(cardNameList).toEqual([PUBLISHED_WORKSPACE.name]);
   });
 
   it('should have tutorial workspaces as default tab', async () => {

--- a/ui/src/app/pages/workspace/workspace-library.tsx
+++ b/ui/src/app/pages/workspace/workspace-library.tsx
@@ -7,7 +7,6 @@ import {
   Profile,
 } from 'generated/fetch';
 
-import { environment } from 'environments/environment';
 import { AlertDanger } from 'app/components/alert';
 import { Clickable } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
@@ -84,6 +83,7 @@ const styles = reactStyles({
 });
 
 const libraryTabs = {
+  // TODO delete? this is an old feature which was abandoned before launching
   PUBLISHED_WORKSPACES: {
     title: 'Published Workspaces',
     // TODO: Find the right icon when we intend to release this.
@@ -221,7 +221,6 @@ interface CurrentTab {
 }
 
 interface Props extends WithSpinnerOverlayProps {
-  enablePublishedWorkspaces: boolean;
   profileState: { profile: Profile; reload: Function; updateCache: Function };
 }
 
@@ -246,25 +245,11 @@ export const WorkspaceLibrary = fp.flow(withUserProfile())(
       };
     }
 
-    // Defaulting to the environment variable value here, but allowing it to be overridden by props.
-    // This is to make our testing easier. We don't use environment variable injection anywhere in
-    // our unit testing framework, so we have to pass it in via props. We also don't create this
-    // component in any way except for legacy Angular magic, so we have to get this information via
-    // environment variable.
-    libraryTabs =
-      this.props.enablePublishedWorkspaces ||
-      environment.enablePublishedWorkspaces
-        ? [
-            libraryTabs.TUTORIAL_WORKSPACES,
-            libraryTabs.DEMO_PROJECTS,
-            libraryTabs.PHENOTYPE_LIBRARY,
-            libraryTabs.PUBLISHED_WORKSPACES,
-          ]
-        : [
-            libraryTabs.TUTORIAL_WORKSPACES,
-            libraryTabs.DEMO_PROJECTS,
-            libraryTabs.PHENOTYPE_LIBRARY,
-          ];
+    libraryTabs = [
+      libraryTabs.TUTORIAL_WORKSPACES,
+      libraryTabs.DEMO_PROJECTS,
+      libraryTabs.PHENOTYPE_LIBRARY,
+    ];
 
     async componentDidMount() {
       this.props.hideSpinner();

--- a/ui/src/app/pages/workspace/workspace-library.tsx
+++ b/ui/src/app/pages/workspace/workspace-library.tsx
@@ -83,25 +83,6 @@ const styles = reactStyles({
 });
 
 const libraryTabs = {
-  // TODO delete? this is an old feature which was abandoned before launching
-  PUBLISHED_WORKSPACES: {
-    title: 'Published Workspaces',
-    // TODO: Find the right icon when we intend to release this.
-    icon: phenotypeLibrary,
-    filter: (
-      workspaceList: WorkspacePermissions[],
-      featuredWorkspaces: FeaturedWorkspace[]
-    ) => {
-      return workspaceList.filter(
-        (workspace) =>
-          !featuredWorkspaces.find(
-            (featuredWorkspace) =>
-              workspace.workspace.id === featuredWorkspace.id &&
-              workspace.workspace.namespace === featuredWorkspace.namespace
-          )
-      );
-    },
-  },
   PHENOTYPE_LIBRARY: {
     title: 'Phenotype Library',
     description: (

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -66,8 +66,6 @@ export interface EnvironmentBase {
   enablePublishedWorkspaces: boolean;
   // Enable Captcha during registration
   enableCaptcha: boolean;
-  // Enable redirect to v2 demographic survey if not submitted by user
-  enableDemographicSurveyV2Redirect: boolean;
   // Show the AppsPanel component to enable the use of User Apps in the UI
   showAppsPanel: boolean;
   // Show the new Analysis Tab in the UI

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -61,8 +61,6 @@ export interface EnvironmentBase {
   shouldShowDisplayTag: boolean;
   // Whether to allow for sign in token overrides; alternate auth scheme for testing purposes.
   allowTestAccessTokenOverride: boolean;
-  // Enable Captcha during registration
-  enableCaptcha: boolean;
   // Show the AppsPanel component to enable the use of User Apps in the UI
   showAppsPanel: boolean;
   // Show the new Analysis Tab in the UI

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -56,8 +56,6 @@ export interface EnvironmentBase {
   // The UI environment config should be restricted to truly UI-specific environment variables, such
   // as server API endpoints and client IDs.
 
-  // Enable workbench footer on the signed in pages
-  enableFooter: boolean;
   // Indicates if the displayTag should be shown in the web app. If it is true,
   // a small label will be added under the "All of Us" logo in the header.
   shouldShowDisplayTag: boolean;

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -61,9 +61,6 @@ export interface EnvironmentBase {
   shouldShowDisplayTag: boolean;
   // Whether to allow for sign in token overrides; alternate auth scheme for testing purposes.
   allowTestAccessTokenOverride: boolean;
-  // Whether users should be able to see the Published Workspaces
-  // tab in the Workspace Library.
-  enablePublishedWorkspaces: boolean;
   // Enable Captcha during registration
   enableCaptcha: boolean;
   // Show the AppsPanel component to enable the use of User Apps in the UI

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -16,9 +16,6 @@ export interface EnvironmentBase {
   // The OAuth2 client ID. Used by the sign-in module to authenticate the user.
   // Example value: '56507752110-ovdus1lkreopsfhlovejvfgmsosveda6.apps.googleusercontent.com'
   clientId: string;
-  // Indicates if the displayTag should be shown in the web app. If it is true,
-  // a small label will be added under the "All of Us" logo in the header.
-  shouldShowDisplayTag: boolean;
   // The Google Analytics account ID for logging actions and page views.
   // Example value: 'UA-112406425-3'
   gaId: string;
@@ -47,11 +44,6 @@ export interface EnvironmentBase {
   zendeskEnv: ZendeskEnv;
   inactivityTimeoutSeconds: number;
   inactivityWarningBeforeSeconds: number;
-  // Whether to allow for sign in token overrides; alternate auth scheme for testing purposes.
-  allowTestAccessTokenOverride: boolean;
-  // Whether users should be able to see the Published Workspaces
-  // tab in the Workspace Library.
-  enablePublishedWorkspaces: boolean;
   // Captcha site key registered with the domain
   captchaSiteKey: string;
 
@@ -66,6 +58,16 @@ export interface EnvironmentBase {
 
   // Enable workbench footer on the signed in pages
   enableFooter: boolean;
+  // Indicates if the displayTag should be shown in the web app. If it is true,
+  // a small label will be added under the "All of Us" logo in the header.
+  shouldShowDisplayTag: boolean;
+  // Whether to allow for sign in token overrides; alternate auth scheme for testing purposes.
+  allowTestAccessTokenOverride: boolean;
+  // Whether users should be able to see the Published Workspaces
+  // tab in the Workspace Library.
+  enablePublishedWorkspaces: boolean;
+  // Enable Captcha during registration
+  enableCaptcha: boolean;
   // Enable redirect to v2 demographic survey if not submitted by user
   enableDemographicSurveyV2Redirect: boolean;
   // Show the AppsPanel component to enable the use of User Apps in the UI

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -20,7 +20,6 @@ export const environment: Environment = {
   inactivityTimeoutSeconds: 99999999999,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
-  enablePublishedWorkspaces: false,
   showAppsPanel: true,
   showNewAnalysisTab: true,
 };

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -21,7 +21,6 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
   enablePublishedWorkspaces: false,
-  enableDemographicSurveyV2Redirect: true,
   showAppsPanel: true,
   showNewAnalysisTab: true,
 };

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -21,7 +21,6 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
   enablePublishedWorkspaces: false,
-  enableFooter: true,
   enableDemographicSurveyV2Redirect: false,
   showAppsPanel: true,
   showNewAnalysisTab: true,

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -21,7 +21,7 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
   enablePublishedWorkspaces: false,
-  enableDemographicSurveyV2Redirect: false,
+  enableDemographicSurveyV2Redirect: true,
   showAppsPanel: true,
   showNewAnalysisTab: true,
 };

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -20,7 +20,6 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
   enablePublishedWorkspaces: false,
-  enableFooter: true,
   enableDemographicSurveyV2Redirect: false,
   showAppsPanel: false,
   showNewAnalysisTab: false,

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -19,7 +19,6 @@ export const environment: Environment = {
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
-  enablePublishedWorkspaces: false,
   showAppsPanel: false,
   showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -20,7 +20,7 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
   enablePublishedWorkspaces: false,
-  enableDemographicSurveyV2Redirect: false,
+  enableDemographicSurveyV2Redirect: true,
   showAppsPanel: false,
   showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -20,7 +20,6 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
   enablePublishedWorkspaces: false,
-  enableDemographicSurveyV2Redirect: true,
   showAppsPanel: false,
   showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.preprod.ts
+++ b/ui/src/environments/environment.preprod.ts
@@ -19,7 +19,6 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
   enablePublishedWorkspaces: false,
-  enableDemographicSurveyV2Redirect: true,
   showAppsPanel: false,
   showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.preprod.ts
+++ b/ui/src/environments/environment.preprod.ts
@@ -18,7 +18,6 @@ export const environment: Environment = {
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
-  enablePublishedWorkspaces: false,
   showAppsPanel: false,
   showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.preprod.ts
+++ b/ui/src/environments/environment.preprod.ts
@@ -19,7 +19,6 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
   enablePublishedWorkspaces: false,
-  enableFooter: true,
   enableDemographicSurveyV2Redirect: true,
   showAppsPanel: false,
   showNewAnalysisTab: false,

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -19,7 +19,6 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
   enablePublishedWorkspaces: false,
-  enableDemographicSurveyV2Redirect: true,
   showAppsPanel: false,
   showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -18,7 +18,6 @@ export const environment: Environment = {
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
-  enablePublishedWorkspaces: false,
   showAppsPanel: false,
   showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -19,7 +19,6 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
   enablePublishedWorkspaces: false,
-  enableFooter: true,
   enableDemographicSurveyV2Redirect: true,
   showAppsPanel: false,
   showNewAnalysisTab: false,

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -19,7 +19,7 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
   enablePublishedWorkspaces: false,
-  enableDemographicSurveyV2Redirect: false,
+  enableDemographicSurveyV2Redirect: true,
   showAppsPanel: false,
   showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -19,7 +19,6 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
   enablePublishedWorkspaces: false,
-  enableDemographicSurveyV2Redirect: true,
   showAppsPanel: false,
   showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -19,7 +19,6 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
   enablePublishedWorkspaces: false,
-  enableFooter: true,
   enableDemographicSurveyV2Redirect: false,
   showAppsPanel: false,
   showNewAnalysisTab: false,

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -18,7 +18,6 @@ export const environment: Environment = {
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
-  enablePublishedWorkspaces: false,
   showAppsPanel: false,
   showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -18,7 +18,6 @@ export const environment: Environment = {
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
-  enablePublishedWorkspaces: false,
   showAppsPanel: false,
   showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -19,7 +19,6 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
   enablePublishedWorkspaces: false,
-  enableDemographicSurveyV2Redirect: true,
   showAppsPanel: false,
   showNewAnalysisTab: false,
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -19,7 +19,6 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
   enablePublishedWorkspaces: false,
-  enableFooter: true,
   enableDemographicSurveyV2Redirect: false,
   showAppsPanel: false,
   showNewAnalysisTab: false,

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -19,7 +19,7 @@ export const environment: Environment = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
   enablePublishedWorkspaces: false,
-  enableDemographicSurveyV2Redirect: false,
+  enableDemographicSurveyV2Redirect: true,
   showAppsPanel: false,
   showNewAnalysisTab: false,
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -22,7 +22,6 @@ export const testEnvironmentBase: EnvironmentBase = {
   inactivityTimeoutSeconds: 99999999999,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
-  enablePublishedWorkspaces: false,
   showAppsPanel: true,
   showNewAnalysisTab: true,
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -23,7 +23,7 @@ export const testEnvironmentBase: EnvironmentBase = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
   enablePublishedWorkspaces: false,
-  enableDemographicSurveyV2Redirect: false,
+  enableDemographicSurveyV2Redirect: true,
   showAppsPanel: true,
   showNewAnalysisTab: true,
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -23,7 +23,6 @@ export const testEnvironmentBase: EnvironmentBase = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
   enablePublishedWorkspaces: false,
-  enableDemographicSurveyV2Redirect: true,
   showAppsPanel: true,
   showNewAnalysisTab: true,
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -23,7 +23,6 @@ export const testEnvironmentBase: EnvironmentBase = {
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
   enablePublishedWorkspaces: false,
-  enableFooter: true,
   enableDemographicSurveyV2Redirect: false,
   showAppsPanel: true,
   showNewAnalysisTab: true,


### PR DESCRIPTION
Remove the UI environment flags **enablePublishedWorkspaces**, **enableFooter**, and **enableDemographicSurveyV2Redirect**
* enablePublishedWorkspaces refers to an abandoned feature.  I have removed the last traces of it here.
* enableFooter has been all=true for a long time.  All environments show a footer.
* enableDemographicSurveyV2Redirect was true in some envs but not others, as a workaround to get tests to pass.  It's been true in Prod for a long time, so all other envs should reflect this if possible.  Tests are passing now, so we can remove it.


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
