### PR TITLE
[risk=low][RW-10024] Restore HttpTransport bean to CommandLineToolConfig

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/CommandLineToolConfig.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/CommandLineToolConfig.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.tools;
 
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.apache.v2.ApacheHttpTransport;
 import com.google.gson.Gson;
 import org.pmiops.workbench.config.CommonConfig;
 import org.pmiops.workbench.config.RetryConfig;
@@ -55,6 +57,15 @@ public class CommandLineToolConfig {
   @Bean
   public Sleeper sleeper() {
     return new ThreadWaitSleeper();
+  }
+
+  /**
+   * Returns the Apache HTTP transport. Compare to CommonConfig which returns the App Engine HTTP
+   * transport.
+   */
+  @Bean
+  HttpTransport httpTransport() {
+    return new ApacheHttpTransport();
   }
 
   @Bean


### PR DESCRIPTION
This was removed in #7698 to fix a deprecation warning.  This restores it, replacing the deprecated `com.google.api.client.http.apache.ApacheHttpTransport` with the non-deprecated `com.google.api.client.http.apache.v2.ApacheHttpTransport`.

I need this because it's breaking my in-progress updates to DeleteWorkspaces.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
