### PR TITLE
[no ticket][risk=no] Better handling of environment variables

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/CdrDataSource.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CdrDataSource.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.logging.Logger;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -84,13 +83,5 @@ public class CdrDataSource extends AbstractRoutingDataSource {
   @Override
   protected Object determineCurrentLookupKey() {
     return CdrVersionContext.getCdrVersion().getCdrVersionId();
-  }
-
-  Optional<String> getEnv(String name) {
-    return Optional.ofNullable(System.getenv(name)).map(s -> s.trim()).filter(s -> s != "");
-  }
-
-  String getEnvRequired(String name) {
-    return getEnv(name).orElseThrow(() -> new IllegalStateException(name + " not defined"));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/DbParams.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/DbParams.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.cdr;
 
 import java.util.logging.Logger;
+import org.pmiops.workbench.config.EnvVars;
 import org.pmiops.workbench.db.Params;
 import org.springframework.context.annotation.Configuration;
 
@@ -8,11 +9,15 @@ import org.springframework.context.annotation.Configuration;
 public class DbParams extends Params {
   private static final Logger log = Logger.getLogger(DbParams.class.getName());
 
+  public DbParams(EnvVars envVars) {
+    super(envVars);
+  }
+
   @Override
   public void loadFromEnvironment() {
-    hostname = getEnv("CDR_DB_HOST").orElse(null);
-    cloudSqlInstanceName = getEnv("CDR_CLOUD_SQL_INSTANCE_NAME").orElse(null);
-    password = getEnv("CDR_DB_PASSWORD").orElse(null);
+    hostname = envVars.get("CDR_DB_HOST").orElse(null);
+    cloudSqlInstanceName = envVars.get("CDR_CLOUD_SQL_INSTANCE_NAME").orElse(null);
+    password = envVars.get("CDR_DB_PASSWORD").orElse(null);
     try {
       validate();
       log.info("CDR SQL instance params: " + this.toString());

--- a/api/src/main/java/org/pmiops/workbench/config/EnvVars.java
+++ b/api/src/main/java/org/pmiops/workbench/config/EnvVars.java
@@ -1,0 +1,12 @@
+package org.pmiops.workbench.config;
+
+import java.util.Optional;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration // provide as an injectible dependency
+// This class is just a proxy for retrieving environment variables that can be overriden in tests.
+public class EnvVars {
+  public Optional<String> get(String name) {
+    return Optional.ofNullable(System.getenv(name)).filter(s -> !s.isBlank());
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/db/WorkbenchDbConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/db/WorkbenchDbConfig.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.db;
 
 import com.zaxxer.hikari.HikariDataSource;
-import java.util.Optional;
 import java.util.logging.Logger;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
@@ -75,13 +74,5 @@ public class WorkbenchDbConfig {
   @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   public PoolConfiguration poolConfig() {
     return new PoolProperties();
-  }
-
-  static Optional<String> getEnv(String name) {
-    return Optional.ofNullable(System.getenv(name)).map(s -> s.trim()).filter(s -> s != "");
-  }
-
-  static String getEnvRequired(String name) {
-    return getEnv(name).orElseThrow(() -> new IllegalStateException(name + " not defined"));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/monitoring/StackdriverStatsExporterServiceTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.monitoring;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
 
 import com.google.api.MonitoredResource;
 import io.opencensus.exporter.stats.stackdriver.StackdriverStatsConfiguration;
@@ -8,10 +9,12 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
+import org.pmiops.workbench.config.EnvVars;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.ServerConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -22,6 +25,7 @@ public class StackdriverStatsExporterServiceTest {
   private static final String PROJECT_ID = "fake-project";
   private static final String FOUND_NODE_ID = "node-11001001";
   @Autowired private StackdriverStatsExporterService exporterService;
+  @MockBean private EnvVars envVars;
 
   @TestConfiguration
   @Import({StackdriverStatsExporterService.class, FakeClockConfiguration.class})
@@ -40,7 +44,7 @@ public class StackdriverStatsExporterServiceTest {
 
   @Test
   public void testMakeConfiguration() {
-    exporterService.gaeInstanceId = Optional.of(FOUND_NODE_ID);
+    when(envVars.get("GAE_INSTANCE")).thenReturn(Optional.of(FOUND_NODE_ID));
 
     StackdriverStatsConfiguration statsConfiguration =
         exporterService.makeStackdriverStatsConfiguration();
@@ -57,7 +61,7 @@ public class StackdriverStatsExporterServiceTest {
 
   @Test
   public void testMakeMonitoredResource_noInstanceIdAvailable() {
-    exporterService.gaeInstanceId = Optional.empty();
+    when(envVars.get("GAE_INSTANCE")).thenReturn(Optional.empty());
     final MonitoredResource monitoredResource =
         exporterService.makeStackdriverStatsConfiguration().getMonitoredResource();
     assertThat(monitoredResource.getLabelsMap().get("node_id")).isNotEmpty();

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/Tool.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/Tool.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.tools;
 
+import org.pmiops.workbench.config.EnvVars;
 import org.pmiops.workbench.db.Params;
 import org.pmiops.workbench.db.WorkbenchDbConfig;
 import org.springframework.context.annotation.Configuration;
@@ -7,5 +8,5 @@ import org.springframework.context.annotation.Import;
 
 // This is a common ancestor that brings in the main database configuration.
 @Configuration
-@Import({Params.class, WorkbenchDbConfig.class})
+@Import({EnvVars.class, Params.class, WorkbenchDbConfig.class})
 public abstract class Tool {}


### PR DESCRIPTION
This change adds one layer of indirection between our code and `System.getenv`. By using a Spring Bean to proxy that method call, we are able to mock it when writing tests.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [ ] If this PR is intended to complete a JIRA story, I have checked that all AC are met for that story
- [ ] I have manually tested this change and my testing process is described above
- [x] This PR includes appropriate automated tests, and I have documented any behavior that cannot be tested with code
- [ ] If this fixes a bug, ensure the steps to reproduce are in the Jira ticket or provided above.
- [x] I have added explanatory comments where the logic is not obvious
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented the impacts in the description
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this includes an API change, I have run the relevant E2E tests locally because API changes are not covered by our PR checks
