### PR TITLE
one step toward consuming the newly published Leonardo client

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -475,7 +475,7 @@ dependencies {
     implementation 'jakarta.mail:jakarta.mail-api:2.1.1'
     testAnnotationProcessor "org.mapstruct:mapstruct-processor:$project.ext.MAPSTRUCT_VERSION"
 
-    implementation "org.broadinstitute.dsde.workbench:leonardo-client_2.11:1.3.6-f6a1109"
+    implementation "org.broadinstitute.dsde.workbench:leonardo-client_2.11:1.3.6-cc87fed-SNAP"
 
     // Dependencies for Swagger codegen-generated sources. This should include all dependencies required by Swagger's
     // default okhttp API codegen templates (see https://github.com/swagger-api/swagger-codegen/blob/v2.2.3/samples/client/petstore/spring-stubs/pom.xml)

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -357,6 +357,10 @@ clean.doFirst {
 }
 
 repositories {
+    maven {
+        // for the Leonardo client
+        url 'https://broadinstitute.jfrog.io/artifactory/libs-release-local'
+    }
     mavenCentral()
 }
 
@@ -470,6 +474,8 @@ dependencies {
     implementation "org.mapstruct:mapstruct:$project.ext.MAPSTRUCT_VERSION"
     implementation 'jakarta.mail:jakarta.mail-api:2.1.1'
     testAnnotationProcessor "org.mapstruct:mapstruct-processor:$project.ext.MAPSTRUCT_VERSION"
+
+    implementation "org.broadinstitute.dsde.workbench:leonardo-client_2.11:1.3.6-f6a1109"
 
     // Dependencies for Swagger codegen-generated sources. This should include all dependencies required by Swagger's
     // default okhttp API codegen templates (see https://github.com/swagger-api/swagger-codegen/blob/v2.2.3/samples/client/petstore/spring-stubs/pom.xml)

--- a/api/src/main/java/org/pmiops/workbench/api/DisksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DisksController.java
@@ -3,6 +3,8 @@ package org.pmiops.workbench.api;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.pmiops.workbench.apiclients.leonardo.NewLeonardoApiClient;
+import org.pmiops.workbench.apiclients.leonardo.NewLeonardoMapper;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.PersistentDiskUtils;
 import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
@@ -21,16 +23,23 @@ public class DisksController implements DisksApiDelegate {
   private static final Logger log = Logger.getLogger(DisksController.class.getName());
 
   private final LeonardoApiClient leonardoNotebooksClient;
+  private final NewLeonardoApiClient newLeonardoClient;
   private final LeonardoMapper leonardoMapper;
+  private final NewLeonardoMapper newLeonardoMapper;
+
   private final WorkspaceService workspaceService;
 
   @Autowired
   public DisksController(
       LeonardoApiClient leonardoNotebooksClient,
+      NewLeonardoApiClient newLeonardoClient,
       LeonardoMapper leonardoMapper,
+      NewLeonardoMapper newLeonardoMapper,
       WorkspaceService workspaceService) {
     this.leonardoNotebooksClient = leonardoNotebooksClient;
+    this.newLeonardoClient = newLeonardoClient;
     this.leonardoMapper = leonardoMapper;
+    this.newLeonardoMapper = newLeonardoMapper;
     this.workspaceService = workspaceService;
   }
 
@@ -39,8 +48,8 @@ public class DisksController implements DisksApiDelegate {
     String googleProject =
         workspaceService.lookupWorkspaceByNamespace(workspaceNamespace).getGoogleProject();
     Disk disk =
-        leonardoMapper.toApiGetDiskResponse(
-            leonardoNotebooksClient.getPersistentDisk(googleProject, diskName));
+        newLeonardoMapper.toApiGetDiskResponse(
+            newLeonardoClient.getPersistentDisk(googleProject, diskName));
 
     if (DiskStatus.FAILED.equals(disk.getStatus())) {
       log.warning(

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -19,6 +19,8 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.inject.Provider;
 import org.json.JSONObject;
+import org.pmiops.workbench.apiclients.leonardo.NewLeonardoApiClient;
+import org.pmiops.workbench.apiclients.leonardo.NewLeonardoMapper;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
@@ -74,6 +76,7 @@ public class RuntimeController implements RuntimeApiDelegate {
   private static final Logger log = Logger.getLogger(RuntimeController.class.getName());
 
   private final LeonardoApiClient leonardoNotebooksClient;
+  private final NewLeonardoApiClient newLeonardoClient;
   private final Provider<DbUser> userProvider;
   private final WorkspaceAuthService workspaceAuthService;
   private final WorkspaceService workspaceService;
@@ -81,11 +84,13 @@ public class RuntimeController implements RuntimeApiDelegate {
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final UserRecentResourceService userRecentResourceService;
   private final LeonardoMapper leonardoMapper;
+  private final NewLeonardoMapper newLeonardoMapper;
   private final LeonardoApiHelper leonardoApiHelper;
 
   @Autowired
   RuntimeController(
       LeonardoApiClient leonardoNotebooksClient,
+      NewLeonardoApiClient newLeonardoClient,
       Provider<DbUser> userProvider,
       WorkspaceAuthService workspaceAuthService,
       WorkspaceService workspaceService,
@@ -93,8 +98,10 @@ public class RuntimeController implements RuntimeApiDelegate {
       Provider<WorkbenchConfig> workbenchConfigProvider,
       UserRecentResourceService userRecentResourceService,
       LeonardoMapper leonardoMapper,
+      NewLeonardoMapper newLeonardoMapper,
       LeonardoApiHelper leonardoApiHelper) {
     this.leonardoNotebooksClient = leonardoNotebooksClient;
+    this.newLeonardoClient = newLeonardoClient;
     this.userProvider = userProvider;
     this.workspaceAuthService = workspaceAuthService;
     this.workspaceService = workspaceService;
@@ -102,6 +109,7 @@ public class RuntimeController implements RuntimeApiDelegate {
     this.workbenchConfigProvider = workbenchConfigProvider;
     this.userRecentResourceService = userRecentResourceService;
     this.leonardoMapper = leonardoMapper;
+    this.newLeonardoMapper = newLeonardoMapper;
     this.leonardoApiHelper = leonardoApiHelper;
   }
 
@@ -201,11 +209,11 @@ public class RuntimeController implements RuntimeApiDelegate {
         // Check with Leo again see if user have READY disk, if so, block this request or logging
         List<Disk> diskList =
             PersistentDiskUtils.findTheMostRecentActiveDisks(
-                leonardoNotebooksClient
+                newLeonardoClient
                     .listPersistentDiskByProjectCreatedByCreator(
                         dbWorkspace.getGoogleProject(), false)
                     .stream()
-                    .map(leonardoMapper::toApiListDisksResponse)
+                    .map(newLeonardoMapper::toApiListDisksResponse)
                     .collect(Collectors.toList()));
         List<Disk> runtimeDisks =
             diskList.stream().filter(Disk::getIsGceRuntime).collect(Collectors.toList());

--- a/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoApiClient.java
@@ -1,0 +1,21 @@
+package org.pmiops.workbench.apiclients.leonardo;
+
+import java.util.List;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.GetPersistentDiskResponse;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
+import org.pmiops.workbench.exceptions.WorkbenchException;
+
+public interface NewLeonardoApiClient {
+  String LEONARDO_CREATOR_ROLE = "creator";
+
+  GetPersistentDiskResponse getPersistentDisk(String googleProject, String diskName)
+      throws WorkbenchException;
+
+  void deletePersistentDisk(String googleProject, String diskName) throws WorkbenchException;
+
+  void updatePersistentDisk(String googleProject, String diskName, Integer diskSize)
+      throws WorkbenchException;
+
+  List<ListPersistentDiskResponse> listPersistentDiskByProjectCreatedByCreator(
+      String googleProject, boolean includeDeleted);
+}

--- a/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoApiClientFactory.java
+++ b/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoApiClientFactory.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class NewLeonardoApiClientFactory {
+class NewLeonardoApiClientFactory {
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
 
   @Autowired

--- a/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoApiClientFactory.java
+++ b/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoApiClientFactory.java
@@ -1,0 +1,34 @@
+package org.pmiops.workbench.apiclients.leonardo;
+
+import javax.inject.Provider;
+import org.broadinstitute.dsde.workbench.client.leonardo.ApiClient;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.firecloud.FirecloudApiClientFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NewLeonardoApiClientFactory {
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
+
+  @Autowired
+  public NewLeonardoApiClientFactory(Provider<WorkbenchConfig> workbenchConfigProvider) {
+    this.workbenchConfigProvider = workbenchConfigProvider;
+  }
+
+  /**
+   * Creates a Leonardo API client, unauthenticated. Most clients should use an authenticated,
+   * request scoped bean instead of calling this directly.
+   */
+  public ApiClient newApiClient() {
+    WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
+    final ApiClient apiClient =
+        new ApiClient()
+            .setBasePath(workbenchConfig.firecloud.leoBaseUrl)
+            .setDebugging(workbenchConfig.firecloud.debugEndpoints)
+            .addDefaultHeader(
+                FirecloudApiClientFactory.X_APP_ID_HEADER, workbenchConfig.firecloud.xAppIdValue);
+    apiClient.setReadTimeout(workbenchConfig.firecloud.timeoutInSeconds * 1000);
+    return apiClient;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoApiClientImpl.java
@@ -1,0 +1,77 @@
+package org.pmiops.workbench.apiclients.leonardo;
+
+import java.util.List;
+import javax.inject.Provider;
+import org.broadinstitute.dsde.workbench.client.leonardo.ApiException;
+import org.broadinstitute.dsde.workbench.client.leonardo.api.DisksApi;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.GetPersistentDiskResponse;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.UpdateDiskRequest;
+import org.pmiops.workbench.exceptions.ExceptionUtils;
+import org.pmiops.workbench.exceptions.WorkbenchException;
+import org.pmiops.workbench.leonardo.LeonardoLabelHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NewLeonardoApiClientImpl implements NewLeonardoApiClient {
+  private final NewLeonardoRetryHandler leonardoRetryHandler;
+  private final Provider<DisksApi> disksApiProvider;
+
+  @Autowired
+  public NewLeonardoApiClientImpl(
+      NewLeonardoRetryHandler leonardoRetryHandler,
+      @Qualifier(NewLeonardoConfig.USER_DISKS_API) Provider<DisksApi> disksApiProvider) {
+    this.leonardoRetryHandler = leonardoRetryHandler;
+    this.disksApiProvider = disksApiProvider;
+  }
+
+  @Override
+  public GetPersistentDiskResponse getPersistentDisk(String googleProject, String diskName)
+      throws WorkbenchException {
+    DisksApi disksApi = disksApiProvider.get();
+    try {
+      return leonardoRetryHandler.runAndThrowChecked(
+          (context) -> disksApi.getDisk(googleProject, diskName));
+    } catch (ApiException e) {
+      throw ExceptionUtils.newConvertLeonardoException(e);
+    }
+  }
+
+  @Override
+  public void deletePersistentDisk(String googleProject, String diskName)
+      throws WorkbenchException {
+    DisksApi disksApi = disksApiProvider.get();
+    leonardoRetryHandler.run(
+        (context) -> {
+          disksApi.deleteDisk(googleProject, diskName);
+          return null;
+        });
+  }
+
+  @Override
+  public void updatePersistentDisk(String googleProject, String diskName, Integer diskSize)
+      throws WorkbenchException {
+    DisksApi disksApi = disksApiProvider.get();
+    leonardoRetryHandler.run(
+        (context) -> {
+          disksApi.updateDisk(googleProject, diskName, new UpdateDiskRequest().size(diskSize));
+          return null;
+        });
+  }
+
+  @Override
+  public List<ListPersistentDiskResponse> listPersistentDiskByProjectCreatedByCreator(
+      String googleProject, boolean includeDeleted) {
+    DisksApi disksApi = disksApiProvider.get();
+    return leonardoRetryHandler.run(
+        (context) ->
+            disksApi.listDisksByProject(
+                googleProject,
+                null,
+                includeDeleted,
+                LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS,
+                LEONARDO_CREATOR_ROLE));
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoConfig.java
@@ -1,0 +1,35 @@
+package org.pmiops.workbench.apiclients.leonardo;
+
+import org.broadinstitute.dsde.workbench.client.leonardo.ApiClient;
+import org.broadinstitute.dsde.workbench.client.leonardo.api.DisksApi;
+import org.pmiops.workbench.auth.UserAuthentication;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Configuration
+public class NewLeonardoConfig {
+
+  public static final String USER_DISKS_API = "NEW userDisksApi";
+
+  private static final String USER_LEONARDO_CLIENT = "NEW leonardoApiClient";
+
+  @Bean(name = USER_LEONARDO_CLIENT)
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  public ApiClient leoUserApiClient(
+      UserAuthentication userAuthentication, NewLeonardoApiClientFactory factory) {
+    ApiClient apiClient = factory.newApiClient();
+    apiClient.setAccessToken(userAuthentication.getCredentials());
+    return apiClient;
+  }
+
+  @Bean(name = USER_DISKS_API)
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  public DisksApi disksApi(@Qualifier(USER_LEONARDO_CLIENT) ApiClient apiClient) {
+    DisksApi api = new DisksApi();
+    api.setApiClient(apiClient);
+    return api;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoConfig.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.web.context.annotation.RequestScope;
 
 @Configuration
-public class NewLeonardoConfig {
+class NewLeonardoConfig {
 
   public static final String USER_DISKS_API = "NEW userDisksApi";
 

--- a/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoMapper.java
@@ -4,6 +4,7 @@ import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.mapDiskLabelsToD
 
 import java.util.Map;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.GetPersistentDiskResponse;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -27,5 +28,21 @@ public interface NewLeonardoMapper {
   default void getDiskAfterMapper(
       @MappingTarget Disk disk, GetPersistentDiskResponse leoGetDiskResponse) {
     mapDiskLabelsToDiskAppType(disk, (Map<String, String>) leoGetDiskResponse.getLabels());
+  }
+
+  @Mapping(target = "creator", source = "auditInfo.creator")
+  @Mapping(target = "createdDate", source = "auditInfo.createdDate")
+  @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
+  // applied via listDisksAfterMapper() -> mapDiskLabelsToDiskAppType()
+  @Mapping(target = "appType", ignore = true)
+  // applied via listDisksAfterMapper() -> mapDiskLabelsToDiskAppType()
+  @Mapping(target = "isGceRuntime", ignore = true)
+  Disk toApiListDisksResponse(ListPersistentDiskResponse listPersistentDiskResponse);
+
+  @SuppressWarnings("unchecked")
+  @AfterMapping
+  default void listDisksAfterMapper(
+      @MappingTarget Disk disk, ListPersistentDiskResponse leoListDisksResponse) {
+    mapDiskLabelsToDiskAppType(disk, (Map<String, String>) leoListDisksResponse.getLabels());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoMapper.java
@@ -1,0 +1,31 @@
+package org.pmiops.workbench.apiclients.leonardo;
+
+import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.mapDiskLabelsToDiskAppType;
+
+import java.util.Map;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.GetPersistentDiskResponse;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.pmiops.workbench.model.Disk;
+import org.pmiops.workbench.utils.mappers.MapStructConfig;
+
+@Mapper(config = MapStructConfig.class)
+public interface NewLeonardoMapper {
+  @Mapping(target = "creator", source = "auditInfo.creator")
+  @Mapping(target = "createdDate", source = "auditInfo.createdDate")
+  @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
+  // applied via getDiskAfterMapper() -> mapDiskLabelsToDiskAppType()
+  @Mapping(target = "appType", ignore = true)
+  // applied via getDiskAfterMapper() -> mapDiskLabelsToDiskAppType()
+  @Mapping(target = "isGceRuntime", ignore = true)
+  Disk toApiGetDiskResponse(GetPersistentDiskResponse response);
+
+  @SuppressWarnings("unchecked")
+  @AfterMapping
+  default void getDiskAfterMapper(
+      @MappingTarget Disk disk, GetPersistentDiskResponse leoGetDiskResponse) {
+    mapDiskLabelsToDiskAppType(disk, (Map<String, String>) leoGetDiskResponse.getLabels());
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoRetryHandler.java
+++ b/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoRetryHandler.java
@@ -15,7 +15,7 @@ import org.springframework.retry.backoff.BackOffPolicy;
 import org.springframework.stereotype.Service;
 
 @Service
-public class NewLeonardoRetryHandler extends TerraServiceRetryHandler<ApiException> {
+class NewLeonardoRetryHandler extends TerraServiceRetryHandler<ApiException> {
 
   private static final Logger logger = Logger.getLogger(NewLeonardoRetryHandler.class.getName());
 

--- a/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoRetryHandler.java
+++ b/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/NewLeonardoRetryHandler.java
@@ -1,0 +1,74 @@
+package org.pmiops.workbench.apiclients.leonardo;
+
+import java.net.SocketTimeoutException;
+import java.util.logging.Logger;
+import javax.inject.Provider;
+import javax.servlet.http.HttpServletResponse;
+import org.broadinstitute.dsde.workbench.client.leonardo.ApiException;
+import org.pmiops.workbench.exceptions.ExceptionUtils;
+import org.pmiops.workbench.exceptions.WorkbenchException;
+import org.pmiops.workbench.firecloud.api.TermsOfServiceApi;
+import org.pmiops.workbench.utils.ResponseCodeRetryPolicy;
+import org.pmiops.workbench.utils.TerraServiceRetryHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.retry.backoff.BackOffPolicy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NewLeonardoRetryHandler extends TerraServiceRetryHandler<ApiException> {
+
+  private static final Logger logger = Logger.getLogger(NewLeonardoRetryHandler.class.getName());
+
+  private static class NewLeonardoRetryPolicy extends ResponseCodeRetryPolicy {
+
+    public NewLeonardoRetryPolicy() {
+      super("Leonardo API");
+    }
+
+    @Override
+    protected int getResponseCode(Throwable lastException) {
+      if (lastException instanceof ApiException) {
+        return ((ApiException) lastException).getCode();
+      }
+      if (lastException instanceof SocketTimeoutException) {
+        return HttpServletResponse.SC_GATEWAY_TIMEOUT;
+      }
+      return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    protected void logNoRetry(Throwable t, int responseCode) {
+      if (t instanceof ApiException) {
+        if (responseCode == 404) {
+          logger.log(
+              getLogLevel(responseCode),
+              String.format(
+                  "Exception calling Leonardo API with response: %s. This is likely because a runtime "
+                      + "has not yet been created and is being polled for. Suppressing stack trace.",
+                  responseCode));
+        } else {
+          logger.log(
+              getLogLevel(responseCode),
+              String.format(
+                  "Exception calling Leonardo API with response: %s",
+                  ((ApiException) t).getResponseBody()),
+              t);
+        }
+      } else {
+        super.logNoRetry(t, responseCode);
+      }
+    }
+  }
+
+  @Autowired
+  public NewLeonardoRetryHandler(
+      BackOffPolicy backoffPolicy, Provider<TermsOfServiceApi> termsOfServiceApiProvider) {
+    super(backoffPolicy, new NewLeonardoRetryPolicy(), termsOfServiceApiProvider);
+  }
+
+  @Override
+  protected WorkbenchException convertException(ApiException exception) {
+    return maybeConvertMessageForTos(exception.getCode())
+        .orElseGet(() -> ExceptionUtils.newConvertLeonardoException(exception));
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/README.md
+++ b/api/src/main/java/org/pmiops/workbench/apiclients/leonardo/README.md
@@ -1,0 +1,7 @@
+This is an experimental new module as of May 2023, intended to help us migrate to the new Leonardo 
+client published by that team at 
+[The Broad Institute's JFrog repository](https://broadinstitute.jfrog.io/ui/packages/gav:%2F%2Forg.broadinstitute.dsde.workbench:leonardo-client_2.11?name=leonardo-client&type=packages).
+
+It consists of copies of the older (Swagger-generated) client's classes, with a "NewLeonardo" 
+prefix to keep them distinct.  We expect to drop this prefix when the migration is
+complete.

--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionUtils.java
@@ -66,8 +66,22 @@ public class ExceptionUtils {
     throw codeToException(e.getCode());
   }
 
+  // converts exceptions from the "old" Swagger client we generated
   public static WorkbenchException convertLeonardoException(
       org.pmiops.workbench.leonardo.ApiException e) {
+    if (isSocketTimeoutException(e.getCause())) {
+      throw new GatewayTimeoutException();
+    }
+    if (e.getCode() == HttpServletResponse.SC_CONFLICT) {
+      throw new ConflictException(
+          "Please wait a few minutes and try to create your environment again.");
+    }
+    throw codeToException(e.getCode());
+  }
+
+  // converts exceptions from the "new" Swagger client Leonardo generated and published
+  public static WorkbenchException newConvertLeonardoException(
+      org.broadinstitute.dsde.workbench.client.leonardo.ApiException e) {
     if (isSocketTimeoutException(e.getCause())) {
       throw new GatewayTimeoutException();
     }

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
@@ -4,9 +4,7 @@ import java.util.List;
 import java.util.Map;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.WorkbenchException;
-import org.pmiops.workbench.leonardo.model.LeonardoGetPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
-import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.model.CreateAppRequest;
 import org.pmiops.workbench.model.Runtime;
@@ -61,20 +59,20 @@ public interface LeonardoApiClient {
   /** Create a new data synchronization Welder storage link on a runtime. */
   StorageLink createStorageLink(String googleProject, String runtime, StorageLink storageLink);
 
-  /** Gets information about a persistent disk */
-  LeonardoGetPersistentDiskResponse getPersistentDisk(String googleProject, String diskName)
-      throws WorkbenchException;
-
-  /** Deletes a persistent disk */
-  void deletePersistentDisk(String googleProject, String diskName) throws WorkbenchException;
-
-  /** Update a persistent disk */
-  void updatePersistentDisk(String googleProject, String diskName, Integer diskSize)
-      throws WorkbenchException;
-
-  /** List all persistent disks by google project */
-  List<LeonardoListPersistentDiskResponse> listPersistentDiskByProjectCreatedByCreator(
-      String googleProject, boolean includeDeleted);
+  //  /** Gets information about a persistent disk */
+  //  LeonardoGetPersistentDiskResponse getPersistentDisk(String googleProject, String diskName)
+  //      throws WorkbenchException;
+  //
+  //  /** Deletes a persistent disk */
+  //  void deletePersistentDisk(String googleProject, String diskName) throws WorkbenchException;
+  //
+  //  /** Update a persistent disk */
+  //  void updatePersistentDisk(String googleProject, String diskName, Integer diskSize)
+  //      throws WorkbenchException;
+  //
+  //    /** List all persistent disks by google project */
+  //    List<LeonardoListPersistentDiskResponse> listPersistentDiskByProjectCreatedByCreator(
+  //        String googleProject, boolean includeDeleted);
 
   /**
    * Creates Leonardo app owned by the current authenticated user.

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -34,7 +34,6 @@ import org.pmiops.workbench.leonardo.model.LeonardoAppStatus;
 import org.pmiops.workbench.leonardo.model.LeonardoCreateAppRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoCreateRuntimeRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoGetAppResponse;
-import org.pmiops.workbench.leonardo.model.LeonardoGetPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListAppResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
@@ -42,7 +41,6 @@ import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoMachineConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoPersistentDiskRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeStatus;
-import org.pmiops.workbench.leonardo.model.LeonardoUpdateDiskRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoUpdateRuntimeRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoUserJupyterExtensionConfig;
 import org.pmiops.workbench.model.AppType;
@@ -397,44 +395,44 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
     return notebooksRetryHandler.run(
         (context) -> proxyApi.welderCreateStorageLink(storageLink, googleProject, runtime));
   }
-
-  @Override
-  public LeonardoGetPersistentDiskResponse getPersistentDisk(String googleProject, String diskName)
-      throws WorkbenchException {
-    DisksApi disksApi = diskApiProvider.get();
-    try {
-      return leonardoRetryHandler.runAndThrowChecked(
-          (context) -> disksApi.getDisk(googleProject, diskName));
-    } catch (ApiException e) {
-      throw ExceptionUtils.convertLeonardoException(e);
-    }
-  }
-
-  @Override
-  public void deletePersistentDisk(String googleProject, String diskName)
-      throws WorkbenchException {
-    DisksApi disksApi = diskApiProvider.get();
-    leonardoRetryHandler.run(
-        (context) -> {
-          disksApi.deleteDisk(googleProject, diskName);
-          return null;
-        });
-  }
-
-  @Override
-  public void updatePersistentDisk(String googleProject, String diskName, Integer diskSize)
-      throws WorkbenchException {
-    DisksApi disksApi = diskApiProvider.get();
-    leonardoRetryHandler.run(
-        (context) -> {
-          disksApi.updateDisk(
-              googleProject, diskName, new LeonardoUpdateDiskRequest().size(diskSize));
-          return null;
-        });
-  }
-
-  @Override
-  public List<LeonardoListPersistentDiskResponse> listPersistentDiskByProjectCreatedByCreator(
+  //
+  //  @Override
+  //  public LeonardoGetPersistentDiskResponse getPersistentDisk(String googleProject, String
+  // diskName)
+  //      throws WorkbenchException {
+  //    DisksApi disksApi = diskApiProvider.get();
+  //    try {
+  //      return leonardoRetryHandler.runAndThrowChecked(
+  //          (context) -> disksApi.getDisk(googleProject, diskName));
+  //    } catch (ApiException e) {
+  //      throw ExceptionUtils.convertLeonardoException(e);
+  //    }
+  //  }
+  //
+  //  @Override
+  //  public void deletePersistentDisk(String googleProject, String diskName)
+  //      throws WorkbenchException {
+  //    DisksApi disksApi = diskApiProvider.get();
+  //    leonardoRetryHandler.run(
+  //        (context) -> {
+  //          disksApi.deleteDisk(googleProject, diskName);
+  //          return null;
+  //        });
+  //  }
+  //
+  //  @Override
+  //  public void updatePersistentDisk(String googleProject, String diskName, Integer diskSize)
+  //      throws WorkbenchException {
+  //    DisksApi disksApi = diskApiProvider.get();
+  //    leonardoRetryHandler.run(
+  //        (context) -> {
+  //          disksApi.updateDisk(
+  //              googleProject, diskName, new LeonardoUpdateDiskRequest().size(diskSize));
+  //          return null;
+  //        });
+  //  }
+  //
+  private List<LeonardoListPersistentDiskResponse> listPersistentDiskByProjectCreatedByCreator(
       String googleProject, boolean includeDeleted) {
     DisksApi disksApi = diskApiProvider.get();
     return leonardoRetryHandler.run(

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoLabelHelper.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoLabelHelper.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.pmiops.workbench.model.AppType;
+import org.pmiops.workbench.model.Disk;
 
 /** Helper class for setting Leonardo labels. */
 public class LeonardoLabelHelper {
@@ -39,5 +40,14 @@ public class LeonardoLabelHelper {
             Optional.ofNullable(rawLabelObject).orElse(new HashMap<String, String>());
     labels.put(labelKey, labelValue);
     return labels;
+  }
+
+  public static Disk mapDiskLabelsToDiskAppType(Disk disk, Map<String, String> diskLabels) {
+    if (diskLabels != null && diskLabels.containsKey(LEONARDO_LABEL_APP_TYPE)) {
+      disk.appType(labelValueToAppType(diskLabels.get(LEONARDO_LABEL_APP_TYPE)));
+    } else {
+      disk.isGceRuntime(true);
+    }
+    return disk;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -22,7 +22,6 @@ import org.pmiops.workbench.leonardo.model.LeonardoDiskStatus;
 import org.pmiops.workbench.leonardo.model.LeonardoGceConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoGceWithPdConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoGetAppResponse;
-import org.pmiops.workbench.leonardo.model.LeonardoGetPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoKubernetesRuntimeConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoListAppResponse;
@@ -112,13 +111,14 @@ public interface LeonardoMapper {
     leonardoGceWithPdConfig.setCloudService(LeonardoGceWithPdConfig.CloudServiceEnum.GCE);
   }
 
-  @Mapping(target = "creator", source = "auditInfo.creator")
-  @Mapping(target = "createdDate", source = "auditInfo.createdDate")
-  @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
-  @Mapping(target = "appType", ignore = true)
-  @Mapping(target = "isGceRuntime", ignore = true)
-  Disk toApiGetDiskResponse(LeonardoGetPersistentDiskResponse disk);
+  //  @Mapping(target = "creator", source = "auditInfo.creator")
+  //  @Mapping(target = "createdDate", source = "auditInfo.createdDate")
+  //  @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
+  //  @Mapping(target = "appType", ignore = true)
+  //  @Mapping(target = "isGceRuntime", ignore = true)
+  //  Disk toApiGetDiskResponse(LeonardoGetPersistentDiskResponse disk);
 
+  // need to retain this old-client version because it's used by createApp
   @Mapping(target = "creator", source = "auditInfo.creator")
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
   @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
@@ -126,13 +126,15 @@ public interface LeonardoMapper {
   @Mapping(target = "isGceRuntime", ignore = true)
   Disk toApiListDisksResponse(LeonardoListPersistentDiskResponse disk);
 
-  @SuppressWarnings("unchecked")
-  @AfterMapping
-  default void getDiskAfterMapper(
-      @MappingTarget Disk disk, LeonardoGetPersistentDiskResponse leoGetDiskResponse) {
-    mapDiskLabelsToDiskAppType(disk, (Map<String, String>) leoGetDiskResponse.getLabels());
-  }
+  //  @SuppressWarnings("unchecked")
+  //  @AfterMapping
+  //  default void getDiskAfterMapper(
+  //      @MappingTarget Disk disk, LeonardoGetPersistentDiskResponse leoGetDiskResponse) {
+  //    mapDiskLabelsToDiskAppType(disk, (Map<String, String>) leoGetDiskResponse.getLabels());
+  //  }
+  //
 
+  // need to retain this old-client version because it's used by createApp
   @SuppressWarnings("unchecked")
   @AfterMapping
   default void listDisksAfterMapper(

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.utils.mappers;
 
-import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE;
-import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.labelValueToAppType;
+import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.mapDiskLabelsToDiskAppType;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
@@ -139,14 +138,6 @@ public interface LeonardoMapper {
   default void listDisksAfterMapper(
       @MappingTarget Disk disk, LeonardoListPersistentDiskResponse leoListDisksResponse) {
     mapDiskLabelsToDiskAppType(disk, (Map<String, String>) leoListDisksResponse.getLabels());
-  }
-
-  default void mapDiskLabelsToDiskAppType(Disk disk, Map<String, String> diskLabels) {
-    if (diskLabels != null && diskLabels.containsKey(LEONARDO_LABEL_APP_TYPE)) {
-      disk.appType(labelValueToAppType(diskLabels.get(LEONARDO_LABEL_APP_TYPE)));
-    } else {
-      disk.isGceRuntime(true);
-    }
   }
 
   @Mapping(target = "patchInProgress", ignore = true)

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -1934,6 +1934,7 @@ components:
       enum:
         - pd-standard
         - pd-ssd
+        - pd-balanced
     CloudProvider:
       type: string
       enum:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4860,6 +4860,7 @@ definitions:
     enum:
       - pd-standard
       - pd-ssd
+      - pd-balanced
   Disk:
     description: The configuration of a persistent disk, returned in disk responses
     type: object

--- a/api/src/test/java/org/pmiops/workbench/NewLeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/NewLeonardoMapperTest.java
@@ -1,0 +1,87 @@
+package org.pmiops.workbench;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.GetPersistentDiskResponse;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pmiops.workbench.apiclients.leonardo.NewLeonardoMapper;
+import org.pmiops.workbench.apiclients.leonardo.NewLeonardoMapperImpl;
+import org.pmiops.workbench.model.AppType;
+import org.pmiops.workbench.model.Disk;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@Import(NewLeonardoMapperImpl.class)
+@SpringJUnitConfig
+public class NewLeonardoMapperTest {
+  @Autowired private NewLeonardoMapper mapper;
+  private AuditInfo auditInfo;
+
+  @BeforeEach
+  public void setUp() {
+    auditInfo =
+        new AuditInfo()
+            .createdDate("2022-10-10")
+            .creator("bob@gmail.com")
+            .dateAccessed("2022-10-10");
+  }
+
+  @Test
+  public void testToApiDiskFromListDiskResponse() {
+    ListPersistentDiskResponse listPersistentDiskResponse =
+        new ListPersistentDiskResponse()
+            .diskType(DiskType.SSD)
+            .auditInfo(auditInfo)
+            .status(DiskStatus.READY);
+
+    Disk disk =
+        new Disk()
+            .diskType(org.pmiops.workbench.model.DiskType.SSD)
+            .isGceRuntime(true)
+            .creator(auditInfo.getCreator())
+            .dateAccessed(auditInfo.getDateAccessed())
+            .createdDate(auditInfo.getCreatedDate())
+            .status(org.pmiops.workbench.model.DiskStatus.READY);
+    assertThat(mapper.toApiListDisksResponse(listPersistentDiskResponse)).isEqualTo(disk);
+
+    // RSTUDIO
+    Map<String, String> rstudioLabel = new HashMap<>();
+    rstudioLabel.put(LEONARDO_LABEL_APP_TYPE, "rstudio");
+    assertThat(mapper.toApiListDisksResponse(listPersistentDiskResponse.labels(rstudioLabel)))
+        .isEqualTo(disk.appType(AppType.RSTUDIO).isGceRuntime(false));
+  }
+
+  @Test
+  public void testToApiDiskFromGetDiskResponse() {
+    GetPersistentDiskResponse getPersistentDiskResponse =
+        new GetPersistentDiskResponse()
+            .diskType(DiskType.SSD)
+            .auditInfo(auditInfo)
+            .status(DiskStatus.READY);
+
+    Disk disk =
+        new Disk()
+            .diskType(org.pmiops.workbench.model.DiskType.SSD)
+            .isGceRuntime(true)
+            .creator(auditInfo.getCreator())
+            .dateAccessed(auditInfo.getDateAccessed())
+            .createdDate(auditInfo.getCreatedDate())
+            .status(org.pmiops.workbench.model.DiskStatus.READY);
+    assertThat(mapper.toApiGetDiskResponse(getPersistentDiskResponse)).isEqualTo(disk);
+
+    // RSTUDIO
+    Map<String, String> rstudioLabel = new HashMap<>();
+    rstudioLabel.put(LEONARDO_LABEL_APP_TYPE, "rstudio");
+    assertThat(mapper.toApiGetDiskResponse(getPersistentDiskResponse.labels(rstudioLabel)))
+        .isEqualTo(disk.appType(AppType.RSTUDIO).isGceRuntime(false));
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -321,8 +321,7 @@ public class DisksControllerTest {
             .size(300)
             .diskType(org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType.STANDARD)
             .status(status)
-            .auditInfo(new AuditInfo().createdDate(date).creator(user.getUsername()))
-            .googleProject(GOOGLE_PROJECT_ID);
+            .auditInfo(new AuditInfo().createdDate(date).creator(user.getUsername()));
     if (appType != null) {
       Map<String, String> label = new HashMap<>();
       label.put(LEONARDO_LABEL_APP_TYPE, appType.toString().toLowerCase());

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -16,7 +16,6 @@ import org.pmiops.workbench.leonardo.model.LeonardoCloudContext;
 import org.pmiops.workbench.leonardo.model.LeonardoDiskStatus;
 import org.pmiops.workbench.leonardo.model.LeonardoDiskType;
 import org.pmiops.workbench.leonardo.model.LeonardoGetAppResponse;
-import org.pmiops.workbench.leonardo.model.LeonardoGetPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoKubernetesError;
 import org.pmiops.workbench.leonardo.model.LeonardoKubernetesRuntimeConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoListAppResponse;
@@ -196,29 +195,29 @@ public class LeonardoMapperTest {
     assertThat(mapper.toApiListDisksResponse(listPersistentDiskResponse.labels(rstudioLabel)))
         .isEqualTo(disk.appType(AppType.RSTUDIO).isGceRuntime(false));
   }
-
-  @Test
-  public void testToApiDiskFromGetDiskResponse() {
-    LeonardoGetPersistentDiskResponse getPersistentDiskResponse =
-        new LeonardoGetPersistentDiskResponse()
-            .diskType(LeonardoDiskType.SSD)
-            .auditInfo(leonardoAuditInfo)
-            .status(LeonardoDiskStatus.READY);
-
-    Disk disk =
-        new Disk()
-            .diskType(DiskType.SSD)
-            .isGceRuntime(true)
-            .creator(leonardoAuditInfo.getCreator())
-            .dateAccessed(leonardoAuditInfo.getDateAccessed())
-            .createdDate(leonardoAuditInfo.getCreatedDate())
-            .status(DiskStatus.READY);
-    assertThat(mapper.toApiGetDiskResponse(getPersistentDiskResponse)).isEqualTo(disk);
-
-    // RSTUDIO
-    Map<String, String> rstudioLabel = new HashMap<>();
-    rstudioLabel.put(LEONARDO_LABEL_APP_TYPE, "rstudio");
-    assertThat(mapper.toApiGetDiskResponse(getPersistentDiskResponse.labels(rstudioLabel)))
-        .isEqualTo(disk.appType(AppType.RSTUDIO).isGceRuntime(false));
-  }
+  //
+  //  @Test
+  //  public void testToApiDiskFromGetDiskResponse() {
+  //    LeonardoGetPersistentDiskResponse getPersistentDiskResponse =
+  //        new LeonardoGetPersistentDiskResponse()
+  //            .diskType(LeonardoDiskType.SSD)
+  //            .auditInfo(leonardoAuditInfo)
+  //            .status(LeonardoDiskStatus.READY);
+  //
+  //    Disk disk =
+  //        new Disk()
+  //            .diskType(DiskType.SSD)
+  //            .isGceRuntime(true)
+  //            .creator(leonardoAuditInfo.getCreator())
+  //            .dateAccessed(leonardoAuditInfo.getDateAccessed())
+  //            .createdDate(leonardoAuditInfo.getCreatedDate())
+  //            .status(DiskStatus.READY);
+  //    assertThat(mapper.toApiGetDiskResponse(getPersistentDiskResponse)).isEqualTo(disk);
+  //
+  //    // RSTUDIO
+  //    Map<String, String> rstudioLabel = new HashMap<>();
+  //    rstudioLabel.put(LEONARDO_LABEL_APP_TYPE, "rstudio");
+  //    assertThat(mapper.toApiGetDiskResponse(getPersistentDiskResponse.labels(rstudioLabel)))
+  //        .isEqualTo(disk.appType(AppType.RSTUDIO).isGceRuntime(false));
+  //  }
 }


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-10064

Leonardo just published a Java client for their APIs.  It's Swagger-generated, so it should be a compatible replacement for our own Swagger-generated Leo client -> https://github.com/DataBiosphere/leonardo/pull/3240

This PR adds new client code for the Persistent Disks API (4 calls) and replaces the use of our old client code for a single call: Get Persistent Disk.

**[oops: this was a poor choice, because we don't use this in the UI.  will update, ha]**

The new client code has the prefix "NewLeonardo" and is grouped together in a new package, to help clarify which pieces are which, for a potential migration.

Related https://broadworkbench.atlassian.net/browse/IA-4329

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
