### PR TITLE
[RW-9105][risk=low] Fix missing LastModifiedBy information from notebook list

### DIFF
--- a/ui/src/app/components/resource-list.spec.tsx
+++ b/ui/src/app/components/resource-list.spec.tsx
@@ -13,6 +13,7 @@ import { ResourceList } from './resource-list';
 export const RESOURCE_TYPE_COLUMN_NUMBER = 1;
 export const NAME_COLUMN_NUMBER = 2;
 export const MODIFIED_DATE_COLUMN_NUMBER = 3;
+export const MODIFIED_BY_COLUMN_NUMBER = 4;
 
 export const resourceTable = (wrapper) =>
   wrapper.find('[data-test-id="resource-list"]').find('tbody');

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import { NotebooksApi, ProfileApi, WorkspacesApi } from 'generated/fetch';
 
 import {
+  MODIFIED_BY_COLUMN_NUMBER,
   MODIFIED_DATE_COLUMN_NUMBER,
   NAME_COLUMN_NUMBER,
   RESOURCE_TYPE_COLUMN_NUMBER,
@@ -58,6 +59,11 @@ describe('NotebookList', () => {
         NotebooksApiStub.stubNotebookList()[0].lastModifiedTime
       )
     );
+
+    // Fifth column of notebook table displays last modified by
+    expect(
+      resourceTableColumns(wrapper).at(MODIFIED_BY_COLUMN_NUMBER).text()
+    ).toMatch(NotebooksApiStub.stubNotebookList()[0].lastModifiedBy);
   });
 
   it('should redirect to notebook playground mode when either resource type or name is clicked', async () => {

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -161,6 +161,7 @@ export function convertToResource(
         ? (inputResource as FileDetail)
         : null,
     lastModifiedEpochMillis: inputResource.lastModifiedTime,
+    lastModifiedBy: inputResource.lastModifiedBy,
     adminLocked,
   };
 }

--- a/ui/src/testing/stubs/notebooks-api-stub.ts
+++ b/ui/src/testing/stubs/notebooks-api-stub.ts
@@ -29,6 +29,7 @@ export class NotebooksApiStub extends NotebooksApi {
         name: 'mockFile.ipynb',
         path: 'gs://bucket/notebooks/mockFile.ipynb',
         lastModifiedTime: 100,
+        lastModifiedBy: 'stubUser@fake-researcher.aou',
       },
     ];
   }


### PR DESCRIPTION
**FIXED:**
<img width="1561" alt="Screenshot 2023-05-08 at 10 59 37 AM" src="https://user-images.githubusercontent.com/34481816/236862061-26d7e626-5bc1-46bf-8430-696ac73c0b56.png">

The resource list table was unable to display who made the last modification to notebook. 

**Why:**

While converting the FileDetail[] to the resource type for displaying the table in a notebook, the value was getting set to null. This approach would work for other resources, because the dataPage function calls the API workspace.getWorkspaceResourcesV2() to update the lastModifiedBy parameter from the Workbench Database

The reason why notebook isnt calling the same endpoint, could be because notebook information is not stored in our Database and we get the information from Leonardo. 

**Next PR:**

This PR will solve the lastModifiedBy issue on Notebook list page (analysis and new analysis tab) however the userRecentResource still does not have this information. This will require API work. I will create a new PR for that


**Description**

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md)
- [ ] If this PR is intended to complete a JIRA story, I have checked that all AC are met for that story
- [x] I have manually tested this change and my testing process is described above
- [x] This PR includes appropriate automated tests, and I have documented any behavior that cannot be tested with code
- [ ] If this fixes a bug, ensure the steps to reproduce are in the Jira ticket or provided above.
- [ ] I have added explanatory comments where the logic is not obvious
- [ ] If this change impacts deployment safety (e.g. removing/altering APIs which are in use) I have documented the impacts in the description
- [ ] If this includes a new feature flag, I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later
- [ ] If this includes a UI change, I have taken screen recordings or screenshots of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P)
- [ ] If this includes an API change, I have run the relevant E2E tests locally because API changes are not covered by our PR checks
