### PR TITLE
[RW-9950][risk=low] Switch to use RSTUDIO app type in Leo. 

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -21,10 +21,7 @@
       "gce": ["test-gce-docker-image"],
       "dataproc": ["test-dataproc-docker-image"]
     },
-    "gceVmZone": "us-central1-c",
-    "userApps": {
-      "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
-    }
+    "gceVmZone": "us-central1-c"
   },
   "billing": {
     "accountId": "013713-75CFF6-1751E5",

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -21,10 +21,7 @@
       "gce": [],
       "dataproc": []
     },
-    "gceVmZone": "us-central1-a",
-    "userApps": {
-      "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
-    }
+    "gceVmZone": "us-central1-a"
   },
   "billing": {
     "accountId": "01DDC8-7ED304-6E46FE",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -21,10 +21,7 @@
       "gce": [],
       "dataproc": []
     },
-    "gceVmZone": "us-central1-a",
-    "userApps": {
-      "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
-    }
+    "gceVmZone": "us-central1-a"
   },
   "billing": {
     "accountId": "01DDC8-7ED304-6E46FE",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -21,10 +21,7 @@
       "gce": [],
       "dataproc": []
     },
-    "gceVmZone": "us-central1-a",
-    "userApps": {
-      "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
-    }
+    "gceVmZone": "us-central1-a"
   },
   "billing": {
     "accountId": "01DDC8-7ED304-6E46FE",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -21,10 +21,7 @@
       "gce": [],
       "dataproc": []
     },
-    "gceVmZone": "us-central1-a",
-    "userApps": {
-      "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
-    }
+    "gceVmZone": "us-central1-a"
   },
   "billing": {
     "accountId": "01DDC8-7ED304-6E46FE",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -21,10 +21,7 @@
       "gce": [],
       "dataproc": []
     },
-    "gceVmZone": "us-central1-c",
-    "userApps": {
-      "rStudioDescriptorPath": "https:\/\/raw.githubusercontent.com\/DataBiosphere\/terra-app\/39c602e20ba027eb065dcb7690e76f2236ac2848\/apps\/rstudio\/app.yaml"
-    }
+    "gceVmZone": "us-central1-c"
   },
   "billing": {
     "accountId": "013713-75CFF6-1751E5",

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -55,7 +55,6 @@ public class WorkbenchConfig {
     config.egressAlertRemediationPolicy = new EgressAlertRemediationPolicy();
     config.featureFlags = new FeatureFlagsConfig();
     config.firecloud = new FireCloudConfig();
-    config.firecloud.userApps = new UserApps();
     config.googleCloudStorageService = new GoogleCloudStorageServiceConfig();
     config.googleDirectoryService = new GoogleDirectoryServiceConfig();
     config.mandrill = new MandrillConfig();
@@ -171,18 +170,11 @@ public class WorkbenchConfig {
 
     // The deployment area of the GCE VM. For example, us-east1-a or europe-west2-c
     public String gceVmZone;
-
-    public UserApps userApps;
   }
 
   public static class RuntimeImages {
     public List<String> gce;
     public List<String> dataproc;
-  }
-
-  public static class UserApps {
-    /** The descriptor path which defines RStudio application configuration. */
-    public String rStudioDescriptorPath;
   }
 
   public static class AuthConfig {

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -551,11 +551,6 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
         .customEnvironmentVariables(appCustomEnvVars)
         .labels(appLabels);
 
-    if (appType.equals(AppType.RSTUDIO)) {
-      leonardoCreateAppRequest.descriptorPath(
-          workbenchConfigProvider.get().firecloud.userApps.rStudioDescriptorPath);
-    }
-
     leonardoRetryHandler.run(
         (context) -> {
           appsApi.createApp(

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -250,11 +250,10 @@ public interface LeonardoMapper {
   LeonardoKubernetesRuntimeConfig toLeonardoKubernetesRuntimeConfig(
       KubernetesRuntimeConfig kubernetesRuntimeConfig);
 
-  @ValueMapping(source = "RSTUDIO", target = "CUSTOM")
   LeonardoAppType toLeonardoAppType(AppType appType);
 
-  @ValueMapping(source = "CUSTOM", target = "RSTUDIO")
   @ValueMapping(source = "GALAXY", target = MappingConstants.NULL) // we don't support Galaxy
+  @ValueMapping(source = "CUSTOM", target = MappingConstants.NULL) // we don't support Galaxy
   AppType toApiAppType(LeonardoAppType appType);
 
   default void mapLabels(Runtime runtime, Object runtimeLabelsObj) {

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -253,7 +253,7 @@ public interface LeonardoMapper {
   LeonardoAppType toLeonardoAppType(AppType appType);
 
   @ValueMapping(source = "GALAXY", target = MappingConstants.NULL) // we don't support Galaxy
-  @ValueMapping(source = "CUSTOM", target = MappingConstants.NULL) // we don't support Galaxy
+  @ValueMapping(source = "CUSTOM", target = MappingConstants.NULL) // we don't support CUSTOM apps
   AppType toApiAppType(LeonardoAppType appType);
 
   default void mapLabels(Runtime runtime, Object runtimeLabelsObj) {

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -1496,6 +1496,7 @@ components:
         - CROMWELL
         - CUSTOM
         - GALAXY
+        - RSTUDIO
     AppStatus:
       type: string
       enum:

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -124,7 +124,6 @@ public class LeonardoApiClientTest {
   private static final String GOOGLE_PROJECT_ID = "aou-gcp-id";
   private static final String MACHINE_TYPE = "n1-standard-1";
   private static final String LOGGED_IN_USER_EMAIL = "bob@gmail.com";
-  private static final String RSTUDIO_DESCRIPTOR_PATH = "rstudio/path";
   private static final String CDR_BUCKET = "gs://cdr-bucket";
   private static final String CDR_STORAGE_BASE_PATH = "v99";
   private static final String WGS_PATH = "wgs/cram/manifest.csv";
@@ -145,7 +144,6 @@ public class LeonardoApiClientTest {
   @BeforeEach
   public void setUp() throws Exception {
     config = WorkbenchConfig.createEmptyConfig();
-    config.firecloud.userApps.rStudioDescriptorPath = RSTUDIO_DESCRIPTOR_PATH;
     config.firecloud.leoBaseUrl = LEONARDO_BASE_URL;
 
     user = new DbUser().setUsername(LOGGED_IN_USER_EMAIL).setUserId(123L);
@@ -230,9 +228,8 @@ public class LeonardoApiClientTest {
     customEnvironmentVariables.put("OWNER_EMAIL", user.getUsername());
     LeonardoCreateAppRequest expectedAppRequest =
         new LeonardoCreateAppRequest()
-            .appType(LeonardoAppType.CUSTOM)
+            .appType(LeonardoAppType.RSTUDIO)
             .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig)
-            .descriptorPath(RSTUDIO_DESCRIPTOR_PATH)
             .labels(appLabels)
             .diskConfig(leonardoPersistentDiskRequest.labels(diskLabels).name("pd-name"))
             .customEnvironmentVariables(customEnvironmentVariables);

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -128,13 +128,14 @@ public class LeonardoMapperTest {
   @Test
   public void testToApiAppType() {
     assertThat(mapper.toApiAppType(LeonardoAppType.CROMWELL)).isEqualTo(AppType.CROMWELL);
-    assertThat(mapper.toApiAppType(LeonardoAppType.CUSTOM)).isEqualTo(AppType.RSTUDIO);
+    assertThat(mapper.toApiAppType(LeonardoAppType.RSTUDIO)).isEqualTo(AppType.RSTUDIO);
     assertThat(mapper.toApiAppType(LeonardoAppType.GALAXY)).isNull();
+    assertThat(mapper.toApiAppType(LeonardoAppType.CUSTOM)).isNull();
   }
 
   @Test
   public void testToLeonardoAppType() {
-    assertThat(mapper.toLeonardoAppType(AppType.RSTUDIO)).isEqualTo(LeonardoAppType.CUSTOM);
+    assertThat(mapper.toLeonardoAppType(AppType.RSTUDIO)).isEqualTo(LeonardoAppType.RSTUDIO);
     assertThat(mapper.toLeonardoAppType(AppType.CROMWELL)).isEqualTo(LeonardoAppType.CROMWELL);
   }
 


### PR DESCRIPTION
after https://github.com/DataBiosphere/leonardo/pull/3338, Leonardo introduced a new app type RSTUDIO, instead of the custom one with `descriptorPath`


<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
