### PR TITLE
[RW-9746][risk=no] Add RStudio config icon

### DIFF
--- a/ui/src/app/components/apps-panel.tsx
+++ b/ui/src/app/components/apps-panel.tsx
@@ -5,6 +5,7 @@ import { BillingStatus, Workspace } from 'generated/fetch';
 
 import { Clickable, CloseButton } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
+import { cromwellConfigIconId } from 'app/components/help-sidebar-icons';
 import { DisabledPanel } from 'app/components/runtime-configuration-panel/disabled-panel';
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
@@ -143,7 +144,7 @@ export const AppsPanel = (props: {
                 key={availableApp.appType}
                 onClick={() => {
                   if (availableApp.appType === UIAppType.CROMWELL) {
-                    setSidebarActiveIconStore.next('cromwellConfig');
+                    setSidebarActiveIconStore.next(cromwellConfigIconId);
                   } else {
                     addToExpandedApps(availableApp.appType);
                   }

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -14,6 +14,7 @@ import { AppStatusIndicator } from 'app/components/app-status-indicator';
 import { DeleteCromwellConfirmationModal } from 'app/components/apps-panel/delete-cromwell-modal';
 import { Clickable } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
+import { cromwellConfigIconId } from 'app/components/help-sidebar-icons';
 import { withErrorModal } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
 import { RuntimeStatusIndicator } from 'app/components/runtime-status-indicator';
@@ -142,7 +143,7 @@ const CromwellButtonRow = (props: {
   return (
     <FlexRow>
       <SettingsButton
-        onClick={() => setSidebarActiveIconStore.next('cromwellConfig')}
+        onClick={() => setSidebarActiveIconStore.next(cromwellConfigIconId)}
         data-test-id='Cromwell-settings-button'
       />
       <PauseUserAppButton {...{ userApp, workspaceNamespace }} />

--- a/ui/src/app/components/apps-panel/utils.tsx
+++ b/ui/src/app/components/apps-panel/utils.tsx
@@ -108,7 +108,7 @@ export const toAppType = (type: UIAppType): AppType =>
   );
 
 export const findApp = (
-  apps: UserAppEnvironment[],
+  apps: UserAppEnvironment[] | null | undefined,
   appType: UIAppType
 ): UserAppEnvironment =>
   apps?.find((app) => app.appType === toAppType(appType));

--- a/ui/src/app/components/help-sidebar-icons.spec.tsx
+++ b/ui/src/app/components/help-sidebar-icons.spec.tsx
@@ -3,11 +3,22 @@ import { mount, ReactWrapper } from 'enzyme';
 
 import { AppStatus } from 'generated/fetch';
 
-import { IconConfig, RuntimeIcon } from 'app/components/help-sidebar-icons';
-import { serverConfigStore } from 'app/utils/stores';
+import {
+  cromwellConfigIconId,
+  IconConfig,
+  rstudioConfigIconId,
+  RuntimeIcon,
+} from 'app/components/help-sidebar-icons';
+import { serverConfigStore, userAppsStore } from 'app/utils/stores';
 import thunderstorm from 'assets/icons/thunderstorm-solid.svg';
 import cromwellIcon from 'assets/images/Cromwell-icon.png';
 import jupyterIcon from 'assets/images/Jupyter-icon.png';
+import rstudioIcon from 'assets/images/RStudio-icon.png';
+
+import {
+  createListAppsCromwellResponse,
+  createListAppsRStudioResponse,
+} from 'testing/stubs/apps-api-stub';
 
 import { UIAppType } from './apps-panel/utils';
 import { UserAppIcon } from './help-sidebar-icons';
@@ -40,21 +51,57 @@ describe('CompoundIcons', () => {
 
   it('UserAppIcon renders for Cromwell', () => {
     const icon = cromwellIcon;
-    const iconId = 'cromwellConfig';
     const label = 'Cromwell Icon';
-    const iconConfig = getIconConfig(iconId, label);
+    const iconConfig = getIconConfig(cromwellConfigIconId, label);
+
+    userAppsStore.set({
+      userApps: [createListAppsCromwellResponse({ status: AppStatus.RUNNING })],
+    });
 
     const wrapper = mount(
       <UserAppIcon
         iconConfig={iconConfig}
-        workspaceNamespace=''
         userSuspended={false}
-        status={AppStatus.RUNNING}
         appType={UIAppType.CROMWELL}
       />
     );
 
-    verifySidebarIcon(wrapper, `help-sidebar-icon-${iconId}`, icon, label);
+    verifySidebarIcon(
+      wrapper,
+      `help-sidebar-icon-${cromwellConfigIconId}`,
+      icon,
+      label
+    );
+
+    const statusIndicator = wrapper.find(
+      `[data-test-id="app-status-icon-container"]`
+    );
+    expect(statusIndicator.exists()).toBeTruthy();
+  });
+
+  it('UserAppIcon renders for RStudio', () => {
+    const icon = rstudioIcon;
+    const label = 'RStudio Icon';
+    const iconConfig = getIconConfig(rstudioConfigIconId, label);
+
+    userAppsStore.set({
+      userApps: [createListAppsRStudioResponse({ status: AppStatus.RUNNING })],
+    });
+
+    const wrapper = mount(
+      <UserAppIcon
+        iconConfig={iconConfig}
+        userSuspended={false}
+        appType={UIAppType.RSTUDIO}
+      />
+    );
+
+    verifySidebarIcon(
+      wrapper,
+      `help-sidebar-icon-${rstudioConfigIconId}`,
+      icon,
+      label
+    );
 
     const statusIndicator = wrapper.find(
       `[data-test-id="app-status-icon-container"]`

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -649,4 +649,70 @@ describe('HelpSidebar', () => {
     expect(wrapper.find(AppsPanel).exists()).toBeFalsy();
     expect(wrapper.find(CromwellConfigurationPanel).exists()).toBeTruthy();
   });
+
+  it('should not show the Cromwell icon if Cromwell is disabled', async () => {
+    serverConfigStore.set({
+      config: { ...defaultServerConfig, enableCromwellGKEApp: false },
+    });
+    const wrapper = await component();
+
+    expect(
+      wrapper
+        .find({ 'data-test-id': 'help-sidebar-icon-cromwellConfig' })
+        .exists()
+    ).toBeFalsy();
+  });
+
+  it('should open the Cromwell config panel after clicking the Cromwell icon', async () => {
+    serverConfigStore.set({
+      config: { ...defaultServerConfig, enableCromwellGKEApp: true },
+    });
+    const wrapper = await component();
+
+    const cromwellIcon = wrapper.find({
+      'data-test-id': 'help-sidebar-icon-cromwellConfig',
+    });
+    expect(cromwellIcon.exists()).toBeTruthy();
+
+    cromwellIcon.simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(wrapper.find(CromwellConfigurationPanel).exists()).toBeTruthy();
+  });
+
+  it('should not show the RStudio icon if RStudio is disabled', async () => {
+    serverConfigStore.set({
+      config: { ...defaultServerConfig, enableRStudioGKEApp: false },
+    });
+    const wrapper = await component();
+
+    expect(
+      wrapper
+        .find({ 'data-test-id': 'help-sidebar-icon-rstudioConfig' })
+        .exists()
+    ).toBeFalsy();
+  });
+
+  it('should open the RStudio config panel after clicking the RStudio icon', async () => {
+    serverConfigStore.set({
+      config: { ...defaultServerConfig, enableRStudioGKEApp: true },
+    });
+    const wrapper = await component();
+
+    expect(wrapper.text()).not.toContain(
+      'RStudio Cloud Environment (Config coming soon)'
+    );
+
+    const cromwellIcon = wrapper.find({
+      'data-test-id': 'help-sidebar-icon-rstudioConfig',
+    });
+    expect(cromwellIcon.exists()).toBeTruthy();
+
+    cromwellIcon.simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(wrapper.text()).toContain(
+      'RStudio Cloud Environment (Config coming soon)'
+    );
+  });
 });

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -21,8 +21,10 @@ import { ConfirmWorkspaceDeleteModal } from 'app/components/confirm-workspace-de
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { GenomicsExtractionTable } from 'app/components/genomics-extraction-table';
 import {
+  cromwellConfigIconId,
   HelpSidebarIcons,
   IconConfig,
+  rstudioConfigIconId,
   showConceptIcon,
   showCriteriaIcon,
   SidebarIconId,
@@ -155,7 +157,8 @@ const styles = reactStyles({
 const SIDEBAR_ICONS_DISABLED_WHEN_USER_SUSPENDED = [
   'apps',
   'runtimeConfig',
-  'cromwellConfig',
+  cromwellConfigIconId,
+  rstudioConfigIconId,
   'terminal',
 ] as SidebarIconId[];
 
@@ -451,6 +454,13 @@ export const HelpSidebar = fp.flow(
     } {
       const { pageKey, workspace, cohortContext } = this.props;
 
+      const sharedGKEAppConfigSidebarContent = {
+        headerPadding: '1.125rem',
+        bodyWidthRem: '55',
+        bodyPadding: '0 1.875rem',
+        showFooter: false,
+      };
+
       switch (activeIcon) {
         case 'help':
           return {
@@ -516,9 +526,9 @@ export const HelpSidebar = fp.flow(
             ),
             showFooter: false,
           };
-        case 'cromwellConfig':
+        case cromwellConfigIconId:
           return {
-            headerPadding: '1.125rem',
+            ...sharedGKEAppConfigSidebarContent,
             renderHeader: () => (
               <div style={{ display: 'flex', alignItems: 'center' }}>
                 <h3
@@ -536,8 +546,6 @@ export const HelpSidebar = fp.flow(
                 />
               </div>
             ),
-            bodyWidthRem: '55',
-            bodyPadding: '0 1.875rem',
             renderBody: () => (
               <ConfigurationPanel
                 type='cromwell'
@@ -545,7 +553,23 @@ export const HelpSidebar = fp.flow(
                 runtimeConfPanelInitialState={null}
               />
             ),
-            showFooter: false,
+          };
+        case rstudioConfigIconId:
+          return {
+            ...sharedGKEAppConfigSidebarContent,
+            renderHeader: () => (
+              <div style={{ display: 'flex', alignItems: 'center' }}>
+                <h3
+                  style={{
+                    ...styles.sectionTitle,
+                    lineHeight: 1.75,
+                  }}
+                >
+                  RStudio Cloud Environment (Config coming soon)
+                </h3>
+              </div>
+            ),
+            renderBody: () => null,
           };
         case 'notebooksHelp':
           return {

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -46,6 +46,8 @@ global.beforeEach(() => {
   const popupRoot = document.createElement('div');
   popupRoot.setAttribute('id', 'popup-root');
   document.body.appendChild(popupRoot);
+
+  window.localStorage.clear();
 });
 
 global.afterEach(() => {


### PR DESCRIPTION
Description:

Adds a sidebar icon for the RStudio config panel.

Adds a minimally-implemented RStudio config panel.

For the reviewer: How do you feel about this PR introducing a non-functional panel? Am I splitting up the story into too many PRs? It will only be visible locally and in test and will be updated within a few days.

[Relevant workbench-ux thread](https://pmi-engteam.slack.com/archives/C02MWP2RN5P/p1681331039881969).

Our `TooltipTrigger` component is difficult to test with Enzyme so I have manually tested it and included a screenshot below.

Screenshots:

Icon with tooltip
![image](https://user-images.githubusercontent.com/31020403/231576091-2c50ac31-75c3-4423-9589-516ca1df140e.png)

Empty config panel
<img width="976" alt="image" src="https://user-images.githubusercontent.com/31020403/231576173-e0c6c4e7-8052-4ea3-be53-dcc3ce99ba84.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
