### PR TITLE
[risk=low][RW-9445] Don't crash when selecting Dataset export from homepage

### DIFF
--- a/ui/src/app/components/render-resource-card.spec.tsx
+++ b/ui/src/app/components/render-resource-card.spec.tsx
@@ -9,6 +9,7 @@ import { serverConfigStore } from 'app/utils/stores';
 import { exampleCohortStubs } from 'testing/stubs/cohorts-api-stub';
 import { stubDataSet } from 'testing/stubs/data-set-api-stub';
 import { stubResource } from 'testing/stubs/resources-stub';
+import { workspaceDataStub } from 'testing/stubs/workspaces';
 
 import { renderResourceCard } from './render-resource-card';
 
@@ -31,6 +32,7 @@ describe('renderResourceCard', () => {
 
     const card = renderResourceCard({
       resource: testCohort,
+      workspace: workspaceDataStub,
       existingNameList: [],
       onUpdate: async () => {},
       menuOnly: false,
@@ -46,6 +48,7 @@ describe('renderResourceCard', () => {
   it('does not render a card for an invalid resource', () => {
     const card = renderResourceCard({
       resource: stubResource,
+      workspace: workspaceDataStub,
       existingNameList: [],
       onUpdate: async () => {},
       menuOnly: false,
@@ -61,6 +64,7 @@ describe('renderResourceCard', () => {
 
     const menu = renderResourceCard({
       resource: testCohort,
+      workspace: workspaceDataStub,
       existingNameList: [],
       onUpdate: async () => {},
       menuOnly: true,
@@ -81,6 +85,7 @@ describe('renderResourceCard', () => {
 
     const menu = renderResourceCard({
       resource: testDataSet,
+      workspace: workspaceDataStub,
       existingNameList: [],
       onUpdate: async () => {},
       menuOnly: true,
@@ -108,6 +113,7 @@ describe('renderResourceCard', () => {
 
     const menu = renderResourceCard({
       resource: testDataSet,
+      workspace: workspaceDataStub,
       existingNameList: [],
       onUpdate: async () => {},
       menuOnly: true,

--- a/ui/src/app/components/render-resource-card.tsx
+++ b/ui/src/app/components/render-resource-card.tsx
@@ -41,10 +41,7 @@ function renderResourceCard(props: RenderResourceCardProps) {
     [
       isNotebook,
       () => (
-        <NotebookResourceCard
-          {...{ ...props }}
-          disableDuplicate={inactiveBilling}
-        />
+        <NotebookResourceCard {...props} disableDuplicate={inactiveBilling} />
       ),
     ],
   ])(resource);

--- a/ui/src/app/components/render-resource-card.tsx
+++ b/ui/src/app/components/render-resource-card.tsx
@@ -40,7 +40,12 @@ function renderResourceCard(props: RenderResourceCardProps) {
     ],
     [
       isNotebook,
-      () => <NotebookResourceCard {...{ ...props, inactiveBilling }} />,
+      () => (
+        <NotebookResourceCard
+          {...{ ...props }}
+          disableDuplicate={inactiveBilling}
+        />
+      ),
     ],
   ])(resource);
 }

--- a/ui/src/app/components/render-resource-card.tsx
+++ b/ui/src/app/components/render-resource-card.tsx
@@ -15,9 +15,11 @@ import {
   isDataSet,
   isNotebook,
 } from 'app/utils/resources';
+import { WorkspaceData } from 'app/utils/workspace-data';
 
 interface RenderResourceCardProps {
   resource: WorkspaceResource;
+  workspace: WorkspaceData;
   existingNameList: string[];
   onUpdate: () => Promise<void>;
   menuOnly: boolean;
@@ -34,15 +36,11 @@ function renderResourceCard(props: RenderResourceCardProps) {
     [isConceptSet, () => <ConceptSetResourceCard {...props} />],
     [
       isDataSet,
-      () => (
-        <DatasetResourceCard {...props} inactiveBilling={inactiveBilling} />
-      ),
+      () => <DatasetResourceCard {...{ ...props, inactiveBilling }} />,
     ],
     [
       isNotebook,
-      () => (
-        <NotebookResourceCard {...props} disableDuplicate={inactiveBilling} />
-      ),
+      () => <NotebookResourceCard {...{ ...props, inactiveBilling }} />,
     ],
   ])(resource);
 }

--- a/ui/src/app/components/resource-list.tsx
+++ b/ui/src/app/components/resource-list.tsx
@@ -32,6 +32,7 @@ import {
   getTypeString,
   isNotebook,
 } from 'app/utils/resources';
+import { WorkspaceData } from 'app/utils/workspace-data';
 
 const styles = reactStyles({
   column: {
@@ -98,7 +99,7 @@ interface Props {
   existingNameList: string[];
   workspaceResources: WorkspaceResource[];
   onUpdate: Function;
-  workspaces: Workspace[];
+  workspaces: WorkspaceData[];
   cdrVersionTiersResponse: CdrVersionTiersResponse;
   recentResourceSource?: boolean;
 }
@@ -125,9 +126,13 @@ export const ResourceList = fp.flow(withCdrVersions())((props: Props) => {
   };
   const resourceTypeNameMap = getResourceMap();
 
-  const renderResourceMenu = (resource: WorkspaceResource) => {
+  const renderResourceMenu = (
+    resource: WorkspaceResource,
+    workspace: WorkspaceData
+  ) => {
     return renderResourceCard({
       resource,
+      workspace,
       menuOnly: true,
       existingNameList: resourceTypeNameMap.get(getType(resource)),
       onUpdate: reloadResources,
@@ -161,6 +166,7 @@ export const ResourceList = fp.flow(withCdrVersions())((props: Props) => {
           const workspace = workspaces.find(
             (w) => w.namespace === r.workspaceNamespace
           );
+
           // Don't return resources where we no longer have access to the workspace.
           // For example: the owner has unshared the workspace, but a recent-resource entry remains.
           return workspace
@@ -168,7 +174,7 @@ export const ResourceList = fp.flow(withCdrVersions())((props: Props) => {
                 {
                   resource: r,
                   workspace,
-                  menu: renderResourceMenu(r),
+                  menu: renderResourceMenu(r, workspace),
                   resourceType: getTypeString(r),
                   resourceName: getDisplayName(r),
                   formattedLastModified: displayDateWithoutHours(

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -2067,6 +2067,7 @@ export const DatasetPage = fp.flow(
             ModalState.Export,
             () => (
               <ExportDatasetModal
+                {...{ workspace }}
                 dataset={dataSet}
                 closeFunction={() => setModalState(ModalState.None)}
               />

--- a/ui/src/app/pages/data/data-set/dataset-resource-card.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-resource-card.tsx
@@ -34,6 +34,7 @@ import { getDescription, getDisplayName, getType } from 'app/utils/resources';
 import { serverConfigStore } from 'app/utils/stores';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
+import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { ExportDatasetModal } from './export-dataset-modal';
 
@@ -43,6 +44,7 @@ interface Props
     WithSpinnerOverlayProps,
     NavigationProps {
   resource: WorkspaceResource;
+  workspace: WorkspaceData;
   existingNameList: string[];
   onUpdate: () => Promise<void>;
   inactiveBilling: boolean;
@@ -187,11 +189,12 @@ export const DatasetResourceCard = fp.flow(
     }
 
     render() {
-      const { resource, menuOnly } = this.props;
+      const { resource, workspace, menuOnly } = this.props;
       return (
         <React.Fragment>
           {this.state.showExportToNotebookModal && (
             <ExportDatasetModal
+              {...{ workspace }}
               dataset={resource.dataSet}
               closeFunction={() =>
                 this.setState({ showExportToNotebookModal: false })

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -22,7 +22,6 @@ import {
   dataSetApi,
   registerApiClient,
 } from 'app/services/swagger-fetch-clients';
-import { currentWorkspaceStore } from 'app/utils/navigation';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { DataSetApiStub } from 'testing/stubs/data-set-api-stub';
@@ -58,9 +57,9 @@ describe('ExportDatasetModal', () => {
     registerApiClient(DataSetApi, datasetApiStub);
 
     workspace = workspaceDataStub;
-    currentWorkspaceStore.next(workspace);
 
     testProps = {
+      workspace,
       closeFunction: () => {},
       dataset: dataset,
     };

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -33,7 +33,7 @@ import {
 } from 'app/pages/analysis/util';
 import { dataSetApi, notebooksApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
-import { reactStyles, summarizeErrors, withCurrentWorkspace } from 'app/utils';
+import { reactStyles, summarizeErrors } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { encodeURIComponentStrict, useNavigation } from 'app/utils/navigation';
 import { nameValidationFormat } from 'app/utils/resources';
@@ -44,10 +44,6 @@ import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
 interface Props {
   closeFunction: Function;
   dataset: DataSet;
-}
-
-// HocProps includes all props that are inherited through HOC
-interface HocProps extends Props {
   workspace: WorkspaceData;
 }
 
@@ -61,9 +57,11 @@ const styles = reactStyles({
   },
 });
 
-export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
-  withCurrentWorkspace()
-)(({ workspace, dataset, closeFunction }: HocProps) => {
+export const ExportDatasetModal = ({
+  workspace,
+  dataset,
+  closeFunction,
+}: Props) => {
   const [existingNotebooks, setExistingNotebooks] = useState(undefined);
   const [kernelType, setKernelType] = useState(KernelTypeEnum.Python);
   const [genomicsAnalysisTool, setGenomicsAnalysisTool] = useState(
@@ -395,4 +393,4 @@ export const ExportDatasetModal: (props: Props) => JSX.Element = fp.flow(
       </FlexRow>
     </AnimatedModal>
   );
-});
+};

--- a/ui/src/app/pages/homepage/recent-resources.spec.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.spec.tsx
@@ -2,11 +2,7 @@ import * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { mount } from 'enzyme';
 
-import {
-  UserMetricsApi,
-  WorkspaceAccessLevel,
-  WorkspaceResponse,
-} from 'generated/fetch';
+import { UserMetricsApi, WorkspaceAccessLevel } from 'generated/fetch';
 
 import {
   MODIFIED_DATE_COLUMN_NUMBER,

--- a/ui/src/app/pages/homepage/recent-resources.spec.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.spec.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { mount } from 'enzyme';
 
-import { UserMetricsApi, WorkspaceAccessLevel } from 'generated/fetch';
+import {
+  UserMetricsApi,
+  WorkspaceAccessLevel,
+  WorkspaceResponse,
+} from 'generated/fetch';
 
 import {
   MODIFIED_DATE_COLUMN_NUMBER,

--- a/ui/src/app/pages/homepage/recent-resources.tsx
+++ b/ui/src/app/pages/homepage/recent-resources.tsx
@@ -15,12 +15,21 @@ import { ResourceList } from 'app/components/resource-list';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { userMetricsApi } from 'app/services/swagger-fetch-clients';
 import { cond, withCdrVersions } from 'app/utils';
+import { WorkspaceData } from 'app/utils/workspace-data';
+
+// these types contain the same data in a slightly different shape
+const convert = (wr: WorkspaceResponse): WorkspaceData => {
+  const { workspace, accessLevel } = wr;
+  return {
+    ...workspace,
+    accessLevel,
+  };
+};
 
 interface Props {
   cdrVersionTiersResponse: CdrVersionTiersResponse;
   workspaces: WorkspaceResponse[];
 }
-
 export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
   const [loading, setLoading] = useState(true);
   const [resources, setResources] = useState<WorkspaceResourceResponse>();
@@ -69,7 +78,7 @@ export const RecentResources = fp.flow(withCdrVersions())((props: Props) => {
           >
             <ResourceList
               recentResourceSource
-              workspaces={props.workspaces.map((w) => w.workspace)}
+              workspaces={props.workspaces.map(convert)}
               workspaceResources={resources}
               onUpdate={loadResources}
             />


### PR DESCRIPTION
To reproduce:
* create a dataset
* go to homepage
* open the snowman menu for the dataset in the Recently Accessed Items
* choose Export to Notebook

Crashes on Test, fixed in this PR

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
