### PR TITLE
[DT-191-1][risk=no] CDR indexing - Fix issue after removing OMOP v5.3.1 check

### DIFF
--- a/api/db-cdr/generate-cdr/build-ds-linking.sh
+++ b/api/db-cdr/generate-cdr/build-ds-linking.sh
@@ -15,6 +15,11 @@ then
 fi
 
 # Remove references to OMOP versions older than OMOP 5.3.1 - DT-196
+# run query to initialize our .bigqueryrc configuration file
+# otherwise error in bigquery job?
+query="select count(*) from \`$BQ_PROJECT.$BQ_DATASET.concept\`"
+bq --quiet --project_id="$BQ_PROJECT" query --nouse_legacy_sql --format=csv "$query"
+
 # query to find max of id column after inserting rows for a table
 MAX_ID_QRY="query --quiet --project_id=$BQ_PROJECT --nouse_legacy_sql --format=csv select coalesce(max(id),0) from \`$BQ_PROJECT.$BQ_DATASET.ds_linking\`"
 ################################################
@@ -22,6 +27,7 @@ MAX_ID_QRY="query --quiet --project_id=$BQ_PROJECT --nouse_legacy_sql --format=c
 ################################################
 echo "ds_linking - inserting condition data"
 MAX_ID=$(bq $MAX_ID_QRY | awk '{if(NR>1)print}')
+# echo "Starting at ID $MAX_ID"
 bq --quiet --project_id=$BQ_PROJECT query --nouse_legacy_sql \
 "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (ID, DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
 VALUES

--- a/api/db-cdr/generate-cdr/build-ds-linking.sh
+++ b/api/db-cdr/generate-cdr/build-ds-linking.sh
@@ -17,7 +17,7 @@ fi
 # Remove references to OMOP versions older than OMOP 5.3.1 - DT-196
 # run query to initialize our .bigqueryrc configuration file
 # otherwise error in bigquery job?
-query="select count(*) from \`$BQ_PROJECT.$BQ_DATASET.concept\`"
+query="select count(*) from \`$BQ_PROJECT.$BQ_DATASET.ds_linking\`"
 bq --quiet --project_id="$BQ_PROJECT" query --nouse_legacy_sql --format=csv "$query"
 
 # query to find max of id column after inserting rows for a table

--- a/api/db-cdr/generate-cdr/build-ds-linking.sh
+++ b/api/db-cdr/generate-cdr/build-ds-linking.sh
@@ -27,7 +27,6 @@ MAX_ID_QRY="query --quiet --project_id=$BQ_PROJECT --nouse_legacy_sql --format=c
 ################################################
 echo "ds_linking - inserting condition data"
 MAX_ID=$(bq $MAX_ID_QRY | awk '{if(NR>1)print}')
-# echo "Starting at ID $MAX_ID"
 bq --quiet --project_id=$BQ_PROJECT query --nouse_legacy_sql \
 "INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (ID, DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
 VALUES

--- a/api/db-cdr/generate-cdr/build-ds-linking.sh
+++ b/api/db-cdr/generate-cdr/build-ds-linking.sh
@@ -21,7 +21,7 @@ query="select count(*) from \`$BQ_PROJECT.$BQ_DATASET.concept\`"
 bq --quiet --project_id="$BQ_PROJECT" query --nouse_legacy_sql --format=csv "$query"
 
 # query to find max of id column after inserting rows for a table
-MAX_ID_QRY="bq query --quiet --project_id=$BQ_PROJECT --nouse_legacy_sql --format=csv select coalesce(max(id),0) from \`$BQ_PROJECT.$BQ_DATASET.ds_linking\`"
+MAX_ID_QRY="query --quiet --project_id=$BQ_PROJECT --nouse_legacy_sql --format=csv select coalesce(max(id),0) from \`$BQ_PROJECT.$BQ_DATASET.ds_linking\`"
 ################################################
 # INSERT DATA
 ################################################

--- a/api/db-cdr/generate-cdr/build-ds-linking.sh
+++ b/api/db-cdr/generate-cdr/build-ds-linking.sh
@@ -21,7 +21,7 @@ query="select count(*) from \`$BQ_PROJECT.$BQ_DATASET.concept\`"
 bq --quiet --project_id="$BQ_PROJECT" query --nouse_legacy_sql --format=csv "$query"
 
 # query to find max of id column after inserting rows for a table
-MAX_ID_QRY="query --quiet --project_id=$BQ_PROJECT --nouse_legacy_sql --format=csv select coalesce(max(id),0) from \`$BQ_PROJECT.$BQ_DATASET.ds_linking\`"
+MAX_ID_QRY="bq query --quiet --project_id=$BQ_PROJECT --nouse_legacy_sql --format=csv select coalesce(max(id),0) from \`$BQ_PROJECT.$BQ_DATASET.ds_linking\`"
 ################################################
 # INSERT DATA
 ################################################


### PR DESCRIPTION
Description:
---
- after removing initial query for getting table list, indexing fails. Local run works fine so doing
  - initialize .bigqueryrc by running a count for some table


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
