### PR TITLE
[risk=low][RW-10177] Upgrade shibboleth.yaml to OpenAPI 3

### DIFF
--- a/api/src/main/resources/shibboleth.yaml
+++ b/api/src/main/resources/shibboleth.yaml
@@ -2,64 +2,60 @@
 # RW-4257 for documentation and links to the service source code.
 #
 # The Shibboleth service does not publish its own structured API, so this file was hand-crafted
-# to allow client API code to be auto-generated in this repo.
-swagger: '2.0'
+# (and then auto-converted to OpenAPI 3) to allow client API code auto-generation.
+
+openapi: 3.0.1
 info:
   title: Shibboleth
   description: Workbench Shibboleth service
-  version: '1.0'
-host: profile-dot-broad-shibboleth-prod.appspot.com
-schemes:
-  - 'https'
-basePath: /
-
-produces:
-  - application/json
-
-# The securityDefinitions and security stanzas are copied from notebooks.yaml. The intent is
-# to force the generated API client to pass along a Google access token when necessary.
-securityDefinitions:
-  googleoauth:
-    type: oauth2
-    authorizationUrl: 'https://accounts.google.com/o/oauth2/auth'
-    flow: implicit
-    scopes:
-      openid: open id authorization
-      email: email authorization
-      profile: profile authorization
-
+  version: "1.0"
+servers:
+  - url: https://profile-dot-broad-shibboleth-prod.appspot.com/
 security:
   - googleoauth:
       - openid
       - email
       - profile
-
 paths:
-  '/shibboleth-token':
+  /shibboleth-token:
     post:
+      tags:
+        - shibboleth
       summary: Update Terra eRA Commons linkage with a Shibboleth token.
       description: |
         Updates the linkage between a Terra user and eRA Commons user by parsing a Shibboleth
         JWT and storing the contained eRA Commons username in the Terra profile service. The
         linkge will be stored with an expiration time of 30 days.
       operationId: postShibbolethToken
-      tags:
-        - shibboleth
-      consumes:
-        - text/plain
-      parameters:
-        - name: jwt
-          in: body
-          description: JWT returned from the Shibboleth browser-based login flow.
-          required: true
-          schema:
-            type: string
+      requestBody:
+        description: JWT returned from the Shibboleth browser-based login flow.
+        content:
+          text/plain:
+            schema:
+              type: string
+        required: true
       responses:
         200:
           description: OK
+          content: {}
         400:
           description: Invalid or malformed JWT
+          content: {}
         401:
           description: Unauthorized
+          content: {}
         500:
           description: Internal Server Error
+          content: {}
+      x-codegen-request-body-name: jwt
+components:
+  securitySchemes:
+    googleoauth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://accounts.google.com/o/oauth2/auth
+          scopes:
+            openid: open id authorization
+            email: email authorization
+            profile: profile authorization


### PR DESCRIPTION
Another success from https://editor.swagger.io/

To test:
1. Run local API+UI
2. Navigate to Data Access Requirements in the UI

3A. If ERA Commons has not been completed
* complete it, and observe that the user now has a completed module in AoU 

3B. If ERA Commons has been completed
* delete the user's completed entry in the DB (user_access_module table, access_module_id = 1)
* reload the UI, and observe that the user now has a completed module in AoU 

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
