### PR TITLE
[no ticket][risk=no] Support for Java lint in build

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -56,9 +56,28 @@ plugins {
     id 'org.springframework.boot' version '2.7.4'
 }
 
-
 if (JavaVersion.current() != JavaVersion.VERSION_11) {
     throw new GradleException("This build must be run with Java 11. See developer-system-initialization.md. The java version used ${JavaVersion.current()}")
+}
+
+if (System.getenv("ADD_XLINT_DEPRECATION")) {
+  allprojects {
+    gradle.projectsEvaluated {
+      tasks.withType(JavaCompile) {
+        options.compilerArgs.add("-Xlint:deprecation")
+      }
+    }
+  }
+}
+
+if (System.getenv("ADD_XLINT_UNCHECKED")) {
+  allprojects {
+    gradle.projectsEvaluated {
+      tasks.withType(JavaCompile) {
+        options.compilerArgs.add("-Xlint:unchecked")
+      }
+    }
+  }
 }
 
 // Artifact configurations derived from base configs. Configuration names


### PR DESCRIPTION
Allows control of `-Xlint:*` options from environment variables.

Tested by running some compile tasks with and without the variables defined.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [ ] If this PR is intended to complete a JIRA story, I have checked that all AC are met for that story
- [x] I have manually tested this change and my testing process is described above
- [ ] This PR includes appropriate automated tests, and I have documented any behavior that cannot be tested with code
- [ ] If this fixes a bug, ensure the steps to reproduce are in the Jira ticket or provided above.
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented the impacts in the description
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this includes an API change, I have run the relevant E2E tests locally because API changes are not covered by our PR checks
