### PR TITLE
[risk=low] Fail faster for invalid file preview

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -329,14 +329,6 @@ public class NotebooksServiceImpl implements NotebooksService {
           String.format("Converting %s to read-only HTML is not supported", notebookName));
     }
 
-    return convertToHtml(workspaceNamespace, workspaceName, notebookName, converter);
-  }
-
-  private String convertToHtml(
-      String workspaceNamespace,
-      String workspaceName,
-      String notebookName,
-      Function<byte[], String> converter) {
     String bucketName =
         fireCloudService
             .getWorkspace(workspaceNamespace, workspaceName)
@@ -344,7 +336,6 @@ public class NotebooksServiceImpl implements NotebooksService {
             .getBucketName();
 
     Blob blob = getBlobWithSizeConstraint(bucketName, notebookName);
-
     return converter.apply(blob.getContent());
   }
 
@@ -357,11 +348,14 @@ public class NotebooksServiceImpl implements NotebooksService {
               "%s is a type of file that is not yet supported", notebookNameWithFileExtension));
     }
 
-    return convertToHtml(
-        workspaceNamespace,
-        workspaceName,
-        notebookNameWithFileExtension,
-        this::convertJupyterNotebookToHtml);
+    String bucketName =
+        fireCloudService
+            .getWorkspaceAsService(workspaceNamespace, workspaceName)
+            .getWorkspace()
+            .getBucketName();
+
+    Blob blob = getBlobWithSizeConstraint(bucketName, notebookNameWithFileExtension);
+    return convertJupyterNotebookToHtml(blob.getContent());
   }
 
   private GoogleCloudLocators getNotebookLocators(

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
@@ -644,12 +645,12 @@ public class NotebooksServiceTest {
   }
 
   @Test
-  public void testGetReadOnlyHtml_unSupportFileFormat() {
+  public void testGetReadOnlyHtml_unsupportedFileFormat() {
     stubNotebookToJson("notebook without suffix");
     Assertions.assertThrows(
         NotImplementedException.class,
         () -> notebooksService.getReadOnlyHtml("", "", "notebook without suffix"));
-    verify(mockCloudStorageClient).getBlob("bkt", "notebooks/notebook without suffix");
+    verifyNoInteractions(mockCloudStorageClient);
   }
 
   @Test

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -112,8 +112,6 @@ export const AppFilesList = withCurrentWorkspace()(
       } = props;
       const { name } = row;
       const url = `/workspaces/${namespace}/${id}/notebooks/preview/${name}`;
-      // Currently, RStudio files are not linked with the appropriate app, hence they are shown as
-      // labels instead of links.
       return (
         <Clickable>
           <RouterLink to={url} data-test-id='notebook-navigation'>


### PR DESCRIPTION
Micro-optimization: we can check the file type before calling Terra or Google, letting us fail more quickly.

Tested by running Local API+UI and testing every changed method: preview Jupyter, preview Rstudio, and getKernel

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
