### PR TITLE
[RW-1003][risk=no] Migrate Leo setCookie calls to the non-deprecated version

### DIFF
--- a/api/src/main/resources/notebooks.yaml
+++ b/api/src/main/resources/notebooks.yaml
@@ -111,37 +111,25 @@ paths:
         "500":
           description: Internal Error
 
-  "/proxy/{googleProject}/{runtimeName}/setCookie":
+  "/proxy/setCookie":
     get:
-      summary: Sets a browser cookie needed to authorize connections to a Dataproc
-        runtime
+      summary: Sets a browser cookie needed to authorize connections to a Leonardo runtime
       description: >
         If using Google token-based authorization to a runtime, the Leo proxy
-        accepts a
-
-        Google token passed as a cookie value. This endpoint facilitates setting that cookie.
+        accepts a Google token passed as a cookie value. This endpoint facilitates setting that cookie.
 
         It accepts a bearer token in an Authorization header and responds with a Set-Cookie header.
+
+        If no bearer token is present, it unsets the cookie by returning a Set-Cookie header with a null
+        value and expiration date in the past.
       operationId: setCookie
       tags:
         - proxy
-      parameters:
-        - in: path
-          name: googleProject
-          required: true
-          type: string
-        - in: path
-          name: runtimeName
-          description: runtimeName
-          required: true
-          type: string
       responses:
         "204":
           description: Successfully set a cookie
         "401":
           description: Proxy connection unauthorized
-        "404":
-          description: Runtime not found
         "500":
           description: Internal Error
 

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -360,11 +360,7 @@ describe('ExpandedApp', () => {
     const setCookieSpy = jest.spyOn(leoProxyApi(), 'setCookie');
     launchButton.simulate('click');
 
-    expect(setCookieSpy).toHaveBeenCalledWith(
-      workspace.googleProject,
-      appName,
-      { credentials: 'include' }
-    );
+    expect(setCookieSpy).toHaveBeenCalledWith({ credentials: 'include' });
   });
 
   describe('should disable the launch button when the RStudio app status is not RUNNING', () => {

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -177,7 +177,7 @@ const RStudioButtonRow = (props: {
       message: 'Please try again.',
     },
     async () => {
-      await leoProxyApi().setCookie(userApp.googleProject, userApp.appName, {
+      await leoProxyApi().setCookie({
         credentials: 'include',
       });
       window.open(userApp.proxyUrls.rstudio, '_blank').focus();

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -460,9 +460,9 @@ export const LeonardoAppLauncher = fp.flow(
       return appendNotebookFileSuffix(this.getNotebookName());
     }
 
-    private async initializeNotebookCookies(c: Runtime) {
+    private async initializeNotebookCookies() {
       return await this.runtimeRetry(() =>
-        leoProxyApi().setCookie(c.googleProject, c.runtimeName, {
+        leoProxyApi().setCookie({
           withCredentials: true,
           crossDomain: true,
           credentials: 'include',
@@ -578,7 +578,7 @@ export const LeonardoAppLauncher = fp.flow(
     private async connectToRunningRuntime(runtime: Runtime) {
       const { namespace, id } = this.props.workspace;
       this.incrementProgress(Progress.Authenticating);
-      await this.initializeNotebookCookies(runtime);
+      await this.initializeNotebookCookies();
 
       const leoAppLocation = await this.getLeoAppPathAndLocalize(runtime);
       if (this.isCreatingNewNotebook()) {

--- a/ui/src/testing/stubs/leo-proxy-api-stub.ts
+++ b/ui/src/testing/stubs/leo-proxy-api-stub.ts
@@ -9,11 +9,7 @@ export class LeoProxyApiStub extends ProxyApi {
     });
   }
 
-  public setCookie(
-    _googleProject: string,
-    _runtimeName: string,
-    _options?: any
-  ): Promise<Response> {
+  public setCookie(_options?: any): Promise<Response> {
     return new Promise<Response>((resolve) => {
       resolve(new Response());
     });


### PR DESCRIPTION
**Description**

Migrates Leo `setCookie` calls to the non-deprecated version.

The version of `setCookie` we were using is [deprecated](https://leonardo.dsde-prod.broadinstitute.org/#/proxy). The new version does not require the google project or runtime arguments.

The behavior should be exactly the same before and after this change.

To test this, open a notebook and observe that the Leo cookie named `LeoToken` is still set to the current access token.

The YAML changes were copied from [Leo's YAML](https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/resources/swagger/api-docs.yaml).

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [x] If this PR is intended to complete a JIRA story, I have checked that all AC are met for that story
- [x] I have manually tested this change and my testing process is described above
- [x] This PR includes appropriate automated tests, and I have documented any behavior that cannot be tested with code
- [x] If this fixes a bug, ensure the steps to reproduce are in the Jira ticket or provided above.
- [x] I have added explanatory comments where the logic is not obvious
- [x] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented the impacts in the description
- [x] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [x] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [x] If this includes an API change, I have run the relevant E2E tests locally because API changes are not covered by our PR checks
