### PR TITLE
[RW-9893 ][risk=no]  [MVP] warn users jobs may be terminated

### DIFF
--- a/e2e/app/modal/warning-delete-cromwell-modal.ts
+++ b/e2e/app/modal/warning-delete-cromwell-modal.ts
@@ -1,0 +1,29 @@
+import Modal from './modal';
+import { Page } from 'puppeteer';
+import { waitForText } from 'utils/waits-utils';
+import { LinkText } from 'app/text-labels';
+
+const title = 'Delete Cromwell: check for running jobs';
+
+export default class WarningDeleteCromwellModal extends Modal {
+  constructor(page: Page, opts?: { xpath?: string; modalIndex?: number }) {
+    super(page, opts);
+  }
+
+  async isLoaded(): Promise<boolean> {
+    await waitForText(this.page, title, { container: this });
+    return true;
+  }
+
+  async clickYesDeleteButton(): Promise<string[]> {
+    const contentText = await this.getTextContent();
+    await this.clickButton(LinkText.YesDelete, { waitForClose: true });
+    return contentText;
+  }
+
+  async clickNoDeleteButton(): Promise<string[]> {
+    const contentText = await this.getTextContent();
+    await this.clickButton(LinkText.No, { waitForClose: true });
+    return contentText;
+  }
+}

--- a/e2e/tests/nightly/gke-apps/cromwell.spec.ts
+++ b/e2e/tests/nightly/gke-apps/cromwell.spec.ts
@@ -4,6 +4,7 @@ import Button from 'app/element/button';
 import CromwellConfigurationPanel from 'app/sidebar/cromwell-configuration-panel';
 import BaseElement from 'app/element/base-element';
 import { waitForFn } from 'utils/waits-utils';
+import WarningDeleteCromwellModal from 'app/modal/warning-delete-cromwell-modal';
 
 // Cluster provisioning can take a while, so set a 20 min timeout
 jest.setTimeout(20 * 60 * 1000);
@@ -69,6 +70,10 @@ describe('Cromwell GKE App', () => {
     const deleteButton = new Button(page, deleteXPath);
     expect(await deleteButton.exists()).toBeTruthy();
     await deleteButton.click();
+
+    const warningDeleteCromwellModal = new WarningDeleteCromwellModal(page);
+    expect(warningDeleteCromwellModal.isLoaded());
+    await warningDeleteCromwellModal.clickYesDeleteButton();
 
     await appsPanel.pollForStatus(expandedCromwellXpath, 'DELETING');
 

--- a/ui/src/app/components/apps-panel/delete-cromwell-modal.tsx
+++ b/ui/src/app/components/apps-panel/delete-cromwell-modal.tsx
@@ -9,38 +9,42 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import colors from 'app/styles/colors';
-import { reactStyles } from 'app/utils';
 
-const styles = reactStyles({
-  toast: {
-    position: 'absolute',
-    top: 0,
-    right: 0,
-    width: '13rem',
-  },
-  commandBox: {
-    fontSize: 'medium',
-    borderStyle: 'solid',
-    padding: '0.5rem 1rem 0.5rem 1rem ',
-  },
-  commandRow: {
-    paddingTop: '1rem',
-    paddingBottom: '1rem',
-    justifyContent: 'center',
-    fontWeight: 'bold',
-  },
-  copyIcon: {
-    marginLeft: 20,
-    marginRight: 10,
-    marginTop: 8,
-  },
-});
+// const styles = reactStyles({
+//   toast: {
+//     position: 'absolute',
+//     top: 0,
+//     right: 0,
+//     width: '13rem',
+//   },
+//   commandBox: {
+//     fontSize: 'medium',
+//     borderStyle: 'solid',
+//     padding: '0.5rem 1rem 0.5rem 1rem ',
+//   },
+//   commandRow: {
+//     paddingTop: '1rem',
+//     paddingBottom: '1rem',
+//     justifyContent: 'center',
+//     fontWeight: 'bold',
+//   },
+//   copyIcon: {
+//     marginLeft: 20,
+//     marginRight: 10,
+//     marginTop: 8,
+//   },
+// });
 
 export const DeleteCromwellConfirmationModal = (props: {
   clickYes;
   clickNo;
 }) => {
-  let toast: any;
+  {
+    /* The command to list jobs is not supported in cromshell-alpha. Ticket to address this
+           https://precisionmedicineinitiative.atlassian.net/browse/RW-9847?search_id=32e4287f-9e8d-4327-9017-d5120d8fabe8,*/
+  }
+
+  /* let toast: any;
   let toastTimer: NodeJS.Timer;
 
   const cromshell_job_check_command = 'cromshell-beta list -u';
@@ -56,7 +60,8 @@ export const DeleteCromwellConfirmationModal = (props: {
     if (!!toastTimer) {
       clearTimeout(toastTimer);
     }
-  };
+  };*/
+
   return (
     <Modal data-test-id='delete-cromwell-modal' width={500}>
       <ModalTitle> Delete Cromwell: check for running jobs </ModalTitle>
@@ -69,9 +74,8 @@ export const DeleteCromwellConfirmationModal = (props: {
           </div>
         </WarningMessage>
         <div style={{ paddingTop: '1rem' }}>
-          {/* the command to list Jobs is not available for cromshell-alpha*/}
-          {/* Ticket https://precisionmedicineinitiative.atlassian.net/browse/RW-9847?search_id=32e4287f-9e8d-4327-9017-d5120d8fabe8
-          will install cromshell-beta*/}
+          {/* The command to list jobs is not supported in cromshell-alpha. Ticket to address this
+           https://precisionmedicineinitiative.atlassian.net/browse/RW-9847?search_id=32e4287f-9e8d-4327-9017-d5120d8fabe8,*/}
           {/*  Use the following command in Jupyter/Terminal to check if you have any*/}
           {/*  jobs running{' '}*/}
           {/*  <FlexRow style={styles.commandRow}>*/}

--- a/ui/src/app/components/apps-panel/delete-cromwell-modal.tsx
+++ b/ui/src/app/components/apps-panel/delete-cromwell-modal.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+
+import { Button } from 'app/components/buttons';
+import { WarningMessage } from 'app/components/messages';
+import {
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalTitle,
+} from 'app/components/modals';
+import colors from 'app/styles/colors';
+import { reactStyles } from 'app/utils';
+
+const styles = reactStyles({
+  toast: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    width: '13rem',
+  },
+  commandBox: {
+    fontSize: 'medium',
+    borderStyle: 'solid',
+    padding: '0.5rem 1rem 0.5rem 1rem ',
+  },
+  commandRow: {
+    paddingTop: '1rem',
+    paddingBottom: '1rem',
+    justifyContent: 'center',
+    fontWeight: 'bold',
+  },
+  copyIcon: {
+    marginLeft: 20,
+    marginRight: 10,
+    marginTop: 8,
+  },
+});
+
+export const DeleteCromwellConfirmationModal = (props: {
+  clickYes;
+  clickNo;
+}) => {
+  let toast: any;
+  let toastTimer: NodeJS.Timer;
+
+  const cromshell_job_check_command = 'cromshell-beta list -u';
+
+  const onCopyTextClick = () => {
+    navigator.clipboard.writeText(cromshell_job_check_command);
+    toast.show({
+      severity: 'success',
+      detail: 'Text Copied',
+      closable: false,
+      life: 1000,
+    });
+    if (!!toastTimer) {
+      clearTimeout(toastTimer);
+    }
+  };
+  return (
+    <Modal data-test-id='delete-cromwell-modal' width={500}>
+      <ModalTitle> Delete Cromwell: check for running jobs </ModalTitle>
+      <ModalBody style={{ color: colors.primary }}>
+        <WarningMessage>
+          <div style={{ color: colors.primary }}>
+            <b>Warning: </b> If you delete your Cromwell environment while any
+            of your jobs are still running, you will lose the results of your
+            jobs.
+          </div>
+        </WarningMessage>
+        <div style={{ paddingTop: '1rem' }}>
+          {/* the command to list Jobs is not available for cromshell-alpha*/}
+          {/* Ticket https://precisionmedicineinitiative.atlassian.net/browse/RW-9847?search_id=32e4287f-9e8d-4327-9017-d5120d8fabe8
+          will install cromshell-beta*/}
+          {/*  Use the following command in Jupyter/Terminal to check if you have any*/}
+          {/*  jobs running{' '}*/}
+          {/*  <FlexRow style={styles.commandRow}>*/}
+          {/*    <div style={styles.commandBox}>{cromshell_job_check_command}</div>*/}
+          {/*    <Clickable*/}
+          {/*      data-test-id={'copy-to-clipboard'}*/}
+          {/*      onClick={() => onCopyTextClick()}*/}
+          {/*    >*/}
+          {/*      <TooltipTrigger content={'Click to Copy Command'}>*/}
+          {/*        <FontAwesomeIcon*/}
+          {/*          size={'xl'}*/}
+          {/*          icon={faClipboard}*/}
+          {/*          style={styles.copyIcon}*/}
+          {/*        />*/}
+          {/*      </TooltipTrigger>*/}
+          {/*    </Clickable>*/}
+          {/*    <Toast ref={(el) => (toast = el)} style={styles.toast} />*/}
+          {/*  </FlexRow>*/}
+          Do you still want to delete your Cromwell environment?
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          data-test-id={'delete-cromwell-btn'}
+          type='primary'
+          onClick={props.clickYes}
+        >
+          YES, DELETE
+        </Button>
+        <Button type='secondary' onClick={props.clickNo}>
+          No
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -335,6 +335,27 @@ describe('ExpandedApp', () => {
         .mockImplementation(() => Promise.resolve({}));
       const { onClick } = deletion.props();
       await onClick();
+      await waitOneTickAndUpdate(wrapper);
+      if (appType === UIAppType.CROMWELL) {
+        /* For Cromwell, on delete we show user a modal asking them to confirm manually that there are
+            no cromwell Jobs running. Only after user confirming YES we close the modal and start the delete process */
+        let cromwell_delete_modal = wrapper.find({
+          'data-test-id': 'delete-cromwell-modal',
+        });
+
+        expect(cromwell_delete_modal).toBeTruthy();
+        const button_delete_cromwell = cromwell_delete_modal.find({
+          'data-test-id': 'delete-cromwell-btn',
+        });
+
+        button_delete_cromwell.simulate('click');
+
+        // Clicking button YES i.e confirming deletion of cromwell should close the modal
+        cromwell_delete_modal = wrapper.find({
+          'data-test-id': 'delete-cromwell-modal',
+        });
+        expect(cromwell_delete_modal.length).toBe(0);
+      }
 
       expect(deleteSpy).toHaveBeenCalledWith(
         workspace.namespace,

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -10,14 +10,14 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { AppStatus, UserAppEnvironment, Workspace } from 'generated/fetch';
 
+import { AppStatusIndicator } from 'app/components/app-status-indicator';
 import { DeleteCromwellConfirmationModal } from 'app/components/apps-panel/delete-cromwell-modal';
 import { Clickable } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { withErrorModal } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
-import {
-  leoProxyApi,
-} from 'app/services/notebooks-swagger-fetch-clients';
+import { RuntimeStatusIndicator } from 'app/components/runtime-status-indicator';
+import { leoProxyApi } from 'app/services/notebooks-swagger-fetch-clients';
 import { appsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { cond, reactStyles } from 'app/utils';
@@ -28,6 +28,11 @@ import {
   useRuntimeStatus,
 } from 'app/utils/runtime-utils';
 import { runtimeStore, useStore } from 'app/utils/stores';
+import {
+  createUserApp,
+  pauseUserApp,
+  resumeUserApp,
+} from 'app/utils/user-apps-utils';
 
 import { AppLogo } from './app-logo';
 import { AppsPanelButton } from './apps-panel-button';
@@ -43,9 +48,6 @@ import {
   fromUserAppStatusWithFallback,
   UIAppType,
 } from './utils';
-import {RuntimeStatusIndicator} from "app/components/runtime-status-indicator";
-import {AppStatusIndicator} from "app/components/app-status-indicator";
-import {createUserApp, pauseUserApp, resumeUserApp} from "app/utils/user-apps-utils";
 
 const styles = reactStyles({
   expandedAppContainer: {

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -18,7 +18,6 @@ import { withErrorModal } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
 import { RuntimeStatusIndicator } from 'app/components/runtime-status-indicator';
 import { leoProxyApi } from 'app/services/notebooks-swagger-fetch-clients';
-import { appsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { cond, reactStyles } from 'app/utils';
 import { setSidebarActiveIconStore } from 'app/utils/navigation';
@@ -30,6 +29,7 @@ import {
 import { runtimeStore, useStore } from 'app/utils/stores';
 import {
   createUserApp,
+  deleteUserApp,
   pauseUserApp,
   resumeUserApp,
 } from 'app/utils/user-apps-utils';
@@ -248,9 +248,9 @@ export const ExpandedApp = (props: ExpandedAppProps) => {
   // TODO allow configuration
   const deleteDiskWithUserApp = true;
 
-  const deleteGkeApp = () => {
+  const deleteGkeApp = async () => {
     setDeletingApp(true);
-    appsApi().deleteApp(
+    await deleteUserApp(
       workspace.namespace,
       initialUserAppInfo.appName,
       deleteDiskWithUserApp


### PR DESCRIPTION

<img width="511" alt="Screenshot 2023-04-11 at 1 23 58 AM" src="https://user-images.githubusercontent.com/34481816/231063930-67f2cae7-d581-421c-9d68-efca0200d94f.png">


Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
