### PR TITLE
[risk=no][RW-10063] Remove deprecated fields from leonardo.yaml

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -154,7 +154,6 @@ public interface LeonardoMapper {
   }
 
   @Mapping(target = "patchInProgress", ignore = true)
-  @Mapping(target = "googleProject", ignore = true) // deprecated in favor of cloudContext
   LeonardoListRuntimeResponse toListRuntimeResponse(LeonardoGetRuntimeResponse runtime);
 
   @Nullable

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -1877,9 +1877,6 @@ components:
           description: The labels to be placed on the cluster. Of type Map[String,String]
         userJupyterExtensionConfig:
           $ref: "#/components/schemas/UserJupyterExtensionConfig"
-        jupyterExtensionUri:
-          type: string
-          description: Deprecated. Please use userJupyterExtensionConfig.
         jupyterUserScriptUri:
           type: string
           description: >
@@ -1944,9 +1941,6 @@ components:
         defaultClientId:
           type: string
           description: The default Google Client ID.
-        jupyterDockerImage:
-          type: string
-          description: Deprecated. Please use toolDockerImage.
         toolDockerImage:
           type: string
           description: The tool docker image to install. May be Dockerhub or GCR. If not

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -1622,9 +1622,6 @@ components:
         runtimeName:
           type: string
           description: The user-supplied name for the runtime
-        googleProject:
-          type: string
-          description: Deprecated. The Google Project used to create the runtime
         cloudContext:
           $ref: '#/components/schemas/CloudContext'
         serviceAccount:
@@ -1723,9 +1720,6 @@ components:
         runtimeName:
           type: string
           description: The user-supplied name for the runtime
-        googleProject:
-          type: string
-          description: Deprecated. The Google Project used to create the runtime
         cloudContext:
           $ref: '#/components/schemas/CloudContext'
         runtimeConfig:
@@ -1762,9 +1756,6 @@ components:
         id:
           type: integer
           description: Internal Leonardo ID of the persistent disk
-        googleProject:
-          type: string
-          description: Deprecated. The Google Project used to create the persistent disk
         cloudContext:
           $ref: '#/components/schemas/CloudContext'
         zone:
@@ -1808,9 +1799,6 @@ components:
         id:
           type: integer
           description: Internal Leonardo ID of the persistent disk
-        googleProject:
-          type: string
-          description: Deprecated. The Google Project used to create the persistent disk
         cloudContext:
           $ref: '#/components/schemas/CloudContext'
         zone:
@@ -2543,9 +2531,6 @@ components:
         - auditInfo
       type: object
       properties:
-        googleProject:
-          type: string
-          description: Deprecated. The project this app is associated with
         cloudContext:
           $ref: '#/components/schemas/CloudContext'
         kubernetesRuntimeConfig:

--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -109,7 +109,7 @@ public class DisksControllerTest {
   }
 
   @Test
-  public void test_getDisk() throws ApiException {
+  public void test_getDisk() {
     String createDate = "2021-08-06T16:57:29.827954Z";
     String pdName = "pdName";
     LeonardoGetPersistentDiskResponse getResponse =
@@ -119,7 +119,10 @@ public class DisksControllerTest {
             .diskType(LeonardoDiskType.STANDARD)
             .status(LeonardoDiskStatus.READY)
             .auditInfo(new LeonardoAuditInfo().createdDate(createDate).creator(user.getUsername()))
-            .googleProject(GOOGLE_PROJECT_ID);
+            .cloudContext(
+                new LeonardoCloudContext()
+                    .cloudProvider(LeonardoCloudProvider.GCP)
+                    .cloudResource(GOOGLE_PROJECT_ID));
 
     Disk disk =
         new Disk()
@@ -147,7 +150,10 @@ public class DisksControllerTest {
             .diskType(LeonardoDiskType.STANDARD)
             .status(LeonardoDiskStatus.READY)
             .auditInfo(new LeonardoAuditInfo().createdDate(createDate).creator(user.getUsername()))
-            .googleProject(GOOGLE_PROJECT_ID);
+            .cloudContext(
+                new LeonardoCloudContext()
+                    .cloudProvider(LeonardoCloudProvider.GCP)
+                    .cloudResource(GOOGLE_PROJECT_ID));
 
     when(mockLeonardoApiClient.getPersistentDisk(GOOGLE_PROJECT_ID, pdName))
         .thenReturn(getResponse);

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
@@ -151,7 +151,10 @@ public class OfflineRuntimeControllerTest {
     // each runtime created per test.
     return new LeonardoGetRuntimeResponse()
         .runtimeName("all-of-us")
-        .googleProject(String.format("proj-%d", runtimeProjectIdIndex++))
+        .cloudContext(
+            new LeonardoCloudContext()
+                .cloudProvider(LeonardoCloudProvider.GCP)
+                .cloudResource(String.format("proj-%d", runtimeProjectIdIndex++)))
         .status(LeonardoRuntimeStatus.RUNNING)
         .auditInfo(
             new LeonardoAuditInfo()

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -220,7 +220,10 @@ public class WorkspaceAdminServiceTest {
     testLeoRuntimeDifferentProject =
         new LeonardoGetRuntimeResponse()
             .runtimeName(EXTRA_RUNTIME_NAME_DIFFERENT_PROJECT)
-            .googleProject(GOOGLE_PROJECT_ID_2)
+            .cloudContext(
+                new LeonardoCloudContext()
+                    .cloudProvider(LeonardoCloudProvider.GCP)
+                    .cloudResource(GOOGLE_PROJECT_ID_2))
             .status(LeonardoRuntimeStatus.RUNNING)
             .auditInfo(new LeonardoAuditInfo().createdDate(CREATED_DATE));
   }


### PR DESCRIPTION
We may accidentally use fields which exist - so it's better to remove them entirely.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
