### PR TITLE
[risk=low][RW-10024] Add a tool to delete a user's Rawls workspaces which are not present in the AoU DB

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -840,6 +840,14 @@ task exportWorkspaceOperations(type: JavaExec) {
     }
 }
 
+// See project.rb command: delete-orphaned-workspaces
+task deleteOrphanedWorkspaces(type: JavaExec) {
+    classpath = sourceSets.__tools__.runtimeClasspath
+    mainClass = "org.pmiops.workbench.tools.DeleteOrphanedWorkspaces"
+    if (project.hasProperty("appArgs")) {
+        args Eval.me(appArgs)
+    }
+}
 //
 // Kotlin Plugin compiler arguments
 // https://kotlinlang.org/docs/reference/using-gradle.html#compiler-options

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2725,7 +2725,7 @@ def delete_orphaned_workspaces(cmd_name, *args)
     ["--project", op.opts.project],
     ["--username", op.opts.username],
     ["--limit", op.opts.limit],
-#    ["--delete", op.opts.delete],
+    ["--delete", op.opts.delete],
   ]).map { |kv| "#{kv[0]}=#{kv[1]}" }
   # Gradle args need to be single-quote wrapped.
   gradle_args.map! { |f| "'#{f}'" }

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2740,6 +2740,6 @@ DELETE_ORPHANED_WORKSPACES_CMD = "delete-orphaned-workspaces"
 
 Common.register_command({
     :invocation => DELETE_ORPHANED_WORKSPACES_CMD,
-    :description => "Do something with orphaned projects I guess",
+    :description => "Delete a user's workspaces in Rawls which are no longer in AoU",
     :fn => ->(*args) {delete_orphaned_workspaces(DELETE_ORPHANED_WORKSPACES_CMD, *args)}
 })

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2702,11 +2702,17 @@ def delete_orphaned_workspaces(cmd_name, *args)
   op.add_validator ->(opts) { raise ArgumentError.new("Username required") unless opts.username }
 
   op.add_typed_option(
-      '--dry-run [false]',
+      '--limit [limit]',
+      String,
+      ->(opts, v) { opts.limit = v },
+      'The maximum number of workspaces to delete per step.')
+
+  op.add_typed_option(
+      '--delete',
       TrueClass,
-      ->(opts, v) { opts.dry_run = v},
-      "Don't actually delete, but show what would have happened.  Defaults to true.")
-  op.opts.dry_run = true
+      ->(opts, v) { opts.delete = v },
+      'Set to delete. Defaults to count only.')
+  op.opts.delete = false
 
   op.parse.validate
 
@@ -2718,7 +2724,8 @@ def delete_orphaned_workspaces(cmd_name, *args)
   gradle_args = ([
     ["--project", op.opts.project],
     ["--username", op.opts.username],
-    ["--dry-run", op.opts.dry_run],
+    ["--limit", op.opts.limit],
+#    ["--delete", op.opts.delete],
   ]).map { |kv| "#{kv[0]}=#{kv[1]}" }
   # Gradle args need to be single-quote wrapped.
   gradle_args.map! { |f| "'#{f}'" }

--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceService.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.impersonation;
 
 import java.util.List;
+import org.pmiops.workbench.firecloud.model.FirecloudWorkspaceResponse;
 import org.pmiops.workbench.model.WorkspaceResponse;
 
 /**
@@ -10,7 +11,15 @@ import org.pmiops.workbench.model.WorkspaceResponse;
  * production, except where absolutely necessary.
  */
 public interface ImpersonatedWorkspaceService {
+  // return a list of workspaces owned by the user
   List<WorkspaceResponse> getOwnedWorkspaces(String username);
 
+  // return a list of workspaces which are present in Rawls as owned by the user
+  // but not present (or deleted) in the AoU RW DB
+  List<FirecloudWorkspaceResponse> getOwnedWorkspacesOrphanedInRawls(String username);
+
   void deleteWorkspace(String username, String wsNamespace, String wsId);
+
+  void deleteOrphanedRawlsWorkspace(
+      String username, String wsNamespace, String googleProject, String wsId);
 }

--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
@@ -198,14 +198,24 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
       throw new ServerErrorException(e);
     }
 
-    try {
-      // use the real FirecloudService here because impersonation is not needed;
-      // billing projects are owned by the App SA
-      firecloudService.deleteBillingProject(wsNamespace);
-    } catch (Exception e) {
-      String msg =
-          String.format("Error deleting billing project %s: %s", wsNamespace, e.getMessage());
-      logger.warning(msg);
-    }
+    // TODO
+    // I can't figure out how to make this work from a tool
+
+    // 2023-05-03 18:52:06.815  WARN 20371 --- [           main]
+    // o.p.w.i.ImpersonatedWorkspaceServiceImpl :
+    // Error deleting billing project aou-rw-test-cce862eb: No qualifying bean of type
+    // 'org.pmiops.workbench.rawls.api.BillingV2Api' available: expected at least 1 bean which
+    // qualifies as autowire candidate. Dependency annotations:
+    // {@org.springframework.beans.factory.annotation.Qualifier(value="serviceAccountBillingV2Api")}
+
+    //    try {
+    //      // use the real FirecloudService here because impersonation is not needed;
+    //      // billing projects are owned by the App SA
+    //      firecloudService.deleteBillingProject(wsNamespace);
+    //    } catch (Exception e) {
+    //      String msg =
+    //          String.format("Error deleting billing project %s: %s", wsNamespace, e.getMessage());
+    //      logger.warning(msg);
+    //    }
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteOrphanedWorkspaces.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteOrphanedWorkspaces.java
@@ -60,14 +60,12 @@ public class DeleteOrphanedWorkspaces extends Tool {
           .required()
           .hasArg()
           .build();
-
   private static final Option LIMIT_OPT =
       Option.builder()
           .longOpt("limit")
           .desc("The maximum number of workspaces to delete, per step. Optional.")
           .hasArg()
           .build();
-
   private static final Option DELETE_OPT =
       Option.builder()
           .longOpt("delete")

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteOrphanedWorkspaces.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteOrphanedWorkspaces.java
@@ -6,13 +6,18 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.pmiops.workbench.actionaudit.ActionAuditServiceImpl;
 import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditorImpl;
-import org.pmiops.workbench.db.dao.UserDao;
-import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.audit.ActionAuditSpringConfiguration;
 import org.pmiops.workbench.firecloud.FireCloudServiceImpl;
+import org.pmiops.workbench.firecloud.FirecloudApiClientFactory;
+import org.pmiops.workbench.google.GoogleConfig;
+import org.pmiops.workbench.iam.SamApiClientFactory;
+import org.pmiops.workbench.iam.SamRetryHandler;
 import org.pmiops.workbench.impersonation.ImpersonatedFirecloudServiceImpl;
 import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceService;
 import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceServiceImpl;
+import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapperImpl;
 import org.springframework.boot.CommandLineRunner;
@@ -20,14 +25,19 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 @Import({
-    BillingProjectAuditorImpl.class,
-    FireCloudServiceImpl.class,
-    FirecloudMapperImpl.class,
-    ImpersonatedFirecloudServiceImpl.class,
-    ImpersonatedWorkspaceServiceImpl.class,
-    UserDao.class,
-    WorkspaceDao.class,
-    WorkspaceMapperImpl.class,
+  ActionAuditServiceImpl.class,
+  ActionAuditSpringConfiguration.class, // injects com.google.cloud.logging.Logging
+  BillingProjectAuditorImpl.class,
+  CommonMappers.class,
+  FireCloudServiceImpl.class,
+  FirecloudApiClientFactory.class,
+  FirecloudMapperImpl.class,
+  GoogleConfig.class, // injects com.google.cloud.iam.credentials.v1.IamCredentialsClient
+  ImpersonatedFirecloudServiceImpl.class,
+  ImpersonatedWorkspaceServiceImpl.class,
+  SamApiClientFactory.class,
+  SamRetryHandler.class,
+  WorkspaceMapperImpl.class,
 })
 public class DeleteOrphanedWorkspaces extends Tool {
   private static final Logger LOG = Logger.getLogger(DeleteOrphanedWorkspaces.class.getName());
@@ -37,12 +47,27 @@ public class DeleteOrphanedWorkspaces extends Tool {
   private static final Option RW_PROJ_OPT =
       Option.builder()
           .longOpt("project")
-          .desc("The AoU project to access.")
+          .desc("The AoU project (environment) to access.")
+          .required()
+          .hasArg()
+          .build();
+  private static final Option USERNAME_OPT =
+      Option.builder()
+          .longOpt("username")
+          .desc("The user whose workspaces we want to delete.")
           .required()
           .hasArg()
           .build();
 
-  private static final Options OPTIONS = new Options().addOption(RW_PROJ_OPT);
+  private static final Option DRY_RUN_OPT =
+      Option.builder()
+          .longOpt("dry-run")
+          .desc("If true, the tool runs in dry run mode; no modifications are made")
+          .hasArg()
+          .build();
+
+  private static final Options OPTIONS =
+      new Options().addOption(RW_PROJ_OPT).addOption(USERNAME_OPT).addOption(DRY_RUN_OPT);
 
   public static void main(String[] args) {
     CommandLineToolConfig.runCommandLine(DeleteOrphanedWorkspaces.class, args);
@@ -56,19 +81,31 @@ public class DeleteOrphanedWorkspaces extends Tool {
       if (!ALLOWED_RW_ENVS.contains(rwEnvOpt)) {
         throw new IllegalArgumentException("Unsupported RW environment: " + rwEnvOpt);
       }
+      final String usernameOpt = opts.getOptionValue(USERNAME_OPT.getLongOpt());
+      // default to true if missing
+      final boolean dryRunOpt =
+          !"false".equalsIgnoreCase(opts.getOptionValue(DRY_RUN_OPT.getLongOpt()));
+      final String dryRunPrefix = dryRunOpt ? "[DRY RUN] " : "";
 
-      var workspaces =
-          workspaceService.getOwnedWorkspacesOrphanedInRawls(
-              "puppeteer-tester-7@fake-research-aou.org");
-      LOG.info(String.format("Saw %d Rawls workspaces", workspaces.size()));
-      workspaces.stream()
-          .limit(5)
-          .forEach(
-              ws ->
-                  LOG.info(
-                      String.format(
-                          "Saw Rawls workspace %s/%s",
-                          ws.getWorkspace().getNamespace(), ws.getWorkspace().getName())));
+      var workspaces = workspaceService.getOwnedWorkspacesOrphanedInRawls(usernameOpt);
+      LOG.info(
+          String.format(
+              "Saw %d Rawls workspaces which are not present in the %s DB",
+              workspaces.size(), rwEnvOpt));
+      workspaces.forEach(
+          ws -> {
+            LOG.info(
+                String.format(
+                    "%sDeleting Rawls workspace %s/%s",
+                    dryRunPrefix, ws.getWorkspace().getNamespace(), ws.getWorkspace().getName()));
+            if (!dryRunOpt) {
+              workspaceService.deleteOrphanedRawlsWorkspace(
+                  usernameOpt,
+                  ws.getWorkspace().getNamespace(),
+                  ws.getWorkspace().getGoogleProject(),
+                  ws.getWorkspace().getName());
+            }
+          });
     };
   }
 }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteOrphanedWorkspaces.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteOrphanedWorkspaces.java
@@ -72,6 +72,7 @@ public class DeleteOrphanedWorkspaces extends Tool {
       Option.builder()
           .longOpt("delete")
           .desc("Enable to actually delete the workspaces.  Defaults to count only.")
+          .hasArg()
           .build();
 
   private static final Options OPTIONS =

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteOrphanedWorkspaces.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteOrphanedWorkspaces.java
@@ -1,0 +1,74 @@
+package org.pmiops.workbench.tools;
+
+import java.util.List;
+import java.util.logging.Logger;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditorImpl;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.firecloud.FireCloudServiceImpl;
+import org.pmiops.workbench.impersonation.ImpersonatedFirecloudServiceImpl;
+import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceService;
+import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceServiceImpl;
+import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
+import org.pmiops.workbench.utils.mappers.WorkspaceMapperImpl;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+@Import({
+    BillingProjectAuditorImpl.class,
+    FireCloudServiceImpl.class,
+    FirecloudMapperImpl.class,
+    ImpersonatedFirecloudServiceImpl.class,
+    ImpersonatedWorkspaceServiceImpl.class,
+    UserDao.class,
+    WorkspaceDao.class,
+    WorkspaceMapperImpl.class,
+})
+public class DeleteOrphanedWorkspaces extends Tool {
+  private static final Logger LOG = Logger.getLogger(DeleteOrphanedWorkspaces.class.getName());
+
+  private static final List<String> ALLOWED_RW_ENVS = List.of("all-of-us-workbench-test");
+
+  private static final Option RW_PROJ_OPT =
+      Option.builder()
+          .longOpt("project")
+          .desc("The AoU project to access.")
+          .required()
+          .hasArg()
+          .build();
+
+  private static final Options OPTIONS = new Options().addOption(RW_PROJ_OPT);
+
+  public static void main(String[] args) {
+    CommandLineToolConfig.runCommandLine(DeleteOrphanedWorkspaces.class, args);
+  }
+
+  @Bean
+  public CommandLineRunner run(ImpersonatedWorkspaceService workspaceService) {
+    return (args) -> {
+      final CommandLine opts = new DefaultParser().parse(OPTIONS, args);
+      final String rwEnvOpt = opts.getOptionValue(RW_PROJ_OPT.getLongOpt());
+      if (!ALLOWED_RW_ENVS.contains(rwEnvOpt)) {
+        throw new IllegalArgumentException("Unsupported RW environment: " + rwEnvOpt);
+      }
+
+      var workspaces =
+          workspaceService.getOwnedWorkspacesOrphanedInRawls(
+              "puppeteer-tester-7@fake-research-aou.org");
+      LOG.info(String.format("Saw %d Rawls workspaces", workspaces.size()));
+      workspaces.stream()
+          .limit(5)
+          .forEach(
+              ws ->
+                  LOG.info(
+                      String.format(
+                          "Saw Rawls workspace %s/%s",
+                          ws.getWorkspace().getNamespace(), ws.getWorkspace().getName())));
+    };
+  }
+}


### PR DESCRIPTION
Sometimes, the AoU DB and Terra's Workspace service (Rawls) can get out of sync.  This tool queries Rawls for which workspaces it believes the user owns, and deletes those that the AoU DB does not believe the user owns (or has been marked as deleted)

Possible future work:
* add AoU workspace deletion also / replace the DeleteWorkspaces tool
* add Terra-Sam workspace resource deletion (in case it is out of sync with Rawls)
* cron-ify this for test users: #7653

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [ ] If this PR is intended to complete a JIRA story, I have checked that all AC are met for that story
- [ ] I have manually tested this change and my testing process is described above
- [ ] This PR includes appropriate automated tests, and I have documented any behavior that cannot be tested with code
- [ ] If this fixes a bug, ensure the steps to reproduce are in the Jira ticket or provided above.
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented the impacts in the description
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this includes an API change, I have run the relevant E2E tests locally because API changes are not covered by our PR checks
