### PR TITLE
[DT-359][risk=no] Fixing db port for cdr-indices build

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -930,7 +930,6 @@ def import_cdr_indices_build_to_cloudsql(cmd_name, *args)
 
   ENV.update(read_db_vars(gcc))
   ENV.update(must_get_env_value(gcc.project, :gae_vars))
-  ENV["DB_PORT"] = "3307" # TODO(dmohs): Use MYSQL_TCP_PORT to be consistent with mysql CLI.
 
   common = Common.new
   CloudSqlProxyContext.new(gcc.project).run do


### PR DESCRIPTION
Fixing db port for cdr-indices build. The indexing build generated the following error:

```
./generate-cdr/init-new-cdr-db.sh: line 59: DB_HOST: unbound variable
++ finish
++ rm -f /tmp/create_db.sql
Failed
```

Had to add back the read of the env variables that got removed in the following PR: https://github.com/all-of-us/workbench/pull/7555
