### PR TITLE
[RW-5609][risk=no] Enable app-engine-apis flag

### DIFF
--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -8,8 +8,10 @@
   libraries on the java11 runtime throws a:
     com.google.apphosting.api.ApiProxy$FeatureNotEnabledException
 
-  See: https://cloud.google.com/appengine/docs/standard/java-gen2/services/access
-  and: https://www.googlecloudcommunity.com/gc/Serverless/FeatureNotEnabledException-using-App-Engine-bundled-service/m-p/181253
+  See:
+    https://cloud.google.com/appengine/docs/standard/bundled-services-overview
+    https://cloud.google.com/appengine/docs/standard/java-gen2/services/access
+    https://www.googlecloudcommunity.com/gc/Serverless/FeatureNotEnabledException-using-App-Engine-bundled-service/m-p/181253
 
   The following flag enables these libraries in the java11 runtime, allowing us to migrate away
   from them in subsequent steps.

--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -1,6 +1,21 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
   <service>api</service>
   <runtime>java8</runtime>
+
+  <!--
+  The GAE java8 runtime restricts certain JVM APIs. The java11 runtime has fewer restrictions.
+  Google provides GAE-specific libraries to work around these restrictions, but using these
+  libraries on the java11 runtime throws a:
+    com.google.apphosting.api.ApiProxy$FeatureNotEnabledException
+
+  See: https://cloud.google.com/appengine/docs/standard/java-gen2/services/access
+  and: https://www.googlecloudcommunity.com/gc/Serverless/FeatureNotEnabledException-using-App-Engine-bundled-service/m-p/181253
+
+  The following flag enables these libraries in the java11 runtime, allowing us to migrate away
+  from them in subsequent steps.
+  -->
+  <app-engine-apis>true</app-engine-apis>
+
   <threadsafe>true</threadsafe>
   <!-- Deploy complains about this tag, bug BigQuery needs it. -->
   <application>all-of-us-workbench-test</application>


### PR DESCRIPTION
See comment inline.

Note that the docs state that the `threadsafe` flag must be removed, as it is now assumed, but this had no effect in my testing, so it can be done in a follow-up.

Tested by deploying to ephemeral GAE instance.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
