### PR TITLE
[RW-9582][risk=no] Re-enable and fix ApplicationTest

### DIFF
--- a/api/src/integration/java/org/pmiops/workbench/ApplicationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/ApplicationTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,7 +15,6 @@ import org.springframework.stereotype.Component;
  * This test that all application injection is done properly. It loads all JPA repositories,
  * Services, Controllers, Components and Configurations.
  */
-@Disabled
 @SpringBootTest
 public class ApplicationTest {
 
@@ -30,8 +28,6 @@ public class ApplicationTest {
    * of spring.datasource.platform. This allows you to switch to database-specific scripts if
    * necessary. For example, you might choose to set it to the vendor name of the database (hsqldb,
    * h2, oracle, mysql, postgresql, and so on).
-   *
-   * <p>Ignoring this test due to observed flakiness and false positives. RW-4806
    */
   @Test
   public void contextLoads() {

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrDataSource.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrDataSource.java
@@ -12,7 +12,6 @@ import javax.persistence.TypedQuery;
 import javax.sql.DataSource;
 import org.apache.tomcat.jdbc.pool.PoolConfiguration;
 import org.apache.tomcat.jdbc.pool.PoolProperties;
-import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -25,18 +24,15 @@ public class CdrDataSource extends AbstractRoutingDataSource {
 
   private static final Logger log = Logger.getLogger(CdrDataSource.class.getName());
 
-  private final CdrVersionDao cdrVersionDao;
   private final PoolConfiguration basePoolConfig;
   private final PoolConfiguration cdrPoolConfig;
   private final EntityManagerFactory emFactory;
 
   CdrDataSource(
-      CdrVersionDao cdrVersionDao,
       @Qualifier("poolConfiguration") PoolConfiguration basePoolConfig,
       @Qualifier("cdrPoolConfiguration") PoolConfiguration cdrPoolConfig,
       // Using CdrDbConfig.cdrEntityManagerFactory would cause a circular dependency.
       @Qualifier("entityManagerFactory") EntityManagerFactory emFactory) {
-    this.cdrVersionDao = cdrVersionDao;
     this.basePoolConfig = basePoolConfig;
     this.cdrPoolConfig = cdrPoolConfig;
     this.emFactory = emFactory;

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrDataSource.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrDataSource.java
@@ -1,10 +1,14 @@
 package org.pmiops.workbench.cdr;
 
-import java.util.HashMap;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceException;
+import javax.persistence.TypedQuery;
 import javax.sql.DataSource;
 import org.apache.tomcat.jdbc.pool.PoolConfiguration;
 import org.apache.tomcat.jdbc.pool.PoolProperties;
@@ -13,22 +17,8 @@ import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.jdbc.DataSourceBuilder;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.stereotype.Service;
-import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
-import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
-import org.springframework.context.annotation.Bean;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.TypedQuery;
-import java.util.List;
-import javax.persistence.EntityManager;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
-import java.sql.SQLException;
-import javax.persistence.PersistenceException;
 
 @Service("cdrDataSource")
 public class CdrDataSource extends AbstractRoutingDataSource {

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrDataSource.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrDataSource.java
@@ -1,0 +1,125 @@
+package org.pmiops.workbench.cdr;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import javax.sql.DataSource;
+import org.apache.tomcat.jdbc.pool.PoolConfiguration;
+import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.pmiops.workbench.db.dao.CdrVersionDao;
+import org.pmiops.workbench.db.model.DbCdrVersion;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.stereotype.Service;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.context.annotation.Bean;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.TypedQuery;
+import java.util.List;
+import javax.persistence.EntityManager;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.sql.SQLException;
+import javax.persistence.PersistenceException;
+
+@Service("cdrDataSource")
+public class CdrDataSource extends AbstractRoutingDataSource {
+
+  private static final Logger log = Logger.getLogger(CdrDataSource.class.getName());
+
+  private final CdrVersionDao cdrVersionDao;
+  private final PoolConfiguration basePoolConfig;
+  private final PoolConfiguration cdrPoolConfig;
+  private final EntityManagerFactory emFactory;
+
+  CdrDataSource(
+      CdrVersionDao cdrVersionDao,
+      @Qualifier("poolConfiguration") PoolConfiguration basePoolConfig,
+      @Qualifier("cdrPoolConfiguration") PoolConfiguration cdrPoolConfig,
+      // Using CdrDbConfig.cdrEntityManagerFactory would cause a circular dependency.
+      @Qualifier("entityManagerFactory") EntityManagerFactory emFactory) {
+    this.cdrVersionDao = cdrVersionDao;
+    this.basePoolConfig = basePoolConfig;
+    this.cdrPoolConfig = cdrPoolConfig;
+    this.emFactory = emFactory;
+    resetTargetDataSources();
+  }
+
+  List<DbCdrVersion> getCdrVersions() {
+    EntityManager em = emFactory.createEntityManager();
+    String jpql = "SELECT v FROM DbCdrVersion v";
+    TypedQuery<DbCdrVersion> query = em.createQuery(jpql, DbCdrVersion.class);
+    try {
+      return query.getResultList();
+    } catch (PersistenceException e) {
+      // This emits "Table 'CDR_VERSION' not found" before throwing to this catch, so it is not
+      // necessary to warn further.
+      return new ArrayList<>();
+    }
+  }
+
+  void resetTargetDataSources() {
+    String dbUser = cdrPoolConfig.getUsername();
+    String dbPassword = cdrPoolConfig.getPassword();
+    String originalDbUrl = cdrPoolConfig.getUrl();
+
+    // Build a map of CDR version ID -> DataSource for use later, based on all the entries in the
+    // cdr_version table. Note that if new CDR versions are inserted, we need to restart the
+    // server in order for it to be used.
+    // TODO: find a way to make sure CDR versions aren't shown in the UI until they are in use by
+    // all servers.
+    Map<Object, Object> cdrVersionDataSourceMap = new HashMap<>();
+    for (DbCdrVersion cdrVersion : getCdrVersions()) {
+      int slashIndex = originalDbUrl.lastIndexOf('/');
+      String dbUrl =
+          originalDbUrl.substring(0, slashIndex + 1) + cdrVersion.getCdrDbName() + "?useSSL=false";
+      DataSource dataSource =
+          DataSourceBuilder.create()
+              .driverClassName(basePoolConfig.getDriverClassName())
+              .username(dbUser)
+              .password(dbPassword)
+              .url(dbUrl)
+              .build();
+      if (dataSource instanceof org.apache.tomcat.jdbc.pool.DataSource) {
+        org.apache.tomcat.jdbc.pool.DataSource tomcatSource =
+            (org.apache.tomcat.jdbc.pool.DataSource) dataSource;
+        // A Tomcat DataSource implements PoolConfiguration, therefore these pool parameters can
+        // normally be populated via @ConfigurationProperties. Since we are directly initializing
+        // DataSources here without a hook to @ConfigurationProperties, we instead need to
+        // explicitly initialize the pool parameters here. We override the primary connection
+        // info, as the autowired PoolConfiguration is initialized from the same set of properties
+        // as the workbench DB.
+        PoolConfiguration cdrPool = new PoolProperties();
+        BeanUtils.copyProperties(basePoolConfig, cdrPool);
+        cdrPool.setUsername(dbUser);
+        cdrPool.setPassword(dbPassword);
+        cdrPool.setUrl(dbUrl);
+        tomcatSource.setPoolProperties(cdrPool);
+
+        // The Spring autowiring is a bit of a maze here, log something concrete which will allow
+        // verification that the DB settings in application.properties are actually being loaded.
+        log.info("using Tomcat pool for CDR data source, with minIdle: " + cdrPool.getMinIdle());
+      } else {
+        log.warning(
+            "not using Tomcat pool or initializing pool configuration; "
+                + "this should only happen within tests");
+      }
+
+      cdrVersionDataSourceMap.put(cdrVersion.getCdrVersionId(), dataSource);
+    }
+    setTargetDataSources(cdrVersionDataSourceMap);
+  }
+
+  @Override
+  protected Object determineCurrentLookupKey() {
+    return CdrVersionContext.getCdrVersion().getCdrVersionId();
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
@@ -1,27 +1,18 @@
 package org.pmiops.workbench.cdr;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.logging.Logger;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 import org.apache.tomcat.jdbc.pool.PoolConfiguration;
 import org.apache.tomcat.jdbc.pool.PoolProperties;
-import org.pmiops.workbench.db.dao.CdrVersionDao;
-import org.pmiops.workbench.db.model.DbCdrVersion;
-import org.springframework.beans.BeanUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
-import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -37,79 +28,6 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  */
 public class CdrDbConfig {
   private static final Logger log = Logger.getLogger(CdrDbConfig.class.getName());
-
-  @Service
-  public static class CdrDataSource extends AbstractRoutingDataSource {
-    @Autowired
-    public CdrDataSource(
-        CdrVersionDao cdrVersionDao,
-        @Qualifier("poolConfiguration") PoolConfiguration basePoolConfig,
-        @Qualifier("cdrPoolConfiguration") PoolConfiguration cdrPoolConfig) {
-      String dbUser = cdrPoolConfig.getUsername();
-      String dbPassword = cdrPoolConfig.getPassword();
-      String originalDbUrl = cdrPoolConfig.getUrl();
-
-      // Build a map of CDR version ID -> DataSource for use later, based on all the entries in the
-      // cdr_version table. Note that if new CDR versions are inserted, we need to restart the
-      // server in order for it to be used.
-      // TODO: find a way to make sure CDR versions aren't shown in the UI until they are in use by
-      // all servers.
-      Map<Object, Object> cdrVersionDataSourceMap = new HashMap<>();
-      for (DbCdrVersion cdrVersion : cdrVersionDao.findAll()) {
-        int slashIndex = originalDbUrl.lastIndexOf('/');
-        String dbUrl =
-            originalDbUrl.substring(0, slashIndex + 1)
-                + cdrVersion.getCdrDbName()
-                + "?useSSL=false";
-        DataSource dataSource =
-            DataSourceBuilder.create()
-                .driverClassName(basePoolConfig.getDriverClassName())
-                .username(dbUser)
-                .password(dbPassword)
-                .url(dbUrl)
-                .build();
-        if (dataSource instanceof org.apache.tomcat.jdbc.pool.DataSource) {
-          org.apache.tomcat.jdbc.pool.DataSource tomcatSource =
-              (org.apache.tomcat.jdbc.pool.DataSource) dataSource;
-          // A Tomcat DataSource implements PoolConfiguration, therefore these pool parameters can
-          // normally be populated via @ConfigurationProperties. Since we are directly initializing
-          // DataSources here without a hook to @ConfigurationProperties, we instead need to
-          // explicitly initialize the pool parameters here. We override the primary connection
-          // info, as the autowired PoolConfiguration is initialized from the same set of properties
-          // as the workbench DB.
-          PoolConfiguration cdrPool = new PoolProperties();
-          BeanUtils.copyProperties(basePoolConfig, cdrPool);
-          cdrPool.setUsername(dbUser);
-          cdrPool.setPassword(dbPassword);
-          cdrPool.setUrl(dbUrl);
-          tomcatSource.setPoolProperties(cdrPool);
-
-          // The Spring autowiring is a bit of a maze here, log something concrete which will allow
-          // verification that the DB settings in application.properties are actually being loaded.
-          log.info("using Tomcat pool for CDR data source, with minIdle: " + cdrPool.getMinIdle());
-        } else {
-          log.warning(
-              "not using Tomcat pool or initializing pool configuration; "
-                  + "this should only happen within tests");
-        }
-
-        cdrVersionDataSourceMap.put(cdrVersion.getCdrVersionId(), dataSource);
-      }
-
-      setTargetDataSources(cdrVersionDataSourceMap);
-      afterPropertiesSet();
-    }
-
-    @Override
-    protected Object determineCurrentLookupKey() {
-      return CdrVersionContext.getCdrVersion().getCdrVersionId();
-    }
-  }
-
-  @Bean("cdrDataSource")
-  public DataSource cdrDataSource(CdrDataSource cdrDataSource) {
-    return cdrDataSource;
-  }
 
   @Bean(name = "cdrEntityManagerFactory")
   public LocalContainerEntityManagerFactoryBean getCdrEntityManagerFactory(


### PR DESCRIPTION
Re-enable Spring's no-op integration test to allow for more of this style of testing. This is needed to test the functionality of RW-9582.

CDR criteria loads:
![Screen Shot 2023-03-16 at 11 35 35](https://user-images.githubusercontent.com/1545444/225670218-6750cdbf-3a7b-4378-91b0-0f5614aa26c1.png)

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
