### PR TITLE
[risk=low][no ticket] Default to Data tab if the tabPath is not set

### DIFF
--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -44,9 +44,12 @@ describe('WorkspaceNavBar', () => {
     cdrVersionStore.set(cdrVersionTiersResponse);
   });
 
-  it('should render', () => {
+  it('should render the Data tab by default', () => {
     const wrapper = component();
     expect(wrapper).toBeTruthy();
+    expect(
+      wrapper.find({ 'data-test-id': 'Data', 'aria-selected': true }).exists()
+    ).toBeTruthy();
   });
 
   it('should highlight the active tab', () => {

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -167,7 +167,8 @@ export const WorkspaceNavBar = fp.flow(
   withCdrVersions()
 )((props) => {
   const { tabPath, workspace, cdrVersionTiersResponse } = props;
-  const activeTabIndex = fp.findIndex(['link', tabPath], tabs);
+  // default to Data tab if the tabPath is not set
+  const activeTabIndex = fp.findIndex(['link', tabPath ?? 'data'], tabs);
   const [navigate] = useNavigation();
   const { ns, wsid } = useParams<MatchParams>();
 
@@ -191,9 +192,10 @@ export const WorkspaceNavBar = fp.flow(
 
   const navTab = (currentTab, disabled) => {
     const { name, link } = currentTab;
-    const selected = tabPath === link;
-    const hideSeparator =
-      selected || activeTabIndex === tabs.indexOf(currentTab) + 1;
+    const currentTabIndex = tabs.indexOf(currentTab);
+    const selected = activeTabIndex === currentTabIndex;
+    const hideSeparator = selected || activeTabIndex === currentTabIndex + 1;
+
     return (
       <React.Fragment key={name}>
         <Clickable


### PR DESCRIPTION
This fixes the issue where sometimes the Data tab is not selected when initially navigating to a workspace.

Tested by running local UI and navigating to workspaces I have not visited in a long time (this seems to be the trigger) on Local->Test and Test.  I can cause the bad behavior in Test but not Local->Test.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
