### PR TITLE
[risk=low][RW-9550] Correct text per-tier for AAR UI notifications

### DIFF
--- a/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
+import { MemoryRouter } from 'react-router';
 import { mount } from 'enzyme';
 
+import { AccessModule, AccessModuleStatus } from 'generated/fetch';
+
 import { AccessTierShortNames } from 'app/utils/access-tiers';
+import { nowPlusDays } from 'app/utils/dates';
 import { profileStore, serverConfigStore } from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
@@ -12,28 +16,153 @@ import {
   AccessRenewalNotificationProps,
 } from './access-renewal-notification';
 
-const profile = ProfileStubVariables.PROFILE_STUB;
 const load = jest.fn();
 const reload = jest.fn();
 const updateCache = jest.fn();
 
+const allModules = [
+  AccessModule.DATAUSERCODEOFCONDUCT,
+  AccessModule.COMPLIANCETRAINING,
+  AccessModule.CTCOMPLIANCETRAINING,
+  AccessModule.ERACOMMONS,
+  AccessModule.TWOFACTORAUTH,
+  AccessModule.RASLINKLOGINGOV,
+  AccessModule.PROFILECONFIRMATION,
+  AccessModule.PUBLICATIONCONFIRMATION,
+];
+
+const allCompleteNotExpiring: AccessModuleStatus[] = allModules.map(
+  (moduleName) => ({
+    moduleName,
+    completionEpochMillis: Date.now(),
+    expirationEpochMillis: nowPlusDays(365),
+  })
+);
+
+const allCompleteOneExpiring = (moduleName: AccessModule) => [
+  ...allCompleteNotExpiring,
+  {
+    moduleName,
+    completionEpochMillis: Date.now(),
+    expirationEpochMillis: nowPlusDays(1),
+  },
+];
+
+const allCompleteOneExpired = (moduleName: AccessModule) => [
+  ...allCompleteNotExpiring,
+  {
+    moduleName,
+    completionEpochMillis: Date.now(),
+    expirationEpochMillis: nowPlusDays(-1),
+  },
+];
+
+const updateModules = (modules: AccessModuleStatus[]) => {
+  profileStore.set({
+    profile: {
+      ...ProfileStubVariables.PROFILE_STUB,
+      accessModules: { modules },
+    },
+    load,
+    reload,
+    updateCache,
+  });
+};
+
 describe('Access Renewal Notification', () => {
   const component = (props: AccessRenewalNotificationProps) => {
-    return mount(<AccessRenewalNotificationMaybe {...props} />);
+    return mount(
+      <MemoryRouter>
+        <AccessRenewalNotificationMaybe {...props} />
+      </MemoryRouter>
+    );
   };
 
   beforeEach(() => {
     serverConfigStore.set({ config: defaultServerConfig });
-    profileStore.set({ profile, load, reload, updateCache });
-  });
-
-  it('Should not render when renewal is not needed (no modules)', async () => {
-    const wrapper = component({ accessTier: AccessTierShortNames.Registered });
-    expect(wrapper.exists()).toBeTruthy();
-
-    const banner = wrapper.find({
-      'data-test-id': 'access-renewal-notification',
+    profileStore.set({
+      profile: ProfileStubVariables.PROFILE_STUB,
+      load,
+      reload,
+      updateCache,
     });
-    expect(banner.exists()).toBeFalsy();
   });
+
+  test.each([
+    [
+      false,
+      'for RT when there are no modules',
+      AccessTierShortNames.Registered,
+      [],
+    ],
+    [
+      false,
+      'for CT when there are no modules',
+      AccessTierShortNames.Controlled,
+      [],
+    ],
+    [
+      false,
+      'for RT when there are no expiring modules',
+      AccessTierShortNames.Registered,
+      allCompleteNotExpiring,
+    ],
+    [
+      false,
+      'for CT when there are no expiring modules',
+      AccessTierShortNames.Controlled,
+      allCompleteNotExpiring,
+    ],
+    [
+      true,
+      'for RT when there is one expiring module',
+      AccessTierShortNames.Registered,
+      allCompleteOneExpiring(AccessModule.DATAUSERCODEOFCONDUCT),
+    ],
+    [
+      true,
+      'for CT when there is one expiring module',
+      AccessTierShortNames.Controlled,
+      allCompleteOneExpiring(AccessModule.DATAUSERCODEOFCONDUCT),
+    ],
+    [
+      true,
+      'for RT when there is one expired module',
+      AccessTierShortNames.Registered,
+      allCompleteOneExpired(AccessModule.DATAUSERCODEOFCONDUCT),
+    ],
+    [
+      true,
+      'for CT when there is one expired module',
+      AccessTierShortNames.Controlled,
+      allCompleteOneExpired(AccessModule.DATAUSERCODEOFCONDUCT),
+    ],
+    [
+      false,
+      'for RT when only CT training is expiring',
+      AccessTierShortNames.Registered,
+      allCompleteOneExpiring(AccessModule.CTCOMPLIANCETRAINING),
+    ],
+    [
+      false,
+      'for RT when only CT training is expired',
+      AccessTierShortNames.Registered,
+      allCompleteOneExpired(AccessModule.CTCOMPLIANCETRAINING),
+    ],
+  ])(
+    'display=%s %s',
+    async (expected, condition, accessTier, moduleStatuses) => {
+      updateModules(moduleStatuses);
+
+      const wrapper = component({
+        accessTier,
+      });
+      expect(wrapper.exists()).toBeTruthy();
+
+      const banner = wrapper.find({
+        'data-test-id': 'access-renewal-notification',
+      });
+      expect(banner.exists()).toEqual(expected);
+    }
+  );
 });

--- a/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
@@ -238,9 +238,7 @@ describe('Access Renewal Notification', () => {
     async (expected, condition, accessTier, moduleStatuses) => {
       updateModules(moduleStatuses);
 
-      const wrapper = component({
-        accessTier,
-      });
+      const wrapper = component({ accessTier });
       expect(wrapper.exists()).toBeTruthy();
 
       const banner = wrapper.find({

--- a/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
@@ -16,10 +16,6 @@ import {
   AccessRenewalNotificationProps,
 } from './access-renewal-notification';
 
-const load = jest.fn();
-const reload = jest.fn();
-const updateCache = jest.fn();
-
 const allModules = [
   AccessModule.DATAUSERCODEOFCONDUCT,
   AccessModule.COMPLIANCETRAINING,
@@ -100,6 +96,10 @@ const ctExpiresFirst = [
     expirationEpochMillis: nowPlusDays(5),
   },
 ];
+
+const load = jest.fn();
+const reload = jest.fn();
+const updateCache = jest.fn();
 
 const updateModules = (modules: AccessModuleStatus[]) => {
   profileStore.set({

--- a/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
@@ -61,6 +61,46 @@ const allCompleteOneExpired = (moduleName: AccessModule) => [
   },
 ];
 
+const rtExpiresFirst = [
+  ...allCompleteNotExpiring.filter(
+    (status) =>
+      ![
+        AccessModule.COMPLIANCETRAINING,
+        AccessModule.CTCOMPLIANCETRAINING,
+      ].includes(status.moduleName)
+  ),
+  {
+    moduleName: AccessModule.COMPLIANCETRAINING, // RT
+    completionEpochMillis: Date.now(),
+    expirationEpochMillis: nowPlusDays(5),
+  },
+  {
+    moduleName: AccessModule.CTCOMPLIANCETRAINING,
+    completionEpochMillis: Date.now(),
+    expirationEpochMillis: nowPlusDays(10),
+  },
+];
+
+const ctExpiresFirst = [
+  ...allCompleteNotExpiring.filter(
+    (status) =>
+      ![
+        AccessModule.COMPLIANCETRAINING,
+        AccessModule.CTCOMPLIANCETRAINING,
+      ].includes(status.moduleName)
+  ),
+  {
+    moduleName: AccessModule.COMPLIANCETRAINING, // RT
+    completionEpochMillis: Date.now(),
+    expirationEpochMillis: nowPlusDays(10),
+  },
+  {
+    moduleName: AccessModule.CTCOMPLIANCETRAINING,
+    completionEpochMillis: Date.now(),
+    expirationEpochMillis: nowPlusDays(5),
+  },
+];
+
 const updateModules = (modules: AccessModuleStatus[]) => {
   profileStore.set({
     profile: {
@@ -168,29 +208,30 @@ describe('Access Renewal Notification', () => {
       allCompleteOneExpired(AccessModule.CTCOMPLIANCETRAINING),
     ],
     [
+      true,
+      'for RT when RT is expiring sooner',
+      AccessTierShortNames.Registered,
+      rtExpiresFirst,
+    ],
+    [
       // Showing the RT banner appears in this case, so CT is not needed
       false,
       'for CT when RT is expiring sooner',
       AccessTierShortNames.Controlled,
-      [
-        ...allCompleteNotExpiring.filter(
-          (status) =>
-            ![
-              AccessModule.COMPLIANCETRAINING,
-              AccessModule.CTCOMPLIANCETRAINING,
-            ].includes(status.moduleName)
-        ),
-        {
-          moduleName: AccessModule.COMPLIANCETRAINING, // RT
-          completionEpochMillis: Date.now(),
-          expirationEpochMillis: nowPlusDays(5),
-        },
-        {
-          moduleName: AccessModule.CTCOMPLIANCETRAINING,
-          completionEpochMillis: Date.now(),
-          expirationEpochMillis: nowPlusDays(10),
-        },
-      ],
+      rtExpiresFirst,
+    ],
+    [
+      // Still need to show RT, because it's more important
+      true,
+      'for RT when CT is expiring sooner',
+      AccessTierShortNames.Registered,
+      ctExpiresFirst,
+    ],
+    [
+      true,
+      'for CT when CT is expiring sooner',
+      AccessTierShortNames.Controlled,
+      ctExpiresFirst,
     ],
   ])(
     'display=%s %s',

--- a/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
@@ -40,7 +40,9 @@ const allCompleteNotExpiring: AccessModuleStatus[] = allModules.map(
 );
 
 const allCompleteOneExpiring = (moduleName: AccessModule) => [
-  ...allCompleteNotExpiring,
+  ...allCompleteNotExpiring.filter(
+    (status) => status.moduleName !== moduleName
+  ),
   {
     moduleName,
     completionEpochMillis: Date.now(),
@@ -49,7 +51,9 @@ const allCompleteOneExpiring = (moduleName: AccessModule) => [
 ];
 
 const allCompleteOneExpired = (moduleName: AccessModule) => [
-  ...allCompleteNotExpiring,
+  ...allCompleteNotExpiring.filter(
+    (status) => status.moduleName !== moduleName
+  ),
   {
     moduleName,
     completionEpochMillis: Date.now(),
@@ -120,7 +124,8 @@ describe('Access Renewal Notification', () => {
       allCompleteOneExpiring(AccessModule.DATAUSERCODEOFCONDUCT),
     ],
     [
-      true,
+      // Showing the RT banner appears in this case, so CT is not needed
+      false,
       'for CT when there is one expiring module',
       AccessTierShortNames.Controlled,
       allCompleteOneExpiring(AccessModule.DATAUSERCODEOFCONDUCT),
@@ -132,7 +137,8 @@ describe('Access Renewal Notification', () => {
       allCompleteOneExpired(AccessModule.DATAUSERCODEOFCONDUCT),
     ],
     [
-      true,
+      // Showing the RT banner appears in this case, so CT is not needed
+      false,
       'for CT when there is one expired module',
       AccessTierShortNames.Controlled,
       allCompleteOneExpired(AccessModule.DATAUSERCODEOFCONDUCT),
@@ -148,6 +154,43 @@ describe('Access Renewal Notification', () => {
       'for RT when only CT training is expired',
       AccessTierShortNames.Registered,
       allCompleteOneExpired(AccessModule.CTCOMPLIANCETRAINING),
+    ],
+    [
+      true,
+      'for CT when only CT training is expiring',
+      AccessTierShortNames.Controlled,
+      allCompleteOneExpiring(AccessModule.CTCOMPLIANCETRAINING),
+    ],
+    [
+      true,
+      'for CT when only CT training is expired',
+      AccessTierShortNames.Controlled,
+      allCompleteOneExpired(AccessModule.CTCOMPLIANCETRAINING),
+    ],
+    [
+      // Showing the RT banner appears in this case, so CT is not needed
+      false,
+      'for CT when RT is expiring sooner',
+      AccessTierShortNames.Controlled,
+      [
+        ...allCompleteNotExpiring.filter(
+          (status) =>
+            ![
+              AccessModule.COMPLIANCETRAINING,
+              AccessModule.CTCOMPLIANCETRAINING,
+            ].includes(status.moduleName)
+        ),
+        {
+          moduleName: AccessModule.COMPLIANCETRAINING, // RT
+          completionEpochMillis: Date.now(),
+          expirationEpochMillis: nowPlusDays(5),
+        },
+        {
+          moduleName: AccessModule.CTCOMPLIANCETRAINING,
+          completionEpochMillis: Date.now(),
+          expirationEpochMillis: nowPlusDays(10),
+        },
+      ],
     ],
   ])(
     'display=%s %s',

--- a/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import { AccessTierShortNames } from 'app/utils/access-tiers';
+import { profileStore, serverConfigStore } from 'app/utils/stores';
+
+import defaultServerConfig from 'testing/default-server-config';
+import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
+
+import {
+  AccessRenewalNotificationMaybe,
+  AccessRenewalNotificationProps,
+} from './access-renewal-notification';
+
+const profile = ProfileStubVariables.PROFILE_STUB;
+const load = jest.fn();
+const reload = jest.fn();
+const updateCache = jest.fn();
+
+describe('Access Renewal Notification', () => {
+  const component = (props: AccessRenewalNotificationProps) => {
+    return mount(<AccessRenewalNotificationMaybe {...props} />);
+  };
+
+  beforeEach(() => {
+    serverConfigStore.set({ config: defaultServerConfig });
+    profileStore.set({ profile, load, reload, updateCache });
+  });
+
+  it('Should not render when renewal is not needed (no modules)', async () => {
+    const wrapper = component({ accessTier: AccessTierShortNames.Registered });
+    expect(wrapper.exists()).toBeTruthy();
+
+    const banner = wrapper.find({
+      'data-test-id': 'access-renewal-notification',
+    });
+    expect(banner.exists()).toBeFalsy();
+  });
+});

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -11,14 +11,13 @@ import { profileStore, useStore } from 'app/utils/stores';
 export interface AccessRenewalNotificationProps {
   accessTier: AccessTierShortNames;
 }
-
 export const AccessRenewalNotificationMaybe = (
   props: AccessRenewalNotificationProps
 ) => {
   const { profile } = useStore(profileStore);
   const daysRemaining = maybeDaysRemaining(profile, props.accessTier);
 
-  // special handling for Controlled Tier: don't display when RT is more urgent
+  // special handling for Controlled Tier: don't render when RT is more urgent
   // because CT renewal is redundant in that case
   if (
     props.accessTier === AccessTierShortNames.Controlled &&

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -35,7 +35,9 @@ export const AccessRenewalNotificationMaybe = (props: {
       buttonText='Get Started'
       buttonPath={ACCESS_RENEWAL_PATH}
       buttonDisabled={fullPagePath === ACCESS_RENEWAL_PATH}
-      bannerTextWidth='177px'
+      bannerTextWidth={
+        props.accessTier === AccessTierShortNames.Registered ? '177px' : '250px'
+      }
     />
   ) : null;
 };

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -8,9 +8,13 @@ import {
 } from 'app/utils/access-utils';
 import { profileStore, useStore } from 'app/utils/stores';
 
-export const AccessRenewalNotificationMaybe = (props: {
+export interface AccessRenewalNotificationProps {
   accessTier: AccessTierShortNames;
-}) => {
+}
+
+export const AccessRenewalNotificationMaybe = (
+  props: AccessRenewalNotificationProps
+) => {
   const { profile } = useStore(profileStore);
   const daysRemaining = maybeDaysRemaining(profile, props.accessTier);
 

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -1,22 +1,27 @@
 import * as React from 'react';
 
 import { NotificationBanner } from 'app/components/notification-banner';
+import { AccessTierShortNames } from 'app/utils/access-tiers';
 import {
   ACCESS_RENEWAL_PATH,
   maybeDaysRemaining,
 } from 'app/utils/access-utils';
 import { profileStore, useStore } from 'app/utils/stores';
 
-export const AccessRenewalNotificationMaybe = () => {
+export const AccessRenewalNotificationMaybe = (props: {
+  accessTier: AccessTierShortNames;
+}) => {
   const { profile } = useStore(profileStore);
-  const daysRemaining = maybeDaysRemaining(profile);
-  const notificationText =
-    'Time for access renewal. ' +
-    `${
-      daysRemaining >= 0
-        ? daysRemaining + ' days remaining.'
-        : 'Your access has expired.'
-    }`;
+  const daysRemaining = maybeDaysRemaining(profile, props.accessTier);
+
+  const accessType =
+    props.accessTier === AccessTierShortNames.Controlled
+      ? 'Controlled Tier access'
+      : 'access';
+  const timeLeft =
+    daysRemaining >= 0
+      ? daysRemaining + ' days remaining.'
+      : 'Your access has expired.';
 
   // Must use pathname and search because ACCESS_RENEWAL_PATH includes a path with a search parameter.
   const { pathname, search } = window.location;
@@ -26,7 +31,7 @@ export const AccessRenewalNotificationMaybe = () => {
   return daysRemaining !== undefined ? (
     <NotificationBanner
       dataTestId='access-renewal-notification'
-      text={notificationText}
+      text={`Time for ${accessType} renewal. ${timeLeft}`}
       buttonText='Get Started'
       buttonPath={ACCESS_RENEWAL_PATH}
       buttonDisabled={fullPagePath === ACCESS_RENEWAL_PATH}

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -18,10 +18,21 @@ export const AccessRenewalNotificationMaybe = (
   const { profile } = useStore(profileStore);
   const daysRemaining = maybeDaysRemaining(profile, props.accessTier);
 
+  // special handling for Controlled Tier: don't display when RT is more urgent
+  // because CT renewal is redundant in that case
+  if (
+    props.accessTier === AccessTierShortNames.Controlled &&
+    maybeDaysRemaining(profile, AccessTierShortNames.Registered) <=
+      daysRemaining
+  ) {
+    return null;
+  }
+
   const accessType =
     props.accessTier === AccessTierShortNames.Controlled
       ? 'Controlled Tier access'
       : 'access';
+
   const timeLeft =
     daysRemaining >= 0
       ? daysRemaining + ' days remaining.'

--- a/ui/src/app/pages/signed-in/nav-bar.tsx
+++ b/ui/src/app/pages/signed-in/nav-bar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 
+import { AccessTierShortNames } from '../../utils/access-tiers';
 import { Breadcrumb } from 'app/components/breadcrumb';
 import { CTAvailableBannerMaybe } from 'app/components/ct-available-banner-maybe';
 import { SignedInAouHeaderWithDisplayTag } from 'app/components/headers';
@@ -111,7 +112,12 @@ export const NavBar = () => {
       </div>
       <SignedInAouHeaderWithDisplayTag />
       <Breadcrumb />
-      <AccessRenewalNotificationMaybe />
+      <AccessRenewalNotificationMaybe
+        accessTier={AccessTierShortNames.Registered}
+      />
+      <AccessRenewalNotificationMaybe
+        accessTier={AccessTierShortNames.Controlled}
+      />
       <StatusAlertBannerMaybe />
       <TakeDemographicSurveyV2BannerMaybe />
       <NewUserSatisfactionSurveyBannerMaybe />

--- a/ui/src/app/pages/signed-in/nav-bar.tsx
+++ b/ui/src/app/pages/signed-in/nav-bar.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 
-import { AccessTierShortNames } from '../../utils/access-tiers';
 import { Breadcrumb } from 'app/components/breadcrumb';
 import { CTAvailableBannerMaybe } from 'app/components/ct-available-banner-maybe';
 import { SignedInAouHeaderWithDisplayTag } from 'app/components/headers';
@@ -13,6 +12,7 @@ import { TakeDemographicSurveyV2BannerMaybe } from 'app/components/take-demograp
 import { AccessRenewalNotificationMaybe } from 'app/pages/signed-in/access-renewal-notification';
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
+import { AccessTierShortNames } from 'app/utils/access-tiers';
 import { profileStore, useStore } from 'app/utils/stores';
 
 const styles = reactStyles({


### PR DESCRIPTION
A basic fix for the current behavior on Prod:
* Update the RT AAR notification so it does not consider CT-only modules
* Add a new CT AAR notification

When RT expiration is coming before CT, **we do not show the CT banner**, because the RT expiration is what's relevant.  This is equivalent to the current behavior.

When CT expiration is **sooner** than RT, we will show both banners:

<img width="1380" alt="Two Notifications" src="https://user-images.githubusercontent.com/2701406/219066121-9ddfff35-cdfe-466f-b765-9e723e9624f6.png">

We probably want to do something more intelligent here, like combining them.  That's https://precisionmedicineinitiative.atlassian.net/browse/RW-9546

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
