### PR TITLE
[RW-9757][risk=no] Add tooltip when GKE app cannot be deleted

### DIFF
--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -269,19 +269,24 @@ export const ExpandedApp = (props: ExpandedAppProps) => {
           // TODO: support Cromwell + other User Apps
           appType === UIAppType.JUPYTER && <RuntimeCost />
         }
-        <Clickable
-          disabled={!trashEnabled}
-          style={
-            trashEnabled
-              ? styles.enabledTrashButton
-              : styles.disabledTrashButton
-          }
-          onClick={onClickDelete}
-          data-test-id={`${appType}-delete-button`}
-          propagateDataTestId
+        <TooltipTrigger
+          disabled={trashEnabled}
+          content='Your application must be running in order to be deleted.'
         >
-          <FontAwesomeIcon icon={faTrashCan} />
-        </Clickable>
+          <Clickable
+            disabled={!trashEnabled}
+            style={
+              trashEnabled
+                ? styles.enabledTrashButton
+                : styles.disabledTrashButton
+            }
+            onClick={onClickDelete}
+            data-test-id={`${appType}-delete-button`}
+            propagateDataTestId
+          >
+            <FontAwesomeIcon icon={faTrashCan} />
+          </Clickable>
+        </TooltipTrigger>
       </FlexRow>
       {appType === UIAppType.JUPYTER ? (
         <JupyterButtonRow {...{ workspace, onClickRuntimeConf }} />


### PR DESCRIPTION
Description:

Adds a tooltip when the GKE app cannot be deleted.

You can test this locally by hovering over a disabled trash can for a GKE app.

I didn't add a unit test for the same reason mentioned in [this PR](https://github.com/all-of-us/workbench/pull/7518). Let me know if you think I should add one.

[Relevant UX Slack thread](https://pmi-engteam.slack.com/archives/C02MWP2RN5P/p1680026939784289).

Screenshot:
<img width="507" alt="image (2)" src="https://user-images.githubusercontent.com/31020403/228329488-a3470f9c-690e-4f74-a3d7-07a4c6b5318c.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
