### PR TITLE
[risk=no][no ticket] Demote or adjust uses of Long in some tests

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -2421,10 +2421,10 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
     return new CohortDefinition().includes(groups);
   }
 
-  private void assertParticipants(ResponseEntity response, Integer expectedCount) {
+  private void assertParticipants(ResponseEntity<Long> response, Integer expectedCount) {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-    Long participantCount = (Long) response.getBody();
+    Long participantCount = response.getBody();
     assertThat(participantCount).isEqualTo(expectedCount);
   }
 

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -152,8 +152,8 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
 
   private static final String NAMESPACE = "aou-test";
   private static final String NAME = "test";
-  private static final Long PARTICIPANT_ID = 102246L;
-  private static final Long PARTICIPANT_ID2 = 102247L;
+  private static final long PARTICIPANT_ID = 102246L;
+  private static final long PARTICIPANT_ID2 = 102247L;
   private static final FakeClock CLOCK = new FakeClock(Instant.now(), ZoneId.systemDefault());
   private DbCdrVersion cdrVersion;
   private DbWorkspace workspace;
@@ -641,7 +641,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
         .isEqualTo(new Vocabulary().type("Source").domain("ALL_EVENTS").vocabulary("ICD9CM"));
   }
 
-  private void saveParticipantCohortStatus(Long participantId, Long reviewId) {
+  private void saveParticipantCohortStatus(long participantId, long reviewId) {
     participantCohortStatusDao.save(
         new DbParticipantCohortStatus()
             .participantKey(

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -983,7 +983,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                     new DataSetPreviewValueList().addQueryValueItem("1").value("person_id")));
   }
 
-  private void assertAndExecutePythonQuery(String code, int index, Domain domain, Long count) {
+  private void assertAndExecutePythonQuery(String code, int index, Domain domain, long count) {
     String expected =
         String.format(
             "import pandas\n"

--- a/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortBuilderControllerTest.java
@@ -1381,18 +1381,15 @@ public class CohortBuilderControllerTest {
             .findSurveyVersionByQuestionConceptId(WORKSPACE_NAMESPACE, WORKSPACE_ID, 715713L)
             .getBody();
     assert response != null;
-    assertThat(response.getItems().get(0).getSurveyVersionConceptId())
-        .isEqualTo(Long.valueOf("100"));
+    assertThat(response.getItems().get(0).getSurveyVersionConceptId()).isEqualTo(100);
     assertThat(response.getItems().get(0).getDisplayName()).isEqualTo("May 2020");
-    assertThat(response.getItems().get(0).getItemCount()).isEqualTo(Long.valueOf("291"));
-    assertThat(response.getItems().get(1).getSurveyVersionConceptId())
-        .isEqualTo(Long.valueOf("101"));
+    assertThat(response.getItems().get(0).getItemCount()).isEqualTo(291);
+    assertThat(response.getItems().get(1).getSurveyVersionConceptId()).isEqualTo(101);
     assertThat(response.getItems().get(1).getDisplayName()).isEqualTo("June 2020");
-    assertThat(response.getItems().get(1).getItemCount()).isEqualTo(Long.valueOf("148"));
-    assertThat(response.getItems().get(2).getSurveyVersionConceptId())
-        .isEqualTo(Long.valueOf("102"));
+    assertThat(response.getItems().get(1).getItemCount()).isEqualTo(148);
+    assertThat(response.getItems().get(2).getSurveyVersionConceptId()).isEqualTo(102);
     assertThat(response.getItems().get(2).getDisplayName()).isEqualTo("July 2020");
-    assertThat(response.getItems().get(2).getItemCount()).isEqualTo(Long.valueOf("150"));
+    assertThat(response.getItems().get(2).getItemCount()).isEqualTo(150);
     jdbcTemplate.execute("drop table cb_survey_version");
     jdbcTemplate.execute("drop table cb_survey_attribute");
   }

--- a/api/src/test/java/org/pmiops/workbench/api/EgressEventsAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/EgressEventsAdminControllerTest.java
@@ -459,7 +459,7 @@ public class EgressEventsAdminControllerTest {
     assertThat(gotEntries).containsExactlyElementsIn(expected);
   }
 
-  private Instant timeMinusHours(Integer h) {
+  private Instant timeMinusHours(long h) {
     return TIME0.minus(Duration.ofHours(h));
   }
 

--- a/api/src/test/java/org/pmiops/workbench/cohortreview/mapper/CohortReviewMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cohortreview/mapper/CohortReviewMapperTest.java
@@ -57,7 +57,7 @@ public class CohortReviewMapperTest {
                     .cohortName("name")
                     .version(1)
                     .reviewSize(10L)
-                    .reviewStatus(Short.valueOf("1"))
+                    .reviewStatus((short) 1)
                     .reviewedCount(10L)
                     .cdrVersionId(1L)
                     .creationTime(timestamp)

--- a/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDaoTest.java
@@ -35,7 +35,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringJUnitConfig
 public class ParticipantCohortStatusDaoTest {
-  private static final Long COHORT_REVIEW_ID = 1L;
+  private static final long COHORT_REVIEW_ID = 1L;
   private static final Date birthDate = new Date(System.currentTimeMillis());
   private static final int PAGE = 0;
   private static final int PAGE_SIZE = 25;
@@ -123,7 +123,7 @@ public class ParticipantCohortStatusDaoTest {
 
     String sql = "select count(*) from participant_cohort_status where cohort_review_id = ?";
     final Object[] sqlParams = {key1.getCohortReviewId()};
-    final Integer expectedCount = Integer.valueOf("2");
+    final int expectedCount = 2;
 
     assertThat(jdbcTemplate.queryForObject(sql, sqlParams, Integer.class)).isEqualTo(expectedCount);
   }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/ParticipantCohortStatusDaoTest.java
@@ -123,7 +123,7 @@ public class ParticipantCohortStatusDaoTest {
 
     String sql = "select count(*) from participant_cohort_status where cohort_review_id = ?";
     final Object[] sqlParams = {key1.getCohortReviewId()};
-    final int expectedCount = 2;
+    final Integer expectedCount = 2;
 
     assertThat(jdbcTemplate.queryForObject(sql, sqlParams, Integer.class)).isEqualTo(expectedCount);
   }


### PR DESCRIPTION
Test changes only.

I noticed after seeing #7694 that we were using `Long` suboptimally in some cases.

We generally want to use primitive `long` wherever possible, because it's non-nullable and uses fewer resources. 

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
