### PR TITLE
Fix nightly test

### DIFF
--- a/e2e/tests/nightly/detachable-disk.spec.ts
+++ b/e2e/tests/nightly/detachable-disk.spec.ts
@@ -56,6 +56,7 @@ describe('Updating runtime status', () => {
 
     // Create a new runtime, reattaching the PD and increasing the size.
     await runtimePanel.open();
+    await runtimePanel.getCustomizeButton().click();
     await runtimePanel.pickDetachableDisk();
     await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 10);
     await runtimePanel.createRuntime({ waitForComplete: false });

--- a/e2e/tests/nightly/detachable-disk.spec.ts
+++ b/e2e/tests/nightly/detachable-disk.spec.ts
@@ -56,7 +56,6 @@ describe('Updating runtime status', () => {
 
     // Create a new runtime, reattaching the PD and increasing the size.
     await runtimePanel.open();
-    await runtimePanel.getCustomizeButton().click();
     await runtimePanel.pickDetachableDisk();
     await runtimePanel.pickDetachableDiskGbs((await runtimePanel.getDetachableDiskGbs()) + 10);
     await runtimePanel.createRuntime({ waitForComplete: false });

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -246,7 +246,10 @@ const PanelMain = fp.flow(
           () => PanelContent.Create,
         ],
         [
+          // General Analysis consist of GCE + PD. Even if runtime has been deleted, PD could still exist
+          // In that case show the configuration page else if everything is deleted show create pannel
           currentRuntime?.status === RuntimeStatus.Deleted &&
+            !currentRuntime?.gceWithPdConfig &&
             [
               RuntimeConfigurationType.GeneralAnalysis,
               RuntimeConfigurationType.HailGenomicAnalysis,

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -246,8 +246,9 @@ const PanelMain = fp.flow(
           () => PanelContent.Create,
         ],
         [
-          // General Analysis consist of GCE + PD. Even if runtime has been deleted, PD could still exist
-          // In that case show the configuration page else if everything is deleted show create pannel
+          // General Analysis consist of GCE + PD. Display create page only if
+          // 1) currentRuntime + pd both are deleted and
+          // 2) configurationType is either GeneralAnalysis or HailGenomicAnalysis
           currentRuntime?.status === RuntimeStatus.Deleted &&
             !currentRuntime?.gceWithPdConfig &&
             [


### PR DESCRIPTION
Earlier GeneralAnalysis had default standard disk, hence selecting PD was considered User override.

Now since the default of GeneralAnalysis is PD, there could be a scenario that the runtime is deleted but PD remains. In that scenario, if the user selects the jupyter button on side bar we should be showing the configuration page and not the create pannel



Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
