### PR TITLE
[risk=low][no ticket] rm UI logic based on FFs useGpu and usePersistentDisk

### DIFF
--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -76,8 +76,6 @@ describe('RuntimeConfigurationPanel', () => {
   let runtimeApiStub: RuntimeApiStub;
   let disksApiStub: DisksApiStub;
   let workspacesApiStub: WorkspacesApiStub;
-  let enableGpu: boolean;
-  let enablePersistentDisk: boolean;
   let freeTierBillingAccountId: string;
 
   const component = async (
@@ -144,8 +142,6 @@ describe('RuntimeConfigurationPanel', () => {
   beforeEach(async () => {
     cdrVersionStore.set(cdrVersionTiersResponse);
     serverConfigStore.set({ config: { ...defaultServerConfig } });
-    enableGpu = serverConfigStore.get().config.enableGpu;
-    enablePersistentDisk = serverConfigStore.get().config.enablePersistentDisk;
     freeTierBillingAccountId =
       serverConfigStore.get().config.freeTierBillingAccountId;
 
@@ -250,17 +246,9 @@ describe('RuntimeConfigurationPanel', () => {
   const pickMainRam = (wrapper, ram) =>
     pickDropdownOption(wrapper, '#runtime-ram', ram);
 
-  const getMainDiskSize = (wrapper) =>
-    getInputValue(
-      wrapper,
-      enablePersistentDisk ? '#standard-disk' : '#runtime-disk'
-    );
+  const getMainDiskSize = (wrapper) => getInputValue(wrapper, '#standard-disk');
   const pickMainDiskSize = (wrapper, diskSize) =>
-    enterNumberInput(
-      wrapper,
-      enablePersistentDisk ? '#standard-disk' : '#runtime-disk',
-      diskSize
-    );
+    enterNumberInput(wrapper, '#standard-disk', diskSize);
 
   const enableDetachable = (wrapper, detachable = true) =>
     wrapper
@@ -1774,9 +1762,6 @@ describe('RuntimeConfigurationPanel', () => {
   });
 
   it('should allow creating gce without GPU', async () => {
-    if (!enableGpu) {
-      return;
-    }
     setCurrentRuntime(null);
     const wrapper = await component();
     await mustClickButton(wrapper, 'Customize');

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -22,7 +22,6 @@ import { ConfirmUpdatePanel } from 'app/components/runtime-configuration-panel/c
 import { DataProcConfigSelector } from 'app/components/runtime-configuration-panel/dataproc-config-selector';
 import { DisabledPanel } from 'app/components/runtime-configuration-panel/disabled-panel';
 import { DiskSelector } from 'app/components/runtime-configuration-panel/disk-selector';
-import { DiskSizeSelector } from 'app/components/runtime-configuration-panel/disk-size-selector';
 import { GpuConfigSelector } from 'app/components/runtime-configuration-panel/gpu-config-selector';
 import { MachineSelector } from 'app/components/runtime-configuration-panel/machine-selector';
 import { OfferDeleteDiskWithUpdate } from 'app/components/runtime-configuration-panel/offer-delete-disk-with-update';
@@ -187,7 +186,6 @@ const PanelMain = fp.flow(
   }) => {
     const { profile } = profileState;
     const { namespace, cdrVersionId, googleProject } = workspace;
-    const { enableGpu, enablePersistentDisk } = serverConfigStore.get().config;
 
     const { hasWgsData: allowDataproc } = findCdrVersion(
       cdrVersionId,
@@ -701,36 +699,17 @@ const PanelMain = fp.flow(
                       validMachineTypes={validMainMachineTypes}
                       machineType={analysisConfig.machine.name}
                     />
-                    {enablePersistentDisk || (
-                      <DiskSizeSelector
-                        idPrefix='runtime'
-                        onChange={(size: number) =>
-                          setAnalysisConfig({
-                            ...analysisConfig,
-                            diskConfig: {
-                              size,
-                              detachable: false,
-                              detachableType: null,
-                              existingDiskName: null,
-                            },
-                          })
-                        }
-                        diskSize={analysisConfig.diskConfig.size}
-                        disabled={disableControls}
-                      />
-                    )}
                   </div>
-                  {enableGpu &&
-                    analysisConfig.computeType === ComputeType.Standard && (
-                      <GpuConfigSelector
-                        disabled={disableControls}
-                        onChange={(gpuConfig: GpuConfig) =>
-                          setAnalysisConfig({ ...analysisConfig, gpuConfig })
-                        }
-                        selectedMachine={analysisConfig.machine}
-                        gpuConfig={analysisConfig.gpuConfig}
-                      />
-                    )}
+                  {analysisConfig.computeType === ComputeType.Standard && (
+                    <GpuConfigSelector
+                      disabled={disableControls}
+                      onChange={(gpuConfig: GpuConfig) =>
+                        setAnalysisConfig({ ...analysisConfig, gpuConfig })
+                      }
+                      selectedMachine={analysisConfig.machine}
+                      gpuConfig={analysisConfig.gpuConfig}
+                    />
+                  )}
                   <FlexRow
                     style={{
                       marginTop: '1.5rem',
@@ -834,24 +813,22 @@ const PanelMain = fp.flow(
                     </FlexColumn>
                   </FlexRow>
                 </div>
-                {enablePersistentDisk && (
-                  <DiskSelector
-                    diskConfig={analysisConfig.diskConfig}
-                    onChange={(diskConfig) =>
-                      setAnalysisConfig({
-                        ...analysisConfig,
-                        diskConfig,
-                        detachedDisk: diskConfig.detachable
-                          ? null
-                          : gcePersistentDisk,
-                      })
-                    }
-                    disabled={disableControls}
-                    disableDetachableReason={disableDetachableReason}
-                    existingDisk={gcePersistentDisk}
-                    computeType={analysisConfig.computeType}
-                  />
-                )}
+                <DiskSelector
+                  diskConfig={analysisConfig.diskConfig}
+                  onChange={(diskConfig) =>
+                    setAnalysisConfig({
+                      ...analysisConfig,
+                      diskConfig,
+                      detachedDisk: diskConfig.detachable
+                        ? null
+                        : gcePersistentDisk,
+                    })
+                  }
+                  disabled={disableControls}
+                  disableDetachableReason={disableDetachableReason}
+                  existingDisk={gcePersistentDisk}
+                  computeType={analysisConfig.computeType}
+                />
                 {runtimeExists && updateMessaging.warn && (
                   <WarningMessage iconSize={30} iconPosition={'center'}>
                     <div>{updateMessaging.warn}</div>

--- a/ui/src/app/utils/runtime-utils.spec.tsx
+++ b/ui/src/app/utils/runtime-utils.spec.tsx
@@ -41,13 +41,11 @@ const TestComponent = () => {
 
 describe('runtime-utils', () => {
   let runtimeApiStub: RuntimeApiStub;
-  let enablePd: boolean;
 
   beforeEach(() => {
     runtimeApiStub = new RuntimeApiStub();
     registerApiClient(RuntimeApi, runtimeApiStub);
     serverConfigStore.set({ config: { ...defaultServerConfig } });
-    enablePd = serverConfigStore.get().config.enablePersistentDisk;
 
     // For a component using the runtime store to function properly, there must
     // be an active workspace context provided - in the real application this is
@@ -58,12 +56,10 @@ describe('runtime-utils', () => {
       runtime: undefined,
       runtimeLoaded: true,
     });
-    if (enablePd) {
-      diskStore.set({
-        workspaceNamespace: WORKSPACE_NS,
-        gcePersistentDisk: undefined,
-      });
-    }
+    diskStore.set({
+      workspaceNamespace: WORKSPACE_NS,
+      gcePersistentDisk: undefined,
+    });
     jest.useFakeTimers();
   });
 

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -40,7 +40,6 @@ import {
   markCompoundRuntimeOperationCompleted,
   registerCompoundRuntimeOperation,
   runtimeStore,
-  serverConfigStore,
   useStore,
 } from 'app/utils/stores';
 
@@ -929,9 +928,8 @@ export const maybeInitializeRuntime = async (
 // useDisk hook is a simple hook to populate the disk store.
 // This is only used by other disk hooks
 export const useDisk = (currentWorkspaceNamespace: string) => {
-  const enablePD = serverConfigStore.get().config.enablePersistentDisk;
   useEffect(() => {
-    if (!enablePD || !currentWorkspaceNamespace) {
+    if (!currentWorkspaceNamespace) {
       return;
     }
     const getDisk = withAsyncErrorHandling(

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -68,8 +68,6 @@ const defaultServerConfig: ConfigResponse = {
   rasHost: 'https://stsstg.nih.gov/',
   rasClientId: '903cfaeb-57d9-4ef6-5659-04377794ed65',
   enableRasLoginGovLinking: true,
-  enableGpu: true,
-  enablePersistentDisk: true,
   accessRenewalLookback: 330,
   complianceTrainingRenewalLookback: 30,
   freeTierBillingAccountId: 'freetier',


### PR DESCRIPTION
useGpu and usePersistentDisk are always true, and we are removing these Feature Flags (see #7592) so we can remove the UI logic which checks if they are false.

After a release, we can fully remove these FFs.

<!--
Replace this template with your PR description.
Please remember to keep in mind the security levels outlined in
[CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md) and to
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->


---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
