### PR TITLE
[RW-9746][risk=no] Miscellaneous Cromwell config panel refactors

### DIFF
--- a/ui/src/app/components/cromwell-configuration-panel.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.tsx
@@ -54,9 +54,7 @@ const DEFAULT_MACHINE_TYPE: Machine = findMachineByName(
 const { cpu, memory } = DEFAULT_MACHINE_TYPE;
 
 const analysisConfig: Partial<AnalysisConfig> = {
-  machine: findMachineByName(
-    defaultCromwellConfig.kubernetesRuntimeConfig.machineType
-  ),
+  machine: DEFAULT_MACHINE_TYPE,
   diskConfig: {
     size: defaultCromwellConfig.persistentDiskRequest.size,
     detachable: true,

--- a/ui/src/app/components/cromwell-configuration-panel.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.tsx
@@ -126,92 +126,90 @@ export const CromwellConfigurationPanel = ({
         You will need to create a Jupyter terminal environment in order to
         interact with Cromwell.
       </div>
-      <FlexColumn style={{ height: '100%' }}>
-        <div
-          data-test-id='cromwell-create-panel'
-          style={{ ...styles.controlSection, marginTop: '1rem' }}
-        >
-          <EnvironmentInformedActionPanel
-            {...{
-              creatorFreeCreditsRemaining,
-              profile,
-              workspace,
-              analysisConfig,
-            }}
-            status={app?.status}
-            onPause={Promise.resolve()}
-            onResume={Promise.resolve()}
-            appType={AppType.CROMWELL}
-          />
-          <WarningMessage>
-            This cost is only for running the Cromwell Engine, there will be
-            additional cost for interactions with the workflow.
-            <a
-              style={{ marginLeft: '0.25rem' }}
-              href={CROMWELL_INFORMATION_LINK}
-              target={'_blank'}
-            >
-              Learn more{' '}
-            </a>
-            <i
-              className='pi pi-external-link'
-              style={{
-                marginLeft: '0.25rem',
-                fontSize: '0.75rem',
-                color: '#6fb4ff',
-                cursor: 'pointer',
-              }}
-            />
-          </WarningMessage>
-        </div>
-        <div style={{ ...styles.controlSection, marginTop: '1rem' }}>
-          <FlexRow style={{ alignItems: 'center' }}>
-            <div style={{ fontWeight: 'bold', marginRight: '0.5rem' }}>
-              Cloud compute profile
-            </div>
-            <TooltipTrigger
-              content='The cloud compute profile for Cromwell beta is non-configurable.'
-              side={'right'}
-            >
-              <div style={styles.disabledCloudProfile}>
-                {`${cpu} CPUS, ${memory}GB RAM, ${defaultCromwellConfig.persistentDiskRequest.size}GB disk`}
-              </div>
-            </TooltipTrigger>
-          </FlexRow>
-        </div>
-        <div style={{ ...styles.controlSection, marginTop: '1rem' }}>
-          <div style={{ fontWeight: 'bold' }}>Cromwell support articles</div>
-          {cromwellSupportArticles.map((article, index) => (
-            <div key={index} style={{ display: 'block' }}>
-              <a href={article.link} target='_blank'>
-                {index + 1}. {article.text}
-              </a>
-            </div>
-          ))}
-        </div>
-        <FlexRow
-          style={{
-            marginTop: '1rem',
-            alignItems: 'center',
+      <div
+        data-test-id='cromwell-create-panel'
+        style={{ ...styles.controlSection, marginTop: '1rem' }}
+      >
+        <EnvironmentInformedActionPanel
+          {...{
+            creatorFreeCreditsRemaining,
+            profile,
+            workspace,
+            analysisConfig,
           }}
-        >
-          <div style={{ margin: '0rem 1rem 1rem 0rem ' }}>
-            <div style={{ fontWeight: 'bold' }}>Next Steps:</div>
-            <div>
-              You can interact with the workflow by using the Cromshell in
-              Jupyter Terminal or Jupyter notebook
-            </div>
-          </div>
-          <Button
-            id='cromwell-cloud-environment-create-button'
-            aria-label='cromwell cloud environment create button'
-            onClick={onCreate}
-            disabled={!createEnabled}
+          status={app?.status}
+          onPause={Promise.resolve()}
+          onResume={Promise.resolve()}
+          appType={AppType.CROMWELL}
+        />
+        <WarningMessage>
+          This cost is only for running the Cromwell Engine, there will be
+          additional cost for interactions with the workflow.
+          <a
+            style={{ marginLeft: '0.25rem' }}
+            href={CROMWELL_INFORMATION_LINK}
+            target={'_blank'}
           >
-            Start
-          </Button>
+            Learn more{' '}
+          </a>
+          <i
+            className='pi pi-external-link'
+            style={{
+              marginLeft: '0.25rem',
+              fontSize: '0.75rem',
+              color: '#6fb4ff',
+              cursor: 'pointer',
+            }}
+          />
+        </WarningMessage>
+      </div>
+      <div style={{ ...styles.controlSection, marginTop: '1rem' }}>
+        <FlexRow style={{ alignItems: 'center' }}>
+          <div style={{ fontWeight: 'bold', marginRight: '0.5rem' }}>
+            Cloud compute profile
+          </div>
+          <TooltipTrigger
+            content='The cloud compute profile for Cromwell beta is non-configurable.'
+            side={'right'}
+          >
+            <div style={styles.disabledCloudProfile}>
+              {`${cpu} CPUS, ${memory}GB RAM, ${defaultCromwellConfig.persistentDiskRequest.size}GB disk`}
+            </div>
+          </TooltipTrigger>
         </FlexRow>
-      </FlexColumn>
+      </div>
+      <div style={{ ...styles.controlSection, marginTop: '1rem' }}>
+        <div style={{ fontWeight: 'bold' }}>Cromwell support articles</div>
+        {cromwellSupportArticles.map((article, index) => (
+          <div key={index} style={{ display: 'block' }}>
+            <a href={article.link} target='_blank'>
+              {index + 1}. {article.text}
+            </a>
+          </div>
+        ))}
+      </div>
+      <FlexRow
+        style={{
+          marginTop: '1rem',
+          alignItems: 'center',
+        }}
+      >
+        <div style={{ margin: '0rem 1rem 1rem 0rem ' }}>
+          <div style={{ fontWeight: 'bold' }}>Next Steps:</div>
+          <div>
+            You can interact with the workflow by using the Cromshell in Jupyter
+            Terminal or Jupyter notebook
+          </div>
+        </div>
+        <Button
+          id='cromwell-cloud-environment-create-button'
+          aria-label='cromwell cloud environment create button'
+          onClick={onCreate}
+          disabled={!createEnabled}
+        >
+          Start
+        </Button>
+      </FlexRow>
     </FlexColumn>
   );
 };

--- a/ui/src/app/components/cromwell-configuration-panel.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.tsx
@@ -119,14 +119,17 @@ export const CromwellConfigurationPanel = ({
   };
 
   return (
-    <FlexColumn id='cromwell-configuration-panel' style={{ height: '100%' }}>
+    <FlexColumn
+      id='cromwell-configuration-panel'
+      style={{ height: '100%', rowGap: '1rem' }}
+    >
       <div>
         A cloud environment consists of an application configuration, cloud
         compute and persistent disk(s). Cromwell is a workflow execution engine.
         You will need to create a Jupyter terminal environment in order to
         interact with Cromwell.
       </div>
-      <div style={{ ...styles.controlSection, marginTop: '1rem' }}>
+      <div style={{ ...styles.controlSection }}>
         <EnvironmentInformedActionPanel
           {...{
             creatorFreeCreditsRemaining,
@@ -160,7 +163,7 @@ export const CromwellConfigurationPanel = ({
           />
         </WarningMessage>
       </div>
-      <div style={{ ...styles.controlSection, marginTop: '1rem' }}>
+      <div style={{ ...styles.controlSection }}>
         <FlexRow style={{ alignItems: 'center' }}>
           <div style={{ fontWeight: 'bold', marginRight: '0.5rem' }}>
             Cloud compute profile
@@ -175,7 +178,7 @@ export const CromwellConfigurationPanel = ({
           </TooltipTrigger>
         </FlexRow>
       </div>
-      <div style={{ ...styles.controlSection, marginTop: '1rem' }}>
+      <div style={{ ...styles.controlSection }}>
         <div style={{ fontWeight: 'bold' }}>Cromwell support articles</div>
         {cromwellSupportArticles.map((article, index) => (
           <div key={index} style={{ display: 'block' }}>
@@ -187,7 +190,6 @@ export const CromwellConfigurationPanel = ({
       </div>
       <FlexRow
         style={{
-          marginTop: '1rem',
           alignItems: 'center',
         }}
       >

--- a/ui/src/app/components/cromwell-configuration-panel.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.tsx
@@ -126,10 +126,7 @@ export const CromwellConfigurationPanel = ({
         You will need to create a Jupyter terminal environment in order to
         interact with Cromwell.
       </div>
-      <div
-        data-test-id='cromwell-create-panel'
-        style={{ ...styles.controlSection, marginTop: '1rem' }}
-      >
+      <div style={{ ...styles.controlSection, marginTop: '1rem' }}>
         <EnvironmentInformedActionPanel
           {...{
             creatorFreeCreditsRemaining,


### PR DESCRIPTION
Description:

Miscellaneous Cromwell configuration panel refactors. There are no product-facing changes.

This should simplify sharing code with a comparable RStudio config panel.

**Reviewer note: This PR is most easily reviewed commit-by-commit.**

This PR is very similar to [this refactoring PR](https://github.com/all-of-us/workbench/pull/7594). If I had noticed these updates earlier I would have included them there.

This can be verified by comparing the behavior of the Cromwell config panel before and after this change. Everything should be the same.

Screenshots (there should be no differences):

Before:
<img width="889" alt="image" src="https://user-images.githubusercontent.com/31020403/232529295-10f2a66b-dbcc-4ab2-acef-c8318fd1e764.png">

After:
<img width="885" alt="image" src="https://user-images.githubusercontent.com/31020403/232529022-dc0cb4da-ed4a-47ae-a217-97dffc4c4f09.png">


---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
