### PR TITLE
[risk=no][no-ticket] Only show user's apps

### DIFF
--- a/ui/src/app/pages/runtimes-list.tsx
+++ b/ui/src/app/pages/runtimes-list.tsx
@@ -42,12 +42,12 @@ const ajax = (signal) => {
     },
     Apps: {
       listWithoutProject: () =>
-        jsonLeoFetch('/api/google/v1/apps?includeDeleted=false'),
+        jsonLeoFetch('/api/google/v1/apps?role=creator&includeDeleted=false'),
     },
     Metrics: { captureEvent: () => undefined },
     Disks: {
       disksV1: () => ({
-        list: () => jsonLeoFetch('/api/google/v1/disks'),
+        list: () => jsonLeoFetch('/api/google/v1/disks?role=creator'),
         disk: (googleProject, name) => ({
           delete: () =>
             jsonLeoFetch(


### PR DESCRIPTION
The Cloud Environments page in Terra adds a `role=creator` filter to the API calls that improve both the latency and the relevance of the information.

Deployed here for manual testing: https://pr-6-dot-all-of-us-workbench-test.appspot.com/runtimes

Compare to test or production to see difference in page load latency and results.

---
**PR checklist**

- [X] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [X] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
