### PR TITLE
[DT-276][risk=no] Add concept set option to cohort item menu

### DIFF
--- a/ui/src/app/pages/data/cohort/search-group-item.tsx
+++ b/ui/src/app/pages/data/cohort/search-group-item.tsx
@@ -37,6 +37,7 @@ import {
   currentCohortCriteriaStore,
   currentWorkspaceStore,
 } from 'app/utils/navigation';
+import { serverConfigStore } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 const styles = reactStyles({
@@ -447,6 +448,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
         item: { searchParameters, type },
       } = this.props;
       return (
+        !serverConfigStore.get().config.enableConceptSetsInCohortBuilder ||
         this.preventItemEdit ||
         type === Domain.PERSON.toString() ||
         !searchParameters.some(

--- a/ui/src/app/pages/data/cohort/search-group-item.tsx
+++ b/ui/src/app/pages/data/cohort/search-group-item.tsx
@@ -4,6 +4,7 @@ import { OverlayPanel } from 'primereact/overlaypanel';
 
 import {
   CohortDefinition,
+  CriteriaSubType,
   CriteriaType,
   Domain,
   Modifier,
@@ -14,6 +15,7 @@ import {
 
 import { Button, Clickable } from 'app/components/buttons';
 import { ClrIcon } from 'app/components/icons';
+import { Modal, ModalFooter, ModalTitle } from 'app/components/modals';
 import { RenameModal } from 'app/components/rename-modal';
 import { MODIFIERS_MAP } from 'app/pages/data/cohort/constant';
 import {
@@ -26,6 +28,7 @@ import {
   mapGroupItem,
   typeToTitle,
 } from 'app/pages/data/cohort/utils';
+import { ConceptAddModal } from 'app/pages/data/concept/concept-add-modal';
 import { cohortBuilderApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCurrentWorkspace } from 'app/utils';
@@ -192,6 +195,8 @@ interface State {
   loading: boolean;
   paramListOpen: boolean;
   renaming: boolean;
+  showConceptSetModal: boolean;
+  showConceptSuccessModal: boolean;
   timeout: NodeJS.Timeout;
 }
 
@@ -206,6 +211,8 @@ export const SearchGroupItem = withCurrentWorkspace()(
         loading: true,
         paramListOpen: false,
         renaming: false,
+        showConceptSetModal: false,
+        showConceptSuccessModal: false,
         timeout: null,
       };
     }
@@ -435,11 +442,31 @@ export const SearchGroupItem = withCurrentWorkspace()(
       );
     }
 
+    get hideConceptOption() {
+      const {
+        item: { searchParameters, type },
+      } = this.props;
+      return (
+        this.preventItemEdit ||
+        type === Domain.PERSON.toString() ||
+        !searchParameters.some(
+          (param) => param.subtype !== CriteriaSubType.ANSWER.toString()
+        )
+      );
+    }
+
     render() {
       const {
-        item: { count, modifiers, name, searchParameters, status },
+        item: { count, modifiers, name, searchParameters, status, type },
       } = this.props;
-      const { error, loading, paramListOpen, renaming } = this.state;
+      const {
+        error,
+        loading,
+        paramListOpen,
+        renaming,
+        showConceptSetModal,
+        showConceptSuccessModal,
+      } = this.state;
       const showCount = !loading && status !== 'hidden' && count !== undefined;
       const actionItems = [
         {
@@ -456,6 +483,11 @@ export const SearchGroupItem = withCurrentWorkspace()(
           command: () => this.suppress(),
         },
         { label: 'Delete criteria', command: () => this.remove() },
+        {
+          label: 'Add criteria to concept set',
+          command: () => this.setState({ showConceptSetModal: true }),
+          style: this.hideConceptOption ? { display: 'none' } : {},
+        },
       ];
       return (
         <React.Fragment>
@@ -593,6 +625,37 @@ export const SearchGroupItem = withCurrentWorkspace()(
               onRename={(v) => this.rename(v)}
               resourceType={ResourceType.COHORTSEARCHITEM}
             />
+          )}
+          {showConceptSetModal && (
+            <ConceptAddModal
+              activeDomainTab={{
+                domain: type,
+                name: domainToTitle(type),
+                count: 0,
+              }}
+              selectedConcepts={searchParameters}
+              onSave={() =>
+                this.setState({
+                  showConceptSetModal: false,
+                  showConceptSuccessModal: true,
+                })
+              }
+              onClose={() => this.setState({ showConceptSetModal: false })}
+            />
+          )}
+          {showConceptSuccessModal && (
+            <Modal>
+              <ModalTitle>Concepts successfully saved</ModalTitle>
+              <ModalFooter>
+                <Button
+                  onClick={() =>
+                    this.setState({ showConceptSuccessModal: false })
+                  }
+                >
+                  OK
+                </Button>
+              </ModalFooter>
+            </Modal>
           )}
         </React.Fragment>
       );


### PR DESCRIPTION
- Adds option to the cohort item menu to add all concepts from the cohort item to a new or existing concept set
- New menu item is. hidden in the menu for any concepts that skip cohort search (Fitbit, WGS, etc.), demographics and survey items that only contain answers since answers cannot be added to a concept set.

https://user-images.githubusercontent.com/40036095/225078160-c6b3ca2a-f5dd-49ff-a646-b696d63bba57.mov


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
