### PR TITLE
[RW-9766][risk=no] Add base cost estimate for GKE apps

### DIFF
--- a/ui/src/app/components/cromwell-configuration-panel.spec.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.spec.tsx
@@ -170,4 +170,18 @@ describe('CromwellConfigurationPanel', () => {
       ).toBeTruthy();
     });
   });
+
+  it('should display a cost of $0.40 per hour when running and $0.20 per hour when paused', async () => {
+    const wrapper = await component();
+
+    const costEstimator = (w) => w.find('[data-test-id="cost-estimator"]');
+    const runningCost = (w) =>
+      costEstimator(w).find('[data-test-id="running-cost"]');
+    const pausedCost = (w) =>
+      costEstimator(w).find('[data-test-id="paused-cost"]');
+
+    expect(costEstimator(wrapper).exists()).toBeTruthy();
+    expect(runningCost(wrapper).text()).toEqual('$0.40 per hour');
+    expect(pausedCost(wrapper).text()).toEqual('$0.20 per hour');
+  });
 });

--- a/ui/src/app/components/environment-informed-action-panel.tsx
+++ b/ui/src/app/components/environment-informed-action-panel.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { UIAppType } from 'app/components/apps-panel/utils';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { formatUsd } from 'app/utils/numbers';
 import { isUsingFreeTierBillingAccount } from 'app/utils/workspace-utils';
@@ -16,6 +17,7 @@ const CostInfo = ({
   analysisConfig,
   currentUser,
   workspace,
+  isGKEApp,
 }) => {
   const remainingCredits =
     creatorFreeCreditsRemaining === null ? (
@@ -36,7 +38,7 @@ const CostInfo = ({
             : {}),
         }}
       >
-        <EnvironmentCostEstimator {...{ analysisConfig }} />
+        <EnvironmentCostEstimator {...{ analysisConfig }} isGKEApp={isGKEApp} />
       </div>
       {isUsingFreeTierBillingAccount(workspace) &&
         currentUser === workspace.creator && (
@@ -80,6 +82,7 @@ export const EnvironmentInformedActionPanel = ({
       currentUser={profile.username}
       workspace={workspace}
       creatorFreeCreditsRemaining={creatorFreeCreditsRemaining}
+      isGKEApp={appType !== UIAppType.JUPYTER}
     />
   </FlexRow>
 );

--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -99,8 +99,8 @@ describe('RuntimeConfigurationPanel', () => {
 
   const runningCost = (wrapper) =>
     costEstimator(wrapper).find('[data-test-id="running-cost"]');
-  const storageCost = (wrapper) =>
-    costEstimator(wrapper).find('[data-test-id="storage-cost"]');
+  const pausedCost = (wrapper) =>
+    costEstimator(wrapper).find('[data-test-id="paused-cost"]');
 
   const detachableDiskRuntime = (): Runtime => {
     const { size, diskType, name } = existingDisk();
@@ -1224,22 +1224,22 @@ describe('RuntimeConfigurationPanel', () => {
 
     // Default GCE machine, n1-standard-4, makes the running cost 20 cents an hour and the storage cost less than 1 cent an hour.
     expect(runningCost(wrapper).text()).toEqual('$0.20 per hour');
-    expect(storageCost(wrapper).text()).toEqual('< $0.01 per hour');
+    expect(pausedCost(wrapper).text()).toEqual('< $0.01 per hour');
 
     // Change the machine to n1-standard-8 and bump the storage to 300GB.
     await pickMainCpu(wrapper, 8);
     await pickMainRam(wrapper, 30);
     await pickDetachableDiskSize(wrapper, 300);
     expect(runningCost(wrapper).text()).toEqual('$0.40 per hour');
-    expect(storageCost(wrapper).text()).toEqual('$0.02 per hour');
+    expect(pausedCost(wrapper).text()).toEqual('$0.02 per hour');
 
     await pickPreset(wrapper, { displayName: 'General Analysis' });
     expect(runningCost(wrapper).text()).toEqual('$0.20 per hour');
-    expect(storageCost(wrapper).text()).toEqual('< $0.01 per hour');
+    expect(pausedCost(wrapper).text()).toEqual('< $0.01 per hour');
 
     await pickComputeType(wrapper, ComputeType.Dataproc);
     expect(runningCost(wrapper).text()).toEqual('$0.73 per hour');
-    expect(storageCost(wrapper).text()).toEqual('$0.02 per hour');
+    expect(pausedCost(wrapper).text()).toEqual('$0.02 per hour');
 
     // Bump up all the worker values to increase the price on everything.
     await pickNumWorkers(wrapper, 4);
@@ -1248,7 +1248,7 @@ describe('RuntimeConfigurationPanel', () => {
     await pickWorkerRam(wrapper, 30);
     await pickWorkerDiskSize(wrapper, 300);
     expect(runningCost(wrapper).text()).toEqual('$2.88 per hour');
-    expect(storageCost(wrapper).text()).toEqual('$0.14 per hour');
+    expect(pausedCost(wrapper).text()).toEqual('$0.14 per hour');
   });
 
   it('should update the cost estimator when master machine changes', async () => {
@@ -1274,7 +1274,7 @@ describe('RuntimeConfigurationPanel', () => {
     expect(costEstimator(wrapper).exists()).toBeTruthy();
 
     expect(runningCost(wrapper).text()).toEqual('$0.77 per hour');
-    expect(storageCost(wrapper).text()).toEqual('$0.07 per hour');
+    expect(pausedCost(wrapper).text()).toEqual('$0.07 per hour');
 
     // Change the Master disk size or master size to 150
     await pickMainDiskSize(wrapper, DATAPROC_MIN_DISK_SIZE_GB);
@@ -1282,12 +1282,12 @@ describe('RuntimeConfigurationPanel', () => {
     expect(costEstimator(wrapper).exists()).toBeTruthy();
 
     expect(runningCost(wrapper).text()).toEqual('$0.73 per hour');
-    expect(storageCost(wrapper).text()).toEqual('$0.02 per hour');
+    expect(pausedCost(wrapper).text()).toEqual('$0.02 per hour');
     // Switch to n1-highmem-4, double disk size.
     await pickMainRam(wrapper, 26);
     await pickMainDiskSize(wrapper, 2000);
     expect(runningCost(wrapper).text()).toEqual('$0.87 per hour');
-    expect(storageCost(wrapper).text()).toEqual('$0.13 per hour');
+    expect(pausedCost(wrapper).text()).toEqual('$0.13 per hour');
   });
 
   it('should allow runtime deletion', async () => {

--- a/ui/src/app/components/runtime-configuration-panel/confirm-update-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/confirm-update-panel.tsx
@@ -54,7 +54,10 @@ export const ConfirmUpdatePanel = ({
                 ...styles.costComparison,
               }}
             >
-              <EnvironmentCostEstimator analysisConfig={newAnalysisConfig} />
+              <EnvironmentCostEstimator
+                analysisConfig={newAnalysisConfig}
+                isGKEApp={false}
+              />
             </div>
           </div>
           <div>
@@ -69,6 +72,7 @@ export const ConfirmUpdatePanel = ({
             >
               <EnvironmentCostEstimator
                 analysisConfig={existingAnalysisConfig}
+                isGKEApp={false}
                 costTextColor='grey'
               />
             </div>

--- a/ui/src/app/components/runtime-initializer-modal.tsx
+++ b/ui/src/app/components/runtime-initializer-modal.tsx
@@ -60,6 +60,7 @@ export const RuntimeInitializerModal = ({
         </WarningMessage>
         <EnvironmentCostEstimator
           analysisConfig={defaultAnalysisConfig}
+          isGKEApp={false}
           style={{ ...styles.bodyElement, justifyContent: 'space-evenly' }}
         />
         <Clickable


### PR DESCRIPTION
Description:

Add a base cost estimate for GKE apps. Per the Jira ticket, this updates the displayed cost for a running Cromwell instance to be $0.40/hour and the displayed cost for a paused Cromwell instance to be $0.20/hour.

Tested locally by checking all uses of the cost estimate component:
- Cromwell config panel
- Jupyter config panel (unchanged)
- Jupyter app creation flow via modals (unchanged)
- Updating configuration for a running Jupyter app (unchanged)

[Relevant #workbench-ux thread](https://pmi-engteam.slack.com/archives/C02MWP2RN5P/p1681138168930999)

Screenshots:

![image](https://user-images.githubusercontent.com/31020403/230983297-e463b6a0-af43-417b-86af-f3a2d06590aa.png)
![image (1)](https://user-images.githubusercontent.com/31020403/230983304-d98ec24a-8a17-4090-bc59-cc9c313033aa.png)


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
