### PR TITLE
[risk=no][RW-9762] Allow reattaching a detached PD to GKE apps

### DIFF
--- a/ui/src/app/components/apps-panel/utils.tsx
+++ b/ui/src/app/components/apps-panel/utils.tsx
@@ -12,8 +12,9 @@ import {
 } from 'generated/fetch';
 
 import { cond, switchCase } from 'app/utils';
-import { DEFAULT_MACHINE_NAME } from 'app/utils/machines';
+import { DEFAULT_MACHINE_NAME, findMachineByName } from 'app/utils/machines';
 import * as runtimeUitils from 'app/utils/runtime-utils';
+import { AnalysisConfig } from 'app/utils/runtime-utils';
 import cromwellLogo from 'assets/images/Cromwell.png';
 import cromwellIcon from 'assets/images/Cromwell-icon.png';
 import jupyterLogo from 'assets/images/Jupyter.png';
@@ -76,6 +77,23 @@ export const defaultRStudioConfig: CreateAppRequest = {
     size: 100,
     diskType: DiskType.Standard,
   },
+};
+
+export const createAppRequestToAnalysisConfig = (
+  createAppRequest: CreateAppRequest
+): Partial<AnalysisConfig> => {
+  return {
+    machine: findMachineByName(
+      createAppRequest.kubernetesRuntimeConfig.machineType
+    ),
+    diskConfig: {
+      size: createAppRequest.persistentDiskRequest.size,
+      detachable: true,
+      detachableType: createAppRequest.persistentDiskRequest.diskType,
+      existingDiskName: null,
+    },
+    numNodes: createAppRequest.kubernetesRuntimeConfig.numNodes,
+  };
 };
 
 const isVisible = (status: AppStatus): boolean =>

--- a/ui/src/app/components/cromwell-configuration-panel.spec.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.spec.tsx
@@ -128,13 +128,7 @@ describe('CromwellConfigurationPanel', () => {
     startButton.simulate('click');
     await waitOneTickAndUpdate(wrapper);
     expect(spyCreateApp).toHaveBeenCalledTimes(1);
-    expect(spyCreateApp).toHaveBeenCalledWith(
-      WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-      {
-        ...defaultCromwellConfig,
-        persistentDiskRequest: disk,
-      }
-    );
+    expect(spyCreateApp.mock.calls[0][1].persistentDiskRequest).toEqual(disk);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/ui/src/app/components/cromwell-configuration-panel.spec.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.spec.tsx
@@ -49,7 +49,7 @@ describe('CromwellConfigurationPanel', () => {
       updateCache: jest.fn(),
     },
     gkeAppsInWorkspace: [],
-    disk: stubDisk(),
+    disk: undefined,
     onClickDeleteUnattachedPersistentDisk: jest.fn(),
   };
 
@@ -89,6 +89,7 @@ describe('CromwellConfigurationPanel', () => {
   it('start button should create cromwell and close panel', async () => {
     const wrapper = await component({
       gkeAppsInWorkspace: [],
+      disk: undefined,
     });
     await waitOneTickAndUpdate(wrapper);
 
@@ -105,6 +106,34 @@ describe('CromwellConfigurationPanel', () => {
     expect(spyCreateApp).toHaveBeenCalledWith(
       WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
       defaultCromwellConfig
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use the existing PD when creating', async () => {
+    const disk = stubDisk();
+    const wrapper = await component({
+      gkeAppsInWorkspace: [],
+      disk,
+    });
+    await waitOneTickAndUpdate(wrapper);
+
+    const spyCreateApp = jest
+      .spyOn(appsApi(), 'createApp')
+      .mockImplementation((): Promise<any> => Promise.resolve());
+    const startButton = wrapper
+      .find('#Cromwell-cloud-environment-create-button')
+      .first();
+
+    startButton.simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+    expect(spyCreateApp).toHaveBeenCalledTimes(1);
+    expect(spyCreateApp).toHaveBeenCalledWith(
+      WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+      {
+        ...defaultCromwellConfig,
+        persistentDiskRequest: disk,
+      }
     );
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/ui/src/app/components/rstudio-configuration-panel.spec.tsx
+++ b/ui/src/app/components/rstudio-configuration-panel.spec.tsx
@@ -127,13 +127,7 @@ describe('RStudioConfigurationPanel', () => {
     startButton.simulate('click');
     await waitOneTickAndUpdate(wrapper);
     expect(spyCreateApp).toHaveBeenCalledTimes(1);
-    expect(spyCreateApp).toHaveBeenCalledWith(
-      WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-      {
-        ...defaultRStudioConfig,
-        persistentDiskRequest: disk,
-      }
-    );
+    expect(spyCreateApp.mock.calls[0][1].persistentDiskRequest).toEqual(disk);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/ui/src/app/components/rstudio-configuration-panel.spec.tsx
+++ b/ui/src/app/components/rstudio-configuration-panel.spec.tsx
@@ -88,6 +88,7 @@ describe('RStudioConfigurationPanel', () => {
   it('start button should create rstudio and close panel', async () => {
     const wrapper = await component({
       gkeAppsInWorkspace: [],
+      disk: undefined,
     });
     await waitOneTickAndUpdate(wrapper);
 
@@ -104,6 +105,34 @@ describe('RStudioConfigurationPanel', () => {
     expect(spyCreateApp).toHaveBeenCalledWith(
       WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
       defaultRStudioConfig
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use the existing PD when creating', async () => {
+    const disk = stubDisk();
+    const wrapper = await component({
+      gkeAppsInWorkspace: [],
+      disk,
+    });
+    await waitOneTickAndUpdate(wrapper);
+
+    const spyCreateApp = jest
+      .spyOn(appsApi(), 'createApp')
+      .mockImplementation((): Promise<any> => Promise.resolve());
+    const startButton = wrapper
+      .find('#RStudio-cloud-environment-create-button')
+      .first();
+
+    startButton.simulate('click');
+    await waitOneTickAndUpdate(wrapper);
+    expect(spyCreateApp).toHaveBeenCalledTimes(1);
+    expect(spyCreateApp).toHaveBeenCalledWith(
+      WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+      {
+        ...defaultRStudioConfig,
+        persistentDiskRequest: disk,
+      }
     );
     expect(onClose).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
Allows reattaching a detached PD to GKE apps (partially).

**Note: This does not currently work for RStudio** as outlined in [this thread](https://broadinstitute.slack.com/archives/CA3NP1733/p1685121296882289?thread_ts=1684953375.577249&cid=CA3NP1733). Once [this PR](https://github.com/all-of-us/workbench/pull/7730) is merged RStudio should start working with no changes needed here. Because RStudio is not in pre-prod yet, and this is an unlikely state to be in, I think it's OK to merge as-is but am open to waiting.

As mentioned in [this PR](https://github.com/all-of-us/workbench/pull/7692), manually testing this requires an API call. The only difference here is that instead of deleting the disk, you can re-create the app (use Cromwell).

Like the above PR, I will create a workbench-ux thread once this feature is fully-built.

This PR also includes some code sharing refactors between the Cromwell and RStudio creation panels.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.