### PR TITLE
[RW-9746][risk=no] Add RStudio config panel header

### DIFF
--- a/ui/src/app/components/configuration-panel.tsx
+++ b/ui/src/app/components/configuration-panel.tsx
@@ -93,7 +93,9 @@ export const ConfigurationPanel = fp.flow(
             ),
           ],
           // UIAppType.RStudio
-          () => null
+          () => (
+            <p>The RStudio configuration panel is currently in development.</p>
+          )
         )}
       </div>
     );

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -699,9 +699,7 @@ describe('HelpSidebar', () => {
     });
     const wrapper = await component();
 
-    expect(wrapper.text()).not.toContain(
-      'RStudio Cloud Environment (Config coming soon)'
-    );
+    expect(wrapper.text()).not.toContain('RStudio Cloud Environment');
 
     const cromwellIcon = wrapper.find({
       'data-test-id': 'help-sidebar-icon-rstudioConfig',
@@ -711,8 +709,6 @@ describe('HelpSidebar', () => {
     cromwellIcon.simulate('click');
     await waitOneTickAndUpdate(wrapper);
 
-    expect(wrapper.text()).toContain(
-      'RStudio Cloud Environment (Config coming soon)'
-    );
+    expect(wrapper.text()).toContain('RStudio Cloud Environment');
   });
 });

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -146,12 +146,18 @@ const styles = reactStyles({
     paddingLeft: 12,
     width: 160,
   },
-  cromwellBetaBadge: {
-    border: `3px solid #F0B1D0`,
+  betaBadge: {
+    border: `3px solid`,
     borderRadius: '11px',
     padding: '0 0.5rem',
     backgroundColor: colors.white,
     lineHeight: '1rem',
+  },
+  cromwellBetaBadge: {
+    borderColor: `#F0B1D0`,
+  },
+  rstudioBetaBadge: {
+    borderColor: `#72abdc`,
   },
 });
 
@@ -241,15 +247,11 @@ interface State {
   runtimeConfPanelInitialState: PanelContent | null;
 }
 
-const CromwellBetaBadge = ({ style }) => (
-  <TooltipTrigger
-    content={
-      'We are regularly improving the Cromwell experience. If you have feedback, reach out to support@researchallofus.org'
-    }
-  >
+const BetaBadge = ({ tooltipContent, style }) => (
+  <TooltipTrigger content={tooltipContent}>
     <div
       style={{
-        ...styles.cromwellBetaBadge,
+        ...styles.betaBadge,
         ...style,
       }}
     >
@@ -541,9 +543,13 @@ export const HelpSidebar = fp.flow(
                 >
                   Cromwell Cloud Environment
                 </h3>
-                <CromwellBetaBadge
+                <BetaBadge
+                  tooltipContent={
+                    'We are regularly improving the Cromwell experience. If you have feedback, reach out to support@researchallofus.org'
+                  }
                   style={{
                     marginLeft: '0.5rem',
+                    ...styles.cromwellBetaBadge,
                   }}
                 />
               </div>
@@ -566,8 +572,17 @@ export const HelpSidebar = fp.flow(
                     lineHeight: 1.75,
                   }}
                 >
-                  RStudio Cloud Environment (Config coming soon)
+                  RStudio Cloud Environment
                 </h3>
+                <BetaBadge
+                  tooltipContent={
+                    'We are regularly improving the RStudio experience. If you have feedback, reach out to support@researchallofus.org'
+                  }
+                  style={{
+                    marginLeft: '0.5rem',
+                    ...styles.rstudioBetaBadge,
+                  }}
+                />
               </div>
             ),
             renderBody: () => (


### PR DESCRIPTION
Description:

Completes the RStudio config panel header. Adds minimal panel body text, which will be replaced in the immediate next PR.

My approach here favors composition over inheritance. Rather than creating an `<AppHeader>` component with several props and internal logic, I just made the `<BetaBadge>` component more reusable. If this seems OK, I intend to try a similar approach for the panel content.

I have not posted this to #workbench-ux yet. I intend to do that once the entire panel is complete (likely the next PR) for final feedback.

Screenshots:

<img width="958" alt="image" src="https://user-images.githubusercontent.com/31020403/232138750-a01557ec-4170-45dd-b588-793b8d9d7fbb.png">

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
