### PR TITLE
[RW-9505][risk=low] Disable user from using apps if they have an open egress event

### DIFF
--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -11,7 +11,6 @@ import {
   NotebooksApi,
   RuntimeApi,
   RuntimeStatus,
-  SecuritySuspendedErrorParameters,
   TerraJobStatus,
   WorkspaceAccessLevel,
   WorkspacesApi,
@@ -28,7 +27,6 @@ import {
   currentWorkspaceStore,
   setSidebarActiveIconStore,
 } from 'app/utils/navigation';
-import { ComputeSecuritySuspendedError } from 'app/utils/runtime-utils';
 import {
   cdrVersionStore,
   clearCompoundRuntimeOperations,
@@ -406,17 +404,7 @@ describe('HelpSidebar', () => {
   });
 
   it('should display security suspended UX on compute suspended', async () => {
-    const suspendedParams: SecuritySuspendedErrorParameters = {
-      suspendedUntil: new Date('2000-01-01 03:00:00').toISOString(),
-    };
-    runtimeStub.runtime = null;
     runtimeStub.getRuntime = COMPUTE_SUSPENDED_RESPONSE_STUB;
-    runtimeStore.set({
-      workspaceNamespace: workspaceDataStub.namespace,
-      runtime: undefined,
-      runtimeLoaded: false,
-      loadingError: new ComputeSecuritySuspendedError(suspendedParams),
-    });
     const wrapper = await component();
     await waitForFakeTimersAndUpdate(wrapper);
 

--- a/ui/src/app/components/runtime-status-icon.tsx
+++ b/ui/src/app/components/runtime-status-icon.tsx
@@ -54,8 +54,10 @@ export const RuntimeStatusIcon = fp.flow(
     style: CSSProperties;
     compoundRuntimeOps: CompoundRuntimeOpStore;
     workspaceNamespace: string;
+    userSuspended: boolean;
   }) => {
-    const { style, compoundRuntimeOps, workspaceNamespace } = props;
+    const { style, compoundRuntimeOps, workspaceNamespace, userSuspended } =
+      props;
 
     const { runtime, loadingError } = useStore(runtimeStore);
     let status = runtime?.status;
@@ -76,8 +78,11 @@ export const RuntimeStatusIcon = fp.flow(
     return (
       <FlexRow {...{ style }} data-test-id='runtime-status-icon-container'>
         {(() => {
-          if (loadingError) {
-            if (loadingError instanceof ComputeSecuritySuspendedError) {
+          if (loadingError || userSuspended) {
+            if (
+              loadingError instanceof ComputeSecuritySuspendedError ||
+              userSuspended
+            ) {
               return (
                 <FontAwesomeIcon
                   icon={faLock}


### PR DESCRIPTION
Description:

Disable users from using apps if they have an open egress event.

This was partially implemented already. Currently, if we detect that the user is suspended, we disable opening the apps panel. We detect this by responding to failed API calls to various runtime endpoints. We are individually treating many different endpoints as indicators that the user is suspended.

This approach has a few problems:
1. The app isn't aware that a user is suspended until the user attempts to perform an action
2. Leo does not have a concept of user suspension, so this approach cannot prevent direct calls to Leo
3. There are many intertwined code paths leading to the same end result

This PR moves us toward a "top-down" approach by detecting user suspension and disabling the apps panel before we show the apps panel at all. It does this by making a call to the runtime endpoint and checking for the relevant error. In the future, I think we should create a user suspension API for this purpose instead of relying on an error code.

This PR covers the edge case where the sidebar is automatically opened if the user previously had it open.

However, this PR does not address the edge case when a user is suspended while they have the sidebar open (for example, if they have multiple tabs). This seems like a rare edge case as well as being more difficult to implement, so I don't think it's necessary for this story. A fully-realized top-down approach could handle this by periodically polling for suspension status and making it easier for in-panel API calls to bubble up suspended state error codes.

Other things this PR does *not* do:
- We don’t make any changes for the case where the user is **disabled** since we already block the entire UI.
- We don’t change any API endpoints since the app endpoints already return an error when the user is suspended.
- We do not handle the majority of cases that notebooks currently do since we haven’t implemented those features yet (such as previewing a notebook or changing the status icon).

Screenshot for reference. This matches existing UX for when the user is detected to be suspended.

<img width="470" alt="image" src="https://user-images.githubusercontent.com/31020403/220992612-372fd71b-0d6a-4bb2-92ca-e33c64f4c1d6.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
