### PR TITLE
[RW-9614][risk=no] Combine Cromwell Settings and Launch buttons

### DIFF
--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -356,19 +356,6 @@ describe('ExpandedApp', () => {
     );
   });
 
-  it('should not be possible to configure a Cromwell app', async () => {
-    const wrapper = await component(UIAppType.CROMWELL, {
-      appName: 'my-app',
-      googleProject,
-      status: AppStatus.RUNNING,
-    });
-    expect(
-      wrapper
-        .find({ 'data-test-id': 'Cromwell-settings-button' })
-        .prop('disabled')
-    ).toBeTruthy();
-  });
-
   it('should allow launching RStudio when the RStudio app status is RUNNING', async () => {
     const appName = 'my-app';
     const wrapper = await component(UIAppType.RSTUDIO, {

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -51,7 +51,6 @@ const styles = reactStyles({
     marginLeft: '1em',
     marginBottom: '1em',
     padding: '1em',
-    width: 'fit-content',
   },
   enabledTrashButton: {
     alignSelf: 'center',
@@ -129,34 +128,11 @@ const CromwellButtonRow = (props: {
 
   return (
     <FlexRow>
-      <TooltipTrigger
-        disabled={false}
-        content='Support for configuring Cromwell is not yet available'
-      >
-        {/* tooltip trigger needs a div for some reason */}
-        <div>
-          <SettingsButton
-            disabled={true}
-            onClick={() => {}}
-            data-test-id='Cromwell-settings-button'
-          />
-        </div>
-      </TooltipTrigger>
+      <SettingsButton
+        onClick={() => setSidebarActiveIconStore.next('cromwellConfig')}
+        data-test-id='Cromwell-settings-button'
+      />
       <PauseUserAppButton {...{ userApp }} />
-      <TooltipTrigger
-        disabled={canCreateApp(userApp)}
-        content='A Cromwell app exists or is being created'
-      >
-        {/* tooltip trigger needs a div for some reason */}
-        <div>
-          <AppsPanelButton
-            disabled={!canCreateApp(userApp)}
-            onClick={() => setSidebarActiveIconStore.next('cromwellConfig')}
-            icon={faPlay}
-            buttonText='Launch'
-          />
-        </div>
-      </TooltipTrigger>
     </FlexRow>
   );
 };
@@ -304,9 +280,9 @@ export const ExpandedApp = (props: ExpandedAppProps) => {
       {appType === UIAppType.JUPYTER ? (
         <JupyterButtonRow {...{ workspace, onClickRuntimeConf }} />
       ) : (
-        <FlexColumn style={{ alignItems: 'center' }}>
+        <FlexColumn>
           {/* TODO: keep status updated internally */}
-          <div>
+          <div style={{ textAlign: 'center' }}>
             status: {fromUserAppStatusWithFallback(initialUserAppInfo?.status)}{' '}
             (refresh to update)
           </div>

--- a/ui/src/testing/stubs/apps-api-stub.ts
+++ b/ui/src/testing/stubs/apps-api-stub.ts
@@ -9,11 +9,9 @@ import {
 
 import { stubNotImplementedError } from 'testing/stubs/stub-utils';
 
-const createRStudioListAppsResponseDefaults: UserAppEnvironment = {
-  googleProject: 'terra-vpc-sc-dev-1234',
-  appName: 'all-of-us-2-rstudio-1234',
-  appType: AppType.RSTUDIO,
-  createdDate: '2023-02-28T21:10:28.723328Z',
+const listAppsAppResponseSharedDefaults = {
+  googleProject: 'terra-vpc-sc-dev-42c21469',
+  createdDate: '2023-03-13T18:16:49.481854Z',
   status: AppStatus.RUNNING,
   autopauseThreshold: null,
   kubernetesRuntimeConfig: {
@@ -21,17 +19,45 @@ const createRStudioListAppsResponseDefaults: UserAppEnvironment = {
     machineType: 'n1-standard-4',
     autoscalingEnabled: false,
   },
+  dateAccessed: '2023-03-13T18:16:49.481854Z',
+  errors: [],
+};
+
+const createCromwellListAppsResponseDefaults: UserAppEnvironment = {
+  ...listAppsAppResponseSharedDefaults,
+  appName: 'all-of-us-2-cromwell-1234',
+  appType: AppType.CROMWELL,
+  creator: 'peterlavigne_local_001@fake-research-aou.org',
+  proxyUrls: {
+    'cromwell-service':
+      'https://leonardo.dsde-dev.broadinstitute.org/proxy/google/v1/apps/terra-vpc-sc-dev-1234/all-of-us-2-cromwell-1234/cromwell-service',
+  },
+  diskName: 'all-of-us-pd-2-cromwell-1234',
+  labels: {
+    'created-by': 'fake@fake-research-aou.org',
+    'aou-app-type': 'cromwell',
+  },
+};
+
+const createRStudioListAppsResponseDefaults: UserAppEnvironment = {
+  ...listAppsAppResponseSharedDefaults,
+  appName: 'all-of-us-2-rstudio-1234',
+  appType: AppType.RSTUDIO,
   proxyUrls: {
     rstudio:
       'https://leonardo.dsde-dev.broadinstitute.org/proxy/google/v1/apps/terra-vpc-sc-dev-1234/all-of-us-2-rstudio-1234/rstudio',
   },
   diskName: 'all-of-us-pd-2-rstudio-1234',
-  dateAccessed: '2023-02-28T21:10:28.723328Z',
-  errors: [],
   labels: {
     'created-by': 'fake@fake-research-aou.org',
     'aou-app-type': 'rstudio',
   },
+};
+
+export const createListAppsCromwellResponse = (
+  overrides: Partial<UserAppEnvironment> = {}
+): UserAppEnvironment => {
+  return { ...createCromwellListAppsResponseDefaults, ...overrides };
 };
 
 export const createListAppsRStudioResponse = (


### PR DESCRIPTION
Description:

This PR removes the Cromwell Launch button.

This PR updates the Cromwell Settings button to link to the Cromwell configuration panel.

This does not complete the ticket yet. I have [another PR](https://github.com/all-of-us/workbench/pull/7480) addressing an issue with the Cromwell configuration page.

![image](https://user-images.githubusercontent.com/31020403/225044371-8c230cb5-efe6-495f-bd18-fb84d8d9a2b5.png)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
