### PR TITLE
[risk=no][no ticket] Accurately describe how our JIRA/release process parses PR titles

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,8 @@ Typical naming convention is `username/feature`. Username could be
 your initials or some other similar identifier. Feature could be a short 
 description of the feature or a reference to the jira ticket number
 
-Preface the PR title with JIRA issue number and security risk (e.g. `[RW-123][risk=no]`)
+Preface the PR title with the security risk, then any JIRA ticket numbers if applicable 
+(e.g. `[risk=low][RW-123]`, `[risk=no][no ticket]`, `[risk=low][RW-123][RW-456]`)
 to the PR title. This will allow automated deployment processes to generate appropriate 
 documentation. 
 


### PR DESCRIPTION
The PR title parser we use requires the security risk to appear **first** in the title, before JIRA tickets.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
