### PR TITLE
[No-Ticket][risk-no] Enhanced chart to expand chart for selected legend

### DIFF
--- a/ui/src/app/components/combo-chart.component.tsx
+++ b/ui/src/app/components/combo-chart.component.tsx
@@ -81,6 +81,30 @@ export class ComboChart extends React.Component<Props, State> {
         },
         series: {
           stacking: normalized ? 'percent' : 'normal',
+          events: {
+            legendItemClick: function () {
+              console.log('this object name: ' + this.constructor.name);
+              console.log(this);
+              const seriesIndex = this.index;
+              if (this.visible && this.chart.restIsHidden) {
+                for (let i = 0; i < this.chart.series.length; i++) {
+                  if (this.chart.series[i].index !== seriesIndex) {
+                    this.chart.series[i].show();
+                  }
+                }
+                this.chart.restIsHidden = false;
+              } else {
+                for (let i = 0; i < this.chart.series.length; i++) {
+                  if (this.chart.series[i].index !== seriesIndex) {
+                    this.chart.series[i].hide();
+                  }
+                }
+                this.show();
+                this.chart.restIsHidden = true;
+              }
+              return false;
+            },
+          },
         },
       },
       series,


### PR DESCRIPTION
Description:
---
- Improve user experience by showing chart for selected legend (clicked on legend: for `>65`
  - Currently clicking on legend **_hides_** the bars for selected-legend
![image](https://user-images.githubusercontent.com/4452480/218170889-02ea26d4-68cf-4a31-9a89-61ece23bf470.png)
  - and selecting every legend can get you into this state:
![image](https://user-images.githubusercontent.com/4452480/218178856-859c3c8b-6bd5-4b46-b830-01b4a207e334.png)

 - Changed to **_show_** selected legend (this maybe a better option) (click a second time to un-select) and see all
![image](https://user-images.githubusercontent.com/4452480/218171319-aa581eb8-6c8c-4f8d-8472-9e5a8ae7c5b2.png)
  - selecting a different legend switches the selected legend 
 ![image](https://user-images.githubusercontent.com/4452480/218179157-a11990c4-ee3d-4a52-9e25-4207f4de15ac.png)


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
