### PR TITLE
[risk=low][RW-6541] Remove last_accessed_time from the Reporting flow and the Java DB entity

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -491,7 +491,6 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 .creationTime(offsetDateTimeUtc(rs.getTimestamp("creation_time")))
                 .creatorId(rs.getLong("creator_id"))
                 .disseminateResearchOther(rs.getString("disseminate_research_other"))
-                .lastAccessedTime(offsetDateTimeUtc(rs.getTimestamp("last_accessed_time")))
                 .lastModifiedTime(offsetDateTimeUtc(rs.getTimestamp("last_modified_time")))
                 .name(rs.getString("name"))
                 .needsRpReviewPrompt((int) rs.getShort("needs_rp_review_prompt"))

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
@@ -43,7 +43,6 @@ public class DbWorkspace {
   private String lastModifiedBy;
   private Timestamp creationTime;
   private Timestamp lastModifiedTime;
-  private Timestamp lastAccessedTime;
   private Set<DbCohort> cohorts = new HashSet<>();
   private Set<DbConceptSet> conceptSets = new HashSet<>();
   private Set<DbDataset> dataSets = new HashSet<>();
@@ -197,16 +196,6 @@ public class DbWorkspace {
 
   public DbWorkspace setLastModifiedTime(Timestamp lastModifiedTime) {
     this.lastModifiedTime = lastModifiedTime;
-    return this;
-  }
-
-  @Column(name = "last_accessed_time")
-  public Timestamp getLastAccessedTime() {
-    return lastAccessedTime;
-  }
-
-  public DbWorkspace setLastAccessedTime(Timestamp lastAccessedTime) {
-    this.lastAccessedTime = lastAccessedTime;
     return this;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceColumnValueExtractor.java
@@ -18,7 +18,6 @@ public enum WorkspaceColumnValueExtractor implements ColumnValueExtractor<Report
   CREATOR_ID("creator_id", ReportingWorkspace::getCreatorId),
   DISSEMINATE_RESEARCH_OTHER(
       "disseminate_research_other", ReportingWorkspace::getDisseminateResearchOther),
-  LAST_ACCESSED_TIME("last_accessed_time", w -> toInsertRowString(w.getLastAccessedTime())),
   LAST_MODIFIED_TIME("last_modified_time", w -> toInsertRowString(w.getLastModifiedTime())),
   NAME("name", ReportingWorkspace::getName),
   NEEDS_RP_REVIEW_PROMPT("needs_rp_review_prompt", ReportingWorkspace::getNeedsRpReviewPrompt),

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -150,7 +150,6 @@ public interface WorkspaceMapper {
   @Mapping(target = "firecloudName", ignore = true)
   @Mapping(target = "firecloudUuid", ignore = true)
   @Mapping(target = "googleProject", ignore = true)
-  @Mapping(target = "lastAccessedTime", ignore = true)
   @Mapping(target = "lastModifiedBy", ignore = true)
   @Mapping(target = "lastModifiedTime", ignore = true)
   @Mapping(target = "name", ignore = true)

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8033,7 +8033,7 @@ definitions:
       cohortReviewId:
         type: integer
         format: int64
-        description: the cohort reivew id.
+        description: the cohort review id.
       participantId:
         type: integer
         format: int64
@@ -9783,10 +9783,6 @@ definitions:
         type: string
         description: Description of user-defined research dissemination option (when
           "Other" is selected).
-      lastAccessedTime:
-        type: string
-        format: date-time
-        description: No longer in use. Column should be ignored.
       lastModifiedTime:
         type: string
         format: date-time
@@ -9831,7 +9827,7 @@ definitions:
       rpControlSet:
         type: boolean
         description: |-
-          Reserch Control selected. All of Us data will be used as a reference or control
+          Research Control selected. All of Us data will be used as a reference or control
           dataset for comparison with another dataset from a different resource (e.g.
           Case-control studies).
       rpDiseaseFocusedResearch:
@@ -9844,7 +9840,7 @@ definitions:
       rpDiseaseOfFocus:
         type: string
         description: |-
-          For workspaces that include Disese-focused Research, the user-supplied name of the diseas
+          For workspaces that include Disease-focused Research, the user-supplied name of the diseas
           of focus (in the Name of Disease field).
       rpDrugDevelopment:
         type: boolean
@@ -9896,7 +9892,7 @@ definitions:
       rpReviewRequested:
         type: boolean
         description: |-
-          If true, a reivew has been requested by the Resource Access Board. This
+          If true, a review has been requested by the Resource Access Board. This
           flag is currently not reset when a review is completed.
       rpScientificApproach:
         type: string
@@ -9916,12 +9912,12 @@ definitions:
         type: integer
         format: int64
         description: |-
-          Prirmary key of the workspace table in Workrbench application database. Along with
+          Primary key of the workspace table in Workbench application database. Along with
           snapshot_timestamp, serves as a pseudo-primary key for this table.
       workspaceNamespace:
         type: string
         description: |-
-          The workspace "namespace", which corresponds to the Google Cloud Project ID associated with
+          The workspace "namespace", which corresponds to the Terra Billing Project ID associated with
           the workspace.
   ReportingWorkspaceFreeTierUsage:
     x-aou-note: |-

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9840,8 +9840,8 @@ definitions:
       rpDiseaseOfFocus:
         type: string
         description: |-
-          For workspaces that include Disease-focused Research, the user-supplied name of the diseas
-          of focus (in the Name of Disease field).
+          For workspaces that include Disease-focused Research, the user-supplied name of the 
+          disease of focus (in the Name of Disease field).
       rpDrugDevelopment:
         type: boolean
         description: |-

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
@@ -133,7 +133,6 @@ public class WorkspaceAuditorTest {
 
     dbWorkspace1 = new DbWorkspace();
     dbWorkspace1.setWorkspaceId(WORKSPACE_1_DB_ID);
-    dbWorkspace1.setLastAccessedTime(new Timestamp(now));
     dbWorkspace1.setLastModifiedTime(new Timestamp(now));
     dbWorkspace1.setCreationTime(new Timestamp(now));
 

--- a/api/src/test/java/org/pmiops/workbench/reporting/insertion/InsertAllRequestBuilderTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/insertion/InsertAllRequestBuilderTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static org.pmiops.workbench.cohortbuilder.util.QueryParameterValues.rowToInsertStringToOffsetTimestamp;
 import static org.pmiops.workbench.testconfig.ReportingTestUtils.WORKSPACE__CDR_VERSION_ID;
-import static org.pmiops.workbench.testconfig.ReportingTestUtils.WORKSPACE__LAST_ACCESSED_TIME;
 import static org.pmiops.workbench.testconfig.ReportingTestUtils.WORKSPACE__NAME;
 import static org.pmiops.workbench.testconfig.ReportingTestUtils.WORKSPACE__PUBLISHED;
 import static org.pmiops.workbench.testconfig.ReportingTestUtils.createDtoWorkspace;
@@ -27,7 +26,6 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
-import org.pmiops.workbench.cohortbuilder.util.QueryParameterValues;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.model.ReportingUser;
 import org.pmiops.workbench.model.ReportingWorkspace;
@@ -133,10 +131,5 @@ public class InsertAllRequestBuilderTest {
     assertThat(contentMap.get("cdr_version_id")).isEqualTo(WORKSPACE__CDR_VERSION_ID);
     assertThat(contentMap.get("name")).isEqualTo(WORKSPACE__NAME);
     assertThat(contentMap.get("published")).isEqualTo(WORKSPACE__PUBLISHED);
-
-    final String timeString = (String) contentMap.get("last_accessed_time");
-    final OffsetDateTime offsetDateTime =
-        QueryParameterValues.rowToInsertStringToOffsetTimestamp(timeString).get();
-    assertTimeApprox(offsetDateTime, WORKSPACE__LAST_ACCESSED_TIME);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
@@ -43,8 +43,6 @@ public class ReportingTestUtils {
       Timestamp.from(Instant.parse("2015-05-08T00:00:00.00Z"));
   public static final Long WORKSPACE__CREATOR_ID = 4L;
   public static final String WORKSPACE__DISSEMINATE_RESEARCH_OTHER = "foo_6";
-  public static final Timestamp WORKSPACE__LAST_ACCESSED_TIME =
-      Timestamp.from(Instant.parse("2015-05-12T00:00:00.00Z"));
   public static final Timestamp WORKSPACE__LAST_MODIFIED_TIME =
       Timestamp.from(Instant.parse("2015-05-13T00:00:00.00Z"));
   public static final String WORKSPACE__NAME = "foo_9";
@@ -130,7 +128,6 @@ public class ReportingTestUtils {
         .creationTime(offsetDateTimeUtc(WORKSPACE__CREATION_TIME))
         .creatorId(WORKSPACE__CREATOR_ID)
         .disseminateResearchOther(WORKSPACE__DISSEMINATE_RESEARCH_OTHER)
-        .lastAccessedTime(offsetDateTimeUtc(WORKSPACE__LAST_ACCESSED_TIME))
         .lastModifiedTime(offsetDateTimeUtc(WORKSPACE__LAST_MODIFIED_TIME))
         .name(WORKSPACE__NAME)
         .needsRpReviewPrompt(WORKSPACE__NEEDS_RP_REVIEW_PROMPT.intValue()) // manual adjustment
@@ -167,7 +164,6 @@ public class ReportingTestUtils {
     workspace.setCreationTime(WORKSPACE__CREATION_TIME);
     workspace.setCreator(creator);
     workspace.setDisseminateResearchOther(WORKSPACE__DISSEMINATE_RESEARCH_OTHER);
-    workspace.setLastAccessedTime(WORKSPACE__LAST_ACCESSED_TIME);
     workspace.setLastModifiedTime(WORKSPACE__LAST_MODIFIED_TIME);
     workspace.setName(WORKSPACE__NAME);
     workspace.setNeedsResearchPurposeReviewPrompt(WORKSPACE__NEEDS_RP_REVIEW_PROMPT);

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import java.sql.Timestamp;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
@@ -112,8 +111,6 @@ public class WorkspaceMapperTest {
     sourceDbWorkspace.setCreator(creatorUser);
     sourceDbWorkspace.setCreationTime(DB_CREATION_TIMESTAMP);
     sourceDbWorkspace.setLastModifiedTime(DB_CREATION_TIMESTAMP);
-    sourceDbWorkspace.setLastAccessedTime(
-        Timestamp.from(DB_CREATION_TIMESTAMP.toInstant().plus(Duration.ofMinutes(15))));
     sourceDbWorkspace.setCohorts(Collections.emptySet());
     sourceDbWorkspace.setConceptSets(Collections.emptySet());
     sourceDbWorkspace.setDataSets(Collections.emptySet());


### PR DESCRIPTION
Already done before this PR:
* Deprecated/nulled in the Reporting BigQuery table
* Removed (never existed?) in the `Workspace` API/UI entity object

Removed in this PR:
* Logic to handle Last Accessed Time in the Reporting flow
* The `DbWorkspace` field `lastAccessedTime`

Work to do after a release cycle:
* Remove the `last_accessed_time` field from the `workspace` DB table 

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
