### PR TITLE
[RW-9737][risk=no] Ignore the workspace prop when loading the workspace create page

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -244,6 +244,43 @@ describe('WorkspaceEdit', () => {
     ).toEqual(true);
   });
 
+  it('should initialize cdr versions dropdown options to the default tier when creating workspaces', async () => {
+    cdrVersionStore.set(cdrVersionTiersResponse);
+    workspace.accessTierShortName = AccessTierShortNames.Controlled;
+
+    workspaceEditMode = WorkspaceEditMode.Create;
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    const cdrSelectionOptions = wrapper
+      .find('[data-test-id="select-cdr-version"]')
+      .find('select')
+      .find('option')
+      .map((option) => option.prop('value'));
+
+    expect(cdrSelectionOptions).toEqual([
+      CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
+      CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION_ID,
+    ]);
+  });
+
+  it('should initialize the specific populations checkbox as unchecked when creating workspaces', async () => {
+    workspace.researchPurpose.populationDetails = [
+      SpecificPopulationEnum.AGECHILDREN,
+    ];
+    workspaceEditMode = WorkspaceEditMode.Create;
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(
+      wrapper
+        .find('[data-test-id="specific-population-yes"]')
+        .first()
+        .prop('checked')
+    ).toEqual(false);
+  });
+
   it('should clear all selected specific populations if NO underrepresented populations study is selected', async () => {
     // Set the workspace state to represent a workspace which is studying a
     // specific population group.
@@ -922,6 +959,7 @@ describe('WorkspaceEdit', () => {
   });
 
   it('should show error message if Other text for Special Population is more than 100 characters', async () => {
+    workspaceEditMode = WorkspaceEditMode.Edit;
     const wrapper = component();
     expect(
       wrapper

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -376,23 +376,17 @@ export const WorkspaceEdit = fp.flow(
     }
 
     initializeCdrVersions(props: WorkspaceEditProps) {
-      const defaultValue = this.getCdrVersions(DEFAULT_ACCESS_TIER);
-      if (this.isMode(WorkspaceEditMode.Create)) {
-        return defaultValue;
+      if (this.isMode(WorkspaceEditMode.Create) || !props.workspace) {
+        return this.getCdrVersions(DEFAULT_ACCESS_TIER);
       }
-      return props.workspace
-        ? this.getCdrVersions(props.workspace.accessTierShortName)
-        : defaultValue;
+      return this.getCdrVersions(props.workspace.accessTierShortName);
     }
 
     initializePopulationChecked(props: WorkspaceEditProps) {
-      const defaultValue = undefined;
-      if (this.isMode(WorkspaceEditMode.Create)) {
-        return defaultValue;
+      if (this.isMode(WorkspaceEditMode.Create) || !props.workspace) {
+        return undefined;
       }
-      return props.workspace
-        ? props.workspace.researchPurpose.populationDetails.length > 0
-        : defaultValue;
+      return props.workspace.researchPurpose.populationDetails.length > 0;
     }
 
     cancel(): void {

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -353,14 +353,10 @@ export const WorkspaceEdit = fp.flow(
       this.state = {
         billingAccountFetched: false,
         billingAccounts: [],
-        cdrVersions: props.workspace
-          ? this.getCdrVersions(props.workspace.accessTierShortName)
-          : this.getCdrVersions(DEFAULT_ACCESS_TIER),
+        cdrVersions: this.initializeCdrVersions(props),
         cloneUserRole: false,
         loading: false,
-        populationChecked: props.workspace
-          ? props.workspace.researchPurpose.populationDetails.length > 0
-          : undefined,
+        populationChecked: this.initializePopulationChecked(props),
         selectResearchPurpose: this.updateSelectedResearch(),
         fetchBillingAccountError: false,
         fetchBillingAccountLoading: false,
@@ -377,6 +373,26 @@ export const WorkspaceEdit = fp.flow(
         workspaceNewAclDelayed: false,
         workspaceNewAclDelayedContinueFn: () => {},
       };
+    }
+
+    initializeCdrVersions(props: WorkspaceEditProps) {
+      const defaultValue = this.getCdrVersions(DEFAULT_ACCESS_TIER);
+      if (this.isMode(WorkspaceEditMode.Create)) {
+        return defaultValue;
+      }
+      return props.workspace
+        ? this.getCdrVersions(props.workspace.accessTierShortName)
+        : defaultValue;
+    }
+
+    initializePopulationChecked(props: WorkspaceEditProps) {
+      const defaultValue = undefined;
+      if (this.isMode(WorkspaceEditMode.Create)) {
+        return defaultValue;
+      }
+      return props.workspace
+        ? props.workspace.researchPurpose.populationDetails.length > 0
+        : defaultValue;
     }
 
     cancel(): void {


### PR DESCRIPTION
Description:

Ignore the workspace prop when loading the workspace create page for the CDR dropdown (as described in the ticket) and the specific populations checkbox (which used the same logic, leading to the same error).

I chose the simplest approach to fix the exact issue described in the ticket. The tests in this PR fail on the `main` branch, but pass here.

The underlying problem here is that our create workspace page is injected with the current workspace from global state, allowing it to double as the edit page. I'd like to remove that dependency to prevent issues like this in the future, but I think it's out of scope for this bug.

To verify this change, follow the STR from the ticket.

---
**PR checklist**

- [x] This PR meets the Acceptance Criteria in the JIRA story
- [x] The JIRA story has been moved to Dev Review
- [x] This PR includes appropriate unit tests
- [x] I have added explanatory comments where the logic is not obvious
- [x] I have run and tested this change locally, and my testing process is described here
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes an API change, I have run the E2E tests on this change against my local server with [yarn test-local](https://github.com/all-of-us/workbench/blob/master/e2e/README.md#examples) because this PR won't be covered by the CircleCI tests 
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented these in the description
- [x] If this includes an API change, I have updated the appropriate Swagger definitions and updated the appropriate API consumers
  * AoU UI
  * [Perf tests](https://github.com/broadinstitute/mcnulty/blob/develop/src/test/scala/services/AoU.scala)
  * [Researcher Directory export](https://github.com/all-of-us/workbench/wiki/Researcher-Directory-(RDR-export))
  * Cron tasks - for Offline*Controllers
  * SumoLogic - for EgressAlert 
