### PR TITLE
[no ticket][risk=no] Add missing env vars that is required for GKE APP

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -530,14 +530,19 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
       diskRequest.setName(userProvider.get().generatePDNameForUserApps(appType));
     }
 
+    Map<String, String> appCustomEnvVars =
+        LeonardoCustomEnvVarUtils.getBaseEnvironmentVariables(
+            dbWorkspace, fireCloudService, workbenchConfigProvider.get());
+    appCustomEnvVars.put("WORKSPACE_NAME", dbWorkspace.getFirecloudName());
+    appCustomEnvVars.put("GOOGLE_PROJECT", dbWorkspace.getGoogleProject());
+    appCustomEnvVars.put("OWNER_EMAIL", userProvider.get().getUsername());
+
     leonardoCreateAppRequest
         .appType(leonardoMapper.toLeonardoAppType(appType))
         .kubernetesRuntimeConfig(
             leonardoMapper.toLeonardoKubernetesRuntimeConfig(kubernetesRuntimeConfig))
         .diskConfig(diskRequest)
-        .customEnvironmentVariables(
-            LeonardoCustomEnvVarUtils.getBaseEnvironmentVariables(
-                dbWorkspace, fireCloudService, workbenchConfigProvider.get()))
+        .customEnvironmentVariables(appCustomEnvVars)
         .labels(appLabels);
 
     if (appType.equals(AppType.RSTUDIO)) {

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -536,7 +536,10 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
     Map<String, String> appCustomEnvVars =
         LeonardoCustomEnvVarUtils.getBaseEnvironmentVariables(
             dbWorkspace, fireCloudService, workbenchConfigProvider.get());
+    // Required by Leo to validate one App per user per workspace (namespace with workspace name)
     appCustomEnvVars.put(WORKSPACE_NAME_ENV_KEY, dbWorkspace.getFirecloudName());
+
+    // Used by AoU RW and but not set by Leo for GKE APP.
     appCustomEnvVars.put(GOOGLE_PROJECT_ENV_KEY, dbWorkspace.getGoogleProject());
     appCustomEnvVars.put(OWNER_EMAIL_ENV_KEY, userProvider.get().getUsername());
 

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -1,5 +1,8 @@
 package org.pmiops.workbench.leonardo;
 
+import static org.pmiops.workbench.leonardo.LeonardoCustomEnvVarUtils.GOOGLE_PROJECT_ENV_KEY;
+import static org.pmiops.workbench.leonardo.LeonardoCustomEnvVarUtils.OWNER_EMAIL_ENV_KEY;
+import static org.pmiops.workbench.leonardo.LeonardoCustomEnvVarUtils.WORKSPACE_NAME_ENV_KEY;
 import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.appTypeToLabelValue;
 import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.upsertLeonardoLabel;
 
@@ -533,9 +536,9 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
     Map<String, String> appCustomEnvVars =
         LeonardoCustomEnvVarUtils.getBaseEnvironmentVariables(
             dbWorkspace, fireCloudService, workbenchConfigProvider.get());
-    appCustomEnvVars.put("WORKSPACE_NAME", dbWorkspace.getFirecloudName());
-    appCustomEnvVars.put("GOOGLE_PROJECT", dbWorkspace.getGoogleProject());
-    appCustomEnvVars.put("OWNER_EMAIL", userProvider.get().getUsername());
+    appCustomEnvVars.put(WORKSPACE_NAME_ENV_KEY, dbWorkspace.getFirecloudName());
+    appCustomEnvVars.put(GOOGLE_PROJECT_ENV_KEY, dbWorkspace.getGoogleProject());
+    appCustomEnvVars.put(OWNER_EMAIL_ENV_KEY, userProvider.get().getUsername());
 
     leonardoCreateAppRequest
         .appType(leonardoMapper.toLeonardoAppType(appType))

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoCustomEnvVarUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoCustomEnvVarUtils.java
@@ -20,6 +20,10 @@ import org.pmiops.workbench.rawls.model.RawlsWorkspaceResponse;
 /** Utility class for holding Leonardo APP environment variables constant and methods. */
 public class LeonardoCustomEnvVarUtils {
 
+  public static String WORKSPACE_NAME_ENV_KEY = "WORKSPACE_NAME";
+  public static String GOOGLE_PROJECT_ENV_KEY = "GOOGLE_PROJECT";
+  public static String OWNER_EMAIL_ENV_KEY = "OWNER_EMAIL";
+
   private static final String MICROARRAY_HAIL_STORAGE_PATH_KEY = "MICROARRAY_HAIL_STORAGE_PATH";
   @VisibleForTesting public static final String WORKSPACE_CDR_ENV_KEY = "WORKSPACE_CDR";
 

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -225,7 +225,9 @@ public class LeonardoApiClientTest {
     LeonardoCreateAppRequest createAppRequest = createAppRequestArgumentCaptor.getValue();
     appLabels.put(
         LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE, AppType.RSTUDIO.toString().toLowerCase());
-
+    customEnvironmentVariables.put("WORKSPACE_NAME", testWorkspace.getFirecloudName());
+    customEnvironmentVariables.put("GOOGLE_PROJECT", testWorkspace.getGoogleProject());
+    customEnvironmentVariables.put("OWNER_EMAIL", user.getUsername());
     LeonardoCreateAppRequest expectedAppRequest =
         new LeonardoCreateAppRequest()
             .appType(LeonardoAppType.CUSTOM)


### PR DESCRIPTION
Those env vars are missing in GKE APP but available in Runtime

- `GOOGLE_PROJECT` and `OWNER_EMAIL` is required for dataset builder generated query.  Having those two we can easily copy the generate code from Jupyter to RStudio
- `WORKSPACE_NAME` is required by Leo to look up which app belongs to which user within one workspace.  Confirmed it is the firecloud name in Jupyter in terra-ui

![Screenshot 2023-05-24 at 5 06 10 PM](https://github.com/all-of-us/workbench/assets/6351731/1ec5995a-0f91-43ab-bc4b-2460a1c21d5d)



 <!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
