### PR TITLE
[RW-9048][risk=no] Fix some warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,7 +460,7 @@ jobs:
       - run:
           name: Build UI with strict compilation
           working_directory: ~/workbench/ui
-          command: CI=false ./project.rb build --environment test
+          command: ./project.rb build --environment test
       - run:
           # Lint last; it's more important to surface test failures early.
           name: Lint typescript

--- a/ui/src/circle-build.sh
+++ b/ui/src/circle-build.sh
@@ -7,5 +7,5 @@ set -v
 gsutil cp gs://all-of-us-workbench-test-credentials/.npmrc .
 yarn install
 yarn deps
-CI=false REACT_APP_ENVIRONMENT=test yarn run build --aot --no-watch --no-progress
+REACT_APP_ENVIRONMENT=test yarn run build --aot --no-watch --no-progress
 

--- a/ui/src/terraui/build.sh
+++ b/ui/src/terraui/build.sh
@@ -17,6 +17,9 @@ if [[ -e $REPODIR ]]; then
   if [ $? -eq 0 ]; then
     echo Repo exists and is current. Delete "$WD"/$REPODIR to rebuild.
     exit 0
+  else
+    echo Repo is out of date. Delete "$WD"/$REPODIR to rebuild.
+    exit 1
   fi
 fi
 

--- a/ui/src/terraui/patches/adjusttstarget.sh
+++ b/ui/src/terraui/patches/adjusttstarget.sh
@@ -4,4 +4,4 @@
 
 set -v
 
-vi -e -s -c '%s/"target": "es5"/"target": "es2022"' -c wq $@
+node patches/patch.mjs '"target": "es5"' "() => '\"target\": \"es2022\"'" "$@"

--- a/ui/src/terraui/patches/commentoutbadimportline.sh
+++ b/ui/src/terraui/patches/commentoutbadimportline.sh
@@ -7,18 +7,18 @@
 set -euo pipefail
 set -v
 
-WD="$(dirname "$(dirname "$0")")"
-cd "${WD:="$PWD"}"
-ZF="$PWD"/.repo/.yarn/cache/react-virtualized-npm-9.22.3-0fff3cbf64-5e3b566592.zip
+WD="$PWD"
 
 TMPDIR="$(mktemp -d)"
 cd "$TMPDIR"
 
+ZF="$WD"/.repo/.yarn/cache/react-virtualized-npm-9.22.3-0fff3cbf64-5e3b566592.zip
 BADFILE=node_modules/react-virtualized/dist/es/WindowScroller/utils/onScroll.js
 
 unzip "$ZF" $BADFILE
 
-vi -e -c '%s/\(import { bpfrpt_proptype_WindowScroller\)/\/\/ \1' -c wq $BADFILE
+node "$WD"/patches/patch.mjs '(import [{] bpfrpt_proptype_WindowScroller)' \
+  "s => '// '+s" "$BADFILE"
 
 zip -f "$ZF" $BADFILE
 

--- a/ui/src/terraui/patches/patch.mjs
+++ b/ui/src/terraui/patches/patch.mjs
@@ -1,0 +1,9 @@
+import * as fs from 'fs'
+
+const [,, regex, fns, fpath] = process.argv
+const fn = eval(fns)
+
+fs.promises.readFile(fpath, 'utf8')
+.then(c => c.replace(new RegExp(regex, 'g'), fn))
+.then(c => fs.promises.writeFile(fpath, c))
+

--- a/ui/src/terraui/patches/removenodeversioncheck.sh
+++ b/ui/src/terraui/patches/removenodeversioncheck.sh
@@ -4,4 +4,4 @@
 
 set -v
 
-vi -e -s -c '%s/- .\/.hooks\/plugin-warning-logger.js/' -c wq $@
+node patches/patch.mjs '- [.][/][.]hooks[/]plugin-warning-logger[.]js' "() => ''" "$@"

--- a/ui/src/terraui/patches/removereactcomponentfromsvgimports.sh
+++ b/ui/src/terraui/patches/removereactcomponentfromsvgimports.sh
@@ -5,4 +5,4 @@
 
 set -v
 
-vi -e -c '%s/[{]\s*ReactComponent\s\+as\s\+\(\S\+\)\s*[}]/\1' -c wq $@
+node patches/patch.mjs '[{]\s*ReactComponent\s+as\s+(\S+)\s*[}]' "(m, s) => s" "$@"

--- a/ui/src/terraui/patches/restorerequire.sh
+++ b/ui/src/terraui/patches/restorerequire.sh
@@ -5,10 +5,10 @@
 
 set -v
 
-vi -e -s -c '%s/__require("react")/require("react")' -c x $@
+node patches/patch.mjs '__require[(]"react"[)]' "() => 'require(\"react\")'" "$@"
 
 # Webpack warns if any indirect requires are present even if they are not used.
 # There are two offending usages.
 
-vi -e -s -c '%s/? require /? () => null ' -c x $@
-vi -e -s -c '%s/return require.apply/return (() => null)' -c x $@
+node patches/patch.mjs '[?] require ' "() => '? () => null '" "$@"
+node patches/patch.mjs 'return require.apply' "() => 'return (() => null)'" "$@"

--- a/ui/src/terraui/patches/restorerequire.sh
+++ b/ui/src/terraui/patches/restorerequire.sh
@@ -5,4 +5,10 @@
 
 set -v
 
-vi -e -s -c '%s/__require("react")/require("react")' -c wq $@
+vi -e -s -c '%s/__require("react")/require("react")' -c x $@
+
+# Webpack warns if any indirect requires are present even if they are not used.
+# There are two offending usages.
+
+vi -e -s -c '%s/? require /? () => null ' -c x $@
+vi -e -s -c '%s/return require.apply/return (() => null)' -c x $@


### PR DESCRIPTION
In https://github.com/all-of-us/workbench/pull/7319, we set `CI=false` for some builds because the benign Webpack-emitted warnings were causing builds to fail on Circle (which sets `CI=true`). This fixes those warnings and obviates the need for setting the flag to false.

main branch:
```
CI=true REACT_APP_ENVIRONMENT=test yarn build           
yarn run v1.22.19                                                                                  
$ react-app-rewired build                                                                          
Creating an optimized production build...
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme

Treating warnings as errors because process.env.CI = true.
Most CI servers set it automatically.

Failed to compile.

Critical dependency: require function is used in a way in which dependencies cannot be statically extracted

Critical dependency: require function is used in a way in which dependencies cannot be statically extracted


error Command failed with exit code 1.
```

This branch:
```
CI=true REACT_APP_ENVIRONMENT=test yarn build
yarn run v1.22.19                                                                                  
$ react-app-rewired build                                                                          
Creating an optimized production build...
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Compiled with warnings.

Failed to parse source map from '/Users/dmohs/b/r/aou/rlquality/ui/src/terraui/.repo/.yarn/cache/file-selector-npm-0.2.4-ba143a8c28-83341e7416.zip/node_modules/file-selector/src/file-selector.ts' file: Error: ENOTDIR: not a directory, open '/Users/dmohs/b/r/aou/rlquality/ui/src/terraui/.repo/.yarn/cache/file-selector-npm-0.2.4-ba143a8c28-83341e7416.zip/node_modules/file-selector/src/file-selector.ts'

Failed to parse source map from '/Users/dmohs/b/r/aou/rlquality/ui/src/terraui/.repo/.yarn/cache/file-selector-npm-0.2.4-ba143a8c28-83341e7416.zip/node_modules/file-selector/src/file.ts' file: Error: ENOTDIR: not a directory, open '/Users/dmohs/b/r/aou/rlquality/ui/src/terraui/.repo/.yarn/cache/file-selector-npm-0.2.4-ba143a8c28-83341e7416.zip/node_modules/file-selector/src/file.ts'

Failed to parse source map from '/Users/dmohs/b/r/aou/rlquality/ui/src/terraui/.repo/.yarn/cache/paging-algorithm-npm-1.0.1-38bf355389-310950fa25.zip/node_modules/paging-algorithm/src/index.ts' file: Error: ENOTDIR: not a directory, open '/Users/dmohs/b/r/aou/rlquality/ui/src/terraui/.repo/.yarn/cache/paging-algorithm-npm-1.0.1-38bf355389-310950fa25.zip/node_modules/paging-algorithm/src/index.ts'

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.

File sizes after gzip:

  1.6 MB (-45 B)  build/static/js/main.0d04d72e.js
  52.61 kB        build/static/css/main.64302e0a.css

The bundle size is significantly larger than recommended.
Consider reducing it with code splitting: https://goo.gl/9VhYWB
You can also analyze the project dependencies: https://goo.gl/LeUzfb

The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  yarn global add serve
  serve -s build

Find out more about deployment here:

  https://cra.link/deployment

✨  Done in 76.72s.
```

Source map warnings should also be addressed but is out of scope for this PR.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
