### PR TITLE
[RW-9990][risk=no] Moved LeonardoListPersistentDiskResponse mocking to TestMockFactory.

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -6,12 +6,10 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE;
+import static org.pmiops.workbench.utils.TestMockFactory.createLeonardoListPersistentDiskResponse;
 
 import com.google.common.collect.ImmutableList;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -175,23 +173,29 @@ public class DisksControllerTest {
   public void test_listOwnedDisksInWorkspace() throws ApiException {
     // RStudio Disk: 3 are active, returns the newest one.
     LeonardoListPersistentDiskResponse oldRstudioDisk =
-        newListPdResponse(
+        createLeonardoListPersistentDiskResponse(
             user.generatePDNameForUserApps(AppType.RSTUDIO),
             LeonardoDiskStatus.READY,
             NOW.minusSeconds(100).toString(),
-            AppType.RSTUDIO);
+            AppType.RSTUDIO,
+            GOOGLE_PROJECT_ID,
+            user);
     LeonardoListPersistentDiskResponse newestRstudioDisk =
-        newListPdResponse(
+        createLeonardoListPersistentDiskResponse(
             user.generatePDNameForUserApps(AppType.RSTUDIO),
             LeonardoDiskStatus.READY,
             NOW.toString(),
-            AppType.RSTUDIO);
+            AppType.RSTUDIO,
+            GOOGLE_PROJECT_ID,
+            user);
     LeonardoListPersistentDiskResponse olderRstudioDisk =
-        newListPdResponse(
+        createLeonardoListPersistentDiskResponse(
             user.generatePDNameForUserApps(AppType.RSTUDIO),
             LeonardoDiskStatus.READY,
             NOW.minusSeconds(200).toString(),
-            AppType.RSTUDIO);
+            AppType.RSTUDIO,
+            GOOGLE_PROJECT_ID,
+            user);
     Disk expectedRStudioDisk =
         newDisk(
             newestRstudioDisk.getName(),
@@ -202,13 +206,29 @@ public class DisksControllerTest {
     // GCE Disk: 3 disks in total, 2 are active, newer one is inactive, returns the most recent
     // active ones.
     LeonardoListPersistentDiskResponse olderGceDisk =
-        newListPdResponse(
-            user.generatePDName(), LeonardoDiskStatus.READY, NOW.minusMillis(200).toString(), null);
+        createLeonardoListPersistentDiskResponse(
+            user.generatePDName(),
+            LeonardoDiskStatus.READY,
+            NOW.minusMillis(200).toString(),
+            null,
+            GOOGLE_PROJECT_ID,
+            user);
     LeonardoListPersistentDiskResponse oldGceDisk =
-        newListPdResponse(
-            user.generatePDName(), LeonardoDiskStatus.READY, NOW.minusMillis(100).toString(), null);
+        createLeonardoListPersistentDiskResponse(
+            user.generatePDName(),
+            LeonardoDiskStatus.READY,
+            NOW.minusMillis(100).toString(),
+            null,
+            GOOGLE_PROJECT_ID,
+            user);
     LeonardoListPersistentDiskResponse newerInactiveGceDisk =
-        newListPdResponse(user.generatePDName(), LeonardoDiskStatus.DELETING, NOW.toString(), null);
+        createLeonardoListPersistentDiskResponse(
+            user.generatePDName(),
+            LeonardoDiskStatus.DELETING,
+            NOW.toString(),
+            null,
+            GOOGLE_PROJECT_ID,
+            user);
     Disk expectedGceDisk =
         newDisk(
             oldGceDisk.getName(),
@@ -218,17 +238,21 @@ public class DisksControllerTest {
 
     // Cromwell Disk: both are inactive, nothing to return.
     LeonardoListPersistentDiskResponse oldInactiveCromwellDisk =
-        newListPdResponse(
+        createLeonardoListPersistentDiskResponse(
             user.generatePDNameForUserApps(AppType.CROMWELL),
             LeonardoDiskStatus.DELETING,
             NOW.minusMillis(100).toString(),
-            AppType.CROMWELL);
+            AppType.CROMWELL,
+            GOOGLE_PROJECT_ID,
+            user);
     LeonardoListPersistentDiskResponse newerCromwellDisk =
-        newListPdResponse(
+        createLeonardoListPersistentDiskResponse(
             user.generatePDNameForUserApps(AppType.CROMWELL),
             LeonardoDiskStatus.DELETED,
             NOW.toString(),
-            AppType.CROMWELL);
+            AppType.CROMWELL,
+            GOOGLE_PROJECT_ID,
+            user);
 
     when(mockLeonardoApiClient.listPersistentDiskByProjectCreatedByCreator(
             GOOGLE_PROJECT_ID, false))
@@ -308,27 +332,6 @@ public class DisksControllerTest {
         .deletePersistentDisk(GOOGLE_PROJECT_ID, diskName);
 
     assertThrows(NotFoundException.class, () -> disksController.deleteDisk(WORKSPACE_NS, diskName));
-  }
-
-  private LeonardoListPersistentDiskResponse newListPdResponse(
-      String pdName, LeonardoDiskStatus status, String date, @Nullable AppType appType) {
-    LeonardoListPersistentDiskResponse response =
-        new LeonardoListPersistentDiskResponse()
-            .name(pdName)
-            .size(300)
-            .diskType(LeonardoDiskType.STANDARD)
-            .status(status)
-            .auditInfo(new LeonardoAuditInfo().createdDate(date).creator(user.getUsername()))
-            .cloudContext(
-                new LeonardoCloudContext()
-                    .cloudProvider(LeonardoCloudProvider.GCP)
-                    .cloudResource(GOOGLE_PROJECT_ID));
-    if (appType != null) {
-      Map<String, String> label = new HashMap<>();
-      label.put(LEONARDO_LABEL_APP_TYPE, appType.toString().toLowerCase());
-      response.labels(label);
-    }
-    return response;
   }
 
   private Disk newDisk(String pdName, DiskStatus status, String date, @Nullable AppType appType) {

--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.utils.TestMockFactory.createLeonardoListPersistentDiskResponse;
+import static org.pmiops.workbench.utils.TestMockFactory.createLeonardoListRuntimePDResponse;
 
 import com.google.common.collect.ImmutableList;
 import java.time.Instant;
@@ -21,7 +22,6 @@ import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.NotFoundException;
-import org.pmiops.workbench.leonardo.ApiException;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.LeonardoApiHelper;
 import org.pmiops.workbench.leonardo.model.LeonardoAuditInfo;
@@ -170,32 +170,32 @@ public class DisksControllerTest {
   }
 
   @Test
-  public void test_listOwnedDisksInWorkspace() throws ApiException {
+  public void test_listOwnedDisksInWorkspace() {
     // RStudio Disk: 3 are active, returns the newest one.
     LeonardoListPersistentDiskResponse oldRstudioDisk =
         createLeonardoListPersistentDiskResponse(
             user.generatePDNameForUserApps(AppType.RSTUDIO),
             LeonardoDiskStatus.READY,
             NOW.minusSeconds(100).toString(),
-            AppType.RSTUDIO,
             GOOGLE_PROJECT_ID,
-            user);
+            user,
+            AppType.RSTUDIO);
     LeonardoListPersistentDiskResponse newestRstudioDisk =
         createLeonardoListPersistentDiskResponse(
             user.generatePDNameForUserApps(AppType.RSTUDIO),
             LeonardoDiskStatus.READY,
             NOW.toString(),
-            AppType.RSTUDIO,
             GOOGLE_PROJECT_ID,
-            user);
+            user,
+            AppType.RSTUDIO);
     LeonardoListPersistentDiskResponse olderRstudioDisk =
         createLeonardoListPersistentDiskResponse(
             user.generatePDNameForUserApps(AppType.RSTUDIO),
             LeonardoDiskStatus.READY,
             NOW.minusSeconds(200).toString(),
-            AppType.RSTUDIO,
             GOOGLE_PROJECT_ID,
-            user);
+            user,
+            AppType.RSTUDIO);
     Disk expectedRStudioDisk =
         newDisk(
             newestRstudioDisk.getName(),
@@ -206,27 +206,24 @@ public class DisksControllerTest {
     // GCE Disk: 3 disks in total, 2 are active, newer one is inactive, returns the most recent
     // active ones.
     LeonardoListPersistentDiskResponse olderGceDisk =
-        createLeonardoListPersistentDiskResponse(
+        createLeonardoListRuntimePDResponse(
             user.generatePDName(),
             LeonardoDiskStatus.READY,
             NOW.minusMillis(200).toString(),
-            null,
             GOOGLE_PROJECT_ID,
             user);
     LeonardoListPersistentDiskResponse oldGceDisk =
-        createLeonardoListPersistentDiskResponse(
+        createLeonardoListRuntimePDResponse(
             user.generatePDName(),
             LeonardoDiskStatus.READY,
             NOW.minusMillis(100).toString(),
-            null,
             GOOGLE_PROJECT_ID,
             user);
     LeonardoListPersistentDiskResponse newerInactiveGceDisk =
-        createLeonardoListPersistentDiskResponse(
+        createLeonardoListRuntimePDResponse(
             user.generatePDName(),
             LeonardoDiskStatus.DELETING,
             NOW.toString(),
-            null,
             GOOGLE_PROJECT_ID,
             user);
     Disk expectedGceDisk =
@@ -242,17 +239,17 @@ public class DisksControllerTest {
             user.generatePDNameForUserApps(AppType.CROMWELL),
             LeonardoDiskStatus.DELETING,
             NOW.minusMillis(100).toString(),
-            AppType.CROMWELL,
             GOOGLE_PROJECT_ID,
-            user);
+            user,
+            AppType.CROMWELL);
     LeonardoListPersistentDiskResponse newerCromwellDisk =
         createLeonardoListPersistentDiskResponse(
             user.generatePDNameForUserApps(AppType.CROMWELL),
             LeonardoDiskStatus.DELETED,
             NOW.toString(),
-            AppType.CROMWELL,
             GOOGLE_PROJECT_ID,
-            user);
+            user,
+            AppType.CROMWELL);
 
     when(mockLeonardoApiClient.listPersistentDiskByProjectCreatedByCreator(
             GOOGLE_PROJECT_ID, false))
@@ -272,7 +269,7 @@ public class DisksControllerTest {
   }
 
   @Test
-  public void updateDisk() throws ApiException {
+  public void updateDisk() {
     int diskSize = 200;
     String diskName = user.generatePDName();
     disksController.updateDisk(WORKSPACE_NS, diskName, diskSize);
@@ -307,7 +304,7 @@ public class DisksControllerTest {
   }
 
   @Test
-  public void deleteDisk() throws ApiException {
+  public void deleteDisk() {
     String diskName = user.generatePDName();
     disksController.deleteDisk(WORKSPACE_NS, diskName);
     verify(mockLeonardoApiClient).deletePersistentDisk(GOOGLE_PROJECT_ID, diskName);

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE;
+import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.appTypeToLabelValue;
 
 import com.google.api.services.cloudbilling.Cloudbilling;
 import com.google.api.services.cloudbilling.model.BillingAccount;
@@ -392,18 +393,14 @@ public class TestMockFactory {
                     .cloudResource(googleProjectId));
     if (appType != null) {
       Map<String, String> label = new HashMap<>();
-      label.put(LEONARDO_LABEL_APP_TYPE, appType.toString().toLowerCase());
+      label.put(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(appType));
       response.labels(label);
     }
     return response;
   }
 
   public static LeonardoListPersistentDiskResponse createLeonardoListRuntimePDResponse(
-      String pdName,
-      LeonardoDiskStatus status,
-      String date,
-      String googleProjectId,
-      DbUser user) {
+      String pdName, LeonardoDiskStatus status, String date, String googleProjectId, DbUser user) {
     return createLeonardoListPersistentDiskResponse(
         pdName, status, date, googleProjectId, user, /*appType*/ null);
   }

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE;
 
 import com.google.api.services.cloudbilling.Cloudbilling;
 import com.google.api.services.cloudbilling.model.BillingAccount;
@@ -16,10 +17,13 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.javers.common.collections.Lists;
 import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.db.dao.AccessModuleDao;
@@ -33,10 +37,15 @@ import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudBillingClient;
+import org.pmiops.workbench.leonardo.model.LeonardoAuditInfo;
 import org.pmiops.workbench.leonardo.model.LeonardoCloudContext;
 import org.pmiops.workbench.leonardo.model.LeonardoCloudProvider;
+import org.pmiops.workbench.leonardo.model.LeonardoDiskStatus;
+import org.pmiops.workbench.leonardo.model.LeonardoDiskType;
+import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeStatus;
+import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.DemographicSurveyV2;
 import org.pmiops.workbench.model.DisseminateResearchEnum;
 import org.pmiops.workbench.model.EducationV2;
@@ -361,6 +370,32 @@ public class TestMockFactory {
   public static void assertEqualDemographicSurveys(
       DemographicSurveyV2 survey1, DemographicSurveyV2 survey2) {
     assertThat(normalizeLists(survey1)).isEqualTo(normalizeLists(survey2));
+  }
+
+  public static LeonardoListPersistentDiskResponse createLeonardoListPersistentDiskResponse(
+      String pdName,
+      LeonardoDiskStatus status,
+      String date,
+      @Nullable AppType appType,
+      String googleProjectId,
+      DbUser user) {
+    LeonardoListPersistentDiskResponse response =
+        new LeonardoListPersistentDiskResponse()
+            .name(pdName)
+            .size(300)
+            .diskType(LeonardoDiskType.STANDARD)
+            .status(status)
+            .auditInfo(new LeonardoAuditInfo().createdDate(date).creator(user.getUsername()))
+            .cloudContext(
+                new LeonardoCloudContext()
+                    .cloudProvider(LeonardoCloudProvider.GCP)
+                    .cloudResource(googleProjectId));
+    if (appType != null) {
+      Map<String, String> label = new HashMap<>();
+      label.put(LEONARDO_LABEL_APP_TYPE, appType.toString().toLowerCase());
+      response.labels(label);
+    }
+    return response;
   }
 
   // we make no guarantees about the order of the lists in DemographicSurveyV2

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -376,9 +376,9 @@ public class TestMockFactory {
       String pdName,
       LeonardoDiskStatus status,
       String date,
-      @Nullable AppType appType,
       String googleProjectId,
-      DbUser user) {
+      DbUser user,
+      @Nullable AppType appType) {
     LeonardoListPersistentDiskResponse response =
         new LeonardoListPersistentDiskResponse()
             .name(pdName)
@@ -396,6 +396,16 @@ public class TestMockFactory {
       response.labels(label);
     }
     return response;
+  }
+
+  public static LeonardoListPersistentDiskResponse createLeonardoListRuntimePDResponse(
+      String pdName,
+      LeonardoDiskStatus status,
+      String date,
+      String googleProjectId,
+      DbUser user) {
+    return createLeonardoListPersistentDiskResponse(
+        pdName, status, date, googleProjectId, user, /*appType*/ null);
   }
 
   // we make no guarantees about the order of the lists in DemographicSurveyV2


### PR DESCRIPTION
I want to use the LeoPdResponse mocking function in a service test as well, so I moved it to a more central location.

Ran DisksControllerTest.java locally in order to verify that the change works.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
