### PR TITLE
[RW-9958][risk=no] Move user confirmation from Ruby into Java

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/SetAuthority.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/SetAuthority.java
@@ -45,18 +45,29 @@ public class SetAuthority extends Tool {
     return (args) -> {
       // User-friendly command-line parsing is done in devstart.rb, so we do only simple positional
       // argument parsing here.
-      if (args.length != 4) {
+      if (args.length != 5) {
         throw new IllegalArgumentException(
-            "Expected 4 args (email_list, authorities, remove, dry_run). Got "
+            "Expected 5 args (email_list, authorities, remove, dry_run, confirm_add_all). Got "
                 + Arrays.asList(args));
       }
       Set<String> emails = commaDelimitedStringToSet(args[0]);
-      Set<Authority> authorities = commaDelimitedStringToAuthoritySet(args[1]);
+      String authoritiesArgument = args[1];
+      Set<Authority> authorities = commaDelimitedStringToAuthoritySet(authoritiesArgument);
       boolean remove = Boolean.valueOf(args[2]);
       boolean dryRun = Boolean.valueOf(args[3]);
+      boolean confirmAddAll = Boolean.valueOf(args[4]);
       int numUsers = 0;
       int numErrors = 0;
       int numChanged = 0;
+
+      if (!remove
+          && authoritiesArgument.toUpperCase().contains(ALL_AUTHORITIES)
+          && !confirmAddAll) {
+        String addAllWarning =
+            "Adding ALL authorities is redundant and rarely useful; to transitively grant all authorities, simply add the all-encompassing DEVELOPER authority. If you still want to add ALL authorities, set the --confirm_add_all flag.";
+        log.log(Level.SEVERE, addAllWarning);
+        throw new IllegalArgumentException(addAllWarning);
+      }
 
       for (String email : emails) {
         numUsers++;


### PR DESCRIPTION
**Description**

Moves user confirmation logic for the `set-authority` command from Ruby into Java. I'm seeking feedback on the approach.

This approach adds a new flag: `confirm_add_all`. If the flag is not set and the user tries to add all authorities, we throw an error and request they add the flag.

Overall, I think the UX tradeoffs described below are worth the [future refactors](https://docs.google.com/document/d/1-4BPwzEAfxlQqMnF0EAPFmnLOPgp9-fpyMXhPywpgzQ/edit#) that this enables.

Today's behavior:

<img src="https://user-images.githubusercontent.com/31020403/235515458-0055ebe0-d30b-4fd5-ad65-b1124097822f.png">

After this change:

<img src="https://user-images.githubusercontent.com/31020403/235515382-3bde2cec-1df1-4c71-bf5b-34b9bf99a87c.png">

**Pros**

One benefit of this change is that all `set-authority`-specific logic to is moved into Java task. Our ruby script has many responsibilities, but this removes the most ambiguous one: "arbitrary logic".

Another benefit is that the command relies less on the arguments passed to the task. Eventually, this will allow us to do argument parsing in Java. A couple PRs from now, our ruby may be a small wrapper around gradle that sets up environment variables.

**Cons**

Unfortunately, in terms of developer UX, I think this is worse than what we have now:
- It's classifying valid behavior as an "error"
- Users need to run the command twice
- This doesn't prevent dangerous commands from being copied and pasted or accidentally entered
- Output may be obscured by other threads

**Additional Notes**

I created [another branch](https://github.com/all-of-us/workbench/tree/peterlavigne/rw-9958-user-input-v1) where I attempted to do this the same way as Ruby. This works well when connecting to the local database. However, when I connect to a cloud database, we use multiple threads. Logging from the other thread hides the prompt for user input:

<img src="https://user-images.githubusercontent.com/31020403/235512099-e6e75ff7-9711-4890-8255-903a9397ad13.png">

One argument against the cons is that I suspect this situation is rare. I have never needed to run this command.

Another option may be to remove the `ALL` flag entirely. The `ALL` flag is only a helper for passing all of the authorities individually, in which case the user is currently not stopped.

I tested this by running it manually locally and in test. Later, I'm considering adding automated tests to `SetAuthority`, but I consider that a lower priority than creating proof-of-concepts for refactoring code out of the ruby scripts. This behavior is untested today, so I am OK with skipping that here.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [x] If this PR is intended to complete a JIRA story, I have checked that all AC are met for that story
- [x] I have manually tested this change and my testing process is described above
- [x] This PR includes appropriate automated tests, and I have documented any behavior that cannot be tested with code
- [x] If this fixes a bug, ensure the steps to reproduce are in the Jira ticket or provided above.
- [x] I have added explanatory comments where the logic is not obvious
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented the impacts in the description
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this includes an API change, I have run the relevant E2E tests locally because API changes are not covered by our PR checks
