### PR TITLE
[no-ticket][risk=no] Reduce build noise

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -460,7 +460,9 @@ dependencies {
     compile "org.springframework:spring-aspects:$project.ext.SPRING_FRAMEWORK_VERSION"
     compile "org.springframework:spring-beans:$project.ext.SPRING_FRAMEWORK_VERSION"
     compile "org.springframework:spring-context:$project.ext.SPRING_FRAMEWORK_VERSION"
-    compile "org.springframework:spring-core:$project.ext.SPRING_FRAMEWORK_VERSION"
+    compile("org.springframework:spring-core:$project.ext.SPRING_FRAMEWORK_VERSION") {
+      exclude group: 'org.springframework', module: 'spring-jcl'
+    }
     compile "org.springframework:spring-expression:$project.ext.SPRING_FRAMEWORK_VERSION"
     compile "org.springframework:spring-jcl:$project.ext.SPRING_FRAMEWORK_VERSION"
     compile "org.springframework:spring-jdbc:$project.ext.SPRING_FRAMEWORK_VERSION"
@@ -855,4 +857,37 @@ compileTestKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+}
+
+dependencies {
+  modules {
+    module("com.sun.activation:jakarta.activation") {
+      replacedBy("jakarta.annotation:jakarta.annotation-api")
+    }
+    module("javax.annotation:javax.annotation-api") {
+      replacedBy("jakarta.annotation:jakarta.annotation-api")
+    }
+    module("org.apache.tomcat:tomcat-annotations-api") {
+      replacedBy("jakarta.annotation:jakarta.annotation-api")
+    }
+    module("javax.persistence:javax.persistence-api") {
+      replacedBy("jakarta.persistence:jakarta.persistence-api")
+    }
+    module("org.aspectj:aspectjrt") { replacedBy("org.aspectj:aspectjweaver") }
+    module("javax.xml.bind:javax.xml.bind-api") {
+      replacedBy("jakarta.xml.bind:jakarta.xml.bind-api")
+    }
+    module("javax.xml.bind:jaxb-api") { replacedBy("jakarta.xml.bind:jakarta.xml.bind-api") }
+    module("javax.activation:javax.activation-api") {
+      replacedBy("jakarta.activation:jakarta.activation-api")
+    }
+    module("org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec") {
+      replacedBy("jakarta.transaction:jakarta.transaction-api")
+    }
+    module("org.springframework:spring-jcl") { replacedBy("commons-logging:commons-logging") }
+    module("javax.servlet:servlet-api") { replacedBy("javax.servlet:javax.servlet-api") }
+    module("org.apache.tomcat:tomcat-juli") {
+      replacedBy("org.apache.tomcat.embed:tomcat-embed-core")
+    }
+  }
 }


### PR DESCRIPTION
This change eliminates all instances of the warning:
```
com.example.Classname scanned from multiple locations: ...
```
except for those that are duplicated in the appengine-api-1.0-sdk jar, which will go away once we are on AppEngine's Java 11 runtime and we've migrated off of it.

Tested by building locally.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
