### PR TITLE
[no ticket][risk=no] Avoid mocking java.lang.reflect.Method in tests

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/interceptors/RequestTimeMetricInterceptorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interceptors/RequestTimeMetricInterceptorTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 import com.google.api.client.http.HttpMethods;
-import java.lang.reflect.Method;
 import java.time.Instant;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -19,6 +18,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.pmiops.workbench.FakeClockConfiguration;
+import org.pmiops.workbench.api.ProfileApi;
 import org.pmiops.workbench.monitoring.LogsBasedMetricService;
 import org.pmiops.workbench.monitoring.MeasurementBundle;
 import org.pmiops.workbench.monitoring.labels.MetricLabel;
@@ -38,12 +38,11 @@ public class RequestTimeMetricInterceptorTest {
   private static final Instant START_INSTANT = FakeClockConfiguration.NOW.toInstant();
   private static final long DURATION_MILLIS = 1500L;
   private static final Instant END_INSTANT = START_INSTANT.plusMillis(DURATION_MILLIS);
-  private static final String METHOD_NAME = "frobnicate";
+  private static final String METHOD_NAME = "getMe";
 
   @Mock private HttpServletRequest mockHttpServletRequest;
   @Mock private HttpServletResponse mockHttpServletResponse;
   @Mock private HandlerMethod mockHandlerMethod;
-  @Mock private Method mockMethod;
   @Mock private ModelAndView mockModelAndView;
 
   @MockBean private LogsBasedMetricService mockLogsBasedMetricService;
@@ -60,10 +59,9 @@ public class RequestTimeMetricInterceptorTest {
   public static class Config {}
 
   @BeforeEach
-  public void setup() {
+  public void setup() throws NoSuchMethodException {
     doReturn(HttpMethods.GET).when(mockHttpServletRequest).getMethod();
-    doReturn(METHOD_NAME).when(mockMethod).getName();
-    doReturn(mockMethod).when(mockHandlerMethod).getMethod();
+    doReturn(ProfileApi.class.getMethod(METHOD_NAME)).when(mockHandlerMethod).getMethod();
   }
 
   @Test


### PR DESCRIPTION
Mocking the java.lang.reflect.Method via Mockito is considered hazardous:
https://github.com/mockito/mockito/issues/2081
https://github.com/mockito/mockito/issues/2026

It seems this worked without causing issues before version 3.5.0, but after that, mocked Method classes caused pollution in the test process.

I reproduced this issue consistently using various versions of Mockito>3.5.x:
```
RequestTimeMetricInterceptorTest > testPostHandle() FAILED
    java.lang.NullPointerException
        at java.base/java.lang.reflect.Method.getParameterTypes(Method.java:311)
        at org.mockito.internal.creation.DelegatingMethod.<init>(DelegatingMethod.java:20)
        at org.mockito.internal.invocation.DefaultInvocationFactory.createMockitoMethod(DefaultInvocationFactory.java:81)
        at org.mockito.internal.invocation.DefaultInvocationFactory.createInvocation(DefaultInvocationFactory.java:60)
        at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.doIntercept(MockMethodInterceptor.java:83)
        at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.doIntercept(MockMethodInterceptor.java:56)
        at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor$DispatcherDefaultingToRealMethod.interceptAbstract(MockMethodInterceptor.java:161)
        at org.pmiops.workbench.monitoring.LogsBasedMetricService$MockitoMock$2029870725.record(Unknown Source)
        at org.pmiops.workbench.interceptors.RequestTimeMetricInterceptor.lambda$postHandle$2(RequestTimeMetricInterceptor.java:73)
        at java.base/java.util.Optional.ifPresent(Optional.java:183)
        at org.pmiops.workbench.interceptors.RequestTimeMetricInterceptor.postHandle(RequestTimeMetricInterceptor.java:71)
        at org.pmiops.workbench.interceptors.RequestTimeMetricInterceptorTest.testPostHandle(RequestTimeMetricInterceptorTest.java:111)
```

Tests pass with the fix.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [ ] If this PR is intended to complete a JIRA story, I have checked that all AC are met for that story
- [x] I have manually tested this change and my testing process is described above
- [x] This PR includes appropriate automated tests, and I have documented any behavior that cannot be tested with code
- [ ] If this fixes a bug, ensure the steps to reproduce are in the Jira ticket or provided above.
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented the impacts in the description
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this includes an API change, I have run the relevant E2E tests locally because API changes are not covered by our PR checks
