### PR TITLE
[DT-279][risk=no] Add Concept Quick Add modal to CB

### DIFF
--- a/ui/src/app/pages/data/cohort/cohort-search.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-search.tsx
@@ -19,6 +19,7 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { AddConceptSetToCohortModal } from 'app/pages/data/cohort/addConceptSetToCohortModal';
+import { ConceptQuickAddModal } from 'app/pages/data/cohort/concept-quick-add-modal';
 import { Demographics } from 'app/pages/data/cohort/demographics';
 import { searchRequestStore } from 'app/pages/data/cohort/search-state.service';
 import { Selection } from 'app/pages/data/cohort/selection-list';
@@ -169,6 +170,7 @@ interface State {
   selectedIds: Array<string>;
   selections: Array<Selection>;
   showAddConceptSetModal: boolean;
+  showConceptQuickAddModal: boolean;
   showUnsavedModal: boolean;
   toastVisible: boolean;
   unsavedChanges: boolean;
@@ -189,6 +191,7 @@ export const CohortSearch = fp.flow(
         selectedIds: [],
         selections: [],
         showAddConceptSetModal: false,
+        showConceptQuickAddModal: false,
         showUnsavedModal: false,
         toastVisible: false,
         unsavedChanges: false,
@@ -215,6 +218,8 @@ export const CohortSearch = fp.flow(
         this.selectStructuralVariantData();
       } else if (domain === Domain.CONCEPTSET) {
         this.setState({ showAddConceptSetModal: true });
+      } else if (domain === Domain.CONCEPTQUICKADD) {
+        this.setState({ showConceptQuickAddModal: true });
       } else {
         this.setState({ initCriteriaSearch: true });
       }
@@ -465,16 +470,30 @@ export const CohortSearch = fp.flow(
         selectedIds,
         selections,
         showAddConceptSetModal,
+        showConceptQuickAddModal,
         showUnsavedModal,
         toastVisible,
       } = this.state;
       return (
         !!cohortContext && (
           <>
-            {showAddConceptSetModal ? (
-              <AddConceptSetToCohortModal
-                onClose={() => currentCohortSearchContextStore.next(undefined)}
-              />
+            {showAddConceptSetModal || showConceptQuickAddModal ? (
+              <>
+                {showAddConceptSetModal && (
+                  <AddConceptSetToCohortModal
+                    onClose={() =>
+                      currentCohortSearchContextStore.next(undefined)
+                    }
+                  />
+                )}
+                {showConceptQuickAddModal && (
+                  <ConceptQuickAddModal
+                    onClose={() =>
+                      currentCohortSearchContextStore.next(undefined)
+                    }
+                  />
+                )}
+              </>
             ) : (
               <FlexRowWrap style={styles.searchContainer}>
                 <style>{toastCSS}</style>

--- a/ui/src/app/pages/data/cohort/cohort-search.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-search.tsx
@@ -101,10 +101,10 @@ const styles = reactStyles({
   },
 });
 
-function initGroup(role: string, item: any) {
+export function initGroup(role: string, items: any) {
   return {
     id: generateId(role),
-    items: [item],
+    items,
     count: null,
     temporal: false,
     mention: TemporalMention.ANYMENTION,
@@ -152,7 +152,7 @@ export function saveCriteria(selections?: Array<Selection>) {
       }
     }
   } else {
-    searchRequest[role].push(initGroup(role, item));
+    searchRequest[role].push(initGroup(role, [item]));
   }
   searchRequestStore.next(searchRequest);
   currentCohortSearchContextStore.next(undefined);

--- a/ui/src/app/pages/data/cohort/cohort-search.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-search.tsx
@@ -133,7 +133,7 @@ export function saveCriteria(selections?: Array<Selection>) {
     currentCohortSearchContextStore.getValue();
   AnalyticsTracker.CohortBuilder.SaveCriteria(domainToTitle(domain));
   const searchRequest = searchRequestStore.getValue();
-  if (domain === Domain.CONCEPTSET) {
+  if (domain === Domain.CONCEPTSET || domain === Domain.CONCEPTQUICKADD) {
     item.type = selections[0]?.domainId;
   }
   item.searchParameters = selections || currentCohortCriteriaStore.getValue();

--- a/ui/src/app/pages/data/cohort/concept-quick-add-modal.tsx
+++ b/ui/src/app/pages/data/cohort/concept-quick-add-modal.tsx
@@ -15,20 +15,40 @@ import {
 import { TooltipTrigger } from 'app/components/popups';
 import { Spinner } from 'app/components/spinners';
 import { saveCriteria } from 'app/pages/data/cohort/cohort-search';
-import { conceptSetsApi } from 'app/services/swagger-fetch-clients';
+import { cohortBuilderApi } from 'app/services/swagger-fetch-clients';
 import { MatchParams } from 'app/utils/stores';
 import { ClrIcon } from 'app/components/icons';
 import colors from 'app/styles/colors';
 
-const { useEffect, useState } = React;
+const { useState } = React;
 
 export const ConceptQuickAddModal = ({ onClose }) => {
+  const { ns, wsid } = useParams<MatchParams>();
   const [conceptIdInput, setConceptIdInput] = useState<string>();
   const [matchedConcepts, setMatchedConcepts] = useState<Criteria[]>();
   const [error, setError] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
 
-  const lookupConcepts = () => {};
+  const lookupConcepts = async () => {
+    setError(false);
+    setLoading(true);
+    const conceptsRequest = {
+      conceptKeys: conceptIdInput.split(/[\n,]/)
+    };
+    try {
+      const matchedConceptsResp = await cohortBuilderApi().findCriteriaByConceptIdsOrConceptCodes(
+        ns,
+        wsid,
+        conceptsRequest
+      );
+      setMatchedConcepts(matchedConceptsResp.items);
+    } catch (error) {
+      console.error(error);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const addConceptsAsItem = () => {};
 
@@ -55,13 +75,17 @@ export const ConceptQuickAddModal = ({ onClose }) => {
         <InputTextarea
           rows={3}
           value={conceptIdInput}
+          disabled={loading}
           onChange={(e) => setConceptIdInput(e.target.value)}
         />
         <Button
           type='secondary'
-          disabled={!conceptIdInput}
+          disabled={!conceptIdInput || loading}
           onClick={() => lookupConcepts()}
         >
+          {loading && (
+            <Spinner size={16} style={{ marginRight: '0.25rem' }} />
+          )}
           Lookup
         </Button>
         {!!matchedConcepts && (

--- a/ui/src/app/pages/data/cohort/concept-quick-add-modal.tsx
+++ b/ui/src/app/pages/data/cohort/concept-quick-add-modal.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { useParams } from 'react-router';
+import { InputTextarea } from 'primereact/inputtextarea';
+
+import { Criteria } from 'generated/fetch';
+
+import { AlertWarning } from 'app/components/alert';
+import { Button, Clickable } from 'app/components/buttons';
+import {
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalTitle,
+} from 'app/components/modals';
+import { TooltipTrigger } from 'app/components/popups';
+import { Spinner } from 'app/components/spinners';
+import { saveCriteria } from 'app/pages/data/cohort/cohort-search';
+import { conceptSetsApi } from 'app/services/swagger-fetch-clients';
+import { MatchParams } from 'app/utils/stores';
+import { ClrIcon } from 'app/components/icons';
+import colors from 'app/styles/colors';
+
+const { useEffect, useState } = React;
+
+export const ConceptQuickAddModal = ({ onClose }) => {
+  const [conceptIdInput, setConceptIdInput] = useState<string>();
+  const [matchedConcepts, setMatchedConcepts] = useState<Criteria[]>();
+  const [error, setError] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const lookupConcepts = () => {};
+
+  const addConceptsAsItem = () => {};
+
+  return (
+    <Modal>
+      <ModalTitle data-test-id='add-concept-title'>
+        Concept ID Lookup
+        <Clickable style={{ float: 'right' }} onClick={() => onClose()}>
+          <ClrIcon shape='times' size='24' style={{ color: colors.accent }} />
+        </Clickable>
+      </ModalTitle>
+      <ModalBody>
+        {loading && (
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <Spinner style={{ alignContent: 'center' }} />
+          </div>
+        )}
+        {error && (
+          <AlertWarning>
+            Sorry, the request cannot be completed. Please try again or contact
+            Support in the left hand navigation.
+          </AlertWarning>
+        )}
+        <InputTextarea
+          rows={3}
+          value={conceptIdInput}
+          onChange={(e) => setConceptIdInput(e.target.value)}
+        />
+        <Button
+          type='secondary'
+          disabled={!conceptIdInput}
+          onClick={() => lookupConcepts()}
+        >
+          Lookup
+        </Button>
+        {!!matchedConcepts && (
+          <table>
+            <thead>
+              <tr>
+                <th>Concept Id</th>
+                <th>Code</th>
+                <th>Name</th>
+              </tr>
+            </thead>
+            <tbody>
+              {matchedConcepts.map((concept, index) => (
+                <tr>
+                  <td>{concept.conceptId}</td>
+                  <td>{concept.code}</td>
+                  <td>{concept.name}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </ModalBody>
+      <ModalFooter>
+        {!!matchedConcepts && (
+          <Button
+            style={{ marginLeft: '0.75rem' }}
+            onClick={() => addConceptsAsItem()}
+          >
+            Add
+          </Button>
+        )}
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/ui/src/app/pages/data/cohort/concept-quick-add-modal.tsx
+++ b/ui/src/app/pages/data/cohort/concept-quick-add-modal.tsx
@@ -125,11 +125,6 @@ export const ConceptQuickAddModal = withCurrentCohortSearchContext()(
           </Clickable>
         </ModalTitle>
         <ModalBody style={{ color: colors.primary }}>
-          {loading && (
-            <div style={{ display: 'flex', justifyContent: 'center' }}>
-              <Spinner style={{ alignContent: 'center' }} />
-            </div>
-          )}
           {error && (
             <AlertWarning>
               Sorry, the request cannot be completed. Please try again or
@@ -184,39 +179,50 @@ export const ConceptQuickAddModal = withCurrentCohortSearchContext()(
               Lookup
             </Button>
           </div>
-          {!!matchedConcepts && (
+          {!loading && !!matchedConcepts && (
             <div style={{ fontSize: '12px', marginTop: '0.5rem' }}>
-              {matchedConcepts.length > 0 && (
-                <div style={{ color: colors.select, fontWeight: 500 }}>
+              {matchedConcepts.length === 0 ? (
+                <div style={{ color: colors.warning, fontWeight: 500 }}>
                   <ClrIcon
-                    shape='check-circle'
+                    shape='exclamation-triangle'
                     size='20'
                     className='is-solid'
                   />{' '}
-                  {matchedConcepts.length.toLocaleString()} Concept
-                  {matchedConcepts.length > 1 && 's'} found
+                  No matching concepts found
                 </div>
+              ) : (
+                <>
+                  <div style={{ color: colors.select, fontWeight: 500 }}>
+                    <ClrIcon
+                      shape='check-circle'
+                      size='20'
+                      className='is-solid'
+                    />{' '}
+                    {matchedConcepts.length.toLocaleString()} Concept
+                    {matchedConcepts.length > 1 && 's'} found
+                  </div>
+                  <table style={{ textAlign: 'left', width: '100%' }}>
+                    <thead>
+                      <tr>
+                        <th style={{ width: '40%' }}>Name</th>
+                        <th style={{ width: '20%' }}>Concept Id</th>
+                        <th style={{ width: '20%' }}>Code</th>
+                        <th style={{ width: '20%' }}>Domain</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {matchedConcepts.map((concept, index) => (
+                        <tr key={index}>
+                          <td>{concept.name}</td>
+                          <td>{concept.conceptId}</td>
+                          <td>{concept.code}</td>
+                          <td>{domainToTitle(concept.domainId)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </>
               )}
-              <table style={{ textAlign: 'left', width: '100%' }}>
-                <thead>
-                  <tr>
-                    <th style={{ width: '40%' }}>Name</th>
-                    <th style={{ width: '20%' }}>Concept Id</th>
-                    <th style={{ width: '20%' }}>Code</th>
-                    <th style={{ width: '20%' }}>Domain</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {matchedConcepts.map((concept, index) => (
-                    <tr key={index}>
-                      <td>{concept.name}</td>
-                      <td>{concept.conceptId}</td>
-                      <td>{concept.code}</td>
-                      <td>{domainToTitle(concept.domainId)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
             </div>
           )}
         </ModalBody>

--- a/ui/src/app/pages/data/cohort/search-group-list.tsx
+++ b/ui/src/app/pages/data/cohort/search-group-list.tsx
@@ -22,7 +22,7 @@ import { currentWorkspaceStore } from 'app/utils/navigation';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { Subscription } from 'rxjs/Subscription';
 
-function initItem(id: string, type: string) {
+export function initItem(id: string, type: string) {
   return {
     id,
     type,


### PR DESCRIPTION
- New modal to lookup concepts by id or code and add directly to a cohort
- Can enter ids/codes separated by commas or one per line
- Will add multiple items if multiple domains are returned

https://user-images.githubusercontent.com/40036095/226938465-26204605-aa30-4765-856e-9c95617046f0.mov

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
