### PR TITLE
[RW-9614][risk=no] Refactor Cromwell configuration panel

### DIFF
--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -36,6 +36,7 @@ import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
 import { RuntimeApiStub } from 'testing/stubs/runtime-api-stub';
 import { RuntimesApiStub } from 'testing/stubs/runtimes-api-stub';
 import { workspaceDataStub } from 'testing/stubs/workspaces';
+import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
 
 import { ExpandedApp } from './expanded-app';
 import { defaultRStudioConfig, UIAppType } from './utils';
@@ -47,13 +48,6 @@ const workspace = {
 };
 const onClickRuntimeConf = jest.fn();
 const onClickDeleteRuntime = jest.fn();
-
-function minus<T>(a1: T[], a2: T[]): T[] {
-  return a1.filter((e) => !a2.includes(e));
-}
-const ALL_STATUSES = Object.keys(AppStatus)
-  .map((k) => AppStatus[k])
-  .concat([null, undefined]);
 
 const component = async (
   appType: UIAppType,
@@ -381,7 +375,7 @@ describe('ExpandedApp', () => {
   });
 
   describe('should disable the launch button when the RStudio app status is not RUNNING', () => {
-    test.each(minus(ALL_STATUSES, [AppStatus.RUNNING]))(
+    test.each(minus(ALL_GKE_APP_STATUSES, [AppStatus.RUNNING]))(
       'Status %s',
       async (appStatus) => {
         const wrapper = await component(UIAppType.RSTUDIO, {
@@ -419,7 +413,10 @@ describe('ExpandedApp', () => {
   });
 
   const createEnabledStatuses = [AppStatus.DELETED, null, undefined];
-  const createDisabledStatuses = minus(ALL_STATUSES, createEnabledStatuses);
+  const createDisabledStatuses = minus(
+    ALL_GKE_APP_STATUSES,
+    createEnabledStatuses
+  );
 
   describe('should allow creating an RStudio app for certain app statuses', () => {
     test.each(createEnabledStatuses)('Status %s', async (appStatus) => {

--- a/ui/src/app/components/cromwell-configuration-panel.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.tsx
@@ -22,7 +22,12 @@ import {
 } from 'app/utils/machines';
 import { setSidebarActiveIconStore } from 'app/utils/navigation';
 
-import { defaultCromwellConfig, findApp, UIAppType } from './apps-panel/utils';
+import {
+  canCreateApp,
+  defaultCromwellConfig,
+  findApp,
+  UIAppType,
+} from './apps-panel/utils';
 import { EnvironmentInformedActionPanel } from './environment-informed-action-panel';
 import { TooltipTrigger } from './popups';
 
@@ -53,18 +58,18 @@ const PanelMain = fp.flow(
   }) => {
     // all apps besides Jupyter
     const [userApps, setUserApps] = useState<UserAppEnvironment[]>();
-    const [creating, setCreating] = useState(false);
+    const [creatingCromwellApp, setCreatingCromwellApp] = useState(false);
 
     const app = findApp(userApps, UIAppType.CROMWELL);
-    const loading = userApps === undefined;
+    const loadingApps = userApps === undefined;
 
     useEffect(() => {
       appsApi().listAppsInWorkspace(workspace.namespace).then(setUserApps);
     }, []);
 
     const onCreate = () => {
-      if (!creating) {
-        setCreating(true);
+      if (!creatingCromwellApp) {
+        setCreatingCromwellApp(true);
         appsApi().createApp(workspace.namespace, defaultCromwellConfig);
         onClose();
         setTimeout(() => setSidebarActiveIconStore.next('apps'), 3000);
@@ -72,6 +77,9 @@ const PanelMain = fp.flow(
     };
 
     const { profile } = profileState;
+
+    const createEnabled =
+      !loadingApps && !creatingCromwellApp && canCreateApp(app);
 
     return (
       <FlexColumn style={{ height: '100%' }}>
@@ -168,7 +176,7 @@ const PanelMain = fp.flow(
             id='cromwell-cloud-environment-create-button'
             aria-label='cromwell cloud environment create button'
             onClick={onCreate}
-            disabled={loading || !!app?.status || creating}
+            disabled={!createEnabled}
           >
             Start
           </Button>

--- a/ui/src/testing/stubs/apps-api-stub.ts
+++ b/ui/src/testing/stubs/apps-api-stub.ts
@@ -27,7 +27,7 @@ const createCromwellListAppsResponseDefaults: UserAppEnvironment = {
   ...listAppsAppResponseSharedDefaults,
   appName: 'all-of-us-2-cromwell-1234',
   appType: AppType.CROMWELL,
-  creator: 'peterlavigne_local_001@fake-research-aou.org',
+  creator: 'fake@fake-research-aou.org',
   proxyUrls: {
     'cromwell-service':
       'https://leonardo.dsde-dev.broadinstitute.org/proxy/google/v1/apps/terra-vpc-sc-dev-1234/all-of-us-2-cromwell-1234/cromwell-service',

--- a/ui/src/testing/utils.ts
+++ b/ui/src/testing/utils.ts
@@ -1,0 +1,9 @@
+import { AppStatus } from 'generated/fetch';
+
+export function minus<T>(a1: T[], a2: T[]): T[] {
+  return a1.filter((e) => !a2.includes(e));
+}
+
+export const ALL_GKE_APP_STATUSES = Object.keys(AppStatus)
+  .map((k) => AppStatus[k])
+  .concat([null, undefined]);


### PR DESCRIPTION
Description:

Refactors the Cromwell configuration panel to use shared logic for when a GKE app can be created.

Additionally, adds some tests.

~~Fixes a pre-existing bug where the user cannot create a Cromwell app if their previously-deleted app is in a DELETED state.~~

~~It's difficult to test or notice this locally since the app is quickly removed from the list of apps returned by the list apps endpoint.~~

~~Question for the reviewer: When are apps in a "DELETED" state, anyway? What happens if a user has a “deleted” app, then creates another? Would the user have two apps in that scenario, and does our code account for this?~~

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 