### PR TITLE
[RW-9889][risk=no] Remove pause/resume functionality for Cromwell & RStudio

### DIFF
--- a/ui/src/app/components/apps-panel/apps-panel-button.tsx
+++ b/ui/src/app/components/apps-panel/apps-panel-button.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { Clickable } from 'app/components/buttons';
 import { FlexColumn } from 'app/components/flex';
+import { TooltipTrigger } from 'app/components/popups';
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
 
@@ -52,28 +53,36 @@ interface Props {
   icon: IconProp;
   buttonText: string;
   disabled?: boolean;
+  disabledTooltip?: string;
 }
 export const AppsPanelButton = (props: Props) => {
-  const { disabled, onClick, icon, buttonText } = props;
+  const { disabled, onClick, icon, buttonText, disabledTooltip } = props;
+
+  const showTooltip = disabled && disabledTooltip;
+
   return (
-    <Clickable
-      {...{ disabled, onClick }}
-      style={{ padding: '0.5em' }}
-      data-test-id={`apps-panel-button-${buttonText}`}
-      propagateDataTestId
-    >
-      <FlexColumn
-        style={disabled ? buttonStyles.disabledButton : buttonStyles.button}
+    <TooltipTrigger content={disabledTooltip} disabled={!showTooltip}>
+      <Clickable
+        {...{ disabled, onClick }}
+        style={{ padding: '0.5em' }}
+        data-test-id={`apps-panel-button-${buttonText}`}
+        propagateDataTestId
       >
-        <FontAwesomeIcon {...{ icon }} style={buttonStyles.buttonIcon} />
-        <div
-          style={
-            disabled ? buttonStyles.disabledButtonText : buttonStyles.buttonText
-          }
+        <FlexColumn
+          style={disabled ? buttonStyles.disabledButton : buttonStyles.button}
         >
-          {buttonText}
-        </div>
-      </FlexColumn>
-    </Clickable>
+          <FontAwesomeIcon {...{ icon }} style={buttonStyles.buttonIcon} />
+          <div
+            style={
+              disabled
+                ? buttonStyles.disabledButtonText
+                : buttonStyles.buttonText
+            }
+          >
+            {buttonText}
+          </div>
+        </FlexColumn>
+      </Clickable>
+    </TooltipTrigger>
   );
 };

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -10,7 +10,6 @@ import {
 } from 'generated/fetch';
 
 import {
-  leoAppsApi,
   leoProxyApi,
   leoRuntimesApi,
   registerApiClient as leoRegisterApiClient,
@@ -220,59 +219,10 @@ describe('ExpandedApp', () => {
 
   const gkeAppTypes = [UIAppType.CROMWELL, UIAppType.RSTUDIO];
   describe.each(gkeAppTypes)('GKE App %s', (appType) => {
-    it('should allow clicking Pause when the app status is RUNNING', async () => {
-      const appName = 'my-app';
-
-      const wrapper = await component(appType, {
-        appName,
-        googleProject,
-        status: AppStatus.RUNNING,
-      });
-      expect(wrapper.exists()).toBeTruthy();
-
-      const pauseButton = wrapper
-        .find({
-          'data-test-id': 'apps-panel-button-Pause',
-        })
-        .first();
-      expect(pauseButton.exists()).toBeTruthy();
-      const { disabled } = pauseButton.props();
-      expect(disabled).toBeFalsy();
-
-      const pauseSpy = jest.spyOn(leoAppsApi(), 'stopApp');
-      const { onClick } = pauseButton.props();
-      await onClick();
-
-      expect(pauseSpy).toHaveBeenCalledWith(workspace.googleProject, appName);
-    });
-
-    it('should allow clicking Resume when the app status is STOPPED', async () => {
-      const appName = 'my-app';
-
-      const wrapper = await component(appType, {
-        appName,
-        googleProject,
-        status: AppStatus.STOPPED,
-      });
-      expect(wrapper.exists()).toBeTruthy();
-
-      const pauseButton = wrapper
-        .find({
-          'data-test-id': 'apps-panel-button-Resume',
-        })
-        .first();
-      expect(pauseButton.exists()).toBeTruthy();
-      const { disabled } = pauseButton.props();
-      expect(disabled).toBeFalsy();
-
-      const resumeSpy = jest.spyOn(leoAppsApi(), 'startApp');
-      const { onClick } = pauseButton.props();
-      await onClick();
-
-      expect(resumeSpy).toHaveBeenCalledWith(workspace.googleProject, appName);
-    });
-
     test.each([
+      [AppStatus.RUNNING, 'Pause'],
+      [AppStatus.STOPPED, 'Resume'],
+
       [AppStatus.STARTING, 'Resuming'],
       [AppStatus.STOPPING, 'Pausing'],
 

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -125,6 +125,8 @@ const PauseUserAppButton = (props: {
       onResume={() =>
         resumeUserApp(googleProject, appName, props.workspaceNamespace)
       }
+      disabled
+      disabledTooltip='Pause and resume are not currently available.'
     />
   );
 };

--- a/ui/src/app/components/apps-panel/pause-resume-button.tsx
+++ b/ui/src/app/components/apps-panel/pause-resume-button.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
 import * as React from 'react';
+import { useEffect, useState } from 'react';
 import { faPause, faPlay } from '@fortawesome/free-solid-svg-icons';
 import { faSyncAlt } from '@fortawesome/free-solid-svg-icons/faSyncAlt';
 
@@ -12,9 +12,17 @@ interface Props {
   externalStatus: UserEnvironmentStatus;
   onPause: Function;
   onResume: Function;
+  disabled?: boolean;
+  disabledTooltip?: string;
 }
 export const PauseResumeButton = (props: Props) => {
-  const { externalStatus, onPause, onResume } = props;
+  const {
+    externalStatus,
+    onPause,
+    onResume,
+    disabled: disabledByProp,
+    disabledTooltip,
+  } = props;
 
   const [envStatus, setEnvStatus] =
     useState<UserEnvironmentStatus>(externalStatus);
@@ -45,7 +53,7 @@ export const PauseResumeButton = (props: Props) => {
       ]
     );
 
-  const [icon, buttonText, disabled] = cond(
+  const [icon, buttonText, disabledByStatus] = cond(
     [
       envStatus === UserEnvironmentStatus.PAUSING,
       () => [faSyncAlt, UserEnvironmentStatus.PAUSING, true],
@@ -66,5 +74,11 @@ export const PauseResumeButton = (props: Props) => {
     () => [faPause, 'Pause', true]
   );
 
-  return <AppsPanelButton {...{ icon, buttonText, disabled, onClick }} />;
+  const disabled = disabledByProp || disabledByStatus;
+
+  return (
+    <AppsPanelButton
+      {...{ icon, buttonText, disabled, onClick, disabledTooltip }}
+    />
+  );
 };

--- a/ui/src/app/components/environment-informed-action-panel.tsx
+++ b/ui/src/app/components/environment-informed-action-panel.tsx
@@ -76,7 +76,9 @@ export const EnvironmentInformedActionPanel = ({
   environmentChanged = false,
 }) => (
   <FlexRow style={styles.environmentInformedActionPanelWrapper}>
-    <StartStopEnvironmentButton {...{ status, onPause, onResume, appType }} />
+    {appType === UIAppType.JUPYTER && (
+      <StartStopEnvironmentButton {...{ status, onPause, onResume, appType }} />
+    )}
     <CostInfo
       {...{ analysisConfig, environmentChanged }}
       currentUser={profile.username}


### PR DESCRIPTION
Description:

Remove pause/resume functionality for Cromwell & RStudio

- Disables pause/resume on the Applications panel
- Removes the pause/resume button on the Cromwell config page

[Relevant Workbench-UX slack thread](https://pmi-engteam.slack.com/archives/C02MWP2RN5P/p1681220802599489).

Screenshots:

On the Applications panel, the pause/resume button is disabled with a tooltip.

![image](https://user-images.githubusercontent.com/31020403/231257639-0239de47-d055-45dc-8748-5fb2b404557f.png)

On the Cromwell config page the pause/resume button has been removed.

![image (1)](https://user-images.githubusercontent.com/31020403/231257665-014019eb-398c-4b44-b78f-686c7bae23b5.png)

Existing Jupyter config page for reference. No changes were made.

![image (2)](https://user-images.githubusercontent.com/31020403/231257650-000abc73-7a16-4475-a824-5adb802d42a4.png)


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
