### PR TITLE
[no ticket][risk=no] Upgrade Kotlin to latest

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         HIBERNATE_VERSION = '5.6.9.Final'
         JACKSON_DATABIND_VERSION = '2.13.4'
         JACKSON_VERSION = '2.13.4'
-        KOTLIN_VERSION = '1.5.32'
+        KOTLIN_VERSION = '1.8.20'
         LIQUIBASE_VERSION = '4.16.1'
         MAPSTRUCT_VERSION = '1.4.2.Final'
         MOCKITO_KOTLIN_VERSION = '4.1.0'
@@ -28,6 +28,12 @@ buildscript {
     repositories {
         mavenCentral()
     }
+
+    // https://github.com/spring-projects/spring-boot/issues/26864
+    // https://github.com/spring-projects/spring-boot/issues/26946
+    // https://github.com/spring-projects/spring-boot/issues/26947
+    // https://github.com/spring-projects/spring-boot/commit/cd808d2f189a7a550adec286c1722b5b6f1c19e7
+    project.getExtensions().getExtraProperties().set('kotlin.version', '1.8.20') // KOTLIN_VERSION
 }
 
 plugins {
@@ -39,7 +45,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'com.diffplug.spotless' version '5.12.5'
     id 'com.google.cloud.tools.appengine-appenginewebxml' version '2.4.5'
-    id 'org.jetbrains.kotlin.jvm' version '1.5.32'
+    id 'org.jetbrains.kotlin.jvm' version '1.8.20' // KOTLIN_VERSION
     // Note: if you plan to upgrade the version of swagger-codegen beyond 2.2.3, be aware of two
     // implicit dependencies: (1) the set of "generatedCompile" Gradle dependencies need to be updated
     // to match the modules imported by the Swagger codegen templates, and (2) some template files
@@ -263,7 +269,7 @@ sourceSets {
     // SorceSets added by Java plugin. These share a namespace with the ones users create.
     //
     generated {
-        compileClasspath = configurations.generatedCompile
+        compileClasspath = configurations.generatedCompileClasspath
         java {
             srcDir SWAGGER_2_CODEGEN_DIR
             srcDir SWAGGER_3_CODEGEN_DIR


### PR DESCRIPTION
This fixes the following warning when Gradle is executed with `--warning-mode=all`:
```
IncrementalTaskInputs has been deprecated. This is scheduled to be removed in Gradle 8.0. On method 'AbstractKotlinCompile.execute' use 'org.gradle.work.InputChanges' instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.6.1/userguide/upgrading_version_7.html#incremental_task_inputs_deprecation
```

---
**PR checklist**

- [ ] This PR meets the Acceptance Criteria in the JIRA story
- [ ] The JIRA story has been moved to Dev Review
- [ ] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [ ] I have run and tested this change locally, and my testing process is described here
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [ ] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
