### PR TITLE
[DT-216][risk=no] cleanup script parameters with new conditional workflows

### DIFF
--- a/api/db-cdr/generate-cdr/build-backup-cb-ds-tables.sh
+++ b/api/db-cdr/generate-cdr/build-backup-cb-ds-tables.sh
@@ -8,13 +8,6 @@ export BQ_PROJECT=$1     # project
 export BQ_DATASET=$2     # dataset
 export OUTPUT_PROJECT=$3 # output project
 export OUTPUT_DATASET=$4 # output dataset
-export DATA_BROWSER=$5   # data browser build
-
-if [[ "$DATA_BROWSER" == true ]]
-then
-  echo "Building index for data browser. Skipping backup of cb and ds tables."
-  exit 0
-fi
 
 BACKUP_DATASET=${OUTPUT_DATASET}_backup
 

--- a/api/db-cdr/generate-cdr/build-cb-criteria-menu.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-menu.sh
@@ -6,13 +6,6 @@ set -e
 
 export BQ_PROJECT=$1   # project
 export BQ_DATASET=$2   # dataset
-export DATA_BROWSER=$3 # data browser build
-
-if [[ "$DATA_BROWSER" == true ]]
-then
-  echo "Building index for data browser. Skipping creation of the cb_criteria_menu table."
-  exit 0
-fi
 
 echo "Getting fitbit count"
 query="select count(*) as count from \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`

--- a/api/db-cdr/generate-cdr/build-cb-search-person.sh
+++ b/api/db-cdr/generate-cdr/build-cb-search-person.sh
@@ -6,13 +6,6 @@ set -e
 
 export BQ_PROJECT=$1                # CDR project
 export BQ_DATASET=$2                # CDR dataset
-export DATA_BROWSER=$3              # data browser build
-
-if [[ "$DATA_BROWSER" == true ]]
-then
-  echo "Building index for data browser. Skipping creation of the cb_search_person table."
-  exit 0
-fi
 
 ################################################
 # insert person data into cb_search_person

--- a/api/db-cdr/generate-cdr/build-cloudsql-tables.sh
+++ b/api/db-cdr/generate-cdr/build-cloudsql-tables.sh
@@ -8,13 +8,6 @@ export BQ_PROJECT=$1     # project
 export BQ_DATASET=$2     # dataset
 export OUTPUT_PROJECT=$3 # output project
 export OUTPUT_DATASET=$4 # output dataset
-export DATA_BROWSER=$5   # data browser build
-
-if [[ "$DATA_BROWSER" == true ]]
-then
-  echo "Building index for data browser. Skipping creation of cloudsql tables."
-  exit 0
-fi
 
 # Check that bq_dataset exists and exit if not
 datasets=$(bq --project_id="$BQ_PROJECT" ls --max_results=1000)

--- a/api/db-cdr/generate-cdr/build-ds-linking.sh
+++ b/api/db-cdr/generate-cdr/build-ds-linking.sh
@@ -6,13 +6,6 @@ set -e
 
 export BQ_PROJECT=$1   # project
 export BQ_DATASET=$2   # dataset
-export DATA_BROWSER=$3 # data browser build
-
-if [[ "$DATA_BROWSER" == true ]]
-then
-  echo "Building index for data browser. Skipping creation of the ds_linking table."
-  exit 0
-fi
 
 ID=1
 

--- a/api/db-cdr/generate-cdr/build-ds-tables.sh
+++ b/api/db-cdr/generate-cdr/build-ds-tables.sh
@@ -6,14 +6,8 @@ set -e
 
 export BQ_PROJECT=$1   # project
 export BQ_DATASET=$2   # dataset
-export DATA_BROWSER=$3 # data browser build
-export TABLE_TOKEN=$4  # specific table to build
+export TABLE_TOKEN=$3  # specific table to build
 
-if [[ "$DATA_BROWSER" == true ]]
-then
-  echo "Building index for data browser. Skipping creation of the ds tables."
-  exit 0
-fi
 
 function do_ds_condition_occurrence(){
   echo "ds_condition_occurrence - inserting data"

--- a/api/db-cdr/generate-cdr/build-prep-survey.sh
+++ b/api/db-cdr/generate-cdr/build-prep-survey.sh
@@ -7,7 +7,6 @@ set -e
 export BQ_PROJECT=$1         # CDR project
 export BQ_DATASET=$2         # CDR dataset
 export FILE_NAME=$3          # Filename to process
-export CREATE_SURVEYS=$4     # Create surveys flag
 
 # ID Starting id position
 # map filename_staged.csv to start ID
@@ -27,12 +26,6 @@ if [[ -n "${ID_START_MAP[$FILE_NAME]}" ]]; then
 else
   echo "Failed - Filename $FILE_NAME is not mapped to start ID"
   exit 1
-fi
-
-if [[ "$CREATE_SURVEYS" == false ]]
-then
-  echo "Skipping creation of the prep_survey table for $FILE_NAME."
-  exit 0
 fi
 
 BUCKET="all-of-us-workbench-private-cloudsql"

--- a/api/db-cdr/generate-cdr/build-review-all-events.sh
+++ b/api/db-cdr/generate-cdr/build-review-all-events.sh
@@ -6,13 +6,6 @@ set -e
 
 export BQ_PROJECT=$1   # project
 export BQ_DATASET=$2   # dataset
-export DATA_BROWSER=$3 # data browser build
-
-if [[ "$DATA_BROWSER" == true ]]
-then
-  echo "Building index for data browser. Skipping creation of the cb_review_all_events table."
-  exit 0
-fi
 
 #########################################
 # insert survey data into cb_review_survey #

--- a/api/db-cdr/generate-cdr/create-tables.sh
+++ b/api/db-cdr/generate-cdr/create-tables.sh
@@ -30,7 +30,7 @@ function deleteAndCreateTable(){
   wait
 }
 
-INCOMPATIBLE_DATASETS=("R2019Q4R3" "R2019Q4R4" "R2020Q4R3", "R2021Q3R5", "C2021Q2R1", "C2021Q3R6", "R2022Q2R2", "C2022Q2R2", "R2022Q2R6", "SR2022Q2R6", "SC2022Q2R6", "SC2021Q2R1")
+INCOMPATIBLE_DATASETS=("R2019Q4R3" "R2019Q4R4" "R2020Q4R3" "R2021Q3R5" "C2021Q2R1" "C2021Q3R6" "R2022Q2R2" "C2022Q2R2" "R2022Q2R6" "SR2022Q2R6" "SC2022Q2R6" "SC2021Q2R1")
 
 if [[ ${INCOMPATIBLE_DATASETS[@]} =~ $BQ_DATASET ]];
   then
@@ -62,6 +62,8 @@ do
       if [[ "$TABLE_LIST" == *"zip3_ses_map"* ]]; then
         deleteAndCreateTable "$table_name"
       fi
+    # We need to check for any tables that start with prep_ in case we are not building them
+    # We need to check for ds_data_dictionary cause it's the only non prep_ table that is built in the build-static-prep-tables.sh
     elif [[ "$table_name" == prep* ]] || [[ "$table_name" == 'ds_data_dictionary' ]]; then
       if [[ "$CREATE_PREP_TABLES" == true ]]; then
         deleteAndCreateTable "$table_name"

--- a/api/db-cdr/generate-cdr/create-tables.sh
+++ b/api/db-cdr/generate-cdr/create-tables.sh
@@ -9,7 +9,7 @@ set -e
 
 export BQ_PROJECT=$1         # CDR project
 export BQ_DATASET=$2         # CDR dataset
-export CREATE_SURVEYS=$3     # Create surveys flag
+export CREATE_PREP_SURVEYS=$3     # Create surveys flag
 
 function deleteAndCreateTable(){
   local table_name=$1
@@ -63,7 +63,7 @@ do
         deleteAndCreateTable "$table_name"
       fi
     elif [[ "$table_name" == 'prep_survey' ]]; then
-      if [[ "$CREATE_SURVEYS" == true ]]; then
+      if [[ "$CREATE_PREP_SURVEYS" == true ]]; then
         deleteAndCreateTable "$table_name"
       else
         echo "Keeping existing prep_survey table"

--- a/api/db-cdr/generate-cdr/create-tables.sh
+++ b/api/db-cdr/generate-cdr/create-tables.sh
@@ -9,7 +9,7 @@ set -e
 
 export BQ_PROJECT=$1         # CDR project
 export BQ_DATASET=$2         # CDR dataset
-export CREATE_PREP_SURVEYS=$3     # Create surveys flag
+export CREATE_PREP_TABLES=$3     # Create surveys flag
 
 function deleteAndCreateTable(){
   local table_name=$1
@@ -62,11 +62,11 @@ do
       if [[ "$TABLE_LIST" == *"zip3_ses_map"* ]]; then
         deleteAndCreateTable "$table_name"
       fi
-    elif [[ "$table_name" == 'prep_survey' ]]; then
-      if [[ "$CREATE_PREP_SURVEYS" == true ]]; then
+    elif [[ "$table_name" == prep* ]] || [[ "$table_name" == 'ds_data_dictionary' ]]; then
+      if [[ "$CREATE_PREP_TABLES" == true ]]; then
         deleteAndCreateTable "$table_name"
       else
-        echo "Keeping existing prep_survey table"
+        echo "Keeping existing table: $table_name"
       fi
     else
       deleteAndCreateTable "$table_name"

--- a/api/db-cdr/generate-cdr/import-cdr-indices-build-to-cloudsql.sh
+++ b/api/db-cdr/generate-cdr/import-cdr-indices-build-to-cloudsql.sh
@@ -6,58 +6,52 @@ export BQ_PROJECT=$1  # project
 export BQ_DATASET=$2  # dataset
 export WORKBENCH_PROJECT=$3 # workbench project
 export CDR_VERSION=$4 # cdr version
-export DATA_BROWSER=$5 # data browser flag
 
-if [ "$DATA_BROWSER" == false ]
+WORKBENCH_DATASET=$CDR_VERSION
+BUCKET="all-of-us-workbench-private-cloudsql"
+
+startDate=$(date)
+echo $(date) " Starting import-cdr-indices-to-cloudsql $startDate"
+
+## Dump workbench cdr count data
+echo "Dumping BigQuery cdr dataset to .csv"
+if ./generate-cdr/make-bq-data-dump.sh $WORKBENCH_PROJECT "$BUCKET/$BQ_DATASET" $WORKBENCH_DATASET
 then
-
-  WORKBENCH_DATASET=$CDR_VERSION
-  BUCKET="all-of-us-workbench-private-cloudsql"
-
-  startDate=$(date)
-  echo $(date) " Starting import-cdr-indices-to-cloudsql $startDate"
-
-  ## Dump workbench cdr count data
-  echo "Dumping BigQuery cdr dataset to .csv"
-  if ./generate-cdr/make-bq-data-dump.sh $WORKBENCH_PROJECT "$BUCKET/$BQ_DATASET" $WORKBENCH_DATASET
-  then
-      echo "Workbench cdr count data dumped"
-  else
-      echo "FAILED to dump Workbench cdr count data"
-      exit 1
-  fi
-
-  # Init the local database
-  echo "Initializing new  $DATABASE"
-  if ./generate-cdr/init-new-cdr-db.sh --drop-if-exists --cdr-db-name $WORKBENCH_DATASET
-  then
-    echo "Success"
-  else
-    echo "Failed"
+    echo "Workbench cdr count data dumped"
+else
+    echo "FAILED to dump Workbench cdr count data"
     exit 1
-  fi
-
-  # Make empty sql dump
-  if ./generate-cdr/make-mysqldump.sh --db-name $WORKBENCH_DATASET --bucket "$BUCKET/$BQ_DATASET/$CDR_VERSION"
-  then
-    echo "Success"
-  else
-    echo "Failed"
-    exit 1
-  fi
-
-  # Import Sql dump and data in bucket to cloudsql
-  if ./generate-cdr/cloudsql-import.sh --project $WORKBENCH_PROJECT --instance workbenchmaindb --bucket "$BUCKET/$BQ_DATASET/$CDR_VERSION" \
-      --database $WORKBENCH_DATASET --create-db-sql-file $WORKBENCH_DATASET.sql
-  then
-    echo "Success"
-  else
-    echo "Failed"
-    exit 1
-  fi
-
-  stopDate=$(date)
-  echo "Start $startDate Stop: $stopDate"
-  echo $(date) " Finished import-cdr-indices-to-cloudsql"
-
 fi
+
+# Init the local database
+echo "Initializing new  $DATABASE"
+if ./generate-cdr/init-new-cdr-db.sh --drop-if-exists --cdr-db-name $WORKBENCH_DATASET
+then
+  echo "Success"
+else
+  echo "Failed"
+  exit 1
+fi
+
+# Make empty sql dump
+if ./generate-cdr/make-mysqldump.sh --db-name $WORKBENCH_DATASET --bucket "$BUCKET/$BQ_DATASET/$CDR_VERSION"
+then
+  echo "Success"
+else
+  echo "Failed"
+  exit 1
+fi
+
+# Import Sql dump and data in bucket to cloudsql
+if ./generate-cdr/cloudsql-import.sh --project $WORKBENCH_PROJECT --instance workbenchmaindb --bucket "$BUCKET/$BQ_DATASET/$CDR_VERSION" \
+    --database $WORKBENCH_DATASET --create-db-sql-file $WORKBENCH_DATASET.sql
+then
+  echo "Success"
+else
+  echo "Failed"
+  exit 1
+fi
+
+stopDate=$(date)
+echo "Start $startDate Stop: $stopDate"
+echo $(date) " Finished import-cdr-indices-to-cloudsql"

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -516,7 +516,7 @@ Common.register_command({
 def create_cdr_indices(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
   op.opts.data_browser = false
-  op.opts.create_surveys = true
+  op.opts.create_prep_tables = true
   op.opts.branch = "main"
   op.add_option(
     "--branch [branch]",
@@ -544,9 +544,9 @@ def create_cdr_indices(cmd_name, *args)
     "Generate for data browser. Optional - Default is false"
   )
   op.add_option(
-    "--create-surveys [create-surveys]",
-    ->(opts, v) { opts.create_surveys = v},
-    "Create all surveys. Optional - Default is true"
+    "--create-prep-tables [create-prep-tables]",
+    ->(opts, v) { opts.create_prep_tables = v},
+    "Create all prep tables. Optional - Default is true"
   )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.project and opts.bq_dataset and opts.cdr_version}
@@ -561,7 +561,7 @@ def create_cdr_indices(cmd_name, *args)
   content_type = "Content-Type: application/json"
   accept = "Accept: application/json"
   circle_token = "Circle-Token: "
-  payload = "{ \"branch\": \"#{op.opts.branch}\", \"parameters\": { \"wb_create_cdr_indices\": true, \"cdr_source_project\": \"#{cdr_source}\", \"cdr_source_dataset\": \"#{op.opts.bq_dataset}\", \"project\": \"#{op.opts.project}\", \"cdr_version_db_name\": \"#{op.opts.cdr_version}\", \"data_browser\": #{op.opts.data_browser}, \"create_surveys\": #{op.opts.create_surveys} }}"
+  payload = "{ \"branch\": \"#{op.opts.branch}\", \"parameters\": { \"wb_create_cdr_indices\": true, \"cdr_source_project\": \"#{cdr_source}\", \"cdr_source_dataset\": \"#{op.opts.bq_dataset}\", \"project\": \"#{op.opts.project}\", \"cdr_version_db_name\": \"#{op.opts.cdr_version}\", \"data_browser\": #{op.opts.data_browser}, \"create_prep_tables\": #{op.opts.create_prep_tables} }}"
   common.run_inline "curl -X POST https://circleci.com/api/v2/project/github/all-of-us/cdr-indices/pipeline -H '#{content_type}' -H '#{accept}' -H \"#{circle_token}\ $(cat ~/.circle-creds/key.txt)\" -d '#{payload}'"
 end
 
@@ -573,7 +573,6 @@ Common.register_command({
 
 def build_prep_survey(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
-  op.opts.create_surveys = true
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -589,18 +588,13 @@ def build_prep_survey(cmd_name, *args)
       ->(opts, v) { opts.filename = v},
       "Filename"
   )
-  op.add_option(
-    "--create-surveys [create-surveys]",
-    ->(opts, v) { opts.create_surveys = v},
-    "Create all surveys. Optional - Default is true"
-  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset and opts.filename}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-prep-survey.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.filename} #{op.opts.create_surveys}}
+    common.run_inline %W{./generate-cdr/build-prep-survey.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.filename}}
   end
 end
 
@@ -612,7 +606,7 @@ Common.register_command({
 
 def create_tables(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
-  op.opts.create_surveys = true
+  op.opts.create_prep_tables = true
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -624,9 +618,9 @@ def create_tables(cmd_name, *args)
       "BQ Dataset name"
   )
   op.add_option(
-    "--create-surveys [create-surveys]",
-    ->(opts, v) { opts.create_surveys = v},
-    "Create all surveys. Optional - Default is true"
+    "--create-prep-tables [create-prep-tables]",
+    ->(opts, v) { opts.create_prep_tables = v},
+    "Create all prep tables. Optional - Default is true"
   )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset}
@@ -634,7 +628,7 @@ def create_tables(cmd_name, *args)
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/create-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.create_surveys}}
+    common.run_inline %W{./generate-cdr/create-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.create_prep_tables}}
   end
 end
 
@@ -768,7 +762,6 @@ Common.register_command({
 
 def build_ds_linking(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
-  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -779,18 +772,13 @@ def build_ds_linking(cmd_name, *args)
       ->(opts, v) { opts.bq_dataset = v},
       "BQ dataset. Required."
   )
-  op.add_option(
-      "--data-browser [data-browser]",
-      ->(opts, v) { opts.data_browser = v},
-      "Generate for data browser. Optional - Default is false"
-  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-ds-linking.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser}}
+    common.run_inline %W{./generate-cdr/build-ds-linking.sh #{op.opts.bq_project} #{op.opts.bq_dataset}}
   end
 end
 
@@ -802,7 +790,6 @@ Common.register_command({
 
 def build_ds_tables(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
-  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -812,11 +799,6 @@ def build_ds_tables(cmd_name, *args)
       "--bq-dataset [bq-dataset]",
       ->(opts, v) { opts.bq_dataset = v},
       "BQ dataset. Required."
-  )
-  op.add_option(
-      "--data-browser [data-browser]",
-      ->(opts, v) { opts.data_browser = v},
-      "Generate for data browser. Optional - Default is false"
   )
   op.add_option(
       "--table-token [table-token]",
@@ -829,7 +811,7 @@ def build_ds_tables(cmd_name, *args)
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-ds-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser} #{op.opts.table_token}}
+    common.run_inline %W{./generate-cdr/build-ds-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.table_token}}
   end
 end
 
@@ -841,7 +823,6 @@ Common.register_command({
 
 def build_review_all_events(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
-  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -852,18 +833,13 @@ def build_review_all_events(cmd_name, *args)
       ->(opts, v) { opts.bq_dataset = v},
       "BQ dataset. Required."
   )
-  op.add_option(
-      "--data-browser [data-browser]",
-      ->(opts, v) { opts.data_browser = v},
-      "Generate for data browser. Optional - Default is false"
-  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-review-all-events.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser}}
+    common.run_inline %W{./generate-cdr/build-review-all-events.sh #{op.opts.bq_project} #{op.opts.bq_dataset}}
   end
 end
 
@@ -875,7 +851,6 @@ Common.register_command({
 
 def build_cb_search_person(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
-  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -886,18 +861,13 @@ def build_cb_search_person(cmd_name, *args)
       ->(opts, v) { opts.bq_dataset = v},
       "BQ dataset. Required."
   )
-  op.add_option(
-      "--data-browser [data-browser]",
-      ->(opts, v) { opts.data_browser = v},
-      "Generate for data browser. Optional - Default is false"
-  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-cb-search-person.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser}}
+    common.run_inline %W{./generate-cdr/build-cb-search-person.sh #{op.opts.bq_project} #{op.opts.bq_dataset}}
   end
 end
 
@@ -937,7 +907,6 @@ Common.register_command({
 
 def build_cb_criteria_menu(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
-  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -948,18 +917,13 @@ def build_cb_criteria_menu(cmd_name, *args)
       ->(opts, v) { opts.bq_dataset = v},
       "BQ dataset. Required."
   )
-  op.add_option(
-      "--data-browser [data-browser]",
-      ->(opts, v) { opts.data_browser = v},
-      "Generate for data browser. Optional - Default is false"
-  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-cb-criteria-menu.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.data_browser}}
+    common.run_inline %W{./generate-cdr/build-cb-criteria-menu.sh #{op.opts.bq_project} #{op.opts.bq_dataset}}
   end
 end
 
@@ -971,7 +935,6 @@ Common.register_command({
 
 def build_cloudsql_tables(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
-  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -992,18 +955,13 @@ def build_cloudsql_tables(cmd_name, *args)
       ->(opts, v) { opts.output_dataset = v},
       "Output dataset. Required."
   )
-  op.add_option(
-      "--data-browser [data-browser]",
-      ->(opts, v) { opts.data_browser = v},
-      "Generate for data browser. Optional - Default is false"
-  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset and opts.output_project and opts.output_dataset}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-cloudsql-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.output_project} #{op.opts.output_dataset} #{op.opts.data_browser}}
+    common.run_inline %W{./generate-cdr/build-cloudsql-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.output_project} #{op.opts.output_dataset}}
   end
 end
 
@@ -1015,7 +973,6 @@ Common.register_command({
 
 def build_backup_cb_ds_tables(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
-  op.opts.data_browser = false
   op.add_option(
       "--bq-project [bq-project]",
       ->(opts, v) { opts.bq_project = v},
@@ -1036,18 +993,13 @@ def build_backup_cb_ds_tables(cmd_name, *args)
       ->(opts, v) { opts.output_dataset = v},
       "Output dataset. Required."
   )
-  op.add_option(
-      "--data-browser [data-browser]",
-      ->(opts, v) { opts.data_browser = v},
-      "Generate for data browser. Optional - Default is false"
-  )
 
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset and opts.output_project and opts.output_dataset}
   op.parse.validate
 
   common = Common.new
   Dir.chdir('db-cdr') do
-    common.run_inline %W{./generate-cdr/build-backup-cb-ds-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.output_project} #{op.opts.output_dataset} #{op.opts.data_browser}}
+    common.run_inline %W{./generate-cdr/build-backup-cb-ds-tables.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.output_project} #{op.opts.output_dataset}}
   end
 end
 
@@ -1293,7 +1245,6 @@ Common.register_command({
 
 def import_cdr_indices_build_to_cloudsql(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
-  op.opts.data_browser = false
   op.add_option(
     "--bq-project [bq-project]",
     ->(opts, v) { opts.bq_project = v},
@@ -1314,11 +1265,6 @@ def import_cdr_indices_build_to_cloudsql(cmd_name, *args)
     ->(opts, v) { opts.cdr_version = v},
     "CDR version. Required."
   )
-  op.add_option(
-    "--data-browser [data-browser]",
-    ->(opts, v) { opts.data_browser = v},
-    "Generate for data browser. Optional - Default is false"
-  )
   op.add_validator ->(opts) { raise ArgumentError unless opts.bq_project and opts.bq_dataset and opts.project and opts.cdr_version }
   op.parse.validate
   gcc = GcloudContextV2.new(op)
@@ -1328,7 +1274,7 @@ def import_cdr_indices_build_to_cloudsql(cmd_name, *args)
   with_cloud_proxy_and_db(gcc) do
     common = Common.new
     Dir.chdir('db-cdr') do
-      common.run_inline %W{./generate-cdr/import-cdr-indices-build-to-cloudsql.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.project} #{op.opts.cdr_version} #{op.opts.data_browser}}
+      common.run_inline %W{./generate-cdr/import-cdr-indices-build-to-cloudsql.sh #{op.opts.bq_project} #{op.opts.bq_dataset} #{op.opts.project} #{op.opts.cdr_version}}
     end
   end
 end


### PR DESCRIPTION
Cleanup script parameters with new conditional workflows. This PR has done the following:

- Removed all data-browser parameters from scripts since it's now checked on the circleCi workflow level
- Removed create-surveys parameters from scripts since it's now checked on the circeCi workflow level
- For scripts that still use create-surveys parameter - renamed it to create-prep-tables - This parameter now triggers the build/non-build of all prep_ tables. The intent of this is to gain more efficiency. 

Command will now look like so:
`./project.rb create-cdr-indices --project all-of-us-workbench-test --bq-dataset SR2022Q4R6 --cdr-version sr_2022q4_6 --create-prep-tables false`
