### PR TITLE
[RW-9762][risk=no] Refactor: Rename diskStore to runtimeDiskStore

### DIFF
--- a/ui/src/app/components/apps-panel/runtime-cost.tsx
+++ b/ui/src/app/components/apps-panel/runtime-cost.tsx
@@ -6,11 +6,11 @@ import { switchCase } from 'app/utils';
 import { machineRunningCost, machineStorageCost } from 'app/utils/machines';
 import { formatUsd } from 'app/utils/numbers';
 import { isVisible, toAnalysisConfig } from 'app/utils/runtime-utils';
-import { diskStore, runtimeStore, useStore } from 'app/utils/stores';
+import { runtimeDiskStore, runtimeStore, useStore } from 'app/utils/stores';
 
 export const RuntimeCost = () => {
   const { runtime } = useStore(runtimeStore);
-  const { gcePersistentDisk } = useStore(diskStore);
+  const { gcePersistentDisk } = useStore(runtimeDiskStore);
 
   if (!isVisible(runtime?.status)) {
     return null;

--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -38,7 +38,7 @@ import { diskTypeLabels, isActionable } from 'app/utils/runtime-utils';
 import {
   cdrVersionStore,
   clearCompoundRuntimeOperations,
-  diskStore,
+  runtimeDiskStore,
   runtimeStore,
   serverConfigStore,
 } from 'app/utils/stores';
@@ -127,11 +127,11 @@ describe('RuntimeConfigurationPanel', () => {
   };
 
   let runtimeStoreStub;
-  let diskStoreStub;
+  let runtimeDiskStoreStub;
 
   const setCurrentDisk = (d: Disk) => {
     disksApiStub.disk = d;
-    diskStoreStub.gcePersistentDisk = d;
+    runtimeDiskStoreStub.gcePersistentDisk = d;
   };
 
   const setCurrentRuntime = (r: Runtime) => {
@@ -171,11 +171,11 @@ describe('RuntimeConfigurationPanel', () => {
     };
     runtimeStore.set(runtimeStoreStub);
 
-    diskStoreStub = {
+    runtimeDiskStoreStub = {
       workspaceNamespace: workspaceStubs[0].namespace,
       gcePersistentDisk: null,
     };
-    diskStore.set(diskStoreStub);
+    runtimeDiskStore.set(runtimeDiskStoreStub);
 
     jest.useFakeTimers();
   });

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -69,8 +69,8 @@ import {
   withAnalysisConfigDefaults,
 } from 'app/utils/runtime-utils';
 import {
-  diskStore,
   ProfileStore,
+  runtimeDiskStore,
   runtimeStore,
   serverConfigStore,
   useStore,
@@ -192,7 +192,7 @@ const PanelMain = fp.flow(
       cdrVersionTiersResponse
     ) || { hasWgsData: false };
 
-    const { gcePersistentDisk } = useStore(diskStore);
+    const { gcePersistentDisk } = useStore(runtimeDiskStore);
     let [{ currentRuntime, pendingRuntime }, setRuntimeRequest] =
       useCustomRuntime(namespace, gcePersistentDisk);
 

--- a/ui/src/app/components/runtime-initializer-modal.tsx
+++ b/ui/src/app/components/runtime-initializer-modal.tsx
@@ -7,7 +7,7 @@ import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
 import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { toAnalysisConfig } from 'app/utils/runtime-utils';
-import { diskStore, useStore } from 'app/utils/stores';
+import { runtimeDiskStore, useStore } from 'app/utils/stores';
 
 import { Button, Clickable } from './buttons';
 import { EnvironmentCostEstimator } from './environment-cost-estimator';
@@ -40,7 +40,7 @@ export const RuntimeInitializerModal = ({
   defaultRuntime,
 }: Props) => {
   const [showDetails, setShowDetails] = useState(false);
-  const { gcePersistentDisk } = useStore(diskStore);
+  const { gcePersistentDisk } = useStore(runtimeDiskStore);
 
   const defaultAnalysisConfig = toAnalysisConfig(
     defaultRuntime,

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -22,9 +22,9 @@ import {
   useNavigation,
 } from 'app/utils/navigation';
 import {
-  diskStore,
   MatchParams,
   routeDataStore,
+  runtimeDiskStore,
   runtimeStore,
   userAppsStore,
   useStore,
@@ -137,7 +137,7 @@ export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
 
     useEffect(() => {
       const updateStores = async (namespace) => {
-        diskStore.set({
+        runtimeDiskStore.set({
           workspaceNamespace: namespace,
           gcePersistentDisk: undefined,
         });

--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -4,7 +4,7 @@ import { leoRuntimesApi } from 'app/services/notebooks-swagger-fetch-clients';
 import { runtimeApi } from 'app/services/swagger-fetch-clients';
 import { isAbortError, reportError } from 'app/utils/errors';
 import { applyPresetOverride, runtimePresets } from 'app/utils/runtime-presets';
-import { diskStore, runtimeStore } from 'app/utils/stores';
+import { runtimeDiskStore, runtimeStore } from 'app/utils/stores';
 
 import { maybeWithExistingDisk } from './runtime-utils';
 
@@ -204,7 +204,7 @@ export class LeoRuntimeInitializer {
   }
 
   private async createRuntime(): Promise<void> {
-    const { gcePersistentDisk } = diskStore.get();
+    const { gcePersistentDisk } = runtimeDiskStore.get();
 
     if (!this.targetRuntime) {
       // Automatic lazy creation is not supported; the caller must specify a target.

--- a/ui/src/app/utils/runtime-utils.spec.tsx
+++ b/ui/src/app/utils/runtime-utils.spec.tsx
@@ -10,7 +10,11 @@ import {
   findMostSevereDiffState,
   useCustomRuntime,
 } from 'app/utils/runtime-utils';
-import { diskStore, runtimeStore, serverConfigStore } from 'app/utils/stores';
+import {
+  runtimeDiskStore,
+  runtimeStore,
+  serverConfigStore,
+} from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
 import {
@@ -24,7 +28,7 @@ const WORKSPACE_NS = 'test';
 const Runtime = ({ id }) => {
   const [{ currentRuntime }] = useCustomRuntime(
     WORKSPACE_NS,
-    diskStore.get().gcePersistentDisk
+    runtimeDiskStore.get().gcePersistentDisk
   );
   const { runtimeName = '' } = currentRuntime || {};
   return <div id={id}>{runtimeName}</div>;
@@ -56,7 +60,7 @@ describe('runtime-utils', () => {
       runtime: undefined,
       runtimeLoaded: true,
     });
-    diskStore.set({
+    runtimeDiskStore.set({
       workspaceNamespace: WORKSPACE_NS,
       gcePersistentDisk: undefined,
     });

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -36,9 +36,9 @@ import {
 } from 'app/utils/machines';
 import {
   compoundRuntimeOpStore,
-  diskStore,
   markCompoundRuntimeOperationCompleted,
   registerCompoundRuntimeOperation,
+  runtimeDiskStore,
   runtimeStore,
   useStore,
 } from 'app/utils/stores';
@@ -934,7 +934,10 @@ export const useDisk = (currentWorkspaceNamespace: string) => {
     }
     const getDisk = withAsyncErrorHandling(
       () =>
-        diskStore.set({ workspaceNamespace: null, gcePersistentDisk: null }),
+        runtimeDiskStore.set({
+          workspaceNamespace: null,
+          gcePersistentDisk: null,
+        }),
       async () => {
         let gcePersistentDisk: Disk = null;
         try {
@@ -949,8 +952,11 @@ export const useDisk = (currentWorkspaceNamespace: string) => {
             throw e;
           }
         }
-        if (currentWorkspaceNamespace === diskStore.get().workspaceNamespace) {
-          diskStore.set({
+        if (
+          currentWorkspaceNamespace ===
+          runtimeDiskStore.get().workspaceNamespace
+        ) {
+          runtimeDiskStore.set({
             workspaceNamespace: currentWorkspaceNamespace,
             gcePersistentDisk,
           });
@@ -1047,7 +1053,7 @@ export const useRuntimeStatus = (
         () => {
           return disksApi().deleteDisk(
             currentWorkspaceNamespace,
-            diskStore.get().gcePersistentDisk.name
+            runtimeDiskStore.get().gcePersistentDisk.name
           );
         },
       ],
@@ -1106,7 +1112,7 @@ export const useCustomRuntime = (
   useEffect(() => {
     let mounted = true;
     const aborter = new AbortController();
-    const existingDisk = diskStore.get().gcePersistentDisk;
+    const existingDisk = runtimeDiskStore.get().gcePersistentDisk;
     const requestedDisk = request?.runtime?.gceWithPdConfig?.persistentDisk;
     const runAction = async () => {
       const applyRuntimeUpdate = async () => {

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -195,12 +195,12 @@ export const runtimeStore = atom<RuntimeStore>({
 });
 
 // runtime store states: undefined(initial state) -> Runtime (user selected) <--> null (delete only - no recreate)
-export interface DiskStore {
+export interface RuntimeDiskStore {
   workspaceNamespace: string | null | undefined;
   gcePersistentDisk: Disk | null | undefined;
 }
 
-export const diskStore = atom<DiskStore>({
+export const runtimeDiskStore = atom<RuntimeDiskStore>({
   workspaceNamespace: undefined,
   gcePersistentDisk: undefined,
 });


### PR DESCRIPTION
Renames `diskStore` to `runtimeDiskStore`.

`DiskStore` holds a single GCE disk for a single workspace. The new name indicates that it is unrelated to GKE apps.

There are no user-facing changes.

Manually testing by performing CRUD operations on Jupyter disks.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
