### PR TITLE
[no ticket][risk=no] fixing update-cdr-config command

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2036,7 +2036,9 @@ def update_cdr_config(cmd_name, *args)
 
   ENV.update(read_db_vars(gcc))
   cdr_config_file = must_get_env_value(gcc.project, :cdr_config_json)
-  update_cdr_config_for_project("config/#{cdr_config_file}", op.opts.dry_run)
+  ServiceAccountContext.new(gcc.project).run do
+    update_cdr_config_for_project("config/#{cdr_config_file}", op.opts.dry_run)
+  end
 end
 
 Common.register_command({


### PR DESCRIPTION
If I wrap the ServiceAccountContext around the update_cdr_config_for_project call it updates the sa-key.json and works. Found this comment in the tools.md file: 

`Wrapping the gradle call with ServiceAccountContext like in list-runtime will ensure that the correct sa-key.json credentials are set.`