### PR TITLE
[RW-9048][risk=no] Use large resource class for deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,6 +545,7 @@ jobs:
 
   ui-deploy-to-test:
     executor: workbench-executor
+    resource_class: large
     steps:
       - checkout-code
       - attach_workspace:


### PR DESCRIPTION
UI deploys to GAE are hanging. This may fix it.

This a graph of RAM usage over time from CircleCI:
![ram-usage](https://user-images.githubusercontent.com/1545444/215148295-9e82e58f-929e-4c66-9487-ecf1313104ad.png)

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
