### PR TITLE
[DT-19][risk=no] Modal for adding a concept set as a cohort item

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -216,6 +216,8 @@ public final class DbStorageEnums {
           .put(Domain.FITBIT_SLEEP_LEVEL, (short) 24)
           .put(Domain.LR_WHOLE_GENOME_VARIANT, (short) 25)
           .put(Domain.STRUCTURAL_VARIANT_DATA, (short) 26)
+          .put(Domain.CONCEPT_SET, (short) 27)
+          .put(Domain.CONCEPT_QUICK_ADD, (short) 28)
           .build();
 
   // A mapping from our Domain enum to OMOP domain ID values.
@@ -248,6 +250,8 @@ public final class DbStorageEnums {
           .put(Domain.STRUCTURAL_VARIANT_DATA, "Structural Variant Data")
           .put(Domain.ZIP_CODE_SOCIOECONOMIC, "Zip Code Socioeconomic Status")
           .put(Domain.ARRAY_DATA, "Global Diversity Array")
+          .put(Domain.CONCEPT_SET, "Concept Set")
+          .put(Domain.CONCEPT_QUICK_ADD, "Concept Quick Add")
           .build();
 
   public static Domain domainFromStorage(Short domain) {

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4257,6 +4257,8 @@ definitions:
     - STRUCTURAL_VARIANT_DATA
     - ZIP_CODE_SOCIOECONOMIC
     - ARRAY_DATA
+    - CONCEPT_SET
+    - CONCEPT_QUICK_ADD
   Surveys:
     type: string
     description: a survey for concepts

--- a/ui/src/app/pages/data/cohort/addConceptSetToCohortModal.tsx
+++ b/ui/src/app/pages/data/cohort/addConceptSetToCohortModal.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { useParams } from 'react-router';
+import { Dropdown } from 'primereact/dropdown';
+
+import { ConceptSet, Criteria } from 'generated/fetch';
+
+import { AlertWarning } from 'app/components/alert';
+import { Button } from 'app/components/buttons';
+import {
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalTitle,
+} from 'app/components/modals';
+import { TooltipTrigger } from 'app/components/popups';
+import { Spinner } from 'app/components/spinners';
+import { saveCriteria } from 'app/pages/data/cohort/cohort-search';
+import { conceptSetsApi } from 'app/services/swagger-fetch-clients';
+import { MatchParams } from 'app/utils/stores';
+
+const { useEffect, useState } = React;
+
+export const AddConceptSetToCohortModal = ({ onClose }) => {
+  const { ns, wsid } = useParams<MatchParams>();
+  const [conceptSets, setConceptSets] = useState<ConceptSet[]>();
+  const [selectedConceptSetIndex, setSelectedConceptSetIndex] =
+    useState<number>(-1);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [saveError, setSaveError] = useState<boolean>(false);
+  const [saving, setSaving] = useState<boolean>(false);
+
+  const getConceptSets = async () => {
+    try {
+      const conceptSetsResponse =
+        await conceptSetsApi().getConceptSetsInWorkspace(ns, wsid);
+      setConceptSets(conceptSetsResponse.items);
+      setLoading(false);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    getConceptSets();
+  }, []);
+
+  const getParamId = ({ code, conceptId, id, isStandard }: Criteria) => {
+    return `param${conceptId ? conceptId + code : id}${isStandard}`;
+  };
+
+  const addConceptSetAsItem = async () => {
+    setSaving(true);
+    const selectedConceptSet = await conceptSetsApi().getConceptSet(
+      ns,
+      wsid,
+      conceptSets[selectedConceptSetIndex].id
+    );
+    if (selectedConceptSet) {
+      saveCriteria(
+        selectedConceptSet.criteriums.map((crit) => ({
+          parameterId: getParamId(crit),
+          ...crit,
+        }))
+      );
+    } else {
+      setSaveError(true);
+    }
+    setSaving(false);
+  };
+
+  return (
+    <Modal>
+      <ModalTitle data-test-id='add-concept-title'>
+        Concept sets created from this workspace
+      </ModalTitle>
+      {loading ? (
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <Spinner style={{ alignContent: 'center' }} />
+        </div>
+      ) : (
+        <>
+          <ModalBody>
+            {saveError && (
+              <AlertWarning>
+                Sorry, the request cannot be completed. Please try again or
+                contact Support in the left hand navigation.
+              </AlertWarning>
+            )}
+            <Dropdown
+              style={{
+                height: '2.25rem',
+                width: '100%',
+              }}
+              value={selectedConceptSetIndex}
+              options={conceptSets.map((set: ConceptSet, i) => ({
+                label: set.name,
+                value: i,
+              }))}
+              onChange={(e) => setSelectedConceptSetIndex(e.value)}
+              placeholder='Select Concept Set'
+            />
+          </ModalBody>
+          <ModalFooter>
+            <Button type='secondary' disabled={saving} onClick={onClose}>
+              Cancel
+            </Button>
+            <TooltipTrigger
+              content={<div>No concept set selected</div>}
+              disabled={selectedConceptSetIndex > -1}
+            >
+              <Button
+                style={{ marginLeft: '0.75rem' }}
+                disabled={selectedConceptSetIndex === -1 || saving}
+                onClick={() => addConceptSetAsItem()}
+              >
+                {saving && (
+                  <Spinner size={16} style={{ marginRight: '0.25rem' }} />
+                )}
+                Add
+              </Button>
+            </TooltipTrigger>
+          </ModalFooter>
+        </>
+      )}
+    </Modal>
+  );
+};

--- a/ui/src/app/pages/data/cohort/cohort-search.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-search.tsx
@@ -165,11 +165,12 @@ interface Props extends RouteComponentProps<MatchParams> {
 }
 
 interface State {
-  toastVisible: boolean;
+  initCriteriaSearch: boolean;
   selectedIds: Array<string>;
   selections: Array<Selection>;
   showAddConceptSetModal: boolean;
   showUnsavedModal: boolean;
+  toastVisible: boolean;
   unsavedChanges: boolean;
 }
 
@@ -184,11 +185,12 @@ export const CohortSearch = fp.flow(
     constructor(props: Props) {
       super(props);
       this.state = {
-        toastVisible: false,
+        initCriteriaSearch: false,
         selectedIds: [],
         selections: [],
         showAddConceptSetModal: false,
         showUnsavedModal: false,
+        toastVisible: false,
         unsavedChanges: false,
       };
     }
@@ -213,6 +215,8 @@ export const CohortSearch = fp.flow(
         this.selectStructuralVariantData();
       } else if (domain === 'CONCEPT_SET') {
         this.setState({ showAddConceptSetModal: true });
+      } else {
+        this.setState({ initCriteriaSearch: true });
       }
 
       currentCohortCriteriaStore.next(selections);
@@ -457,11 +461,12 @@ export const CohortSearch = fp.flow(
         cohortContext: { domain, type },
       } = this.props;
       const {
-        toastVisible,
+        initCriteriaSearch,
         selectedIds,
         selections,
         showAddConceptSetModal,
         showUnsavedModal,
+        toastVisible,
       } = this.state;
       return (
         !!cohortContext && (
@@ -515,11 +520,13 @@ export const CohortSearch = fp.flow(
                         />
                       </div>
                     ) : (
-                      <CriteriaSearch
-                        backFn={() => this.checkUnsavedChanges()}
-                        cohortContext={cohortContext}
-                        conceptSearchTerms={cohortContext.searchTerms}
-                      />
+                      initCriteriaSearch && (
+                        <CriteriaSearch
+                          backFn={() => this.checkUnsavedChanges()}
+                          cohortContext={cohortContext}
+                          conceptSearchTerms={cohortContext.searchTerms}
+                        />
+                      )
                     )}
                   </div>
                 </div>

--- a/ui/src/app/pages/data/cohort/cohort-search.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-search.tsx
@@ -18,6 +18,7 @@ import {
   ModalFooter,
   ModalTitle,
 } from 'app/components/modals';
+import { AddConceptSetToCohortModal } from 'app/pages/data/cohort/addConceptSetToCohortModal';
 import { Demographics } from 'app/pages/data/cohort/demographics';
 import { searchRequestStore } from 'app/pages/data/cohort/search-state.service';
 import { Selection } from 'app/pages/data/cohort/selection-list';
@@ -131,6 +132,9 @@ export function saveCriteria(selections?: Array<Selection>) {
     currentCohortSearchContextStore.getValue();
   AnalyticsTracker.CohortBuilder.SaveCriteria(domainToTitle(domain));
   const searchRequest = searchRequestStore.getValue();
+  if (domain === 'CONCEPT_SET') {
+    item.type = selections[0]?.domainId;
+  }
   item.searchParameters = selections || currentCohortCriteriaStore.getValue();
   if (groupId) {
     const groupIndex = searchRequest[role].findIndex(
@@ -164,6 +168,7 @@ interface State {
   toastVisible: boolean;
   selectedIds: Array<string>;
   selections: Array<Selection>;
+  showAddConceptSetModal: boolean;
   showUnsavedModal: boolean;
   unsavedChanges: boolean;
 }
@@ -182,6 +187,7 @@ export const CohortSearch = fp.flow(
         toastVisible: false,
         selectedIds: [],
         selections: [],
+        showAddConceptSetModal: false,
         showUnsavedModal: false,
         unsavedChanges: false,
       };
@@ -205,6 +211,8 @@ export const CohortSearch = fp.flow(
         this.selectArrayData();
       } else if (domain === Domain.STRUCTURALVARIANTDATA) {
         this.selectStructuralVariantData();
+      } else if (domain === 'CONCEPT_SET') {
+        this.setState({ showAddConceptSetModal: true });
       }
 
       currentCohortCriteriaStore.next(selections);
@@ -448,92 +456,107 @@ export const CohortSearch = fp.flow(
         cohortContext,
         cohortContext: { domain, type },
       } = this.props;
-      const { toastVisible, selectedIds, selections, showUnsavedModal } =
-        this.state;
+      const {
+        toastVisible,
+        selectedIds,
+        selections,
+        showAddConceptSetModal,
+        showUnsavedModal,
+      } = this.state;
       return (
         !!cohortContext && (
-          <FlexRowWrap style={styles.searchContainer}>
-            <style>{toastCSS}</style>
-            <Toast
-              ref={(el) => (this.toast = el)}
-              style={
-                !toastVisible
-                  ? { ...styles.toast, display: 'none' }
-                  : styles.toast
-              }
-            />
-            <div id='cohort-search-container' style={styles.searchContent}>
-              {domain === Domain.PERSON && (
-                <div style={styles.titleBar}>
-                  <Clickable
-                    data-test-id='cohort-search-back-arrow'
-                    style={styles.backArrow}
-                    onClick={() => this.checkUnsavedChanges()}
+          <>
+            {showAddConceptSetModal ? (
+              <AddConceptSetToCohortModal
+                onClose={() => currentCohortSearchContextStore.next(undefined)}
+              />
+            ) : (
+              <FlexRowWrap style={styles.searchContainer}>
+                <style>{toastCSS}</style>
+                <Toast
+                  ref={(el) => (this.toast = el)}
+                  style={
+                    !toastVisible
+                      ? { ...styles.toast, display: 'none' }
+                      : styles.toast
+                  }
+                />
+                <div id='cohort-search-container' style={styles.searchContent}>
+                  {domain === Domain.PERSON && (
+                    <div style={styles.titleBar}>
+                      <Clickable
+                        data-test-id='cohort-search-back-arrow'
+                        style={styles.backArrow}
+                        onClick={() => this.checkUnsavedChanges()}
+                      >
+                        <img
+                          src={arrowIcon}
+                          style={styles.arrowIcon}
+                          alt='Go back'
+                        />
+                      </Clickable>
+                      <h2 style={styles.titleHeader}>{typeToTitle(type)}</h2>
+                    </div>
+                  )}
+                  <div
+                    style={
+                      domain === Domain.PERSON && type !== CriteriaType.AGE
+                        ? { marginBottom: '5.25rem' }
+                        : { height: 'calc(100% - 5.25rem)' }
+                    }
                   >
-                    <img
-                      src={arrowIcon}
-                      style={styles.arrowIcon}
-                      alt='Go back'
-                    />
-                  </Clickable>
-                  <h2 style={styles.titleHeader}>{typeToTitle(type)}</h2>
-                </div>
-              )}
-              <div
-                style={
-                  domain === Domain.PERSON && type !== CriteriaType.AGE
-                    ? { marginBottom: '5.25rem' }
-                    : { height: 'calc(100% - 5.25rem)' }
-                }
-              >
-                {domain === Domain.PERSON ? (
-                  <div data-test-id='demographics'>
-                    <Demographics
-                      criteriaType={type}
-                      select={this.addSelection}
-                      selectedIds={selectedIds}
-                      selections={selections}
-                    />
+                    {domain === Domain.PERSON ? (
+                      <div data-test-id='demographics'>
+                        <Demographics
+                          criteriaType={type}
+                          select={this.addSelection}
+                          selectedIds={selectedIds}
+                          selections={selections}
+                        />
+                      </div>
+                    ) : (
+                      <CriteriaSearch
+                        backFn={() => this.checkUnsavedChanges()}
+                        cohortContext={cohortContext}
+                        conceptSearchTerms={cohortContext.searchTerms}
+                      />
+                    )}
                   </div>
-                ) : (
-                  <CriteriaSearch
-                    backFn={() => this.checkUnsavedChanges()}
-                    cohortContext={cohortContext}
-                    conceptSearchTerms={cohortContext.searchTerms}
-                  />
+                </div>
+                <Button
+                  type='primary'
+                  style={styles.finishButton}
+                  disabled={!!selectedIds && selectedIds.length === 0}
+                  onClick={() => setSidebarActiveIconStore.next('criteria')}
+                >
+                  Finish & Review
+                </Button>
+                {showUnsavedModal && (
+                  <Modal>
+                    <ModalTitle>Warning! </ModalTitle>
+                    <ModalBody data-test-id='cohort-search-unsaved-message'>
+                      Your cohort has not been saved. If you’d like to save your
+                      cohort criteria, please click CANCEL and save your changes
+                      in the right sidebar.
+                    </ModalBody>
+                    <ModalFooter>
+                      <Button
+                        type='link'
+                        onClick={() =>
+                          this.setState({ showUnsavedModal: false })
+                        }
+                      >
+                        Cancel
+                      </Button>
+                      <Button type='primary' onClick={() => this.closeSearch()}>
+                        Discard Changes
+                      </Button>
+                    </ModalFooter>
+                  </Modal>
                 )}
-              </div>
-            </div>
-            <Button
-              type='primary'
-              style={styles.finishButton}
-              disabled={!!selectedIds && selectedIds.length === 0}
-              onClick={() => setSidebarActiveIconStore.next('criteria')}
-            >
-              Finish & Review
-            </Button>
-            {showUnsavedModal && (
-              <Modal>
-                <ModalTitle>Warning! </ModalTitle>
-                <ModalBody data-test-id='cohort-search-unsaved-message'>
-                  Your cohort has not been saved. If you’d like to save your
-                  cohort criteria, please click CANCEL and save your changes in
-                  the right sidebar.
-                </ModalBody>
-                <ModalFooter>
-                  <Button
-                    type='link'
-                    onClick={() => this.setState({ showUnsavedModal: false })}
-                  >
-                    Cancel
-                  </Button>
-                  <Button type='primary' onClick={() => this.closeSearch()}>
-                    Discard Changes
-                  </Button>
-                </ModalFooter>
-              </Modal>
+              </FlexRowWrap>
             )}
-          </FlexRowWrap>
+          </>
         )
       );
     }

--- a/ui/src/app/pages/data/cohort/cohort-search.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-search.tsx
@@ -132,7 +132,7 @@ export function saveCriteria(selections?: Array<Selection>) {
     currentCohortSearchContextStore.getValue();
   AnalyticsTracker.CohortBuilder.SaveCriteria(domainToTitle(domain));
   const searchRequest = searchRequestStore.getValue();
-  if (domain === 'CONCEPT_SET') {
+  if (domain === Domain.CONCEPTSET) {
     item.type = selections[0]?.domainId;
   }
   item.searchParameters = selections || currentCohortCriteriaStore.getValue();
@@ -213,7 +213,7 @@ export const CohortSearch = fp.flow(
         this.selectArrayData();
       } else if (domain === Domain.STRUCTURALVARIANTDATA) {
         this.selectStructuralVariantData();
-      } else if (domain === 'CONCEPT_SET') {
+      } else if (domain === Domain.CONCEPTSET) {
         this.setState({ showAddConceptSetModal: true });
       } else {
         this.setState({ initCriteriaSearch: true });


### PR DESCRIPTION
Add modal for selecting a concept set to add as a cohort line item. Concept menu items will only show when `enableConceptSetsInCohortBuilder` flag is enabled

https://user-images.githubusercontent.com/40036095/224393936-2fc0f20c-0b2d-4aa6-90ac-ba4d85f27f4e.mov

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
