### PR TITLE
[risk=low][RW-9518][RW-9608][RW-9526] Update Cromwell/RStudio e2e tests for polling

### DIFF
--- a/e2e/app/sidebar/apps-panel.ts
+++ b/e2e/app/sidebar/apps-panel.ts
@@ -12,17 +12,16 @@ export default class AppsPanel extends BaseEnvironmentPanel {
   }
 
   async pollForStatus(xPath: string, status: string, timeout: number = 10 * 60e3): Promise<void> {
+    const interval = 10e3; // every 10 sec
     const success = await waitForFn(
       async () => {
-        await this.close();
-        await this.open();
         const text = await BaseElement.asBaseElement(page, await page.waitForXPath(xPath)).getTextContent();
-        return text.includes(`status: ${status}`);
+        return text.includes(`Status: ${status}`);
       },
-      10e3, // every 10 sec
+      interval,
       timeout
     );
+    console.log(success ? `Polling complete, status = ${status}` : `Polling timed out after ${interval / 1e3} seconds`);
     expect(success).toBeTruthy();
-    console.log(`Polling complete, status = ${status}`);
   }
 }

--- a/e2e/tests/nightly/gke-apps/cromwell.spec.ts
+++ b/e2e/tests/nightly/gke-apps/cromwell.spec.ts
@@ -60,10 +60,9 @@ describe('Cromwell GKE App', () => {
       page,
       await page.waitForXPath(expandedCromwellXpath)
     ).getTextContent();
-    expect(cromwellText).toContain('status: PROVISIONING');
+    expect(cromwellText).toContain('Status: PROVISIONING');
     console.log('Cromwell status: PROVISIONING');
 
-    // poll for "Running" by repeatedly closing and opening
     await appsPanel.pollForStatus(expandedCromwellXpath, 'Running', 15 * 60e3);
 
     const deleteXPath = `${expandedCromwellXpath}//*[@data-test-id="Cromwell-delete-button"]`;
@@ -71,20 +70,17 @@ describe('Cromwell GKE App', () => {
     expect(await deleteButton.exists()).toBeTruthy();
     await deleteButton.click();
 
-    // poll for "DELETING" by repeatedly closing and opening
     await appsPanel.pollForStatus(expandedCromwellXpath, 'DELETING');
 
-    // poll for deleted (unexpanded) by repeatedly closing and opening
+    // poll for deleted (unexpanded)
 
     const isDeleted = await waitForFn(
       async () => {
-        await appsPanel.close();
-        await appsPanel.open();
         const unexpanded = new Button(page, unexpandedCromwellXPath);
         return await unexpanded.exists();
       },
       10e3, // every 10 sec
-      60e3 // with a 1 min timeout
+      2 * 60e3 // with a 2 min timeout
     );
     expect(isDeleted).toBeTruthy();
   });

--- a/e2e/tests/nightly/gke-apps/cromwell.spec.ts
+++ b/e2e/tests/nightly/gke-apps/cromwell.spec.ts
@@ -72,15 +72,17 @@ describe('Cromwell GKE App', () => {
 
     await appsPanel.pollForStatus(expandedCromwellXpath, 'DELETING');
 
-    // poll for deleted (unexpanded)
+    // poll for deleted (unexpanded) by repeatedly closing and opening
 
     const isDeleted = await waitForFn(
       async () => {
+        await appsPanel.close();
+        await appsPanel.open();
         const unexpanded = new Button(page, unexpandedCromwellXPath);
         return await unexpanded.exists();
       },
       10e3, // every 10 sec
-      2 * 60e3 // with a 2 min timeout
+      60e3 // with a 1 min timeout
     );
     expect(isDeleted).toBeTruthy();
   });

--- a/e2e/tests/nightly/gke-apps/rstudio.spec.ts
+++ b/e2e/tests/nightly/gke-apps/rstudio.spec.ts
@@ -46,10 +46,8 @@ describe('RStudio GKE App', () => {
 
     await createButton.click();
 
-    // poll for "PROVISIONING" by repeatedly closing and opening
     await appsPanel.pollForStatus(expandedRStudioXpath, 'PROVISIONING');
 
-    // poll for "Running" by repeatedly closing and opening
     await appsPanel.pollForStatus(expandedRStudioXpath, 'Running', 15 * 60e3);
 
     const deleteXPath = `${expandedRStudioXpath}//*[@data-test-id="RStudio-delete-button"]`;
@@ -57,7 +55,6 @@ describe('RStudio GKE App', () => {
     expect(await deleteButton.exists()).toBeTruthy();
     await deleteButton.click();
 
-    // poll for "DELETING" by repeatedly closing and opening
     await appsPanel.pollForStatus(expandedRStudioXpath, 'DELETING');
 
     // poll for deleted (unexpanded) by repeatedly closing and opening


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
