### PR TITLE
[no ticket][risk=no] Fix warning

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -474,7 +474,9 @@ dependencies {
     testAnnotationProcessor "org.mapstruct:mapstruct-processor:$project.ext.MAPSTRUCT_VERSION"
 
     // latest as of 12 May 2023 10:19:45 -0400
-    implementation "org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-00d8cfd-SNAP"
+    implementation("org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-00d8cfd-SNAP") {
+      exclude group: 'org.apache.oltu.oauth2', module: 'org.apache.oltu.oauth2.common'
+    }
 
     // Dependencies for Swagger codegen-generated sources. This should include all dependencies required by Swagger's
     // default okhttp API codegen templates (see https://github.com/swagger-api/swagger-codegen/blob/v2.2.3/samples/client/petstore/spring-stubs/pom.xml)


### PR DESCRIPTION
Addresses the warning:
```
2023-05-18 12:06:14.903:WARN:oeja.AnnotationParser:qtp1150284200-39: org.apache.oltu.oauth2.common.OAuth$ContentType scanned from multiple locations: jar:file:///Users/dmohs/b/r/aou/gc/api/build/exploded-api/WEB-INF/lib/org.apache.oltu.oauth2.common-1.0.1.jar!/org/apache/oltu/oauth2/common/OAuth$ContentType.class, jar:file:///Users/dmohs/b/r/aou/gc/api/build/exploded-api/WEB-INF/lib/org.apache.oltu.oauth2.client-1.0.1.jar!/org/apache/oltu/oauth2/common/OAuth$ContentType.class
```
that occurs when running:
```
./gradlew appengineRun
```

---
**PR checklist**

- [X] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [X] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
