### PR TITLE
[DT-345][risk=no] Updated to fix participant counts for surveys across: cb/ds survey tables

### DIFF
--- a/api/db-cdr/generate-cdr/build-review-all-events.sh
+++ b/api/db-cdr/generate-cdr/build-review-all-events.sh
@@ -31,7 +31,7 @@ JOIN
         WHERE ancestor_concept_id in
             (
                 SELECT concept_id
-                FROM \`$BQ_PROJECT.$Q_DATASET.cb_criteria\`
+                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
                 WHERE domain_id = 'SURVEY'
                     and parent_id = 0
                     and concept_id not in (1333342, 1740639)

--- a/api/db-cdr/generate-cdr/build-review-all-events.sh
+++ b/api/db-cdr/generate-cdr/build-review-all-events.sh
@@ -60,7 +60,7 @@ JOIN
         WHERE ancestor_concept_id in
             (
                 SELECT concept_id
-                FROM \`$BQ_PROJECT.$Q_DATASET.cb_criteria\`
+                FROM \`$BQ_PROJECT.$BQ_DATASET.cb_criteria\`
                 WHERE domain_id = 'SURVEY'
                     AND parent_id = 0
                     AND concept_id IN (1333342)


### PR DESCRIPTION
Description:
---
- Updated indexing build for cb_review_survey to fix participant counts for surveys across: cb_criteria, cb_review_survey and ds_survey tables.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
