### PR TITLE
[RW-9274][risk=low] Exclude those apps are created by other when list apps. Also improve listDisk

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -84,7 +84,7 @@ public class AppsController implements AppsApiDelegate {
     validateCanPerformApiAction(dbWorkspace);
 
     ListAppsResponse response = new ListAppsResponse();
-    response.addAll(leonardoApiClient.listAppsInProject(dbWorkspace.getGoogleProject()));
+    response.addAll(leonardoApiClient.listAppsInProjectCreatedByCreator(dbWorkspace.getGoogleProject()));
     return ResponseEntity.ok(response);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -84,7 +84,8 @@ public class AppsController implements AppsApiDelegate {
     validateCanPerformApiAction(dbWorkspace);
 
     ListAppsResponse response = new ListAppsResponse();
-    response.addAll(leonardoApiClient.listAppsInProjectCreatedByCreator(dbWorkspace.getGoogleProject()));
+    response.addAll(
+        leonardoApiClient.listAppsInProjectCreatedByCreator(dbWorkspace.getGoogleProject()));
     return ResponseEntity.ok(response);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/DiskController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DiskController.java
@@ -46,7 +46,7 @@ public class DiskController implements DiskApiDelegate {
     String pdNamePrefix = userProvider.get().getUserPDNamePrefix();
 
     List<LeonardoListPersistentDiskResponse> responseList =
-        leonardoNotebooksClient.listPersistentDiskByProject(googleProject, false).stream()
+        leonardoNotebooksClient.listPersistentDiskByProjectCreatedByCreator(googleProject, false).stream()
             .filter(r -> r.getName().startsWith(pdNamePrefix))
             .collect(Collectors.toList());
 

--- a/api/src/main/java/org/pmiops/workbench/api/DiskController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DiskController.java
@@ -46,7 +46,8 @@ public class DiskController implements DiskApiDelegate {
     String pdNamePrefix = userProvider.get().getUserPDNamePrefix();
 
     List<LeonardoListPersistentDiskResponse> responseList =
-        leonardoNotebooksClient.listPersistentDiskByProjectCreatedByCreator(googleProject, false).stream()
+        leonardoNotebooksClient.listPersistentDiskByProjectCreatedByCreator(googleProject, false)
+            .stream()
             .filter(r -> r.getName().startsWith(pdNamePrefix))
             .collect(Collectors.toList());
 

--- a/api/src/main/java/org/pmiops/workbench/api/DisksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DisksController.java
@@ -116,9 +116,7 @@ public class DisksController implements DisksApiDelegate {
 
     List<Disk> activeDisks =
         disksToValidate.stream()
-            .filter(
-                d ->
-                    ACTIVE_DISK_STATUSES.contains(d.getStatus()))
+            .filter(d -> ACTIVE_DISK_STATUSES.contains(d.getStatus()))
             .collect(Collectors.toList());
     if (activeDisks.size() > (AppType.values().length + 1)) {
       String diskNameList =

--- a/api/src/main/java/org/pmiops/workbench/api/DisksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DisksController.java
@@ -91,7 +91,7 @@ public class DisksController implements DisksApiDelegate {
         workspaceService.lookupWorkspaceByNamespace(workspaceNamespace).getGoogleProject();
 
     List<LeonardoListPersistentDiskResponse> responseList =
-        leonardoNotebooksClient.listPersistentDiskByProject(googleProject, false);
+        leonardoNotebooksClient.listPersistentDiskByProjectCreatedByCreator(googleProject, false);
 
     List<Disk> diskList =
         findTheMostRecentActiveDisks(
@@ -118,8 +118,7 @@ public class DisksController implements DisksApiDelegate {
         disksToValidate.stream()
             .filter(
                 d ->
-                    ACTIVE_DISK_STATUSES.contains(d.getStatus())
-                        && d.getCreator().equals(userProvider.get().getUsername()))
+                    ACTIVE_DISK_STATUSES.contains(d.getStatus()))
             .collect(Collectors.toList());
     if (activeDisks.size() > (AppType.values().length + 1)) {
       String diskNameList =

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
@@ -214,7 +214,7 @@ public class OfflineRuntimeController implements OfflineRuntimeApiDelegate {
       disks =
           disksApiProvider
               .get()
-              .listDisks(/* labels */ null, /* includeDeleted */ false, LEONARDO_DISK_LABEL_KEYS);
+              .listDisks(/* labels */ null, /* includeDeleted */ false, LEONARDO_DISK_LABEL_KEYS, null);
     } catch (ApiException e) {
       throw new ServerErrorException("listDisks failed", e);
     }

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
@@ -214,7 +214,8 @@ public class OfflineRuntimeController implements OfflineRuntimeApiDelegate {
       disks =
           disksApiProvider
               .get()
-              .listDisks(/* labels */ null, /* includeDeleted */ false, LEONARDO_DISK_LABEL_KEYS, null);
+              .listDisks(
+                  /* labels */ null, /* includeDeleted */ false, LEONARDO_DISK_LABEL_KEYS, null);
     } catch (ApiException e) {
       throw new ServerErrorException("listDisks failed", e);
     }

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
@@ -77,7 +77,7 @@ public interface LeonardoApiClient {
       throws WorkbenchException;
 
   /** List all persistent disks by google project */
-  List<LeonardoListPersistentDiskResponse> listPersistentDiskByProject(
+  List<LeonardoListPersistentDiskResponse> listPersistentDiskByProjectCreatedByCreator(
       String googleProject, boolean includeDeleted);
 
   /**
@@ -98,11 +98,11 @@ public interface LeonardoApiClient {
   UserAppEnvironment getAppByNameByProjectId(String googleProjectId, String appName);
 
   /**
-   * Lists all apps the user has permission on in the given workspace GCP project
+   * Lists all apps the user creates on in the given workspace GCP project
    *
    * @param googleProjectId the GCP project the app belongs to
    */
-  List<UserAppEnvironment> listAppsInProject(String googleProjectId);
+  List<UserAppEnvironment> listAppsInProjectCreatedByCreator(String googleProjectId);
 
   /**
    * Deletes a Leonardo app

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
@@ -98,7 +98,7 @@ public interface LeonardoApiClient {
   UserAppEnvironment getAppByNameByProjectId(String googleProjectId, String appName);
 
   /**
-   * Lists all apps the user creates on in the given workspace GCP project
+   * Lists all apps the user creates in the given workspace GCP project
    *
    * @param googleProjectId the GCP project the app belongs to
    */

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -89,6 +89,9 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
   private static final String MICROARRAY_VCF_MANIFEST_PATH_KEY = "MICROARRAY_VCF_MANIFEST_PATH";
   private static final String MICROARRAY_IDAT_MANIFEST_PATH_KEY = "MICROARRAY_IDAT_MANIFEST_PATH";
 
+  // The Leonardo user role who creates Leonardo APP or disks.
+  private static final String LEONARDO_CREATOR_ROLE = "creator";
+
   // Keep in sync with
   // https://github.com/DataBiosphere/leonardo/blob/develop/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala#L162
   private static Set<LeonardoRuntimeStatus> STOPPABLE_RUNTIME_STATUSES =
@@ -501,13 +504,13 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
   }
 
   @Override
-  public List<LeonardoListPersistentDiskResponse> listPersistentDiskByProject(
+  public List<LeonardoListPersistentDiskResponse> listPersistentDiskByProjectCreatedByCreator(
       String googleProject, boolean includeDeleted) {
     DisksApi disksApi = diskApiProvider.get();
     return leonardoRetryHandler.run(
         (context) ->
             disksApi.listDisksByProject(
-                googleProject, null, includeDeleted, LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS));
+                googleProject, null, includeDeleted, LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS, LEONARDO_CREATOR_ROLE));
   }
 
   @Override
@@ -573,7 +576,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
   }
 
   @Override
-  public List<UserAppEnvironment> listAppsInProject(String googleProjectId) {
+  public List<UserAppEnvironment> listAppsInProjectCreatedByCreator(String googleProjectId) {
     AppsApi appsApi = appsApiProvider.get();
     List<LeonardoListAppResponse> listAppResponses =
         leonardoRetryHandler.run(
@@ -582,7 +585,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
                     googleProjectId,
                     /* labels= */ null,
                     /* includeDeleted= */ false,
-                    /* includeLabels= */ LeonardoLabelHelper.LEONARDO_APP_LABEL_KEYS));
+                    /* includeLabels= */ LeonardoLabelHelper.LEONARDO_APP_LABEL_KEYS, LEONARDO_CREATOR_ROLE));
 
     return listAppResponses.stream().map(leonardoMapper::toApiApp).collect(Collectors.toList());
   }

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -510,7 +510,11 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
     return leonardoRetryHandler.run(
         (context) ->
             disksApi.listDisksByProject(
-                googleProject, null, includeDeleted, LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS, LEONARDO_CREATOR_ROLE));
+                googleProject,
+                null,
+                includeDeleted,
+                LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS,
+                LEONARDO_CREATOR_ROLE));
   }
 
   @Override
@@ -585,7 +589,8 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
                     googleProjectId,
                     /* labels= */ null,
                     /* includeDeleted= */ false,
-                    /* includeLabels= */ LeonardoLabelHelper.LEONARDO_APP_LABEL_KEYS, LEONARDO_CREATOR_ROLE));
+                    /* includeLabels= */ LeonardoLabelHelper.LEONARDO_APP_LABEL_KEYS,
+                    LEONARDO_CREATOR_ROLE));
 
     return listAppResponses.stream().map(leonardoMapper::toApiApp).collect(Collectors.toList());
   }

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -480,6 +480,12 @@ paths:
           required: false
           schema:
             type: string
+        - in: query
+          name: role
+          description: Optional filter that excludes persistent disks you did not create. Accepts "creator" or nothing.
+          required: false
+          schema:
+            type: string
       responses:
         "200":
           description: List of persistent disks
@@ -541,6 +547,12 @@ paths:
             Optional label keys of the labels returned in response. Example:
             Querying by key1,key2,key3
             returns all labels key1/val1 key2/val2 and key3 and val3 for each app in response
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: role
+          description: Optional filter that excludes persistent disks you did not create. Accepts "creator" or nothing.
           required: false
           schema:
             type: string
@@ -1187,6 +1199,12 @@ paths:
           required: false
           schema:
             type: string
+        - in: query
+          name: role
+          description: Optional filter that excludes apps you did not create. Accepts "creator" or nothing.
+          required: false
+          schema:
+            type: string
       responses:
         "200":
           description: List of apps
@@ -1252,6 +1270,12 @@ paths:
             Optional label keys of the labels returned in response. Example:
             Querying by key1,key2,key3
             returns all labels key1/val1 key2/val2 and key3 and val3 for each app in response
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: role
+          description: Optional filter that excludes apps you did not create. Accepts "creator" or nothing.
           required: false
           schema:
             type: string

--- a/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
@@ -118,7 +118,7 @@ public class AppsControllerTest {
   @Test
   public void testListAppSuccess() throws Exception {
     controller.listAppsInWorkspace(WORKSPACE_NS);
-    verify(mockLeonardoApiClient).listAppsInProject(GOOGLE_PROJECT_ID);
+    verify(mockLeonardoApiClient).listAppsInProjectCreatedByCreator(GOOGLE_PROJECT_ID);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/DiskControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DiskControllerTest.java
@@ -220,7 +220,11 @@ public class DiskControllerTest {
             .createdDate("2021-08-06T17:57:29.827954Z");
 
     when(userDisksApi.listDisksByProject(
-            GOOGLE_PROJECT_ID, null, false, LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS))
+            GOOGLE_PROJECT_ID,
+            null,
+            false,
+            LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS,
+            "creator"))
         .thenReturn(ImmutableList.of(deletingPDResponse, readyPDResponse));
     assertThat(diskController.getDisk(WORKSPACE_NS).getBody()).isEqualTo(readyPD);
   }
@@ -246,7 +250,11 @@ public class DiskControllerTest {
             .createdDate("2021-08-06T19:57:29.827954Z");
 
     when(userDisksApi.listDisksByProject(
-            GOOGLE_PROJECT_ID, null, false, LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS))
+            GOOGLE_PROJECT_ID,
+            null,
+            false,
+            LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS,
+            "creator"))
         .thenReturn(ImmutableList.of(deletingPDResponse, readyPDResponse));
     assertThat(diskController.getDisk(WORKSPACE_NS).getBody()).isEqualTo(deletingPD);
   }
@@ -254,7 +262,11 @@ public class DiskControllerTest {
   @Test
   public void testGetDisk_noDisks() throws ApiException {
     when(userDisksApi.listDisksByProject(
-            GOOGLE_PROJECT_ID, null, false, LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS))
+            GOOGLE_PROJECT_ID,
+            null,
+            false,
+            LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS,
+            "creator"))
         .thenReturn(Collections.emptyList());
     assertThrows(NotFoundException.class, () -> diskController.getDisk(WORKSPACE_NS));
   }
@@ -270,7 +282,11 @@ public class DiskControllerTest {
             .auditInfo(new LeonardoAuditInfo().createdDate("2021-08-06T16:57:29.827954Z"))
             .googleProject(GOOGLE_PROJECT_ID);
     when(userDisksApi.listDisksByProject(
-            GOOGLE_PROJECT_ID, null, false, LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS))
+            GOOGLE_PROJECT_ID,
+            null,
+            false,
+            LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS,
+            "creator"))
         .thenReturn(ImmutableList.of(response));
     assertThat(diskController.getDisk(WORKSPACE_NS).getBody().getStatus())
         .isEqualTo(DiskStatus.UNKNOWN);

--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -190,7 +190,7 @@ public class DisksControllerTest {
             NOW.toString(),
             AppType.CROMWELL);
 
-    when(mockLeonardoApiClient.listPersistentDiskByProject(GOOGLE_PROJECT_ID, false))
+    when(mockLeonardoApiClient.listPersistentDiskByProjectCreatedByCreator(GOOGLE_PROJECT_ID, false))
         .thenReturn(
             ImmutableList.of(
                 oldRstudioDisk,
@@ -216,7 +216,7 @@ public class DisksControllerTest {
             AppType.RSTUDIO);
 
     rstudioDisk.auditInfo(rstudioDisk.getAuditInfo().creator("other@gmail.com"));
-    when(mockLeonardoApiClient.listPersistentDiskByProject(GOOGLE_PROJECT_ID, false))
+    when(mockLeonardoApiClient.listPersistentDiskByProjectCreatedByCreator(GOOGLE_PROJECT_ID, false))
         .thenReturn(ImmutableList.of(rstudioDisk));
 
     assertThat(disksController.listDisksInWorkspace(WORKSPACE_NS).getBody()).isEmpty();

--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -208,23 +208,6 @@ public class DisksControllerTest {
   }
 
   @Test
-  public void testListPD_nameNotMatchingPrefix() throws ApiException {
-    LeonardoListPersistentDiskResponse rstudioDisk =
-        newListPdResponse(
-            "rstudio1",
-            LeonardoDiskStatus.READY,
-            NOW.minusSeconds(100).toString(),
-            AppType.RSTUDIO);
-
-    rstudioDisk.auditInfo(rstudioDisk.getAuditInfo().creator("other@gmail.com"));
-    when(mockLeonardoApiClient.listPersistentDiskByProjectCreatedByCreator(
-            GOOGLE_PROJECT_ID, false))
-        .thenReturn(ImmutableList.of(rstudioDisk));
-
-    assertThat(disksController.listDisksInWorkspace(WORKSPACE_NS).getBody()).isEmpty();
-  }
-
-  @Test
   public void testUpdateDisk() throws ApiException {
     int diskSize = 200;
     String diskName = user.generatePDName();

--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -190,7 +190,8 @@ public class DisksControllerTest {
             NOW.toString(),
             AppType.CROMWELL);
 
-    when(mockLeonardoApiClient.listPersistentDiskByProjectCreatedByCreator(GOOGLE_PROJECT_ID, false))
+    when(mockLeonardoApiClient.listPersistentDiskByProjectCreatedByCreator(
+            GOOGLE_PROJECT_ID, false))
         .thenReturn(
             ImmutableList.of(
                 oldRstudioDisk,
@@ -216,7 +217,8 @@ public class DisksControllerTest {
             AppType.RSTUDIO);
 
     rstudioDisk.auditInfo(rstudioDisk.getAuditInfo().creator("other@gmail.com"));
-    when(mockLeonardoApiClient.listPersistentDiskByProjectCreatedByCreator(GOOGLE_PROJECT_ID, false))
+    when(mockLeonardoApiClient.listPersistentDiskByProjectCreatedByCreator(
+            GOOGLE_PROJECT_ID, false))
         .thenReturn(ImmutableList.of(rstudioDisk));
 
     assertThat(disksController.listDisksInWorkspace(WORKSPACE_NS).getBody()).isEmpty();

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
@@ -192,7 +192,7 @@ public class OfflineRuntimeControllerTest {
   }
 
   private void stubDisks(List<LeonardoListPersistentDiskResponse> disks) throws Exception {
-    when(mockDisksApi.listDisks(any(), any(), anyString())).thenReturn(disks);
+    when(mockDisksApi.listDisks(any(), any(), anyString(), anyString())).thenReturn(disks);
   }
 
   private void stubWorkspaceOwners(DbWorkspace w, List<DbUser> users) {

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
@@ -192,7 +192,7 @@ public class OfflineRuntimeControllerTest {
   }
 
   private void stubDisks(List<LeonardoListPersistentDiskResponse> disks) throws Exception {
-    when(mockDisksApi.listDisks(any(), any(), anyString(), anyString())).thenReturn(disks);
+    when(mockDisksApi.listDisks(any(), any(), anyString(), any())).thenReturn(disks);
   }
 
   private void stubWorkspaceOwners(DbWorkspace w, List<DbUser> users) {

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -245,7 +245,7 @@ public class LeonardoApiClientTest {
 
   @Test
   public void testListAppSuccess() throws Exception {
-    leonardoApiClient.listAppsInProject(GOOGLE_PROJECT_ID);
+    leonardoApiClient.listAppsInProjectCreatedByCreator(GOOGLE_PROJECT_ID);
     verify(userAppsApi)
         .listAppByProject(
             GOOGLE_PROJECT_ID, null, false, LeonardoLabelHelper.LEONARDO_APP_LABEL_KEYS);

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -248,7 +248,7 @@ public class LeonardoApiClientTest {
     leonardoApiClient.listAppsInProjectCreatedByCreator(GOOGLE_PROJECT_ID);
     verify(userAppsApi)
         .listAppByProject(
-            GOOGLE_PROJECT_ID, null, false, LeonardoLabelHelper.LEONARDO_APP_LABEL_KEYS);
+            GOOGLE_PROJECT_ID, null, false, LeonardoLabelHelper.LEONARDO_APP_LABEL_KEYS, "creator");
   }
 
   @Test


### PR DESCRIPTION
Description:
When implement disks, Leo does not support the new API yet. Now change disk API to be the same. 

In the future we want to support `AdminListAppInWorkspace` when we want to display apps in admin workspace page. 
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
