### PR TITLE
[no ticket][risk=no] e2e: Make Python kernel name check more flexible

### DIFF
--- a/e2e/app/text-labels.ts
+++ b/e2e/app/text-labels.ts
@@ -142,7 +142,7 @@ export enum Language {
 
 // Displayed text for Jupyter kernels, by language
 export enum JupyterKernels {
-  Python = 'Python 3 (ipykernel)',
+  Python = 'Python 3',
   R = 'R'
 }
 

--- a/e2e/tests/notebook/notebook-create-python.spec.ts
+++ b/e2e/tests/notebook/notebook-create-python.spec.ts
@@ -53,7 +53,7 @@ describe('Python Kernel Notebook Test', () => {
 
     // Verify kernel name.
     const kernelName = await notebook.getKernelName();
-    expect(kernelName).toBe(JupyterKernels.Python);
+    expect(kernelName).toContain(JupyterKernels.Python);
 
     let cellIndex = 1;
     const cell1OutputText = await notebook.runCodeCell(cellIndex, {

--- a/e2e/tests/notebook/notebook-snippets.spec.ts
+++ b/e2e/tests/notebook/notebook-snippets.spec.ts
@@ -42,7 +42,7 @@ describe('Notebook Snippets Tests', () => {
 
     // Verify kernel name.
     const kernelName = await notebook.getKernelName();
-    expect(kernelName).toBe(expectedKernelName);
+    expect(kernelName).toContain(expectedKernelName);
 
     const notebookIFrame = await notebook.getIFrame();
 

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -69,8 +69,8 @@ export interface Environment extends EnvironmentBase {
   // Indicates that the current server is a local server where client-side
   // debugging should be enabled (e.g. console.log, or devtools APIs).
   debug: boolean;
+
   // A prefix to add to the site title (shown in the tab title).
-  //
   // Example value: 'Test' would cause the following full title:
   // "Homepage | [Test] All of Us Researcher Workbench"
   displayTag: string;


### PR DESCRIPTION
Followup to #7700 - make test more flexible so it passes for both docker image versions (2.1.15 and 2.1.20).  We regressed on this when we reverted the docker image.

I ran the 2 relevant tests locally and they passed.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
