### PR TITLE
[DT-379][risk=no] Fix tidyverse read_csv problem.

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -226,7 +226,9 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
         "ds_heart_rate_summary",
         "ds_steps_intraday",
         "ds_condition_occurrence",
-        "ds_measurement", "ds_person", "ds_procedure_occurrence");
+        "ds_measurement",
+        "ds_person",
+        "ds_procedure_occurrence");
   }
 
   @Override

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -226,7 +226,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
         "ds_heart_rate_summary",
         "ds_steps_intraday",
         "ds_condition_occurrence",
-        "ds_measurement");
+        "ds_measurement", "ds_person", "ds_procedure_occurrence");
   }
 
   @Override

--- a/api/src/bigquerytest/resources/bigquery/cbdata/ds_person_data.json
+++ b/api/src/bigquerytest/resources/bigquery/cbdata/ds_person_data.json
@@ -1,0 +1,14 @@
+[
+  {
+    "PERSON_ID": "1",
+    "GENDER_CONCEPT_ID": "1",
+    "GENDER": "Male",
+    "DATE_OF_BIRTH": "2020-01-31 00:00:00 UTC",
+    "RACE_CONCEPT_ID": "1",
+    "RACE": "African-American",
+    "ETHNICITY_CONCEPT_ID": "1",
+    "ETHNICITY": "Ethnicity",
+    "SEX_AT_BIRTH_CONCEPT_ID": "1",
+    "SEX_AT_BIRTH": "sex at birth"
+  }
+]

--- a/api/src/bigquerytest/resources/bigquery/cbdata/ds_procedure_occurrence_data.json
+++ b/api/src/bigquerytest/resources/bigquery/cbdata/ds_procedure_occurrence_data.json
@@ -1,0 +1,6 @@
+[
+  {
+    "person_id": 1,
+    "procedure_source_concept_id": 44823922
+  }
+]

--- a/api/src/bigquerytest/resources/bigquery/schema/ds_person.json
+++ b/api/src/bigquerytest/resources/bigquery/schema/ds_person.json
@@ -1,0 +1,52 @@
+[
+  {
+    "type": "INTEGER",
+    "name": "PERSON_ID",
+    "mode": "NULLABLE"
+  },
+  {
+    "type": "INTEGER",
+    "name": "GENDER_CONCEPT_ID",
+    "mode": "NULLABLE"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "GENDER",
+    "type": "STRING"
+  },
+  {
+    "type": "TIMESTAMP",
+    "name": "DATE_OF_BIRTH",
+    "mode": "NULLABLE"
+  },
+  {
+    "type": "INTEGER",
+    "name": "RACE_CONCEPT_ID",
+    "mode": "NULLABLE"
+  },
+  {
+    "type": "STRING",
+    "name": "RACE",
+    "mode": "NULLABLE"
+  },
+  {
+    "type": "INTEGER",
+    "name": "ETHNICITY_CONCEPT_ID",
+    "mode": "NULLABLE"
+  },
+  {
+    "type": "STRING",
+    "name": "ETHNICITY",
+    "mode": "NULLABLE"
+  },
+  {
+    "type": "INTEGER",
+    "name": "SEX_AT_BIRTH_CONCEPT_ID",
+    "mode": "NULLABLE"
+  },
+  {
+    "type": "STRING",
+    "name": "SEX_AT_BIRTH",
+    "mode": "NULLABLE"
+  }
+]

--- a/api/src/bigquerytest/resources/bigquery/schema/ds_procedure_occurrence.json
+++ b/api/src/bigquerytest/resources/bigquery/schema/ds_procedure_occurrence.json
@@ -1,0 +1,78 @@
+[
+  {
+    "name": "PERSON_ID",
+    "type": "INTEGER"
+  },
+  {
+    "name": "PROCEDURE_CONCEPT_ID",
+    "type": "INTEGER"
+  },
+  {
+    "name": "STANDARD_CONCEPT_NAME",
+    "type": "STRING"
+  },
+  {
+    "name": "STANDARD_CONCEPT_CODE",
+    "type": "STRING"
+  },
+  {
+    "name": "STANDARD_VOCABULARY",
+    "type": "STRING"
+  },
+  {
+    "name": "PROCEDURE_DATETIME",
+    "type": "TIMESTAMP"
+  },
+  {
+    "name": "PROCEDURE_TYPE_CONCEPT_ID",
+    "type": "INTEGER"
+  },
+  {
+    "name": "PROCEDURE_TYPE_CONCEPT_NAME",
+    "type": "STRING"
+  },
+  {
+    "name": "MODIFIER_CONCEPT_ID",
+    "type": "INTEGER"
+  },
+  {
+    "name": "MODIFIER_CONCEPT_NAME",
+    "type": "STRING"
+  },
+  {
+    "name": "QUANTITY",
+    "type": "INTEGER"
+  },
+  {
+    "name": "VISIT_OCCURRENCE_ID",
+    "type": "INTEGER"
+  },
+  {
+    "name": "VISIT_OCCURRENCE_CONCEPT_NAME",
+    "type": "STRING"
+  },
+  {
+    "name": "PROCEDURE_SOURCE_VALUE",
+    "type": "STRING"
+  },
+  {
+    "name": "PROCEDURE_SOURCE_CONCEPT_ID",
+    "type": "INTEGER"
+  },
+  {
+    "name": "SOURCE_CONCEPT_NAME",
+    "type": "STRING"
+  },
+  {
+    "name": "SOURCE_CONCEPT_CODE",
+    "type": "STRING"
+  },
+  {
+    "name": "SOURCE_VOCABULARY",
+    "type": "STRING"
+  },
+  {
+    "name": "MODIFIER_SOURCE_VALUE",
+    "type": "STRING"
+  }
+]

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -1492,6 +1492,11 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                 + namespace
                 + "df.head(5)");
       case R:
+        // Fix tidyverse read_csv problem. In R notebooks the tidyverse plugin tries
+        // to dynamically determine the column types in a csv file. Sometimes it incorrectly
+        // determines that a string column is a double/integer. This fix will force any
+        // string columns to always be strings, so that merging of csv files won't fail
+        // do to incompatible types. https://precisionmedicineinitiative.atlassian.net/browse/DST-1056
         List<String> columns =
             fieldList.stream()
                 .filter(

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -1496,7 +1496,8 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
         // to dynamically determine the column types in a csv file. Sometimes it incorrectly
         // determines that a string column is a double/integer. This fix will force any
         // string columns to always be strings, so that merging of csv files won't fail
-        // do to incompatible types. https://precisionmedicineinitiative.atlassian.net/browse/DST-1056
+        // do to incompatible types.
+        // https://precisionmedicineinitiative.atlassian.net/browse/DST-1056
         List<String> columns =
             fieldList.stream()
                 .filter(
@@ -1504,8 +1505,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                         field.getType().equals(LegacySQLTypeName.STRING)
                             && StringUtils.containsIgnoreCase(
                                 queryJobConfiguration.getQuery(), field.getName()))
-                .map(
-                    field -> field.getName().toLowerCase() + " = " + getColumnType(field.getType()))
+                .map(field -> field.getName().toLowerCase() + " = col_character()")
                 .collect(Collectors.toList());
         String colTypes =
             columns.isEmpty()
@@ -1587,22 +1587,6 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                 + "df, 5)");
       default:
         throw new BadRequestException("Language " + kernelTypeEnum + " not supported.");
-    }
-  }
-
-  private static String getColumnType(LegacySQLTypeName type) {
-    if (type.equals(LegacySQLTypeName.DATE)) {
-      return "col_date()";
-    } else if (type.equals(LegacySQLTypeName.DATETIME)) {
-      return "col_date()";
-    } else if (type.equals(LegacySQLTypeName.INTEGER)) {
-      return "col_integer()";
-    } else if (type.equals(LegacySQLTypeName.NUMERIC)) {
-      return "col_integer()";
-    } else if (type.equals(LegacySQLTypeName.FLOAT)) {
-      return "col_double()";
-    } else {
-      return "col_character()";
     }
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -481,6 +481,8 @@ public class DataSetControllerTest {
               returnSql = returnSql.replace("${dataSetId}", TEST_CDR_DATA_SET_ID);
               return queryJobConfiguration.toBuilder().setQuery(returnSql).build();
             });
+    when(mockBigQueryService.getTableFieldsFromDomain(any()))
+            .thenReturn(FieldList.of(Field.newBuilder("person_id", LegacySQLTypeName.INTEGER).build()));
     // Allow access initially for setup, update the mocks after initialization to remove access.
     stubWorkspaceAccessLevel(noAccessWorkspace, WorkspaceAccessLevel.NO_ACCESS);
   }

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -482,7 +482,7 @@ public class DataSetControllerTest {
               return queryJobConfiguration.toBuilder().setQuery(returnSql).build();
             });
     when(mockBigQueryService.getTableFieldsFromDomain(any()))
-            .thenReturn(FieldList.of(Field.newBuilder("person_id", LegacySQLTypeName.INTEGER).build()));
+        .thenReturn(FieldList.of(Field.newBuilder("person_id", LegacySQLTypeName.INTEGER).build()));
     // Allow access initially for setup, update the mocks after initialization to remove access.
     stubWorkspaceAccessLevel(noAccessWorkspace, WorkspaceAccessLevel.NO_ACCESS);
   }


### PR DESCRIPTION
Fix tidyverse read_csv problem. In R notebooks the tidyverse plugin tries to dynamically determine the column types in a csv file. Sometimes it incorrectly determines that a string column is a double/integer. This fix will force any string columns to always be strings, so that merging of csv files won't fail do to incompatible types.