### PR TITLE
[no ticket][risk=no] Change tsconfig target to es2022

### DIFF
--- a/ui/src/app/components/popups.tsx
+++ b/ui/src/app/components/popups.tsx
@@ -66,14 +66,18 @@ const computeNewDimensions = (el, target) =>
 
 interface WithDynamicPositionProps {
   target: string;
+  handleClickOutside?: () => void;
+  outsideClickIgnoreClass?: string;
+  onClick?: () => void;
 }
 
 export const withDynamicPosition = () => (WrappedComponent) => {
-  const Wrapper = class WithDynamicPosition extends React.Component {
+  const Wrapper = class WithDynamicPosition extends React.Component<
+    WithDynamicPositionProps,
+    any
+  > {
     static displayName = 'withDynamicPosition()';
 
-    props: WithDynamicPositionProps;
-    state: any;
     element: any;
     animation: number;
 
@@ -243,12 +247,10 @@ export const PopupPortal = ({ children }) => {
 };
 
 export const Tooltip = withDynamicPosition()(
-  class TooltipComponent extends React.Component {
+  class TooltipComponent extends React.Component<any> {
     static readonly defaultProps = {
       side: 'bottom',
     };
-
-    props: any;
 
     render() {
       const {
@@ -308,9 +310,7 @@ export const Tooltip = withDynamicPosition()(
   }
 );
 
-export class TooltipTrigger extends React.Component {
-  props: any;
-  state: any;
+export class TooltipTrigger extends React.Component<any, any> {
   id: string;
 
   constructor(props) {
@@ -325,7 +325,7 @@ export class TooltipTrigger extends React.Component {
     if (!content) {
       return children;
     }
-    const child = React.Children.only(children);
+    const child = React.Children.only(children) as React.ReactElement;
     return (
       <React.Fragment>
         {React.cloneElement(child, {
@@ -357,14 +357,12 @@ export const Popup = fp.flow(
   onClickOutside,
   withDynamicPosition()
 )(
-  class PopupComponent extends React.Component {
+  class PopupComponent extends React.Component<any> {
     static displayName = 'Popup';
 
     static readonly defaultProps = {
       side: 'right',
     };
-
-    props: any;
 
     render() {
       const {
@@ -412,15 +410,13 @@ interface PopupTriggerProps {
 }
 
 // to test PopupTrigger using Enzyme simulate a click on the child element
-export class PopupTrigger extends React.Component<PopupTriggerProps> {
+export class PopupTrigger extends React.Component<PopupTriggerProps, any> {
   static readonly defaultProps = {
     closeOnClick: false,
     onOpen: () => {},
     onClose: () => {},
   };
 
-  props: any;
-  state: any;
   id: string;
 
   constructor(props: any) {

--- a/ui/src/testing/stubs/cohort-review-service-stub.ts
+++ b/ui/src/testing/stubs/cohort-review-service-stub.ts
@@ -106,10 +106,6 @@ const cohortChartDataStub = {
 };
 
 export class CohortReviewServiceStub extends CohortReviewApi {
-  configuration;
-  basePath;
-  fetch;
-
   constructor() {
     super(undefined, undefined, (..._: any[]) => {
       throw stubNotImplementedError;

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -8,12 +8,8 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es5",
-    "lib": [
-      "es2016",
-      "es2018.promise",
-      "dom"
-    ],
+    "target": "es2022",
+    "lib": ["dom"],
     "module": "esnext",
     "baseUrl": "./src",
     "jsx": "react-jsx",


### PR DESCRIPTION
Use es2022 target for TypeScript build and fix type check errors.

Manually tested the UI by clicking through and testing various components.

The es5 target is from 2011. Compiling to that version introduces extra code (e.g. `function () {}` instead of `() => {}` that is not necessary for our target browser (Chrome).

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
