### PR TITLE
[RW-9762][risk=no] Allow deleting unattached PDs from GKE apps

### DIFF
--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1015,7 +1015,7 @@ paths:
             "$ref": "#/definitions/ErrorResponse"
     delete:
       summary: Delete a persistent disk.
-      description: Delete a persistent disk
+      description: Delete a persistent disk by name.
       operationId: deleteDisk
       tags:
         - disks

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1015,7 +1015,7 @@ paths:
             "$ref": "#/definitions/ErrorResponse"
     delete:
       summary: Delete a persistent disk.
-      description: Delete the current user's latest created persistent disk
+      description: Delete a persistent disk
       operationId: deleteDisk
       tags:
         - disks

--- a/ui/src/app/components/cromwell-configuration-panel.spec.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.spec.tsx
@@ -15,9 +15,12 @@ import {
   mountWithRouter,
   waitOneTickAndUpdate,
 } from 'testing/react-test-helpers';
-import { AppsApiStub } from 'testing/stubs/apps-api-stub';
+import {
+  AppsApiStub,
+  createListAppsCromwellResponse,
+} from 'testing/stubs/apps-api-stub';
 import { CdrVersionsStubVariables } from 'testing/stubs/cdr-versions-api-stub';
-import { DisksApiStub } from 'testing/stubs/disks-api-stub';
+import { DisksApiStub, stubDisk } from 'testing/stubs/disks-api-stub';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
 import {
   workspaceStubs,
@@ -46,6 +49,8 @@ describe('CromwellConfigurationPanel', () => {
       updateCache: jest.fn(),
     },
     gkeAppsInWorkspace: [],
+    disk: stubDisk(),
+    onClickDeleteUnattachedPersistentDisk: jest.fn(),
   };
 
   let disksApiStub: DisksApiStub;
@@ -116,5 +121,40 @@ describe('CromwellConfigurationPanel', () => {
     expect(costEstimator(wrapper).exists()).toBeTruthy();
     expect(runningCost(wrapper).text()).toEqual('$0.40 per hour');
     expect(pausedCost(wrapper).text()).toEqual('$0.20 per hour');
+  });
+
+  it('should render a DeletePersistentDiskButton when a disk is present but no app', async () => {
+    const disk = stubDisk();
+    const onClickDeleteUnattachedPersistentDisk = jest.fn();
+    const wrapper = await component({
+      gkeAppsInWorkspace: [],
+      disk,
+      onClickDeleteUnattachedPersistentDisk,
+    });
+    const deleteButton = wrapper.find('DeletePersistentDiskButton');
+    expect(deleteButton.exists()).toBeTruthy();
+
+    // validate that onClickDeleteUnattachedPersistentDisk is passed correctly
+    deleteButton.simulate('click');
+    expect(onClickDeleteUnattachedPersistentDisk).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not render a DeletePersistentDiskButton when an app is present', async () => {
+    const disk = stubDisk();
+    const wrapper = await component({
+      gkeAppsInWorkspace: [createListAppsCromwellResponse()],
+      disk,
+    });
+    const deleteButton = wrapper.find('DeletePersistentDiskButton');
+    expect(deleteButton.exists()).toBeFalsy();
+  });
+
+  it('should not render a DeletePersistentDiskButton no disk is present', async () => {
+    const wrapper = await component({
+      gkeAppsInWorkspace: [],
+      disk: undefined,
+    });
+    const deleteButton = wrapper.find('DeletePersistentDiskButton');
+    expect(deleteButton.exists()).toBeFalsy();
   });
 });

--- a/ui/src/app/components/cromwell-configuration-panel.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
-import { AppType, UserAppEnvironment } from 'generated/fetch';
+import { AppType, Disk, UserAppEnvironment } from 'generated/fetch';
 
+import { DeletePersistentDiskButton } from 'app/components/delete-persistent-disk-button';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { CreateGKEAppButton } from 'app/components/gke-app-configuration-panels/create-gke-app-button';
 import { DisabledCloudComputeProfile } from 'app/components/gke-app-configuration-panels/disabled-cloud-compute-profile';
@@ -16,6 +17,7 @@ import { findMachineByName, Machine } from 'app/utils/machines';
 import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { AnalysisConfig } from 'app/utils/runtime-utils';
 import { ProfileStore } from 'app/utils/stores';
+import { unattachedDiskExists } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { defaultCromwellConfig, findApp, UIAppType } from './apps-panel/utils';
@@ -59,6 +61,8 @@ export interface CromwellConfigurationPanelProps {
   workspace: WorkspaceData;
   profileState: ProfileStore;
   gkeAppsInWorkspace: NonNullable<UserAppEnvironment[]>;
+  disk: Disk | undefined;
+  onClickDeleteUnattachedPersistentDisk: () => void;
 }
 
 export const CromwellConfigurationPanel = ({
@@ -67,6 +71,8 @@ export const CromwellConfigurationPanel = ({
   workspace,
   profileState,
   gkeAppsInWorkspace,
+  disk,
+  onClickDeleteUnattachedPersistentDisk,
 }: CromwellConfigurationPanelProps) => {
   const app = findApp(gkeAppsInWorkspace, UIAppType.CROMWELL);
   const { profile } = profileState;
@@ -144,9 +150,17 @@ export const CromwellConfigurationPanel = ({
       <FlexRow
         style={{
           alignItems: 'center',
+          justifyContent: 'flex-end',
+          gap: '2rem',
         }}
       >
-        <div style={{ margin: '0rem 1rem 1rem 0rem ' }}>
+        {unattachedDiskExists(app, disk) && (
+          <DeletePersistentDiskButton
+            onClick={onClickDeleteUnattachedPersistentDisk}
+            style={{ flexShrink: 0 }}
+          />
+        )}
+        <div style={{ flexGrow: 1 }}>
           <div style={{ fontWeight: 'bold' }}>Next Steps:</div>
           <div>
             You can interact with the workflow by using the Cromshell in Jupyter

--- a/ui/src/app/components/delete-persistent-disk-button.tsx
+++ b/ui/src/app/components/delete-persistent-disk-button.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+import { LinkButton } from 'app/components/buttons';
+import { styles } from 'app/components/runtime-configuration-panel/styles';
+
+interface DeletePersistentDiskProps {
+  onClick: () => void;
+  style?: React.CSSProperties;
+}
+
+export const DeletePersistentDiskButton = ({
+  onClick,
+  style = {},
+}: DeletePersistentDiskProps) => (
+  <LinkButton
+    style={{
+      ...styles.deleteLink,
+      ...style,
+    }}
+    aria-label='Delete Persistent Disk'
+    onClick={onClick}
+  >
+    Delete Persistent Disk
+  </LinkButton>
+);

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 
-import { AppsApi, AppType } from 'generated/fetch';
+import { AppsApi, AppType, DisksApi } from 'generated/fetch';
 
 import { CromwellConfigurationPanel } from 'app/components/cromwell-configuration-panel';
 import {
@@ -10,8 +11,13 @@ import {
 } from 'app/components/gke-app-configuration-panel';
 import { RStudioConfigurationPanel } from 'app/components/rstudio-configuration-panel';
 import { DEFAULT_PROPS as RSTUDIO_DEFAULT_PROPS } from 'app/components/rstudio-configuration-panel.spec';
+import { ConfirmDeleteUnattachedPD } from 'app/components/runtime-configuration-panel/confirm-delete-unattached-pd';
 import { Spinner } from 'app/components/spinners';
-import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
+import {
+  appsApi,
+  disksApi,
+  registerApiClient,
+} from 'app/services/swagger-fetch-clients';
 import { notificationStore, serverConfigStore } from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
@@ -20,10 +26,12 @@ import {
   AppsApiStub,
   createListAppsCromwellResponse,
 } from 'testing/stubs/apps-api-stub';
+import { DisksApiStub, stubDisk } from 'testing/stubs/disks-api-stub';
 
 describe(GKEAppConfigurationPanel.name, () => {
   beforeEach(() => {
     registerApiClient(AppsApi, new AppsApiStub());
+    registerApiClient(DisksApi, new DisksApiStub());
     notificationStore.set(null);
 
     serverConfigStore.set({
@@ -35,12 +43,22 @@ describe(GKEAppConfigurationPanel.name, () => {
     jest
       .spyOn(appsApi(), 'listAppsInWorkspace')
       .mockImplementation((): Promise<any> => Promise.resolve([]));
+
+    jest
+      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.resolve([]));
   });
 
-  const DEFAULT_PROPS = {
+  const DEFAULT_PROPS: GkeAppConfigurationPanelProps = {
     type: AppType.RSTUDIO,
     workspaceNamespace: 'aou-rw-1234',
-    ...RSTUDIO_DEFAULT_PROPS,
+    onClose: jest.fn(),
+
+    // Use RSTUDIO_DEFAULT_PROPS for the rest of the props since they shouldn't affect this test
+    creatorFreeCreditsRemaining:
+      RSTUDIO_DEFAULT_PROPS.creatorFreeCreditsRemaining,
+    workspace: RSTUDIO_DEFAULT_PROPS.workspace,
+    profileState: RSTUDIO_DEFAULT_PROPS.profileState,
   };
 
   const createWrapper = (
@@ -53,7 +71,7 @@ describe(GKEAppConfigurationPanel.name, () => {
     return mount(<GKEAppConfigurationPanel {...props} />);
   };
 
-  it('should show a loading spinner while waiting for the API call to return', async () => {
+  it('should show a loading spinner while waiting for the list apps API call to return', async () => {
     jest
       .spyOn(appsApi(), 'listAppsInWorkspace')
       .mockImplementation((): Promise<any> => Promise.resolve([]));
@@ -66,7 +84,20 @@ describe(GKEAppConfigurationPanel.name, () => {
     expect(wrapper.childAt(0).is(Spinner)).toBeFalsy();
   });
 
-  it('should show an error if the API call fails', async () => {
+  it('should show a loading spinner while waiting for the list disks API call to return', async () => {
+    jest
+      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.resolve([]));
+    const wrapper = createWrapper();
+
+    expect(wrapper.childAt(0).is(Spinner)).toBeTruthy();
+
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(wrapper.childAt(0).is(Spinner)).toBeFalsy();
+  });
+
+  it('should show an error if the list apps API call fails', async () => {
     jest
       .spyOn(appsApi(), 'listAppsInWorkspace')
       .mockImplementation((): Promise<any> => Promise.reject());
@@ -80,9 +111,26 @@ describe(GKEAppConfigurationPanel.name, () => {
     expect(notificationStore.get().message).toBeTruthy();
   });
 
-  it('should not show an error if API call succeeds', async () => {
+  it('should show an error if the list disks API call fails', async () => {
+    jest
+      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.reject());
+
+    expect(notificationStore.get()).toBeNull();
+
+    const wrapper = createWrapper();
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(notificationStore.get().title).toBeTruthy();
+    expect(notificationStore.get().message).toBeTruthy();
+  });
+
+  it('should not show an error if both fetch API calls succeed', async () => {
     jest
       .spyOn(appsApi(), 'listAppsInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.resolve([]));
+    jest
+      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
       .mockImplementation((): Promise<any> => Promise.resolve([]));
 
     expect(notificationStore.get()).toBeNull();
@@ -112,6 +160,50 @@ describe(GKEAppConfigurationPanel.name, () => {
     expect(cromwellPanel.prop('gkeAppsInWorkspace')).toEqual(apps);
   });
 
+  it('should pass the relevant disk to the specific app if available', async () => {
+    const workspaceNamespace = 'aou-rw-1234';
+    const cromwellDisk = stubDisk();
+    cromwellDisk.appType = AppType.CROMWELL;
+    const rstudioDisk = stubDisk();
+    rstudioDisk.appType = AppType.RSTUDIO;
+    const listDisksStub = jest
+      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
+      .mockImplementation(
+        (): Promise<any> => Promise.resolve([cromwellDisk, rstudioDisk])
+      );
+
+    const wrapper = createWrapper({
+      workspaceNamespace,
+      type: AppType.CROMWELL,
+    });
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(listDisksStub).toHaveBeenCalledWith(workspaceNamespace);
+    const cromwellPanel = wrapper.find(CromwellConfigurationPanel);
+    expect(cromwellPanel.exists()).toBeTruthy();
+    expect(cromwellPanel.prop('disk')).toEqual(cromwellDisk);
+  });
+
+  it('should pass no disk to the specific app component if no relevant disk is available', async () => {
+    const workspaceNamespace = 'aou-rw-1234';
+    const rstudioDisk = stubDisk();
+    rstudioDisk.appType = AppType.RSTUDIO;
+    const listDisksStub = jest
+      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.resolve([rstudioDisk]));
+
+    const wrapper = createWrapper({
+      workspaceNamespace,
+      type: AppType.CROMWELL,
+    });
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(listDisksStub).toHaveBeenCalledWith(workspaceNamespace);
+    const cromwellPanel = wrapper.find(CromwellConfigurationPanel);
+    expect(cromwellPanel.exists()).toBeTruthy();
+    expect(cromwellPanel.prop('disk')).toEqual(undefined);
+  });
+
   it('should display the Cromwell panel when the type is Cromwell', async () => {
     const wrapper = createWrapper({
       type: AppType.CROMWELL,
@@ -134,5 +226,148 @@ describe(GKEAppConfigurationPanel.name, () => {
     expect(rstudioPanel.exists()).toBeTruthy();
     // check that an arbitrary RStudioConfigurationPanelProps prop is passed through
     expect(rstudioPanel.prop('onClose')).toEqual(DEFAULT_PROPS.onClose);
+  });
+
+  it('should change panels from CREATE to DELETE_UNATTACHED_PD after clicking the delete PD button', async () => {
+    const wrapper = createWrapper({
+      type: AppType.CROMWELL,
+    });
+    await waitOneTickAndUpdate(wrapper);
+
+    const cromwellPanel = wrapper.find(CromwellConfigurationPanel);
+    expect(cromwellPanel.exists()).toBeTruthy();
+    expect(wrapper.find(ConfirmDeleteUnattachedPD).exists()).toBeFalsy();
+
+    act(() => {
+      cromwellPanel.prop('onClickDeleteUnattachedPersistentDisk')();
+    });
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(wrapper.find(CromwellConfigurationPanel).exists()).toBeFalsy();
+    expect(wrapper.find(ConfirmDeleteUnattachedPD).exists()).toBeTruthy();
+  });
+
+  it('should call the delete api after confirming deleting PD', async () => {
+    const deleteUnattachedPDStub = jest
+      .spyOn(disksApi(), 'deleteDisk')
+      .mockImplementation((): Promise<any> => Promise.resolve());
+    const onCloseStub = jest.fn();
+
+    // Setup: A Cromwell disk exists and the current app is Cromwell
+    const workspaceNamespace = 'aou-rw-1234';
+    const disk = stubDisk();
+    disk.appType = AppType.CROMWELL;
+    jest
+      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.resolve([disk]));
+    const wrapper = createWrapper({
+      onClose: onCloseStub,
+      type: AppType.CROMWELL,
+      workspaceNamespace,
+    });
+    await waitOneTickAndUpdate(wrapper);
+    // Start with the DELETE_UNATTACHED_PD panel
+    act(() => {
+      wrapper
+        .find(CromwellConfigurationPanel)
+        .prop('onClickDeleteUnattachedPersistentDisk')();
+    });
+    await waitOneTickAndUpdate(wrapper);
+
+    wrapper.find(ConfirmDeleteUnattachedPD).prop('onConfirm')();
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(deleteUnattachedPDStub).toHaveBeenCalledWith(
+      workspaceNamespace,
+      disk.name
+    );
+    expect(onCloseStub).toHaveBeenCalled();
+  });
+
+  it('should show an error modal if the delete PD API call fails', async () => {
+    jest
+      .spyOn(disksApi(), 'deleteDisk')
+      .mockImplementation((): Promise<any> => Promise.reject());
+
+    const wrapper = createWrapper({
+      type: AppType.CROMWELL,
+    });
+    await waitOneTickAndUpdate(wrapper);
+    // Start with the DELETE_UNATTACHED_PD panel
+    act(() => {
+      wrapper
+        .find(CromwellConfigurationPanel)
+        .prop('onClickDeleteUnattachedPersistentDisk')();
+    });
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(notificationStore.get()).toBeNull();
+
+    wrapper.find(ConfirmDeleteUnattachedPD).prop('onConfirm')();
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(notificationStore.get().title).toBeTruthy();
+    expect(notificationStore.get().message).toBeTruthy();
+  });
+
+  it('should not show an error modal if the delete PD API call succeeds', async () => {
+    jest
+      .spyOn(disksApi(), 'deleteDisk')
+      .mockImplementation((): Promise<any> => Promise.resolve());
+    const onCloseStub = jest.fn();
+
+    // Setup: A Cromwell disk exists and the current app is Cromwell
+    const workspaceNamespace = 'aou-rw-1234';
+    const disk = stubDisk();
+    disk.appType = AppType.CROMWELL;
+    jest
+      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.resolve([disk]));
+    const wrapper = createWrapper({
+      onClose: onCloseStub,
+      type: AppType.CROMWELL,
+      workspaceNamespace,
+    });
+    await waitOneTickAndUpdate(wrapper);
+    // Start with the DELETE_UNATTACHED_PD panel
+    act(() => {
+      wrapper
+        .find(CromwellConfigurationPanel)
+        .prop('onClickDeleteUnattachedPersistentDisk')();
+    });
+    await waitOneTickAndUpdate(wrapper);
+
+    wrapper.find(ConfirmDeleteUnattachedPD).prop('onConfirm')();
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(notificationStore.get()).toBeNull();
+  });
+
+  it('should change panels from DELETE_UNATTACHED_PD to CREATE after cancelling delete PD', async () => {
+    const wrapper = createWrapper({
+      type: AppType.CROMWELL,
+    });
+    await waitOneTickAndUpdate(wrapper);
+    // Start with the DELETE_UNATTACHED_PD panel
+    act(() => {
+      wrapper
+        .find(CromwellConfigurationPanel)
+        .prop('onClickDeleteUnattachedPersistentDisk')();
+    });
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(wrapper.find(CromwellConfigurationPanel).exists()).toBeFalsy();
+    const confirmDeleteUnattachedPDPanel = wrapper.find(
+      ConfirmDeleteUnattachedPD
+    );
+    expect(confirmDeleteUnattachedPDPanel.exists()).toBeTruthy();
+
+    act(() => {
+      confirmDeleteUnattachedPDPanel.prop('onCancel')();
+    });
+    await waitOneTickAndUpdate(wrapper);
+
+    expect(wrapper.find(CromwellConfigurationPanel).exists()).toBeTruthy();
+    expect(wrapper.find(ConfirmDeleteUnattachedPD).exists()).toBeFalsy();
   });
 });

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 
 import { AppsApi, AppType, DisksApi } from 'generated/fetch';
 
@@ -27,6 +27,14 @@ import {
   createListAppsCromwellResponse,
 } from 'testing/stubs/apps-api-stub';
 import { DisksApiStub, stubDisk } from 'testing/stubs/disks-api-stub';
+
+async function validateInitialLoadingSpinner(wrapper: ReactWrapper) {
+  expect(wrapper.childAt(0).is(Spinner)).toBeTruthy();
+
+  await waitOneTickAndUpdate(wrapper);
+
+  expect(wrapper.childAt(0).is(Spinner)).toBeFalsy();
+}
 
 describe(GKEAppConfigurationPanel.name, () => {
   beforeEach(() => {
@@ -75,26 +83,14 @@ describe(GKEAppConfigurationPanel.name, () => {
     jest
       .spyOn(appsApi(), 'listAppsInWorkspace')
       .mockImplementation((): Promise<any> => Promise.resolve([]));
-    const wrapper = createWrapper();
-
-    expect(wrapper.childAt(0).is(Spinner)).toBeTruthy();
-
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(wrapper.childAt(0).is(Spinner)).toBeFalsy();
+    await validateInitialLoadingSpinner(createWrapper());
   });
 
   it('should show a loading spinner while waiting for the list disks API call to return', async () => {
     jest
       .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
       .mockImplementation((): Promise<any> => Promise.resolve([]));
-    const wrapper = createWrapper();
-
-    expect(wrapper.childAt(0).is(Spinner)).toBeTruthy();
-
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(wrapper.childAt(0).is(Spinner)).toBeFalsy();
+    await validateInitialLoadingSpinner(createWrapper());
   });
 
   it('should show an error if the list apps API call fails', async () => {

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -278,6 +278,9 @@ describe(GKEAppConfigurationPanel.name, () => {
       disk.name
     );
     expect(onCloseStub).toHaveBeenCalled();
+
+    // Validate there is no error modal if the call succeeds
+    expect(notificationStore.get()).toBeNull();
   });
 
   it('should show an error modal if the delete PD API call fails', async () => {
@@ -304,39 +307,6 @@ describe(GKEAppConfigurationPanel.name, () => {
 
     expect(notificationStore.get().title).toBeTruthy();
     expect(notificationStore.get().message).toBeTruthy();
-  });
-
-  it('should not show an error modal if the delete PD API call succeeds', async () => {
-    jest
-      .spyOn(disksApi(), 'deleteDisk')
-      .mockImplementation((): Promise<any> => Promise.resolve());
-    const onCloseStub = jest.fn();
-
-    // Setup: A Cromwell disk exists and the current app is Cromwell
-    const workspaceNamespace = 'aou-rw-1234';
-    const disk = stubDisk();
-    disk.appType = AppType.CROMWELL;
-    jest
-      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
-      .mockImplementation((): Promise<any> => Promise.resolve([disk]));
-    const wrapper = createWrapper({
-      onClose: onCloseStub,
-      type: AppType.CROMWELL,
-      workspaceNamespace,
-    });
-    await waitOneTickAndUpdate(wrapper);
-    // Start with the DELETE_UNATTACHED_PD panel
-    act(() => {
-      wrapper
-        .find(CromwellConfigurationPanel)
-        .prop('onClickDeleteUnattachedPersistentDisk')();
-    });
-    await waitOneTickAndUpdate(wrapper);
-
-    wrapper.find(ConfirmDeleteUnattachedPD).prop('onConfirm')();
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(notificationStore.get()).toBeNull();
   });
 
   it('should change panels from DELETE_UNATTACHED_PD to CREATE after cancelling delete PD', async () => {

--- a/ui/src/app/components/gke-app-configuration-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 
-import { AppType, UserAppEnvironment } from 'generated/fetch';
+import { AppType, Disk, UserAppEnvironment } from 'generated/fetch';
 
 import {
   CromwellConfigurationPanel,
@@ -11,72 +11,149 @@ import {
   RStudioConfigurationPanel,
   RStudioConfigurationPanelProps,
 } from 'app/components/rstudio-configuration-panel';
+import { ConfirmDeleteUnattachedPD } from 'app/components/runtime-configuration-panel/confirm-delete-unattached-pd';
 import { Spinner } from 'app/components/spinners';
-import { appsApi } from 'app/services/swagger-fetch-clients';
-import { cond } from 'app/utils';
+import { appsApi, disksApi } from 'app/services/swagger-fetch-clients';
+import { switchCase } from 'app/utils';
 import { notificationStore } from 'app/utils/stores';
+import { findDisk } from 'app/utils/user-apps-utils';
 
-type InjectedProps = 'gkeAppsInWorkspace';
+type InjectedProps =
+  | 'gkeAppsInWorkspace'
+  | 'disk'
+  | 'onClickDeleteUnattachedPersistentDisk';
 
 export type GkeAppConfigurationPanelProps = {
   type: AppType;
   workspaceNamespace: string;
-} & Omit<CromwellConfigurationPanelProps, InjectedProps> &
-  Omit<RStudioConfigurationPanelProps, InjectedProps>;
+  onClose: () => void;
+} & Omit<CreateGKEAppPanelProps, InjectedProps>;
+
+export enum GKEAppPanelContent {
+  CREATE,
+  DELETE_UNATTACHED_PD,
+}
+
+type CreateGKEAppPanelProps = {
+  type: AppType;
+} & CromwellConfigurationPanelProps &
+  RStudioConfigurationPanelProps;
+
+const CreateGKEAppPanel = ({ type, ...props }: CreateGKEAppPanelProps) =>
+  switchCase(
+    type,
+    [AppType.CROMWELL, () => <CromwellConfigurationPanel {...props} />],
+    [AppType.RSTUDIO, () => <RStudioConfigurationPanel {...props} />]
+  );
 
 export const GKEAppConfigurationPanel = ({
   type,
   workspaceNamespace,
+  onClose,
   ...props
 }: GkeAppConfigurationPanelProps) => {
   const [gkeAppsInWorkspace, setGkeAppsInWorkspace] = useState<
     UserAppEnvironment[] | undefined
   >();
-  const [error, setError] = useState<Error>();
+  const [listAppsInWorkspaceError, setListAppsInWorkspaceError] =
+    useState<Error>();
+
+  const [ownedDisksInWorkspace, setOwnedDisksInWorkspace] = useState<
+    Disk[] | undefined
+  >();
+  const [listOwnedDisksInWorkspaceError, setListOwnedDisksInWorkspaceError] =
+    useState<Error>();
+
+  const [panelContent, setPanelContent] = useState<GKEAppPanelContent>(
+    GKEAppPanelContent.CREATE
+  );
 
   useEffect(() => {
     appsApi()
       .listAppsInWorkspace(workspaceNamespace)
       .then(setGkeAppsInWorkspace)
       .catch((e) => {
-        setError(e);
+        setListAppsInWorkspaceError(e);
         notificationStore.set({
           title: 'Unable to load applications',
           message:
             'An error occurred trying to load your applications. Please try again.',
         });
       });
+
+    disksApi()
+      .listOwnedDisksInWorkspace(workspaceNamespace)
+      .then(setOwnedDisksInWorkspace)
+      .catch((e) => {
+        setListOwnedDisksInWorkspaceError(e);
+        notificationStore.set({
+          title: 'Unable to load persistent disks',
+          message:
+            'An error occurred trying to load your persistent disks. Please try again.',
+        });
+      });
   }, []);
 
-  if (error) {
+  if (listAppsInWorkspaceError || listOwnedDisksInWorkspaceError) {
     return null;
   }
 
   // loading
-  if (gkeAppsInWorkspace === undefined) {
+  if (gkeAppsInWorkspace === undefined || ownedDisksInWorkspace === undefined) {
     return <Spinner />;
   }
 
-  return cond(
+  const disk = findDisk(ownedDisksInWorkspace, type);
+
+  const onClickDeleteUnattachedPersistentDisk = () => {
+    setPanelContent(GKEAppPanelContent.DELETE_UNATTACHED_PD);
+  };
+
+  const onConfirmDeleteUnattachedPersistentDisk = async () => {
+    try {
+      await disksApi().deleteDisk(workspaceNamespace, disk.name);
+      // Because we immediately close the panel after deleting the disk,
+      // we don't need to update the list of disks. The next time the panel
+      // is opened, the list of disks will be fetched again.
+      onClose();
+    } catch (e) {
+      notificationStore.set({
+        title: 'Unable to delete persistent disk',
+        message:
+          'An error occurred trying to delete your persistent disk. Please try again.',
+      });
+    }
+  };
+
+  const onCancelDeleteUnattachedPersistentDisk = () => {
+    setPanelContent(GKEAppPanelContent.CREATE);
+  };
+
+  return switchCase(
+    panelContent,
     [
-      type === AppType.CROMWELL,
+      GKEAppPanelContent.CREATE,
       () => (
-        <CromwellConfigurationPanel
+        <CreateGKEAppPanel
           {...{
             ...props,
+            type,
             gkeAppsInWorkspace,
+            disk,
+            onClickDeleteUnattachedPersistentDisk,
+            onClose,
           }}
         />
       ),
     ],
-    // AppType.RStudio
-    () => (
-      <RStudioConfigurationPanel
-        {...{
-          ...props,
-          gkeAppsInWorkspace,
-        }}
-      />
-    )
+    [
+      GKEAppPanelContent.DELETE_UNATTACHED_PD,
+      () => (
+        <ConfirmDeleteUnattachedPD
+          onConfirm={onConfirmDeleteUnattachedPersistentDisk}
+          onCancel={onCancelDeleteUnattachedPersistentDisk}
+        />
+      ),
+    ]
   );
 };

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -8,6 +8,7 @@ import {
   CohortAnnotationDefinitionApi,
   CohortReviewApi,
   DataSetApi,
+  DisksApi,
   ErrorCode,
   NotebooksApi,
   ProfileApi,
@@ -62,6 +63,7 @@ import {
   cohortReviewStubs,
 } from 'testing/stubs/cohort-review-service-stub';
 import { DataSetApiStub } from 'testing/stubs/data-set-api-stub';
+import { DisksApiStub } from 'testing/stubs/disks-api-stub';
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
 import { ProfileApiStub } from 'testing/stubs/profile-api-stub';
 import { defaultRuntime, RuntimeApiStub } from 'testing/stubs/runtime-api-stub';
@@ -202,6 +204,7 @@ describe('HelpSidebar', () => {
     registerApiClient(RuntimeApi, runtimeStub);
     registerApiClient(WorkspacesApi, new WorkspacesApiStub());
     registerApiClient(AppsApi, appsStub);
+    registerApiClient(DisksApi, new DisksApiStub());
     registerApiClient(NotebooksApi, new NotebooksApiStub());
     currentWorkspaceStore.next(workspaceDataStub);
     currentCohortReviewStore.next(cohortReviewStubs[0]);

--- a/ui/src/app/components/rstudio-configuration-panel.tsx
+++ b/ui/src/app/components/rstudio-configuration-panel.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
-import { AppType, UserAppEnvironment } from 'generated/fetch';
+import { AppType, Disk, UserAppEnvironment } from 'generated/fetch';
 
+import { DeletePersistentDiskButton } from 'app/components/delete-persistent-disk-button';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { CreateGKEAppButton } from 'app/components/gke-app-configuration-panels/create-gke-app-button';
 import { DisabledCloudComputeProfile } from 'app/components/gke-app-configuration-panels/disabled-cloud-compute-profile';
@@ -10,6 +11,7 @@ import { findMachineByName, Machine } from 'app/utils/machines';
 import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { AnalysisConfig } from 'app/utils/runtime-utils';
 import { ProfileStore } from 'app/utils/stores';
+import { unattachedDiskExists } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { defaultRStudioConfig, findApp, UIAppType } from './apps-panel/utils';
@@ -40,6 +42,8 @@ export interface RStudioConfigurationPanelProps {
   workspace: WorkspaceData;
   profileState: ProfileStore;
   gkeAppsInWorkspace: NonNullable<UserAppEnvironment[]>;
+  disk: Disk | undefined;
+  onClickDeleteUnattachedPersistentDisk: () => void;
 }
 
 export const RStudioConfigurationPanel = ({
@@ -48,6 +52,8 @@ export const RStudioConfigurationPanel = ({
   workspace,
   profileState,
   gkeAppsInWorkspace,
+  disk,
+  onClickDeleteUnattachedPersistentDisk,
 }: RStudioConfigurationPanelProps) => {
   const app = findApp(gkeAppsInWorkspace, UIAppType.RSTUDIO);
   const { profile } = profileState;
@@ -97,6 +103,12 @@ export const RStudioConfigurationPanel = ({
           justifyContent: 'flex-end',
         }}
       >
+        {unattachedDiskExists(app, disk) && (
+          <DeletePersistentDiskButton
+            onClick={onClickDeleteUnattachedPersistentDisk}
+            style={{ flexGrow: 1 }}
+          />
+        )}
         <CreateGKEAppButton
           createAppRequest={defaultRStudioConfig}
           existingApp={app}

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -12,6 +12,7 @@ import {
 } from 'generated/fetch';
 
 import { Button, LinkButton } from 'app/components/buttons';
+import { DeletePersistentDiskButton } from 'app/components/delete-persistent-disk-button';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { ErrorMessage, WarningMessage } from 'app/components/messages';
 import { TooltipTrigger } from 'app/components/popups';
@@ -852,28 +853,18 @@ const PanelMain = fp.flow(
                     {getWarningMessageContent()}
                   </WarningMessage>
                 )}
-                {unattachedPdExists && !runtimeExists ? (
+                {unattachedPdExists ? (
                   <FlexRow
                     style={{
                       justifyContent: 'space-between',
                       marginTop: '1.125rem',
                     }}
                   >
-                    <LinkButton
-                      style={{
-                        ...styles.deleteLink,
-                        ...(disableControls
-                          ? { color: colorWithWhiteness(colors.dark, 0.4) }
-                          : {}),
-                      }}
-                      aria-label='Delete Persistent Disk'
-                      disabled={disableControls}
+                    <DeletePersistentDiskButton
                       onClick={() =>
                         setPanelContent(PanelContent.DeleteUnattachedPd)
                       }
-                    >
-                      Delete Persistent Disk
-                    </LinkButton>
+                    />
                     {unattachedDiskNeedsRecreate
                       ? renderNextWithDiskDeleteButton()
                       : renderCreateButton()}

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -1,4 +1,10 @@
-import { AppStatus, AppType, CreateAppRequest } from 'generated/fetch';
+import {
+  AppStatus,
+  AppType,
+  CreateAppRequest,
+  Disk,
+  UserAppEnvironment,
+} from 'generated/fetch';
 
 import { leoAppsApi } from 'app/services/notebooks-swagger-fetch-clients';
 import { appsApi } from 'app/services/swagger-fetch-clients';
@@ -73,3 +79,13 @@ export const resumeUserApp = (googleProject, appName, namespace) => {
     .startApp(googleProject, appName)
     .then(() => maybeStartPollingForUserApps(namespace));
 };
+
+export const findDisk = (disks: Disk[], appType: AppType): Disk | undefined =>
+  disks.find((disk) => disk.appType === appType);
+
+export function unattachedDiskExists(
+  app: UserAppEnvironment | null | undefined,
+  disk: Disk | undefined
+) {
+  return !app && disk !== undefined;
+}

--- a/ui/src/testing/stubs/disks-api-stub.ts
+++ b/ui/src/testing/stubs/disks-api-stub.ts
@@ -8,7 +8,7 @@ import {
 
 import { stubNotImplementedError } from 'testing/stubs/stub-utils';
 
-export const stubDisk = () => ({
+export const stubDisk = (): Disk => ({
   size: 1000,
   diskType: DiskType.Standard,
   isGceRuntime: true,


### PR DESCRIPTION
Allows users to delete unattached PDs from GKE apps.

This completes the AC "User can delete disk which is currently not attached to APP" but does not complete the story.

I do not expect users to see this feature in prod since we do not allow them to detach disks yet.

There are two refactors in this PR that I considered extracting to separate PRs, but I don't think they make sense without this feature as context:
- Adding support for "panels" in the GKE app sidebar. I think the approach used by runtimes is pretty good and I mostly copied it. Unfortunately, actually sharing that logic would be a larger overhaul that I think is out of scope here.
- Extracting a simple `delete-persistent-disk-button` component from the runtime code

Manually testing:
- Create an app
- Using a direct API call, delete the app, keeping the persistent disk. Example: `curl -X 'DELETE' 'http://localhost:8081/v1/workspaces/aou-rw-local1-9bd1344c/apps/all-of-us-1-cromwell-eb32?deleteDisk=false'`
- Wait for the app to delete
- Observe the new button, panel, etc.

There is no associated #workbench-ux post for this PR. I will create one when the other AC are complete and users are expected to see this.

Screenshots:

New button (bottom left)
![image](https://github.com/all-of-us/workbench/assets/31020403/e1353239-78db-4dda-9ce9-51a42081fba6)

New panel
![image](https://github.com/all-of-us/workbench/assets/31020403/a9e4882e-c374-4eb7-a536-07c14f8a81db)


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
