### PR TITLE
[no ticket][risk=low] Fix some deprecation warnings

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/auth/DelegatedUserCredentials.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/DelegatedUserCredentials.java
@@ -1,12 +1,13 @@
 package org.pmiops.workbench.auth;
 
+import static com.google.api.client.googleapis.util.Utils.getDefaultJsonFactory;
+
 import com.google.api.client.auth.oauth2.TokenRequest;
 import com.google.api.client.auth.oauth2.TokenResponse;
 import com.google.api.client.googleapis.auth.oauth2.GoogleOAuthConstants;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.OAuth2Credentials;
@@ -58,7 +59,7 @@ public class DelegatedUserCredentials extends OAuth2Credentials {
   public static final Duration ACCESS_TOKEN_DURATION = Duration.ofMinutes(60);
   static final String JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
   static final String SERVICE_ACCOUNT_NAME_FORMAT = "projects/-/serviceAccounts/%s";
-  static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+  static final JsonFactory JSON_FACTORY = getDefaultJsonFactory();
 
   // The email of the service account whose system-managed key should be used to sign the JWT
   // assertion which is exchanged for an access token. This service account:

--- a/api/src/main/java/org/pmiops/workbench/auth/UserInfoService.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/UserInfoService.java
@@ -1,7 +1,5 @@
 package org.pmiops.workbench.auth;
 
-import com.google.api.client.http.HttpRequest;
-import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.oauth2.Oauth2;
@@ -32,11 +30,7 @@ public class UserInfoService {
         new Oauth2.Builder(
                 httpTransport,
                 jsonFactory,
-                new HttpRequestInitializer() {
-                  public void initialize(HttpRequest request) {
-                    request.getHeaders().setAuthorization("Bearer " + token);
-                  }
-                })
+                (request) -> request.getHeaders().setAuthorization("Bearer " + token))
             .setApplicationName(APPLICATION_NAME)
             .build();
     return retryHandler.run((context) -> oauth2.userinfo().get().execute());

--- a/api/src/main/java/org/pmiops/workbench/auth/UserInfoService.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/UserInfoService.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.auth;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.oauth2.Oauth2;
@@ -27,9 +28,15 @@ public class UserInfoService {
   }
 
   public Userinfo getUserInfo(String token) {
-    GoogleCredential credential = new GoogleCredential().setAccessToken(token);
     Oauth2 oauth2 =
-        new Oauth2.Builder(httpTransport, jsonFactory, credential)
+        new Oauth2.Builder(
+                httpTransport,
+                jsonFactory,
+                new HttpRequestInitializer() {
+                  public void initialize(HttpRequest request) {
+                    request.getHeaders().setAuthorization("Bearer " + token);
+                  }
+                })
             .setApplicationName(APPLICATION_NAME)
             .build();
     return retryHandler.run((context) -> oauth2.userinfo().get().execute());

--- a/api/src/main/java/org/pmiops/workbench/cdr/CommonTestDialect.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/CommonTestDialect.java
@@ -1,10 +1,10 @@
 package org.pmiops.workbench.cdr;
 
-import org.hibernate.dialect.MySQL57InnoDBDialect;
+import org.hibernate.dialect.MySQL5Dialect;
 import org.hibernate.dialect.function.SQLFunctionTemplate;
 import org.hibernate.type.StandardBasicTypes;
 
-public class CommonTestDialect extends MySQL57InnoDBDialect {
+public class CommonTestDialect extends MySQL5Dialect {
 
   public CommonTestDialect() {
     super();

--- a/api/src/main/java/org/pmiops/workbench/cdr/MySQLDialect.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/MySQLDialect.java
@@ -3,7 +3,7 @@ package org.pmiops.workbench.cdr;
 import org.hibernate.dialect.function.SQLFunctionTemplate;
 import org.hibernate.type.StandardBasicTypes;
 
-public class MySQLDialect extends org.hibernate.dialect.MySQL57InnoDBDialect {
+public class MySQLDialect extends org.hibernate.dialect.MySQL5Dialect {
 
   public MySQLDialect() {
     super();

--- a/api/src/main/java/org/pmiops/workbench/config/CommonConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/CommonConfig.java
@@ -1,7 +1,8 @@
 package org.pmiops.workbench.config;
 
+import static com.google.api.client.googleapis.util.Utils.getDefaultJsonFactory;
+
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
 import java.security.SecureRandom;
 import java.time.Clock;
 import java.util.Random;
@@ -14,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
 public class CommonConfig {
   @Bean
   JsonFactory jsonFactory() {
-    return new JacksonFactory();
+    return getDefaultJsonFactory();
   }
 
   @Bean

--- a/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WebMvcConfig.java
@@ -27,12 +27,12 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @EnableWebMvc
 @Configuration
 @ComponentScan(basePackages = {"org.pmiops.workbench.interceptors", "org.pmiops.workbench.google"})
-public class WebMvcConfig extends WebMvcConfigurerAdapter {
+public class WebMvcConfig implements WebMvcConfigurer {
 
   @Autowired private AuthInterceptor authInterceptor;
 
@@ -87,8 +87,6 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
   @Override
   public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
     configurer.defaultContentType(MediaType.APPLICATION_JSON);
-    // Turn off suffix-based content negotiation
-    configurer.favorPathExtension(false);
   }
 
   static ServletContext getRequestServletContext() {

--- a/api/src/main/java/org/pmiops/workbench/ras/OpenIdConnectClient.java
+++ b/api/src/main/java/org/pmiops/workbench/ras/OpenIdConnectClient.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.ras;
 
+import static com.google.api.client.googleapis.util.Utils.getDefaultJsonFactory;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.auth0.jwt.JWT;
@@ -16,7 +17,6 @@ import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.util.store.MemoryDataStoreFactory;
 import java.io.IOException;
 import java.util.Set;
@@ -26,7 +26,6 @@ import java.util.Set;
  * Connect call</a> using Google OAuth Library.
  */
 public class OpenIdConnectClient {
-  private static final JacksonFactory DEFAULT_JACKSON_FACTORY = new JacksonFactory();
 
   private final AuthorizationCodeFlow codeFlow;
   private final String userInfoUrl;
@@ -83,7 +82,7 @@ public class OpenIdConnectClient {
     return new AuthorizationCodeFlow.Builder(
             BearerToken.queryParameterAccessMethod(),
             httpTransport,
-            DEFAULT_JACKSON_FACTORY,
+            getDefaultJsonFactory(),
             new GenericUrl(tokenUrl),
             new BasicAuthentication(clientId, clientSecret),
             clientId,

--- a/api/src/test/java/org/pmiops/workbench/auth/DelegatedUserCredentialsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/auth/DelegatedUserCredentialsTest.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.auth;
 
+import static com.google.api.client.googleapis.util.Utils.getDefaultJsonFactory;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -7,7 +8,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleOAuthConstants;
 import com.google.api.client.googleapis.testing.auth.oauth2.MockTokenServerTransport;
-import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.api.client.util.PemReader;
@@ -116,10 +116,7 @@ public class DelegatedUserCredentialsTest {
     header.setKeyId(SA_PRIVATE_KEY_ID);
 
     return JsonWebSignature.signUsingRsaSha256(
-        privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8),
-        JacksonFactory.getDefaultInstance(),
-        header,
-        payload);
+        privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8), getDefaultJsonFactory(), header, payload);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDaoTest.java
@@ -125,7 +125,7 @@ public class ParticipantCohortStatusDaoTest {
     final Object[] sqlParams = {key1.getCohortReviewId()};
     final Integer expectedCount = Integer.valueOf("2");
 
-    assertThat(jdbcTemplate.queryForObject(sql, sqlParams, Integer.class)).isEqualTo(expectedCount);
+    assertThat(jdbcTemplate.queryForObject(sql, Integer.class, sqlParams)).isEqualTo(expectedCount);
   }
 
   @Test

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/CommandLineToolConfig.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/CommandLineToolConfig.java
@@ -1,7 +1,5 @@
 package org.pmiops.workbench.tools;
 
-import com.google.api.client.http.HttpTransport;
-import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.gson.Gson;
 import org.pmiops.workbench.config.CommonConfig;
 import org.pmiops.workbench.config.RetryConfig;
@@ -52,15 +50,6 @@ public class CommandLineToolConfig {
 
     Gson gson = new Gson();
     return gson.fromJson(config.getConfiguration(), WorkbenchConfig.class);
-  }
-
-  /**
-   * Returns the Apache HTTP transport. Compare to CommonConfig which returns the App Engine HTTP
-   * transport.
-   */
-  @Bean
-  HttpTransport httpTransport() {
-    return new ApacheHttpTransport();
   }
 
   @Bean

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/GenerateImpersonatedUserTokens.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/GenerateImpersonatedUserTokens.java
@@ -1,12 +1,12 @@
 package org.pmiops.workbench.tools;
 
-import com.google.api.client.http.HttpTransport;
-import com.google.api.client.http.apache.ApacheHttpTransport;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.time.Instant;
 import java.util.logging.Logger;
 import org.apache.commons.cli.CommandLine;
@@ -60,11 +60,10 @@ public class GenerateImpersonatedUserTokens {
       Logger.getLogger(GenerateImpersonatedUserTokens.class.getName());
 
   private void writeTokens(String projectId, String[] usernames, String[] filenames)
-      throws IOException {
+      throws GeneralSecurityException, IOException {
     final String saEmail =
         ServiceAccounts.getServiceAccountEmail(ADMIN_SERVICE_ACCOUNT_NAME, projectId);
     final IamCredentialsClient credsClient = IamCredentialsClient.create();
-    final HttpTransport transport = new ApacheHttpTransport();
 
     final Gson gson = new Gson();
     for (int i = 0; i < usernames.length; i++) {
@@ -76,7 +75,11 @@ public class GenerateImpersonatedUserTokens {
 
       final DelegatedUserCredentials creds =
           new DelegatedUserCredentials(
-              saEmail, username, FireCloudConfig.BILLING_SCOPES, credsClient, transport);
+              saEmail,
+              username,
+              FireCloudConfig.BILLING_SCOPES,
+              credsClient,
+              GoogleNetHttpTransport.newTrustedTransport());
       creds.refresh();
       final String token = creds.getAccessToken().getTokenValue();
 


### PR DESCRIPTION
This fixes the remaining warnings visible with:
```
ADD_XLINT_DEPRECATION=1 ./gradlew clean compileTestJava compile__tools__Java
```
with the following exceptions:
- warnings in Swagger-generated code
- warnings within our own code

There is a separate ticket for fixing the Swagger-generated code. Warnings within our own code are not as risky since we will not be blocked from upgrading libraries due to using deprecated features.

Some testing thoughts described inline.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
