### PR TITLE
Increase stability in e2ev2 tests

### DIFF
--- a/e2ev2/src/test-utils.js
+++ b/e2ev2/src/test-utils.js
@@ -85,7 +85,7 @@ const useApiProxy = async page => {
     })
   })
   await page.setJavaScriptEnabled(false)
-  await page.goto(config.urlRoot(), {waitUntil: 'networkidle0'})
+  await page.goto(config.urlRoot())
   await page.evaluate(
     url => { localStorage.allOfUsApiUrlOverride = url},
     process.env.API_PROXY_URL
@@ -98,7 +98,7 @@ export_({useApiProxy})
 
 const fakeSignIn = async page => {
   await page.evaluate(() => localStorage['test-access-token-override'] = 'fake-bearer-token')
-  await page.reload({waitUntil: 'networkidle0'})
+  await page.reload()
   await expect(page.waitForSelector('[data-test-id="signed-in"]')).resolves.toBeDefined()
 }
 export_({fakeSignIn})

--- a/e2ev2/tests/new-user-satisfaction-survey.test.js
+++ b/e2ev2/tests/new-user-satisfaction-survey.test.js
@@ -17,7 +17,7 @@ browserTest('take the new user satisfaction survey via the relevant notification
   const page = browser.initialPage
   await tu.useApiProxy(page)
   await tu.fakeSignIn(page)
-  await page.goto(config.urlRoot(), {waitUntil: 'networkidle0'})
+  await page.goto(config.urlRoot())
 
   const surveyNotification = await page.waitForSelector('[data-test-id="new-user-satisfaction-survey-notification"]');
   await surveyNotification.waitForSelector('[aria-label="take satisfaction survey"]').then(b => b.click());
@@ -32,7 +32,7 @@ browserTest('take the new user satisfaction survey via an email link', async bro
   const page = browser.initialPage
   const surveyCode = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
   await tu.useApiProxy(page)
-  await page.goto(`${config.urlRoot()}?surveyCode=${surveyCode}`, {waitUntil: 'networkidle0'})
+  await page.goto(`${config.urlRoot()}?surveyCode=${surveyCode}`)
 
   await completeNewUserSatisfactionSurvey(page);
 }, 10e3);

--- a/e2ev2/tests/sanity.browser.test.js
+++ b/e2ev2/tests/sanity.browser.test.js
@@ -5,7 +5,7 @@ const browserTest = tu.browserTest(__filename)
 
 browserTest('page loads', async browser => {
   const page = browser.initialPage
-  await page.goto('https://example.com', {waitUntil: 'networkidle0'})
+  await page.goto('https://example.com')
   const h1 = await page.waitForSelector('h1')
   expect(await h1.evaluate(n => n.innerText)).toBe('Example Domain')
 })
@@ -14,7 +14,7 @@ browserTest('view cookie policy page', async browser => {
   const page = browser.initialPage
   await tu.useApiProxy(page)
     .then(async () => {
-      await page.goto(config.urlRoot()+'/login', {waitUntil: 'networkidle0'})
+      await page.goto(config.urlRoot()+'/login')
       const cpLink = await page.waitForSelector('a[href="/cookie-policy"]')
       expect(cpLink).toBeDefined()
       // click and wait need to happen simultaneously to avoid a race
@@ -37,7 +37,7 @@ for (const p of ['/workspaces', '/profile']) {
   browserTest(`navigation to ${p} redirects to sign-in page`, async browser => {
     const page = browser.initialPage
     await tu.useApiProxy(page)
-    await page.goto(config.urlRoot()+p, {waitUntil: 'networkidle0'})
+    await page.goto(config.urlRoot()+p)
     const button = await page.waitForSelector('[role="button"]')
     expect(await button.evaluate(n => n.textContent)).toBe('Sign In')
   })

--- a/e2ev2/tests/user-create.test.js
+++ b/e2ev2/tests/user-create.test.js
@@ -17,7 +17,7 @@ browserTest('create user', async browser => {
     () => page.waitForSelector(ackCheckboxSel).then(eh => eh.evaluate(e => e.disabled))
 
   await tu.useApiProxy(page)
-  await page.goto(config.urlRoot(), {waitUntil: 'networkidle0'})
+  await page.goto(config.urlRoot())
   await tu.jsClick(page, '[role="button"][aria-label="Create Account"]')
 
   // Agreement Page

--- a/e2ev2/tests/workspace-analysis.test.js
+++ b/e2ev2/tests/workspace-analysis.test.js
@@ -7,7 +7,7 @@ const navigateToNewAnalysisPage = async (browser) => {
   const page = browser.initialPage
   await tu.useApiProxy(page)
   await tu.fakeSignIn(page)
-  await page.goto(config.urlRoot()+'/workspaces/aou-rw-test-53ff4756/mohstest/data', {waitUntil: 'networkidle0'})
+  await page.goto(config.urlRoot()+'/workspaces/aou-rw-test-53ff4756/mohstest/data')
   const newAnalysisTab = await page.waitForSelector('div[role="button"][aria-label="Analysis (New)"]')
   await newAnalysisTab.click()
   return page

--- a/e2ev2/tests/workspace-create.test.js
+++ b/e2ev2/tests/workspace-create.test.js
@@ -12,12 +12,11 @@ browserTest('create a workspace', async browser => {
   const page = browser.initialPage
   await tu.useApiProxy(page)
   await tu.fakeSignIn(page)
-  await page.goto(config.urlRoot(), {waitUntil: 'networkidle0'})
+  await page.goto(config.urlRoot())
 
-  const createWorkspaceLink = await page.waitForSelector('[aria-label="Create Workspace"]')
   // Workspace creation isn't really available until billing accounts have been fetched.
   const [baEventPromise] = await tu.promiseWindowEvent(page, 'billing-accounts-loaded')
-  await Promise.all([baEventPromise, createWorkspaceLink.click()])
+  await Promise.all([baEventPromise, tu.jsClick(page, '[aria-label="Create Workspace"]')])
 
   await expect(page.waitForSelector('title').then(eh => eh.evaluate(n => n.innerText)))
     .resolves.toContain('Create Workspace |')


### PR DESCRIPTION
We should not be waiting for network idle. We can't know when all requests will finish and with polling or other ongoing operations this isn't safe. We can and should wait for page events and selectors to determine when to take the next action.

Tested locally by running e2ev2 tests twenty times in a row.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
