### PR TITLE
[risk=low][no ticket] e2e: waitForFn does not await

### DIFF
--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { Dialog, ElementHandle, Frame, Page } from 'puppeteer';
 import { getPropValue } from 'utils/element-utils';
-import { waitForDocumentTitle, waitForFn, waitForNumericalString, waitWhileLoading } from 'utils/waits-utils';
+import { waitForDocumentTitle, badWaitForFn, waitForNumericalString, waitWhileLoading } from 'utils/waits-utils';
 import { ResourceCard } from 'app/text-labels';
 import RuntimePanel, { StartStopIconState } from 'app/sidebar/runtime-panel';
 import NotebookCell, { CellType } from './notebook-cell';
@@ -161,7 +161,7 @@ export default class NotebookPage extends NotebookFrame {
     // Wait for file existence locally, to confirm download completion.
     const downloadFilename = path.join(downloadPath, filename);
     expect(
-      await waitForFn(() => fs.existsSync(downloadFilename), /* interval */ undefined, /* timeout */ 90 * 1000)
+      await badWaitForFn(() => fs.existsSync(downloadFilename), /* interval */ undefined, /* timeout */ 90 * 1000)
     ).toBeTruthy();
 
     const downloadSizeMB = fs.statSync(downloadFilename).size / 1e6;
@@ -580,7 +580,7 @@ export default class NotebookPage extends NotebookFrame {
     const fileSize = await getPropValue(fileSizeElement, 'textContent');
 
     // Fail if upload proceeded without a dialog prompt.
-    expect(await waitForFn(() => sawDialog)).toBeTruthy();
+    expect(await badWaitForFn(() => sawDialog)).toBeTruthy();
 
     await newPage.close();
     await this.page.bringToFront();

--- a/e2e/utils/waits-utils.ts
+++ b/e2e/utils/waits-utils.ts
@@ -5,10 +5,22 @@ import Container from 'app/container';
 import { makeDateTimeStr } from './str-utils';
 import { getAttrValue } from './element-utils';
 
-export const waitForFn = async (fn: () => any, interval = 2000, timeout = 10000): Promise<boolean> => {
+// does not await async functions - DO NOT USE
+export const badWaitForFn = async (fn: () => any, interval = 2000, timeout = 10000): Promise<boolean> => {
   const start = Date.now();
   while (Date.now() < start + timeout) {
     if (fn()) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+  return false;
+};
+
+export const waitForFn = async (fn: () => Promise<boolean>, interval = 2000, timeout = 10000): Promise<boolean> => {
+  const start = Date.now();
+  while (Date.now() < start + timeout) {
+    if (await fn()) {
       return true;
     }
     await new Promise((resolve) => setTimeout(resolve, interval));


### PR DESCRIPTION
mark the old bad version as "badWaitForFn()" and update to the corrected waitForFn() calls where possible

Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
