### PR TITLE
[no ticket][risk=no] Fix: First party cookie errors now show cookie page

### DIFF
--- a/ui/src/app/components/cookie-banner.tsx
+++ b/ui/src/app/components/cookie-banner.tsx
@@ -6,7 +6,7 @@ import { StyledRouterLink } from 'app/components/buttons';
 import { FlexRow } from 'app/components/flex';
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
-import { cookiesEnabled } from 'app/utils/cookies';
+import { firstPartyCookiesEnabled } from 'app/utils/cookies';
 import cookies from 'assets/images/cookies.png';
 
 const styles = reactStyles({
@@ -47,14 +47,14 @@ export class CookieBanner extends React.Component<{}, CookieBannerState> {
   }
 
   handleCloseCookies() {
-    if (cookiesEnabled()) {
+    if (firstPartyCookiesEnabled()) {
       this.setState({ cookieBannerClosed: true });
       localStorage.setItem(cookieKey, 'cookie-banner-dismissed');
     }
   }
 
   cookieBannerVisible() {
-    if (cookiesEnabled()) {
+    if (firstPartyCookiesEnabled()) {
       return !localStorage.getItem(cookieKey) && !this.state.cookieBannerClosed;
     } else {
       return true;

--- a/ui/src/app/components/ct-available-banner-maybe.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.tsx
@@ -12,7 +12,7 @@ import {
   DATA_ACCESS_REQUIREMENTS_PATH,
   eligibleForTier,
 } from 'app/utils/access-utils';
-import { cookiesEnabled } from 'app/utils/cookies';
+import { firstPartyCookiesEnabled } from 'app/utils/cookies';
 import { cdrVersionStore, profileStore, useStore } from 'app/utils/stores';
 
 import { StyledRouterLink } from './buttons';
@@ -43,7 +43,7 @@ const shouldShowBanner = (
     // the user is not currently visiting the DAR page
     pathname !== DATA_ACCESS_REQUIREMENTS_PATH;
 
-  if (cookiesEnabled()) {
+  if (firstPartyCookiesEnabled()) {
     const cookie = localStorage.getItem(CT_COOKIE_KEY);
     return !cookie && shouldShow;
   } else {
@@ -63,7 +63,7 @@ export const CTAvailableBannerMaybe = () => {
   );
 
   const acknowledgeBanner = () => {
-    if (cookiesEnabled()) {
+    if (firstPartyCookiesEnabled()) {
       localStorage.setItem(CT_COOKIE_KEY, 'acknowledged');
     }
     setShowBanner(false);

--- a/ui/src/app/components/status-alert-banner-maybe.tsx
+++ b/ui/src/app/components/status-alert-banner-maybe.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { StatusAlert } from 'generated/fetch';
 
 import { statusAlertApi } from 'app/services/swagger-fetch-clients';
-import { cookiesEnabled } from 'app/utils/cookies';
+import { firstPartyCookiesEnabled } from 'app/utils/cookies';
 
 import { Button } from './buttons';
 import { ToastBanner, ToastType } from './toast-banner';
@@ -19,7 +19,7 @@ const INITIAL_STATUS_ALERT: StatusAlert = {
 
 const shouldShowStatusAlert = (statusAlert: StatusAlert) => {
   const { statusAlertId, message } = statusAlert;
-  if (cookiesEnabled()) {
+  if (firstPartyCookiesEnabled()) {
     const cookie = localStorage.getItem(STATUS_ALERT_COOKIE_KEY);
     return (!cookie || (cookie && cookie !== `${statusAlertId}`)) && !!message;
   } else {
@@ -45,7 +45,7 @@ export const StatusAlertBannerMaybe = () => {
   }, []);
 
   const acknowledgeAlert = () => {
-    if (cookiesEnabled()) {
+    if (firstPartyCookiesEnabled()) {
       localStorage.setItem(
         STATUS_ALERT_COOKIE_KEY,
         `${statusAlertDetails.statusAlertId}`

--- a/ui/src/app/routing/app-routing.tsx
+++ b/ui/src/app/routing/app-routing.tsx
@@ -39,7 +39,7 @@ import {
 import { initializeAnalytics } from 'app/utils/analytics';
 import { getAccessToken, useAuthentication } from 'app/utils/authentication';
 import {
-  cookiesEnabled,
+  firstPartyCookiesEnabled,
   LOCAL_STORAGE_API_OVERRIDE_KEY,
   LOCAL_STORAGE_KEY_TEST_ACCESS_TOKEN,
 } from 'app/utils/cookies';
@@ -137,7 +137,7 @@ const useOverriddenApiUrl = () => {
   const [overriddenUrl, setOverriddenUrl] = useState('');
 
   useEffect(() => {
-    if (cookiesEnabled()) {
+    if (firstPartyCookiesEnabled()) {
       try {
         setOverriddenUrl(localStorage.getItem(LOCAL_STORAGE_API_OVERRIDE_KEY));
 
@@ -213,12 +213,12 @@ export const AppRoutingComponent: React.FunctionComponent<
     }
   }, [config]);
 
-  const firstPartyCookiesEnabled = cookiesEnabled();
   const thirdPartyCookiesEnabled = !(
     authError &&
     authError.length > 0 &&
     authError.includes('Cookies')
   );
+  const cookiesEnabled = firstPartyCookiesEnabled() && thirdPartyCookiesEnabled;
 
   return (
     <React.Fragment>
@@ -230,7 +230,7 @@ export const AppRoutingComponent: React.FunctionComponent<
         <React.Fragment>
           {/* Once Angular is removed the app structure will change and we can put this in a more appropriate place */}
           <NotificationModal />
-          {firstPartyCookiesEnabled && thirdPartyCookiesEnabled && (
+          {cookiesEnabled && (
             <AppRouter>
               <ScrollToTop />
               {/* Previously, using a top-level Switch with AppRoute and ProtectedRoute has caused bugs: */}
@@ -295,42 +295,41 @@ export const AppRoutingComponent: React.FunctionComponent<
           )}
         </React.Fragment>
       )}
-      {!firstPartyCookiesEnabled ||
-        (!thirdPartyCookiesEnabled && (
-          <div>
+      {!cookiesEnabled && (
+        <div>
+          <div
+            style={{
+              maxWidth: '500px',
+              margin: '1.5rem',
+              fontFamily: 'Montserrat',
+            }}
+          >
+            <SignedInAouHeaderWithDisplayTag />
             <div
               style={{
-                maxWidth: '500px',
-                margin: '1.5rem',
-                fontFamily: 'Montserrat',
+                fontSize: '20pt',
+                color: '#2F2E7E',
+                padding: '1.5rem 0 1.5rem 0',
               }}
             >
-              <SignedInAouHeaderWithDisplayTag />
-              <div
-                style={{
-                  fontSize: '20pt',
-                  color: '#2F2E7E',
-                  padding: '1.5rem 0 1.5rem 0',
-                }}
+              Cookies are Disabled
+            </div>
+            <div style={{ fontSize: '14pt', color: '#000000' }}>
+              For full functionality of this site it is necessary to enable
+              cookies. Here are the{' '}
+              <a
+                href='https://support.google.com/accounts/answer/61416'
+                style={{ color: '#2691D0' }}
+                target='_blank'
+                rel='noopener noreferrer'
               >
-                Cookies are Disabled
-              </div>
-              <div style={{ fontSize: '14pt', color: '#000000' }}>
-                For full functionality of this site it is necessary to enable
-                cookies. Here are the{' '}
-                <a
-                  href='https://support.google.com/accounts/answer/61416'
-                  style={{ color: '#2691D0' }}
-                  target='_blank'
-                  rel='noopener noreferrer'
-                >
-                  instructions how to enable cookies in your web browser
-                </a>
-                .
-              </div>
+                instructions how to enable cookies in your web browser
+              </a>
+              .
             </div>
           </div>
-        ))}
+        </div>
+      )}
     </React.Fragment>
   );
 };

--- a/ui/src/app/services/swagger-fetch-clients.ts
+++ b/ui/src/app/services/swagger-fetch-clients.ts
@@ -51,7 +51,7 @@ import {
 
 import { environment } from 'environments/environment';
 import {
-  cookiesEnabled,
+  firstPartyCookiesEnabled,
   LOCAL_STORAGE_API_OVERRIDE_KEY,
 } from 'app/utils/cookies';
 import * as portableFetch from 'portable-fetch';
@@ -127,7 +127,7 @@ export const workspaceAdminApi = bindCtor(WorkspaceAdminApi);
 export const workspacesApi = bindCtor(WorkspacesApi);
 
 export const getApiBaseUrl = () => {
-  if (cookiesEnabled()) {
+  if (firstPartyCookiesEnabled()) {
     return (
       localStorage.getItem(LOCAL_STORAGE_API_OVERRIDE_KEY) ||
       environment.allOfUsApiUrl

--- a/ui/src/app/utils/cookies.tsx
+++ b/ui/src/app/utils/cookies.tsx
@@ -17,7 +17,7 @@ export const LOCAL_STORAGE_KEY_TEST_ACCESS_TOKEN = 'test-access-token-override';
  * SecurityError if you try to access it; e.g. documents created from data URIs
  * or in sandboxed iframes (depending on flags/context)
  */
-export function cookiesEnabled(): boolean {
+export function firstPartyCookiesEnabled(): boolean {
   try {
     // Create cookie
     document.cookie = 'cookietest=1';


### PR DESCRIPTION
Fixes a logic error where first-party cookies weren't having any effect in app-routing. Only third-party cookies were determining whether to show the cookie page.

This PR also renames the `cookiesEnabled` function to `firstPartyCookiesEnabled` to be more specific.

Original context: https://precisionmedicineinitiative.atlassian.net/browse/RW-7169

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
