### PR TITLE
[no ticket][risk=no] Remove noisy error-based logs

### DIFF
--- a/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
@@ -33,7 +33,6 @@ import { institutionApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { isBlank, reactStyles } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
-import { reportError } from 'app/utils/errors';
 import {
   checkInstitutionalEmail,
   getEmailValidationErrorMessage,
@@ -131,7 +130,6 @@ export class AccountCreationInstitution extends React.Component<
         loadingInstitutions: false,
         institutionLoadError: true,
       });
-      reportError(e);
     }
   }
 

--- a/ui/src/app/pages/login/sign-in.tsx
+++ b/ui/src/app/pages/login/sign-in.tsx
@@ -27,7 +27,7 @@ import { profileApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { reactStyles, WindowSizeProps, withWindowSize } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
-import { convertAPIError, reportError } from 'app/utils/errors';
+import { convertAPIError } from 'app/utils/errors';
 import { serverConfigStore } from 'app/utils/stores';
 import successBackgroundImage from 'assets/images/congrats-female.png';
 import successSmallerBackgroundImage from 'assets/images/congrats-female-standing.png';
@@ -422,7 +422,6 @@ export class SignInImpl extends React.Component<SignInProps, SignInState> {
         isPreviousStep: false,
       });
     } catch (error) {
-      reportError(error);
       const { message } = await convertAPIError(error);
       this.props.showProfileErrorModal(message);
       if (enableCaptcha) {

--- a/ui/src/app/pages/profile/profile-component.tsx
+++ b/ui/src/app/pages/profile/profile-component.tsx
@@ -40,7 +40,7 @@ import {
   wasReferredFromRenewal,
 } from 'app/utils/access-utils';
 import { canRenderSignedDucc } from 'app/utils/code-of-conduct';
-import { convertAPIError, reportError } from 'app/utils/errors';
+import { convertAPIError } from 'app/utils/errors';
 import { NavigationProps } from 'app/utils/navigation';
 import { canonicalizeUrl } from 'app/utils/urls';
 import { notTooLong, required } from 'app/utils/validators';
@@ -141,7 +141,7 @@ export const ProfileComponent = fp.flow(
           await institutionApi().getPublicInstitutionDetails();
         this.setState({ institutions });
       } catch (e) {
-        reportError(e);
+        // continue regardless of error
       }
     }
 
@@ -226,7 +226,6 @@ export const ProfileComponent = fp.flow(
         await reload();
         return profile;
       } catch (error) {
-        reportError(error);
         const errorResponse = await convertAPIError(error);
         this.props.showProfileErrorModal(errorResponse.message);
         console.error(error);

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -489,13 +489,11 @@ export const WorkspaceEdit = fp.flow(
         // We cannot send over the correct billing account info since the current user
         // does not have permissions to set it.
 
-        reportError({
-          name: 'Out of date billing account name',
-          message:
-            `Workspace ${this.props.workspace.namespace} has an out of date billing account name. ` +
+        reportError(
+          `Workspace ${this.props.workspace.namespace} has an out of date billing account name. ` +
             `Stored value is ${this.props.workspace.billingAccountName}. ` +
-            `True value is ${billingInfo.billingAccountName}`,
-        });
+            `True value is ${billingInfo.billingAccountName}`
+        );
       }
       return billingAccounts;
     }
@@ -1218,10 +1216,8 @@ export const WorkspaceEdit = fp.flow(
         };
         if (accessLevel !== WorkspaceAccessLevel.OWNER) {
           reportError(
-            new Error(
-              `ACLs failed to propagate for workspace ${workspace.namespace}/${workspace.id}` +
-                ` accessLevel: ${accessLevel}`
-            )
+            `ACLs failed to propagate for workspace ${workspace.namespace}/${workspace.id}` +
+              ` accessLevel: ${accessLevel}`
           );
           // We intentionally do not preload the created workspace via nextWorkspaceWarmupStore in
           // this situation. This forces a workspace fetch on navigation, which is desired as ACLs

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -15,13 +15,7 @@ import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCurrentWorkspace } from 'app/utils';
 import { AccessTierShortNames } from 'app/utils/access-tiers';
-import { reportError } from 'app/utils/errors';
-import {
-  ExceededActionCountError,
-  InitialRuntimeNotFoundError,
-  LeoRuntimeInitializationAbortedError,
-  LeoRuntimeInitializer,
-} from 'app/utils/leo-runtime-initializer';
+import { LeoRuntimeInitializer } from 'app/utils/leo-runtime-initializer';
 import {
   currentWorkspaceStore,
   nextWorkspaceWarmupStore,
@@ -146,22 +140,14 @@ export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
             maxCreateCount: 0,
             maxResumeCount: 0,
           });
-        } catch (e) {
+        } catch {
+          // Ignore InitialRuntimeNotFoundError.
           // Ignore ExceededActionCountError. This is thrown when the runtime doesn't exist, or
           // isn't started. Both of these scenarios are expected, since we don't want to do any lazy
           // initialization here.
           // Also ignore LeoRuntimeInitializationAbortedError - this is expected when navigating
           // away from a page during a poll.
-          if (
-            !(
-              e instanceof InitialRuntimeNotFoundError ||
-              e instanceof ExceededActionCountError ||
-              e instanceof LeoRuntimeInitializationAbortedError
-            )
-          ) {
-            // Ideally, we would have some top-level error messaging here.
-            reportError(e);
-          }
+          // Ideally, we would handle or log errors except the ones listed above.
         }
       };
       const getWorkspaceAndUpdateStores = async (namespace, id) => {

--- a/ui/src/app/utils/errors.tsx
+++ b/ui/src/app/utils/errors.tsx
@@ -11,7 +11,7 @@ import {
 /**
  * Reports an error to Stackdriver error logging, if enabled.
  */
-export function reportError(err: Error | string) {
+export function reportError(err: string) {
   console.error('Reporting error to Stackdriver: ', err);
   const reporterStore = stackdriverErrorReporterStore.get();
   if (reporterStore?.reporter) {

--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -280,7 +280,6 @@ export class LeoRuntimeInitializer {
     if (!(e instanceof Response) || e.status >= 500) {
       this.serverErrorCount++;
     }
-    reportError(e);
   }
 
   private hasTooManyServerErrors(): boolean {


### PR DESCRIPTION
Description:

Removes most of the logs recently fixed in https://github.com/all-of-us/workbench/pull/7500.

These logs are difficult to act on for a two reasons:
- The stack traces often point to our minified JS instead of our source code ([example](https://console.cloud.google.com/errors/detail/CKrT7_C37drnGg;service=web;time=P7D?project=all-of-us-rw-prod)). This may be fixable using source maps, but requires a more thorough investigation of our build system and logging library to leverage.
- Stack traces are obfuscated by anonymous functions ([example](https://console.cloud.google.com/errors/detail/CL69gZGplO7mfA;service=web;time=P30D?project=all-of-us-rw-prod))

However, the string-based logs messages are working as expected ([example](https://console.cloud.google.com/errors/detail/CIOL2tKXzb3cpwE;service=web;time=P7D?project=all-of-us-rw-prod)). This PR leaves string-based logs as-is and modifies one simple error log to be a string log. The interface of the `reportError` function is updated to only accept strings.

To view the newly-added log messages in full, visit [this site](https://console.cloud.google.com/errors;service=web;time=P7D?project=all-of-us-rw-prod) (using your PMI-ops account) and sort by "First Seen".

I was planning to use these logs to fix recent auth errors, but that issue was fixed in the meantime. The number of auth-related errors I'm seeing in the logs is relatively low, so I don't think there's any specific issues remaining I need to debug ASAP.

I think this change is better than what we have now, but not as good as we could get. I'll create a follow-up ticket with my notes, but I don't plan on immediately investigating this.

Since this is almost entirely code removal, the only manual test I've done is checking that the app runs without any new error messages.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
