### PR TITLE
[risk=low][no ticket] HandlerInterceptorAdapter has been deprecated for literally 20 years

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -33,8 +33,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 /**
  * Intercepts all non-OPTIONS API requests to ensure they have an appropriate auth token.
@@ -43,7 +43,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
  * enforce granular permissions.
  */
 @Service
-public class AuthInterceptor extends HandlerInterceptorAdapter {
+public class AuthInterceptor implements AsyncHandlerInterceptor {
   private static final Logger log = Logger.getLogger(AuthInterceptor.class.getName());
   private static final String authName = "aou_oauth";
 

--- a/api/src/main/java/org/pmiops/workbench/interceptors/ClearCdrVersionContextInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/ClearCdrVersionContextInterceptor.java
@@ -5,14 +5,14 @@ import javax.servlet.http.HttpServletResponse;
 import org.pmiops.workbench.cdr.CdrVersionContext;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 
 /**
  * Clears the CDR version (the controller is expected to then specify it based on the request if CDR
  * metadata is accessed.)
  */
 @Service
-public class ClearCdrVersionContextInterceptor extends HandlerInterceptorAdapter {
+public class ClearCdrVersionContextInterceptor implements AsyncHandlerInterceptor {
 
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)

--- a/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CloudTaskInterceptor.java
@@ -8,7 +8,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.web.method.HandlerMethod;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 
 /**
  * Interceptor for endpoints with tag cloudTask. All such endpoints should have tagged as
@@ -17,7 +17,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
  * https://cloud.google.com/tasks/docs/creating-appengine-handlers#reading_app_engine_task_request_headers
  */
 @Service
-public class CloudTaskInterceptor extends HandlerInterceptorAdapter {
+public class CloudTaskInterceptor implements AsyncHandlerInterceptor {
   public static final String QUEUE_NAME_REQUEST_HEADER = "X-AppEngine-QueueName";
   private static final String CLOUD_TASK_TAG = "cloudTask";
 

--- a/api/src/main/java/org/pmiops/workbench/interceptors/CorsInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CorsInterceptor.java
@@ -3,11 +3,11 @@ package org.pmiops.workbench.interceptors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Service;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 
 /** Intercepts all API requests to ensure they have appropriate CORS headers. */
 @Service
-public class CorsInterceptor extends HandlerInterceptorAdapter {
+public class CorsInterceptor implements AsyncHandlerInterceptor {
   public static final String CREDENTIALS_NAME = "Access-Control-Allow-Credentials";
   public static final String ORIGIN_NAME = "Access-Control-Allow-Origin";
   public static final String METHODS_NAME = "Access-Control-Allow-Methods";

--- a/api/src/main/java/org/pmiops/workbench/interceptors/CronInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/CronInterceptor.java
@@ -7,10 +7,10 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.web.method.HandlerMethod;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 
 @Service
-public class CronInterceptor extends HandlerInterceptorAdapter {
+public class CronInterceptor implements AsyncHandlerInterceptor {
   public static final String GAE_CRON_HEADER = "X-Appengine-Cron";
   private static final String CRON_TAG = "cron";
 

--- a/api/src/main/java/org/pmiops/workbench/interceptors/RequestTimeMetricInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/RequestTimeMetricInterceptor.java
@@ -13,11 +13,11 @@ import org.pmiops.workbench.monitoring.labels.MetricLabel;
 import org.pmiops.workbench.monitoring.views.DistributionMetric;
 import org.springframework.stereotype.Service;
 import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 @Service
-public class RequestTimeMetricInterceptor extends HandlerInterceptorAdapter {
+public class RequestTimeMetricInterceptor implements AsyncHandlerInterceptor {
 
   private final LogsBasedMetricService logsBasedMetricService;
   private Clock clock;

--- a/api/src/main/java/org/pmiops/workbench/interceptors/SecurityHeadersInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/SecurityHeadersInterceptor.java
@@ -4,7 +4,7 @@ import java.time.Duration;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Service;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 
 /**
  * Interceptor for handling request or response headers relating to security.
@@ -14,7 +14,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
  * like basic auth.
  */
 @Service
-public class SecurityHeadersInterceptor extends HandlerInterceptorAdapter {
+public class SecurityHeadersInterceptor implements AsyncHandlerInterceptor {
   private static final long HSTS_MAX_AGE = Duration.ofDays(365).getSeconds();
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/interceptors/TracingInterceptor.java
+++ b/api/src/main/java/org/pmiops/workbench/interceptors/TracingInterceptor.java
@@ -22,11 +22,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.web.method.HandlerMethod;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 
 // Interceptor to create a trace of the lifecycle of api calls.
 @Service
-public class TracingInterceptor extends HandlerInterceptorAdapter {
+public class TracingInterceptor implements AsyncHandlerInterceptor {
   private static final Tracer tracer = Tracing.getTracer();
   private static final Logger log = Logger.getLogger(TracingInterceptor.class.getName());
 


### PR DESCRIPTION
HandlerInterceptorAdapter was deprecated in 2003.  Its implementation is

```
HandlerInterceptorAdapter implements AsyncHandlerInterceptor {

}
```

So I feel pretty safe in how I'm replacing it here.

Tested locally with no obvious concerns.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
