### PR TITLE
[risk=low][RW-9561] Disable CT Renewal Notification Banner via Feature Flag

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -118,7 +118,8 @@
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableUpdatedDemographicSurvey": true,
-    "enableConceptSetsInCohortBuilder": true
+    "enableConceptSetsInCohortBuilder": true,
+    "enableControlledTierTrainingRenewal": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-local",

--- a/api/config/config_perf.json
+++ b/api/config/config_perf.json
@@ -118,7 +118,8 @@
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableUpdatedDemographicSurvey": true,
-    "enableConceptSetsInCohortBuilder": false
+    "enableConceptSetsInCohortBuilder": false,
+    "enableControlledTierTrainingRenewal": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-perf",

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -118,7 +118,8 @@
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": true,
     "enableUpdatedDemographicSurvey": true,
-    "enableConceptSetsInCohortBuilder": false
+    "enableConceptSetsInCohortBuilder": false,
+    "enableControlledTierTrainingRenewal": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-preprod",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -118,7 +118,8 @@
     "enablePrivateDataprocWorker": false,
     "ccSupportWhenAdminLocking": true,
     "enableUpdatedDemographicSurvey": true,
-    "enableConceptSetsInCohortBuilder": false
+    "enableConceptSetsInCohortBuilder": false,
+    "enableControlledTierTrainingRenewal": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-prod",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -118,7 +118,8 @@
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableUpdatedDemographicSurvey": true,
-    "enableConceptSetsInCohortBuilder": false
+    "enableConceptSetsInCohortBuilder": false,
+    "enableControlledTierTrainingRenewal": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-stable",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -118,7 +118,8 @@
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableUpdatedDemographicSurvey": true,
-    "enableConceptSetsInCohortBuilder": false
+    "enableConceptSetsInCohortBuilder": false,
+    "enableControlledTierTrainingRenewal": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-staging",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -118,7 +118,8 @@
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableUpdatedDemographicSurvey": true,
-    "enableConceptSetsInCohortBuilder": false
+    "enableConceptSetsInCohortBuilder": false,
+    "enableControlledTierTrainingRenewal": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -321,6 +321,9 @@ public class WorkbenchConfig {
     public boolean enableUpdatedDemographicSurvey;
     // If true, enable enableConceptSetsInCohortBuilder
     public boolean enableConceptSetsInCohortBuilder;
+    // Whether users are directed to complete Controlled Tier Training renewal.
+    // If false, hide or add text indicating that it is not currently available.
+    public boolean enableControlledTierTrainingRenewal;
   }
 
   public static class ActionAuditConfig {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -82,5 +82,8 @@ public interface WorkbenchConfigMapper {
   @Mapping(
       target = "enableConceptSetsInCohortBuilder",
       source = "config.featureFlags.enableConceptSetsInCohortBuilder")
+  @Mapping(
+      target = "enableControlledTierTrainingRenewal",
+      source = "config.featureFlags.enableControlledTierTrainingRenewal")
   ConfigResponse toModel(WorkbenchConfig config, List<DbAccessModule> accessModules);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4720,6 +4720,12 @@ definitions:
         type: boolean
         default: false
         description: Whether to enable adding ConceptSets to CohortBuilder.
+      enableControlledTierTrainingRenewal:
+        type: boolean
+        default: true
+        description: >
+          Whether users are directed to complete Controlled Tier Training renewal.
+          If false, hide or add text indicating that it is not currently available.
 
   RuntimeImage:
     type: object

--- a/ui/src/app/pages/signed-in/nav-bar.tsx
+++ b/ui/src/app/pages/signed-in/nav-bar.tsx
@@ -13,7 +13,7 @@ import { AccessRenewalNotificationMaybe } from 'app/pages/signed-in/access-renew
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
 import { AccessTierShortNames } from 'app/utils/access-tiers';
-import { profileStore, useStore } from 'app/utils/stores';
+import { profileStore, serverConfigStore, useStore } from 'app/utils/stores';
 
 const styles = reactStyles({
   headerContainer: {
@@ -53,6 +53,9 @@ const barsTransformNotRotated = 'rotate(0deg)';
 const barsTransformRotated = 'rotate(90deg)';
 
 export const NavBar = () => {
+  const {
+    config: { enableControlledTierTrainingRenewal },
+  } = useStore(serverConfigStore);
   const [showSideNav, setShowSideNav] = useState(false);
   const [barsTransform, setBarsTransform] = useState(barsTransformNotRotated);
   const [hovering, setHovering] = useState(false);
@@ -115,9 +118,11 @@ export const NavBar = () => {
       <AccessRenewalNotificationMaybe
         accessTier={AccessTierShortNames.Registered}
       />
-      <AccessRenewalNotificationMaybe
-        accessTier={AccessTierShortNames.Controlled}
-      />
+      {enableControlledTierTrainingRenewal && (
+        <AccessRenewalNotificationMaybe
+          accessTier={AccessTierShortNames.Controlled}
+        />
+      )}
       <StatusAlertBannerMaybe />
       <TakeDemographicSurveyV2BannerMaybe />
       <NewUserSatisfactionSurveyBannerMaybe />

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -83,6 +83,7 @@ const defaultServerConfig: ConfigResponse = {
   freeTierBillingAccountId: 'freetier',
   accessModules: defaultAccessModuleConfig,
   currentDuccVersions: [3, 4],
+  enableControlledTierTrainingRenewal: true,
 };
 
 export default defaultServerConfig;


### PR DESCRIPTION
Add a temporary API feature flag `enableControlledTierTrainingRenewal` to control whether we are displaying (1) CT Renewal Notifications and (2) "coming soon" text for Annual Renewal.

This PR also implements part 1: hide the notification banner.

Tested locally: I saw the banner when the flag was true, and I didn't see when the flag was false. 

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
