### PR TITLE
[RW-9990][risk=no]Updated controller function name in order to allow for more specificity in upcoming disk controller functions.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DisksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DisksController.java
@@ -68,7 +68,7 @@ public class DisksController implements DisksApiDelegate {
   }
 
   @Override
-  public ResponseEntity<ListDisksResponse> listDisksInWorkspace(String workspaceNamespace) {
+  public ResponseEntity<ListDisksResponse> listOwnedDisksInWorkspace(String workspaceNamespace) {
     String googleProject =
         workspaceService.lookupWorkspaceByNamespace(workspaceNamespace).getGoogleProject();
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -976,7 +976,7 @@ paths:
   "/v1/workspaces/{workspaceNamespace}/disks":
     get:
       summary: Lists persistent disks in the user's workspace. Only disks in READY/CREATING/RESTORING state will be returned.
-      operationId: listDisksInWorkspace
+      operationId: listOwnedDisksInWorkspace
       tags:
         - disks
       parameters:

--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -166,7 +166,7 @@ public class DisksControllerTest {
   }
 
   @Test
-  public void test_listDisksInWorkspace() throws ApiException {
+  public void test_listOwnedDisksInWorkspace() throws ApiException {
     // RStudio Disk: 3 are active, returns the newest one.
     LeonardoListPersistentDiskResponse oldRstudioDisk =
         newListPdResponse(
@@ -237,7 +237,7 @@ public class DisksControllerTest {
                 oldInactiveCromwellDisk,
                 newerCromwellDisk));
 
-    assertThat(disksController.listDisksInWorkspace(WORKSPACE_NS).getBody())
+    assertThat(disksController.listOwnedDisksInWorkspace(WORKSPACE_NS).getBody())
         .containsExactly(expectedGceDisk, expectedRStudioDisk);
   }
 

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -938,7 +938,7 @@ export const useDisk = (currentWorkspaceNamespace: string) => {
       async () => {
         let gcePersistentDisk: Disk = null;
         try {
-          const availableDisks = await disksApi().listDisksInWorkspace(
+          const availableDisks = await disksApi().listOwnedDisksInWorkspace(
             currentWorkspaceNamespace
           );
           gcePersistentDisk = availableDisks.find(

--- a/ui/src/testing/stubs/disks-api-stub.ts
+++ b/ui/src/testing/stubs/disks-api-stub.ts
@@ -37,7 +37,7 @@ export class DisksApiStub extends DisksApi {
     });
   }
 
-  listDisksInWorkspace(
+  listOwnedDisksInWorkspace(
     _workspaceNamespace: string,
     _options?: any
   ): Promise<ListDisksResponse> {


### PR DESCRIPTION
Wanted to rename this function, because in a separate PR, I would like to add a separate function that lists all disks in a workspace (not just disks owned by user). The function that I am renaming (listDisksInWorkspace) is ambiguous when we have functions. I am renaming the existing function to listOwnedDisksInWorkspace. I am open to different names if you prefer something different.

Tested by starting a runtime a viewing that the cost in the runtime tab are properly loaded. This indicates that the diskstore is being properly loaded.
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
