### PR TITLE
[RW-9520][risk=no] Added API Exception Handling for Leonardo Conflicts

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
@@ -39,6 +39,10 @@ public class ExceptionUtils {
     throw new ServerErrorException(e);
   }
 
+  public static boolean isConflictException(Throwable e) {
+    return (e instanceof ConflictException);
+  }
+
   public static boolean isSocketTimeoutException(Throwable e) {
     return (e instanceof SocketTimeoutException);
   }
@@ -62,6 +66,10 @@ public class ExceptionUtils {
       org.pmiops.workbench.leonardo.ApiException e) {
     if (isSocketTimeoutException(e.getCause())) {
       throw new GatewayTimeoutException();
+    }
+    if (isConflictException(e.getCause())) {
+      throw new ConflictException(
+          "Please wait a few minutes and try to create your environment again.");
     }
     throw codeToException(e.getCode());
   }

--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
@@ -32,7 +32,7 @@ public class ExceptionUtils {
     if (isGoogleServiceUnavailableException(e)) {
       throw new ServerUnavailableException(e);
     } else if (isGoogleConflictException(e)) {
-      throw new ConflictException(e);
+      throw new ConflictException("eee");
     } else if (e instanceof TokenResponseException) {
       throw codeToException(((TokenResponseException) e).getStatusCode());
     }
@@ -67,7 +67,7 @@ public class ExceptionUtils {
     if (isSocketTimeoutException(e.getCause())) {
       throw new GatewayTimeoutException();
     }
-    if (isConflictException(e.getCause())) {
+    if (e.getCode() == HttpServletResponse.SC_CONFLICT) {
       throw new ConflictException(
           "Please wait a few minutes and try to create your environment again.");
     }

--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
@@ -32,15 +32,11 @@ public class ExceptionUtils {
     if (isGoogleServiceUnavailableException(e)) {
       throw new ServerUnavailableException(e);
     } else if (isGoogleConflictException(e)) {
-      throw new ConflictException("eee");
+      throw new ConflictException(e);
     } else if (e instanceof TokenResponseException) {
       throw codeToException(((TokenResponseException) e).getStatusCode());
     }
     throw new ServerErrorException(e);
-  }
-
-  public static boolean isConflictException(Throwable e) {
-    return (e instanceof ConflictException);
   }
 
   public static boolean isSocketTimeoutException(Throwable e) {

--- a/api/src/test/java/org/pmiops/workbench/exceptions/ExceptionUtilsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/exceptions/ExceptionUtilsTest.java
@@ -14,4 +14,10 @@ public class ExceptionUtilsTest {
     assertThrows(
         GatewayTimeoutException.class, () -> ExceptionUtils.convertNotebookException(cause));
   }
+
+  @Test
+  public void convertLeonardoConflictException() throws Exception {
+    ApiException cause = new ApiException(new ConflictException());
+    assertThrows(AppConflictException.class, () -> ExceptionUtils.convertNotebookException(cause));
+  }
 }

--- a/api/src/test/java/org/pmiops/workbench/exceptions/ExceptionUtilsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/exceptions/ExceptionUtilsTest.java
@@ -3,21 +3,27 @@ package org.pmiops.workbench.exceptions;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.SocketTimeoutException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.pmiops.workbench.notebooks.ApiException;
 
 public class ExceptionUtilsTest {
 
   @Test
   public void convertNotebookException() throws Exception {
-    ApiException cause = new ApiException(new SocketTimeoutException());
+    org.pmiops.workbench.notebooks.ApiException cause =
+        new org.pmiops.workbench.notebooks.ApiException(new SocketTimeoutException());
     assertThrows(
         GatewayTimeoutException.class, () -> ExceptionUtils.convertNotebookException(cause));
   }
 
   @Test
   public void convertLeonardoConflictException() throws Exception {
-    ApiException cause = new ApiException(new ConflictException());
-    assertThrows(AppConflictException.class, () -> ExceptionUtils.convertNotebookException(cause));
+    org.pmiops.workbench.leonardo.ApiException cause =
+        new org.pmiops.workbench.leonardo.ApiException(new ConflictException());
+    WorkbenchException leonardoException =
+        assertThrows(ConflictException.class, () -> ExceptionUtils.convertLeonardoException(cause));
+    Assertions.assertEquals(
+        leonardoException.getMessage(),
+        "Please wait a few minutes and try to create your environment again.");
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/exceptions/ExceptionUtilsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/exceptions/ExceptionUtilsTest.java
@@ -19,7 +19,7 @@ public class ExceptionUtilsTest {
   @Test
   public void convertLeonardoConflictException() throws Exception {
     org.pmiops.workbench.leonardo.ApiException cause =
-        new org.pmiops.workbench.leonardo.ApiException(new ConflictException());
+        new org.pmiops.workbench.leonardo.ApiException(409, "Conflict exception");
     WorkbenchException leonardoException =
         assertThrows(ConflictException.class, () -> ExceptionUtils.convertLeonardoException(cause));
     Assertions.assertEquals(


### PR DESCRIPTION
Description:
Added functionality to convert Leonardo conflict exceptions to a human readable error.
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
