### PR TITLE
[RW-9197][risk=no] Some preprod paths are too long for the db column

### DIFF
--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -225,21 +225,15 @@
       "wgsHailStoragePath": "wgs/hail.mt",
       "microarrayHailStoragePath": "microarray/hail.mt",
       "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample/delta",
-       "wgsVdsPath": "wgs/vds/gvs_export.vds",
-       "wgsExomeMultiHailPath": "wgs/without_ext_aian_prod/vds/exome/multiMT/delta_basis_without_ext_aian_prod_gq0_3regions_exome.mt",
-       "wgsExomeSplitHailPath": "wgs/without_ext_aian_prod/vds/exome/splitMT/delta_basis_without_ext_aian_prod_gq0_3regions.exome.split.mt",
-       "wgsExomeVcfPath": "v7/wgs/without_ext_aian_prod/vds/exome/vcf",
-       "wgsAcafThresholdMultiHailPath": "wgs/without_ext_aian_prod/vds/acaf_threshold/multiMT/delta_basis_without_ext_aian_prod_gq0_3regions_acaf_threshold.mt",
-       "wgsAcafThresholdSplitHailPath": "wgs/without_ext_aian_prod/vds/acaf_threshold/splitMT/delta_basis_without_ext_aian_prod_gq0_3regions.acaf_threshold.split.mt",
-       "wgsAcafThresholdVcfPath": "wgs/without_ext_aian_prod/vds/acaf_threshold/vcf",
-       "wgsClinvarMultiHailPath": "wgs/without_ext_aian_prod/vds/clinvar/multiMT/delta_basis_without_ext_aian_prod_gq0_3regions_clinvar.mt",
-       "wgsClinvarSplitHailPath": "wgs/without_ext_aian_prod/vds/clinvar/splitMT/delta_basis_without_ext_aian_prod_gq0_3regions.clinvar.split.mt",
-       "wgsClinvarVcfPath": "wgs/without_ext_aian_prod/vds/clinvar/vcf",
-       "wgsLongReadsManifestPath": "longreads/manifest.csv",
-       "wgsLongReadsHailGRCh38": "longreads/hail.mt/GRCh38",
-       "wgsLongReadsHailT2T": "longreads/hail.mt/T2T",
-       "wgsLongReadsJointVcfGRCh38": "longreads/joint_vcf/GRCh38",
-       "wgsLongReadsJointVcfT2T": "longreads/joint_vcf/T2T"
+      "wgsVdsPath": "wgs/vds/gvs_export.vds",
+      "wgsExomeVcfPath": "v7/wgs/without_ext_aian_prod/vds/exome/vcf",
+      "wgsAcafThresholdVcfPath": "wgs/without_ext_aian_prod/vds/acaf_threshold/vcf",
+      "wgsClinvarVcfPath": "wgs/without_ext_aian_prod/vds/clinvar/vcf",
+      "wgsLongReadsManifestPath": "longreads/manifest.csv",
+      "wgsLongReadsHailGRCh38": "longreads/hail.mt/GRCh38",
+      "wgsLongReadsHailT2T": "longreads/hail.mt/T2T",
+      "wgsLongReadsJointVcfGRCh38": "longreads/joint_vcf/GRCh38",
+      "wgsLongReadsJointVcfT2T": "longreads/joint_vcf/T2T"
     }
   ]
 }

--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -221,7 +221,7 @@
       "hasCopeSurveyData": true,
       "hasSurveyConductData": true,
       "accessTier": "controlled",
-      "storageBasePath": "7",
+      "storageBasePath": "v7",
       "wgsHailStoragePath": "wgs/hail.mt",
       "microarrayHailStoragePath": "microarray/hail.mt",
       "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample/delta",

--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -226,7 +226,7 @@
       "microarrayHailStoragePath": "microarray/hail.mt",
       "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample/delta",
       "wgsVdsPath": "wgs/vds/gvs_export.vds",
-      "wgsExomeVcfPath": "v7/wgs/without_ext_aian_prod/vds/exome/vcf",
+      "wgsExomeVcfPath": "wgs/without_ext_aian_prod/vds/exome/vcf",
       "wgsAcafThresholdVcfPath": "wgs/without_ext_aian_prod/vds/acaf_threshold/vcf",
       "wgsClinvarVcfPath": "wgs/without_ext_aian_prod/vds/clinvar/vcf",
       "wgsLongReadsManifestPath": "longreads/manifest.csv",


### PR DESCRIPTION
Description:
<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
