### PR TITLE
[risk=low][RW-8978] Convert Moodle Swagger YAML to OpenAPI 3

### DIFF
--- a/api/src/main/resources/moodle.yaml
+++ b/api/src/main/resources/moodle.yaml
@@ -8,8 +8,14 @@ info:
   description: |
     Service for Moodle Interactions.
   version: "0.1"
+
+# We use aoudev.nnlm.gov for Test, Local, and Staging
 servers:
   - url: https://aou.nnlm.gov/webservice/rest
+
+##########################################################################################
+## PATHS
+##########################################################################################
 paths:
   /server.php?wsfunction=local_workbenchapiv2_check_user_badge:
     get:
@@ -49,6 +55,10 @@ paths:
           content: {}
       security:
         - AdminSecurity: []
+
+##########################################################################################
+## COMPONENTS
+##########################################################################################
 components:
   schemas:
     UserBadgeResponseV2:

--- a/api/src/main/resources/moodle.yaml
+++ b/api/src/main/resources/moodle.yaml
@@ -1,69 +1,58 @@
 #This file provide the end points for moodle interactions
-# MOodle API information can be found at :
+# Moodle API information can be found at :
 # https://docs.moodle.org/dev/Web_service_API_functions
 
-
-swagger: '2.0'
-
+openapi: 3.0.1
 info:
   title: Moodle
   description: |
     Service for Moodle Interactions.
   version: "0.1"
-#The host will get updated as per the environment it will be aoudev.nnlm.gov for dev and test
-host: "aou.nnlm.gov"
-schemes:
-  - "https"
-basePath: /webservice/rest
-
-produces:
-  - application/json
-
-##########################################################################################
-## PATHS
-##########################################################################################
-
+servers:
+  - url: https://aou.nnlm.gov/webservice/rest
 paths:
   /server.php?wsfunction=local_workbenchapiv2_check_user_badge:
     get:
-      summary: Get information of badges earned/completed by user.
       tags:
         - Moodle
-      consumes:
-        - application/json
+      summary: Get information of badges earned/completed by user.
       operationId: getMoodleBadgeV2
       parameters:
         - name: moodlewsrestformat
           in: query
           description: Format of the response which will be json for AoU
-          type: string
           required: true
+          schema:
+            type: string
         - name: email
           in: query
-          type: string
+          schema:
+            type: string
         - name: wstoken
           in: query
           description: Secret Token associated with All of us
-          type: string
           required: true
-
+          schema:
+            type: string
       responses:
         200:
           description: Badge /error response
-          schema:
-            $ref: '#/definitions/UserBadgeResponseV2'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserBadgeResponseV2'
         400:
           description: Bad request
+          content: {}
         500:
           description: Moodle Internal Error
+          content: {}
       security:
         - AdminSecurity: []
-
-##########################################################################################
-## DEFINITIONS
-##########################################################################################
-definitions:
+components:
+  schemas:
     UserBadgeResponseV2:
+      type: object
       properties:
         id:
           type: integer
@@ -72,11 +61,9 @@ definitions:
           type: string
           description: Moodle username
         ret:
-          type: object
-          $ref: '#/definitions/BadgeDetailsV2'
+          $ref: '#/components/schemas/BadgeDetailsV2'
         dua:
-          type: object
-          $ref: '#/definitions/BadgeDetailsV2'
+          $ref: '#/components/schemas/BadgeDetailsV2'
         exception:
           type: string
         errorcode:
@@ -84,24 +71,26 @@ definitions:
         message:
           type: string
           description: A message describing the error
-
     BadgeDetailsV2:
+      type: object
       properties:
         valid:
           type: boolean
           description: Whether the badge is valid
         lastissued:
           type: integer
-          format: int64
           description: Date of latest issued badge. As a stringy epoch in SECONDS.
+          format: int64
         dateexpire:
           type: integer
+          description: Latest expiration of obtained badge. As a stringy epoch in
+            SECONDS.
           format: int64
-          description: Latest expiration of obtained badge. As a stringy epoch in SECONDS.
         message:
           type: string
           description: General API message
         globalexpiration:
           type: integer
+          description: Global expiration, overrides badge expiration date. As a stringy
+            epoch in SECONDS.
           format: int64
-          description: Global expiration, overrides badge expiration date. As a stringy epoch in SECONDS.


### PR DESCRIPTION
https://editor.swagger.io/ has a convenient "Convert to OpenAPI 3" button.  This seemed to work, and then added the comments back in.

Tested locally by un-bypassing my user and visiting the Data Access Requirements page, which checks Moodle for user results when we have not recorded any in the AoU DB.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
