### PR TITLE
[RW-9990][risk=no] Moved newDisk into TestMockFactory.

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -8,10 +8,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.utils.TestMockFactory.createLeonardoListPersistentDiskResponse;
 import static org.pmiops.workbench.utils.TestMockFactory.createLeonardoListRuntimePDResponse;
+import static org.pmiops.workbench.utils.TestMockFactory.newDisk;
+import static org.pmiops.workbench.utils.TestMockFactory.newRuntimeDisk;
 
 import com.google.common.collect.ImmutableList;
 import java.time.Instant;
-import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -201,6 +202,7 @@ public class DisksControllerTest {
             newestRstudioDisk.getName(),
             DiskStatus.READY,
             newestRstudioDisk.getAuditInfo().getCreatedDate(),
+            user,
             AppType.RSTUDIO);
 
     // GCE Disk: 3 disks in total, 2 are active, newer one is inactive, returns the most recent
@@ -227,11 +229,11 @@ public class DisksControllerTest {
             GOOGLE_PROJECT_ID,
             user);
     Disk expectedGceDisk =
-        newDisk(
+        newRuntimeDisk(
             oldGceDisk.getName(),
             DiskStatus.READY,
             oldGceDisk.getAuditInfo().getCreatedDate(),
-            null);
+            user);
 
     // Cromwell Disk: both are inactive, nothing to return.
     LeonardoListPersistentDiskResponse oldInactiveCromwellDisk =
@@ -329,23 +331,5 @@ public class DisksControllerTest {
         .deletePersistentDisk(GOOGLE_PROJECT_ID, diskName);
 
     assertThrows(NotFoundException.class, () -> disksController.deleteDisk(WORKSPACE_NS, diskName));
-  }
-
-  private Disk newDisk(String pdName, DiskStatus status, String date, @Nullable AppType appType) {
-
-    Disk disk =
-        new Disk()
-            .name(pdName)
-            .size(300)
-            .diskType(DiskType.STANDARD)
-            .status(status)
-            .createdDate(date)
-            .creator(user.getUsername());
-    if (appType != null) {
-      disk.appType(appType);
-    } else {
-      disk.isGceRuntime(true);
-    }
-    return disk;
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -6,10 +6,10 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.utils.TestMockFactory.createAppDisk;
 import static org.pmiops.workbench.utils.TestMockFactory.createLeonardoListPersistentDiskResponse;
 import static org.pmiops.workbench.utils.TestMockFactory.createLeonardoListRuntimePDResponse;
-import static org.pmiops.workbench.utils.TestMockFactory.newDisk;
-import static org.pmiops.workbench.utils.TestMockFactory.newRuntimeDisk;
+import static org.pmiops.workbench.utils.TestMockFactory.createRuntimeDisk;
 
 import com.google.common.collect.ImmutableList;
 import java.time.Instant;
@@ -198,7 +198,7 @@ public class DisksControllerTest {
             user,
             AppType.RSTUDIO);
     Disk expectedRStudioDisk =
-        newDisk(
+        createAppDisk(
             newestRstudioDisk.getName(),
             DiskStatus.READY,
             newestRstudioDisk.getAuditInfo().getCreatedDate(),
@@ -229,7 +229,7 @@ public class DisksControllerTest {
             GOOGLE_PROJECT_ID,
             user);
     Disk expectedGceDisk =
-        newRuntimeDisk(
+        createRuntimeDisk(
             oldGceDisk.getName(),
             DiskStatus.READY,
             oldGceDisk.getAuditInfo().getCreatedDate(),

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -420,13 +420,11 @@ public class TestMockFactory {
 
   public static Disk createAppDisk(
       String pdName, DiskStatus status, String date, DbUser user, AppType appType) {
-    return createDisk(pdName, status, date, user)
-        .appType(appType);
+    return createDisk(pdName, status, date, user).appType(appType);
   }
 
   public static Disk createRuntimeDisk(String pdName, DiskStatus status, String date, DbUser user) {
-    return createDisk(pdName, status, date, user)
-        .isGceRuntime(true);
+    return createDisk(pdName, status, date, user).isGceRuntime(true);
   }
 
   // we make no guarantees about the order of the lists in DemographicSurveyV2

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -420,15 +420,13 @@ public class TestMockFactory {
 
   public static Disk createAppDisk(
       String pdName, DiskStatus status, String date, DbUser user, AppType appType) {
-    Disk disk = createDisk(pdName, status, date, user);
-    disk.appType(appType);
-    return disk;
+    return createDisk(pdName, status, date, user)
+        .appType(appType);
   }
 
   public static Disk createRuntimeDisk(String pdName, DiskStatus status, String date, DbUser user) {
-    Disk disk = createDisk(pdName, status, date, user);
-    disk.isGceRuntime(true);
-    return disk;
+    return createDisk(pdName, status, date, user)
+        .isGceRuntime(true);
   }
 
   // we make no guarantees about the order of the lists in DemographicSurveyV2

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -48,6 +48,9 @@ import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeStatus;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.DemographicSurveyV2;
+import org.pmiops.workbench.model.Disk;
+import org.pmiops.workbench.model.DiskStatus;
+import org.pmiops.workbench.model.DiskType;
 import org.pmiops.workbench.model.DisseminateResearchEnum;
 import org.pmiops.workbench.model.EducationV2;
 import org.pmiops.workbench.model.EthnicCategory;
@@ -403,6 +406,29 @@ public class TestMockFactory {
       String pdName, LeonardoDiskStatus status, String date, String googleProjectId, DbUser user) {
     return createLeonardoListPersistentDiskResponse(
         pdName, status, date, googleProjectId, user, /*appType*/ null);
+  }
+
+  public static Disk newDisk(
+      String pdName, DiskStatus status, String date, DbUser user, @Nullable AppType appType) {
+
+    Disk disk =
+        new Disk()
+            .name(pdName)
+            .size(300)
+            .diskType(DiskType.STANDARD)
+            .status(status)
+            .createdDate(date)
+            .creator(user.getUsername());
+    if (appType != null) {
+      disk.appType(appType);
+    } else {
+      disk.isGceRuntime(true);
+    }
+    return disk;
+  }
+
+  public static Disk newRuntimeDisk(String pdName, DiskStatus status, String date, DbUser user) {
+    return newDisk(pdName, status, date, user, /*appType*/ null);
   }
 
   // we make no guarantees about the order of the lists in DemographicSurveyV2

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -408,27 +408,27 @@ public class TestMockFactory {
         pdName, status, date, googleProjectId, user, /*appType*/ null);
   }
 
-  public static Disk newDisk(
-      String pdName, DiskStatus status, String date, DbUser user, @Nullable AppType appType) {
+  private static Disk createDisk(String pdName, DiskStatus status, String date, DbUser user) {
+    return new Disk()
+        .name(pdName)
+        .size(300)
+        .diskType(DiskType.STANDARD)
+        .status(status)
+        .createdDate(date)
+        .creator(user.getUsername());
+  }
 
-    Disk disk =
-        new Disk()
-            .name(pdName)
-            .size(300)
-            .diskType(DiskType.STANDARD)
-            .status(status)
-            .createdDate(date)
-            .creator(user.getUsername());
-    if (appType != null) {
-      disk.appType(appType);
-    } else {
-      disk.isGceRuntime(true);
-    }
+  public static Disk createAppDisk(
+      String pdName, DiskStatus status, String date, DbUser user, AppType appType) {
+    Disk disk = createDisk(pdName, status, date, user);
+    disk.appType(appType);
     return disk;
   }
 
-  public static Disk newRuntimeDisk(String pdName, DiskStatus status, String date, DbUser user) {
-    return newDisk(pdName, status, date, user, /*appType*/ null);
+  public static Disk createRuntimeDisk(String pdName, DiskStatus status, String date, DbUser user) {
+    Disk disk = createDisk(pdName, status, date, user);
+    disk.isGceRuntime(true);
+    return disk;
   }
 
   // we make no guarantees about the order of the lists in DemographicSurveyV2


### PR DESCRIPTION
This shifts newDisk to TestMockFactory. I did this, because a future PR will make use of this. 

Ran api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java (the only current user of this method) and it passed.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
