### PR TITLE
[no ticket][risk=no] Increase flaky e2ev2 test timeouts

### DIFF
--- a/e2ev2/tests/workspace-analysis.test.js
+++ b/e2ev2/tests/workspace-analysis.test.js
@@ -33,7 +33,7 @@ browserTest('create an application', async browser => {
   await page.waitForFunction(() => !document.querySelector('div[aria-label="Select Applications Modal"]'));
   await page.waitForSelector('div[aria-label="New Notebook Modal"]')
 
-}, 10e3)
+}, 20e3)
 
 browserTest('Cancel the creation of an application', async browser => {
   const page = await navigateToNewAnalysisPage(browser)
@@ -46,5 +46,5 @@ browserTest('Cancel the creation of an application', async browser => {
 
   await page.waitForFunction(() => !document.querySelector('div[aria-label="Select Applications Modal"]'));
 
-}, 10e3)
+}, 20e3)
 


### PR DESCRIPTION
Description:

These tests were failing unnecessarily in a [previous PR](https://github.com/all-of-us/workbench/pull/7500). They work locally, so increasing the timeout may be sufficient for them to pass.
