### PR TITLE
[risk=low][RW-10024] Delete test user orphaned Rawls workspaces cron

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
@@ -144,7 +144,7 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
     try {
       impersonatedFirecloudService.deleteSamKubernetesResourcesInWorkspace(
           dbUser, dbWorkspace.getGoogleProject());
-    } catch (IOException e) {
+    } catch (Exception e) {
       // Ignore exceptions and proceed with workspace deletion.
       // We don't want an error here to stop us from trying to delete the workspace.
       logger.log(
@@ -156,7 +156,7 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
 
     try {
       impersonatedFirecloudService.deleteWorkspace(dbUser, wsNamespace, wsId);
-    } catch (IOException e) {
+    } catch (Exception e) {
       throw new ServerErrorException(e);
     }
 
@@ -188,7 +188,7 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
 
     try {
       impersonatedFirecloudService.deleteSamKubernetesResourcesInWorkspace(dbUser, googleProject);
-    } catch (IOException e) {
+    } catch (Exception e) {
       // Ignore exceptions and proceed with workspace deletion.
       // We don't want an error here to stop us from trying to delete the workspace.
       logger.log(
@@ -200,7 +200,7 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
 
     try {
       impersonatedFirecloudService.deleteWorkspace(dbUser, wsNamespace, wsId);
-    } catch (IOException e) {
+    } catch (Exception e) {
       throw new ServerErrorException(e);
     }
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2040,6 +2040,17 @@ paths:
       responses:
         204:
           description: No content.
+  "/v1/cron/deleteTestUserWorkspacesOrphanedInRawls":
+    get:
+      security: []
+      tags:
+        - offlineTestUsers
+        - cron
+      description: "Delete all test users' workspaces from Rawls"
+      operationId: deleteAllTestUserWorkspacesOrphanedInRawls
+      responses:
+        204:
+          description: No content.
 
   "/v1/workspaces/{workspaceNamespace}/{workspaceId}/notebooks/{notebookName}/readonly":
     parameters:
@@ -3094,6 +3105,28 @@ paths:
           description: Batch of workspace deletions to process.
           schema:
             "$ref": "#/definitions/DeleteTestUserWorkspacesRequest"
+      responses:
+        200:
+          description: 'Workspaces deleted'
+  "/v1/cloudTask/deleteTestUserWorkspacesInRawls":
+    post:
+      security: []
+      tags:
+        - cloudTaskWorkspaces
+        - cloudTask
+      description: >
+        Deletes the requested test user workspaces in Rawls (Terra Workspace service).
+        This may be necessary in case of a mismatch between the RW and Terra views of workspaces
+      operationId: deleteTestUserWorkspacesInRawls
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: request
+          required: true
+          description: Batch of Rawls workspace deletions to process.
+          schema:
+            "$ref": "#/definitions/DeleteTestUserRawlsWorkspacesRequest"
       responses:
         200:
           description: 'Workspaces deleted'
@@ -9024,6 +9057,11 @@ definitions:
     items:
       "$ref": "#/definitions/TestUserWorkspace"
 
+  DeleteTestUserRawlsWorkspacesRequest:
+    type: array
+    items:
+      "$ref": "#/definitions/TestUserRawlsWorkspace"
+
   TestUserWorkspace:
     type: object
     required:
@@ -9036,6 +9074,27 @@ definitions:
         type: string
       wsNamespace:
         description: 'Workspace Namespace'
+        type: string
+      wsFirecloudId:
+        description: 'Firecloud ID for the Workspace'
+        type: string
+
+  TestUserRawlsWorkspace:
+    type: object
+    required:
+      - username
+      - wsNamespace
+      - wsGoogleProject
+      - wsFirecloudId
+    properties:
+      username:
+        description: 'Test username (email address including GSuite)'
+        type: string
+      wsNamespace:
+        description: 'Workspace Namespace'
+        type: string
+      wsGoogleProject:
+        description: 'Workspace Google Project'
         type: string
       wsFirecloudId:
         description: 'Firecloud ID for the Workspace'

--- a/api/src/main/webapp/WEB-INF/cron_base.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_base.yaml
@@ -89,4 +89,9 @@ cron:
   schedule: every day 20:00
   timezone: America/Chicago
   target: api
+- description: Delete all test user workspaces which have been orphaned in Rawls
+  url: /v1/cron/deleteTestUserWorkspacesInRawls
+  schedule: every day 21:00
+  timezone: America/Chicago
+  target: api
 

--- a/api/src/main/webapp/WEB-INF/queue.yaml
+++ b/api/src/main/webapp/WEB-INF/queue.yaml
@@ -80,3 +80,15 @@ queue:
   retry_parameters:
     task_retry_limit: 1
     task_age_limit: 5m
+
+- name: deleteTestUserRawlsWorkspacesQueue
+  target: api
+
+  # rate parameters
+  bucket_size: 50
+  rate: 1/s
+  max_concurrent_requests: 10
+
+  retry_parameters:
+    task_retry_limit: 1
+    task_age_limit: 5m


### PR DESCRIPTION
Add a new cron task which continues the process of deleting test user workspaces by deleting "orphaned" Rawls workspaces which do not have associated AoU RW DB workspaces.  This can happen in at least two ways:
* attempted workspace creation partially succeeded, recording a Rawls workspace but not an AoU workspace
* attempted deletion partially succeeded, removing the AoU workspace but not the Rawls workspace

As an example, I count 47 AoU workspaces for one test user but 228 Rawls workspaces.  These numbers should match.

Tested by hitting the new cron endpoint locally.

Future work: do we also need to clean up **Sam** resources?  Can these get out of sync with Rawls?
~Future work~ [**done** in #7654] add a tool for cleanup of arbitrary users' workspaces

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [x] If this PR is intended to complete a JIRA story, I have checked that all AC are met for that story
- [x] I have manually tested this change and my testing process is described above
- [ ] This PR includes appropriate automated tests, and I have documented any behavior that cannot be tested with code
- [x] If this fixes a bug, ensure the steps to reproduce are in the Jira ticket or provided above.
- [x] I have added explanatory comments where the logic is not obvious
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented the impacts in the description
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this includes an API change, I have run the relevant E2E tests locally because API changes are not covered by our PR checks
