### PR TITLE
[no ticket][risk=no] Switch from legacy HttpTransport

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/config/AppEngineConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/AppEngineConfig.java
@@ -1,7 +1,9 @@
 package org.pmiops.workbench.config;
 
-import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 public class AppEngineConfig {
 
   @Bean
-  HttpTransport httpTransport() {
-    return UrlFetchTransport.getDefaultInstance();
+  HttpTransport httpTransport() throws GeneralSecurityException, IOException {
+    return GoogleNetHttpTransport.newTrustedTransport();
   }
 }


### PR DESCRIPTION
`com.google.api.client.extensions.appengine.http.UrlFetchTransport` is only available with legacy APIs enabled in GAE. `com.google.api.client.googleapis.javanet.GoogleNetHttpTransport` works with legacy APIs disabled.

Deployed here:
https://mohstest-dot-api-dot-all-of-us-workbench-test.uc.r.appspot.com

Tested manually via UI interactions.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [ ] If this PR is intended to complete a JIRA story, I have checked that all AC are met for that story
- [x] I have manually tested this change and my testing process is described above
- [ ] This PR includes appropriate automated tests, and I have documented any behavior that cannot be tested with code
- [ ] If this fixes a bug, ensure the steps to reproduce are in the Jira ticket or provided above.
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented the impacts in the description
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this includes an API change, I have run the relevant E2E tests locally because API changes are not covered by our PR checks
