### PR TITLE
[RW-9546][risk=no]   Notifications for CT-expiring users

### DIFF
--- a/ui/src/app/components/notification-banner.tsx
+++ b/ui/src/app/components/notification-banner.tsx
@@ -73,6 +73,7 @@ interface NotificationProps {
   buttonOnClick?: () => void;
   bannerTextWidth: CSSProperties['width'];
   buttonAriaLabel?: string;
+  iconStyle?: CSSProperties;
 }
 
 export const NotificationBanner = ({
@@ -88,10 +89,11 @@ export const NotificationBanner = ({
   buttonOnClick,
   buttonAriaLabel,
   bannerTextWidth,
+  iconStyle,
 }: NotificationProps) => {
   return (
     <FlexRow data-test-id={dataTestId} style={{ ...styles.box, ...boxStyle }}>
-      <AlarmExclamation style={styles.icon} />
+      <AlarmExclamation style={{ ...styles.icon, ...iconStyle }} />
       <div style={{ ...styles.text, ...textStyle, width: bannerTextWidth }}>
         {text}
       </div>

--- a/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
@@ -185,17 +185,17 @@ describe('Access Renewal Notification', () => {
       'for RT when there is one expiring module',
       AccessTierShortNames.Registered,
       allCompleteOneExpiring(AccessModule.DATAUSERCODEOFCONDUCT),
-      colors.notificationBanner.EXPIRED,
+      colors.notificationBanner.expiring_within_one_week,
       colors.danger,
     ],
     [
       true,
-      'for RT when there is one module expiring in couple of weeks',
+      'for RT when there is one module expiring in two weeks',
       AccessTierShortNames.Registered,
       allCompleteOneExpiringInMoreThanTwoWeeks(
         AccessModule.DATAUSERCODEOFCONDUCT
       ),
-      colors.notificationBanner.EXPIRING_SOON,
+      colors.notificationBanner.expiring,
       colors.primary,
     ],
     [
@@ -212,7 +212,7 @@ describe('Access Renewal Notification', () => {
       'for RT when there is one expired module',
       AccessTierShortNames.Registered,
       allCompleteOneExpired(AccessModule.DATAUSERCODEOFCONDUCT),
-      colors.notificationBanner.EXPIRED,
+      colors.notificationBanner.expiring_within_one_week,
       colors.danger,
     ],
     [
@@ -245,17 +245,17 @@ describe('Access Renewal Notification', () => {
       'for CT when only CT training is expiring',
       AccessTierShortNames.Controlled,
       allCompleteOneExpiring(AccessModule.CTCOMPLIANCETRAINING),
-      colors.notificationBanner.EXPIRED,
+      colors.notificationBanner.expiring_within_one_week,
       colors.danger,
     ],
     [
       true,
-      'for CT when only CT training is expiring in couple of weeks',
+      'for CT when only CT training is expiring in two weeks',
       AccessTierShortNames.Controlled,
       allCompleteOneExpiringInMoreThanTwoWeeks(
         AccessModule.CTCOMPLIANCETRAINING
       ),
-      colors.notificationBanner.EXPIRING_SOON,
+      colors.notificationBanner.expiring,
       colors.primary,
     ],
     [
@@ -263,7 +263,7 @@ describe('Access Renewal Notification', () => {
       'for CT when only CT training is expired',
       AccessTierShortNames.Controlled,
       allCompleteOneExpired(AccessModule.CTCOMPLIANCETRAINING),
-      colors.notificationBanner.EXPIRED,
+      colors.notificationBanner.expiring_within_one_week,
       colors.danger,
     ],
     [
@@ -271,7 +271,7 @@ describe('Access Renewal Notification', () => {
       'for RT when RT is expiring sooner',
       AccessTierShortNames.Registered,
       rtExpiresFirst,
-      colors.notificationBanner.EXPIRED,
+      colors.notificationBanner.expiring_within_one_week,
       colors.danger,
     ],
     [
@@ -289,7 +289,7 @@ describe('Access Renewal Notification', () => {
       'for RT when CT is expiring sooner',
       AccessTierShortNames.Registered,
       ctExpiresFirst,
-      colors.notificationBanner.EXPIRING,
+      colors.notificationBanner.expiring_in_two_weeks,
       colors.warning,
     ],
     [
@@ -297,7 +297,7 @@ describe('Access Renewal Notification', () => {
       'for CT when CT is expiring sooner',
       AccessTierShortNames.Controlled,
       ctExpiresFirst,
-      colors.notificationBanner.EXPIRED,
+      colors.notificationBanner.expiring_within_one_week,
       colors.danger,
     ],
   ])(

--- a/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
@@ -7,7 +7,6 @@ import { AccessModule, AccessModuleStatus } from 'generated/fetch';
 import { AlarmExclamation } from 'app/components/icons';
 import colors from 'app/styles/colors';
 import { AccessTierShortNames } from 'app/utils/access-tiers';
-import { EXPIRED, EXPIRING, EXPIRING_SOON } from 'app/utils/constants';
 import { nowPlusDays } from 'app/utils/dates';
 import { profileStore, serverConfigStore } from 'app/utils/stores';
 
@@ -40,7 +39,7 @@ const allCompleteNotExpiring: AccessModuleStatus[] = allModules.map(
   })
 );
 
-const allCompleteOneExpiringInTwoWeeks = (moduleName: AccessModule) => [
+const allCompleteOneExpiringInMoreThanTwoWeeks = (moduleName: AccessModule) => [
   ...allCompleteNotExpiring.filter(
     (status) => status.moduleName !== moduleName
   ),
@@ -186,15 +185,15 @@ describe('Access Renewal Notification', () => {
       'for RT when there is one expiring module',
       AccessTierShortNames.Registered,
       allCompleteOneExpiring(AccessModule.DATAUSERCODEOFCONDUCT),
-      EXPIRED,
+      colors.notificationBanner.EXPIRED,
       colors.danger,
     ],
     [
       true,
       'for RT when there is one module expiring in couple of weeks',
       AccessTierShortNames.Registered,
-      allCompleteOneExpiringInTwoWeeks(AccessModule.DATAUSERCODEOFCONDUCT),
-      EXPIRING_SOON,
+      allCompleteOneExpiringInMoreThanTwoWeeks(AccessModule.DATAUSERCODEOFCONDUCT),
+      colors.notificationBanner.EXPIRING_SOON,
       colors.primary,
     ],
     [
@@ -211,7 +210,7 @@ describe('Access Renewal Notification', () => {
       'for RT when there is one expired module',
       AccessTierShortNames.Registered,
       allCompleteOneExpired(AccessModule.DATAUSERCODEOFCONDUCT),
-      EXPIRED,
+      colors.notificationBanner.EXPIRED,
       colors.danger,
     ],
     [
@@ -244,23 +243,23 @@ describe('Access Renewal Notification', () => {
       'for CT when only CT training is expiring',
       AccessTierShortNames.Controlled,
       allCompleteOneExpiring(AccessModule.CTCOMPLIANCETRAINING),
-      EXPIRED,
+      colors.notificationBanner.EXPIRED,
       colors.danger,
     ],
     [
       true,
       'for CT when only CT training is expiring in couple of weeks',
       AccessTierShortNames.Controlled,
-      allCompleteOneExpiringInTwoWeeks(AccessModule.CTCOMPLIANCETRAINING),
-      EXPIRING_SOON,
-      colors.warning,
+      allCompleteOneExpiringInMoreThanTwoWeeks(AccessModule.CTCOMPLIANCETRAINING),
+      colors.notificationBanner.EXPIRING_SOON,
+      colors.primary,
     ],
     [
       true,
       'for CT when only CT training is expired',
       AccessTierShortNames.Controlled,
       allCompleteOneExpired(AccessModule.CTCOMPLIANCETRAINING),
-      EXPIRED,
+      colors.notificationBanner.EXPIRED,
       colors.danger,
     ],
     [
@@ -268,7 +267,7 @@ describe('Access Renewal Notification', () => {
       'for RT when RT is expiring sooner',
       AccessTierShortNames.Registered,
       rtExpiresFirst,
-      EXPIRED,
+      colors.notificationBanner.EXPIRED,
       colors.danger,
     ],
     [
@@ -286,7 +285,7 @@ describe('Access Renewal Notification', () => {
       'for RT when CT is expiring sooner',
       AccessTierShortNames.Registered,
       ctExpiresFirst,
-      EXPIRING,
+      colors.notificationBanner.EXPIRING,
       colors.warning,
     ],
     [
@@ -294,7 +293,7 @@ describe('Access Renewal Notification', () => {
       'for CT when CT is expiring sooner',
       AccessTierShortNames.Controlled,
       ctExpiresFirst,
-      EXPIRED,
+      colors.notificationBanner.EXPIRED,
       colors.danger,
     ],
   ])(

--- a/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
@@ -195,7 +195,7 @@ describe('Access Renewal Notification', () => {
       allCompleteOneExpiringInMoreThanTwoWeeks(
         AccessModule.DATAUSERCODEOFCONDUCT
       ),
-      colors.notificationBanner.expiring,
+      colors.notificationBanner.expiring_after_two_weeks,
       colors.primary,
     ],
     [
@@ -255,7 +255,7 @@ describe('Access Renewal Notification', () => {
       allCompleteOneExpiringInMoreThanTwoWeeks(
         AccessModule.CTCOMPLIANCETRAINING
       ),
-      colors.notificationBanner.expiring,
+      colors.notificationBanner.expiring_after_two_weeks,
       colors.primary,
     ],
     [
@@ -289,7 +289,7 @@ describe('Access Renewal Notification', () => {
       'for RT when CT is expiring sooner',
       AccessTierShortNames.Registered,
       ctExpiresFirst,
-      colors.notificationBanner.expiring_in_two_weeks,
+      colors.notificationBanner.expiring_within_two_weeks,
       colors.warning,
     ],
     [

--- a/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
@@ -192,7 +192,9 @@ describe('Access Renewal Notification', () => {
       true,
       'for RT when there is one module expiring in couple of weeks',
       AccessTierShortNames.Registered,
-      allCompleteOneExpiringInMoreThanTwoWeeks(AccessModule.DATAUSERCODEOFCONDUCT),
+      allCompleteOneExpiringInMoreThanTwoWeeks(
+        AccessModule.DATAUSERCODEOFCONDUCT
+      ),
       colors.notificationBanner.EXPIRING_SOON,
       colors.primary,
     ],
@@ -250,7 +252,9 @@ describe('Access Renewal Notification', () => {
       true,
       'for CT when only CT training is expiring in couple of weeks',
       AccessTierShortNames.Controlled,
-      allCompleteOneExpiringInMoreThanTwoWeeks(AccessModule.CTCOMPLIANCETRAINING),
+      allCompleteOneExpiringInMoreThanTwoWeeks(
+        AccessModule.CTCOMPLIANCETRAINING
+      ),
       colors.notificationBanner.EXPIRING_SOON,
       colors.primary,
     ],

--- a/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
@@ -4,6 +4,8 @@ import { mount } from 'enzyme';
 
 import { AccessModule, AccessModuleStatus } from 'generated/fetch';
 
+import { AlarmExclamation } from 'app/components/icons';
+import colors from 'app/styles/colors';
 import { AccessTierShortNames } from 'app/utils/access-tiers';
 import { EXPIRED, EXPIRING, EXPIRING_SOON } from 'app/utils/constants';
 import { nowPlusDays } from 'app/utils/dates';
@@ -27,6 +29,8 @@ const allModules = [
   AccessModule.PROFILECONFIRMATION,
   AccessModule.PUBLICATIONCONFIRMATION,
 ];
+
+const EMPTY_STRING = '';
 
 const allCompleteNotExpiring: AccessModuleStatus[] = allModules.map(
   (moduleName) => ({
@@ -150,28 +154,32 @@ describe('Access Renewal Notification', () => {
       'for RT when there are no modules',
       AccessTierShortNames.Registered,
       [],
-      '',
+      EMPTY_STRING,
+      EMPTY_STRING,
     ],
     [
       false,
       'for CT when there are no modules',
       AccessTierShortNames.Controlled,
       [],
-      '',
+      EMPTY_STRING,
+      EMPTY_STRING,
     ],
     [
       false,
       'for RT when there are no expiring modules',
       AccessTierShortNames.Registered,
       allCompleteNotExpiring,
-      '',
+      EMPTY_STRING,
+      EMPTY_STRING,
     ],
     [
       false,
       'for CT when there are no expiring modules',
       AccessTierShortNames.Controlled,
       allCompleteNotExpiring,
-      '',
+      EMPTY_STRING,
+      EMPTY_STRING,
     ],
     [
       true,
@@ -179,6 +187,7 @@ describe('Access Renewal Notification', () => {
       AccessTierShortNames.Registered,
       allCompleteOneExpiring(AccessModule.DATAUSERCODEOFCONDUCT),
       EXPIRED,
+      colors.danger,
     ],
     [
       true,
@@ -186,6 +195,7 @@ describe('Access Renewal Notification', () => {
       AccessTierShortNames.Registered,
       allCompleteOneExpiringInTwoWeeks(AccessModule.DATAUSERCODEOFCONDUCT),
       EXPIRING_SOON,
+      colors.primary,
     ],
     [
       // Showing the RT banner appears in this case, so CT is not needed
@@ -193,7 +203,8 @@ describe('Access Renewal Notification', () => {
       'for CT when there is one expiring module',
       AccessTierShortNames.Controlled,
       allCompleteOneExpiring(AccessModule.DATAUSERCODEOFCONDUCT),
-      '',
+      EMPTY_STRING,
+      EMPTY_STRING,
     ],
     [
       true,
@@ -201,6 +212,7 @@ describe('Access Renewal Notification', () => {
       AccessTierShortNames.Registered,
       allCompleteOneExpired(AccessModule.DATAUSERCODEOFCONDUCT),
       EXPIRED,
+      colors.danger,
     ],
     [
       // Showing the RT banner appears in this case, so CT is not needed
@@ -208,21 +220,24 @@ describe('Access Renewal Notification', () => {
       'for CT when there is one expired module',
       AccessTierShortNames.Controlled,
       allCompleteOneExpired(AccessModule.DATAUSERCODEOFCONDUCT),
-      '',
+      EMPTY_STRING,
+      EMPTY_STRING,
     ],
     [
       false,
       'for RT when only CT training is expiring',
       AccessTierShortNames.Registered,
       allCompleteOneExpiring(AccessModule.CTCOMPLIANCETRAINING),
-      '',
+      EMPTY_STRING,
+      EMPTY_STRING,
     ],
     [
       false,
       'for RT when only CT training is expired',
       AccessTierShortNames.Registered,
       allCompleteOneExpired(AccessModule.CTCOMPLIANCETRAINING),
-      '',
+      EMPTY_STRING,
+      EMPTY_STRING,
     ],
     [
       true,
@@ -230,6 +245,7 @@ describe('Access Renewal Notification', () => {
       AccessTierShortNames.Controlled,
       allCompleteOneExpiring(AccessModule.CTCOMPLIANCETRAINING),
       EXPIRED,
+      colors.danger,
     ],
     [
       true,
@@ -237,6 +253,7 @@ describe('Access Renewal Notification', () => {
       AccessTierShortNames.Controlled,
       allCompleteOneExpiringInTwoWeeks(AccessModule.CTCOMPLIANCETRAINING),
       EXPIRING_SOON,
+      colors.warning,
     ],
     [
       true,
@@ -244,6 +261,7 @@ describe('Access Renewal Notification', () => {
       AccessTierShortNames.Controlled,
       allCompleteOneExpired(AccessModule.CTCOMPLIANCETRAINING),
       EXPIRED,
+      colors.danger,
     ],
     [
       true,
@@ -251,6 +269,7 @@ describe('Access Renewal Notification', () => {
       AccessTierShortNames.Registered,
       rtExpiresFirst,
       EXPIRED,
+      colors.danger,
     ],
     [
       // Showing the RT banner appears in this case, so CT is not needed
@@ -258,7 +277,8 @@ describe('Access Renewal Notification', () => {
       'for CT when RT is expiring sooner',
       AccessTierShortNames.Controlled,
       rtExpiresFirst,
-      '',
+      EMPTY_STRING,
+      EMPTY_STRING,
     ],
     [
       // Still need to show RT, because it's more important
@@ -267,6 +287,7 @@ describe('Access Renewal Notification', () => {
       AccessTierShortNames.Registered,
       ctExpiresFirst,
       EXPIRING,
+      colors.warning,
     ],
     [
       true,
@@ -274,10 +295,18 @@ describe('Access Renewal Notification', () => {
       AccessTierShortNames.Controlled,
       ctExpiresFirst,
       EXPIRED,
+      colors.danger,
     ],
   ])(
     'display=%s %s',
-    async (expected, condition, accessTier, moduleStatuses, bannerColor) => {
+    async (
+      expected,
+      condition,
+      accessTier,
+      moduleStatuses,
+      bannerColor,
+      iconColor
+    ) => {
       updateModules(moduleStatuses);
 
       const wrapper = component({ accessTier });
@@ -289,6 +318,9 @@ describe('Access Renewal Notification', () => {
       expect(banner.exists()).toEqual(expected);
       if (expected) {
         expect(banner.first().props().style.backgroundColor).toBe(bannerColor);
+        expect(wrapper.find(AlarmExclamation).prop('style').color).toBe(
+          iconColor
+        );
       }
     }
   );

--- a/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.spec.tsx
@@ -185,7 +185,7 @@ describe('Access Renewal Notification', () => {
       'for RT when there is one module expiring in couple of weeks',
       AccessTierShortNames.Registered,
       allCompleteOneExpiringInTwoWeeks(AccessModule.DATAUSERCODEOFCONDUCT),
-      EXPIRING,
+      EXPIRING_SOON,
     ],
     [
       // Showing the RT banner appears in this case, so CT is not needed
@@ -236,7 +236,7 @@ describe('Access Renewal Notification', () => {
       'for CT when only CT training is expiring in couple of weeks',
       AccessTierShortNames.Controlled,
       allCompleteOneExpiringInTwoWeeks(AccessModule.CTCOMPLIANCETRAINING),
-      EXPIRING,
+      EXPIRING_SOON,
     ],
     [
       true,
@@ -266,7 +266,7 @@ describe('Access Renewal Notification', () => {
       'for RT when CT is expiring sooner',
       AccessTierShortNames.Registered,
       ctExpiresFirst,
-      EXPIRING_SOON,
+      EXPIRING,
     ],
     [
       true,

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -44,7 +44,7 @@ export const AccessRenewalNotificationMaybe = (
       ? { backgroundColor: EXPIRING_SOON }
       : daysRemaining > 6
       ? { backgroundColor: EXPIRING }
-      : {backgroundColor: EXPIRED};
+      : { backgroundColor: EXPIRED };
 
   const iconColor =
     daysRemaining > 13

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -19,6 +19,8 @@ export const AccessRenewalNotificationMaybe = (
   const { profile } = useStore(profileStore);
   const daysRemaining = maybeDaysRemaining(profile, props.accessTier);
 
+  const moreThan14daysRemaining = daysRemaining > 13;
+
   // special handling for Controlled Tier: don't render when RT is more urgent
   // because CT renewal is redundant in that case
   if (
@@ -39,17 +41,15 @@ export const AccessRenewalNotificationMaybe = (
       ? daysRemaining + ' days remaining.'
       : 'Your access has expired.';
 
-  const boxColor =
-    daysRemaining > 13
-      ? { backgroundColor: EXPIRING_SOON }
-      : daysRemaining > 6
-      ? { backgroundColor: EXPIRING }
-      : { backgroundColor: EXPIRED };
+  const boxColor = moreThan14daysRemaining
+    ? { backgroundColor: EXPIRING_SOON }
+    : daysRemaining > 6
+    ? { backgroundColor: EXPIRING }
+    : { backgroundColor: EXPIRED };
 
-  const iconColor =
-    daysRemaining > 13
-      ? { color: colors.primary }
-      : daysRemaining <= 6 && { color: colors.danger };
+  const iconColor = moreThan14daysRemaining
+    ? { color: colors.primary }
+    : daysRemaining <= 6 && { color: colors.danger };
 
   // Must use pathname and search because ACCESS_RENEWAL_PATH includes a path with a search parameter.
   const { pathname, search } = window.location;

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -55,6 +55,8 @@ export const AccessRenewalNotificationMaybe = (
     () => colors.warning
   );
 
+  const iconStyle = { color: iconColor };
+  const boxStyle = { backgroundColor: boxColor };
   // Must use pathname and search because ACCESS_RENEWAL_PATH includes a path with a search parameter.
   const { pathname, search } = window.location;
   const fullPagePath = pathname + search;
@@ -64,14 +66,13 @@ export const AccessRenewalNotificationMaybe = (
     <NotificationBanner
       dataTestId='access-renewal-notification'
       text={`Time for ${accessType} renewal. ${timeLeft}`}
-      boxStyle={{ backgroundColor: boxColor }}
       buttonText='Get Started'
       buttonPath={ACCESS_RENEWAL_PATH}
       buttonDisabled={fullPagePath === ACCESS_RENEWAL_PATH}
-      iconStyle={{ color: iconColor }}
       bannerTextWidth={
         props.accessTier === AccessTierShortNames.Registered ? '177px' : '250px'
       }
+      {...{ boxStyle, iconStyle }}
     />
   ) : null;
 };

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -41,15 +41,15 @@ export const AccessRenewalNotificationMaybe = (
 
   const boxColor =
     daysRemaining > 13
-      ? { backgroundColor: EXPIRING }
-      : daysRemaining < 13 && daysRemaining > 6
       ? { backgroundColor: EXPIRING_SOON }
+      : daysRemaining < 13 && daysRemaining > 6
+      ? { backgroundColor: EXPIRING }
       : daysRemaining <= 6 && {
           backgroundColor: EXPIRED,
         };
 
   const iconColor =
-    daysRemaining < 13 && daysRemaining > 6
+    daysRemaining > 13
       ? { color: colors.primary }
       : daysRemaining <= 6 && { color: colors.danger };
 

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -45,11 +45,17 @@ export const AccessRenewalNotificationMaybe = (
   const [boxColor, iconColor] = cond(
     [
       twoWeeksOrMoreRemaining,
-      () => [colors.notificationBanner.expiring, colors.primary],
+      () => [
+        colors.notificationBanner.expiring_after_two_weeks,
+        colors.primary,
+      ],
     ],
     [
       oneWeekOrMoreRemaining,
-      () => [colors.notificationBanner.expiring_in_two_weeks, colors.warning],
+      () => [
+        colors.notificationBanner.expiring_within_two_weeks,
+        colors.warning,
+      ],
     ],
     () => [colors.notificationBanner.expiring_within_one_week, colors.danger]
   );

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -42,11 +42,9 @@ export const AccessRenewalNotificationMaybe = (
   const boxColor =
     daysRemaining > 13
       ? { backgroundColor: EXPIRING_SOON }
-      : daysRemaining < 13 && daysRemaining > 6
+      : daysRemaining > 6
       ? { backgroundColor: EXPIRING }
-      : daysRemaining <= 6 && {
-          backgroundColor: EXPIRED,
-        };
+      : {backgroundColor: EXPIRED};
 
   const iconColor =
     daysRemaining > 13

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 
 import { NotificationBanner } from 'app/components/notification-banner';
+import colors from 'app/styles/colors';
 import { AccessTierShortNames } from 'app/utils/access-tiers';
 import {
   ACCESS_RENEWAL_PATH,
   maybeDaysRemaining,
 } from 'app/utils/access-utils';
+import { EXPIRED, EXPIRING, EXPIRING_SOON } from 'app/utils/constants';
 import { profileStore, useStore } from 'app/utils/stores';
 
 export interface AccessRenewalNotificationProps {
@@ -37,6 +39,20 @@ export const AccessRenewalNotificationMaybe = (
       ? daysRemaining + ' days remaining.'
       : 'Your access has expired.';
 
+  const boxColor =
+    daysRemaining > 13
+      ? { backgroundColor: EXPIRING }
+      : daysRemaining < 13 && daysRemaining > 6
+      ? { backgroundColor: EXPIRING_SOON }
+      : daysRemaining <= 6 && {
+          backgroundColor: EXPIRED,
+        };
+
+  const iconColor =
+    daysRemaining < 13 && daysRemaining > 6
+      ? { color: colors.primary }
+      : daysRemaining <= 6 && { color: colors.danger };
+
   // Must use pathname and search because ACCESS_RENEWAL_PATH includes a path with a search parameter.
   const { pathname, search } = window.location;
   const fullPagePath = pathname + search;
@@ -46,9 +62,11 @@ export const AccessRenewalNotificationMaybe = (
     <NotificationBanner
       dataTestId='access-renewal-notification'
       text={`Time for ${accessType} renewal. ${timeLeft}`}
+      boxStyle={boxColor}
       buttonText='Get Started'
       buttonPath={ACCESS_RENEWAL_PATH}
       buttonDisabled={fullPagePath === ACCESS_RENEWAL_PATH}
+      iconStyle={iconColor}
       bannerTextWidth={
         props.accessTier === AccessTierShortNames.Registered ? '177px' : '250px'
       }

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -21,7 +21,6 @@ export const AccessRenewalNotificationMaybe = (
 
   const twoWeeksOrMoreRemaining = daysRemaining >= 14;
   const oneWeekOrMoreRemaining = daysRemaining >= 7;
-  const lessThanAWeekRemaining = daysRemaining <= 6;
 
   // special handling for Controlled Tier: don't render when RT is more urgent
   // because CT renewal is redundant in that case
@@ -43,16 +42,16 @@ export const AccessRenewalNotificationMaybe = (
       ? daysRemaining + ' days remaining.'
       : 'Your access has expired.';
 
-  const boxColor = cond(
-    [twoWeeksOrMoreRemaining, () => colors.notificationBanner.EXPIRING_SOON],
-    [oneWeekOrMoreRemaining, () => colors.notificationBanner.EXPIRING],
-    () => colors.notificationBanner.EXPIRED
-  );
-
-  const iconColor = cond(
-    [twoWeeksOrMoreRemaining, () => colors.primary],
-    [lessThanAWeekRemaining, () => colors.danger],
-    () => colors.warning
+  const [boxColor, iconColor] = cond(
+    [
+      twoWeeksOrMoreRemaining,
+      () => [colors.notificationBanner.expiring, colors.primary],
+    ],
+    [
+      oneWeekOrMoreRemaining,
+      () => [colors.notificationBanner.expiring_in_two_weeks, colors.warning],
+    ],
+    () => [colors.notificationBanner.expiring_within_one_week, colors.danger]
   );
 
   const iconStyle = { color: iconColor };

--- a/ui/src/app/styles/colors.ts
+++ b/ui/src/app/styles/colors.ts
@@ -53,6 +53,11 @@ export default {
     stopped: '#F8C954',
     error: '#DB3214',
   },
+  notificationBanner: {
+    EXPIRING_SOON: `rgb(196, 222, 244)`,
+    EXPIRING: `rgb(254, 245, 232)`,
+    EXPIRED: `rgb(237, 153, 138)`,
+  },
 };
 
 class Rgba {

--- a/ui/src/app/styles/colors.ts
+++ b/ui/src/app/styles/colors.ts
@@ -54,8 +54,8 @@ export default {
     error: '#DB3214',
   },
   notificationBanner: {
-    expiring: `rgb(196, 222, 244)`,
-    expiring_in_two_weeks: `rgb(254, 245, 232)`,
+    expiring_after_two_weeks: `rgb(196, 222, 244)`,
+    expiring_within_two_weeks: `rgb(254, 245, 232)`,
     expiring_within_one_week: `rgb(237, 153, 138)`,
   },
 };

--- a/ui/src/app/styles/colors.ts
+++ b/ui/src/app/styles/colors.ts
@@ -54,9 +54,9 @@ export default {
     error: '#DB3214',
   },
   notificationBanner: {
-    EXPIRING_SOON: `rgb(196, 222, 244)`,
-    EXPIRING: `rgb(254, 245, 232)`,
-    EXPIRED: `rgb(237, 153, 138)`,
+    expiring: `rgb(196, 222, 244)`,
+    expiring_in_two_weeks: `rgb(254, 245, 232)`,
+    expiring_within_one_week: `rgb(237, 153, 138)`,
   },
 };
 

--- a/ui/src/app/utils/constants.tsx
+++ b/ui/src/app/utils/constants.tsx
@@ -1,5 +1,3 @@
-import colors, { colorWithWhiteness } from 'app/styles/colors';
-
 export const DEMOGRAPHIC_SURVEY_V2_NOTIFICATION_END_DATE = '8/21/2022';
 
 export const DEMOGRAPHIC_SURVEY_V2_PATH = '/demographic-survey';
@@ -91,8 +89,3 @@ export const STATE_CODE_MAPPING = {
 // ANALYSIS (NEW): APPS LIST
 export const JUPYTER_APP = 'JUPYTER';
 export const APP_LIST = [JUPYTER_APP];
-
-// Access Tier Notification color
-export const EXPIRING_SOON = colorWithWhiteness(colors.secondary, 0.6);
-export const EXPIRING = colorWithWhiteness(colors.warning, 0.9);
-export const EXPIRED = colorWithWhiteness(colors.danger, 0.5);

--- a/ui/src/app/utils/constants.tsx
+++ b/ui/src/app/utils/constants.tsx
@@ -1,3 +1,5 @@
+import colors, { colorWithWhiteness } from 'app/styles/colors';
+
 export const DEMOGRAPHIC_SURVEY_V2_NOTIFICATION_END_DATE = '8/21/2022';
 
 export const DEMOGRAPHIC_SURVEY_V2_PATH = '/demographic-survey';
@@ -89,3 +91,8 @@ export const STATE_CODE_MAPPING = {
 // ANALYSIS (NEW): APPS LIST
 export const JUPYTER_APP = 'JUPYTER';
 export const APP_LIST = [JUPYTER_APP];
+
+// Access Tier Notification color
+export const EXPIRING_SOON = colorWithWhiteness(colors.secondary, 0.6);
+export const EXPIRING = colorWithWhiteness(colors.warning, 0.9);
+export const EXPIRED = colorWithWhiteness(colors.danger, 0.5);


### PR DESCRIPTION
2 weeks - purple / blue : 
<img width="725" alt="Screenshot 2023-02-22 at 9 47 02 PM" src="https://user-images.githubusercontent.com/34481816/220810876-a7874098-3d78-4dff-b99e-d3632e24cf40.png">


1 week - yellow:  
<img width="630" alt="Screenshot 2023-02-22 at 9 47 12 PM" src="https://user-images.githubusercontent.com/34481816/220810903-36219c40-9609-43e3-b449-ca848efd0287.png">


1 day - red : 
<img width="563" alt="Screenshot 2023-02-22 at 9 47 26 PM" src="https://user-images.githubusercontent.com/34481816/220810931-94303083-60a2-42e3-8a81-32c8660038cc.png">

Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
