### PR TITLE
[RW-9652][risk=no] Wait for selector before click

### DIFF
--- a/e2ev2/tests/workspace-create.test.js
+++ b/e2ev2/tests/workspace-create.test.js
@@ -51,7 +51,7 @@ browserTest('create a workspace', async browser => {
   const workspacePageTitleLink =
     await page.waitForSelector('a[href="/workspaces"] + span + div > a')
   await expect(workspacePageTitleLink.evaluate(e => e.innerText)).resolves.toBe(wsName)
-  await page.click('[aria-label="Open Actions Menu"]')
+  await page.waitForSelector('[aria-label="Open Actions Menu"]').then(eh => eh.click())
   // side menu pops up
   await page.click('[aria-label="Delete"]')
   // modal confirmation pops up

--- a/e2ev2/tests/workspace-create.test.js
+++ b/e2ev2/tests/workspace-create.test.js
@@ -58,7 +58,8 @@ browserTest('create a workspace', async browser => {
   const confirmButton =
     await page.waitForSelector('[role="button"][aria-label="Confirm Delete"]')
   await expect(confirmButton.evaluate(n => n.style.cursor)).resolves.toBe('not-allowed')
-  await page.type('[role="dialog"] input[placeholder="type DELETE to confirm"]', 'delete')
+  await page.waitForSelector('[role="dialog"] input[placeholder="type DELETE to confirm"]')
+    .then(eh => eh.type('delete'))
   await expect(confirmButton.evaluate(n => n.style.cursor)).resolves.toBe('pointer')
   await confirmButton.click()
 


### PR DESCRIPTION
Sidebar takes some time to load, so we need to wait for the menu to appear before clicking.

Tested once before the change and saw the failure. Tested after the change and the test passed.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
