### PR TITLE
[RW-9409][risk=no] Pause and resume RStudio GKE apps

### DIFF
--- a/ui/src/app/components/apps-panel/apps-panel-button.tsx
+++ b/ui/src/app/components/apps-panel/apps-panel-button.tsx
@@ -56,7 +56,11 @@ interface Props {
 export const AppsPanelButton = (props: Props) => {
   const { disabled, onClick, icon, buttonText } = props;
   return (
-    <Clickable {...{ disabled, onClick }} style={{ padding: '0.5em' }}>
+    <Clickable
+      {...{ disabled, onClick }}
+      style={{ padding: '0.5em' }}
+      data-test-id={`apps-panel-button-${buttonText}`}
+    >
       <FlexColumn
         style={disabled ? buttonStyles.disabledButton : buttonStyles.button}
       >

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import { useState } from 'react';
-import {
-  faGear,
-  faPause,
-  faPlay,
-  faTrashCan,
-} from '@fortawesome/free-solid-svg-icons';
+import { faGear, faPlay, faTrashCan } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { UserAppEnvironment, Workspace } from 'generated/fetch';
@@ -189,21 +184,7 @@ const RStudioButtonRow = (props: {
           />
         </div>
       </TooltipTrigger>
-      <TooltipTrigger
-        disabled={false}
-        content='Support for pausing RStudio is not yet available'
-      >
-        {/* tooltip trigger needs a div for some reason */}
-        <div>
-          <AppsPanelButton
-            disabled={true}
-            onClick={() => {}}
-            icon={faPause}
-            buttonText='Pause'
-            data-test-id='rstudio-pause-button'
-          />
-        </div>
-      </TooltipTrigger>
+      <PauseUserAppButton {...{ userApp }} />
       <TooltipTrigger
         disabled={!launchButtonDisabled}
         content='An RStudio app exists or is being created'

--- a/ui/src/testing/stubs/apps-api-stub.ts
+++ b/ui/src/testing/stubs/apps-api-stub.ts
@@ -1,6 +1,44 @@
-import { AppsApi, EmptyResponse, ListAppsResponse } from 'generated/fetch';
+import {
+  AppsApi,
+  AppStatus,
+  AppType,
+  EmptyResponse,
+  ListAppsResponse,
+  UserAppEnvironment,
+} from 'generated/fetch';
 
 import { stubNotImplementedError } from 'testing/stubs/stub-utils';
+
+const createRStudioListAppsResponseDefaults: UserAppEnvironment = {
+  googleProject: 'terra-vpc-sc-dev-1234',
+  appName: 'all-of-us-2-rstudio-1234',
+  appType: AppType.RSTUDIO,
+  createdDate: '2023-02-28T21:10:28.723328Z',
+  status: AppStatus.RUNNING,
+  autopauseThreshold: null,
+  kubernetesRuntimeConfig: {
+    numNodes: 1,
+    machineType: 'n1-standard-4',
+    autoscalingEnabled: false,
+  },
+  proxyUrls: {
+    rstudio:
+      'https://leonardo.dsde-dev.broadinstitute.org/proxy/google/v1/apps/terra-vpc-sc-dev-1234/all-of-us-2-rstudio-1234/rstudio',
+  },
+  diskName: 'all-of-us-pd-2-rstudio-1234',
+  dateAccessed: '2023-02-28T21:10:28.723328Z',
+  errors: [],
+  labels: {
+    'created-by': 'fake@fake-research-aou.org',
+    'aou-app-type': 'rstudio',
+  },
+};
+
+export const createListAppsRStudioResponse = (
+  overrides: Partial<UserAppEnvironment> = {}
+): UserAppEnvironment => {
+  return { ...createRStudioListAppsResponseDefaults, ...overrides };
+};
 
 export class AppsApiStub extends AppsApi {
   public listAppsResponse: ListAppsResponse;

--- a/ui/src/testing/stubs/leo-apps-api-stub.ts
+++ b/ui/src/testing/stubs/leo-apps-api-stub.ts
@@ -1,0 +1,27 @@
+import { AppsApi } from 'notebooks-generated/fetch';
+
+import { stubNotImplementedError } from 'testing/stubs/stub-utils';
+
+export class LeoAppsApiStub extends AppsApi {
+  constructor() {
+    super(undefined, undefined, (..._: any[]) => {
+      throw stubNotImplementedError;
+    });
+  }
+
+  public startApp(
+    _googleProject: string,
+    _appName: string,
+    _options?: any
+  ): Promise<Response> {
+    return Promise.resolve(new Response());
+  }
+
+  public stopApp(
+    _googleProject: string,
+    _appName: string,
+    _options?: any
+  ): Promise<Response> {
+    return Promise.resolve(new Response());
+  }
+}


### PR DESCRIPTION
Description:

Allows users to pause and resume RStudio GKE apps.

Status: Running
<img width="423" alt="image" src="https://user-images.githubusercontent.com/31020403/222493869-3e88ce57-1368-499a-a413-169147736741.png">

Status: Pausing
<img width="419" alt="image" src="https://user-images.githubusercontent.com/31020403/222494008-b2c267d3-4f8d-4f31-9c1a-a2e9cda672a4.png">

Status: Paused
<img width="412" alt="image" src="https://user-images.githubusercontent.com/31020403/222495367-bead275b-b7de-4589-b5c6-40820e03289b.png">

Status: Resuming
<img width="421" alt="image" src="https://user-images.githubusercontent.com/31020403/222495439-c98e4ea0-8d7d-40a6-9e5f-e6bbf1cf5dbd.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
