### PR TITLE
[DT-242][risk=no]CDR indexing build - automate export-import of cdr from preprod to prod

### DIFF
--- a/api/db-cdr/generate-cdr/export-import-cloudsql-cdr.sh
+++ b/api/db-cdr/generate-cdr/export-import-cloudsql-cdr.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Vars for the process
+export CDR_DB_NAME=$1
+export PROJECT_PRE_PROD="all-of-us-rw-preprod"
+export PROJECT_PROD="all-of-us-rw-prod"
+
+function validate_cdr(){
+ db_prd=$(gcloud sql databases list --instance workbenchmaindb --project "$PROJECT_PROD" | grep "$CDR_DB_NAME" | cut -d" " -f1)
+ if [[ "$db_prd" == "$CDR_DB_NAME" ]]; then
+   echo ""
+   echo -e "\033[0;31m******************************************************************************************************************\033[0m"
+   echo -e "\033[0;31m**\t\t\t\t\t\t\tWARNING\t\t\t\t\t\t\t**\033[0m"
+   echo -e "\033[0;31m**\t\t\t\033[43m\033[1;5;31m\tCloudSQL database $CDR_DB_NAME exists in Production\t\033[0;31m\t\t\t**\033[0m"
+   echo -e "\033[0;31m**\tEnsure that the CDR you are importing is not LIVE in Production!\t\t\t\t\t**\033[0m"
+   echo -e "\033[0;31m**\tNavigate to google cloud console and check!\t\t\t\t\t\t\t\t**\033[0m"
+   echo -e "\033[0;31m**\thttps://console.cloud.google.com/sql/instances/workbenchmaindb/databases?project=$PROJECT_PROD\t**\033[0m"
+   echo -e "\033[0;31m**\tIf you still want to OVERWRITE CloudSQL database $CDR_DB_NAME Production\t\t\t\t\t**\033[0m"
+   echo -e "\033[0;31m**\t\tFirst manually delete the CloudSQL database $CDR_DB_NAME Production\t\t\t\t**\033[0m"
+   echo -e "\033[0;31m**\t\tbefore running the ./project.rb command\t\t\t\t\t\t\t\t**\033[0m"
+   echo -e "\033[0;31m******************************************************************************************************************\033[0m"
+   echo ""
+   exit 1
+ fi
+ db_pre=$(gcloud sql databases list --instance workbenchmaindb --project "$PROJECT_PRE_PROD" | grep "$CDR_DB_NAME" | cut -d" " -f1)
+ if [[ -z "$db_pre" ]]; then
+   echo ""
+   echo -e "\033[0;31m******************************************************************************************************************\033[0m"
+   echo -e "\033[0;31m**\t\t\t\033[43m\033[1;5;31m\tCloudSQL database $CDR_DB_NAME does not exist in preprod\t\t\033[0;31m\t\t**\033[0m"
+   echo -e "\033[0;31m**\tNavigate to google cloud console and check!\t\t\t\t\t\t\t\t**\033[0m"
+   echo -e "\033[0;31m**\thttps://console.cloud.google.com/sql/instances/workbenchmaindb/databases?project=a$PROJECT_PRE_PROD\t**\033[0m"
+   echo -e "\033[0;31m**\t\tbefore running the ./project.rb command\t\t\t\t\t\t\t\t**\033[0m"
+   echo -e "\033[0;31m******************************************************************************************************************\033[0m"
+      echo ""
+   exit 1
+ elif [[ "$db_pre" == "$CDR_DB_NAME" && -z "$db_prd" ]]; then
+   echo "Exporting preprod:[$db_pre] for importing into prod"
+ fi
+}
+# Validate cdr name for export-import operations
+echo "Validating if database $CDR_DB_NAME can be exported from preprod to import into prod"
+validate_cdr
+# Export to cdr to preprod bucket"
+echo "Exporting sqldump file for cdr: $CDR_DB_NAME to preprod bucket"
+gcloud sql export sql workbenchmaindb \
+       gs://"$PROJECT_PRE_PROD".appspot.com/"$CDR_DB_NAME"_export.sql \
+       --database="$CDR_DB_NAME" --project="$PROJECT_PRE_PROD"
+
+# Copy Exported sqldump file from preprod bucket to prod bucket
+echo "Copying sqldump file $CDR_DB_NAME_export.sql to prod bucket"
+gsutil cp gs://"$PROJECT_PRE_PROD".appspot.com/"$CDR_DB_NAME"_export.sql \
+       gs://"$PROJECT_PROD".appspot.com/"$CDR_DB_NAME"_export.sql
+
+# Create Production cloud SQL cdr from exported sqldump file
+echo "Creating prod database $CDR_DB_NAME from $CDR_DB_NAME_export.sql"
+# Print production Google Cloud Console to monitor import
+echo "Naviagte to the URL below to monitor progress..."
+echo "URL: https://console.cloud.google.com/sql/instances/workbenchmaindb/databases?project=$PROJECT_PROD"
+gcloud sql import sql workbenchmaindb \
+       gs://"$PROJECT_PROD".appspot.com/"$CDR_DB_NAME"_export.sql \
+       --quiet --project="$PROJECT_PROD"
+
+# Remove/delete sqldump files from preprod and prod buckets
+echo "Removing sqldump file from preprod bucket"
+gsutil rm gs://"$PROJECT_PRE_PROD".appspot.com/"$CDR_DB_NAME"_export.sql
+
+echo "Removing sqldump file from prod bucket"
+gsutil rm gs://"$PROJECT_PROD".appspot.com/"$CDR_DB_NAME"_export.sql
+
+echo "Verify table counts"
+echo "`./project.rb verify-cloud-cdr-counts --cdr-db-name $CDR_DB_NAME`"
+echo "done!"
+
+

--- a/api/db-cdr/generate-cdr/export-import-cloudsql-cdr.sh
+++ b/api/db-cdr/generate-cdr/export-import-cloudsql-cdr.sh
@@ -5,7 +5,7 @@ export PROJECT_PRE_PROD="all-of-us-rw-preprod"
 export PROJECT_PROD="all-of-us-rw-prod"
 
 function validate_cdr(){
- db_prd=$(gcloud sql databases list --instance workbenchmaindb --project "$PROJECT_PROD" | grep "$CDR_DB_NAME" | cut -d" " -f1)
+ local db_prd=$(gcloud sql databases list --instance workbenchmaindb --project "$PROJECT_PROD" | grep "$CDR_DB_NAME" | cut -d" " -f1)
  if [[ "$db_prd" == "$CDR_DB_NAME" ]]; then
    echo ""
    echo -e "\033[0;31m******************************************************************************************************************\033[0m"
@@ -21,7 +21,7 @@ function validate_cdr(){
    echo ""
    exit 1
  fi
- db_pre=$(gcloud sql databases list --instance workbenchmaindb --project "$PROJECT_PRE_PROD" | grep "$CDR_DB_NAME" | cut -d" " -f1)
+ local db_pre=$(gcloud sql databases list --instance workbenchmaindb --project "$PROJECT_PRE_PROD" | grep "$CDR_DB_NAME" | cut -d" " -f1)
  if [[ -z "$db_pre" ]]; then
    echo ""
    echo -e "\033[0;31m******************************************************************************************************************\033[0m"
@@ -37,37 +37,50 @@ function validate_cdr(){
  fi
 }
 # Validate cdr name for export-import operations
-echo "Validating if database $CDR_DB_NAME can be exported from preprod to import into prod"
+echo "1. Validating if database $CDR_DB_NAME can be exported from preprod to import into prod"
 validate_cdr
-# Export to cdr to preprod bucket"
-echo "Exporting sqldump file for cdr: $CDR_DB_NAME to preprod bucket"
+
+# Export: cdr to preprod bucket"
+echo "2. Exporting sqldump file for cdr: $CDR_DB_NAME to preprod bucket"
 gcloud sql export sql workbenchmaindb \
        gs://"$PROJECT_PRE_PROD".appspot.com/"$CDR_DB_NAME"_export.sql \
        --database="$CDR_DB_NAME" --project="$PROJECT_PRE_PROD"
 
-# Copy Exported sqldump file from preprod bucket to prod bucket
-echo "Copying sqldump file $CDR_DB_NAME_export.sql to prod bucket"
+# Copy: Sqldump file from preprod bucket to prod bucket
+echo "3. Copying sqldump file $CDR_DB_NAME_export.sql to prod bucket"
 gsutil cp gs://"$PROJECT_PRE_PROD".appspot.com/"$CDR_DB_NAME"_export.sql \
        gs://"$PROJECT_PROD".appspot.com/"$CDR_DB_NAME"_export.sql
 
-# Create Production cloud SQL cdr from exported sqldump file
-echo "Creating prod database $CDR_DB_NAME from $CDR_DB_NAME_export.sql"
+# Import: Create Production cloud SQL cdr from sqldump file
+echo "4. Creating prod database $CDR_DB_NAME from $CDR_DB_NAME_export.sql"
 # Print production Google Cloud Console to monitor import
-echo "Naviagte to the URL below to monitor progress..."
-echo "URL: https://console.cloud.google.com/sql/instances/workbenchmaindb/databases?project=$PROJECT_PROD"
+echo -e "\tNavigate to the URL below to monitor progress..."
+echo -e "\tURL: https://console.cloud.google.com/sql/instances/workbenchmaindb/databases?project=$PROJECT_PROD"
 gcloud sql import sql workbenchmaindb \
        gs://"$PROJECT_PROD".appspot.com/"$CDR_DB_NAME"_export.sql \
        --quiet --project="$PROJECT_PROD"
 
-# Remove/delete sqldump files from preprod and prod buckets
-echo "Removing sqldump file from preprod bucket"
+# Verify:  Newly created database exists in production
+echo "5. Verifying production cdr $CDR_DB_NAME exists"
+db_prd=$(gcloud sql databases list --instance workbenchmaindb --project "$PROJECT_PROD" | grep "$CDR_DB_NAME" | cut -d" " -f1)
+if [[ "$db_prd" == "$CDR_DB_NAME" ]]; then
+  echo -e "\033[0;31m**\t\tProduction CloudSQL database $CDR_DB_NAME created successfully**\033[0m"
+else
+  echo -e "\033[0;31m**\t\033[43m\033[1;5;31m\tProduction CloudSQL database $CDR_DB_NAME creation failed\t\033[0;31m\t**\033[0m"
+  exit 1
+fi
+
+# Remove: sqldump files from preprod and prod buckets
+echo "6a. Removing sqldump file from preprod bucket"
 gsutil rm gs://"$PROJECT_PRE_PROD".appspot.com/"$CDR_DB_NAME"_export.sql
 
-echo "Removing sqldump file from prod bucket"
+echo "6b. Removing sqldump file from prod bucket"
 gsutil rm gs://"$PROJECT_PROD".appspot.com/"$CDR_DB_NAME"_export.sql
 
-echo "Verify table counts"
+# Verify: print out row counts from cdr from preprod and prod for manual verification
+echo "7a. Querying row counts for tables in $CDR_DB_NAME for preprod and prod"
 echo "`./project.rb verify-cloud-cdr-counts --cdr-db-name $CDR_DB_NAME`"
+echo -e "7b. \033[0;31m**Manually check row counts for tables match between preprod and prod**\033[0m"
 echo "done!"
 
 

--- a/api/db-cdr/generate-cdr/export-import-cloudsql-cdr.sh
+++ b/api/db-cdr/generate-cdr/export-import-cloudsql-cdr.sh
@@ -79,7 +79,7 @@ gsutil rm gs://"$PROJECT_PROD".appspot.com/"$CDR_DB_NAME"_export.sql
 
 # Verify: print out row counts from cdr from preprod and prod for manual verification
 echo "7a. Querying row counts for tables in $CDR_DB_NAME for preprod and prod"
-echo "`./project.rb verify-cloud-cdr-counts --cdr-db-name $CDR_DB_NAME`"
+echo "$(./project.rb verify-cloud-cdr-counts --cdr-db-name "$CDR_DB_NAME")"
 echo -e "7b. \033[0;31m**Manually check row counts for tables match between preprod and prod**\033[0m"
 echo "done!"
 

--- a/api/db-cdr/generate-cdr/verify-counts.sql
+++ b/api/db-cdr/generate-cdr/verify-counts.sql
@@ -1,28 +1,31 @@
+-- Use database - replace _SCHEMA_NAME_ with database name
+USE _SCHEMA_NAME_;
 -- SQL for project name
-select ' **@project - @schema_name** ' as project from dual;
+-- Replace _PROJECT_ with GOOGLE_PROJECT name _SCHEMA_NAME_ with database name
+select ' **_PROJECT_ - _SCHEMA_NAME_** ' as project from dual;
 -- SQL for cb_ and ds_ table counts
-select 'cb_criteria' as table_name, count(*) as row_count from @schema_name.cb_criteria
+select 'cb_criteria' as table_name, count(*) as row_count from cb_criteria
 union
-select 'cb_criteria_ancestor' as table_name, count(*) as row_count from @schema_name.cb_criteria_ancestor
+select 'cb_criteria_ancestor' as table_name, count(*) as row_count from cb_criteria_ancestor
 union
-select 'cb_criteria_attribute' as table_name, count(*) as row_count from @schema_name.cb_criteria_attribute
+select 'cb_criteria_attribute' as table_name, count(*) as row_count from cb_criteria_attribute
 union
-select 'cb_criteria_menu' as table_name, count(*) as row_count from @schema_name.cb_criteria_menu
+select 'cb_criteria_menu' as table_name, count(*) as row_count from cb_criteria_menu
 union
-select 'cb_criteria_relationship' as table_name, count(*) as row_count from @schema_name.cb_criteria_relationship
+select 'cb_criteria_relationship' as table_name, count(*) as row_count from cb_criteria_relationship
 union
-select 'cb_data_filter' as table_name, count(*) as row_count from @schema_name.cb_data_filter
+select 'cb_data_filter' as table_name, count(*) as row_count from cb_data_filter
 union
-select 'cb_person' as table_name, count(*) as row_count from @schema_name.cb_person
+select 'cb_person' as table_name, count(*) as row_count from cb_person
 union
-select 'cb_survey_attribute' as table_name, count(*) as row_count from @schema_name.cb_survey_attribute
+select 'cb_survey_attribute' as table_name, count(*) as row_count from cb_survey_attribute
 union
-select 'cb_survey_version' as table_name, count(*) as row_count from @schema_name.cb_survey_version
+select 'cb_survey_version' as table_name, count(*) as row_count from cb_survey_version
 union
-select 'ds_data_dictionary' as table_name, count(*) as row_count from @schema_name.ds_data_dictionary
+select 'ds_data_dictionary' as table_name, count(*) as row_count from ds_data_dictionary
 union
-select 'ds_linking' as table_name, count(*) as row_count from @schema_name.ds_linking
+select 'ds_linking' as table_name, count(*) as row_count from ds_linking
 union
-select 'survey_module' as table_name, count(*) as row_count from @schema_name.survey_module
+select 'survey_module' as table_name, count(*) as row_count from survey_module
 order by 2 desc;
 

--- a/api/db-cdr/generate-cdr/verify-counts.sql
+++ b/api/db-cdr/generate-cdr/verify-counts.sql
@@ -1,5 +1,5 @@
 -- Use database - replace _SCHEMA_NAME_ with database name
-USE _SCHEMA_NAME_;
+use _SCHEMA_NAME_;
 -- SQL for project name
 -- Replace _PROJECT_ with GOOGLE_PROJECT name _SCHEMA_NAME_ with database name
 select ' **_PROJECT_ - _SCHEMA_NAME_** ' as project from dual;
@@ -25,6 +25,8 @@ union
 select 'ds_data_dictionary' as table_name, count(*) as row_count from ds_data_dictionary
 union
 select 'ds_linking' as table_name, count(*) as row_count from ds_linking
+union
+select 'domain_card' as table_name, count(*) as row_count from domain_card
 union
 select 'survey_module' as table_name, count(*) as row_count from survey_module
 order by 2 desc;

--- a/api/db-cdr/generate-cdr/verify-counts.sql
+++ b/api/db-cdr/generate-cdr/verify-counts.sql
@@ -1,0 +1,26 @@
+USE @schema_name;
+select 'cb_criteria' as table_name, count(*) as row_count from cb_criteria
+union
+select 'cb_criteria_ancestor' as table_name, count(*) as row_count from cb_criteria_ancestor
+union
+select 'cb_criteria_attribute' as table_name, count(*) as row_count from cb_criteria_attribute
+union
+select 'cb_criteria_menu' as table_name, count(*) as row_count from cb_criteria_menu
+union
+select 'cb_criteria_relationship' as table_name, count(*) as row_count from cb_criteria_relationship
+union
+select 'cb_data_filter' as table_name, count(*) as row_count from cb_data_filter
+union
+select 'cb_person' as table_name, count(*) as row_count from cb_person
+union
+select 'cb_survey_attribute' as table_name, count(*) as row_count from cb_survey_attribute
+union
+select 'cb_survey_version' as table_name, count(*) as row_count from cb_survey_version
+union
+select 'ds_data_dictionary' as table_name, count(*) as row_count from ds_data_dictionary
+union
+select 'ds_linking' as table_name, count(*) as row_count from ds_linking
+union
+select 'survey_module' as table_name, count(*) as row_count from survey_module
+order by 2 desc;
+

--- a/api/db-cdr/generate-cdr/verify-counts.sql
+++ b/api/db-cdr/generate-cdr/verify-counts.sql
@@ -1,8 +1,8 @@
 -- Use database - replace _SCHEMA_NAME_ with database name
-use _SCHEMA_NAME_;
+USE @SCHEMA_NAME;
 -- SQL for project name
 -- Replace _PROJECT_ with GOOGLE_PROJECT name _SCHEMA_NAME_ with database name
-select ' **_PROJECT_ - _SCHEMA_NAME_** ' as project from dual;
+select ' **@PROJECT - @SCHEMA_NAME** ' as project from dual;
 -- SQL for cb_ and ds_ table counts
 select 'cb_criteria' as table_name, count(*) as row_count from cb_criteria
 union

--- a/api/db-cdr/generate-cdr/verify-counts.sql
+++ b/api/db-cdr/generate-cdr/verify-counts.sql
@@ -1,4 +1,7 @@
 USE @schema_name;
+-- SQL for project name
+select ' **@project - @schema_name** ' as project from dual;
+-- SQL for cb_ and ds_ table counts
 select 'cb_criteria' as table_name, count(*) as row_count from cb_criteria
 union
 select 'cb_criteria_ancestor' as table_name, count(*) as row_count from cb_criteria_ancestor

--- a/api/db-cdr/generate-cdr/verify-counts.sql
+++ b/api/db-cdr/generate-cdr/verify-counts.sql
@@ -1,29 +1,28 @@
-USE @schema_name;
 -- SQL for project name
 select ' **@project - @schema_name** ' as project from dual;
 -- SQL for cb_ and ds_ table counts
-select 'cb_criteria' as table_name, count(*) as row_count from cb_criteria
+select 'cb_criteria' as table_name, count(*) as row_count from @schema_name.cb_criteria
 union
-select 'cb_criteria_ancestor' as table_name, count(*) as row_count from cb_criteria_ancestor
+select 'cb_criteria_ancestor' as table_name, count(*) as row_count from @schema_name.cb_criteria_ancestor
 union
-select 'cb_criteria_attribute' as table_name, count(*) as row_count from cb_criteria_attribute
+select 'cb_criteria_attribute' as table_name, count(*) as row_count from @schema_name.cb_criteria_attribute
 union
-select 'cb_criteria_menu' as table_name, count(*) as row_count from cb_criteria_menu
+select 'cb_criteria_menu' as table_name, count(*) as row_count from @schema_name.cb_criteria_menu
 union
-select 'cb_criteria_relationship' as table_name, count(*) as row_count from cb_criteria_relationship
+select 'cb_criteria_relationship' as table_name, count(*) as row_count from @schema_name.cb_criteria_relationship
 union
-select 'cb_data_filter' as table_name, count(*) as row_count from cb_data_filter
+select 'cb_data_filter' as table_name, count(*) as row_count from @schema_name.cb_data_filter
 union
-select 'cb_person' as table_name, count(*) as row_count from cb_person
+select 'cb_person' as table_name, count(*) as row_count from @schema_name.cb_person
 union
-select 'cb_survey_attribute' as table_name, count(*) as row_count from cb_survey_attribute
+select 'cb_survey_attribute' as table_name, count(*) as row_count from @schema_name.cb_survey_attribute
 union
-select 'cb_survey_version' as table_name, count(*) as row_count from cb_survey_version
+select 'cb_survey_version' as table_name, count(*) as row_count from @schema_name.cb_survey_version
 union
-select 'ds_data_dictionary' as table_name, count(*) as row_count from ds_data_dictionary
+select 'ds_data_dictionary' as table_name, count(*) as row_count from @schema_name.ds_data_dictionary
 union
-select 'ds_linking' as table_name, count(*) as row_count from ds_linking
+select 'ds_linking' as table_name, count(*) as row_count from @schema_name.ds_linking
 union
-select 'survey_module' as table_name, count(*) as row_count from survey_module
+select 'survey_module' as table_name, count(*) as row_count from @schema_name.survey_module
 order by 2 desc;
 

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -3013,6 +3013,27 @@ Common.register_command({
     :fn => ->(*args) {export_workspace_operations(EXPORT_WORKSPACE_OPERATIONS_CMD, *args)}
 })
 
+def export_import_cloudsql_cdr(cmd_name, *args)
+  op = WbOptionsParser.new(cmd_name, args)
+  op.add_option(
+    "--cdr-db-name [cdr-db-name]",
+    ->(opts, v) { opts.cdr_db_name = v},
+    "cdrDbName - Name used cdr_config. Required."
+  )
+  op.add_validator ->(opts) { raise ArgumentError unless opts.cdr_db_name }
+  op.parse.validate
+
+  common = Common.new
+  common.run_inline %W{./db-cdr/generate-cdr/export-import-cloudsql-cdr.sh #{op.opts.cdr_db_name}}
+
+end
+
+Common.register_command({
+  :invocation => "export-import-cloudsql-cdr",
+  :description => "Export cdr database from preprod and import to prod.",
+  :fn => ->(*args) { export_import_cloudsql_cdr("export-import-cloudsql-cdr", *args) }
+})
+
 def verify_cloud_cdr_counts(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
   op.add_option(
@@ -3027,6 +3048,7 @@ def verify_cloud_cdr_counts(cmd_name, *args)
   # for preprod
   op.opts.project = "all-of-us-rw-preprod"
   verify_preprod_prod_counts(op)
+
   # for prod
   op.opts.project = "all-of-us-rw-prod"
   verify_preprod_prod_counts(op)
@@ -3045,30 +3067,22 @@ def verify_preprod_prod_counts(op)
   op.parse.validate
   gcc.validate
   sql = File.read(op.opts.script)
-  new_sql = sql.gsub(/@schema_name/, op.opts.cdr_db_name)
+  sql = sql.gsub(/@schema_name/, op.opts.cdr_db_name)
+  sql = sql.gsub(/@project/, op.opts.project)
   env = read_db_vars(gcc)
-
   user_to_password = {
     "dev-readonly" => env["DEV_READONLY_DB_PASSWORD"],
   }
-
   db_password = user_to_password[op.opts.db_user]
 
   CloudSqlProxyContext.new(gcc.project).run do
-    if op.opts.db_user == "dev-readonly"
-      common.status ""
-      common.status "Database session will be read-only"
-      common.status ""
-    end
-
     common.status "Fetch credentials from #{gcs_vars_path(gcc.project)} to connect through a different SQL tool"
     common.status common.bold_term_text(common.red_term_text("======="+op.opts.project+"======="))
     common.run_inline(
-      run_mysql_cmd(
-        " mysql --table --host=127.0.0.1 --port=3307 --user=#{op.opts.db_user} --database=#{env["DB_NAME"]} --password=#{db_password} -e \"#{new_sql}\""
-      ),
+      run_mysql_cmd(" mysql --table --host=127.0.0.1 --port=3307 --user=#{op.opts.db_user} " +
+          " --database=#{env["DB_NAME"]} --password=#{db_password} -e \"#{sql}\""),
       db_password)
-    common.status common.bold_term_text(common.red_term_text("======="+op.opts.project+"======="))
+    common.status " "
   end
 end
 
@@ -3077,7 +3091,6 @@ def run_mysql_cmd(cmd)
   if Workbench.in_docker?
     return cmd
   end
-  common.status "Outside docker: invoking mysql via docker for portability"
   return "docker run " +
     "--rm " +
     "--network host " +

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -3067,8 +3067,8 @@ def verify_preprod_prod_counts(op)
   op.parse.validate
   gcc.validate
   sql = File.read(op.opts.script)
-  sql = sql.gsub(/@schema_name/, op.opts.cdr_db_name)
-  sql = sql.gsub(/@project/, op.opts.project)
+  sql = sql.gsub(/_SCHEMA_NAME_/, op.opts.cdr_db_name)
+  sql = sql.gsub(/_PROJECT_/, op.opts.project)
   env = read_db_vars(gcc)
   user_to_password = {
     "dev-readonly" => env["DEV_READONLY_DB_PASSWORD"],

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -3087,7 +3087,6 @@ def verify_preprod_prod_counts(op)
 end
 
 def run_mysql_cmd(cmd)
-  common = Common.new
   if Workbench.in_docker?
     return cmd
   end

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -3012,3 +3012,77 @@ Common.register_command({
     :description => "Export the workspace_operations table.",
     :fn => ->(*args) {export_workspace_operations(EXPORT_WORKSPACE_OPERATIONS_CMD, *args)}
 })
+
+def verify_cloud_cdr_counts(cmd_name, *args)
+  op = WbOptionsParser.new(cmd_name, args)
+  op.add_option(
+    "--cdr-db-name [cdr-db-name]",
+    ->(opts, v) { opts.cdr_db_name = v},
+    "cdrDbName - Name used cdr_config. Required."
+  )
+  op.add_validator ->(opts) { raise ArgumentError unless opts.cdr_db_name }
+  op.opts.db_user = "dev-readonly" # do not override always read-only user
+  op.opts.script= "db-cdr/generate-cdr/verify-counts.sql" # script cannot do any modifications
+
+  # for preprod
+  op.opts.project = "all-of-us-rw-preprod"
+  verify_preprod_prod_counts(op)
+  # for prod
+  op.opts.project = "all-of-us-rw-prod"
+  verify_preprod_prod_counts(op)
+
+end
+
+Common.register_command({
+  :invocation => "verify-cloud-cdr-counts",
+  :description => "Connect to a Cloud SQL database via mysql and run the provided sql file.",
+  :fn => ->(*args) { verify_cloud_cdr_counts("verify-cloud-cdr-counts", *args) }
+})
+
+def verify_preprod_prod_counts(op)
+  common = Common.new
+  gcc = GcloudContextV2.new(op)
+  op.parse.validate
+  gcc.validate
+  sql = File.read(op.opts.script)
+  new_sql = sql.gsub(/@schema_name/, op.opts.cdr_db_name)
+  env = read_db_vars(gcc)
+
+  user_to_password = {
+    "dev-readonly" => env["DEV_READONLY_DB_PASSWORD"],
+  }
+
+  db_password = user_to_password[op.opts.db_user]
+
+  CloudSqlProxyContext.new(gcc.project).run do
+    if op.opts.db_user == "dev-readonly"
+      common.status ""
+      common.status "Database session will be read-only"
+      common.status ""
+    end
+
+    common.status "Fetch credentials from #{gcs_vars_path(gcc.project)} to connect through a different SQL tool"
+    common.status common.bold_term_text(common.red_term_text("======="+op.opts.project+"======="))
+    common.run_inline(
+      run_mysql_cmd(
+        " mysql --table --host=127.0.0.1 --port=3307 --user=#{op.opts.db_user} --database=#{env["DB_NAME"]} --password=#{db_password} -e \"#{new_sql}\""
+      ),
+      db_password)
+    common.status common.bold_term_text(common.red_term_text("======="+op.opts.project+"======="))
+  end
+end
+
+def run_mysql_cmd(cmd)
+  common = Common.new
+  if Workbench.in_docker?
+    return cmd
+  end
+  common.status "Outside docker: invoking mysql via docker for portability"
+  return "docker run " +
+    "--rm " +
+    "--network host " +
+    "--entrypoint '' " +
+    "-it " +
+    "mariadb:10.2 " +
+    cmd
+end

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -3067,8 +3067,8 @@ def verify_preprod_prod_counts(op)
   op.parse.validate
   gcc.validate
   sql = File.read(op.opts.script)
-  sql = sql.gsub(/_SCHEMA_NAME_/, op.opts.cdr_db_name)
-  sql = sql.gsub(/_PROJECT_/, op.opts.project)
+  sql = sql.gsub(/@SCHEMA_NAME/, op.opts.cdr_db_name)
+  sql = sql.gsub(/@PROJECT/, op.opts.project)
   env = read_db_vars(gcc)
   user_to_password = {
     "dev-readonly" => env["DEV_READONLY_DB_PASSWORD"],

--- a/api/libproject/gcloudcontext.rb
+++ b/api/libproject/gcloudcontext.rb
@@ -31,6 +31,11 @@ class GcloudContextV2
     @options_parser.add_validator ->(opts) { raise ArgumentError unless opts.project}
   end
 
+  def initialize(options_parser)
+    @options_parser = options_parser
+    # empty ctor
+  end
+
   def validate()
     common = Common.new
     @project = @options_parser.opts.project

--- a/api/libproject/gcloudcontext.rb
+++ b/api/libproject/gcloudcontext.rb
@@ -31,11 +31,6 @@ class GcloudContextV2
     @options_parser.add_validator ->(opts) { raise ArgumentError unless opts.project}
   end
 
-  def initialize(options_parser)
-    @options_parser = options_parser
-    # empty ctor
-  end
-
   def validate()
     common = Common.new
     @project = @options_parser.opts.project


### PR DESCRIPTION
Description:
---
- Automate export/import MySQL databases from preprod to prod.
- Verify that the database cb_ and ds_ and other table row counts match between preprod and prod
- Update [CDR Playbook](https://docs.google.com/document/d/1St6pG_EUFB9oRQUQaOSO7a9UPxPkQ5n4qAVyKF9j9tk/edit#heading=h.vq2ookfjt3a4) documentation once this PR is merged
- There are 2 project.rb commands: Note the project id defaults to as needed for the process. This process is only for export from **preprod** and import to **prod**
  -  `export-import-cloudsql-cdr` For export and subsequent import. This also executes the `verify-cloud-cdr-counts`
     - `./project.rb export-import-cloudsql-cdr --cdr-db-name r_2022q4_1`
  - ` verify-cloud-cdr-counts` Outputs row counts for all cb_* and ds_*, and other tables in the cdr for preprod and prod. Always outputs for both **preprod** and **prod**
    -  `./project.rb verify-cloud-cdr-counts --cdr-db-name r_2022q4_1`

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
