### PR TITLE
[risk=low][no ticket] Updates to ManageLeonardoRuntimes

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -729,7 +729,9 @@ task loadConfig(type: JavaExec) {
 }
 
 // Called by devs from the command-line:
-// - devstart.rb > list_runtimes
+// ./project.rb list-runtimes
+// ./project.rb delete-runtimes
+// ./project.rb describe-runtime
 task manageLeonardoRuntimes(type: JavaExec) {
     classpath sourceSets.__tools__.runtimeClasspath
     mainClass = "org.pmiops.workbench.tools.ManageLeonardoRuntimes"

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -1897,10 +1897,6 @@ def describe_runtime(cmd_name, *args)
       "--id [RUNTIME_ID]",
       ->(opts, v) { opts.runtime_id = v},
       "Required runtime ID to describe, e.g. 'aou-test-f1-1/all-of-us'")
-  op.add_option(
-      "--project [project]",
-      ->(opts, v) { opts.project = v},
-      "Required project ID")
   op.add_validator ->(opts) { raise ArgumentError unless opts.runtime_id }
 
   # Add the GcloudContext after setting up the project parameter to avoid
@@ -1914,7 +1910,7 @@ def describe_runtime(cmd_name, *args)
     common = Common.new
     common.run_inline %W{
        ./gradlew manageLeonardoRuntimes
-      -PappArgs=['describe','#{api_url}','#{gcc.project}','#{ctx.service_account}','#{op.opts.runtime_id}']}
+      -PappArgs=['describe','#{api_url}','#{ctx.service_account}','#{op.opts.runtime_id}']}
   end
 end
 
@@ -1929,19 +1925,19 @@ def list_runtimes(cmd_name, *args)
   op = WbOptionsParser.new(cmd_name, args)
   gcc = GcloudContextV2.new(op)
   op.add_option(
-      "--runtime-project [project]",
-      ->(opts, v) { opts.runtime_project = v},
-      "Optionally filter by runtime project")
+      "--google-project [project]",
+      ->(opts, v) { opts.google_project = v},
+      "Optionally filter by google project")
   op.add_option(
       "--include-deleted",
       ->(opts, _) { opts.include_deleted = true },
       "Whether to include deleted runtimes in the results; typically should only be used in " +
-      "combination with --runtime-project, otherwise this could be very slow")
+      "combination with --google-project, otherwise this could be very slow")
   op.add_option(
       "--format [format]",
       ->(opts, v) { opts.format = v },
       "JSON or TABULAR, defaults to TABULAR (summary)")
-  op.opts.runtime_project = ""
+  op.opts.google_project = ""
   op.opts.include_deleted = false
   op.opts.format = "TABULAR"
 
@@ -1958,7 +1954,7 @@ def list_runtimes(cmd_name, *args)
   ServiceAccountContext.new(gcc.project).run do
     common = Common.new
     common.run_inline %W{
-      ./gradlew manageLeonardoRuntimes -PappArgs=['list','#{api_url}','#{op.opts.include_deleted}','#{op.opts.runtime_project}','#{op.opts.format}']
+      ./gradlew manageLeonardoRuntimes -PappArgs=['list','#{api_url}','#{op.opts.include_deleted}','#{op.opts.google_project}','#{op.opts.format}']
     }
   end
 end

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ManageLeonardoRuntimes.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ManageLeonardoRuntimes.java
@@ -67,7 +67,7 @@ public class ManageLeonardoRuntimes {
         "https://www.googleapis.com/auth/userinfo.email"
       };
   private static final List<String> DESCRIBE_ARG_NAMES =
-      ImmutableList.of("api_url", "project", "service_account", "runtime_id");
+      ImmutableList.of("api_url", "service_account", "runtime_id");
   private static final List<String> DELETE_ARG_NAMES =
       ImmutableList.of("api_url", "min_age", "ids", "dry_run");
   private static final Gson PRETTY_GSON = new GsonBuilder().setPrettyPrinting().create();
@@ -133,13 +133,13 @@ public class ManageLeonardoRuntimes {
   }
 
   private void listRuntimes(
-      String apiUrl, boolean includeDeleted, Optional<String> projectId, OutputFormat fmt)
+      String apiUrl, boolean includeDeleted, Optional<String> googleProjectId, OutputFormat fmt)
       throws IOException, ApiException {
     RuntimesApi api = newApiClient(apiUrl);
 
     List<LeonardoListRuntimeResponse> runtimes;
-    if (projectId.isPresent()) {
-      runtimes = api.listRuntimesByProject(projectId.get(), null, includeDeleted);
+    if (googleProjectId.isPresent()) {
+      runtimes = api.listRuntimesByProject(googleProjectId.get(), null, includeDeleted);
     } else {
       runtimes = api.listRuntimes(null, includeDeleted);
     }
@@ -249,7 +249,7 @@ public class ManageLeonardoRuntimes {
                     "Expected %d args %s. Got: %s",
                     DESCRIBE_ARG_NAMES.size(), DESCRIBE_ARG_NAMES, Arrays.asList(args)));
           }
-          describeRuntime(args[0], args[2], args[3]);
+          describeRuntime(args[0], args[1], args[2]);
           return;
 
         case "list":


### PR DESCRIPTION
I had an occasion to use these tools while helping a user, so I make some small fixes.

Tested by creating a runtime and running these commands locally:
```
./project.rb list-runtimes --project=all-of-us-rw-preprod --google-project terra-vpc-sc-7d68ac3f
./project.rb describe-runtime --project=all-of-us-rw-preprod --id terra-vpc-sc-7d68ac3f/all-of-us-45
./project.rb delete-runtimes --project=all-of-us-rw-preprod --ids terra-vpc-sc-7d68ac3f/all-of-us-45
```

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
