### PR TITLE
[RW-9613][risk=no] Create basic RStudio e2e test

### DIFF
--- a/e2e/app/sidebar/applications-panel.ts
+++ b/e2e/app/sidebar/applications-panel.ts
@@ -1,0 +1,24 @@
+import { Page } from 'puppeteer';
+import { SideBarLink } from 'app/text-labels';
+import BaseSidebar from './base-sidebar';
+import { logger } from 'libs/logger';
+
+export default class ApplicationsPanel extends BaseSidebar {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async open(): Promise<void> {
+    const isOpen = await this.isVisible();
+    if (isOpen) {
+      return;
+    }
+    await this.clickIcon(SideBarLink.Applications);
+    await this.getDeleteIcon();
+    const timeoutForDeletion = 3 * 60 * 1000;
+    await this.waitUntilVisible(timeoutForDeletion);
+    // Wait for visible texts
+    await this.page.waitForXPath(`${this.getXpath()}//h3`, { visible: true });
+    logger.info(`Opened "${await this.getTitle()}" sidebar`);
+  }
+}

--- a/e2e/app/sidebar/base-sidebar.ts
+++ b/e2e/app/sidebar/base-sidebar.ts
@@ -49,6 +49,9 @@ export default abstract class BaseSidebar extends Container {
       case SideBarLink.GenomicExtractionsHistory:
         xpath = `${Selectors.rootXpath}//*[@data-test-id="help-sidebar-icon-genomicExtractions"]`;
         break;
+      case SideBarLink.Applications:
+        xpath = `${Selectors.rootXpath}//*[@data-test-id="help-sidebar-icon-apps"]`;
+        break;
       default:
         throw new Error(`SideBarLink case ${sidebarLink} is undefined.`);
     }

--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -161,7 +161,8 @@ export enum SideBarLink {
   HelpTips,
   WorkspaceMenu,
   EditAnnotations,
-  GenomicExtractionsHistory
+  GenomicExtractionsHistory,
+  Applications
 }
 
 export const Institution = {

--- a/e2e/tests/gke-apps/rstudio.spec.ts
+++ b/e2e/tests/gke-apps/rstudio.spec.ts
@@ -1,0 +1,67 @@
+import { findOrCreateWorkspace, signInWithAccessToken } from 'utils/test-utils';
+import ApplicationsPanel from 'app/sidebar/applications-panel';
+import Button from 'app/element/button';
+import BaseElement from 'app/element/base-element';
+import { waitForAsyncFn } from 'utils/waits-utils';
+
+// 10 minutes
+jest.setTimeout(10 * 60 * 1000);
+
+describe('RStudio GKE app', () => {
+  beforeEach(async () => {
+    await signInWithAccessToken(page);
+  });
+
+  const workspaceName = 'e2eCreateRStudioGkeAppTest';
+
+  test('Users can create, launch, and delete an RStudio GKE app', async () => {
+    await findOrCreateWorkspace(page, { workspaceName });
+
+    // Create an RStudio environment
+    const applicationsPanel = new ApplicationsPanel(page);
+    await applicationsPanel.open();
+    const unexpandedRStudioXpath = `${applicationsPanel.getXpath()}//*[@data-test-id="RStudio-unexpanded"]`;
+    const unexpandedRStudio = new Button(page, unexpandedRStudioXpath);
+    await unexpandedRStudio.click();
+    const expandedRStudioXpath = `${applicationsPanel.getXpath()}//*[@data-test-id="RStudio-expanded"]`;
+    const expandedRStudio = new BaseElement(page, expandedRStudioXpath);
+    await new Button(page, `${expandedRStudioXpath}//*[@data-test-id="apps-panel-button-Create"]`).click();
+    await page.reload();
+    expect(await expandedRStudio.getTextContent()).toContain('status: PROVISIONING');
+    const isRunning = await waitForAsyncFn(
+      async () => {
+        await page.reload();
+        return (await expandedRStudio.getTextContent()).includes('status: Running');
+      },
+      10e3, // every 10 sec
+      5 * 60e3 // with a 5 min timeout
+    );
+    expect(isRunning).toBeTruthy();
+
+    // Launch RStudio
+    // This code is hacky, but we expect it to significantly change when we implement RW-9664
+    await new Button(page, `${expandedRStudioXpath}//*[@data-test-id="apps-panel-button-Launch"]`).click();
+    await new Promise((res) => setTimeout(res, 15 * 1000));
+    const pages = await browser.pages();
+    const rstudioTab = pages[2];
+    const rstudioTabTitle = await rstudioTab.title();
+    expect(rstudioTabTitle).toEqual('RStudio Server');
+    await rstudioTab.close();
+
+    // Delete RStudio
+    await new Button(page, `${expandedRStudioXpath}//*[@data-test-id="RStudio-delete-button"]`).click();
+    await page.reload();
+    expect(await expandedRStudio.getTextContent()).toContain('status: DELETING');
+    const isDeleted = await waitForAsyncFn(
+      async () => {
+        await page.reload();
+        // The apps panel displays before all data has loaded. Wait a few seconds before checking for RStudio.
+        await new Promise((res) => setTimeout(res, 10 * 1000));
+        return !(await expandedRStudio.exists()) && (await unexpandedRStudio.exists());
+      },
+      10e3, // every 10 sec
+      3 * 60e3 // with a 3 min timeout
+    );
+    expect(isDeleted).toBeTruthy();
+  });
+});

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -16,6 +16,17 @@ export const waitForFn = async (fn: () => any, interval = 2000, timeout = 10000)
   return false;
 };
 
+export const waitForAsyncFn = async (fn: () => Promise<any>, intervalMs: number, timeoutMs: number): Promise<boolean> => {
+  const start = Date.now();
+  while (Date.now() < start + timeoutMs) {
+    if ((await fn()) === true) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  return false;
+};
+
 /**
  * Wait for the window location to match sub-string.
  * @param {Page} page The Puppeteer Page.

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -5,11 +5,7 @@ import Container from 'app/container';
 import { makeDateTimeStr } from './str-utils';
 import { getAttrValue } from './element-utils';
 
-export const waitForFn = async (
-  fn: () => any,
-  interval = 2000,
-  timeout = 10000
-): Promise<boolean> => {
+export const waitForFn = async (fn: () => any, interval = 2000, timeout = 10000): Promise<boolean> => {
   const start = Date.now();
   while (Date.now() < start + timeout) {
     if (fn()) {
@@ -20,7 +16,11 @@ export const waitForFn = async (
   return false;
 };
 
-export const waitForAsyncFn = async (fn: () => Promise<any>, intervalMs: number, timeoutMs: number): Promise<boolean> => {
+export const waitForAsyncFn = async (
+  fn: () => Promise<any>,
+  intervalMs: number,
+  timeoutMs: number
+): Promise<boolean> => {
   const start = Date.now();
   while (Date.now() < start + timeoutMs) {
     if ((await fn()) === true) {

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -5,7 +5,11 @@ import Container from 'app/container';
 import { makeDateTimeStr } from './str-utils';
 import { getAttrValue } from './element-utils';
 
-export const waitForFn = async (fn: () => any, interval = 2000, timeout = 10000): Promise<boolean> => {
+export const waitForFn = async (
+  fn: () => any,
+  interval = 2000,
+  timeout = 10000
+): Promise<boolean> => {
   const start = Date.now();
   while (Date.now() < start + timeout) {
     if (fn()) {

--- a/ui/src/app/components/apps-panel.spec.tsx
+++ b/ui/src/app/components/apps-panel.spec.tsx
@@ -64,7 +64,7 @@ const findAvailableApps = (wrapper: ReactWrapper, activeAppsExist: boolean) => {
 };
 
 const findUnexpandedApp = (wrapper: ReactWrapper, appName: string) =>
-  wrapper.find({ 'data-test-id': `${appName}-unexpanded` });
+  wrapper.find({ 'data-test-id': `${appName}-unexpanded` }).at(0);
 
 const findExpandedApp = (wrapper: ReactWrapper, appName: string) =>
   wrapper.find({ 'data-test-id': `${appName}-expanded` });
@@ -356,9 +356,11 @@ describe('AppsPanel', () => {
     expect(
       rstudioPanel.find({ 'data-test-id': `apps-panel-button-Resume` }).exists()
     ).toBeFalsy();
-    const pauseButton = rstudioPanel.find({
-      'data-test-id': `apps-panel-button-Pause`,
-    });
+    const pauseButton = rstudioPanel
+      .find({
+        'data-test-id': `apps-panel-button-Pause`,
+      })
+      .at(0);
     expect(pauseButton.exists()).toBeTruthy();
 
     pauseButton.simulate('click');
@@ -382,9 +384,11 @@ describe('AppsPanel', () => {
     expect(
       rstudioPanel.find({ 'data-test-id': `apps-panel-button-Pause` }).exists()
     ).toBeFalsy();
-    const pauseButton = rstudioPanel.find({
-      'data-test-id': `apps-panel-button-Resume`,
-    });
+    const pauseButton = rstudioPanel
+      .find({
+        'data-test-id': `apps-panel-button-Resume`,
+      })
+      .at(0);
     expect(pauseButton.exists()).toBeTruthy();
 
     pauseButton.simulate('click');
@@ -405,9 +409,11 @@ describe('AppsPanel', () => {
     appsStub.deleteApp = jest.fn(() => Promise.resolve({}));
 
     const deleteButton = () =>
-      findExpandedApp(wrapper, 'RStudio').find({
-        'data-test-id': `RStudio-delete-button`,
-      });
+      findExpandedApp(wrapper, 'RStudio')
+        .find({
+          'data-test-id': `RStudio-delete-button`,
+        })
+        .at(0);
     expect(deleteButton().prop('disabled')).toBeFalsy();
     deleteButton().simulate('click');
 

--- a/ui/src/app/components/apps-panel.tsx
+++ b/ui/src/app/components/apps-panel.tsx
@@ -39,7 +39,11 @@ const styles = reactStyles({
 const UnexpandedApp = (props: { appType: UIAppType; onClick: Function }) => {
   const { appType, onClick } = props;
   return (
-    <Clickable {...{ onClick }} data-test-id={`${appType}-unexpanded`}>
+    <Clickable
+      {...{ onClick }}
+      data-test-id={`${appType}-unexpanded`}
+      propagateDataTestId={true}
+    >
       <FlexRow style={styles.availableApp}>
         <AppLogo {...{ appType }} style={{ marginRight: '1em' }} />
       </FlexRow>

--- a/ui/src/app/components/apps-panel/apps-panel-button.tsx
+++ b/ui/src/app/components/apps-panel/apps-panel-button.tsx
@@ -60,6 +60,7 @@ export const AppsPanelButton = (props: Props) => {
       {...{ disabled, onClick }}
       style={{ padding: '0.5em' }}
       data-test-id={`apps-panel-button-${buttonText}`}
+      propagateDataTestId={true}
     >
       <FlexColumn
         style={disabled ? buttonStyles.disabledButton : buttonStyles.button}

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -96,9 +96,11 @@ describe('ExpandedApp', () => {
     const wrapper = await component(UIAppType.JUPYTER, undefined);
     expect(wrapper.exists()).toBeTruthy();
 
-    const pauseButton = wrapper.find({
-      'data-test-id': 'apps-panel-button-Pause',
-    });
+    const pauseButton = wrapper
+      .find({
+        'data-test-id': 'apps-panel-button-Pause',
+      })
+      .at(0);
     expect(pauseButton.exists()).toBeTruthy();
     const { disabled } = pauseButton.props();
     expect(disabled).toBeFalsy();
@@ -120,9 +122,11 @@ describe('ExpandedApp', () => {
     const wrapper = await component(UIAppType.JUPYTER, undefined);
     expect(wrapper.exists()).toBeTruthy();
 
-    const pauseButton = wrapper.find({
-      'data-test-id': 'apps-panel-button-Resume',
-    });
+    const pauseButton = wrapper
+      .find({
+        'data-test-id': 'apps-panel-button-Resume',
+      })
+      .at(0);
     expect(pauseButton.exists()).toBeTruthy();
     const { disabled } = pauseButton.props();
     expect(disabled).toBeFalsy();
@@ -159,9 +163,11 @@ describe('ExpandedApp', () => {
       const wrapper = await component(UIAppType.JUPYTER, undefined);
       expect(wrapper.exists()).toBeTruthy();
 
-      const pauseButton = wrapper.find({
-        'data-test-id': `apps-panel-button-${buttonText}`,
-      });
+      const pauseButton = wrapper
+        .find({
+          'data-test-id': `apps-panel-button-${buttonText}`,
+        })
+        .at(0);
       expect(pauseButton.exists()).toBeTruthy();
       const { disabled } = pauseButton.props();
       expect(disabled).toBeTruthy();
@@ -176,9 +182,11 @@ describe('ExpandedApp', () => {
       const wrapper = await component(UIAppType.JUPYTER, undefined);
       expect(wrapper.exists()).toBeTruthy();
 
-      const deletion = wrapper.find({
-        'data-test-id': 'Jupyter-delete-button',
-      });
+      const deletion = wrapper
+        .find({
+          'data-test-id': 'Jupyter-delete-button',
+        })
+        .at(0);
       expect(deletion.exists()).toBeTruthy();
       const { disabled } = deletion.props();
       expect(disabled).toBeFalsy();
@@ -205,9 +213,11 @@ describe('ExpandedApp', () => {
       const wrapper = await component(UIAppType.JUPYTER, undefined);
       expect(wrapper.exists()).toBeTruthy();
 
-      const deletion = wrapper.find({
-        'data-test-id': 'Jupyter-delete-button',
-      });
+      const deletion = wrapper
+        .find({
+          'data-test-id': 'Jupyter-delete-button',
+        })
+        .at(0);
       expect(deletion.exists()).toBeTruthy();
       const { disabled } = deletion.props();
       expect(disabled).toBeTruthy();
@@ -226,9 +236,11 @@ describe('ExpandedApp', () => {
       });
       expect(wrapper.exists()).toBeTruthy();
 
-      const pauseButton = wrapper.find({
-        'data-test-id': 'apps-panel-button-Pause',
-      });
+      const pauseButton = wrapper
+        .find({
+          'data-test-id': 'apps-panel-button-Pause',
+        })
+        .at(0);
       expect(pauseButton.exists()).toBeTruthy();
       const { disabled } = pauseButton.props();
       expect(disabled).toBeFalsy();
@@ -250,9 +262,11 @@ describe('ExpandedApp', () => {
       });
       expect(wrapper.exists()).toBeTruthy();
 
-      const pauseButton = wrapper.find({
-        'data-test-id': 'apps-panel-button-Resume',
-      });
+      const pauseButton = wrapper
+        .find({
+          'data-test-id': 'apps-panel-button-Resume',
+        })
+        .at(0);
       expect(pauseButton.exists()).toBeTruthy();
       const { disabled } = pauseButton.props();
       expect(disabled).toBeFalsy();
@@ -288,9 +302,11 @@ describe('ExpandedApp', () => {
         });
         expect(wrapper.exists()).toBeTruthy();
 
-        const pauseButton = wrapper.find({
-          'data-test-id': `apps-panel-button-${buttonText}`,
-        });
+        const pauseButton = wrapper
+          .find({
+            'data-test-id': `apps-panel-button-${buttonText}`,
+          })
+          .at(0);
         expect(pauseButton.exists()).toBeTruthy();
         const { disabled } = pauseButton.props();
         expect(disabled).toBeTruthy();
@@ -311,9 +327,11 @@ describe('ExpandedApp', () => {
       });
       expect(wrapper.exists()).toBeTruthy();
 
-      const deletion = wrapper.find({
-        'data-test-id': `${appType}-delete-button`,
-      });
+      const deletion = wrapper
+        .find({
+          'data-test-id': `${appType}-delete-button`,
+        })
+        .at(0);
       expect(deletion.exists()).toBeTruthy();
       const { disabled } = deletion.props();
       expect(disabled).toBeFalsy();
@@ -346,9 +364,11 @@ describe('ExpandedApp', () => {
         });
         expect(wrapper.exists()).toBeTruthy();
 
-        const deletion = wrapper.find({
-          'data-test-id': `${appType}-delete-button`,
-        });
+        const deletion = wrapper
+          .find({
+            'data-test-id': `${appType}-delete-button`,
+          })
+          .at(0);
         expect(deletion.exists()).toBeTruthy();
         const { disabled } = deletion.props();
         expect(disabled).toBeTruthy();

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -297,6 +297,7 @@ export const ExpandedApp = (props: ExpandedAppProps) => {
           }
           onClick={onClickDelete}
           data-test-id={`${appType}-delete-button`}
+          propagateDataTestId={true}
         >
           <FontAwesomeIcon icon={faTrashCan} />
         </Clickable>


### PR DESCRIPTION
Description:

Adds a minimal RStudio e2e test that does the following:
- Creates an RStudio GKE app
- Opens RStudio
- Deletes RStudio

This test runs in about 3 minutes when a K8S cluster already exists in the workspace.

I attempted to make this test as minimal-critical-path as possible to avoid over-testing with e2e tests. Specifically, I did not test pause / resume. If you think I should test pause / resume, let me know.

This test doesn't interact with RStudio in any meaningful way. Once we open RStudio in the app (RW-9664) we should add simple RStudio functionality, such as running a print statement. If we do that now, it's possible we'll need to rewrite that part of the test later, and writing e2e tests at the moment takes awhile.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
