### PR TITLE
[RW-5609][risk=no] Use environment variables for database configuration

### DIFF
--- a/api/db/local-vars.env
+++ b/api/db/local-vars.env
@@ -15,6 +15,7 @@ LIQUIBASE_DB_PASSWORD=lb-notasecret
 MYSQL_ROOT_PASSWORD=root-notasecret
 WORKBENCH_DB_USER=workbench
 WORKBENCH_DB_PASSWORD=wb-notasecret
+DB_PASSWORD=wb-notasecret
 DEV_READONLY_DB_USER=dev-readonly
 DEV_READONLY_DB_PASSWORD=dev-readonly-notasecret
 CDR_DB_USER=workbench

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -238,6 +238,9 @@ Common.register_command({
 def run_integration_tests(cmd_name, *args)
   common = Common.new
   ServiceAccountContext.new(TEST_PROJECT).run do
+    # These are required to start the application but not currently used.
+    ENV["DB_HOST"] = "placeholder"
+    ENV["DB_PASSWORD"] = "placeholder"
     common.run_inline %W{./gradlew integrationTest} + args
   end
 end

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
@@ -7,7 +7,6 @@ import org.apache.tomcat.jdbc.pool.PoolConfiguration;
 import org.apache.tomcat.jdbc.pool.PoolProperties;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrDbConfig.java
@@ -6,6 +6,7 @@ import javax.sql.DataSource;
 import org.apache.tomcat.jdbc.pool.PoolConfiguration;
 import org.apache.tomcat.jdbc.pool.PoolProperties;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
@@ -46,8 +47,11 @@ public class CdrDbConfig {
   }
 
   @Bean(name = "cdrPoolConfiguration")
-  @ConfigurationProperties(prefix = "cdr.datasource")
-  public PoolConfiguration poolConfig() {
-    return new PoolProperties();
+  public PoolConfiguration poolConfig(DataSourceProperties dsProps) {
+    PoolProperties poolProps = new PoolProperties();
+    poolProps.setUrl(dsProps.getUrl());
+    poolProps.setUsername(dsProps.getUsername());
+    poolProps.setPassword(dsProps.getPassword());
+    return poolProps;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/WorkbenchDbConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/db/WorkbenchDbConfig.java
@@ -43,14 +43,15 @@ public class WorkbenchDbConfig {
     // required.
     Optional<String> dbHost = getEnv("DB_HOST");
     p.setDriverClassName(
-      dbHost.isPresent() ? "com.mysql.jdbc.Driver" : "com.mysql.jdbc.GoogleDriver");
+        dbHost.isPresent() ? "com.mysql.jdbc.Driver" : "com.mysql.jdbc.GoogleDriver");
     String options = dbHost.isPresent() ? "useSSL=false" : "rewriteBatchedStatements=true";
-    p.setUrl(String.format("jdbc:%smysql://%s/%s?%s",
-      dbHost.isPresent() ? "" : "google:",
-      dbHost.orElseGet(() -> getEnvRequired("CLOUD_SQL_INSTANCE_NAME")),
-      "workbench", // database name is consistent across environments
-      options
-    ));
+    p.setUrl(
+        String.format(
+            "jdbc:%smysql://%s/%s?%s",
+            dbHost.isPresent() ? "" : "google:",
+            dbHost.orElseGet(() -> getEnvRequired("CLOUD_SQL_INSTANCE_NAME")),
+            "workbench", // database name is consistent across environments
+            options));
     p.setUsername("workbench"); // consistent across environments
     p.setPassword(getEnvRequired("DB_PASSWORD"));
     return p;

--- a/api/src/main/java/org/pmiops/workbench/db/WorkbenchDbConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/db/WorkbenchDbConfig.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.db;
 
+import java.util.Optional;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 import org.apache.tomcat.jdbc.pool.PoolConfiguration;
@@ -36,14 +37,27 @@ public class WorkbenchDbConfig {
 
   @Primary
   @Bean(name = "dataSourceProperties")
-  @ConfigurationProperties(prefix = "spring.datasource")
   public DataSourceProperties dataSourceProperties() {
-    return new DataSourceProperties();
+    DataSourceProperties p = new DataSourceProperties();
+    // DB_HOST should be defined for local development, otherwise CLOUD_SQL_INSTANCE_NAME is
+    // required.
+    Optional<String> dbHost = getEnv("DB_HOST");
+    p.setDriverClassName(
+      dbHost.isPresent() ? "com.mysql.jdbc.Driver" : "com.mysql.jdbc.GoogleDriver");
+    String options = dbHost.isPresent() ? "useSSL=false" : "rewriteBatchedStatements=true";
+    p.setUrl(String.format("jdbc:%smysql://%s/%s?%s",
+      dbHost.isPresent() ? "" : "google:",
+      dbHost.orElseGet(() -> getEnvRequired("CLOUD_SQL_INSTANCE_NAME")),
+      "workbench", // database name is consistent across environments
+      options
+    ));
+    p.setUsername("workbench"); // consistent across environments
+    p.setPassword(getEnvRequired("DB_PASSWORD"));
+    return p;
   }
 
   @Primary
   @Bean(name = "dataSource")
-  @ConfigurationProperties(prefix = "spring.datasource")
   public DataSource dataSource() {
     return dataSourceProperties().initializeDataSourceBuilder().build();
   }
@@ -75,5 +89,13 @@ public class WorkbenchDbConfig {
   @ConfigurationProperties(prefix = "spring.datasource")
   public PoolConfiguration poolConfig() {
     return new PoolProperties();
+  }
+
+  Optional<String> getEnv(String name) {
+    return Optional.ofNullable(System.getenv(name)).map(s -> s.trim()).filter(s -> s != "");
+  }
+
+  String getEnvRequired(String name) {
+    return getEnv(name).orElseThrow(() -> new IllegalStateException(name + " not defined"));
   }
 }

--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -24,19 +24,12 @@
 
   <env-variables>
     <env-var name="GAE_PROFILER_MODE" value="cpu,heap" />
+    <env-var name="CLOUD_SQL_INSTANCE_NAME" value="${CLOUD_SQL_INSTANCE_NAME}" />
+    <env-var name="DB_PASSWORD" value="${DB_PASSWORD}" />
   </env-variables>
 
   <system-properties>
     <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
-
-    <property name="spring.datasource.driver-class-name" value="${DB_DRIVER}"/>
-    <property name="spring.datasource.url" value="${DB_CONNECTION_STRING}"/>
-    <property name="spring.datasource.username" value="${WORKBENCH_DB_USER}"/>
-    <property name="spring.datasource.password" value="${WORKBENCH_DB_PASSWORD}"/>
-
-    <property name="cdr.datasource.url" value="${CDR_DB_CONNECTION_STRING}"/>
-    <property name="cdr.datasource.username" value="${CDR_DB_USER}"/>
-    <property name="cdr.datasource.password" value="${CDR_DB_PASSWORD}"/>
   </system-properties>
 
   <static-error-handlers>


### PR DESCRIPTION
The Google AppEngine runtime for Java 11 is substantially different than that for Java 8 and requires changes to how our application talks to Cloud SQL. As I iterated on this, having the additional burden of ambiguity around whether or not Spring would decide to use my specified configuration parameters would have caused significant fatigue. This PR addresses that problem by making that relationship more explicit.

How do I know that my changes to configuration parameters will affect the application?

Before:

```
% grep -R DB_CONNECTION_STRING
src/main/webapp/WEB-INF/appengine-web.xml.template
33:    <property name="spring.datasource.url" value="${DB_CONNECTION_STRING}"/>
37:    <property name="cdr.datasource.url" value="${CDR_DB_CONNECTION_STRING}"/>

db-cdr/vars.env
1:DB_CONNECTION_STRING=jdbc:mysql://db/cdr
```

```
% grep -R spring.datasource.url
src/main/webapp/WEB-INF/appengine-web.xml.template
33:    <property name="spring.datasource.url" value="${DB_CONNECTION_STRING}"/>

build.gradle
673:        'spring.datasource.url'              : "jdbc:mysql://${db_host}:${db_port}/workbench?useSSL=false",

src/test/resources/application.properties
2:spring.datasource.url=jdbc:h2:mem:db;DB_CLOSE_DELAY=-1;INIT=CREATE SCHEMA IF NOT EXISTS workbench;DB_CLOSE_ON_EXIT=FALSE
```
Now I must refer to Spring's documentation to determine how spring.datasource.url affects the system.

After:

```
% grep -R DB_HOST
src/main/java/org/pmiops/workbench/db/WorkbenchDbConfig.java
42:    // DB_HOST should be defined for local development, otherwise CLOUD_SQL_INSTANCE_NAME is
44:    Optional<String> dbHost = getEnv("DB_HOST");

vars.env
6:DB_HOST=127.0.0.1
```

Tested locally and deployed to AppEngine.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
