### PR TITLE
[risk=low][RW-9561] Disable CT Training on Renewal page based on FF

### DIFF
--- a/ui/src/app/pages/access/controlled-tier-card.tsx
+++ b/ui/src/app/pages/access/controlled-tier-card.tsx
@@ -67,7 +67,10 @@ const TemporaryTrainingModule = (props: { profile: Profile }) => {
   const moduleName = AccessModule.CTCOMPLIANCETRAINING;
   const { DARTitleComponent } = getAccessModuleConfig(moduleName);
   return (
-    <FlexRow data-test-id={`module-${moduleName}`}>
+    <FlexRow
+      data-test-id={`module-${moduleName}`}
+      style={{ paddingTop: '1.4em' }}
+    >
       <FlexRow style={styles.moduleCTA} />
       <FlexRow style={styles.backgroundModuleBox}>
         <ModuleIcon

--- a/ui/src/app/pages/access/controlled-tier-card.tsx
+++ b/ui/src/app/pages/access/controlled-tier-card.tsx
@@ -18,6 +18,7 @@ import {
 } from 'app/utils/access-tiers';
 import {
   DARPageMode,
+  getAccessModuleConfig,
   getAccessModuleStatusByName,
   isCompliant,
   redirectToNiH,
@@ -27,6 +28,7 @@ import { getCustomOrDefaultUrl } from 'app/utils/urls';
 
 import { DataDetail, styles } from './data-access-requirements';
 import { Module } from './module';
+import { ModuleIcon } from './module-icon';
 import { ModulesForAnnualRenewal } from './modules-for-annual-renewal';
 import { ModulesForInitialRegistration } from './modules-for-initial-registration';
 
@@ -57,6 +59,32 @@ const ControlledTierEraModule = (props: {
       active={false}
       moduleAction={redirectToNiH}
     />
+  );
+};
+
+// Placeholder until CT Training has been updated; see TemporaryRASModule for inspiration
+const TemporaryTrainingModule = (props: { profile: Profile }) => {
+  const moduleName = AccessModule.CTCOMPLIANCETRAINING;
+  const { DARTitleComponent } = getAccessModuleConfig(moduleName);
+  return (
+    <FlexRow data-test-id={`module-${moduleName}`}>
+      <FlexRow style={styles.moduleCTA} />
+      <FlexRow style={styles.backgroundModuleBox}>
+        <ModuleIcon
+          {...{ moduleName }}
+          completedOrBypassed={false}
+          eligible={false}
+        />
+        <FlexColumn style={styles.backgroundModuleText}>
+          <DARTitleComponent profile={props.profile} />
+          <div style={{ fontSize: '14px', marginTop: '0.5em' }}>
+            <b>Temporarily disabled.</b> Due to technical difficulties, this
+            step is disabled. Renewing Controlled Tier Training will be possible
+            in early March 2023.
+          </div>
+        </FlexColumn>
+      </FlexRow>
+    </FlexRow>
   );
 };
 
@@ -126,7 +154,8 @@ export const ControlledTierCard = (props: {
   const rtDisplayName = AccessTierDisplayNames.Registered;
   const ctDisplayName = AccessTierDisplayNames.Controlled;
 
-  const { enableComplianceTraining } = serverConfigStore.get().config;
+  const { enableComplianceTraining, enableControlledTierTrainingRenewal } =
+    serverConfigStore.get().config;
 
   return (
     <FlexRow
@@ -196,9 +225,12 @@ export const ControlledTierCard = (props: {
           )}
         {enableComplianceTraining &&
           pageMode === DARPageMode.ANNUAL_RENEWAL &&
-          isEligible && (
+          isEligible &&
+          (enableControlledTierTrainingRenewal ? (
             <ModulesForAnnualRenewal profile={profile} modules={[ctModule]} />
-          )}
+          ) : (
+            <TemporaryTrainingModule {...{ profile }} />
+          ))}
       </FlexColumn>
     </FlexRow>
   );

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -1708,7 +1708,54 @@ describe('DataAccessRequirements', () => {
     expectNoCtRenewalBanner(wrapper);
   });
 
-  it('should show the correct state when RT modules are complete but CT training is expired', async () => {
+  it('should show the correct state when RT=complete, CT=expired, enableControlledTierTrainingRenewal=false', async () => {
+    serverConfigStore.set({
+      config: {
+        ...defaultServerConfig,
+        unsafeAllowSelfBypass: true,
+        enableControlledTierTrainingRenewal: false,
+      },
+    });
+
+    expireAllRTModules();
+    addOneModule(oneExpiredModule(AccessModule.CTCOMPLIANCETRAINING));
+
+    updateOneModuleExpirationTime(
+      AccessModule.PROFILECONFIRMATION,
+      oneYearFromNow()
+    );
+    updateOneModuleExpirationTime(
+      AccessModule.PUBLICATIONCONFIRMATION,
+      oneYearFromNow()
+    );
+    updateOneModuleExpirationTime(
+      AccessModule.COMPLIANCETRAINING,
+      oneYearFromNow()
+    );
+    updateOneModuleExpirationTime(
+      AccessModule.DATAUSERCODEOFCONDUCT,
+      oneYearFromNow()
+    );
+
+    setCompletionTimes(() => Date.now());
+
+    const wrapper = component(DARPageMode.ANNUAL_RENEWAL);
+
+    await waitOneTickAndUpdate(wrapper);
+
+    expectNoCompletionBanner(wrapper);
+    expectNoCtRenewalBanner(wrapper);
+  });
+
+  it('should show the correct state when RT=complete, CT=expired, enableControlledTierTrainingRenewal=true', async () => {
+    serverConfigStore.set({
+      config: {
+        ...defaultServerConfig,
+        unsafeAllowSelfBypass: true,
+        enableControlledTierTrainingRenewal: true,
+      },
+    });
+
     expireAllRTModules();
     addOneModule(oneExpiredModule(AccessModule.CTCOMPLIANCETRAINING));
 

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -614,7 +614,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
     // Local Variables
     const { profile, reload } = useStore(profileStore);
     const {
-      config: { unsafeAllowSelfBypass },
+      config: { unsafeAllowSelfBypass, enableControlledTierTrainingRenewal },
     } = useStore(serverConfigStore);
 
     const query = useQuery();
@@ -638,6 +638,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
     );
 
     const showCtRenewalBanner =
+      enableControlledTierTrainingRenewal &&
       pageMode === DARPageMode.ANNUAL_RENEWAL &&
       isCompliant(getAccessModuleStatusByName(profile, ctModule)) &&
       !isRenewalCompleteForModule(

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -637,15 +637,15 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
       pageMode
     );
 
-    const showCtRenewalBanner =
-      enableControlledTierTrainingRenewal &&
+    const ctNeedsRenewal =
       pageMode === DARPageMode.ANNUAL_RENEWAL &&
       isCompliant(getAccessModuleStatusByName(profile, ctModule)) &&
       !isRenewalCompleteForModule(
         getAccessModuleStatusByName(profile, ctModule)
       );
-    const showCompletionBanner =
-      profile && !nextRequired && !showCtRenewalBanner;
+    const showCtRenewalBanner =
+      enableControlledTierTrainingRenewal && ctNeedsRenewal;
+    const showCompletionBanner = profile && !nextRequired && !ctNeedsRenewal;
 
     const rtCard = (
       <RegisteredTierCard


### PR DESCRIPTION
When `enableControlledTierTrainingRenewal` is false, make two changes to the Annual Renewal page (Data Access Requirements in ANNUAL_RENEWAL mode)
* Don't show the new ControlledTierRenewalBanner
* Replace the CT Training module with this

<img width="1238" alt="Temp CT Training" src="https://user-images.githubusercontent.com/2701406/219787971-9b01a47b-200a-4a68-886a-8e95764b28cd.png">


<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
