### PR TITLE
[RW-10031][risk=no] Periodically refresh the Leo cookie

### DIFF
--- a/e2ev2/src/utils.js
+++ b/e2ev2/src/utils.js
@@ -107,3 +107,10 @@ export_({readStream})
 const denseDateTime = () =>
   (new Date()).toISOString().slice(0, 'XXXX-XX-XXTXX:XX'.length).replace(/[-T:]/g, '')
 export_({denseDateTime})
+
+// Currently, we don't mock Leo requests so the setCookie request always fails. This hack dismisses the error modal
+// and should be removed when we mock Leo requests.
+const dismissLeoAuthErrorModal = (page) => {
+  return page.waitForXPath("//div[@role='dialog']//div[@role='button'][contains(., 'OK')]").then(b => b.click());
+}
+export_({dismissLeoAuthErrorModal})

--- a/e2ev2/tests/new-user-satisfaction-survey.test.js
+++ b/e2ev2/tests/new-user-satisfaction-survey.test.js
@@ -1,5 +1,6 @@
 const config = require('../src/config')
 const tu = require('../src/test-utils')
+const utils = require('../src/utils')
 
 const browserTest = tu.browserTest(__filename)
 
@@ -18,6 +19,7 @@ browserTest('take the new user satisfaction survey via the relevant notification
   await tu.useApiProxy(page)
   await tu.fakeSignIn(page)
   await page.goto(config.urlRoot())
+  await utils.dismissLeoAuthErrorModal(page);
 
   const surveyNotification = await page.waitForSelector('[data-test-id="new-user-satisfaction-survey-notification"]');
   await surveyNotification.waitForSelector('[aria-label="take satisfaction survey"]').then(b => b.click());

--- a/e2ev2/tests/sanity.browser.test.js
+++ b/e2ev2/tests/sanity.browser.test.js
@@ -1,5 +1,6 @@
 const config = require('../src/config')
 const tu = require('../src/test-utils')
+const utils = require("../src/utils");
 
 const browserTest = tu.browserTest(__filename)
 

--- a/e2ev2/tests/workspace-analysis.test.js
+++ b/e2ev2/tests/workspace-analysis.test.js
@@ -1,5 +1,6 @@
 const config = require('../src/config')
 const tu = require('../src/test-utils')
+const utils = require("../src/utils");
 
 const browserTest = tu.browserTest(__filename)
 
@@ -7,7 +8,9 @@ const navigateToNewAnalysisPage = async (browser) => {
   const page = browser.initialPage
   await tu.useApiProxy(page)
   await tu.fakeSignIn(page)
+  await utils.dismissLeoAuthErrorModal(page);
   await page.goto(config.urlRoot()+'/workspaces/aou-rw-test-53ff4756/mohstest/data')
+  await utils.dismissLeoAuthErrorModal(page);
   const newAnalysisTab = await page.waitForSelector('div[role="button"][aria-label="Analysis (New)"]')
   await newAnalysisTab.click()
   return page

--- a/e2ev2/tests/workspace-create.test.js
+++ b/e2ev2/tests/workspace-create.test.js
@@ -3,6 +3,7 @@ const config = require('../src/config')
 const impersonate = require('../src/impersonate')
 const tu = require('../src/test-utils')
 const u = require('../src/utils')
+const utils = require("../src/utils");
 
 const browserTest = tu.browserTest(__filename)
 
@@ -13,6 +14,7 @@ browserTest('create a workspace', async browser => {
   await tu.useApiProxy(page)
   await tu.fakeSignIn(page)
   await page.goto(config.urlRoot())
+  await utils.dismissLeoAuthErrorModal(page);
 
   // Workspace creation isn't really available until billing accounts have been fetched.
   const [baEventPromise] = await tu.promiseWindowEvent(page, 'billing-accounts-loaded')

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -10,7 +10,6 @@ import {
 } from 'generated/fetch';
 
 import {
-  leoProxyApi,
   leoRuntimesApi,
   registerApiClient as leoRegisterApiClient,
 } from 'app/services/notebooks-swagger-fetch-clients';
@@ -81,6 +80,12 @@ describe('ExpandedApp', () => {
       runtime: runtimeStub.runtime,
       runtimeLoaded: true,
     });
+
+    window.open = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should allow pausing when the Jupyter app is Running', async () => {
@@ -345,11 +350,21 @@ describe('ExpandedApp', () => {
 
   it('should allow launching RStudio when the RStudio app status is RUNNING', async () => {
     const appName = 'my-app';
+    const proxyUrl = 'https://example.com';
     const wrapper = await component(UIAppType.RSTUDIO, {
       appName,
       googleProject,
       status: AppStatus.RUNNING,
+      proxyUrls: {
+        rstudio: proxyUrl,
+      },
     });
+
+    const focusStub = jest.fn();
+    const windowOpenSpy = jest
+      .spyOn(window, 'open')
+      // @ts-ignore
+      .mockReturnValue({ focus: focusStub });
 
     const launchButton = wrapper.find({
       'data-test-id': 'RStudio-launch-button',
@@ -357,10 +372,10 @@ describe('ExpandedApp', () => {
     expect(launchButton.exists()).toBeTruthy();
     expect(launchButton.prop('disabled')).toBeFalsy();
 
-    const setCookieSpy = jest.spyOn(leoProxyApi(), 'setCookie');
     launchButton.simulate('click');
 
-    expect(setCookieSpy).toHaveBeenCalledWith({ credentials: 'include' });
+    expect(windowOpenSpy).toHaveBeenCalledWith(proxyUrl, '_blank');
+    expect(focusStub).toHaveBeenCalled();
   });
 
   describe('should disable the launch button when the RStudio app status is not RUNNING', () => {
@@ -378,26 +393,6 @@ describe('ExpandedApp', () => {
         });
         expect(launchButton.prop('disabled')).toBeTruthy();
       }
-    );
-  });
-
-  it('should show an error if launching RStudio fails', async () => {
-    const wrapper = await component(UIAppType.RSTUDIO, {
-      appName: 'my-app',
-      googleProject,
-      status: AppStatus.RUNNING,
-    });
-
-    leoProxyApiStub.setCookie = () => Promise.reject();
-    wrapper
-      .find({
-        'data-test-id': 'RStudio-launch-button',
-      })
-      .simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(notificationStore.get().title).toEqual(
-      'Error Opening RStudio Environment'
     );
   });
 

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -363,8 +363,7 @@ describe('ExpandedApp', () => {
     const focusStub = jest.fn();
     const windowOpenSpy = jest
       .spyOn(window, 'open')
-      // @ts-ignore
-      .mockReturnValue({ focus: focusStub });
+      .mockReturnValue({ focus: focusStub } as any as Window);
 
     const launchButton = wrapper.find({
       'data-test-id': 'RStudio-launch-button',

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -18,7 +18,6 @@ import { cromwellConfigIconId } from 'app/components/help-sidebar-icons';
 import { withErrorModal } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
 import { RuntimeStatusIndicator } from 'app/components/runtime-status-indicator';
-import { leoProxyApi } from 'app/services/notebooks-swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { cond, reactStyles } from 'app/utils';
 import { setSidebarActiveIconStore } from 'app/utils/navigation';
@@ -171,18 +170,9 @@ const RStudioButtonRow = (props: {
     }
   );
 
-  const onClickLaunch = withErrorModal(
-    {
-      title: 'Error Opening RStudio Environment',
-      message: 'Please try again.',
-    },
-    async () => {
-      await leoProxyApi().setCookie({
-        credentials: 'include',
-      });
-      window.open(userApp.proxyUrls.rstudio, '_blank').focus();
-    }
-  );
+  const onClickLaunch = () => {
+    window.open(userApp.proxyUrls.rstudio, '_blank').focus();
+  };
 
   const createButtonDisabled = creating || !canCreateApp(userApp);
   const launchButtonDisabled = userApp?.status !== AppStatus.RUNNING;

--- a/ui/src/app/components/with-leo-cookie.spec.tsx
+++ b/ui/src/app/components/with-leo-cookie.spec.tsx
@@ -1,0 +1,167 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import { withLeoCookie } from 'app/components/with-leo-cookie';
+import {
+  leoProxyApi,
+  registerApiClient as leoRegisterApiClient,
+} from 'app/services/notebooks-swagger-fetch-clients';
+import { authStore, notificationStore } from 'app/utils/stores';
+import { ProxyApi } from 'notebooks-generated/fetch';
+
+import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
+import { LeoProxyApiStub } from 'testing/stubs/leo-proxy-api-stub';
+
+const createWrapper = () => {
+  const Component = () => <div />;
+  const WrappedComponent = withLeoCookie(Component);
+  return mount(<WrappedComponent />);
+};
+
+describe(withLeoCookie.name, () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    const leoProxyApiStub = new LeoProxyApiStub();
+    leoRegisterApiClient(ProxyApi, leoProxyApiStub);
+
+    authStore.set({
+      authLoaded: true,
+      isSignedIn: true,
+      auth: {
+        // @ts-ignore
+        settings: {
+          accessTokenExpiringNotificationTimeInSeconds: 500,
+        },
+      },
+    });
+    notificationStore.set(null);
+  });
+
+  it('should render the children once the cookie loads', async () => {
+    const setCookieStub = jest
+      .spyOn(leoProxyApi(), 'setCookie')
+      .mockResolvedValue(null);
+
+    const Component = () => <div />;
+    const WrappedComponent = withLeoCookie(Component);
+    const wrapper = mount(<WrappedComponent />);
+
+    expect(setCookieStub).toHaveBeenCalled();
+
+    // Children should not be rendered until the cookie loads
+    expect(wrapper.find(Component).exists()).toBeFalsy();
+
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(wrapper.find(Component).exists()).toBeTruthy();
+  });
+
+  it('should show an error notification if the cookie fails to load', async () => {
+    const setCookieStub = jest
+      .spyOn(leoProxyApi(), 'setCookie')
+      .mockRejectedValue(null);
+
+    const wrapper = createWrapper();
+
+    expect(setCookieStub).toHaveBeenCalled();
+
+    // Notification should not be shown until the cookie loads
+    expect(notificationStore.get()).toBeNull();
+
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(notificationStore.get()).not.toBeNull();
+  });
+
+  it('should not show an error notification if the cookie loads successfully', async () => {
+    const setCookieStub = jest
+      .spyOn(leoProxyApi(), 'setCookie')
+      .mockResolvedValue(null);
+
+    const wrapper = createWrapper();
+
+    expect(setCookieStub).toHaveBeenCalled();
+
+    // Notification should not be shown until the cookie loads
+    expect(notificationStore.get()).toBeNull();
+
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(notificationStore.get()).toBeNull();
+  });
+
+  it('should periodically refresh the cookie', async () => {
+    const authRefreshPeriodSeconds = 500;
+    const expectedCookieRefreshPeriodMs =
+      (authRefreshPeriodSeconds - 30) * 1000;
+
+    authStore.set({
+      ...authStore.get(),
+      auth: {
+        ...authStore.get().auth,
+        settings: {
+          ...authStore.get().auth.settings,
+          accessTokenExpiringNotificationTimeInSeconds:
+            authRefreshPeriodSeconds,
+        },
+      },
+    });
+
+    const setCookieStub = jest
+      .spyOn(leoProxyApi(), 'setCookie')
+      .mockResolvedValue(null);
+
+    const wrapper = createWrapper();
+
+    expect(setCookieStub).toHaveBeenCalledTimes(1);
+
+    // check that we don't immediately refresh the cookie
+    jest.advanceTimersByTime(expectedCookieRefreshPeriodMs - 1);
+    await waitOneTickAndUpdate(wrapper);
+    expect(setCookieStub).toHaveBeenCalledTimes(1);
+
+    // the cookie refreshes after the expected refresh period
+    jest.advanceTimersByTime(1);
+    await waitOneTickAndUpdate(wrapper);
+    expect(setCookieStub).toHaveBeenCalledTimes(2);
+
+    // the cookie refreshes again after the expected refresh period
+    jest.advanceTimersByTime(expectedCookieRefreshPeriodMs);
+    await waitOneTickAndUpdate(wrapper);
+    expect(setCookieStub).toHaveBeenCalledTimes(3);
+  });
+
+  it('should stop periodically refreshing the cookie after unmounting', async () => {
+    const authRefreshPeriodSeconds = 500;
+    const expectedCookieRefreshPeriodMs =
+      (authRefreshPeriodSeconds - 30) * 1000;
+
+    authStore.set({
+      ...authStore.get(),
+      auth: {
+        ...authStore.get().auth,
+        settings: {
+          ...authStore.get().auth.settings,
+          accessTokenExpiringNotificationTimeInSeconds:
+            authRefreshPeriodSeconds,
+        },
+      },
+    });
+
+    const setCookieStub = jest
+      .spyOn(leoProxyApi(), 'setCookie')
+      .mockResolvedValue(null);
+
+    const wrapper = createWrapper();
+
+    expect(setCookieStub).toHaveBeenCalledTimes(1);
+
+    wrapper.unmount();
+
+    // the cookie does not refresh again
+    jest.advanceTimersByTime(expectedCookieRefreshPeriodMs);
+    await waitOneTickAndUpdate(wrapper);
+    expect(setCookieStub).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/app/components/with-leo-cookie.tsx
+++ b/ui/src/app/components/with-leo-cookie.tsx
@@ -13,7 +13,6 @@ const LeoCookieWrapper = ({ children }) => {
     const pollAborter = new AbortController();
 
     const setLeoCookie = () => {
-      console.log('setting cookie');
       leoProxyApi()
         .setCookie({
           withCredentials: true,
@@ -34,7 +33,6 @@ const LeoCookieWrapper = ({ children }) => {
           });
         })
         .finally(() => {
-          console.log('Done setting cookie.');
           setLoading(false);
         });
     };
@@ -54,7 +52,6 @@ const LeoCookieWrapper = ({ children }) => {
 
     return () => {
       clearTimeout(timer);
-      console.log('aborting');
       pollAborter.abort();
     };
   }, []);

--- a/ui/src/app/components/with-leo-cookie.tsx
+++ b/ui/src/app/components/with-leo-cookie.tsx
@@ -42,6 +42,12 @@ const LeoCookieWrapper = ({ children }) => {
     setLeoCookie();
     const timer = setInterval(
       setLeoCookie,
+      // The Leo cookie is associated with an access token and expires when the access token expires.
+      // When we refresh a soon-to-expire access token "X" to obtain access token "Y", there is a small window of time
+      // equal to accessTokenExpiringNotificationTimeInSeconds where both tokens are valid.
+      // The Leo refresh interval must be shorter than this window to prevent an edge case where the cookie expires
+      // before we associate the cookie with Y.
+      // This implementation is based on Terra UI's implementation:
       // https://github.com/DataBiosphere/terra-ui/blob/356f27342ff44d322b2b52077fa4efb1c5f920ce/src/libs/auth.js#LL49C10-L49C10
       (auth.settings.accessTokenExpiringNotificationTimeInSeconds - 30) * 1000
     );

--- a/ui/src/app/components/with-leo-cookie.tsx
+++ b/ui/src/app/components/with-leo-cookie.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+
+import { leoProxyApi } from 'app/services/notebooks-swagger-fetch-clients';
+import { authStore, notificationStore, useStore } from 'app/utils/stores';
+
+const LeoCookieWrapper = ({ children }) => {
+  const { auth } = useStore(authStore);
+
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const pollAborter = new AbortController();
+
+    const setLeoCookie = () => {
+      console.log('setting cookie');
+      leoProxyApi()
+        .setCookie({
+          withCredentials: true,
+          crossDomain: true,
+          credentials: 'include',
+          signal: pollAborter.signal,
+        })
+        .catch(() => {
+          if (pollAborter.signal.aborted) {
+            return;
+          }
+
+          notificationStore.set({
+            title: 'Authentication Error',
+            message:
+              'There was an error authenticating with the environments server. Please refresh the page.',
+            showBugReportLink: true,
+          });
+        })
+        .finally(() => {
+          console.log('Done setting cookie.');
+          setLoading(false);
+        });
+    };
+
+    setLeoCookie();
+    const timer = setInterval(
+      setLeoCookie,
+      // https://github.com/DataBiosphere/terra-ui/blob/356f27342ff44d322b2b52077fa4efb1c5f920ce/src/libs/auth.js#LL49C10-L49C10
+      (auth.settings.accessTokenExpiringNotificationTimeInSeconds - 30) * 1000
+    );
+
+    return () => {
+      clearTimeout(timer);
+      console.log('aborting');
+      pollAborter.abort();
+    };
+  }, []);
+
+  if (loading) {
+    return null;
+  }
+
+  return children;
+};
+
+export const withLeoCookie = (WrappedComponent) => {
+  return (props) => (
+    <LeoCookieWrapper>
+      <WrappedComponent {...props} />
+    </LeoCookieWrapper>
+  );
+};

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -460,17 +460,6 @@ export const LeonardoAppLauncher = fp.flow(
       return appendNotebookFileSuffix(this.getNotebookName());
     }
 
-    private async initializeNotebookCookies() {
-      return await this.runtimeRetry(() =>
-        leoProxyApi().setCookie({
-          withCredentials: true,
-          crossDomain: true,
-          credentials: 'include',
-          signal: this.pollAborter.signal,
-        })
-      );
-    }
-
     private incrementProgress(p: Progress): void {
       this.setState((state) => ({
         progress: p,
@@ -578,7 +567,6 @@ export const LeonardoAppLauncher = fp.flow(
     private async connectToRunningRuntime(runtime: Runtime) {
       const { namespace, id } = this.props.workspace;
       this.incrementProgress(Progress.Authenticating);
-      await this.initializeNotebookCookies();
 
       const leoAppLocation = await this.getLeoAppPathAndLocalize(runtime);
       if (this.isCreatingNewNotebook()) {

--- a/ui/src/app/routing/app-routing.tsx
+++ b/ui/src/app/routing/app-routing.tsx
@@ -12,6 +12,7 @@ import { AppRoute, AppRouter, withRouteData } from 'app/components/app-router';
 import { SignedInAouHeaderWithDisplayTag } from 'app/components/headers';
 import { NotificationModal } from 'app/components/modals';
 import { TermsOfService } from 'app/components/terms-of-service';
+import { withLeoCookie } from 'app/components/with-leo-cookie';
 import { withRoutingSpinner } from 'app/components/with-routing-spinner';
 import { CookiePolicy } from 'app/pages/cookie-policy';
 import { SignIn } from 'app/pages/login/sign-in';
@@ -58,7 +59,11 @@ const SessionExpiredPage = fp.flow(
   withRouteData,
   withRoutingSpinner
 )(SessionExpired);
-const SignedInPage = fp.flow(withRouteData, withRoutingSpinner)(SignedIn);
+const SignedInPage = fp.flow(
+  withRouteData,
+  withRoutingSpinner,
+  withLeoCookie
+)(SignedIn);
 const SignInAgainPage = fp.flow(withRouteData, withRoutingSpinner)(SignInAgain);
 const SignInPage = fp.flow(withRouteData, withRoutingSpinner)(SignIn);
 const UserDisabledPage = fp.flow(

--- a/ui/src/app/utils/authentication.tsx
+++ b/ui/src/app/utils/authentication.tsx
@@ -71,6 +71,8 @@ export const makeOIDC = (config: ConfigResponse): AuthProviderProps => {
     onSigninCallback: (_user: User | void): void => {
       window.history.replaceState({}, document.title, window.location.pathname);
     },
+    // https://github.com/DataBiosphere/terra-ui/blob/356f27342ff44d322b2b52077fa4efb1c5f920ce/src/libs/auth.js#LL49C10-L49C10
+    accessTokenExpiringNotificationTimeInSeconds: 330,
   };
 };
 

--- a/ui/src/app/utils/authentication.tsx
+++ b/ui/src/app/utils/authentication.tsx
@@ -71,7 +71,8 @@ export const makeOIDC = (config: ConfigResponse): AuthProviderProps => {
     onSigninCallback: (_user: User | void): void => {
       window.history.replaceState({}, document.title, window.location.pathname);
     },
-    // https://github.com/DataBiosphere/terra-ui/blob/356f27342ff44d322b2b52077fa4efb1c5f920ce/src/libs/auth.js#LL49C10-L49C10
+    // This setting reduces the token refresh interval to 54.5 minutes (= 60 minutes - 330 seconds).
+    // See the use of accessTokenExpiringNotificationTimeInSeconds in the Leo cookie-setting code for why we do this.
     accessTokenExpiringNotificationTimeInSeconds: 330,
   };
 };


### PR DESCRIPTION
Periodically refreshes the Leo cookie to match Terra's implementation. This removes our reliance on the [Jupyter auth extension](https://github.com/DataBiosphere/terra-docker/blob/c762c950896983e760015460ab9a29ab9411e249/terra-jupyter-base/custom/google_sign_in.js).

[This thread](https://broadinstitute.slack.com/archives/CA3NP1733/p1683126985418719) provides additional background info.

Unfortunately, this does not fully resolve the problem because there is still contention between the extension and our implementation. To completely fix the bug we will need to remove our reliance on the extension. After merging this, I will find a way to remove the contention with the extension (Terra is not impacted by this contention but I haven't investigated why yet) or deprecate the extension entirely.

To manually test this, load any page and observe the `setCookie` endpoint being called every five minutes.

We could use `withLeoCookie` only on the pages that actually need it. However, I think converging on their approach is acceptable to alleviate the "it works in Terra" problem we're running into with auth.

[Relevant #workbench-ux thread](https://pmi-engteam.slack.com/archives/C02MWP2RN5P/p1683665947528789).

**Manually testing the AbortController**

Testing the abort behavior with an automated test is difficult for reasons described [here](https://github.com/all-of-us/workbench/pull/7664). Instead, I have tested this manually.

See my testing process described [here](https://github.com/all-of-us/workbench/pull/7664). However, in order to unmount the component before the page loads, I added `<Link to='/not-found'>TEST UNMOUNT ABORT</Link>` immediately below the `<AppRouter>` line in `ui/src/app/routing/app-routing.tsx`. Clicking on that while the request is pending will trigger an abort.

**Screenshots**

Existing behavior: When `setCookie` fails for Jupyter:
![image](https://github.com/all-of-us/workbench/assets/31020403/dcb7bf97-4c89-4e79-ac97-07a7cd45a245)

New behavior: When `setCookie` fails (not app-specific):
![image (1)](https://github.com/all-of-us/workbench/assets/31020403/905866f4-cc5c-4c55-9d44-f43460699435)

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
