### PR TITLE
[risk=low][RW-9446] Fix bug that prevents Cromwell apps panel expansion

### DIFF
--- a/ui/src/app/components/apps-panel/utils.spec.tsx
+++ b/ui/src/app/components/apps-panel/utils.spec.tsx
@@ -1,0 +1,80 @@
+import { AppStatus, RuntimeStatus } from 'generated/fetch';
+
+import {
+  fromRuntimeStatus,
+  fromUserAppStatus,
+  fromUserAppStatusWithFallback,
+  UserEnvironmentStatus,
+} from './utils';
+
+describe('AppsPanel utils', () => {
+  test.each([
+    [RuntimeStatus.Running, 'Running'],
+    [RuntimeStatus.Stopping, 'Pausing'],
+    [RuntimeStatus.Stopped, 'Paused'],
+    [RuntimeStatus.Starting, 'Resuming'],
+
+    // no other RuntimeStatuses are mapped currently
+
+    [RuntimeStatus.Creating, 'UNKNOWN'],
+    [RuntimeStatus.Deleted, 'UNKNOWN'],
+    [RuntimeStatus.Deleting, 'UNKNOWN'],
+    [RuntimeStatus.Error, 'UNKNOWN'],
+    [RuntimeStatus.Unknown, 'UNKNOWN'],
+    [RuntimeStatus.Updating, 'UNKNOWN'],
+
+    [undefined, 'UNKNOWN'],
+    [null, 'UNKNOWN'],
+  ])(
+    'Should convert RuntimeStatus %s to the correct UserEnvironmentStatus',
+    (runtimeStatus: RuntimeStatus, expected: UserEnvironmentStatus) => {
+      expect(fromRuntimeStatus(runtimeStatus)).toBe(expected);
+    }
+  );
+
+  test.each([
+    [AppStatus.RUNNING, 'Running'],
+    [AppStatus.STOPPING, 'Pausing'],
+    [AppStatus.STOPPED, 'Paused'],
+    [AppStatus.STARTING, 'Resuming'],
+
+    // no other AppStatuses are mapped currently
+
+    [AppStatus.DELETED, 'UNKNOWN'],
+    [AppStatus.DELETING, 'UNKNOWN'],
+    [AppStatus.ERROR, 'UNKNOWN'],
+    [AppStatus.PROVISIONING, 'UNKNOWN'],
+    [AppStatus.STATUSUNSPECIFIED, 'UNKNOWN'],
+
+    [undefined, 'UNKNOWN'],
+    [null, 'UNKNOWN'],
+  ])(
+    'Should convert AppStatus %s to the correct UserEnvironmentStatus',
+    (userAppStatus: AppStatus, expected: UserEnvironmentStatus) => {
+      expect(fromUserAppStatus(userAppStatus)).toBe(expected);
+    }
+  );
+
+  test.each([
+    [AppStatus.RUNNING, 'Running'],
+    [AppStatus.STOPPING, 'Pausing'],
+    [AppStatus.STOPPED, 'Paused'],
+    [AppStatus.STARTING, 'Resuming'],
+
+    // no other AppStatuses are mapped currently
+
+    [AppStatus.DELETED, AppStatus.DELETED],
+    [AppStatus.DELETING, AppStatus.DELETING],
+    [AppStatus.ERROR, AppStatus.ERROR],
+    [AppStatus.PROVISIONING, AppStatus.PROVISIONING],
+    [AppStatus.STATUSUNSPECIFIED, AppStatus.STATUSUNSPECIFIED],
+
+    [undefined, undefined],
+    [null, undefined],
+  ])(
+    'Should convert AppStatus %s to the correct UserEnvironmentStatus with fallback',
+    (userAppStatus: AppStatus, expected: string) => {
+      expect(fromUserAppStatusWithFallback(userAppStatus)).toBe(expected);
+    }
+  );
+});

--- a/ui/src/app/components/apps-panel/utils.tsx
+++ b/ui/src/app/components/apps-panel/utils.tsx
@@ -124,5 +124,5 @@ export const fromUserAppStatus = (status: AppStatus): UserEnvironmentStatus =>
 // else return the original status
 export const fromUserAppStatusWithFallback = (status: AppStatus): string => {
   const mappedStatus = fromUserAppStatus(status);
-  return mappedStatus === 'UNKNOWN' ? status.toString() : mappedStatus;
+  return mappedStatus === 'UNKNOWN' ? status?.toString() : mappedStatus;
 };


### PR DESCRIPTION
Don't make the incorrect assumption that Cromwell already exists!

To test: can you expand the Cromwell logo in the Apps Panel in a newly created workspace?
 
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
