### PR TITLE
[no-ticket][risk=no] Avoid parallelization on Circle

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -250,7 +250,8 @@ spotless {
 
 test {
     useJUnitPlatform()
-    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    maxParallelForks = System.getenv('CIRCLECI') == 'true' ? 1 :
+      Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 // The plugin generates configuration names by concatenating SourceSet names

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -250,6 +250,8 @@ spotless {
 
 test {
     useJUnitPlatform()
+    // Unit testing time is cut roughly in half by running them in parallel. We avoid this on
+    // Circle because they are already split apart using a different algorithm.
     maxParallelForks = System.getenv('CIRCLECI') == 'true' ? 1 :
       Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }


### PR DESCRIPTION
We split tests by timing on Circle, so there is no need to also run them in parallel.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
