### PR TITLE
[no ticket][risk=no] Suppress timestamps in generated code to reduce diff noise

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         JACKSON_VERSION = '2.13.4'
         KOTLIN_VERSION = '1.8.20'
         LIQUIBASE_VERSION = '4.16.1'
-        MAPSTRUCT_VERSION = '1.4.2.Final'
+        MAPSTRUCT_VERSION = '1.5.5.Final'
         MOCKITO_KOTLIN_VERSION = '4.1.0'
         OKHTTP_VERSION = '2.7.5'
         OPENCENSUS_VERSION = '0.31.1'
@@ -140,6 +140,7 @@ def swagger3JavaClient(yaml, pkg, rawOptExtras = []) {
                     'invokerPackage'   : "${SWAGGER_CODEGEN_BASE_PKG}.${pkg}",
                     'modelPackage'     : "${SWAGGER_CODEGEN_BASE_PKG}.${pkg}.model",
                     'apiPackage'       : "${SWAGGER_CODEGEN_BASE_PKG}.${pkg}.api",
+                    'hideGenerationTimestamp': 'true',
             ]
         }
         // Validation only works for Swagger 2 - skip.
@@ -203,7 +204,8 @@ swaggerSources {
                     // Generates delegate interfaces; used to make method annotations work without
                     // having to copy them to our implementations.
                     'delegatePattern': 'true',
-                    'dateLibrary'    : 'java8'
+                    'dateLibrary'    : 'java8',
+                    'hideGenerationTimestamp': 'true',
             ]
         }
     }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/FirecloudMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/FirecloudMapper.java
@@ -7,7 +7,7 @@ import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessEntry;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessLevel;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", suppressTimestampInGenerated = true)
 public interface FirecloudMapper {
 
   default WorkspaceAccessLevel fcAccessLevelToApiAccessLevel(RawlsWorkspaceAccessEntry acl) {

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/MapStructConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/MapStructConfig.java
@@ -3,5 +3,8 @@ package org.pmiops.workbench.utils.mappers;
 import org.mapstruct.MapperConfig;
 import org.mapstruct.ReportingPolicy;
 
-@MapperConfig(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.ERROR)
+@MapperConfig(
+    componentModel = "spring",
+    unmappedTargetPolicy = ReportingPolicy.ERROR,
+    suppressTimestampInGenerated = true)
 public class MapStructConfig {}


### PR DESCRIPTION
This should have no impact on the compiled code.

I tested by compiling with and without these flags and running `diff -r` on the result. The diff on this change is way shorter and much more helpful.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
