### PR TITLE
[no ticket][risk=no] Wrap calls previously using CloudSqlProxyContext in ServiceAccountContext

### DIFF
--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2427,9 +2427,6 @@ def deploy(cmd_name, args)
   ServiceAccountContext.new(gcc.project).run do
     # Note: `gcc` does not get correctly initialized with 'op.opts.account' so we need to be explicit
     migrate_database(gcc, op.opts.account, op.opts.dry_run)
-    if (op.opts.key_file)
-      ENV["GOOGLE_APPLICATION_CREDENTIALS"] = op.opts.key_file
-    end
     load_config(gcc.project, op.opts.dry_run)
     cdr_config_file = must_get_env_value(gcc.project, :cdr_config_json)
     update_cdr_config_for_project("config/#{cdr_config_file}", op.opts.dry_run)


### PR DESCRIPTION
# Description

Fixes recent authentication errors with project.rb tools by wrapping all calls previously using CloudSqlProxyContext in ServiceAccountContext.

This bug was introduced in https://github.com/all-of-us/workbench/pull/7555. The CloudSqlProxyContext wrapper was removed from many functions because CloudSqlProxyContext's functionality was no longer needed. However, CloudSqlProxyContext is a subclass of ServiceAccountContext, and that functionality is needed for those commands to function in non-test environments.

Two hotfixes for this issue using the same approach as this PR have been made: https://github.com/all-of-us/workbench/pull/7571, https://github.com/all-of-us/workbench/pull/7583.

A different fix for this issue was introduced in https://github.com/all-of-us/workbench/pull/7566. Questions for @dmohs:
 1. Do we still need the fix introduced in that PR? In this PR I wrap the relevant code in a ServiceAccountContext object.
 2. Could you validate that the deploy command works as expected or describe how you did that last time? In the PR description you mentioned you "Verified on Circle with ssh enabled" but I'm unsure how to do that.

# Testing process

I validated the `set-authority` command in multiple environments. On main, it is broken on staging but working in test. On this branch, it is working in both. This is the same process used [here](https://github.com/all-of-us/workbench/pull/7583#discussion_r1164690022).

I have not checked the other commands as that requires significant manual effort to learn each command.

## `main` branch + `test` env (passes)

Command: `./project.rb set-authority --email peterlavigne@fake-research-aou.org --authority DEVELOPER --project $AOU_TEST`

Output:
```
...
2023-04-27 15:40:37.413  INFO 74327 --- [onnection adder] c.g.cloud.sql.core.CoreSocketFactory     : Connecting to Cloud SQL instance [all-of-us-workbench-test:us-central1:workbenchmaindb] via SSL socket.
2023-04-27 15:40:37.422  INFO 74327 --- [           main] org.pmiops.workbench.tools.SetAuthority  : peterlavigne@fake-research-aou.org unchanged.
2023-04-27 15:40:37.422  INFO 74327 --- [           main] org.pmiops.workbench.tools.SetAuthority  : Done. 0 of 1 users changed, 0 errors.
2023-04-27 15:40:37.430  INFO 74327 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
2023-04-27 15:40:37.864  INFO 74327 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
```

## `main` branch + `staging` env (fails)

Command: `./project.rb set-authority --email peterlavigne@staging.fake-research-aou.org --authority DEVELOPER --project $AOU_STAGING`

Output:
```
...
java.lang.RuntimeException: [all-of-us-rw-staging:us-central1:workbenchmaindb] The Cloud SQL Instance does not exist or your account is not authorized to access it. Please verify the instance connection name and check the IAM permissions for project "all-of-us-rw-staging" 
        at com.google.cloud.sql.core.CloudSqlInstance.addExceptionContext(CloudSqlInstance.java:621) ~[jdbc-socket-factory-core-1.7.0.jar:na]
        at com.google.cloud.sql.core.CloudSqlInstance.fetchMetadata(CloudSqlInstance.java:510) ~[jdbc-socket-factory-core-1.7.0.jar:na]
        at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131) ~[guava-31.1-jre.jar:na]
...
```

## `fix-project-rb-auth-error` branch + `test` env (passes)

Command: `./project.rb set-authority --email peterlavigne@fake-research-aou.org --authority DEVELOPER --project $AOU_TEST`

Output:
```
...
2023-04-27 15:39:20.524  INFO 73921 --- [onnection adder] c.g.cloud.sql.core.CoreSocketFactory     : Connecting to Cloud SQL instance [all-of-us-workbench-test:us-central1:workbenchmaindb] via SSL socket.
2023-04-27 15:39:20.553  INFO 73921 --- [           main] org.pmiops.workbench.tools.SetAuthority  : peterlavigne@fake-research-aou.org unchanged.
2023-04-27 15:39:20.553  INFO 73921 --- [           main] org.pmiops.workbench.tools.SetAuthority  : Done. 0 of 1 users changed, 0 errors.
2023-04-27 15:39:20.562  INFO 73921 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
2023-04-27 15:39:20.987  INFO 73921 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
```

## `fix-project-rb-auth-error` branch + `staging` env (passes)

Command: `./project.rb set-authority --email peterlavigne@staging.fake-research-aou.org --authority DEVELOPER --project $AOU_STAGING`

Output:
```
...
2023-04-27 15:38:59.138  INFO 73754 --- [onnection adder] c.g.cloud.sql.core.CoreSocketFactory     : Connecting to Cloud SQL instance [all-of-us-rw-staging:us-central1:workbenchmaindb] via SSL socket.
2023-04-27 15:38:59.187  INFO 73754 --- [           main] org.pmiops.workbench.tools.SetAuthority  : peterlavigne@staging.fake-research-aou.org unchanged.
2023-04-27 15:38:59.188  INFO 73754 --- [           main] org.pmiops.workbench.tools.SetAuthority  : Done. 0 of 1 users changed, 0 errors.
2023-04-27 15:38:59.198  INFO 73754 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
2023-04-27 15:38:59.605  INFO 73754 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
```

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [x] If this PR is intended to complete a JIRA story, I have checked that all AC are met for that story
- [x] I have manually tested this change and my testing process is described above
- [x] This PR includes appropriate automated tests, and I have documented any behavior that cannot be tested with code
- [x] If this fixes a bug, ensure the steps to reproduce are in the Jira ticket or provided above.
- [x] I have added explanatory comments where the logic is not obvious
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented the impacts in the description
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this includes an API change, I have run the relevant E2E tests locally because API changes are not covered by our PR checks
