### PR TITLE
[no-ticket][risk=no] Clean up DB config

### DIFF
--- a/api/src/integration/java/org/pmiops/workbench/ApplicationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/ApplicationTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.cdr.CdrDataSource;
+import org.pmiops.workbench.cdr.DbParams;
+import org.pmiops.workbench.db.Params;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -22,7 +24,12 @@ import org.springframework.stereotype.Component;
 public class ApplicationTest {
 
   @Autowired private ApplicationContext context;
+
+  @MockBean(name = "params")
+  private Params params;
+
   @MockBean private DataSource dataSource;
+  @MockBean private DbParams cdrParams;
   @MockBean private CdrDataSource cdrDataSource;
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrDataSource.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrDataSource.java
@@ -1,7 +1,5 @@
 package org.pmiops.workbench.cdr;
 
-import static org.pmiops.workbench.db.WorkbenchDbConfig.createConfig;
-
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.pool.HikariPool;
 import java.util.ArrayList;
@@ -16,9 +14,7 @@ import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
 import javax.sql.DataSource;
 import org.apache.tomcat.jdbc.pool.PoolConfiguration;
-import org.apache.tomcat.jdbc.pool.PoolProperties;
 import org.pmiops.workbench.db.model.DbCdrVersion;
-import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.stereotype.Service;
@@ -28,15 +24,18 @@ public class CdrDataSource extends AbstractRoutingDataSource {
 
   private static final Logger log = Logger.getLogger(CdrDataSource.class.getName());
 
+  private final DbParams params;
   private final PoolConfiguration basePoolConfig;
   private final PoolConfiguration cdrPoolConfig;
   private final EntityManagerFactory emFactory;
 
   CdrDataSource(
+      DbParams params,
       @Qualifier("poolConfiguration") PoolConfiguration basePoolConfig,
       @Qualifier("cdrPoolConfiguration") PoolConfiguration cdrPoolConfig,
       // Using CdrDbConfig.cdrEntityManagerFactory would cause a circular dependency.
       @Qualifier("entityManagerFactory") EntityManagerFactory emFactory) {
+    this.params = params;
     this.basePoolConfig = basePoolConfig;
     this.cdrPoolConfig = cdrPoolConfig;
     this.emFactory = emFactory;
@@ -57,7 +56,7 @@ public class CdrDataSource extends AbstractRoutingDataSource {
   }
 
   DataSource createCdrDs(String dbName) {
-    return new HikariDataSource(createConfig(dbName));
+    return new HikariDataSource(params.createConfig(dbName));
   }
 
   void resetTargetDataSources() {
@@ -70,31 +69,9 @@ public class CdrDataSource extends AbstractRoutingDataSource {
     for (DbCdrVersion cdrVersion : getCdrVersions()) {
       try {
         DataSource dataSource = createCdrDs(cdrVersion.getCdrDbName());
-        if (dataSource instanceof org.apache.tomcat.jdbc.pool.DataSource) {
-          org.apache.tomcat.jdbc.pool.DataSource tomcatSource =
-              (org.apache.tomcat.jdbc.pool.DataSource) dataSource;
-          // A Tomcat DataSource implements PoolConfiguration, therefore these pool parameters can
-          // normally be populated via @ConfigurationProperties. Since we are directly initializing
-          // DataSources here without a hook to @ConfigurationProperties, we instead need to
-          // explicitly initialize the pool parameters here. We override the primary connection
-          // info, as the autowired PoolConfiguration is initialized from the same set of properties
-          // as the workbench DB.
-          PoolConfiguration cdrPool = new PoolProperties();
-          BeanUtils.copyProperties(basePoolConfig, cdrPool);
-          cdrPool.setUsername("workbench"); // consistent across environments
-          cdrPool.setPassword(getEnvRequired("WORKBENCH_DB_PASSWORD"));
-          cdrPool.setUrl(String.format("jdbc:mysql:///%s", cdrVersion.getCdrDbName()));
-          tomcatSource.setPoolProperties(cdrPool);
-
-          // The Spring autowiring is a bit of a maze here, log something concrete which will allow
-          // verification that the DB settings in application.properties are actually being loaded.
-          log.info("using Tomcat pool for CDR data source, with minIdle: " + cdrPool.getMinIdle());
-        } else {
-          log.warning(
-              "not using Tomcat pool or initializing pool configuration; "
-                  + "this should only happen within tests");
+        if (dataSource == null) {
+          continue;
         }
-
         cdrVersionDataSourceMap.put(cdrVersion.getCdrVersionId(), dataSource);
       } catch (HikariPool.PoolInitializationException e) {
         // If this is caught, java.sql.SQLSyntaxErrorException: Unknown database 'name'

--- a/api/src/main/java/org/pmiops/workbench/cdr/DbParams.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/DbParams.java
@@ -1,0 +1,28 @@
+package org.pmiops.workbench.cdr;
+
+import java.util.logging.Logger;
+import org.pmiops.workbench.db.Params;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DbParams extends Params {
+  private static final Logger log = Logger.getLogger(DbParams.class.getName());
+
+  @Override
+  public void loadFromEnvironment() {
+    hostname = getEnv("CDR_DB_HOST").orElse(null);
+    cloudSqlInstanceName = getEnv("CDR_CLOUD_SQL_INSTANCE_NAME").orElse(null);
+    password = getEnv("CDR_DB_PASSWORD").orElse(null);
+    try {
+      validate();
+      log.info("CDR SQL instance params: " + this.toString());
+    } catch (IllegalStateException e) {
+      super.loadFromEnvironment();
+      log.info("CDR SQL instance params: [Workbench instance params]");
+    }
+  }
+
+  protected void logParams() {
+    // Logged above.
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/db/Params.java
+++ b/api/src/main/java/org/pmiops/workbench/db/Params.java
@@ -1,0 +1,105 @@
+package org.pmiops.workbench.db;
+
+import com.zaxxer.hikari.HikariConfig;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.Socket;
+import java.util.Optional;
+import java.util.logging.Logger;
+import org.springframework.context.annotation.Configuration;
+
+// @Configuration means, "Provide this as an injectable dependency."
+// This is a singleton, which means that the load is done only once and, more importantly, the
+// logging only happens once.
+@Configuration
+public class Params {
+  private static final Logger log = Logger.getLogger(Params.class.getName());
+
+  public static final int mysqlDefaultPort = 3306;
+  public String hostname;
+  public final String username = "workbench"; // consistent across environments
+  public String cloudSqlInstanceName;
+  public String password;
+  private boolean loaded;
+
+  public Params() {
+    loadFromEnvironment();
+    validate();
+    logParams();
+  }
+
+  public void loadFromEnvironment() {
+    hostname = getEnv("DB_HOST").orElse(null);
+    cloudSqlInstanceName = getEnv("CLOUD_SQL_INSTANCE_NAME").orElse(null);
+    password = getEnv("WORKBENCH_DB_PASSWORD").orElse(null);
+  }
+
+  protected void logParams() {
+    log.info("Workbench SQL instance params: " + this.toString());
+  }
+
+  public HikariConfig createConfig(String dbName) {
+    HikariConfig config = new HikariConfig();
+    config.setDriverClassName("com.mysql.cj.jdbc.Driver");
+    config.setJdbcUrl(
+        String.format("jdbc:mysql://%s/%s", useAppEngineSocket() ? "" : hostname, dbName));
+    config.setUsername("workbench"); // consistent across environments
+    config.setPassword(password);
+    if (useAppEngineSocket()) {
+      config.addDataSourceProperty("socketFactory", "com.google.cloud.sql.mysql.SocketFactory");
+      config.addDataSourceProperty("cloudSqlInstance", cloudSqlInstanceName);
+    }
+    return config;
+  }
+
+  public void validate() {
+    if (hostname == null && cloudSqlInstanceName == null) {
+      throw new IllegalStateException(
+          "Database connection requires either a hostname (DB_HOST)"
+              + " or a Cloud SQL instance name (CLOUD_SQL_INSTANCE_NAME).");
+    }
+    if (hostname != null) {
+      try {
+        new Socket(hostname, mysqlDefaultPort).close();
+      } catch (ConnectException e) {
+        throw new RuntimeException(
+            String.format("Failed to connect to database on host %s.", hostname), e);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    } else {
+      // assert cloudSqlInstanceName != null
+      if (!getEnv("GOOGLE_APPLICATION_CREDENTIALS").isPresent()
+          && !getEnv("GAE_INSTANCE").isPresent()) {
+        throw new IllegalStateException(
+            "Google Application Default Credentials are required to connect directly to Cloud SQL."
+                + " Outside of App Engine, they can be provided with the environment variable"
+                + " GOOGLE_APPLICATION_CREDENTIALS.");
+      }
+    }
+  }
+
+  public boolean useAppEngineSocket() {
+    return hostname == null ? true : false;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "[hostname:%s cloudSqlInstanceName:%s username:%s password:%s]",
+        hostname,
+        cloudSqlInstanceName,
+        username,
+        // We wouldn't want to give a password hint in a public forum, but our logs are
+        // relatively private.
+        password != null ? shadow(2, password) : null);
+  }
+
+  private static String shadow(int visibleCount, String s) {
+    return s.substring(0, visibleCount) + s.substring(visibleCount).replaceAll(".", "*");
+  }
+
+  public static Optional<String> getEnv(String name) {
+    return Optional.ofNullable(System.getenv(name)).map(s -> s.trim()).filter(s -> s != "");
+  }
+}

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/Tool.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/Tool.java
@@ -1,10 +1,11 @@
 package org.pmiops.workbench.tools;
 
+import org.pmiops.workbench.db.Params;
 import org.pmiops.workbench.db.WorkbenchDbConfig;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 // This is a common ancestor that brings in the main database configuration.
 @Configuration
-@Import({WorkbenchDbConfig.class})
+@Import({Params.class, WorkbenchDbConfig.class})
 public abstract class Tool {}


### PR DESCRIPTION
This should unbreak stable and staging by reading and using CDR DB config variables when they are present.

Ran locally with different combinations of environment variables, deployed and tested on App Engine.

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
