### PR TITLE
[no-ticket][risk=no] Avoid Cloud SQL Proxy when running Java tools

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -63,6 +63,7 @@ def read_db_vars(gcc)
     Common.new.error "Failed to read #{cdr_vars_path}"
     exit 1
   end
+  vars["GOOGLE_APPLICATION_CREDENTIALS"] = "sa-key.json"
   return vars.merge({
     'CDR_DB_CONNECTION_STRING' => cdr_vars['DB_CONNECTION_STRING'],
     'CDR_DB_USER' => cdr_vars['WORKBENCH_DB_USER'],

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1124,39 +1124,6 @@ Common.register_command({
   :fn => ->(*args) { run_cloud_data_migrations("run-cloud-data-migrations", args) }
 })
 
-def write_db_creds_file(project, cdr_db_name, root_password, workbench_password, readonly_password)
-  instance_name = "#{project}:us-central1:workbenchmaindb"
-  db_creds_file = Tempfile.new("#{project}-vars.env")
-  if db_creds_file
-    begin
-      db_creds_file.puts "DB_CONNECTION_STRING=jdbc:google:mysql://#{instance_name}/workbench?rewriteBatchedStatements=true"
-      db_creds_file.puts "DB_DRIVER=com.mysql.jdbc.GoogleDriver"
-      db_creds_file.puts "DB_HOST=127.0.0.1"
-      db_creds_file.puts "DB_NAME=workbench"
-      # TODO: make our CDR migration scripts update *all* CDR versions listed in the cdr_version
-      # table of the workbench DB; then this shouldn't be needed anymore.
-      db_creds_file.puts "CDR_DB_NAME=#{cdr_db_name}"
-      # TODO: wait one release and then remove
-      db_creds_file.puts "CLOUD_SQL_INSTANCE=#{instance_name}"
-      db_creds_file.puts "CLOUD_SQL_INSTANCE_NAME=#{instance_name}"
-      db_creds_file.puts "LIQUIBASE_DB_USER=liquibase"
-      db_creds_file.puts "LIQUIBASE_DB_PASSWORD=#{workbench_password}"
-      db_creds_file.puts "MYSQL_ROOT_PASSWORD=#{root_password}"
-      db_creds_file.puts "WORKBENCH_DB_USER=workbench"
-      db_creds_file.puts "WORKBENCH_DB_PASSWORD=#{workbench_password}"
-      db_creds_file.puts "DEV_READONLY_DB_USER=dev-readonly"
-      db_creds_file.puts "DEV_READONLY_DB_PASSWORD=#{readonly_password}"
-      db_creds_file.close
-
-      copy_file_to_gcs(db_creds_file.path, "#{project}-credentials", "vars.env")
-    ensure
-      db_creds_file.unlink
-    end
-  else
-    raise("Error creating file.")
-  end
-end
-
 def create_auth_domain(cmd_name, args)
   op = WbOptionsParser.new(cmd_name, args)
   op.add_option(

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -183,7 +183,7 @@ def run_api_incremental()
     common.status "Starting API server..."
     # appengineStart must be run with the Gradle daemon or it will stop outputting logs as soon as
     # the application has finished starting.
-    common.run_inline "DB_HOST=127.0.0.1 ./gradlew --daemon appengineRun &"
+    common.run_inline "./gradlew --daemon appengineRun &"
 
     # incrementalHotSwap must be run without the Gradle daemon or stdout and stderr will not appear
     # in the output.
@@ -2286,7 +2286,6 @@ def migrate_database(dry_run = false)
   common = Common.new
   common.status "Migrating main database..."
   Dir.chdir("db") do
-    ENV["DB_HOST"] = nil
     run_inline_or_log(dry_run, %W{../gradlew update -PrunList=main})
   end
 end

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2261,6 +2261,7 @@ def create_or_update_workbench_db()
 end
 
 def create_or_update_workbench_db_cmd(cmd_name, args)
+  op = WbOptionsParser.new(cmd_name, args)
   gcc = GcloudContextV2.new(op)
   op.parse.validate
   gcc.validate()
@@ -2425,6 +2426,7 @@ Common.register_command({
 
 
 def run_cloud_migrations(cmd_name, args)
+  op = WbOptionsParser.new(cmd_name, args)
   gcc = GcloudContextV2.new(op)
   op.parse.validate
   gcc.validate()
@@ -2439,6 +2441,7 @@ Common.register_command({
 })
 
 def update_cloud_config(cmd_name, args)
+  op = WbOptionsParser.new(cmd_name, args)
   gcc = GcloudContextV2.new(op)
   op.parse.validate
   gcc.validate()


### PR DESCRIPTION
This avoids starting Cloud SQL Proxy whenever we run a Java tool, since our datasource configuration no longer needs it.

Manually ran few commands locally.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
