### PR TITLE
[RW-9685][risk=no] Report unexpected auth errors

### DIFF
--- a/ui/src/app/routing/app-routing.tsx
+++ b/ui/src/app/routing/app-routing.tsx
@@ -96,7 +96,7 @@ const loadErrorReporter = () => {
     projectId: config.projectId,
   });
 
-  stackdriverErrorReporterStore.set(reporter);
+  stackdriverErrorReporterStore.set({ reporter });
 };
 
 const ScrollToTop = () => {

--- a/ui/src/app/utils/authentication.tsx
+++ b/ui/src/app/utils/authentication.tsx
@@ -7,6 +7,7 @@ import { environment } from 'environments/environment';
 import { userApi } from 'app/services/swagger-fetch-clients';
 import { AnalyticsTracker, setLoggedInState } from 'app/utils/analytics';
 import { LOCAL_STORAGE_KEY_TEST_ACCESS_TOKEN } from 'app/utils/cookies';
+import { reportError } from 'app/utils/errors';
 import { navigateSignOut } from 'app/utils/navigation';
 import { authStore, serverConfigStore } from 'app/utils/stores';
 import { delay } from 'app/utils/subscribable';
@@ -91,6 +92,7 @@ export const signOut = async (continuePath: string = '/login') => {
   try {
     await userApi().signOut();
   } catch (e) {
+    reportError(e);
     signOutApiCallSucceeded = false;
   }
 
@@ -101,6 +103,7 @@ export const signOut = async (continuePath: string = '/login') => {
     // `revokeTokens` can fail if the token has already been revoked.
     // Recover from invalid_token errors to make sure the sign-out process completes successfully.
     if (e.error !== 'invalid_token') {
+      reportError(e);
       throw e;
     }
   }
@@ -151,7 +154,10 @@ export const useAuthentication = () => {
     // Unfortunately, this function triggers _after_ auth declares the user as unauthenticated. In that case, we
     // return early to allow signinSilent to trigger and re-run this function without disrupting the user.
     const expiredCallback = auth.events.addAccessTokenExpired(() => {
-      auth.signinSilent().catch(signOutWithoutLooping);
+      auth.signinSilent().catch((e) => {
+        reportError(e);
+        signOutWithoutLooping();
+      });
     });
     if (!auth.isLoading && auth.user?.expired && !auth.error) {
       return expiredCallback;
@@ -181,6 +187,7 @@ export const useAuthentication = () => {
     setLoggedInState(authStore.get().isSignedIn);
 
     if (auth.error) {
+      reportError(auth.error);
       signOutWithoutLooping();
     }
 


### PR DESCRIPTION
Description:

Users are being randomly signed out and we aren't sure why. This PR reports unexpected auth errors to aid further debugging.

This PR also fixes our `reportError` function; the store was not being initialized correctly. Existing uses of `reportError` will now actually report errors. Our reporting was still working for uncaught errors (i.e. those not explicitly logged), so the configuration of our reporting is still correct.

To reproduce this, a few steps are needed.

1. Change the `loadErrorReporter` function to the following to get error reporting happening locally:

```
const loadErrorReporter = () => {
  // We don't report to stackdriver on local servers.
  // if (environment.debug) {
  //   return;
  // }
  const reporter = new StackdriverErrorReporter();
  // const { config } = serverConfigStore.get();
  // if (!config.publicApiKeyForErrorReports) {
  //   return;
  // }
  reporter.start({
    key: 'FAKE_KEY',
    projectId: 'FAKE_PROJECT_ID',
  });

  stackdriverErrorReporterStore.set({ reporter });
};
```

2. Modify your localstorage so your auth is in a broken state. For example, modifying the refresh token.

3. Modify your localstorage so your auth requests a new token by modifying the token expiration time to be in the past.

4. Refresh the page

5. Note in the network tab that a request to our error reporter is made containing a relevant stack trace.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
