### PR TITLE
[RW-9208][risk=no] Remove test references to unbypassable modules

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -279,7 +279,7 @@ public class UserServiceAccessTest {
         });
   }
 
-  // ERA Commons can be bypassed and is not subject to annual renewal.
+  // ERA Commons is not subject to annual renewal.
 
   @Test
   public void test_updateUserWithRetries_era_unbypassed_noncompliant() {
@@ -291,7 +291,7 @@ public class UserServiceAccessTest {
         });
   }
 
-  // Two Factor Auth (2FA) can be bypassed and is not subject to annual renewal.
+  // Two Factor Auth (2FA) is not subject to annual renewal.
 
   @Test
   public void test_updateUserWithRetries_2fa_unbypassed_noncompliant() {
@@ -303,7 +303,7 @@ public class UserServiceAccessTest {
         });
   }
 
-  // Compliance training can be bypassed, and is subject to annual renewal.
+  // Compliance training is subject to annual renewal.
 
   @Test
   public void test_updateUserWithRetries_training_unbypassed_aar_noncompliant() {
@@ -331,7 +331,7 @@ public class UserServiceAccessTest {
         });
   }
 
-  // DUCC can be bypassed, and is subject to annual renewal.
+  // DUCC is subject to annual renewal.
   // A missing DUCC version or a version other than the latest is also noncompliant.
 
   @Test
@@ -389,12 +389,14 @@ public class UserServiceAccessTest {
         });
   }
 
-  // Publications confirmation is subject to annual renewal and cannot be bypassed.
+  // Publications confirmation is subject to annual renewal.
 
   @Test
-  public void test_updateUserWithRetries_publications_not_confirmed() {
+  public void test_updateUserWithRetries_publications_unbypassed_publications_not_confirmed() {
     testUnregistration(
         user -> {
+          accessModuleService.updateBypassTime(
+                  dbUser.getUserId(), DbAccessModuleName.PUBLICATION_CONFIRMATION, false);
           accessModuleService.updateCompletionTime(
               dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, null);
           return userDao.save(user);
@@ -402,9 +404,11 @@ public class UserServiceAccessTest {
   }
 
   @Test
-  public void test_updateUserWithRetries_publications_expired() {
+  public void test_updateUserWithRetries_publications_unbypassed_publications_expired() {
     testUnregistration(
         user -> {
+          accessModuleService.updateBypassTime(
+                  dbUser.getUserId(), DbAccessModuleName.PUBLICATION_CONFIRMATION, false);
           final Timestamp willExpire = Timestamp.from(START_INSTANT);
           accessModuleService.updateCompletionTime(
               dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, willExpire);
@@ -414,12 +418,14 @@ public class UserServiceAccessTest {
         });
   }
 
-  // Profile confirmation is subject to annual renewal and cannot be bypassed.
+  // Profile confirmation is subject to annual renewal.
 
   @Test
-  public void test_updateUserWithRetries_profile_not_confirmed() {
+  public void test_updateUserWithRetries_profile_unbypassed_profile_not_confirmed() {
     testUnregistration(
         user -> {
+          accessModuleService.updateBypassTime(
+                  dbUser.getUserId(), DbAccessModuleName.PROFILE_CONFIRMATION, false);
           accessModuleService.updateCompletionTime(
               dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, null);
           return userDao.save(user);
@@ -427,9 +433,11 @@ public class UserServiceAccessTest {
   }
 
   @Test
-  public void test_updateUserWithRetries_profile_expired() {
+  public void test_updateUserWithRetries_profile_unbypassed_profile_expired() {
     testUnregistration(
         user -> {
+          accessModuleService.updateBypassTime(
+                  dbUser.getUserId(), DbAccessModuleName.PROFILE_CONFIRMATION, false);
           final Timestamp willExpire = Timestamp.from(START_INSTANT);
           accessModuleService.updateCompletionTime(
               dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, willExpire);
@@ -1339,11 +1347,10 @@ public class UserServiceAccessTest {
     accessModuleService.updateBypassTime(
         user.getUserId(), DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, true);
     accessModuleService.updateBypassTime(user.getUserId(), DbAccessModuleName.RAS_LOGIN_GOV, true);
-
-    accessModuleService.updateCompletionTime(
-        user, DbAccessModuleName.PUBLICATION_CONFIRMATION, timestamp);
-    accessModuleService.updateCompletionTime(
-        user, DbAccessModuleName.PROFILE_CONFIRMATION, timestamp);
+    accessModuleService.updateBypassTime(
+        user.getUserId(), DbAccessModuleName.PUBLICATION_CONFIRMATION, true);
+    accessModuleService.updateBypassTime(
+        user.getUserId(), DbAccessModuleName.PROFILE_CONFIRMATION, true);
 
     createAffiliation(user);
     return user;

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -396,7 +396,7 @@ public class UserServiceAccessTest {
     testUnregistration(
         user -> {
           accessModuleService.updateBypassTime(
-                  dbUser.getUserId(), DbAccessModuleName.PUBLICATION_CONFIRMATION, false);
+              dbUser.getUserId(), DbAccessModuleName.PUBLICATION_CONFIRMATION, false);
           accessModuleService.updateCompletionTime(
               dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, null);
           return userDao.save(user);
@@ -408,7 +408,7 @@ public class UserServiceAccessTest {
     testUnregistration(
         user -> {
           accessModuleService.updateBypassTime(
-                  dbUser.getUserId(), DbAccessModuleName.PUBLICATION_CONFIRMATION, false);
+              dbUser.getUserId(), DbAccessModuleName.PUBLICATION_CONFIRMATION, false);
           final Timestamp willExpire = Timestamp.from(START_INSTANT);
           accessModuleService.updateCompletionTime(
               dbUser, DbAccessModuleName.PUBLICATION_CONFIRMATION, willExpire);
@@ -425,7 +425,7 @@ public class UserServiceAccessTest {
     testUnregistration(
         user -> {
           accessModuleService.updateBypassTime(
-                  dbUser.getUserId(), DbAccessModuleName.PROFILE_CONFIRMATION, false);
+              dbUser.getUserId(), DbAccessModuleName.PROFILE_CONFIRMATION, false);
           accessModuleService.updateCompletionTime(
               dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, null);
           return userDao.save(user);
@@ -437,7 +437,7 @@ public class UserServiceAccessTest {
     testUnregistration(
         user -> {
           accessModuleService.updateBypassTime(
-                  dbUser.getUserId(), DbAccessModuleName.PROFILE_CONFIRMATION, false);
+              dbUser.getUserId(), DbAccessModuleName.PROFILE_CONFIRMATION, false);
           final Timestamp willExpire = Timestamp.from(START_INSTANT);
           accessModuleService.updateCompletionTime(
               dbUser, DbAccessModuleName.PROFILE_CONFIRMATION, willExpire);

--- a/ui/src/app/routing/guards.spec.tsx
+++ b/ui/src/app/routing/guards.spec.tsx
@@ -43,23 +43,14 @@ const allCompleteExpiringSoon: AccessModuleStatus[] = Object.keys(
   expirationEpochMillis: nowPlusDays(1),
 }));
 
-const allBypassedPPComplete: AccessModuleStatus[] = Object.keys(
-  AccessModule
-).map((key) => {
-  const moduleName = AccessModule[key];
-  return [
-    AccessModule.PROFILECONFIRMATION,
-    AccessModule.PUBLICATIONCONFIRMATION,
-  ].includes(moduleName)
-    ? {
-        moduleName: AccessModule[key],
-        completionEpochMillis: Date.now(),
-      }
-    : {
-        moduleName: AccessModule[key],
-        bypassEpochMillis: Date.now(),
-      };
-});
+const allBypassed: AccessModuleStatus[] = Object.keys(AccessModule).map(
+  (key) => {
+    return {
+      moduleName: AccessModule[key],
+      bypassEpochMillis: Date.now(),
+    };
+  }
+);
 
 // 2FA is missing (initial, not renewable)
 const allCompleteMissingOneInitial: AccessModuleStatus[] =
@@ -102,27 +93,6 @@ const allCompleteCtTrainingExpired: AccessModuleStatus[] =
       expirationEpochMillis: nowPlusDays(-1),
     });
 
-// RW-8203
-// artificial state for test users - all complete but Profile/Publications are missing
-const allCompleteMissingPP: AccessModuleStatus[] =
-  allCompleteNotExpiring.filter(
-    ({ moduleName }) =>
-      ![
-        AccessModule.PROFILECONFIRMATION,
-        AccessModule.PUBLICATIONCONFIRMATION,
-      ].includes(moduleName)
-  );
-
-// RW-8203
-// artificial state for test users - all bypassed but Profile/Publications are missing
-const allBypassedMissingPP: AccessModuleStatus[] = allBypassedPPComplete.filter(
-  ({ moduleName }) =>
-    ![
-      AccessModule.PROFILECONFIRMATION,
-      AccessModule.PUBLICATIONCONFIRMATION,
-    ].includes(moduleName)
-);
-
 describe('redirectTo', () => {
   beforeEach(() => {
     serverConfigStore.set({ config: defaultServerConfig });
@@ -152,25 +122,13 @@ describe('redirectTo', () => {
       },
     ],
     [
-      'all bypassed except Profile and Publications are missing',
-      // Access Renewal is the only page which allows progress on these modules
-      ACCESS_RENEWAL_PATH,
-      {
-        ...ProfileStubVariables.PROFILE_STUB,
-        accessTierShortNames: [],
-        accessModules: {
-          modules: allBypassedMissingPP,
-        },
-      },
-    ],
-    [
-      'all bypassed except Profile and Publications are complete',
+      'all bypassed',
       undefined,
       {
         ...ProfileStubVariables.PROFILE_STUB,
         accessTierShortNames: [AccessTierShortNames.Registered],
         accessModules: {
-          modules: allBypassedPPComplete,
+          modules: allBypassed,
         },
       },
     ],
@@ -241,19 +199,6 @@ describe('redirectTo', () => {
         accessTierShortNames: [],
         accessModules: {
           modules: allCompleteMissingOneEach,
-        },
-      },
-    ],
-    // RW-8203
-    [
-      'all complete but Profile + Publication Confirmations are missing',
-      // Access Renewal is the only page which allows progress on these modules
-      ACCESS_RENEWAL_PATH,
-      {
-        ...ProfileStubVariables.PROFILE_STUB,
-        accessTierShortNames: [],
-        accessModules: {
-          modules: allCompleteMissingPP,
         },
       },
     ],


### PR DESCRIPTION
# Description

Removes test references to modules that are now bypassable.

It might be possible to remove an [additional check in guards.tsx](https://github.com/all-of-us/workbench/blob/bdefab303b17f355dc0db62feceb4bb3bea88cff/ui/src/app/routing/guards.tsx#L66), but after discussing this with Joel I'm not confident we're covering all the cases without that check. This PR still moves us in a simpler direction.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
