### PR TITLE
[risk=no][no ticket] Fix e2ev2 workspace creation test

### DIFF
--- a/api-proxy/handlers/|v1|workspaces|aou-rw-test-ca61ee0f|apps.get.mjs
+++ b/api-proxy/handlers/|v1|workspaces|aou-rw-test-ca61ee0f|apps.get.mjs
@@ -1,15 +1,15 @@
 const matchReq = req =>
-  req.url.pathname === '/v2/workspaces/aou-rw-local1-a312fa3d/testspace/resources'
-  && req.url.search === '?resourceTypesToFetch=COHORT%2CCOHORT_REVIEW%2CCONCEPT_SET%2CDATASET'
+  req.url.pathname === '/v1/workspaces/aou-rw-test-ca61ee0f/apps'
+  && req.url.search === ''
   && req.method === 'GET'
 
 const body = JSON.stringify(
 {
-  message: null,
-  statusCode: 500,
-  errorClassName: 'org.pmiops.workbench.exceptions.ServerErrorException',
+  message: 'Workspace not found: aou-rw-test-ca61ee0f',
+  statusCode: 404,
+  errorClassName: 'org.pmiops.workbench.exceptions.NotFoundException',
   errorCode: null,
-  errorUniqueId: 'f7b2a3fa-a95e-446a-9d89-6370149eafb5',
+  errorUniqueId: '7e9bd131-e875-43cd-8d65-1b567bfc94af',
   parameters: null
 }
 )
@@ -25,6 +25,6 @@ const headers = {
 const handleReq = (req, res) => {
   if (!matchReq(req)) { return }
   Object.keys(headers).forEach(h => res.setHeader(h, headers[h]))
-  res.status(500).mwrite(body).mend()
+  res.status(404).mwrite(body).mend()
 }
 export default handleReq

--- a/e2ev2/tests/workspace-create.test.js
+++ b/e2ev2/tests/workspace-create.test.js
@@ -55,11 +55,11 @@ browserTest('create a workspace', async browser => {
   // side menu pops up
   await page.click('[aria-label="Delete"]')
   // modal confirmation pops up
-  const confirmationTextSelector = '[role="dialog"] input[placeholder="type DELETE to confirm"]'
-  await page.waitForSelector(confirmationTextSelector)
   const confirmButton =
     await page.waitForSelector('[role="button"][aria-label="Confirm Delete"]')
   await expect(confirmButton.evaluate(n => n.style.cursor)).resolves.toBe('not-allowed')
+  const confirmationTextSelector = '[role="dialog"] input[placeholder="type DELETE to confirm"]'
+  await page.waitForSelector(confirmationTextSelector)
   await page.type(confirmationTextSelector, 'delete')
   await expect(confirmButton.evaluate(n => n.style.cursor)).resolves.toBe('pointer')
   await confirmButton.click()

--- a/e2ev2/tests/workspace-create.test.js
+++ b/e2ev2/tests/workspace-create.test.js
@@ -55,10 +55,12 @@ browserTest('create a workspace', async browser => {
   // side menu pops up
   await page.click('[aria-label="Delete"]')
   // modal confirmation pops up
+  const confirmationTextSelector = '[role="dialog"] input[placeholder="type DELETE to confirm"]'
+  await page.waitForSelector(confirmationTextSelector)
   const confirmButton =
     await page.waitForSelector('[role="button"][aria-label="Confirm Delete"]')
   await expect(confirmButton.evaluate(n => n.style.cursor)).resolves.toBe('not-allowed')
-  await page.type('[role="dialog"] input[placeholder="type DELETE to confirm"]', 'delete')
+  await page.type(confirmationTextSelector, 'delete')
   await expect(confirmButton.evaluate(n => n.style.cursor)).resolves.toBe('pointer')
   await confirmButton.click()
 

--- a/e2ev2/tests/workspace-create.test.js
+++ b/e2ev2/tests/workspace-create.test.js
@@ -58,9 +58,8 @@ browserTest('create a workspace', async browser => {
   const confirmButton =
     await page.waitForSelector('[role="button"][aria-label="Confirm Delete"]')
   await expect(confirmButton.evaluate(n => n.style.cursor)).resolves.toBe('not-allowed')
-  const confirmationTextSelector = '[role="dialog"] input[placeholder="type DELETE to confirm"]'
-  await page.waitForSelector(confirmationTextSelector)
-  await page.type(confirmationTextSelector, 'delete')
+  await page.waitForSelector('[role="dialog"] input[placeholder="type DELETE to confirm"]')
+    .then(eh => eh.type('delete'))
   await expect(confirmButton.evaluate(n => n.style.cursor)).resolves.toBe('pointer')
   await confirmButton.click()
 


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
