### PR TITLE
[RW-9614][risk=no] Open the Cromwell config panel after clicking the unexpanded app

### DIFF
--- a/ui/src/app/components/apps-panel.spec.tsx
+++ b/ui/src/app/components/apps-panel.spec.tsx
@@ -259,7 +259,7 @@ describe('AppsPanel', () => {
     expect(findAvailableApps(wrapper, false).exists()).toBeTruthy();
   });
 
-  it('should allow a user to expand available apps', async () => {
+  it('should allow a user to expand Jupyter and RStudio', async () => {
     // initial state: no apps exist
 
     runtimeStub.runtime.status = undefined;
@@ -281,18 +281,6 @@ describe('AppsPanel', () => {
 
     expect(findUnexpandedApp(wrapper, 'Jupyter').exists()).toBeFalsy();
     expect(findExpandedApp(wrapper, 'Jupyter').exists()).toBeTruthy();
-
-    // Click unexpanded Cromwell app
-
-    expect(findUnexpandedApp(wrapper, 'Cromwell').exists()).toBeTruthy();
-    const clickCromwell = findUnexpandedApp(wrapper, 'Cromwell').prop(
-      'onClick'
-    );
-    await clickCromwell();
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(findUnexpandedApp(wrapper, 'Cromwell').exists()).toBeFalsy();
-    expect(findExpandedApp(wrapper, 'Cromwell').exists()).toBeTruthy();
 
     // Click unexpanded RStudio app
 
@@ -324,22 +312,6 @@ describe('AppsPanel', () => {
 
     expect(findActiveApps(wrapper).exists()).toBeFalsy();
     expect(findAvailableApps(wrapper, false).exists()).toBeFalsy();
-  });
-
-  it('should not be possible to configure a Cromwell app', async () => {
-    runtimeStub.runtime.status = undefined;
-    appsStub.listAppsResponse = [];
-    const wrapper = await component();
-    await waitOneTickAndUpdate(wrapper);
-    await findUnexpandedApp(wrapper, 'Cromwell').simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-    const cromwellPanel = findExpandedApp(wrapper, 'Cromwell');
-
-    expect(
-      cromwellPanel
-        .find({ 'data-test-id': 'Cromwell-settings-button' })
-        .prop('disabled')
-    ).toBeTruthy();
   });
 
   it('should pause a running RStudio app', async () => {

--- a/ui/src/app/components/apps-panel.tsx
+++ b/ui/src/app/components/apps-panel.tsx
@@ -9,6 +9,7 @@ import { DisabledPanel } from 'app/components/runtime-configuration-panel/disabl
 import { appsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
+import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { isVisible } from 'app/utils/runtime-utils';
 import { runtimeStore, serverConfigStore, useStore } from 'app/utils/stores';
 
@@ -150,7 +151,13 @@ export const AppsPanel = (props: {
                 <UnexpandedApp
                   {...{ appType }}
                   key={appType}
-                  onClick={() => addToExpandedApps(appType)}
+                  onClick={() => {
+                    if (appType === UIAppType.CROMWELL) {
+                      setSidebarActiveIconStore.next('cromwellConfig');
+                    } else {
+                      addToExpandedApps(appType);
+                    }
+                  }}
                 />
               ))
           )}

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -356,6 +356,19 @@ describe('ExpandedApp', () => {
     );
   });
 
+  it('should not be possible to configure a Cromwell app', async () => {
+    const wrapper = await component(UIAppType.CROMWELL, {
+      appName: 'my-app',
+      googleProject,
+      status: AppStatus.RUNNING,
+    });
+    expect(
+      wrapper
+        .find({ 'data-test-id': 'Cromwell-settings-button' })
+        .prop('disabled')
+    ).toBeTruthy();
+  });
+
   it('should allow launching RStudio when the RStudio app status is RUNNING', async () => {
     const appName = 'my-app';
     const wrapper = await component(UIAppType.RSTUDIO, {

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -9,6 +9,7 @@ import {
   DataSetApi,
   ErrorCode,
   NotebooksApi,
+  ProfileApi,
   RuntimeApi,
   RuntimeStatus,
   TerraJobStatus,
@@ -18,7 +19,11 @@ import {
 
 import { AppsPanel } from 'app/components/apps-panel';
 import { ConfirmWorkspaceDeleteModal } from 'app/components/confirm-workspace-delete-modal';
-import { registerApiClient } from 'app/services/swagger-fetch-clients';
+import { CromwellConfigurationPanel } from 'app/components/cromwell-configuration-panel';
+import {
+  profileApi,
+  registerApiClient,
+} from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
   currentCohortCriteriaStore,
@@ -29,6 +34,7 @@ import {
 import {
   cdrVersionStore,
   clearCompoundRuntimeOperations,
+  profileStore,
   registerCompoundRuntimeOperation,
   runtimeStore,
   serverConfigStore,
@@ -39,6 +45,7 @@ import defaultServerConfig from 'testing/default-server-config';
 import {
   mountWithRouter,
   waitForFakeTimersAndUpdate,
+  waitOneTickAndUpdate,
 } from 'testing/react-test-helpers';
 import { AppsApiStub } from 'testing/stubs/apps-api-stub';
 import {
@@ -52,6 +59,7 @@ import {
 } from 'testing/stubs/cohort-review-service-stub';
 import { DataSetApiStub } from 'testing/stubs/data-set-api-stub';
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
+import { ProfileApiStub } from 'testing/stubs/profile-api-stub';
 import { defaultRuntime, RuntimeApiStub } from 'testing/stubs/runtime-api-stub';
 import { workspaceDataStub } from 'testing/stubs/workspaces';
 import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
@@ -174,7 +182,7 @@ describe('HelpSidebar', () => {
     await waitForFakeTimersAndUpdate(wrapper);
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     props = {};
     dataSetStub = new DataSetApiStub();
     runtimeStub = new RuntimeApiStub();
@@ -200,6 +208,14 @@ describe('HelpSidebar', () => {
       runtimeLoaded: true,
     });
     cdrVersionStore.set(cdrVersionTiersResponse);
+
+    registerApiClient(ProfileApi, new ProfileApiStub());
+    profileStore.set({
+      profile: await profileApi().getMe(),
+      load: jest.fn(),
+      reload: jest.fn(),
+      updateCache: jest.fn(),
+    });
 
     // mock timers
     jest.useFakeTimers('modern');
@@ -571,10 +587,7 @@ describe('HelpSidebar', () => {
     const activeIcon = 'apps';
     localStorage.setItem(LOCAL_STORAGE_KEY_SIDEBAR_STATE, activeIcon);
     const wrapper = await component();
-    expect(
-      // @ts-ignore
-      wrapper.find('[data-test-id="sidebar-content"]').contains(AppsPanel)
-    ).toBeTruthy();
+    expect(wrapper.find(AppsPanel).exists()).toBeTruthy();
   });
 
   it('should not automatically open previously open panel on load if user is suspended', async () => {
@@ -582,9 +595,23 @@ describe('HelpSidebar', () => {
     const activeIcon = 'apps';
     localStorage.setItem(LOCAL_STORAGE_KEY_SIDEBAR_STATE, activeIcon);
     const wrapper = await component();
-    expect(
-      // @ts-ignore
-      wrapper.find('[data-test-id="sidebar-content"]').contains(AppsPanel)
-    ).toBeFalsy();
+    expect(wrapper.find(AppsPanel).exists()).toBeFalsy();
+  });
+
+  it('should open the Cromwell config panel after clicking the unexpanded app', async () => {
+    const wrapper = await component();
+    wrapper
+      .find({ 'data-test-id': 'help-sidebar-icon-apps' })
+      .simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(wrapper.find(AppsPanel).exists()).toBeTruthy();
+    expect(wrapper.find(CromwellConfigurationPanel).exists()).toBeFalsy();
+
+    wrapper.find({ 'data-test-id': `Cromwell-unexpanded` }).simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(wrapper.find(AppsPanel).exists()).toBeFalsy();
+    expect(wrapper.find(CromwellConfigurationPanel).exists()).toBeTruthy();
   });
 });


### PR DESCRIPTION
Description:

The unexpanded Cromwell app now opens directly to the config page.

Since we will be following this up with the equivalent [RStudio story](https://precisionmedicineinitiative.atlassian.net/browse/RW-9703), I am not doing any refactoring in this PR.

This does not complete all the AC of the story. I will make additional PRs to update the buttons.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
