### PR TITLE
[RW-9208][risk=low] Allow bypassing profile and publication confirmation modules

### DIFF
--- a/api-proxy/handlers/|v1|config.get.mjs
+++ b/api-proxy/handlers/|v1|config.get.mjs
@@ -71,14 +71,14 @@ const body = JSON.stringify(
     {
       name: 'PROFILE_CONFIRMATION',
       expirable: true,
-      bypassable: false,
+      bypassable: true,
       requiredForRTAccess: true,
       requiredForCTAccess: true
     },
     {
       name: 'PUBLICATION_CONFIRMATION',
       expirable: true,
-      bypassable: false,
+      bypassable: true,
       requiredForRTAccess: true,
       requiredForCTAccess: true
     },

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleNameMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleNameMapper.java
@@ -19,9 +19,6 @@ public interface AccessModuleNameMapper {
   @ValueMapping(source = "RAS_LOGIN_GOV", target = "RAS_LINK_LOGIN_GOV")
   AccessModule storageAccessModuleToClient(DbAccessModuleName source);
 
-  // these modules cannot be bypassed
-  @ValueMapping(source = "PROFILE_CONFIRMATION", target = MappingConstants.NULL)
-  @ValueMapping(source = "PUBLICATION_CONFIRMATION", target = MappingConstants.NULL)
   BypassTimeTargetProperty bypassAuditPropertyFromStorage(DbAccessModuleName source);
 
   // only compliance training modules have associated badges

--- a/api/src/main/java/org/pmiops/workbench/actionaudit/targetproperties/BypassTimeTargetProperty.kt
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/targetproperties/BypassTimeTargetProperty.kt
@@ -7,5 +7,7 @@ constructor(override val propertyName: String) : SimpleTargetProperty {
     CT_COMPLIANCE_TRAINING("ct_compliance_training_time"),
     ERA_COMMONS("era_commons_bypass_time"),
     TWO_FACTOR_AUTH("two_factor_auth_bypass_time"),
+    PROFILE_CONFIRMATION("profile_confirmation_bypass_time"),
+    PUBLICATION_CONFIRMATION("publication_confirmation_bypass_time"),
     RAS_LOGIN_GOV("ras_link_login_gov_bypass_time")
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -135,6 +135,10 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
 
     Timestamp getTwoFactorAuthBypassTime();
 
+    Timestamp getProfileConfirmationBypassTime();
+
+    Timestamp getPublicationConfirmationBypassTime();
+
     Timestamp getRasLinkLoginGovBypassTime();
 
     String getAccessTierShortNames();
@@ -163,6 +167,8 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + "uamrt.compliance_training_bypass_time AS complianceTrainingBypassTime, "
               + "uamct.ct_compliance_training_bypass_time AS ctComplianceTrainingBypassTime, "
               + "uame.era_commons_bypass_time AS eraCommonsBypassTime, "
+              + "uamprofile.profile_confirmation_bypass_time AS profileConfirmationBypassTime, "
+              + "uampublication.publication_confirmation_bypass_time AS publicationConfirmationBypassTime, "
               + "uamt.two_factor_auth_bypass_time AS twoFactorAuthBypassTime, "
               + "uamr.ras_link_login_gov_bypass_time AS rasLinkLoginGovBypassTime, "
               + "t.access_tier_short_names AS accessTierShortNames "
@@ -192,6 +198,20 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + "  JOIN access_module am ON am.access_module_id=uam.access_module_id "
               + "  WHERE am.name = 'TWO_FACTOR_AUTH' "
               + ") as uamt ON u.user_id = uamt.user_id "
+              + "LEFT JOIN ( "
+              + "  SELECT uam.user_id, "
+              + "    uam.bypass_time AS profile_confirmation_bypass_time "
+              + "  FROM user_access_module uam "
+              + "  JOIN access_module am ON am.access_module_id=uam.access_module_id "
+              + "  WHERE am.name = 'PROFILE_CONFIRMATION' "
+              + ") as uamprofile ON u.user_id = uamprofile.user_id "
+              + "LEFT JOIN ( "
+              + "  SELECT uam.user_id, "
+              + "    uam.bypass_time AS publication_confirmation_bypass_time "
+              + "  FROM user_access_module uam "
+              + "  JOIN access_module am ON am.access_module_id=uam.access_module_id "
+              + "  WHERE am.name = 'PUBLICATION_CONFIRMATION' "
+              + ") as uampublication ON u.user_id = uampublication.user_id "
               + "LEFT JOIN ( "
               + "  SELECT uam.user_id, "
               + "    uam.bypass_time AS compliance_training_bypass_time "

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbAccessModule.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbAccessModule.java
@@ -45,7 +45,7 @@ public class DbAccessModule {
 
   @Column(name = "bypassable", nullable = false)
   public boolean getBypassable() {
-    return bypassable;
+    return true;
   }
 
   public DbAccessModule setBypassable(boolean bypassable) {

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6040,6 +6040,12 @@ definitions:
       twoFactorAuthBypassTime:
         type: integer
         format: int64
+      profileConfirmationBypassTime:
+        type: integer
+        format: int64
+      publicationConfirmationBypassTime:
+        type: integer
+        format: int64
       eraCommonsBypassTime:
         type: integer
         format: int64

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleNameMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleNameMapperTest.java
@@ -38,15 +38,8 @@ public class AccessModuleNameMapperTest {
 
   @Test
   public void testStorageToBypassPropertyMapping() {
-    // these can't be bypassed, so they don't have a mapping
-    List<DbAccessModuleName> unbypassable =
-        ImmutableList.of(
-            DbAccessModuleName.PROFILE_CONFIRMATION, DbAccessModuleName.PUBLICATION_CONFIRMATION);
-    unbypassable.forEach(name -> assertThat(mapper.bypassAuditPropertyFromStorage(name)).isNull());
-
     assertThat(
             Arrays.stream(DbAccessModuleName.values())
-                .filter(name -> !unbypassable.contains(name))
                 .allMatch(name -> mapper.bypassAuditPropertyFromStorage(name) != null))
         .isTrue();
   }

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.access;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.pmiops.workbench.access.AccessModuleServiceImpl.deriveExpirationTimestamp;
 
@@ -25,7 +24,6 @@ import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserAccessModule;
-import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.model.AccessModule;
 import org.pmiops.workbench.model.AccessModuleStatus;
 import org.pmiops.workbench.utils.TestMockFactory;
@@ -183,15 +181,6 @@ public class AccessModuleServiceTest {
             BypassTimeTargetProperty.TWO_FACTOR_AUTH,
             nullableTimestampToOptionalInstant(existingBypasstime),
             Optional.empty());
-  }
-
-  @Test
-  public void testBypassFail_moduleNotBypassable() {
-    assertThrows(
-        ForbiddenException.class,
-        () ->
-            accessModuleService.updateBypassTime(
-                user.getUserId(), DbAccessModuleName.PROFILE_CONFIRMATION, true));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
@@ -196,6 +196,10 @@ public class UserDaoTest {
         accessModuleDao.findOneByName(DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
     final DbAccessModule rasConfirmModule =
         accessModuleDao.findOneByName(DbAccessModuleName.RAS_LOGIN_GOV).get();
+    final DbAccessModule profileConfirmationModule =
+        accessModuleDao.findOneByName(DbAccessModuleName.PROFILE_CONFIRMATION).get();
+    final DbAccessModule publicationConfirmationModule =
+        accessModuleDao.findOneByName(DbAccessModuleName.PUBLICATION_CONFIRMATION).get();
     Instant now = Instant.now();
     Timestamp twoFactorAuthBypassTime = Timestamp.from(now.minusSeconds(10));
     Timestamp twoFactorAuthCompleteTime = Timestamp.from(now.minusSeconds(20));
@@ -208,6 +212,8 @@ public class UserDaoTest {
     Timestamp rasBypassTime = Timestamp.from(now.minusSeconds(90));
     Timestamp ctTrainingBypassTime = Timestamp.from(now.minusSeconds(100));
     Timestamp ctTrainingCompleteTime = Timestamp.from(now.minusSeconds(110));
+    Timestamp profileConfirmationBypassTime = Timestamp.from(now.minusSeconds(120));
+    Timestamp publicationConfirmationBypassTime = Timestamp.from(now.minusSeconds(130));
     Timestamp rasCompleteTime = Timestamp.from(now);
     addUserAccessModule(
         user, twoFactorAuthModule, twoFactorAuthBypassTime, twoFactorAuthCompleteTime);
@@ -216,6 +222,9 @@ public class UserDaoTest {
     addUserAccessModule(user, eRACommonsModule, eRABypassTime, eRACompleteTime);
     addUserAccessModule(user, duccModule, duccBypassTime, duccCompleteTime);
     addUserAccessModule(user, rasConfirmModule, rasBypassTime, rasCompleteTime);
+    addUserAccessModule(user, profileConfirmationModule, profileConfirmationBypassTime, null);
+    addUserAccessModule(
+        user, publicationConfirmationModule, publicationConfirmationBypassTime, null);
     List<DbAdminTableUser> rows = userDao.getAdminTableUsers();
     assertThat(rows).hasSize(1);
     assertThat(rows.get(0).getEraCommonsBypassTime()).isEqualTo(eRABypassTime);
@@ -224,6 +233,10 @@ public class UserDaoTest {
     assertThat(rows.get(0).getDuccBypassTime()).isEqualTo(duccBypassTime);
     assertThat(rows.get(0).getTwoFactorAuthBypassTime()).isEqualTo(twoFactorAuthBypassTime);
     assertThat(rows.get(0).getRasLinkLoginGovBypassTime()).isEqualTo(rasBypassTime);
+    assertThat(rows.get(0).getProfileConfirmationBypassTime())
+        .isEqualTo(profileConfirmationBypassTime);
+    assertThat(rows.get(0).getPublicationConfirmationBypassTime())
+        .isEqualTo(publicationConfirmationBypassTime);
 
     final DbAdminTableUser row = rows.get(0);
     Class<DbAdminTableUser> dbAdminUserClass = DbAdminTableUser.class;

--- a/ui/src/app/pages/admin/user/admin-user-bypass.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-bypass.tsx
@@ -45,6 +45,12 @@ const getBypassedModules = (user: AdminTableUser): Array<AccessModule> => {
     ...(user.eraCommonsBypassTime ? [AccessModule.ERACOMMONS] : []),
     ...(user.twoFactorAuthBypassTime ? [AccessModule.TWOFACTORAUTH] : []),
     ...(user.rasLinkLoginGovBypassTime ? [AccessModule.RASLINKLOGINGOV] : []),
+    ...(user.profileConfirmationBypassTime
+      ? [AccessModule.PROFILECONFIRMATION]
+      : []),
+    ...(user.publicationConfirmationBypassTime
+      ? [AccessModule.PUBLICATIONCONFIRMATION]
+      : []),
   ];
 };
 
@@ -232,6 +238,34 @@ export class AdminUserBypass extends React.Component<Props, State> {
                 }}
               />
             )}
+            <Toggle
+              name='Profile Confirmation'
+              checked={selectedModules.includes(
+                AccessModule.PROFILECONFIRMATION
+              )}
+              data-test-id='profile-confirmation-toggle'
+              onToggle={() => {
+                this.setState({
+                  selectedModules: fp.xor(selectedModules, [
+                    AccessModule.PROFILECONFIRMATION,
+                  ]),
+                });
+              }}
+            />
+            <Toggle
+              name='Publication Confirmation'
+              checked={selectedModules.includes(
+                AccessModule.PUBLICATIONCONFIRMATION
+              )}
+              data-test-id='publication-confirmation-toggle'
+              onToggle={() => {
+                this.setState({
+                  selectedModules: fp.xor(selectedModules, [
+                    AccessModule.PUBLICATIONCONFIRMATION,
+                  ]),
+                });
+              }}
+            />
             <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
               <Button
                 type='secondary'

--- a/ui/src/app/pages/profile/profile-component.spec.tsx
+++ b/ui/src/app/pages/profile/profile-component.spec.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { mount, ReactWrapper } from 'enzyme';
 
-import { InstitutionApi, Profile, ProfileApi } from 'generated/fetch';
+import {
+  AccessModule,
+  InstitutionApi,
+  Profile,
+  ProfileApi,
+} from 'generated/fetch';
 
 import { TextInput } from 'app/components/inputs';
 import { ProfileComponent } from 'app/pages/profile/profile-component';
@@ -16,6 +21,8 @@ import {
   ProfileApiStub,
   ProfileStubVariables,
 } from 'testing/stubs/profile-api-stub';
+
+const tenMinutesMs = 10 * 60 * 1000;
 
 describe('ProfilePageComponent', () => {
   function getSaveProfileButton(wrapper: ReactWrapper): ReactWrapper {
@@ -169,6 +176,43 @@ describe('ProfilePageComponent', () => {
     const wrapper = component();
     expect(
       wrapper.find('[data-test-id="signed-ducc-panel"]').exists()
+    ).toBeFalsy();
+  });
+
+  it('should show the profile confirmation renewal box if the access module has expired', async () => {
+    updateProfile({
+      accessModules: {
+        modules: [
+          {
+            moduleName: AccessModule.PROFILECONFIRMATION,
+            expirationEpochMillis: Date.now() - tenMinutesMs,
+          },
+        ],
+      },
+    });
+
+    const wrapper = component();
+    expect(
+      wrapper.find('[data-test-id="profile-confirmation-renewal-box"]').exists()
+    ).toBeTruthy();
+  });
+
+  it('should not show the profile confirmation renewal box if the access module was bypassed', async () => {
+    updateProfile({
+      accessModules: {
+        modules: [
+          {
+            moduleName: AccessModule.PROFILECONFIRMATION,
+            expirationEpochMillis: Date.now() - tenMinutesMs,
+            bypassEpochMillis: 1,
+          },
+        ],
+      },
+    });
+
+    const wrapper = component();
+    expect(
+      wrapper.find('[data-test-id="profile-confirmation-renewal-box"]').exists()
     ).toBeFalsy();
   });
 });

--- a/ui/src/app/pages/profile/profile-component.tsx
+++ b/ui/src/app/pages/profile/profile-component.tsx
@@ -255,11 +255,17 @@ export const ProfileComponent = fp.flow(
         },
       } = currentProfile;
 
-      const profileExpiration = fp.flow(
-        fp.find({ moduleName: AccessModule.PROFILECONFIRMATION }),
-        fp.get('expirationEpochMillis')
-      )(profile.accessModules.modules);
-      const hasExpired = profileExpiration && profileExpiration < Date.now();
+      const profileConfirmationAccessModule = fp.find(
+        { moduleName: AccessModule.PROFILECONFIRMATION },
+        profile.accessModules.modules
+      );
+      const hasExpired =
+        profileConfirmationAccessModule.expirationEpochMillis &&
+        profileConfirmationAccessModule.expirationEpochMillis < Date.now();
+      const bypassed = !!profileConfirmationAccessModule.bypassEpochMillis;
+      const showRenewalBox =
+        (hasExpired && !bypassed) ||
+        wasReferredFromRenewal(this.props.location.search);
 
       // validatejs requires a scheme, which we don't necessarily need in the profile; rather than
       // forking their website regex, just ensure a scheme ahead of validation.
@@ -374,9 +380,11 @@ export const ProfileComponent = fp.flow(
             <div style={{ ...styles.h1, marginBottom: '1.05rem' }}>Profile</div>
             <FlexRow style={{ justifyContent: 'spaceBetween' }}>
               <div>
-                {(hasExpired ||
-                  wasReferredFromRenewal(this.props.location.search)) && (
-                  <div style={styles.renewalBox}>
+                {showRenewalBox && (
+                  <div
+                    style={styles.renewalBox}
+                    data-test-id='profile-confirmation-renewal-box'
+                  >
                     <ExclamationTriangle
                       size={25}
                       color={colors.warning}

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -49,14 +49,14 @@ const defaultAccessModuleConfig: AccessModuleConfig[] = [
   },
   {
     name: AccessModule.PROFILECONFIRMATION,
-    bypassable: false,
+    bypassable: true,
     expirable: true,
     requiredForRTAccess: true,
     requiredForCTAccess: true,
   },
   {
     name: AccessModule.PUBLICATIONCONFIRMATION,
-    bypassable: false,
+    bypassable: true,
     expirable: true,
     requiredForRTAccess: true,
     requiredForCTAccess: true,


### PR DESCRIPTION
# Description

Allow bypassing profile and publication confirmation modules. This implements all product-facing changes for the story.

All modules are now bypassable. The remaining PRs will refactor the code based on this.

I marked this as "low" risk because this directly affects access modules.

Manually tested:
- Bypass all continues to work
- The normal renewal flow continues to work

New features:
- Admins can bypass these modules from the user index admin page
- Admins can bypass these modules from the user admin page
- The data requirements page shows that the modules have been bypassed
- The profile page doesn't show the renewal banner if the user is bypassed

# Testing locally

## Marking modules as expired

`​​update user_access_module set completion_time = DATE_SUB(NOW(),INTERVAL 2 YEAR) where user_id = 2 and access_module_id = 6;`

6 = PROFILE_CONFIRMATION
7 = PUBLICATION_CONFIRMATION

## Audit logs

Bypassing a user will create an audit log entry. You can view recent entries in our BigQuery with the following:

```SELECT timestamp, jsonPayload.target_id, jsonPayload.target_property, jsonPayload.target_type, jsonPayload.action_type, jsonPayload.prev_value, jsonPayload.new_value FROM `all-of-us-workbench-test.workbench_action_audit_local.workbench_action_audit_local```

# Screenshots

http://localhost:4200/data-access-requirements?pageMode=ANNUAL_RENEWAL
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/31020403/229900717-d0317bcf-3fd5-4ad3-bc3c-4d719337fd37.png">

http://localhost:4200/admin/users
<img width="339" alt="image" src="https://user-images.githubusercontent.com/31020403/229901004-a80a9393-d9c3-43e0-9edc-ddc649205766.png">

http://localhost:4200/admin/users/peterlavigne_local_001
<img width="1328" alt="image" src="https://user-images.githubusercontent.com/31020403/229901048-c16e18fd-50bb-463b-b0a4-7ee1dff73aeb.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
