### PR TITLE
Cannot create cromwell app if jupyter is starting/paused

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -484,6 +484,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
                   .collect(Collectors.toList()));
       List<Disk> appDisks =
           diskList.stream()
+              .filter(d -> d.getAppType() != null)
               .filter(d -> d.getAppType().equals(createAppRequest.getAppType()))
               .collect(Collectors.toList());
       if (!appDisks.isEmpty()) {


### PR DESCRIPTION

https://user-images.githubusercontent.com/34481816/231254373-349921ce-8443-493d-b2ee-c6933abc8c05.mov

If the jupyter is being created or is paused the appType is not returned from  disksApi.listDisksByProject(
                googleProject,
                null,
                includeDeleted,
                LeonardoLabelHelper.LEONARDO_DISK_LABEL_KEYS,
                LEONARDO_CREATOR_ROLE)) 

because of which the create cromwell was failing at LeonardoApiClientImpl 
diskList.stream()
              .filter(d -> d.getAppType().equals(createAppRequest.getAppType()))
              .collect(Collectors.toList());

Description:

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
