### PR TITLE
[RW-9518][risk=no]  [tests] Cromwell / User App tests - use correct version cromshell-alpha/cromshell-beta

### DIFF
--- a/e2e/tests/nightly/gke-apps/cromwell.spec.ts
+++ b/e2e/tests/nightly/gke-apps/cromwell.spec.ts
@@ -77,8 +77,15 @@ describe('Cromwell GKE App', () => {
     let snippetOutput = await notebook.runCodeCell(1);
 
     // Confirm Cromwell has not started
-    // TODO: Fix the snippet to use cromshell-alpha
-    const cromshell_version = snippetOutput.includes('Found cromshell_alpha') ? 'cromshell-alpha' : 'cromshell-beta';
+    /* The snippet output is usually like
+      Scanning for cromshell 2 beta
+      Scanning for cromshell 2 alpha...
+      Found cromshell-alpha, please use cromshell-alpha
+      Checking status for CROMWELL app....
+     */
+    // We are trying to find the correct version cromshell-alpha or cromshell-beta
+    // This is temp, once docker image is updated, we will always cromshell which will be alias for cromshell-beta
+    const cromshell_version = snippetOutput.split(', please use ')[1].split('\n')[0];
     expect(snippetOutput.includes('CROMWELL app does not exist. Please create cromwell server from workbench')).toBe(
       true
     );


### PR DESCRIPTION
There was a typo in the snippet related to the cromshell version, This was fixed as part of PR https://github.com/all-of-us/workbench/pull/7643
**Description**

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [ ] If this PR is intended to complete a JIRA story, I have checked that all AC are met for that story
- [ ] I have manually tested this change and my testing process is described above
- [ ] This PR includes appropriate automated tests, and I have documented any behavior that cannot be tested with code
- [ ] If this fixes a bug, ensure the steps to reproduce are in the Jira ticket or provided above.
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented the impacts in the description
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this includes an API change, I have run the relevant E2E tests locally because API changes are not covered by our PR checks
