### PR TITLE
[RW-9746][risk=no] Add RStudio configuration panel content

### DIFF
--- a/e2e/tests/nightly/gke-apps/cromwell.spec.ts
+++ b/e2e/tests/nightly/gke-apps/cromwell.spec.ts
@@ -39,7 +39,7 @@ describe('Cromwell GKE App', () => {
 
     // now we can create a Cromwell app by clicking the button on this page
 
-    const createXPath = `${configPanel.getXpath()}//*[@id="cromwell-cloud-environment-create-button"]`;
+    const createXPath = `${configPanel.getXpath()}//*[@id="Cromwell-cloud-environment-create-button"]`;
     const createButton = new Button(page, createXPath);
     expect(await createButton.exists()).toBeTruthy();
     await createButton.click();

--- a/ui/src/app/components/configuration-panel.tsx
+++ b/ui/src/app/components/configuration-panel.tsx
@@ -5,13 +5,13 @@ import * as fp from 'lodash/fp';
 import { BillingStatus } from 'generated/fetch';
 
 import { UIAppType } from 'app/components/apps-panel/utils';
+import { CromwellConfigurationPanel } from 'app/components/cromwell-configuration-panel';
 import { RStudioConfigurationPanel } from 'app/components/rstudio-configuration-panel';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import { cond, withCurrentWorkspace, withUserProfile } from 'app/utils';
 import { ProfileStore } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
-import { CromwellConfigurationPanel } from './cromwell-configuration-panel';
 import {
   RuntimeConfigurationPanel,
   RuntimeConfigurationPanelProps,
@@ -89,6 +89,7 @@ export const ConfigurationPanel = fp.flow(
                   creatorFreeCreditsRemaining,
                   workspace,
                   profileState,
+                  workspaceNamespace: workspace.namespace,
                 }}
               />
             ),
@@ -101,6 +102,7 @@ export const ConfigurationPanel = fp.flow(
                 creatorFreeCreditsRemaining,
                 workspace,
                 profileState,
+                workspaceNamespace: workspace.namespace,
               }}
             />
           )

--- a/ui/src/app/components/configuration-panel.tsx
+++ b/ui/src/app/components/configuration-panel.tsx
@@ -5,6 +5,7 @@ import * as fp from 'lodash/fp';
 import { BillingStatus } from 'generated/fetch';
 
 import { UIAppType } from 'app/components/apps-panel/utils';
+import { RStudioConfigurationPanel } from 'app/components/rstudio-configuration-panel';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import { cond, withCurrentWorkspace, withUserProfile } from 'app/utils';
 import { ProfileStore } from 'app/utils/stores';
@@ -94,7 +95,14 @@ export const ConfigurationPanel = fp.flow(
           ],
           // UIAppType.RStudio
           () => (
-            <p>The RStudio configuration panel is currently in development.</p>
+            <RStudioConfigurationPanel
+              {...{
+                onClose,
+                creatorFreeCreditsRemaining,
+                workspace,
+                profileState,
+              }}
+            />
           )
         )}
       </div>

--- a/ui/src/app/components/cromwell-configuration-panel.spec.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.spec.tsx
@@ -95,7 +95,7 @@ describe('CromwellConfigurationPanel', () => {
       .spyOn(appsApi(), 'createApp')
       .mockImplementation((): Promise<any> => Promise.resolve());
     const startButton = wrapper
-      .find('#cromwell-cloud-environment-create-button')
+      .find('#Cromwell-cloud-environment-create-button')
       .first();
 
     startButton.simulate('click');
@@ -123,7 +123,7 @@ describe('CromwellConfigurationPanel', () => {
       });
       expect(
         wrapper
-          .find('#cromwell-cloud-environment-create-button')
+          .find('#Cromwell-cloud-environment-create-button')
           .first()
           .prop('disabled')
       ).toBeFalsy();
@@ -139,7 +139,7 @@ describe('CromwellConfigurationPanel', () => {
       });
       expect(
         wrapper
-          .find('#cromwell-cloud-environment-create-button')
+          .find('#Cromwell-cloud-environment-create-button')
           .first()
           .prop('disabled')
       ).toBeTruthy();

--- a/ui/src/app/components/cromwell-configuration-panel.spec.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { AppStatus, DisksApi, WorkspaceAccessLevel } from 'generated/fetch';
+import { DisksApi, WorkspaceAccessLevel } from 'generated/fetch';
 import { AppsApi } from 'generated/fetch/api';
 
 import {
@@ -15,10 +15,7 @@ import {
   mountWithRouter,
   waitOneTickAndUpdate,
 } from 'testing/react-test-helpers';
-import {
-  AppsApiStub,
-  createListAppsCromwellResponse,
-} from 'testing/stubs/apps-api-stub';
+import { AppsApiStub } from 'testing/stubs/apps-api-stub';
 import { CdrVersionsStubVariables } from 'testing/stubs/cdr-versions-api-stub';
 import { DisksApiStub } from 'testing/stubs/disks-api-stub';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
@@ -26,7 +23,6 @@ import {
   workspaceStubs,
   WorkspaceStubVariables,
 } from 'testing/stubs/workspaces';
-import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
 
 import { defaultCromwellConfig } from './apps-panel/utils';
 
@@ -106,44 +102,6 @@ describe('CromwellConfigurationPanel', () => {
       defaultCromwellConfig
     );
     expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  const createEnabledStatuses = [AppStatus.DELETED, null, undefined];
-  const createDisabledStatuses = minus(
-    ALL_GKE_APP_STATUSES,
-    createEnabledStatuses
-  );
-
-  describe('should allow creating a Cromwell app for certain app statuses', () => {
-    test.each(createEnabledStatuses)('Status %s', async (appStatus) => {
-      const wrapper = await component({
-        gkeAppsInWorkspace: [
-          createListAppsCromwellResponse({ status: appStatus }),
-        ],
-      });
-      expect(
-        wrapper
-          .find('#Cromwell-cloud-environment-create-button')
-          .first()
-          .prop('disabled')
-      ).toBeFalsy();
-    });
-  });
-
-  describe('should allow creating a Cromwell app for certain app statuses', () => {
-    test.each(createDisabledStatuses)('Status %s', async (appStatus) => {
-      const wrapper = await component({
-        gkeAppsInWorkspace: [
-          createListAppsCromwellResponse({ status: appStatus }),
-        ],
-      });
-      expect(
-        wrapper
-          .find('#Cromwell-cloud-environment-create-button')
-          .first()
-          .prop('disabled')
-      ).toBeTruthy();
-    });
   });
 
   it('should display a cost of $0.40 per hour when running and $0.20 per hour when paused', async () => {

--- a/ui/src/app/components/cromwell-configuration-panel.spec.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.spec.tsx
@@ -3,6 +3,10 @@ import * as React from 'react';
 import { AppStatus, DisksApi, WorkspaceAccessLevel } from 'generated/fetch';
 import { AppsApi } from 'generated/fetch/api';
 
+import {
+  BaseCromwellConfigurationPanel,
+  CromwellConfigurationPanelProps,
+} from 'app/components/cromwell-configuration-panel';
 import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
 import { serverConfigStore } from 'app/utils/stores';
 
@@ -25,10 +29,6 @@ import {
 import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
 
 import { defaultCromwellConfig } from './apps-panel/utils';
-import {
-  CromwellConfigurationPanel,
-  CromwellConfigurationPanelProps,
-} from './cromwell-configuration-panel';
 
 describe('CromwellConfigurationPanel', () => {
   const onClose = jest.fn();
@@ -49,6 +49,7 @@ describe('CromwellConfigurationPanel', () => {
       reload: jest.fn(),
       updateCache: jest.fn(),
     },
+    gkeAppsInWorkspace: [],
   };
 
   let disksApiStub: DisksApiStub;
@@ -57,7 +58,7 @@ describe('CromwellConfigurationPanel', () => {
     propOverrides?: Partial<CromwellConfigurationPanelProps>
   ) => {
     const allProps = { ...DEFAULT_PROPS, ...propOverrides };
-    const c = mountWithRouter(<CromwellConfigurationPanel {...allProps} />);
+    const c = mountWithRouter(<BaseCromwellConfigurationPanel {...allProps} />);
     await waitOneTickAndUpdate(c);
     return c;
   };
@@ -85,10 +86,9 @@ describe('CromwellConfigurationPanel', () => {
   });
 
   it('start button should create cromwell and close panel', async () => {
-    jest
-      .spyOn(appsApi(), 'listAppsInWorkspace')
-      .mockImplementationOnce(() => Promise.resolve([]));
-    const wrapper = await component();
+    const wrapper = await component({
+      gkeAppsInWorkspace: [],
+    });
     await waitOneTickAndUpdate(wrapper);
 
     const spyCreateApp = jest
@@ -116,14 +116,11 @@ describe('CromwellConfigurationPanel', () => {
 
   describe('should allow creating a Cromwell app for certain app statuses', () => {
     test.each(createEnabledStatuses)('Status %s', async (appStatus) => {
-      jest
-        .spyOn(appsApi(), 'listAppsInWorkspace')
-        .mockImplementationOnce(() =>
-          Promise.resolve([
-            createListAppsCromwellResponse({ status: appStatus }),
-          ])
-        );
-      const wrapper = await component();
+      const wrapper = await component({
+        gkeAppsInWorkspace: [
+          createListAppsCromwellResponse({ status: appStatus }),
+        ],
+      });
       expect(
         wrapper
           .find('#cromwell-cloud-environment-create-button')
@@ -135,14 +132,11 @@ describe('CromwellConfigurationPanel', () => {
 
   describe('should allow creating a Cromwell app for certain app statuses', () => {
     test.each(createDisabledStatuses)('Status %s', async (appStatus) => {
-      jest
-        .spyOn(appsApi(), 'listAppsInWorkspace')
-        .mockImplementationOnce(() =>
-          Promise.resolve([
-            createListAppsCromwellResponse({ status: appStatus }),
-          ])
-        );
-      const wrapper = await component();
+      const wrapper = await component({
+        gkeAppsInWorkspace: [
+          createListAppsCromwellResponse({ status: appStatus }),
+        ],
+      });
       expect(
         wrapper
           .find('#cromwell-cloud-environment-create-button')

--- a/ui/src/app/components/cromwell-configuration-panel.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.tsx
@@ -4,6 +4,7 @@ import { AppType, UserAppEnvironment } from 'generated/fetch';
 
 import { Button } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
+import { DisabledCloudComputeProfile } from 'app/components/gke-app-configuration-panels/disabled-cloud-compute-profile';
 import { WarningMessage } from 'app/components/messages';
 import { styles } from 'app/components/runtime-configuration-panel/styles';
 import { withWorkspaceGkeApps } from 'app/components/with-workspace-gke-apps';
@@ -27,7 +28,6 @@ import {
   UIAppType,
 } from './apps-panel/utils';
 import { EnvironmentInformedActionPanel } from './environment-informed-action-panel';
-import { TooltipTrigger } from './popups';
 
 const { useState } = React;
 
@@ -153,19 +153,14 @@ export const BaseCromwellConfigurationPanel = ({
         </WarningMessage>
       </div>
       <div style={{ ...styles.controlSection }}>
-        <FlexRow style={{ alignItems: 'center' }}>
-          <div style={{ fontWeight: 'bold', marginRight: '0.5rem' }}>
-            Cloud compute profile
-          </div>
-          <TooltipTrigger
-            content='The cloud compute profile for Cromwell beta is non-configurable.'
-            side={'right'}
-          >
-            <div style={styles.disabledCloudProfile}>
-              {`${cpu} CPUS, ${memory}GB RAM, ${defaultCromwellConfig.persistentDiskRequest.size}GB disk`}
-            </div>
-          </TooltipTrigger>
-        </FlexRow>
+        <DisabledCloudComputeProfile
+          cpu={cpu}
+          memory={memory}
+          persistentDiskRequestSize={
+            defaultCromwellConfig.persistentDiskRequest.size
+          }
+          appType={AppType.CROMWELL}
+        />
       </div>
       <div style={{ ...styles.controlSection }}>
         <div style={{ fontWeight: 'bold' }}>Cromwell support articles</div>

--- a/ui/src/app/components/cromwell-configuration-panel.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useEffect } from 'react';
 
 import { AppType, UserAppEnvironment } from 'generated/fetch';
 
@@ -7,7 +6,7 @@ import { Button } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { WarningMessage } from 'app/components/messages';
 import { styles } from 'app/components/runtime-configuration-panel/styles';
-import { appsApi } from 'app/services/swagger-fetch-clients';
+import { withWorkspaceGkeApps } from 'app/components/with-workspace-gke-apps';
 import {
   CROMWELL_INFORMATION_LINK,
   CROMWELL_INTRO_LINK,
@@ -69,31 +68,23 @@ export interface CromwellConfigurationPanelProps {
   creatorFreeCreditsRemaining: number | null;
   workspace: WorkspaceData;
   profileState: ProfileStore;
+  gkeAppsInWorkspace: NonNullable<UserAppEnvironment[]>;
 }
 
-export const CromwellConfigurationPanel = ({
+export const BaseCromwellConfigurationPanel = ({
   onClose,
   creatorFreeCreditsRemaining,
   workspace,
   profileState,
+  gkeAppsInWorkspace,
 }: CromwellConfigurationPanelProps) => {
-  const [gkeAppsInWorkspace, setGkeAppsInWorkspace] =
-    useState<UserAppEnvironment[]>();
   const [creatingCromwellApp, setCreatingCromwellApp] = useState(false);
 
   const app = findApp(gkeAppsInWorkspace, UIAppType.CROMWELL);
-  const loadingApps = gkeAppsInWorkspace === undefined;
 
   const { profile } = profileState;
 
-  useEffect(() => {
-    appsApi()
-      .listAppsInWorkspace(workspace.namespace)
-      .then(setGkeAppsInWorkspace);
-  }, []);
-
-  const createEnabled =
-    !loadingApps && !creatingCromwellApp && canCreateApp(app);
+  const createEnabled = !creatingCromwellApp && canCreateApp(app);
 
   const onDismiss = () => {
     onClose();
@@ -210,3 +201,7 @@ export const CromwellConfigurationPanel = ({
     </FlexColumn>
   );
 };
+
+export const CromwellConfigurationPanel = withWorkspaceGkeApps(
+  BaseCromwellConfigurationPanel
+);

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import { AppStatus } from 'generated/fetch';
+
+import { defaultCromwellConfig } from 'app/components/apps-panel/utils';
+import { Button } from 'app/components/buttons';
+import {
+  CreateGKEAppButton,
+  CreateGKEAppButtonProps,
+} from 'app/components/gke-app-configuration-panels/create-gke-app-button';
+
+import { createListAppsCromwellResponse } from 'testing/stubs/apps-api-stub';
+import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
+
+describe(CreateGKEAppButton.name, () => {
+  const DEFAULT_PROPS: CreateGKEAppButtonProps = {
+    createAppRequest: defaultCromwellConfig,
+    existingApp: null,
+    workspaceNamespace: 'aou-rw-test-1',
+    onDismiss: () => {},
+  };
+
+  const component = async (
+    propOverrides?: Partial<CreateGKEAppButtonProps>
+  ) => {
+    const allProps = { ...DEFAULT_PROPS, ...propOverrides };
+    return shallow(<CreateGKEAppButton {...allProps} />);
+  };
+
+  const createEnabledStatuses = [AppStatus.DELETED, null, undefined];
+  const createDisabledStatuses = minus(
+    ALL_GKE_APP_STATUSES,
+    createEnabledStatuses
+  );
+
+  describe('should allow creating a GKE app for certain app statuses', () => {
+    test.each(createEnabledStatuses)('Status %s', async (appStatus) => {
+      const wrapper = await component({
+        createAppRequest: defaultCromwellConfig,
+        existingApp: createListAppsCromwellResponse({ status: appStatus }),
+      });
+      expect(wrapper.find(Button).prop('disabled')).toBeFalsy();
+    });
+  });
+
+  describe('should not allow creating an RStudio app for certain app statuses', () => {
+    test.each(createDisabledStatuses)('Status %s', async (appStatus) => {
+      const wrapper = await component({
+        createAppRequest: defaultCromwellConfig,
+        existingApp: createListAppsCromwellResponse({ status: appStatus }),
+      });
+      expect(wrapper.find(Button).prop('disabled')).toBeTruthy();
+    });
+  });
+});

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
@@ -8,7 +8,7 @@ import { Button } from 'app/components/buttons';
 import { ApiErrorResponse, fetchWithErrorModal } from 'app/utils/errors';
 import { appTypeToString, createUserApp } from 'app/utils/user-apps-utils';
 
-interface CreateGKEAppButtonProps {
+export interface CreateGKEAppButtonProps {
   createAppRequest: CreateAppRequest;
   existingApp: UserAppEnvironment | null | undefined;
   workspaceNamespace: string;

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { useState } from 'react';
+
+import { CreateAppRequest, UserAppEnvironment } from 'generated/fetch';
+
+import { canCreateApp } from 'app/components/apps-panel/utils';
+import { Button } from 'app/components/buttons';
+import { ApiErrorResponse, fetchWithErrorModal } from 'app/utils/errors';
+import { appTypeToString, createUserApp } from 'app/utils/user-apps-utils';
+
+interface CreateGKEAppButtonProps {
+  createAppRequest: CreateAppRequest;
+  existingApp: UserAppEnvironment | null | undefined;
+  workspaceNamespace: string;
+  onDismiss: () => void;
+}
+
+export function CreateGKEAppButton({
+  createAppRequest,
+  existingApp,
+  workspaceNamespace,
+  onDismiss,
+}: CreateGKEAppButtonProps) {
+  const [creatingApp, setCreatingApp] = useState(false);
+  const createEnabled = !creatingApp && canCreateApp(existingApp);
+
+  const appTypeString = appTypeToString[createAppRequest.appType];
+
+  const onCreate = () => {
+    setCreatingApp(true);
+    fetchWithErrorModal(
+      () => createUserApp(workspaceNamespace, createAppRequest),
+      {
+        customErrorResponseFormatter: (error: ApiErrorResponse) =>
+          error?.originalResponse?.status === 409 && {
+            title: `Error Creating ${appTypeString} Environment`,
+            message: `Please wait a few minutes and try to create your ${appTypeString} Environment again.`,
+            onDismiss,
+          },
+      }
+    ).then(() => onDismiss());
+  };
+
+  return (
+    <Button
+      id={`${appTypeString}-cloud-environment-create-button`}
+      aria-label={`${appTypeString} cloud environment create button`}
+      onClick={onCreate}
+      disabled={!createEnabled}
+    >
+      Start
+    </Button>
+  );
+}

--- a/ui/src/app/components/gke-app-configuration-panels/disabled-cloud-compute-profile.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/disabled-cloud-compute-profile.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+
+import { AppType } from 'generated/fetch';
+
+import { FlexRow } from 'app/components/flex';
+import { TooltipTrigger } from 'app/components/popups';
+import { styles } from 'app/components/runtime-configuration-panel/styles';
+import { appTypeToString } from 'app/utils/user-apps-utils';
+
+interface DisabledCloudComputeProfileProps {
+  cpu: number;
+  memory: number;
+  persistentDiskRequestSize: number;
+  appType: AppType;
+}
+
+export function DisabledCloudComputeProfile({
+  cpu,
+  memory,
+  persistentDiskRequestSize,
+  appType,
+}: DisabledCloudComputeProfileProps) {
+  return (
+    <FlexRow style={{ alignItems: 'center' }}>
+      <div style={{ fontWeight: 'bold', marginRight: '0.5rem' }}>
+        Cloud compute profile
+      </div>
+      <TooltipTrigger
+        content={`The cloud compute profile for ${appTypeToString[appType]} beta is non-configurable.`}
+        side={'right'}
+      >
+        <div style={styles.disabledCloudProfile}>
+          {`${cpu} CPUS, ${memory}GB RAM, ${persistentDiskRequestSize}GB disk`}
+        </div>
+      </TooltipTrigger>
+    </FlexRow>
+  );
+}

--- a/ui/src/app/components/rstudio-configuration-panel.spec.tsx
+++ b/ui/src/app/components/rstudio-configuration-panel.spec.tsx
@@ -95,7 +95,7 @@ describe('RStudioConfigurationPanel', () => {
       .spyOn(appsApi(), 'createApp')
       .mockImplementation((): Promise<any> => Promise.resolve());
     const startButton = wrapper
-      .find('#rstudio-cloud-environment-create-button')
+      .find('#RStudio-cloud-environment-create-button')
       .first();
 
     startButton.simulate('click');
@@ -123,7 +123,7 @@ describe('RStudioConfigurationPanel', () => {
       });
       expect(
         wrapper
-          .find('#rstudio-cloud-environment-create-button')
+          .find('#RStudio-cloud-environment-create-button')
           .first()
           .prop('disabled')
       ).toBeFalsy();
@@ -139,7 +139,7 @@ describe('RStudioConfigurationPanel', () => {
       });
       expect(
         wrapper
-          .find('#rstudio-cloud-environment-create-button')
+          .find('#RStudio-cloud-environment-create-button')
           .first()
           .prop('disabled')
       ).toBeTruthy();

--- a/ui/src/app/components/rstudio-configuration-panel.spec.tsx
+++ b/ui/src/app/components/rstudio-configuration-panel.spec.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+
+import { AppStatus, DisksApi, WorkspaceAccessLevel } from 'generated/fetch';
+import { AppsApi } from 'generated/fetch/api';
+
+import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
+import { serverConfigStore } from 'app/utils/stores';
+
+import defaultServerConfig from 'testing/default-server-config';
+import {
+  mountWithRouter,
+  waitOneTickAndUpdate,
+} from 'testing/react-test-helpers';
+import {
+  AppsApiStub,
+  createListAppsRStudioResponse,
+} from 'testing/stubs/apps-api-stub';
+import { CdrVersionsStubVariables } from 'testing/stubs/cdr-versions-api-stub';
+import { DisksApiStub } from 'testing/stubs/disks-api-stub';
+import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
+import {
+  workspaceStubs,
+  WorkspaceStubVariables,
+} from 'testing/stubs/workspaces';
+import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
+
+import { defaultRStudioConfig } from './apps-panel/utils';
+import {
+  RStudioConfigurationPanel,
+  RStudioConfigurationPanelProps,
+} from './rstudio-configuration-panel';
+
+describe('RStudioConfigurationPanel', () => {
+  const onClose = jest.fn();
+  const freeTierBillingAccountId = 'freetier';
+
+  const DEFAULT_PROPS: RStudioConfigurationPanelProps = {
+    onClose,
+    creatorFreeCreditsRemaining: null,
+    workspace: {
+      ...workspaceStubs[0],
+      accessLevel: WorkspaceAccessLevel.WRITER,
+      billingAccountName: 'billingAccounts/' + freeTierBillingAccountId,
+      cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
+    },
+    profileState: {
+      profile: ProfileStubVariables.PROFILE_STUB,
+      load: jest.fn(),
+      reload: jest.fn(),
+      updateCache: jest.fn(),
+    },
+  };
+
+  let disksApiStub: DisksApiStub;
+
+  const component = async (
+    propOverrides?: Partial<RStudioConfigurationPanelProps>
+  ) => {
+    const allProps = { ...DEFAULT_PROPS, ...propOverrides };
+    const c = mountWithRouter(<RStudioConfigurationPanel {...allProps} />);
+    await waitOneTickAndUpdate(c);
+    return c;
+  };
+
+  beforeEach(async () => {
+    disksApiStub = new DisksApiStub();
+    registerApiClient(DisksApi, disksApiStub);
+
+    serverConfigStore.set({
+      config: {
+        ...defaultServerConfig,
+        freeTierBillingAccountId: freeTierBillingAccountId,
+        defaultFreeCreditsDollarLimit: 100.0,
+        gsuiteDomain: '',
+      },
+    });
+
+    registerApiClient(AppsApi, new AppsApiStub());
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('start button should create rstudio and close panel', async () => {
+    jest
+      .spyOn(appsApi(), 'listAppsInWorkspace')
+      .mockImplementationOnce(() => Promise.resolve([]));
+    const wrapper = await component();
+    await waitOneTickAndUpdate(wrapper);
+
+    const spyCreateApp = jest
+      .spyOn(appsApi(), 'createApp')
+      .mockImplementation((): Promise<any> => Promise.resolve());
+    const startButton = wrapper
+      .find('#rstudio-cloud-environment-create-button')
+      .first();
+
+    startButton.simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+    expect(spyCreateApp).toHaveBeenCalledTimes(1);
+    expect(spyCreateApp).toHaveBeenCalledWith(
+      WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+      defaultRStudioConfig
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  const createEnabledStatuses = [AppStatus.DELETED, null, undefined];
+  const createDisabledStatuses = minus(
+    ALL_GKE_APP_STATUSES,
+    createEnabledStatuses
+  );
+
+  describe('should allow creating an RStudio app for certain app statuses', () => {
+    test.each(createEnabledStatuses)('Status %s', async (appStatus) => {
+      jest
+        .spyOn(appsApi(), 'listAppsInWorkspace')
+        .mockImplementationOnce(() =>
+          Promise.resolve([
+            createListAppsRStudioResponse({ status: appStatus }),
+          ])
+        );
+      const wrapper = await component();
+      expect(
+        wrapper
+          .find('#rstudio-cloud-environment-create-button')
+          .first()
+          .prop('disabled')
+      ).toBeFalsy();
+    });
+  });
+
+  describe('should allow creating an RStudio app for certain app statuses', () => {
+    test.each(createDisabledStatuses)('Status %s', async (appStatus) => {
+      jest
+        .spyOn(appsApi(), 'listAppsInWorkspace')
+        .mockImplementationOnce(() =>
+          Promise.resolve([
+            createListAppsRStudioResponse({ status: appStatus }),
+          ])
+        );
+      const wrapper = await component();
+      expect(
+        wrapper
+          .find('#rstudio-cloud-environment-create-button')
+          .first()
+          .prop('disabled')
+      ).toBeTruthy();
+    });
+  });
+
+  it('should display a cost of $0.40 per hour when running and $0.21 per hour when paused', async () => {
+    const wrapper = await component();
+
+    const costEstimator = (w) => w.find('[data-test-id="cost-estimator"]');
+    const runningCost = (w) =>
+      costEstimator(w).find('[data-test-id="running-cost"]');
+    const pausedCost = (w) =>
+      costEstimator(w).find('[data-test-id="paused-cost"]');
+
+    expect(costEstimator(wrapper).exists()).toBeTruthy();
+    expect(runningCost(wrapper).text()).toEqual('$0.40 per hour');
+    expect(pausedCost(wrapper).text()).toEqual('$0.21 per hour');
+  });
+});

--- a/ui/src/app/components/rstudio-configuration-panel.spec.tsx
+++ b/ui/src/app/components/rstudio-configuration-panel.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { AppStatus, DisksApi, WorkspaceAccessLevel } from 'generated/fetch';
+import { DisksApi, WorkspaceAccessLevel } from 'generated/fetch';
 import { AppsApi } from 'generated/fetch/api';
 
 import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
@@ -11,10 +11,7 @@ import {
   mountWithRouter,
   waitOneTickAndUpdate,
 } from 'testing/react-test-helpers';
-import {
-  AppsApiStub,
-  createListAppsRStudioResponse,
-} from 'testing/stubs/apps-api-stub';
+import { AppsApiStub } from 'testing/stubs/apps-api-stub';
 import { CdrVersionsStubVariables } from 'testing/stubs/cdr-versions-api-stub';
 import { DisksApiStub } from 'testing/stubs/disks-api-stub';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
@@ -22,7 +19,6 @@ import {
   workspaceStubs,
   WorkspaceStubVariables,
 } from 'testing/stubs/workspaces';
-import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
 
 import { defaultRStudioConfig } from './apps-panel/utils';
 import {
@@ -106,44 +102,6 @@ describe('RStudioConfigurationPanel', () => {
       defaultRStudioConfig
     );
     expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  const createEnabledStatuses = [AppStatus.DELETED, null, undefined];
-  const createDisabledStatuses = minus(
-    ALL_GKE_APP_STATUSES,
-    createEnabledStatuses
-  );
-
-  describe('should allow creating an RStudio app for certain app statuses', () => {
-    test.each(createEnabledStatuses)('Status %s', async (appStatus) => {
-      const wrapper = await component({
-        gkeAppsInWorkspace: [
-          createListAppsRStudioResponse({ status: appStatus }),
-        ],
-      });
-      expect(
-        wrapper
-          .find('#RStudio-cloud-environment-create-button')
-          .first()
-          .prop('disabled')
-      ).toBeFalsy();
-    });
-  });
-
-  describe('should allow creating an RStudio app for certain app statuses', () => {
-    test.each(createDisabledStatuses)('Status %s', async (appStatus) => {
-      const wrapper = await component({
-        gkeAppsInWorkspace: [
-          createListAppsRStudioResponse({ status: appStatus }),
-        ],
-      });
-      expect(
-        wrapper
-          .find('#RStudio-cloud-environment-create-button')
-          .first()
-          .prop('disabled')
-      ).toBeTruthy();
-    });
   });
 
   it('should display a cost of $0.40 per hour when running and $0.21 per hour when paused', async () => {

--- a/ui/src/app/components/rstudio-configuration-panel.spec.tsx
+++ b/ui/src/app/components/rstudio-configuration-panel.spec.tsx
@@ -26,7 +26,7 @@ import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
 
 import { defaultRStudioConfig } from './apps-panel/utils';
 import {
-  RStudioConfigurationPanel,
+  BaseRStudioConfigurationPanel,
   RStudioConfigurationPanelProps,
 } from './rstudio-configuration-panel';
 
@@ -49,6 +49,7 @@ describe('RStudioConfigurationPanel', () => {
       reload: jest.fn(),
       updateCache: jest.fn(),
     },
+    gkeAppsInWorkspace: [],
   };
 
   let disksApiStub: DisksApiStub;
@@ -57,7 +58,7 @@ describe('RStudioConfigurationPanel', () => {
     propOverrides?: Partial<RStudioConfigurationPanelProps>
   ) => {
     const allProps = { ...DEFAULT_PROPS, ...propOverrides };
-    const c = mountWithRouter(<RStudioConfigurationPanel {...allProps} />);
+    const c = mountWithRouter(<BaseRStudioConfigurationPanel {...allProps} />);
     await waitOneTickAndUpdate(c);
     return c;
   };
@@ -85,10 +86,9 @@ describe('RStudioConfigurationPanel', () => {
   });
 
   it('start button should create rstudio and close panel', async () => {
-    jest
-      .spyOn(appsApi(), 'listAppsInWorkspace')
-      .mockImplementationOnce(() => Promise.resolve([]));
-    const wrapper = await component();
+    const wrapper = await component({
+      gkeAppsInWorkspace: [],
+    });
     await waitOneTickAndUpdate(wrapper);
 
     const spyCreateApp = jest
@@ -116,14 +116,11 @@ describe('RStudioConfigurationPanel', () => {
 
   describe('should allow creating an RStudio app for certain app statuses', () => {
     test.each(createEnabledStatuses)('Status %s', async (appStatus) => {
-      jest
-        .spyOn(appsApi(), 'listAppsInWorkspace')
-        .mockImplementationOnce(() =>
-          Promise.resolve([
-            createListAppsRStudioResponse({ status: appStatus }),
-          ])
-        );
-      const wrapper = await component();
+      const wrapper = await component({
+        gkeAppsInWorkspace: [
+          createListAppsRStudioResponse({ status: appStatus }),
+        ],
+      });
       expect(
         wrapper
           .find('#rstudio-cloud-environment-create-button')
@@ -135,14 +132,11 @@ describe('RStudioConfigurationPanel', () => {
 
   describe('should allow creating an RStudio app for certain app statuses', () => {
     test.each(createDisabledStatuses)('Status %s', async (appStatus) => {
-      jest
-        .spyOn(appsApi(), 'listAppsInWorkspace')
-        .mockImplementationOnce(() =>
-          Promise.resolve([
-            createListAppsRStudioResponse({ status: appStatus }),
-          ])
-        );
-      const wrapper = await component();
+      const wrapper = await component({
+        gkeAppsInWorkspace: [
+          createListAppsRStudioResponse({ status: appStatus }),
+        ],
+      });
       expect(
         wrapper
           .find('#rstudio-cloud-environment-create-button')

--- a/ui/src/app/components/rstudio-configuration-panel.tsx
+++ b/ui/src/app/components/rstudio-configuration-panel.tsx
@@ -1,0 +1,156 @@
+import * as React from 'react';
+import { useEffect } from 'react';
+
+import { AppType, UserAppEnvironment } from 'generated/fetch';
+
+import { Button } from 'app/components/buttons';
+import { FlexColumn, FlexRow } from 'app/components/flex';
+import { styles } from 'app/components/runtime-configuration-panel/styles';
+import { appsApi } from 'app/services/swagger-fetch-clients';
+import { ApiErrorResponse, fetchWithErrorModal } from 'app/utils/errors';
+import { findMachineByName, Machine } from 'app/utils/machines';
+import { setSidebarActiveIconStore } from 'app/utils/navigation';
+import { AnalysisConfig } from 'app/utils/runtime-utils';
+import { ProfileStore } from 'app/utils/stores';
+import { createUserApp } from 'app/utils/user-apps-utils';
+import { WorkspaceData } from 'app/utils/workspace-data';
+
+import {
+  canCreateApp,
+  defaultRStudioConfig,
+  findApp,
+  UIAppType,
+} from './apps-panel/utils';
+import { EnvironmentInformedActionPanel } from './environment-informed-action-panel';
+import { TooltipTrigger } from './popups';
+
+const { useState } = React;
+
+const DEFAULT_MACHINE_TYPE: Machine = findMachineByName(
+  defaultRStudioConfig.kubernetesRuntimeConfig.machineType
+);
+
+const { cpu, memory } = DEFAULT_MACHINE_TYPE;
+
+const analysisConfig: Partial<AnalysisConfig> = {
+  machine: findMachineByName(
+    defaultRStudioConfig.kubernetesRuntimeConfig.machineType
+  ),
+  diskConfig: {
+    size: defaultRStudioConfig.persistentDiskRequest.size,
+    detachable: true,
+    detachableType: defaultRStudioConfig.persistentDiskRequest.diskType,
+    existingDiskName: null,
+  },
+  numNodes: defaultRStudioConfig.kubernetesRuntimeConfig.numNodes,
+};
+
+export interface RStudioConfigurationPanelProps {
+  onClose: () => void;
+  creatorFreeCreditsRemaining: number | null;
+  workspace: WorkspaceData;
+  profileState: ProfileStore;
+}
+
+export const RStudioConfigurationPanel = ({
+  onClose,
+  creatorFreeCreditsRemaining,
+  workspace,
+  profileState,
+}: RStudioConfigurationPanelProps) => {
+  const [gkeAppsInWorkspace, setGkeAppsInWorkspace] =
+    useState<UserAppEnvironment[]>();
+  const [creatingRStudioApp, setCreatingRStudioApp] = useState(false);
+
+  const app = findApp(gkeAppsInWorkspace, UIAppType.RSTUDIO);
+  const loadingApps = gkeAppsInWorkspace === undefined;
+
+  const { profile } = profileState;
+
+  useEffect(() => {
+    appsApi()
+      .listAppsInWorkspace(workspace.namespace)
+      .then(setGkeAppsInWorkspace);
+  }, []);
+
+  const createEnabled =
+    !loadingApps && !creatingRStudioApp && canCreateApp(app);
+
+  const onDismiss = () => {
+    onClose();
+    setTimeout(() => setSidebarActiveIconStore.next('apps'), 3000);
+  };
+
+  const onCreate = () => {
+    setCreatingRStudioApp(true);
+    fetchWithErrorModal(
+      () => createUserApp(workspace.namespace, defaultRStudioConfig),
+      {
+        customErrorResponseFormatter: (error: ApiErrorResponse) =>
+          error?.originalResponse?.status === 409 && {
+            title: 'Error Creating RStudio Environment',
+            message:
+              'Please wait a few minutes and try to create your RStudio Environment again.',
+            onDismiss,
+          },
+      }
+    ).then(() => onDismiss());
+  };
+
+  return (
+    <FlexColumn
+      id='rstudio-configuration-panel'
+      style={{ height: '100%', rowGap: '1rem' }}
+    >
+      <div>
+        Your analysis environment consists of an application and compute
+        resources. Your cloud environment is unique to this workspace and not
+        shared with other users.
+      </div>
+      <div style={{ ...styles.controlSection }}>
+        <EnvironmentInformedActionPanel
+          {...{
+            creatorFreeCreditsRemaining,
+            profile,
+            workspace,
+            analysisConfig,
+          }}
+          status={app?.status}
+          onPause={Promise.resolve()}
+          onResume={Promise.resolve()}
+          appType={AppType.RSTUDIO}
+        />
+      </div>
+      <div style={{ ...styles.controlSection }}>
+        <FlexRow style={{ alignItems: 'center' }}>
+          <div style={{ fontWeight: 'bold', marginRight: '0.5rem' }}>
+            Cloud compute profile
+          </div>
+          <TooltipTrigger
+            content='The cloud compute profile for RStudio beta is non-configurable.'
+            side={'right'}
+          >
+            <div style={styles.disabledCloudProfile}>
+              {`${cpu} CPUS, ${memory}GB RAM, ${defaultRStudioConfig.persistentDiskRequest.size}GB disk`}
+            </div>
+          </TooltipTrigger>
+        </FlexRow>
+      </div>
+      <FlexRow
+        style={{
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+        }}
+      >
+        <Button
+          id='rstudio-cloud-environment-create-button'
+          aria-label='rstudio cloud environment create button'
+          onClick={onCreate}
+          disabled={!createEnabled}
+        >
+          Start
+        </Button>
+      </FlexRow>
+    </FlexColumn>
+  );
+};

--- a/ui/src/app/components/rstudio-configuration-panel.tsx
+++ b/ui/src/app/components/rstudio-configuration-panel.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import { useEffect } from 'react';
 
 import { AppType, UserAppEnvironment } from 'generated/fetch';
 
 import { Button } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { styles } from 'app/components/runtime-configuration-panel/styles';
-import { appsApi } from 'app/services/swagger-fetch-clients';
+import { withWorkspaceGkeApps } from 'app/components/with-workspace-gke-apps';
 import { ApiErrorResponse, fetchWithErrorModal } from 'app/utils/errors';
 import { findMachineByName, Machine } from 'app/utils/machines';
 import { setSidebarActiveIconStore } from 'app/utils/navigation';
@@ -50,31 +49,23 @@ export interface RStudioConfigurationPanelProps {
   creatorFreeCreditsRemaining: number | null;
   workspace: WorkspaceData;
   profileState: ProfileStore;
+  gkeAppsInWorkspace: NonNullable<UserAppEnvironment[]>;
 }
 
-export const RStudioConfigurationPanel = ({
+export const BaseRStudioConfigurationPanel = ({
   onClose,
   creatorFreeCreditsRemaining,
   workspace,
   profileState,
+  gkeAppsInWorkspace,
 }: RStudioConfigurationPanelProps) => {
-  const [gkeAppsInWorkspace, setGkeAppsInWorkspace] =
-    useState<UserAppEnvironment[]>();
   const [creatingRStudioApp, setCreatingRStudioApp] = useState(false);
 
   const app = findApp(gkeAppsInWorkspace, UIAppType.RSTUDIO);
-  const loadingApps = gkeAppsInWorkspace === undefined;
 
   const { profile } = profileState;
 
-  useEffect(() => {
-    appsApi()
-      .listAppsInWorkspace(workspace.namespace)
-      .then(setGkeAppsInWorkspace);
-  }, []);
-
-  const createEnabled =
-    !loadingApps && !creatingRStudioApp && canCreateApp(app);
+  const createEnabled = !creatingRStudioApp && canCreateApp(app);
 
   const onDismiss = () => {
     onClose();
@@ -154,3 +145,7 @@ export const RStudioConfigurationPanel = ({
     </FlexColumn>
   );
 };
+
+export const RStudioConfigurationPanel = withWorkspaceGkeApps(
+  BaseRStudioConfigurationPanel
+);

--- a/ui/src/app/components/rstudio-configuration-panel.tsx
+++ b/ui/src/app/components/rstudio-configuration-panel.tsx
@@ -4,6 +4,7 @@ import { AppType, UserAppEnvironment } from 'generated/fetch';
 
 import { Button } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
+import { DisabledCloudComputeProfile } from 'app/components/gke-app-configuration-panels/disabled-cloud-compute-profile';
 import { styles } from 'app/components/runtime-configuration-panel/styles';
 import { withWorkspaceGkeApps } from 'app/components/with-workspace-gke-apps';
 import { ApiErrorResponse, fetchWithErrorModal } from 'app/utils/errors';
@@ -21,7 +22,6 @@ import {
   UIAppType,
 } from './apps-panel/utils';
 import { EnvironmentInformedActionPanel } from './environment-informed-action-panel';
-import { TooltipTrigger } from './popups';
 
 const { useState } = React;
 
@@ -113,19 +113,14 @@ export const BaseRStudioConfigurationPanel = ({
         />
       </div>
       <div style={{ ...styles.controlSection }}>
-        <FlexRow style={{ alignItems: 'center' }}>
-          <div style={{ fontWeight: 'bold', marginRight: '0.5rem' }}>
-            Cloud compute profile
-          </div>
-          <TooltipTrigger
-            content='The cloud compute profile for RStudio beta is non-configurable.'
-            side={'right'}
-          >
-            <div style={styles.disabledCloudProfile}>
-              {`${cpu} CPUS, ${memory}GB RAM, ${defaultRStudioConfig.persistentDiskRequest.size}GB disk`}
-            </div>
-          </TooltipTrigger>
-        </FlexRow>
+        <DisabledCloudComputeProfile
+          cpu={cpu}
+          memory={memory}
+          persistentDiskRequestSize={
+            defaultRStudioConfig.persistentDiskRequest.size
+          }
+          appType={AppType.RSTUDIO}
+        />
       </div>
       <FlexRow
         style={{

--- a/ui/src/app/components/with-workspace-gke-apps.spec.tsx
+++ b/ui/src/app/components/with-workspace-gke-apps.spec.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import { AppsApi } from 'generated/fetch';
+
+import { Spinner } from 'app/components/spinners';
+import {
+  withWorkspaceGkeApps,
+  WithWorkspaceGKEAppsProps,
+} from 'app/components/with-workspace-gke-apps';
+import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
+import { notificationStore } from 'app/utils/stores';
+
+import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
+import {
+  AppsApiStub,
+  createListAppsCromwellResponse,
+} from 'testing/stubs/apps-api-stub';
+
+describe(withWorkspaceGkeApps.name, () => {
+  beforeEach(() => {
+    registerApiClient(AppsApi, new AppsApiStub());
+    notificationStore.set(null);
+  });
+
+  const TestComponent = (_props) => <div />;
+
+  const defaultProps = {
+    workspaceNamespace: 'aou-rw-1234',
+  };
+
+  const createWrapper = (
+    propOverrides: Partial<WithWorkspaceGKEAppsProps> = {}
+  ) => {
+    const props = {
+      ...defaultProps,
+      ...propOverrides,
+    };
+    const WrappedTestComponent = withWorkspaceGkeApps(TestComponent);
+    return mount(<WrappedTestComponent {...props} />);
+  };
+
+  it('should show a loading spinner while waiting for the API call to return', async () => {
+    jest
+      .spyOn(appsApi(), 'listAppsInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.resolve([]));
+    const wrapper = createWrapper();
+
+    expect(wrapper.find(Spinner).exists()).toBeTruthy();
+
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(wrapper.find(Spinner).exists()).toBeFalsy();
+  });
+
+  it('should show an error if the API call fails', async () => {
+    jest
+      .spyOn(appsApi(), 'listAppsInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.reject());
+
+    expect(notificationStore.get()).toBeNull();
+
+    const wrapper = createWrapper();
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(notificationStore.get().title).toBeTruthy();
+    expect(notificationStore.get().message).toBeTruthy();
+  });
+
+  it('should not show an error if API call succeeds', async () => {
+    jest
+      .spyOn(appsApi(), 'listAppsInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.resolve([]));
+
+    expect(notificationStore.get()).toBeNull();
+
+    const wrapper = createWrapper();
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(notificationStore.get()).toBeNull();
+  });
+
+  it('should pass the user apps to the wrapped component when the API call succeeds', async () => {
+    const workspaceNamespace = 'aou-rw-1234';
+    const apps = createListAppsCromwellResponse();
+    const listAppsStub = jest
+      .spyOn(appsApi(), 'listAppsInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.resolve(apps));
+
+    const wrapper = createWrapper({ workspaceNamespace });
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(listAppsStub).toHaveBeenCalledWith(workspaceNamespace);
+    expect(wrapper.find(TestComponent).prop('gkeAppsInWorkspace')).toEqual(
+      apps
+    );
+  });
+});

--- a/ui/src/app/components/with-workspace-gke-apps.tsx
+++ b/ui/src/app/components/with-workspace-gke-apps.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+
+import { UserAppEnvironment } from 'generated/fetch';
+
+import { Spinner } from 'app/components/spinners';
+import { appsApi } from 'app/services/swagger-fetch-clients';
+import { notificationStore } from 'app/utils/stores';
+
+export interface WithWorkspaceGKEAppsProps {
+  workspaceNamespace: string;
+}
+
+interface WrappedComponentRequiredProps {
+  gkeAppsInWorkspace: NonNullable<UserAppEnvironment[]>;
+}
+
+// Given a Component, returns a new Component that injects a gkeAppsInWorkspace prop into the original component.
+// TODO: Validate that gkeAppsInWorkspace in WrappedComponent is the correct type
+export const withWorkspaceGkeApps = <P,>(
+  WrappedComponent: React.FC<Omit<P, keyof WrappedComponentRequiredProps>>
+): React.FC<
+  Omit<P, keyof WrappedComponentRequiredProps> & WithWorkspaceGKEAppsProps
+> => {
+  return (props) => {
+    const [gkeAppsInWorkspace, setGkeAppsInWorkspace] = useState<
+      UserAppEnvironment[] | undefined
+    >();
+    const [error, setError] = useState<Error>();
+
+    useEffect(() => {
+      appsApi()
+        .listAppsInWorkspace(props.workspaceNamespace)
+        .then(setGkeAppsInWorkspace)
+        .catch((e) => {
+          setError(e);
+          notificationStore.set({
+            title: 'Unable to load applications',
+            message:
+              'An error occurred trying to load your applications. Please try again.',
+          });
+        });
+    }, []);
+
+    if (error) {
+      return null;
+    }
+
+    // loading
+    if (gkeAppsInWorkspace === undefined) {
+      return <Spinner />;
+    }
+
+    return <WrappedComponent {...{ ...props, gkeAppsInWorkspace }} />;
+  };
+};

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -1,9 +1,14 @@
-import { AppStatus, CreateAppRequest } from 'generated/fetch';
+import { AppStatus, AppType, CreateAppRequest } from 'generated/fetch';
 
 import { leoAppsApi } from 'app/services/notebooks-swagger-fetch-clients';
 import { appsApi } from 'app/services/swagger-fetch-clients';
 
 import { userAppsStore } from './stores';
+
+export const appTypeToString: Record<AppType, string> = {
+  [AppType.CROMWELL]: 'Cromwell',
+  [AppType.RSTUDIO]: 'RStudio',
+};
 
 const appStatusesRequiringUpdates = [
   AppStatus.DELETING,


### PR DESCRIPTION
Description:

Add RStudio configuration panel content.

In addition to the AC, this adds the following to both the RStudio and Cromwell config panels:
- A loading spinner when the initial list apps request is processing
- An error modal when the initial list apps request fails

The easiest way I've found to test the above is to use Chrome's network throttling feature and then open the side panel.

I leaned into using composition over inheritance. Instead of creating a single mega-component that handles all apps, I created sharable components that Cromwell and RStudio share. I think this is more testable and readable than a mega-component, but I'd be curious to hear your thoughts.

The first commit adds the RStudio panel and completes all AC. The remaining commits apply individual refactors. I'm unsure whether it's easier to view commit-by-commit or all at once

[Relevant workbench-ux thread](https://pmi-engteam.slack.com/archives/C02MWP2RN5P/p1681502183410689).

Screenshots:
![image (1)](https://user-images.githubusercontent.com/31020403/233653938-7daf1fe5-99f7-458b-9977-616f86e5d654.png)
![image](https://user-images.githubusercontent.com/31020403/233654002-a966b9d2-7082-43ac-a5bd-f78abd2d5812.png)

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
