### PR TITLE
[RW-9730][risk=no] Productionize the Cromwell Beta badge

### DIFF
--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -238,7 +238,11 @@ interface State {
 }
 
 const CromwellBetaBadge = ({ style }) => (
-  <TooltipTrigger content='We are regularly improving the Cromwell experience. If you have feedback, reach out to support@researchallofus.org'>
+  <TooltipTrigger
+    content={
+      'We are regularly improving the Cromwell experience. If you have feedback, reach out to support@researchallofus.org'
+    }
+  >
     <div
       style={{
         ...styles.cromwellBetaBadge,


### PR DESCRIPTION
Description:

- Updates the Cromwell "Beta" badge styling
- Adds a tooltip to the badge


I didn't add or modify any tests.
- Would a "badge should exist" test be valuable? I'm on the fence about it. It's pretty clunky to write that test in Enzyme. Snapshot testing would be the ideal way to test for that, but we don't have that today.
- Testing tooltips is also clunky, so we'd likely test that we passed a certain value to the `TooltipTrigger` component. Similarly to the above, all we'd be testing is that we declared a component in a specific way.

[Workbench-UX slack thread](https://pmi-engteam.slack.com/archives/C02MWP2RN5P/p1679944140649479).

<img width="372" alt="image" src="https://user-images.githubusercontent.com/31020403/228046722-e4e3defd-1d4b-40eb-a4ba-b2cbbaf32c7e.png">
<img width="535" alt="image (1)" src="https://user-images.githubusercontent.com/31020403/228046742-779c41a4-a57f-4308-bc22-fca69aad419c.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
