### PR TITLE
[RW-9613][risk=no] Open RStudio apps

### DIFF
--- a/ui/src/app/components/apps-panel.spec.tsx
+++ b/ui/src/app/components/apps-panel.spec.tsx
@@ -18,11 +18,7 @@ import {
 import { registerApiClient as registerLeoApiClient } from 'app/services/notebooks-swagger-fetch-clients';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { isVisible } from 'app/utils/runtime-utils';
-import {
-  notificationStore,
-  runtimeStore,
-  serverConfigStore,
-} from 'app/utils/stores';
+import { runtimeStore, serverConfigStore } from 'app/utils/stores';
 import { AppsApi as LeoAppsApi } from 'notebooks-generated/fetch';
 
 import defaultServerConfig from 'testing/default-server-config';
@@ -417,28 +413,6 @@ describe('AppsPanel', () => {
 
     expect(appsStub.deleteApp).toHaveBeenCalled();
     expect(deleteButton().prop('disabled')).toBeTruthy();
-  });
-
-  it('should show an error if the initial request to launch RStudio fails', async () => {
-    runtimeStub.runtime.status = undefined;
-    appsStub.listAppsResponse = [];
-    const wrapper = await component();
-    await waitOneTickAndUpdate(wrapper);
-    await findUnexpandedApp(wrapper, 'RStudio').simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    appsStub.createApp = jest.fn(() => Promise.reject());
-
-    findExpandedApp(wrapper, 'RStudio')
-      .find({
-        'data-test-id': `RStudio-launch-button`,
-      })
-      .simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(notificationStore.get().title).toEqual(
-      'Error Creating RStudio Environment'
-    );
   });
 
   test.each([

--- a/ui/src/app/components/apps-panel.spec.tsx
+++ b/ui/src/app/components/apps-panel.spec.tsx
@@ -447,7 +447,7 @@ describe('AppsPanel', () => {
 
     findExpandedApp(wrapper, 'RStudio')
       .find({
-        'data-test-id': `rstudio-launch-button`,
+        'data-test-id': `RStudio-launch-button`,
       })
       .simulate('click');
     await waitOneTickAndUpdate(wrapper);

--- a/ui/src/app/components/apps-panel.spec.tsx
+++ b/ui/src/app/components/apps-panel.spec.tsx
@@ -430,6 +430,7 @@ describe('AppsPanel', () => {
           enableCromwellGKEApp,
         },
       });
+      appsStub.listAppsResponse = [];
 
       const wrapper = await component();
       await waitOneTickAndUpdate(wrapper);

--- a/ui/src/app/components/apps-panel.spec.tsx
+++ b/ui/src/app/components/apps-panel.spec.tsx
@@ -12,7 +12,6 @@ import {
 } from 'generated/fetch';
 
 import {
-  defaultRStudioConfig,
   fromUserAppStatusWithFallback,
   UIAppType,
 } from 'app/components/apps-panel/utils';
@@ -413,34 +412,6 @@ describe('AppsPanel', () => {
       userAppEnvironment.googleProject,
       userAppEnvironment.appName
     );
-  });
-
-  it('should be able to launch an RStudio app', async () => {
-    runtimeStub.runtime.status = undefined;
-    appsStub.listAppsResponse = [];
-    const wrapper = await component();
-    await waitOneTickAndUpdate(wrapper);
-    await findUnexpandedApp(wrapper, 'RStudio').simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    appsStub.createApp = jest.fn(() => Promise.resolve({}));
-
-    const launchButton = () =>
-      findExpandedApp(wrapper, 'RStudio').find({
-        'data-test-id': `rstudio-launch-button`,
-      });
-    expect(launchButton().prop('disabled')).toBeFalsy();
-    expect(launchButton().prop('buttonText')).toEqual('Launch');
-
-    launchButton().simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(appsStub.createApp).toHaveBeenCalledWith(
-      workspaceStub.namespace,
-      defaultRStudioConfig
-    );
-    expect(launchButton().prop('buttonText')).toEqual('Launching');
-    expect(launchButton().prop('disabled')).toBeTruthy();
   });
 
   it('should be able to delete an RStudio app', async () => {

--- a/ui/src/app/components/apps-panel.spec.tsx
+++ b/ui/src/app/components/apps-panel.spec.tsx
@@ -330,22 +330,6 @@ describe('AppsPanel', () => {
     expect(findAvailableApps(wrapper, false).exists()).toBeFalsy();
   });
 
-  it('should not be possible to configure an RStudio app', async () => {
-    runtimeStub.runtime.status = undefined;
-    appsStub.listAppsResponse = [];
-    const wrapper = await component();
-    await waitOneTickAndUpdate(wrapper);
-    await findUnexpandedApp(wrapper, 'RStudio').simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-    const rstudioPanel = findExpandedApp(wrapper, 'RStudio');
-
-    expect(
-      rstudioPanel
-        .find({ 'data-test-id': 'RStudio-settings-button' })
-        .prop('disabled')
-    ).toBeTruthy();
-  });
-
   it('should not be possible to configure a Cromwell app', async () => {
     runtimeStub.runtime.status = undefined;
     appsStub.listAppsResponse = [];

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -465,4 +465,24 @@ describe('ExpandedApp', () => {
       expect(createButton.prop('disabled')).toBeTruthy();
     });
   });
+
+  it('should show an error if the initial request to create RStudio fails', async () => {
+    const wrapper = await component(UIAppType.RSTUDIO, {
+      appName: 'my-app',
+      googleProject,
+      status: null,
+    });
+    appsStub.createApp = jest.fn(() => Promise.reject());
+
+    wrapper
+      .find({
+        'data-test-id': `RStudio-create-button`,
+      })
+      .simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(notificationStore.get().title).toEqual(
+      'Error Creating RStudio Environment'
+    );
+  });
 });

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -215,7 +215,7 @@ const RStudioButtonRow = (props: {
       <PauseUserAppButton {...{ userApp }} />
       <TooltipTrigger
         disabled={!launchButtonDisabled}
-        content='RStudio must be running to launch it'
+        content='Environment must be running to launch RStudio'
       >
         {/* tooltip trigger needs a div for some reason */}
         <div>

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -168,7 +168,7 @@ const RStudioButtonRow = (props: {
   const { userApp, workspaceNamespace } = props;
   const [launching, setLaunching] = useState(false);
 
-  const onClickLaunch = withErrorModal(
+  const onClickCreate = withErrorModal(
     {
       title: 'Error Creating RStudio Environment',
       message: 'Please refresh the page.',
@@ -179,7 +179,7 @@ const RStudioButtonRow = (props: {
     }
   );
 
-  const onClickOpen = withErrorModal(
+  const onClickLaunch = withErrorModal(
     {
       title: 'Error Opening RStudio Environment',
       message: 'Please try again.',
@@ -192,50 +192,42 @@ const RStudioButtonRow = (props: {
     }
   );
 
-  const showOpenButton = userApp?.status === AppStatus.RUNNING;
-
-  const launchButtonDisabled = launching || !canCreateApp(userApp);
+  const createButtonDisabled = launching || !canCreateApp(userApp);
+  const launchButtonDisabled = userApp?.status !== AppStatus.RUNNING;
 
   return (
     <FlexRow>
       <TooltipTrigger
-        disabled={false}
-        content='Support for configuring RStudio is not yet available'
+        disabled={!createButtonDisabled}
+        content='An RStudio app exists or is being created'
       >
         {/* tooltip trigger needs a div for some reason */}
         <div>
-          <SettingsButton
-            disabled={true}
-            onClick={() => {}}
-            data-test-id='RStudio-settings-button'
+          <AppsPanelButton
+            disabled={createButtonDisabled}
+            onClick={onClickCreate}
+            icon={faPlay}
+            buttonText={launching ? 'Creating' : 'Create'}
+            data-test-id='RStudio-create-button'
           />
         </div>
       </TooltipTrigger>
       <PauseUserAppButton {...{ userApp }} />
-      {showOpenButton ? (
-        <AppsPanelButton
-          onClick={onClickOpen}
-          icon={faRocket}
-          buttonText='Open'
-          data-test-id='RStudio-open-button'
-        />
-      ) : (
-        <TooltipTrigger
-          disabled={!launchButtonDisabled}
-          content='An RStudio app exists or is being created'
-        >
-          {/* tooltip trigger needs a div for some reason */}
-          <div>
-            <AppsPanelButton
-              disabled={launchButtonDisabled}
-              onClick={onClickLaunch}
-              icon={faPlay}
-              buttonText={launching ? 'Launching' : 'Launch'}
-              data-test-id='RStudio-launch-button'
-            />
-          </div>
-        </TooltipTrigger>
-      )}
+      <TooltipTrigger
+        disabled={!launchButtonDisabled}
+        content='RStudio must be running to launch it'
+      >
+        {/* tooltip trigger needs a div for some reason */}
+        <div>
+          <AppsPanelButton
+            onClick={onClickLaunch}
+            disabled={launchButtonDisabled}
+            icon={faRocket}
+            buttonText='Launch'
+            data-test-id='RStudio-launch-button'
+          />
+        </div>
+      </TooltipTrigger>
     </FlexRow>
   );
 };

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -166,7 +166,7 @@ const RStudioButtonRow = (props: {
   workspaceNamespace: string;
 }) => {
   const { userApp, workspaceNamespace } = props;
-  const [launching, setLaunching] = useState(false);
+  const [creating, setCreating] = useState(false);
 
   const onClickCreate = withErrorModal(
     {
@@ -174,7 +174,7 @@ const RStudioButtonRow = (props: {
       message: 'Please refresh the page.',
     },
     async () => {
-      setLaunching(true);
+      setCreating(true);
       await appsApi().createApp(workspaceNamespace, defaultRStudioConfig);
     }
   );
@@ -192,7 +192,7 @@ const RStudioButtonRow = (props: {
     }
   );
 
-  const createButtonDisabled = launching || !canCreateApp(userApp);
+  const createButtonDisabled = creating || !canCreateApp(userApp);
   const launchButtonDisabled = userApp?.status !== AppStatus.RUNNING;
 
   return (
@@ -207,7 +207,7 @@ const RStudioButtonRow = (props: {
             disabled={createButtonDisabled}
             onClick={onClickCreate}
             icon={faPlay}
-            buttonText={launching ? 'Creating' : 'Create'}
+            buttonText={creating ? 'Creating' : 'Create'}
             data-test-id='RStudio-create-button'
           />
         </div>

--- a/ui/src/testing/stubs/leo-proxy-api-stub.ts
+++ b/ui/src/testing/stubs/leo-proxy-api-stub.ts
@@ -1,0 +1,21 @@
+import { ProxyApi } from 'notebooks-generated/fetch';
+
+import { stubNotImplementedError } from 'testing/stubs/stub-utils';
+
+export class LeoProxyApiStub extends ProxyApi {
+  constructor() {
+    super(undefined, undefined, (..._: any[]) => {
+      throw stubNotImplementedError;
+    });
+  }
+
+  public setCookie(
+    _googleProject: string,
+    _runtimeName: string,
+    _options?: any
+  ): Promise<Response> {
+    return new Promise<Response>((resolve) => {
+      resolve(new Response());
+    });
+  }
+}


### PR DESCRIPTION
Description:

Allows users to open RStudio apps.

Currently the RStudio app opens in a new browser tab since this was very easy to implement as an MVP. After confirming this is OK with Moira, I've [updated the ticket](https://precisionmedicineinitiative.atlassian.net/browse/RW-9613?focusedCommentId=150310) and created a [follow-up story](https://precisionmedicineinitiative.atlassian.net/browse/RW-9664) to show RStudio in the Analysis tab. Let me know if there are reasons we shouldn't do this.

I also moved a test from `apps-panel.spec.tsx` to `expanded-app.spec.tsx` to simplify it.

@jmthibault79 what testing approach did you settle on for Cromwell? Currently, I am planning to create an e2e test in a follow-up PR before marking this story as done.

I think the exact list of changes is well-reflected by the newly-added tests:
<img width="925" alt="image" src="https://user-images.githubusercontent.com/31020403/223223315-c65c7e3a-6916-4d9d-ba9e-4c11337f3d25.png">

Screenshots:
<img width="413" alt="image" src="https://user-images.githubusercontent.com/31020403/223222907-c341b435-01a5-4880-991c-285df5c39295.png">

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/31020403/223230602-41afe65b-a4d9-433b-b2b0-0549691ad49a.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
