### PR TITLE
[RW-9408][risk=no] Refactor: Generalize some code paths across apps

### DIFF
--- a/ui/src/app/components/apps-panel.tsx
+++ b/ui/src/app/components/apps-panel.tsx
@@ -65,18 +65,15 @@ export const AppsPanel = (props: {
     appsApi().listAppsInWorkspace(workspace.namespace).then(setUserApps);
   }, []);
 
-  const appStates = [
-    {
-      appType: UIAppType.JUPYTER,
-      initializeAsExpanded: isVisible(runtime?.status),
-    },
-    {
-      appType: UIAppType.CROMWELL,
-      initializeAsExpanded: shouldShowApp(
-        findApp(userApps, UIAppType.CROMWELL)
-      ),
-    },
-  ];
+  const appStates = appsToDisplay.map((appType) => {
+    return {
+      appType,
+      initializeAsExpanded:
+        appType === UIAppType.JUPYTER
+          ? isVisible(runtime?.status)
+          : shouldShowApp(findApp(userApps, appType)),
+    };
+  });
 
   // which app(s) have the user explicitly expanded by clicking?
   const [userExpandedApps, setUserExpandedApps] = useState([]);

--- a/ui/src/app/components/apps-panel/utils.tsx
+++ b/ui/src/app/components/apps-panel/utils.tsx
@@ -143,14 +143,6 @@ export const toUserEnvironmentStatusByAppType = (
   status: AppStatus | RuntimeStatus,
   appType: UIAppType
 ): UserEnvironmentStatus =>
-  cond<UserEnvironmentStatus>(
-    [
-      appType === UIAppType.CROMWELL,
-      () => fromUserAppStatus(status as AppStatus),
-    ],
-    [
-      appType === UIAppType.JUPYTER,
-      () => fromRuntimeStatus(status as RuntimeStatus),
-    ],
-    () => UserEnvironmentStatus.UNKNOWN
-  );
+  appType === UIAppType.JUPYTER
+    ? fromRuntimeStatus(status as RuntimeStatus)
+    : fromUserAppStatus(status as AppStatus);


### PR DESCRIPTION
Description: No product changes. This refactor assumes all non-Jupyter "apps" are GKE apps, which I think is reasonable.

This will make the app creation story easier to understand.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
