### PR TITLE
[risk=low][RW-9451] rm UI duplicate FF enableCaptcha

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -139,7 +139,7 @@
     "exportDemoSurveyV2": true
   },
   "captcha": {
-    "enableCaptcha": true,
+    "enableCaptcha": false,
     "useTestCaptcha": true
   },
   "reporting": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -139,7 +139,7 @@
     "exportDemoSurveyV2": true
   },
   "captcha": {
-    "enableCaptcha": true,
+    "enableCaptcha": false,
     "useTestCaptcha": true
   },
   "reporting": {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -80,5 +80,6 @@ public interface WorkbenchConfigMapper {
       target = "enableUpdatedDemographicSurvey",
       source = "config.featureFlags.enableUpdatedDemographicSurvey")
   @Mapping(target = "enableGkeApp", source = "config.featureFlags.enableGkeApp")
+  @Mapping(target = "enableCaptcha", source = "config.captcha.enableCaptcha")
   ConfigResponse toModel(WorkbenchConfig config, List<DbAccessModule> accessModules);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4739,6 +4739,10 @@ definitions:
         type: boolean
         default: false
         description: Whether to enable demographic survey v2 in the UI.
+      enableCaptcha:
+        type: boolean
+        default: true
+        description: Whether a captcha check is part of the new user registration process
 
   RuntimeImage:
     type: object

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -311,13 +311,23 @@ public class ProfileControllerTest extends BaseControllerTest {
 
   @Test
   public void testCreateAccount_invalidCaptchaToken() {
+    config.captcha.enableCaptcha = true;
+    createAccountAndDbUserWithAffiliation();
+    createAccountRequest.setCaptchaVerificationToken(WRONG_CAPTCHA_TOKEN);
+
     assertThrows(
-        BadRequestException.class,
-        () -> {
-          createAccountAndDbUserWithAffiliation();
-          createAccountRequest.setCaptchaVerificationToken(WRONG_CAPTCHA_TOKEN);
-          profileController.createAccount(createAccountRequest);
-        });
+        BadRequestException.class, () -> profileController.createAccount(createAccountRequest));
+  }
+
+  @Test
+  public void testCreateAccount_invalidCaptchaToken_okIfEnableCaptchaFalse() {
+    config.captcha.enableCaptcha = false;
+
+    createAccountAndDbUserWithAffiliation();
+    createAccountRequest.setCaptchaVerificationToken(WRONG_CAPTCHA_TOKEN);
+
+    // no exception
+    profileController.createAccount(createAccountRequest);
   }
 
   @Test

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -446,6 +446,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
     const { enableCaptcha } = serverConfigStore.get().config;
     if (currentStep === SignInStep.DEMOGRAPHIC_SURVEY) {
       const { captcha, errors, loading } = this.state;
+      const invalid = !!errors || (enableCaptcha && !captcha);
       return (
         <div
           style={{
@@ -479,7 +480,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
             </Button>
             <TooltipTrigger
               content={
-                (errors || (enableCaptcha && !captcha)) && (
+                invalid && (
                   <DemographicSurveyValidationMessage
                     {...{ captcha, errors }}
                     isAccountCreation
@@ -489,9 +490,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
             >
               <Button
                 aria-label='Submit'
-                disabled={
-                  !!errors || (enableCaptcha && !this.state.captcha) || loading
-                }
+                disabled={invalid || loading}
                 type='primary'
                 data-test-id='submit-button'
                 onClick={this.onSubmit}

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -479,7 +479,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
             </Button>
             <TooltipTrigger
               content={
-                (errors || !captcha) && (
+                (errors || (enableCaptcha && !captcha)) && (
                   <DemographicSurveyValidationMessage
                     {...{ captcha, errors }}
                     isAccountCreation

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -443,8 +443,8 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
   }
 
   private renderNavigation(currentStep: SignInStep) {
-    const { enableCaptcha } = serverConfigStore.get().config;
     if (currentStep === SignInStep.DEMOGRAPHIC_SURVEY) {
+      const { enableCaptcha } = serverConfigStore.get().config;
       const { captcha, errors, loading } = this.state;
       const invalid = !!errors || (enableCaptcha && !captcha);
       return (

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -28,6 +28,7 @@ import colors from 'app/styles/colors';
 import { reactStyles, WindowSizeProps, withWindowSize } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { convertAPIError, reportError } from 'app/utils/errors';
+import { serverConfigStore } from 'app/utils/stores';
 import successBackgroundImage from 'assets/images/congrats-female.png';
 import successSmallerBackgroundImage from 'assets/images/congrats-female-standing.png';
 import landingBackgroundImage from 'assets/images/login-group.png';
@@ -403,6 +404,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
   }
 
   private onSubmit = async () => {
+    const { enableCaptcha } = serverConfigStore.get().config;
     this.setState({
       loading: true,
     });
@@ -425,7 +427,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
       reportError(error);
       const { message } = await convertAPIError(error);
       this.props.showProfileErrorModal(message);
-      if (environment.enableCaptcha) {
+      if (enableCaptcha) {
         // Reset captcha
         this.captchaRef.current.reset();
         this.setState({ captchaToken: null, captcha: true, loading: false });
@@ -441,6 +443,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
   }
 
   private renderNavigation(currentStep: SignInStep) {
+    const { enableCaptcha } = serverConfigStore.get().config;
     if (currentStep === SignInStep.DEMOGRAPHIC_SURVEY) {
       const { captcha, errors, loading } = this.state;
       return (
@@ -451,7 +454,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
             marginLeft: '1.5rem',
           }}
         >
-          {environment.enableCaptcha && (
+          {enableCaptcha && (
             <div style={{ paddingBottom: '1.5rem' }}>
               <ReCAPTCHA
                 sitekey={environment.captchaSiteKey}
@@ -487,9 +490,7 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
               <Button
                 aria-label='Submit'
                 disabled={
-                  !!errors ||
-                  (environment.enableCaptcha && !this.state.captcha) ||
-                  loading
+                  !!errors || (enableCaptcha && !this.state.captcha) || loading
                 }
                 type='primary'
                 data-test-id='submit-button'

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -52,8 +52,6 @@ export interface EnvironmentBase {
   // Whether users should be able to see the Published Workspaces
   // tab in the Workspace Library.
   enablePublishedWorkspaces: boolean;
-  // Enable Captcha during registration
-  enableCaptcha: boolean;
   // Captcha site key registered with the domain
   captchaSiteKey: string;
 

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -20,7 +20,6 @@ export const environment: Environment = {
   inactivityTimeoutSeconds: 99999999999,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
-  enableCaptcha: false,
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: false,

--- a/ui/src/environments/environment.perf.ts
+++ b/ui/src/environments/environment.perf.ts
@@ -19,7 +19,6 @@ export const environment: Environment = {
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
-  enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: false,

--- a/ui/src/environments/environment.preprod.ts
+++ b/ui/src/environments/environment.preprod.ts
@@ -18,7 +18,6 @@ export const environment: Environment = {
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
-  enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: true,

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -18,7 +18,6 @@ export const environment: Environment = {
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
-  enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: true,

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -18,7 +18,6 @@ export const environment: Environment = {
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
-  enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: false,

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -18,7 +18,6 @@ export const environment: Environment = {
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
-  enableCaptcha: true,
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: false,

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -22,7 +22,6 @@ export const testEnvironmentBase: EnvironmentBase = {
   inactivityTimeoutSeconds: 99999999999,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: true,
-  enableCaptcha: false,
   enablePublishedWorkspaces: false,
   enableFooter: true,
   enableDemographicSurveyV2Redirect: false,


### PR DESCRIPTION
When we need to share a Feature Flag between the API and UI code, the correct thing to do is to pass it via ConfigResponse.  Unfortunately this flag was implemented as two independent flags with the same name instead, allowing the values to get out of sync.  The recent change to the UI version of this flag in Local and Test to remove the Captcha check from the account creation process was not reflected in the API, so the API attempted to check a Captcha token that was not present, thus preventing account creation. 

This PR removes the duplicate UI FF, so the UI now uses the same FF as the API.

Tested locally - I was able to create an account on Local.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
