### PR TITLE
[RW-9582][risk=no] Reduce noise of missing CDR version message

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionContext.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrVersionContext.java
@@ -3,7 +3,6 @@ package org.pmiops.workbench.cdr;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import org.pmiops.workbench.db.model.DbCdrVersion;
-import org.pmiops.workbench.exceptions.ServerErrorException;
 
 /** Maintains state of what CDR version is being used in the context of the current request. */
 public class CdrVersionContext {
@@ -31,10 +30,20 @@ public class CdrVersionContext {
   public static DbCdrVersion getCdrVersion() {
     DbCdrVersion version = cdrVersion.get();
     if (version == null) {
-      throw new ServerErrorException("No CDR version specified!");
+      // CDR versions are not available during startup. The value returned from this is then used
+      // as a key into the set of CDR data sources, which don't handle null values well. Instead
+      // of attempting to return something valid before we're ready, we can stop execution by
+      // throwing an exception.
+      // Since this is a benign situation, we want to avoid log noise, hence the stack suppression.
+      throw suppressStackTrace(new IllegalStateException("No CDR version specified!"));
     }
 
     return version;
+  }
+
+  static <T extends Throwable> T suppressStackTrace(T t) {
+    t.setStackTrace(new StackTraceElement[] {});
+    return t;
   }
 
   /**


### PR DESCRIPTION
See comments in commit. Tested via `./gradlew appengineRun`.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
