### PR TITLE
[DT-353][risk=no] Concept quick add - modify to search only standard codes/ids

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -350,7 +350,6 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
     workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
     if (workbenchConfigProvider.get().featureFlags.enableConceptSetsInCohortBuilder) {
-      System.out.println("enableConceptSetsInCohortBuilder = true");
       return ResponseEntity.ok(
           new CriteriaListResponse()
               .items(

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -480,16 +480,18 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomC
   @Query(
       value =
           "select * from cb_criteria "
-              + "where concept_id in (:conceptIds) and is_selectable = 1 and est_count > 0 "
-              + "and domain_id in (:domainIds)",
+              + "where concept_id in (:conceptIds) and domain_id in (:domainIds) "
+              + "and is_standard = 1 and full_text like '%rank1%' "
+              + "and is_selectable = 1 and est_count > 0 ",
       nativeQuery = true)
   List<DbCriteria> findByConceptIdIn(List<String> conceptIds, List<String> domainIds);
 
   @Query(
       value =
           "select * from cb_criteria "
-              + "where code in (:codes) and is_selectable = 1 and est_count > 0 "
-              + "and domain_id in (:domainIds)",
+              + "where code in (:codes) and domain_id in (:domainIds) "
+              + "and is_standard = 1 and full_text like '%rank1%' "
+              + "and is_selectable = 1 and est_count > 0 ",
       nativeQuery = true)
   List<DbCriteria> findByCodeIn(List<String> codes, List<String> domainIds);
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -482,7 +482,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomC
           "select * from cb_criteria "
               + "where concept_id in (:conceptIds) and domain_id in (:domainIds) "
               + "and is_standard = 1 and full_text like '%rank1%' "
-              + "and is_selectable = 1 and est_count > 0 ",
+              + "and is_selectable = 1 and est_count > 0 order by domain_id",
       nativeQuery = true)
   List<DbCriteria> findByConceptIdIn(List<String> conceptIds, List<String> domainIds);
 
@@ -491,7 +491,7 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomC
           "select * from cb_criteria "
               + "where code in (:codes) and domain_id in (:domainIds) "
               + "and is_standard = 1 and full_text like '%rank1%' "
-              + "and is_selectable = 1 and est_count > 0 ",
+              + "and is_selectable = 1 and est_count > 0 order by domain_id",
       nativeQuery = true)
   List<DbCriteria> findByCodeIn(List<String> codes, List<String> domainIds);
 }

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -1676,6 +1676,8 @@ public class CohortBuilderControllerTest {
             .addCode(conceptCode)
             .addSelectable(true)
             .addCount(1L)
+            .addStandard(true)
+            .addFullText(conceptId + "|[" + domain + "_rank1]")
             .build();
     cbCriteriaDao.save(dbCriteria);
     return dbCriteria;

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -636,6 +636,8 @@ public class CBCriteriaDaoTest {
             .addCode(conceptCode)
             .addSelectable(true)
             .addCount(1L)
+            .addStandard(true)
+            .addFullText(conceptId + "|[" + domain + "_rank1]")
             .build();
     cbCriteriaDao.save(dbCriteria);
     return dbCriteria;


### PR DESCRIPTION
Description:
---
- Fix dao calls to use only standard codes for adding concept sets in cohort builder
---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
