### PR TITLE
[RW-9955][risk=no] Made equivalents of TestMockFactory that do not require repositories.

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -4,7 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTierForTests;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.common.collect.ImmutableList;
@@ -209,7 +209,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     cdrVersion.setCdrVersionId(1L);
     cdrVersion.setBigqueryDataset(testWorkbenchConfig.bigquery.dataSetId);
     cdrVersion.setBigqueryProject(testWorkbenchConfig.bigquery.projectId);
-    cdrVersion.setAccessTier(createRegisteredTierForTests(accessTierDao));
+    cdrVersion.setAccessTier(accessTierDao.save(createRegisteredTier()));
     CdrVersionContext.setCdrVersionNoCheckAuthDomain(cdrVersion);
 
     cdrVersion = cdrVersionDao.save(cdrVersion);

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.api;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
@@ -80,7 +81,6 @@ import org.pmiops.workbench.test.CohortDefinitions;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.testconfig.TestJpaConfig;
 import org.pmiops.workbench.testconfig.TestWorkbenchConfig;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
 import org.pmiops.workbench.utils.mappers.UserMapperImpl;
@@ -213,7 +213,8 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
                         currentUser.getUsername(),
                         new FirecloudWorkspaceAccessEntry().accessLevel("OWNER"))));
 
-    cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+    cdrVersion = createDefaultCdrVersion();
+    accessTierDao.save(cdrVersion.getAccessTier());
     cdrVersion.setBigqueryDataset(testWorkbenchConfig.bigquery.dataSetId);
     cdrVersion.setBigqueryProject(testWorkbenchConfig.bigquery.projectId);
     cdrVersion = cdrVersionDao.save(cdrVersion);

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.api;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableResult;
@@ -271,7 +272,8 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
         .thenReturn(fcResponse)
         .thenReturn(fcResponse);
 
-    dbCdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+    dbCdrVersion = createDefaultCdrVersion();
+    accessTierDao.save(dbCdrVersion.getAccessTier());
     dbCdrVersion.setBigqueryDataset(testWorkbenchConfig.bigquery.dataSetId);
     dbCdrVersion.setBigqueryProject(testWorkbenchConfig.bigquery.projectId);
     dbCdrVersion.setArchivalStatus(DbStorageEnums.archivalStatusToStorage(ArchivalStatus.LIVE));

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -90,7 +90,6 @@ import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.test.TestBigQueryCdrSchemaConfig;
 import org.pmiops.workbench.testconfig.TestJpaConfig;
 import org.pmiops.workbench.testconfig.TestWorkbenchConfig;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.UserMapper;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapperImpl;

--- a/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.access;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import java.sql.Timestamp;
@@ -21,7 +22,6 @@ import org.pmiops.workbench.db.model.DbUserAccessTier;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.TierAccessStatus;
 import org.pmiops.workbench.test.FakeClock;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -87,7 +87,7 @@ public class AccessTierServiceTest {
   @Test
   public void test_getAllTiers_2() {
     final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
-    final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    final DbAccessTier controlledTier = accessTierDao.save(createControlledTier());
 
     assertThat(accessTierService.getAllTiers())
         .containsExactly(controlledTier, registeredTier)
@@ -119,7 +119,7 @@ public class AccessTierServiceTest {
     final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
     addDaoEntry(user, registeredTier, TierAccessStatus.ENABLED);
 
-    final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    final DbAccessTier controlledTier = accessTierDao.save(createControlledTier());
     addDaoEntry(user, controlledTier, TierAccessStatus.ENABLED);
 
     assertThat(accessTierService.getAccessTiersForUser(user))
@@ -134,7 +134,7 @@ public class AccessTierServiceTest {
     final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
 
     // simply to show a non-Registered tier exists but we don't add the user to it
-    TestMockFactory.createControlledTierForTests(accessTierDao);
+    accessTierDao.save(createControlledTier());
 
     accessTierService.addUserToTier(user, registeredTier);
 
@@ -330,7 +330,7 @@ public class AccessTierServiceTest {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
     final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
-    final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    final DbAccessTier controlledTier = accessTierDao.save(createControlledTier());
 
     accessTierService.addUserToAllTiers(user);
 

--- a/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessTierServiceTest.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.access;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import java.sql.Timestamp;
 import java.time.Clock;
@@ -85,7 +86,7 @@ public class AccessTierServiceTest {
 
   @Test
   public void test_getAllTiers_2() {
-    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
     final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
 
     assertThat(accessTierService.getAllTiers())
@@ -95,27 +96,27 @@ public class AccessTierServiceTest {
 
   @Test
   public void test_getAccessTiersForUser_unregistered() {
-    TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    accessTierDao.save(createRegisteredTier());
     assertThat(accessTierService.getAccessTiersForUser(user)).isEmpty();
   }
 
   @Test
   public void test_getAccessTiersForUser_registered() {
-    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
     addDaoEntry(user, registeredTier, TierAccessStatus.ENABLED);
     assertThat(accessTierService.getAccessTiersForUser(user)).containsExactly(registeredTier);
   }
 
   @Test
   public void test_getAccessTiersForUser_registered_disabled() {
-    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
     addDaoEntry(user, registeredTier, TierAccessStatus.DISABLED);
     assertThat(accessTierService.getAccessTiersForUser(user)).isEmpty();
   }
 
   @Test
   public void test_getAccessTiersForUser_registered_controlled() {
-    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
     addDaoEntry(user, registeredTier, TierAccessStatus.ENABLED);
 
     final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
@@ -130,7 +131,7 @@ public class AccessTierServiceTest {
   public void test_addUserToRegisteredTier_new() {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
-    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
 
     // simply to show a non-Registered tier exists but we don't add the user to it
     TestMockFactory.createControlledTierForTests(accessTierDao);
@@ -150,7 +151,7 @@ public class AccessTierServiceTest {
 
   @Test
   public void test_addUserToRegisteredTier_idempotent() {
-    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
 
     accessTierService.addUserToTier(user, registeredTier);
 
@@ -186,7 +187,7 @@ public class AccessTierServiceTest {
   public void test_removeUserFromRegisteredTier_new() {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
-    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
 
     // does nothing
     accessTierService.removeUserFromTier(user, registeredTier);
@@ -197,7 +198,7 @@ public class AccessTierServiceTest {
   public void test_removeUserFromRegisteredTier_existing() {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
-    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
 
     // adds a DB entry for (user, registered)
     accessTierService.addUserToTier(user, registeredTier);
@@ -233,7 +234,7 @@ public class AccessTierServiceTest {
   public void test_removeUserFromRegisteredTier_existing_idempotent() {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
-    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
 
     // adds a DB entry for (user, registered)
     accessTierService.addUserToTier(user, registeredTier);
@@ -265,7 +266,7 @@ public class AccessTierServiceTest {
   public void test_add_remove_add() {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
-    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
 
     // adds a DB entry for (user, registered)
     accessTierService.addUserToTier(user, registeredTier);
@@ -328,7 +329,7 @@ public class AccessTierServiceTest {
   public void test_addUserToAllTiers_two() {
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
-    final DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    final DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
     final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
 
     accessTierService.addUserToAllTiers(user);

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.pmiops.workbench.access.AccessTierService.CONTROLLED_TIER_SHORT_NAME;
 import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHORT_NAME;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.common.collect.ImmutableList;
@@ -173,7 +174,7 @@ public class UserServiceAccessTest {
     providedWorkbenchConfig.access.renewal.expiryDaysWarningThresholds =
         ImmutableList.of(1L, 3L, 7L, 15L, 30L);
     registeredTier = accessTierDao.save(createRegisteredTier());
-    controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    controlledTier = accessTierDao.save(createControlledTier());
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
 
     dbUser = new DbUser();

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.pmiops.workbench.access.AccessTierService.CONTROLLED_TIER_SHORT_NAME;
 import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHORT_NAME;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.common.collect.ImmutableList;
 import java.sql.Timestamp;
@@ -171,7 +172,7 @@ public class UserServiceAccessTest {
     providedWorkbenchConfig.access.renewal.expiryDays = EXPIRATION_DAYS;
     providedWorkbenchConfig.access.renewal.expiryDaysWarningThresholds =
         ImmutableList.of(1L, 3L, 7L, 15L, 30L);
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = accessTierDao.save(createRegisteredTier());
     controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
 

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditorTest.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.actionaudit.auditors;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -51,7 +52,7 @@ public class UserServiceAuditorTest {
 
   @Test
   public void testFireUpdateAccessTiersAction_userAgent_register() {
-    DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
     List<DbAccessTier> newTiers = Collections.singletonList(registeredTier);
 
     DbUser user = createUser();
@@ -69,7 +70,7 @@ public class UserServiceAuditorTest {
 
   @Test
   public void testFireUpdateAccessTiersAction_userAgent_unregister() {
-    DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
     List<DbAccessTier> oldTiers = Collections.singletonList(registeredTier);
 
     DbUser user = createUser();
@@ -87,7 +88,7 @@ public class UserServiceAuditorTest {
 
   @Test
   public void testFireUpdateAccessTiersAction_systemAgent_addControlled() {
-    DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
     DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
     List<DbAccessTier> oldTiers = Collections.singletonList(registeredTier);
     List<DbAccessTier> newTiers = ImmutableList.of(registeredTier, controlledTier);

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/UserServiceAuditorTest.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.actionaudit.auditors;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.common.base.Splitter;
@@ -22,7 +23,6 @@ import org.pmiops.workbench.actionaudit.targetproperties.AccountTargetProperty;
 import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -89,7 +89,7 @@ public class UserServiceAuditorTest {
   @Test
   public void testFireUpdateAccessTiersAction_systemAgent_addControlled() {
     DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
-    DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    DbAccessTier controlledTier = accessTierDao.save(createControlledTier());
     List<DbAccessTier> oldTiers = Collections.singletonList(registeredTier);
     List<DbAccessTier> newTiers = ImmutableList.of(registeredTier, controlledTier);
 

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -340,7 +340,7 @@ public class CohortReviewControllerTest {
     cdrVersion = createDefaultCdrVersion();
     accessTierDao.save(cdrVersion.getAccessTier());
     cdrVersion.setName(CDR_VERSION_NAME);
-    cdrVersionDao.save(cdrVersion);
+    cdrVersion = cdrVersionDao.save(cdrVersion);
 
     workspace =
         createTestWorkspace(WORKSPACE_NAMESPACE, WORKSPACE_NAME, cdrVersion.getCdrVersionId());

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import com.google.cloud.PageImpl;
 import com.google.cloud.bigquery.*;
@@ -336,7 +337,8 @@ public class CohortReviewControllerTest {
     user.setDisabled(false);
     currentUser = userDao.save(user);
 
-    cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+    cdrVersion = createDefaultCdrVersion();
+    accessTierDao.save(cdrVersion.getAccessTier());
     cdrVersion.setName(CDR_VERSION_NAME);
     cdrVersionDao.save(cdrVersion);
 

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -265,7 +265,7 @@ public class CohortsControllerTest {
     cdrVersion = createDefaultCdrVersion();
     accessTierDao.save(cdrVersion.getAccessTier());
     cdrVersion.setName(CDR_VERSION_NAME);
-    cdrVersionDao.save(cdrVersion);
+    cdrVersion = cdrVersionDao.save(cdrVersion);
 
     cohortDefinition = CohortDefinitions.males();
     cohortCriteria = new Gson().toJson(cohortDefinition);

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -267,7 +267,6 @@ public class CohortsControllerTest {
     cdrVersion.setName(CDR_VERSION_NAME);
     cdrVersionDao.save(cdrVersion);
 
-
     cohortDefinition = CohortDefinitions.males();
     cohortCriteria = new Gson().toJson(cohortDefinition);
     badCohortCriteria =

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.api;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
@@ -261,9 +262,11 @@ public class CohortsControllerTest {
     user = userDao.save(user);
     currentUser = user;
 
-    cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+    cdrVersion = createDefaultCdrVersion();
+    accessTierDao.save(cdrVersion.getAccessTier());
     cdrVersion.setName(CDR_VERSION_NAME);
     cdrVersionDao.save(cdrVersion);
+
 
     cohortDefinition = CohortDefinitions.males();
     cohortCriteria = new Gson().toJson(cohortDefinition);

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -295,7 +296,9 @@ public class ConceptSetsControllerTest {
     user = userDao.save(user);
     currentUser = user;
 
-    DbCdrVersion cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+    DbCdrVersion cdrVersion = createDefaultCdrVersion();
+    accessTierDao.save(cdrVersion.getAccessTier());
+    cdrVersionDao.save(cdrVersion);
     workspace =
         createTestWorkspace(
             WORKSPACE_NAMESPACE,

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -298,7 +298,7 @@ public class ConceptSetsControllerTest {
 
     DbCdrVersion cdrVersion = createDefaultCdrVersion();
     accessTierDao.save(cdrVersion.getAccessTier());
-    cdrVersionDao.save(cdrVersion);
+    cdrVersion = cdrVersionDao.save(cdrVersion);
     workspace =
         createTestWorkspace(
             WORKSPACE_NAMESPACE,

--- a/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
@@ -33,7 +33,6 @@ import org.pmiops.workbench.genomics.GenomicExtractionService;
 import org.pmiops.workbench.model.DataDictionaryEntry;
 import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.notebooks.NotebooksService;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.workspaces.WorkspaceAuthService;
 import org.pmiops.workbench.workspaces.WorkspaceService;

--- a/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
@@ -89,7 +89,7 @@ public class DataDictionaryTest {
   public void setUp() {
     cdrVersion = createDefaultCdrVersion();
     accessTierDao.save(cdrVersion.getAccessTier());
-    cdrVersionDao.save(cdrVersion);
+    cdrVersion = cdrVersionDao.save(cdrVersion);
 
     DbDSDataDictionary dbDSDataDictionary = new DbDSDataDictionary();
     dbDSDataDictionary.setRelevantOmopTable(BigQueryTableInfo.getTableName(Domain.DRUG));

--- a/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataDictionaryTest.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,7 +88,9 @@ public class DataDictionaryTest {
 
   @BeforeEach
   public void setUp() {
-    cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+    cdrVersion = createDefaultCdrVersion();
+    accessTierDao.save(cdrVersion.getAccessTier());
+    cdrVersionDao.save(cdrVersion);
 
     DbDSDataDictionary dbDSDataDictionary = new DbDSDataDictionary();
     dbDSDataDictionary.setRelevantOmopTable(BigQueryTableInfo.getTableName(Domain.DRUG));

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.exfiltration.ExfiltrationConstants.EGRESS_OBJECT_LENGTHS_SERVICE_QUALIFIER;
 import static org.pmiops.workbench.google.GoogleConfig.SERVICE_ACCOUNT_CLOUD_BILLING;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import com.google.api.services.cloudbilling.Cloudbilling;
 import com.google.cloud.bigquery.Field;
@@ -335,7 +336,8 @@ public class DataSetControllerTest {
     user = userDao.save(user);
     currentUser = user;
 
-    cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+    cdrVersion = createDefaultCdrVersion();
+    accessTierDao.save(cdrVersion.getAccessTier());
     cdrVersion = cdrVersionDao.save(cdrVersion);
 
     workspace =

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import com.google.common.collect.ImmutableList;
 import java.time.Duration;
@@ -111,7 +112,9 @@ public class OfflineRuntimeControllerTest {
   @BeforeEach
   public void setUp() {
     runtimeProjectIdIndex = 0;
-    DbCdrVersion cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+    DbCdrVersion cdrVersion = createDefaultCdrVersion();
+    accessTierDao.save(cdrVersion.getAccessTier());
+    cdrVersionDao.save(cdrVersion);
 
     user1 = new DbUser();
     user1.setUsername("alice@fake-research-aou.org");

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
@@ -114,7 +114,7 @@ public class OfflineRuntimeControllerTest {
     runtimeProjectIdIndex = 0;
     DbCdrVersion cdrVersion = createDefaultCdrVersion();
     accessTierDao.save(cdrVersion.getAccessTier());
-    cdrVersionDao.save(cdrVersion);
+    cdrVersion = cdrVersionDao.save(cdrVersion);
 
     user1 = new DbUser();
     user1.setUsername("alice@fake-research-aou.org");

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.api.services.directory.model.User;
 import com.google.common.collect.ImmutableList;
@@ -253,7 +254,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     config.googleDirectoryService.gSuiteDomain = GSUITE_DOMAIN;
 
     // key UserService logic depends on the existence of the Registered Tier
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = accessTierDao.save(createRegisteredTier());
 
     rtAddressesConfig =
         new InstitutionTierConfig()

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_IS_RUNTIME;
 import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_IS_RUNTIME_TRUE;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 
 import com.google.cloud.Date;
 import com.google.common.collect.ImmutableList;
@@ -112,7 +113,6 @@ import org.pmiops.workbench.notebooks.model.LocalizationEntry;
 import org.pmiops.workbench.notebooks.model.Localize;
 import org.pmiops.workbench.test.FakeLongRandom;
 import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
@@ -288,7 +288,7 @@ public class RuntimeControllerTest {
             .setCdrDbName("")
             .setBigqueryDataset(BIGQUERY_DATASET)
             .setAccessTier(
-                TestMockFactory.createControlledTierForTests(accessTierDao)
+                accessTierDao.save(createControlledTier())
                     .setDatasetsBucket("gs://cdr-bucket"))
             .setStorageBasePath("v99")
             .setWgsCramManifestPath("wgs/cram/manifest.csv");

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -288,8 +288,7 @@ public class RuntimeControllerTest {
             .setCdrDbName("")
             .setBigqueryDataset(BIGQUERY_DATASET)
             .setAccessTier(
-                accessTierDao.save(createControlledTier())
-                    .setDatasetsBucket("gs://cdr-bucket"))
+                accessTierDao.save(createControlledTier()).setDatasetsBucket("gs://cdr-bucket"))
             .setStorageBasePath("v99")
             .setWgsCramManifestPath("wgs/cram/manifest.csv");
 

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.google.GoogleConfig.END_USER_CLOUD_BILLING;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.api.services.cloudbilling.Cloudbilling;
 import com.google.api.services.cloudbilling.model.ListBillingAccountsResponse;
@@ -124,7 +125,7 @@ public class UserControllerTest {
 
   @BeforeEach
   public void setUp() {
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = accessTierDao.save(createRegisteredTier());
     user = userDao.save(new DbUser());
     addUserToTier(user, registeredTier);
     saveFamily();

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -117,10 +117,10 @@ public class UserMetricsControllerTest {
 
   @BeforeEach
   public void setUp() {
-    final DbCdrVersion dbCdrVersion = createDefaultCdrVersion();
+    DbCdrVersion dbCdrVersion = createDefaultCdrVersion();
 
     accessTierDao.save(dbCdrVersion.getAccessTier());
-    cdrVersionDao.save(dbCdrVersion);
+    dbCdrVersion = cdrVersionDao.save(dbCdrVersion);
 
     dbUser = new DbUser().setUserId(123L);
 

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -52,7 +52,6 @@ import org.pmiops.workbench.model.WorkspaceResource;
 import org.pmiops.workbench.model.WorkspaceResourceResponse;
 import org.pmiops.workbench.notebooks.NotebookUtils;
 import org.pmiops.workbench.test.FakeClock;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
 import org.pmiops.workbench.workspaces.WorkspaceAuthService;
@@ -118,8 +117,7 @@ public class UserMetricsControllerTest {
 
   @BeforeEach
   public void setUp() {
-    final DbCdrVersion dbCdrVersion =
-        createDefaultCdrVersion();
+    final DbCdrVersion dbCdrVersion = createDefaultCdrVersion();
 
     accessTierDao.save(dbCdrVersion.getAccessTier());
     cdrVersionDao.save(dbCdrVersion);

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import com.google.cloud.storage.BlobId;
 import com.google.common.collect.ImmutableList;
@@ -118,7 +119,10 @@ public class UserMetricsControllerTest {
   @BeforeEach
   public void setUp() {
     final DbCdrVersion dbCdrVersion =
-        TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+        createDefaultCdrVersion();
+
+    accessTierDao.save(dbCdrVersion.getAccessTier());
+    cdrVersionDao.save(dbCdrVersion);
 
     dbUser = new DbUser().setUserId(123L);
 

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -21,6 +21,7 @@ import static org.pmiops.workbench.FakeClockConfiguration.NOW_TIME;
 import static org.pmiops.workbench.exfiltration.ExfiltrationConstants.EGRESS_OBJECT_LENGTHS_SERVICE_QUALIFIER;
 import static org.pmiops.workbench.utils.TestMockFactory.DEFAULT_GOOGLE_PROJECT;
 import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo;
@@ -409,7 +410,8 @@ public class WorkspacesControllerTest {
         .thenReturn(Arrays.asList(AccessTierService.REGISTERED_TIER_SHORT_NAME));
     when(accessTierService.getRegisteredTierOrThrow()).thenReturn(registeredTier);
 
-    cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao, 1);
+    cdrVersion = createDefaultCdrVersion(1);
+    accessTierDao.save(cdrVersion.getAccessTier());
     cdrVersion.setName("1");
     // set the db name to be empty since test cases currently
     // run in the workbench schema only.
@@ -419,7 +421,8 @@ public class WorkspacesControllerTest {
     cdrVersionId = Long.toString(cdrVersion.getCdrVersionId());
 
     DbCdrVersion archivedCdrVersion =
-        TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao, 2);
+        createDefaultCdrVersion(2);
+    accessTierDao.save(archivedCdrVersion.getAccessTier());
     archivedCdrVersion.setName("archived");
     archivedCdrVersion.setCdrDbName("");
     archivedCdrVersion.setArchivalStatusEnum(ArchivalStatus.ARCHIVED);

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.FakeClockConfiguration.NOW_TIME;
 import static org.pmiops.workbench.exfiltration.ExfiltrationConstants.EGRESS_OBJECT_LENGTHS_SERVICE_QUALIFIER;
 import static org.pmiops.workbench.utils.TestMockFactory.DEFAULT_GOOGLE_PROJECT;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo;
 import com.google.cloud.PageImpl;
@@ -399,7 +400,7 @@ public class WorkspacesControllerTest {
     workbenchConfig.billing.projectNamePrefix = "aou-local";
 
     currentUser = createUser(LOGGED_IN_USER_EMAIL);
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = accessTierDao.save(createRegisteredTier());
 
     when(cohortBuilderService.findAllDemographicsMap()).thenReturn(HashBasedTable.create());
 

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.FakeClockConfiguration.NOW_TIME;
 import static org.pmiops.workbench.exfiltration.ExfiltrationConstants.EGRESS_OBJECT_LENGTHS_SERVICE_QUALIFIER;
 import static org.pmiops.workbench.utils.TestMockFactory.DEFAULT_GOOGLE_PROJECT;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo;
@@ -1395,7 +1396,7 @@ public class WorkspacesControllerTest {
         () -> {
           Workspace originalWorkspace = createWorkspace();
           originalWorkspace = workspacesController.createWorkspace(originalWorkspace).getBody();
-          DbAccessTier altAccessTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+          DbAccessTier altAccessTier = accessTierDao.save(createControlledTier());
           altAccessTier = accessTierDao.save(altAccessTier);
           DbCdrVersion altCdrVersion = new DbCdrVersion();
           altCdrVersion.setCdrVersionId(2);

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -21,6 +21,7 @@ import static org.pmiops.workbench.FakeClockConfiguration.NOW_TIME;
 import static org.pmiops.workbench.exfiltration.ExfiltrationConstants.EGRESS_OBJECT_LENGTHS_SERVICE_QUALIFIER;
 import static org.pmiops.workbench.utils.TestMockFactory.DEFAULT_GOOGLE_PROJECT;
 import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTierCdrVersion;
 import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
@@ -2172,7 +2173,9 @@ public class WorkspacesControllerTest {
     DbUser reader = createUser("reader@gmail.com");
     DbUser writer = createUser("writer@gmail.com");
     DbCdrVersion controlledTierCdr =
-        TestMockFactory.createControlledTierCdrVersion(cdrVersionDao, accessTierDao, 2);
+        createControlledTierCdrVersion(2);
+    accessTierDao.save(controlledTierCdr.getAccessTier());
+    cdrVersionDao.save(controlledTierCdr);
 
     Workspace workspace =
         workspacesController
@@ -2452,7 +2455,9 @@ public class WorkspacesControllerTest {
   @Test
   public void testShareWorkspacePatch_publishedWorkspace() {
     DbCdrVersion ctCdrVersion =
-        TestMockFactory.createControlledTierCdrVersion(cdrVersionDao, accessTierDao, 5L);
+        createControlledTierCdrVersion(5L);
+    accessTierDao.save(ctCdrVersion.getAccessTier());
+    cdrVersionDao.save(ctCdrVersion);
 
     DbUser writerUser = createAndSaveUser("writerfriend@gmail.com", 124L);
 

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -421,8 +421,7 @@ public class WorkspacesControllerTest {
     cdrVersion = cdrVersionDao.save(cdrVersion);
     cdrVersionId = Long.toString(cdrVersion.getCdrVersionId());
 
-    DbCdrVersion archivedCdrVersion =
-        createDefaultCdrVersion(2);
+    DbCdrVersion archivedCdrVersion = createDefaultCdrVersion(2);
     accessTierDao.save(archivedCdrVersion.getAccessTier());
     archivedCdrVersion.setName("archived");
     archivedCdrVersion.setCdrDbName("");
@@ -2172,8 +2171,7 @@ public class WorkspacesControllerTest {
     DbUser cloner = createUser("cloner@gmail.com");
     DbUser reader = createUser("reader@gmail.com");
     DbUser writer = createUser("writer@gmail.com");
-    DbCdrVersion controlledTierCdr =
-        createControlledTierCdrVersion(2);
+    DbCdrVersion controlledTierCdr = createControlledTierCdrVersion(2);
     accessTierDao.save(controlledTierCdr.getAccessTier());
     cdrVersionDao.save(controlledTierCdr);
 
@@ -2454,8 +2452,7 @@ public class WorkspacesControllerTest {
 
   @Test
   public void testShareWorkspacePatch_publishedWorkspace() {
-    DbCdrVersion ctCdrVersion =
-        createControlledTierCdrVersion(5L);
+    DbCdrVersion ctCdrVersion = createControlledTierCdrVersion(5L);
     accessTierDao.save(ctCdrVersion.getAccessTier());
     cdrVersionDao.save(ctCdrVersion);
 

--- a/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import java.time.Clock;
@@ -31,7 +32,6 @@ import org.pmiops.workbench.model.CdrVersion;
 import org.pmiops.workbench.model.CdrVersionTier;
 import org.pmiops.workbench.model.CdrVersionTiersResponse;
 import org.pmiops.workbench.test.FakeClock;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -132,7 +132,7 @@ public class CdrVersionServiceTest {
             false,
             false);
 
-    controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    controlledTier = accessTierDao.save(createControlledTier());
 
     controlledCdrVersion =
         makeCdrVersion(

--- a/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/CdrVersionServiceTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -106,7 +107,7 @@ public class CdrVersionServiceTest {
     user.setUsername("user");
     user = userDao.save(user);
 
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = accessTierDao.save(createRegisteredTier());
 
     defaultCdrVersion =
         makeCdrVersion(

--- a/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionEmailAddressDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionEmailAddressDaoTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,7 +10,6 @@ import org.pmiops.workbench.config.CommonConfig;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbInstitutionEmailAddress;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -33,7 +33,7 @@ public class InstitutionEmailAddressDaoTest {
     testInst =
         institutionDao.save(
             new DbInstitution().setShortName("Broad").setDisplayName("The Broad Institute"));
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = accessTierDao.save(createRegisteredTier());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionEmailDomainDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionEmailDomainDaoTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,7 +9,6 @@ import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbInstitutionEmailDomain;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -32,7 +32,7 @@ public class InstitutionEmailDomainDaoTest {
     testInst =
         institutionDao.save(
             new DbInstitution().setShortName("Broad").setDisplayName("The Broad Institute"));
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = accessTierDao.save(createRegisteredTier());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionTierRequirementDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionTierRequirementDaoTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,7 @@ public class InstitutionTierRequirementDaoTest {
     testInst =
         institutionDao.save(
             new DbInstitution().setShortName("Broad").setDisplayName("The Broad Institute"));
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = accessTierDao.save(createRegisteredTier());
     controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionTierRequirementDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionTierRequirementDaoTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -11,7 +12,6 @@ import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbInstitutionTierRequirement;
 import org.pmiops.workbench.db.model.DbInstitutionTierRequirement.MembershipRequirement;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -37,7 +37,7 @@ public class InstitutionTierRequirementDaoTest {
         institutionDao.save(
             new DbInstitution().setShortName("Broad").setDisplayName("The Broad Institute"));
     registeredTier = accessTierDao.save(createRegisteredTier());
-    controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    controlledTier = accessTierDao.save(createControlledTier());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessTierDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessTierDaoTest.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -38,7 +39,7 @@ public class UserAccessTierDaoTest {
     user.setUserId(100);
     user = userDao.save(user);
 
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = accessTierDao.save(createRegisteredTier());
     controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessTierDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserAccessTierDaoTest.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import java.sql.Timestamp;
@@ -15,7 +16,6 @@ import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserAccessTier;
 import org.pmiops.workbench.model.TierAccessStatus;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -40,7 +40,7 @@ public class UserAccessTierDaoTest {
     user = userDao.save(user);
 
     registeredTier = accessTierDao.save(createRegisteredTier());
-    controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    controlledTier = accessTierDao.save(createControlledTier());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -66,7 +67,7 @@ public class UserDaoTest {
 
   @BeforeEach
   public void setup() {
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = accessTierDao.save(createRegisteredTier());
     TestMockFactory.createAccessModules(accessModuleDao);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.common.base.Splitter;
@@ -334,7 +335,7 @@ public class UserDaoTest {
     addUserToTier(user, registeredTier);
 
     // this also won't match
-    TestMockFactory.createControlledTierForTests(accessTierDao);
+    accessTierDao.save(createControlledTier());
 
     final Sort ascendingByUsername = Sort.by(Sort.Direction.ASC, "username");
     List<DbUser> result =
@@ -349,7 +350,7 @@ public class UserDaoTest {
     user = userDao.save(user);
     addUserToTier(user, registeredTier);
 
-    final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    final DbAccessTier controlledTier = accessTierDao.save(createControlledTier());
     addUserToTier(user, controlledTier);
 
     final Sort ascendingByUsername = Sort.by(Sort.Direction.ASC, "username");
@@ -369,7 +370,7 @@ public class UserDaoTest {
     user = userDao.save(user);
     addUserToTier(user, registeredTier);
 
-    final DbAccessTier controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    final DbAccessTier controlledTier = accessTierDao.save(createControlledTier());
     addUserToTier(user, controlledTier);
     removeUserFromTier(user, controlledTier);
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHORT_NAME;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.api.services.directory.model.User;
 import com.google.common.collect.ImmutableList;
@@ -154,7 +155,7 @@ public class UserServiceTest {
     providedWorkbenchConfig.termsOfService.latestAouVersion = 5; // arbitrary
 
     // key UserService logic depends on the existence of the Registered Tier
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = accessTierDao.save(createRegisteredTier());
 
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
     Institution institution = new Institution();

--- a/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
@@ -15,6 +15,7 @@ import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__RAS_LOGIN_GOV_COMPLETION_TIME;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__TWO_FACTOR_AUTH_BYPASS_TIME;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__TWO_FACTOR_AUTH_COMPLETION_TIME;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 import static org.pmiops.workbench.utils.mappers.CommonMappers.offsetDateTimeUtc;
 
 import com.google.common.collect.ImmutableList;
@@ -138,7 +139,7 @@ public class ReportingQueryServiceTest {
 
   @BeforeEach
   public void setup() {
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = accessTierDao.save(createRegisteredTier());
     controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
     TestMockFactory.createAccessModules(accessModuleDao);
     dbInstitution = createDbInstitution();

--- a/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
@@ -15,6 +15,7 @@ import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__RAS_LOGIN_GOV_COMPLETION_TIME;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__TWO_FACTOR_AUTH_BYPASS_TIME;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__TWO_FACTOR_AUTH_COMPLETION_TIME;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 import static org.pmiops.workbench.utils.mappers.CommonMappers.offsetDateTimeUtc;
 
@@ -140,7 +141,7 @@ public class ReportingQueryServiceTest {
   @BeforeEach
   public void setup() {
     registeredTier = accessTierDao.save(createRegisteredTier());
-    controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    controlledTier = accessTierDao.save(createControlledTier());
     TestMockFactory.createAccessModules(accessModuleDao);
     dbInstitution = createDbInstitution();
     twoFactorAuthModule = accessModuleDao.findOneByName(DbAccessModuleName.TWO_FACTOR_AUTH).get();

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHORT_NAME;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.common.collect.ImmutableList;
@@ -32,7 +33,6 @@ import org.pmiops.workbench.model.InstitutionUserInstructions;
 import org.pmiops.workbench.model.InstitutionalRole;
 import org.pmiops.workbench.model.OrganizationType;
 import org.pmiops.workbench.model.UserTierEligibility;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -78,7 +78,7 @@ public class InstitutionServiceTest {
     // will be retrieved as roundTrippedTestInst
     service.createInstitution(testInst);
     registeredTier = accessTierDao.save(createRegisteredTier());
-    controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
+    controlledTier = accessTierDao.save(createControlledTier());
     rtTierConfig = new InstitutionTierConfig().accessTierShortName(registeredTier.getShortName());
     ctTierConfig = new InstitutionTierConfig().accessTierShortName(controlledTier.getShortName());
   }

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHORT_NAME;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
@@ -76,7 +77,7 @@ public class InstitutionServiceTest {
   public void setUp() {
     // will be retrieved as roundTrippedTestInst
     service.createInstitution(testInst);
-    registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    registeredTier = accessTierDao.save(createRegisteredTier());
     controlledTier = TestMockFactory.createControlledTierForTests(accessTierDao);
     rtTierConfig = new InstitutionTierConfig().accessTierShortName(registeredTier.getShortName());
     ctTierConfig = new InstitutionTierConfig().accessTierShortName(controlledTier.getShortName());

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -170,9 +170,7 @@ public class LeonardoApiClientTest {
             .setCdrDbName("")
             .setBigqueryProject("cdr")
             .setBigqueryDataset("bq")
-            .setAccessTier(
-                accessTierDao.save(createControlledTier())
-                    .setDatasetsBucket(CDR_BUCKET))
+            .setAccessTier(accessTierDao.save(createControlledTier()).setDatasetsBucket(CDR_BUCKET))
             .setStorageBasePath(CDR_STORAGE_BASE_PATH)
             .setWgsCramManifestPath(WGS_PATH);
     testWorkspace =

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
@@ -48,7 +49,6 @@ import org.pmiops.workbench.model.PersistentDiskRequest;
 import org.pmiops.workbench.model.UserAppEnvironment;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.notebooks.NotebooksRetryHandler;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
 import org.pmiops.workbench.utils.mappers.LeonardoMapperImpl;
@@ -171,7 +171,7 @@ public class LeonardoApiClientTest {
             .setBigqueryProject("cdr")
             .setBigqueryDataset("bq")
             .setAccessTier(
-                TestMockFactory.createControlledTierForTests(accessTierDao)
+                accessTierDao.save(createControlledTier())
                     .setDatasetsBucket(CDR_BUCKET))
             .setStorageBasePath(CDR_STORAGE_BASE_PATH)
             .setWgsCramManifestPath(WGS_PATH);

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -44,7 +44,6 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceDetails;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageClient;
-import org.pmiops.workbench.model.CdrVersion;
 import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.KernelTypeEnum;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -43,6 +44,7 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceDetails;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.google.CloudStorageClient;
+import org.pmiops.workbench.model.CdrVersion;
 import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.KernelTypeEnum;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
@@ -50,7 +52,6 @@ import org.pmiops.workbench.monitoring.LogsBasedMetricService;
 import org.pmiops.workbench.monitoring.views.EventMetric;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.utils.MockNotebook;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.workspaces.WorkspaceAuthService;
 import org.pmiops.workbench.workspaces.resources.UserRecentResourceService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -116,8 +117,10 @@ public class NotebooksServiceTest {
 
     // workspaceDao is a mock, so we don't need to save the workspace
     dbWorkspace = new DbWorkspace();
-    dbWorkspace.setCdrVersion(
-        TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao));
+    DbCdrVersion cdrVersion = createDefaultCdrVersion();
+    accessTierDao.save(cdrVersion.getAccessTier());
+    cdrVersionDao.save(cdrVersion);
+    dbWorkspace.setCdrVersion(cdrVersion);
 
     fromCDRVersion = new DbCdrVersion();
     toCDRVersion = new DbCdrVersion();

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -118,7 +118,7 @@ public class NotebooksServiceTest {
     dbWorkspace = new DbWorkspace();
     DbCdrVersion cdrVersion = createDefaultCdrVersion();
     accessTierDao.save(cdrVersion.getAccessTier());
-    cdrVersionDao.save(cdrVersion);
+    cdrVersion = cdrVersionDao.save(cdrVersion);
     dbWorkspace.setCdrVersion(cdrVersion);
 
     fromCDRVersion = new DbCdrVersion();

--- a/api/src/test/java/org/pmiops/workbench/tools/cdrconfig/CdrConfigVOMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/tools/cdrconfig/CdrConfigVOMapperTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.tools.cdrconfig;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -14,7 +15,6 @@ import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.model.ArchivalStatus;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -118,7 +118,7 @@ public class CdrConfigVOMapperTest {
 
   @Test
   public void test_populateAccessTier() {
-    DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
 
     CdrVersionVO cdrVersionVO = new CdrVersionVO();
     cdrVersionVO.accessTier = registeredTier.getShortName();
@@ -133,7 +133,7 @@ public class CdrConfigVOMapperTest {
 
   @Test
   public void test_populateAccessTier_missing() {
-    DbAccessTier registeredTier = TestMockFactory.createRegisteredTierForTests(accessTierDao);
+    DbAccessTier registeredTier = accessTierDao.save(createRegisteredTier());
 
     CdrVersionVO cdrVersionVO = new CdrVersionVO();
     cdrVersionVO.accessTier = "a tier which doesn't exist";

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -24,7 +24,6 @@ import org.javers.common.collections.Lists;
 import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.db.dao.AccessModuleDao;
 import org.pmiops.workbench.db.dao.AccessTierDao;
-import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -301,16 +301,8 @@ public class TestMockFactory {
     return cdrVersion;
   }
 
-  public static DbCdrVersion createDefaultCdrVersion(
-      CdrVersionDao cdrVersionDao, AccessTierDao accessTierDao) {
-    return createDefaultCdrVersion(cdrVersionDao, accessTierDao, 1);
-  }
-
-  public static DbCdrVersion createDefaultCdrVersion(
-      CdrVersionDao cdrVersionDao, AccessTierDao accessTierDao, long id) {
-    final DbCdrVersion cdrVersion = createDefaultCdrVersion(id);
-    accessTierDao.save(cdrVersion.getAccessTier());
-    return cdrVersionDao.save(cdrVersion);
+  public static DbCdrVersion createDefaultCdrVersion() {
+    return createDefaultCdrVersion(1);
   }
 
   public static DbCdrVersion createControlledTierCdrVersion(long id) {

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -267,10 +267,6 @@ public class TestMockFactory {
         .setEnableUserWorkflows(false);
   }
 
-  public static DbAccessTier createRegisteredTierForTests(AccessTierDao accessTierDao) {
-    return accessTierDao.save(createRegisteredTier());
-  }
-
   public static DbAccessTier createControlledTier() {
     return new DbAccessTier()
         .setAccessTierId(2)
@@ -280,10 +276,6 @@ public class TestMockFactory {
         .setAuthDomainGroupEmail("ct-users@fake-research-aou.org")
         .setServicePerimeter("controlled/tier/perimeter")
         .setEnableUserWorkflows(true);
-  }
-
-  public static DbAccessTier createControlledTierForTests(AccessTierDao accessTierDao) {
-    return accessTierDao.save(createControlledTier());
   }
 
   public static void removeControlledTierForTests(AccessTierDao accessTierDao) {

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -256,8 +256,8 @@ public class TestMockFactory {
     return dbWorkspace;
   }
 
-  public static DbAccessTier createRegisteredTierForTests(AccessTierDao accessTierDao) {
-    final DbAccessTier accessTier =
+  public static DbAccessTier createRegisteredTier(){
+    return
         new DbAccessTier()
             .setAccessTierId(1)
             .setShortName(AccessTierService.REGISTERED_TIER_SHORT_NAME)
@@ -266,11 +266,13 @@ public class TestMockFactory {
             .setAuthDomainGroupEmail("rt-users@fake-research-aou.org")
             .setServicePerimeter("registered/tier/perimeter")
             .setEnableUserWorkflows(false);
-    return accessTierDao.save(accessTier);
+  }
+  public static DbAccessTier createRegisteredTierForTests(AccessTierDao accessTierDao) {
+    return accessTierDao.save(createRegisteredTier());
   }
 
-  public static DbAccessTier createControlledTierForTests(AccessTierDao accessTierDao) {
-    return accessTierDao.save(
+  public static DbAccessTier createControlledTier() {
+    return
         new DbAccessTier()
             .setAccessTierId(2)
             .setShortName("controlled")
@@ -278,7 +280,11 @@ public class TestMockFactory {
             .setAuthDomainName("Controlled Tier Auth Domain")
             .setAuthDomainGroupEmail("ct-users@fake-research-aou.org")
             .setServicePerimeter("controlled/tier/perimeter")
-            .setEnableUserWorkflows(true));
+            .setEnableUserWorkflows(true);
+  }
+
+  public static DbAccessTier createControlledTierForTests(AccessTierDao accessTierDao) {
+    return accessTierDao.save(createControlledTier());
   }
 
   public static void removeControlledTierForTests(AccessTierDao accessTierDao) {
@@ -293,6 +299,17 @@ public class TestMockFactory {
     return accessModuleDao.findAll();
   }
 
+  public static DbCdrVersion createDefaultCdrVersion(long id){
+    final DbCdrVersion cdrVersion = new DbCdrVersion();
+    cdrVersion.setCdrVersionId(id);
+    cdrVersion.setName("1");
+    // set the db name to be empty since test cases currently
+    // run in the workbench schema only.
+    cdrVersion.setCdrDbName("");
+    cdrVersion.setAccessTier(createRegisteredTier());
+    return cdrVersion;
+  }
+
   public static DbCdrVersion createDefaultCdrVersion(
       CdrVersionDao cdrVersionDao, AccessTierDao accessTierDao) {
     return createDefaultCdrVersion(cdrVersionDao, accessTierDao, 1);
@@ -300,20 +317,22 @@ public class TestMockFactory {
 
   public static DbCdrVersion createDefaultCdrVersion(
       CdrVersionDao cdrVersionDao, AccessTierDao accessTierDao, long id) {
-    final DbCdrVersion cdrVersion = new DbCdrVersion();
-    cdrVersion.setCdrVersionId(id);
-    cdrVersion.setName("1");
-    // set the db name to be empty since test cases currently
-    // run in the workbench schema only.
-    cdrVersion.setCdrDbName("");
-    cdrVersion.setAccessTier(createRegisteredTierForTests(accessTierDao));
+    final DbCdrVersion cdrVersion = createDefaultCdrVersion(id);
+    accessTierDao.save(cdrVersion.getAccessTier());
     return cdrVersionDao.save(cdrVersion);
+  }
+
+  public static DbCdrVersion createControlledTierCdrVersion(long id) {
+    DbCdrVersion cdrVersion = createDefaultCdrVersion(id);
+    DbAccessTier controlledTier = createControlledTier();
+    cdrVersion.setAccessTier(controlledTier);
+    return cdrVersion;
   }
 
   public static DbCdrVersion createControlledTierCdrVersion(
       CdrVersionDao cdrVersionDao, AccessTierDao accessTierDao, long id) {
-    DbCdrVersion cdrVersion = createDefaultCdrVersion(cdrVersionDao, accessTierDao, id);
-    cdrVersion.setAccessTier(createControlledTierForTests(accessTierDao));
+    DbCdrVersion cdrVersion = createControlledTierCdrVersion(id);
+    accessTierDao.save(cdrVersion.getAccessTier());
     return cdrVersionDao.save(cdrVersion);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -312,13 +312,6 @@ public class TestMockFactory {
     return cdrVersion;
   }
 
-  public static DbCdrVersion createControlledTierCdrVersion(
-      CdrVersionDao cdrVersionDao, AccessTierDao accessTierDao, long id) {
-    DbCdrVersion cdrVersion = createControlledTierCdrVersion(id);
-    accessTierDao.save(cdrVersion.getAccessTier());
-    return cdrVersionDao.save(cdrVersion);
-  }
-
   public static DbUserCodeOfConductAgreement createDuccAgreement(
       DbUser dbUser, int signedVersion, Timestamp completionTime) {
     DbUserCodeOfConductAgreement ducc = new DbUserCodeOfConductAgreement();

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -256,31 +256,30 @@ public class TestMockFactory {
     return dbWorkspace;
   }
 
-  public static DbAccessTier createRegisteredTier(){
-    return
-        new DbAccessTier()
-            .setAccessTierId(1)
-            .setShortName(AccessTierService.REGISTERED_TIER_SHORT_NAME)
-            .setDisplayName("Registered Tier")
-            .setAuthDomainName("Registered Tier Auth Domain")
-            .setAuthDomainGroupEmail("rt-users@fake-research-aou.org")
-            .setServicePerimeter("registered/tier/perimeter")
-            .setEnableUserWorkflows(false);
+  public static DbAccessTier createRegisteredTier() {
+    return new DbAccessTier()
+        .setAccessTierId(1)
+        .setShortName(AccessTierService.REGISTERED_TIER_SHORT_NAME)
+        .setDisplayName("Registered Tier")
+        .setAuthDomainName("Registered Tier Auth Domain")
+        .setAuthDomainGroupEmail("rt-users@fake-research-aou.org")
+        .setServicePerimeter("registered/tier/perimeter")
+        .setEnableUserWorkflows(false);
   }
+
   public static DbAccessTier createRegisteredTierForTests(AccessTierDao accessTierDao) {
     return accessTierDao.save(createRegisteredTier());
   }
 
   public static DbAccessTier createControlledTier() {
-    return
-        new DbAccessTier()
-            .setAccessTierId(2)
-            .setShortName("controlled")
-            .setDisplayName("Controlled Tier")
-            .setAuthDomainName("Controlled Tier Auth Domain")
-            .setAuthDomainGroupEmail("ct-users@fake-research-aou.org")
-            .setServicePerimeter("controlled/tier/perimeter")
-            .setEnableUserWorkflows(true);
+    return new DbAccessTier()
+        .setAccessTierId(2)
+        .setShortName("controlled")
+        .setDisplayName("Controlled Tier")
+        .setAuthDomainName("Controlled Tier Auth Domain")
+        .setAuthDomainGroupEmail("ct-users@fake-research-aou.org")
+        .setServicePerimeter("controlled/tier/perimeter")
+        .setEnableUserWorkflows(true);
   }
 
   public static DbAccessTier createControlledTierForTests(AccessTierDao accessTierDao) {
@@ -299,7 +298,7 @@ public class TestMockFactory {
     return accessModuleDao.findAll();
   }
 
-  public static DbCdrVersion createDefaultCdrVersion(long id){
+  public static DbCdrVersion createDefaultCdrVersion(long id) {
     final DbCdrVersion cdrVersion = new DbCdrVersion();
     cdrVersion.setCdrVersionId(id);
     cdrVersion.setName("1");

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.utils.TestMockFactory.DEFAULT_GOOGLE_PROJECT;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import com.google.cloud.Date;
 import com.google.cloud.storage.Blob;
@@ -169,7 +170,9 @@ public class WorkspaceAdminServiceTest {
   public void setUp() {
     currentUser = new DbUser();
 
-    cdrVersion = TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+    cdrVersion = createDefaultCdrVersion();
+    accessTierDao.save(cdrVersion.getAccessTier());
+    cdrVersionDao.save(cdrVersion);
 
     when(mockFirecloudService.getWorkspaceAsService(any(), any()))
         .thenReturn(

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceAuthServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceAuthServiceTest.java
@@ -40,7 +40,6 @@ import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceDetails;
 import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceAuthServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceAuthServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
@@ -299,7 +300,7 @@ public class WorkspaceAuthServiceTest {
 
   private void stubRegisteredTier() {
     when(mockAccessTierService.getRegisteredTierOrThrow())
-        .thenReturn(TestMockFactory.createRegisteredTierForTests(accessTierDao));
+        .thenReturn(accessTierDao.save(createRegisteredTier()));
   }
 
   private void stubUpdateAcl(String namespace, String fcName) {

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.workspaces;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 import static org.springframework.test.util.AssertionErrors.fail;
 
 import java.lang.reflect.Method;
@@ -13,6 +14,7 @@ import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao.WorkspaceCountByActiveStatusAndTier;
+import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.pmiops.workbench.testconfig.ReportingTestConfig;
@@ -132,7 +134,10 @@ public class WorkspaceDaoTest {
     workspace.setWorkspaceNamespace(WORKSPACE_NAMESPACE);
     workspace.setGoogleProject(GOOGLE_PROJECT);
     workspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    workspace.setCdrVersion(TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao));
+    DbCdrVersion dbCdrVersion = createDefaultCdrVersion();
+    accessTierDao.save(dbCdrVersion.getAccessTier());
+    cdrVersionDao.save(dbCdrVersion);
+    workspace.setCdrVersion(dbCdrVersion);
     workspace = workspaceDao.save(workspace);
     return workspace;
   }

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
@@ -135,7 +135,7 @@ public class WorkspaceDaoTest {
     workspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
     DbCdrVersion dbCdrVersion = createDefaultCdrVersion();
     accessTierDao.save(dbCdrVersion.getAccessTier());
-    cdrVersionDao.save(dbCdrVersion);
+    dbCdrVersion = cdrVersionDao.save(dbCdrVersion);
     workspace.setCdrVersion(dbCdrVersion);
     workspace = workspaceDao.save(workspace);
     return workspace;

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
@@ -18,7 +18,6 @@ import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.pmiops.workbench.testconfig.ReportingTestConfig;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.exfiltration.ExfiltrationConstants.EGRESS_OBJECT_LENGTHS_SERVICE_QUALIFIER;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTierCdrVersion;
 import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo;
@@ -61,7 +62,6 @@ import org.pmiops.workbench.iam.IamService;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.pmiops.workbench.profile.ProfileMapper;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.FirecloudMapper;
 import org.pmiops.workbench.utils.mappers.UserMapper;
@@ -572,7 +572,9 @@ public class WorkspaceServiceTest {
             DEFAULT_WORKSPACE_NAMESPACE,
             WorkspaceActiveStatus.ACTIVE);
     DbCdrVersion dbCdrVersion =
-        TestMockFactory.createControlledTierCdrVersion(cdrVersionDao, accessTierDao, 1);
+        createControlledTierCdrVersion(1);
+    accessTierDao.save(dbCdrVersion.getAccessTier());
+    cdrVersionDao.save(dbCdrVersion);
     dbWorkspace.setCdrVersion(dbCdrVersion);
     workspaceDao.save(dbWorkspace);
     assertThrows(
@@ -608,7 +610,9 @@ public class WorkspaceServiceTest {
             DEFAULT_WORKSPACE_NAMESPACE,
             WorkspaceActiveStatus.ACTIVE);
     DbCdrVersion dbCdrVersion =
-        TestMockFactory.createControlledTierCdrVersion(cdrVersionDao, accessTierDao, 1);
+        createControlledTierCdrVersion(1);
+    accessTierDao.save(dbCdrVersion.getAccessTier());
+    cdrVersionDao.save(dbCdrVersion);
     dbWorkspace.setCdrVersion(dbCdrVersion);
 
     addMockedWorkspace(dbWorkspace);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -573,9 +573,9 @@ public class WorkspaceServiceTest {
             WorkspaceActiveStatus.ACTIVE);
     DbCdrVersion dbCdrVersion = createControlledTierCdrVersion(1);
     accessTierDao.save(dbCdrVersion.getAccessTier());
-    cdrVersionDao.save(dbCdrVersion);
+    dbCdrVersion = cdrVersionDao.save(dbCdrVersion);
     dbWorkspace.setCdrVersion(dbCdrVersion);
-    workspaceDao.save(dbWorkspace);
+   workspaceDao.save(dbWorkspace);
     assertThrows(
         ForbiddenException.class,
         () ->

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.exfiltration.ExfiltrationConstants.EGRESS_OBJECT_LENGTHS_SERVICE_QUALIFIER;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo;
 import java.sql.Timestamp;
@@ -585,7 +586,9 @@ public class WorkspaceServiceTest {
   public void userWithoutRegisterTierAccessRTWorkspace() {
     DbWorkspace dbWorkspace = dbWorkspaces.get(0);
     DbCdrVersion dbCdrVersion =
-        TestMockFactory.createDefaultCdrVersion(cdrVersionDao, accessTierDao);
+        createDefaultCdrVersion();
+    accessTierDao.save(dbCdrVersion.getAccessTier());
+    cdrVersionDao.save(dbCdrVersion);
     dbWorkspace.setCdrVersion(dbCdrVersion);
     when(accessTierService.getAccessTierShortNamesForUser(currentUser))
         .thenReturn(Collections.singletonList(AccessTierService.CONTROLLED_TIER_SHORT_NAME));

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -575,7 +575,7 @@ public class WorkspaceServiceTest {
     accessTierDao.save(dbCdrVersion.getAccessTier());
     dbCdrVersion = cdrVersionDao.save(dbCdrVersion);
     dbWorkspace.setCdrVersion(dbCdrVersion);
-   workspaceDao.save(dbWorkspace);
+    workspaceDao.save(dbWorkspace);
     assertThrows(
         ForbiddenException.class,
         () ->

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -571,8 +571,7 @@ public class WorkspaceServiceTest {
             "Controlled Tier Workspace",
             DEFAULT_WORKSPACE_NAMESPACE,
             WorkspaceActiveStatus.ACTIVE);
-    DbCdrVersion dbCdrVersion =
-        createControlledTierCdrVersion(1);
+    DbCdrVersion dbCdrVersion = createControlledTierCdrVersion(1);
     accessTierDao.save(dbCdrVersion.getAccessTier());
     cdrVersionDao.save(dbCdrVersion);
     dbWorkspace.setCdrVersion(dbCdrVersion);
@@ -587,8 +586,7 @@ public class WorkspaceServiceTest {
   @Test
   public void userWithoutRegisterTierAccessRTWorkspace() {
     DbWorkspace dbWorkspace = dbWorkspaces.get(0);
-    DbCdrVersion dbCdrVersion =
-        createDefaultCdrVersion();
+    DbCdrVersion dbCdrVersion = createDefaultCdrVersion();
     accessTierDao.save(dbCdrVersion.getAccessTier());
     cdrVersionDao.save(dbCdrVersion);
     dbWorkspace.setCdrVersion(dbCdrVersion);
@@ -609,8 +607,7 @@ public class WorkspaceServiceTest {
             "Controlled Tier Workspace",
             DEFAULT_WORKSPACE_NAMESPACE,
             WorkspaceActiveStatus.ACTIVE);
-    DbCdrVersion dbCdrVersion =
-        createControlledTierCdrVersion(1);
+    DbCdrVersion dbCdrVersion = createControlledTierCdrVersion(1);
     accessTierDao.save(dbCdrVersion.getAccessTier());
     cdrVersionDao.save(dbCdrVersion);
     dbWorkspace.setCdrVersion(dbCdrVersion);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -588,7 +588,7 @@ public class WorkspaceServiceTest {
     DbWorkspace dbWorkspace = dbWorkspaces.get(0);
     DbCdrVersion dbCdrVersion = createDefaultCdrVersion();
     accessTierDao.save(dbCdrVersion.getAccessTier());
-    cdrVersionDao.save(dbCdrVersion);
+    dbCdrVersion = cdrVersionDao.save(dbCdrVersion);
     dbWorkspace.setCdrVersion(dbCdrVersion);
     when(accessTierService.getAccessTierShortNamesForUser(currentUser))
         .thenReturn(Collections.singletonList(AccessTierService.CONTROLLED_TIER_SHORT_NAME));


### PR DESCRIPTION
**Description**

I am hoping to not use a database in the contract test. A few of the TestMockFactory functions utilize daos by default. This PR splits some of those functions between creation and saving them.

Ran unit tests locally and they passed.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [ ] If this PR is intended to complete a JIRA story, I have checked that all AC are met for that story
- [x] I have manually tested this change and my testing process is described above
- [ ] This PR includes appropriate automated tests, and I have documented any behavior that cannot be tested with code
- [ ] If this fixes a bug, ensure the steps to reproduce are in the Jira ticket or provided above.
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented the impacts in the description
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this includes an API change, I have run the relevant E2E tests locally because API changes are not covered by our PR checks
