### PR TITLE
[risk=low][no ticket] Rename the incorrect "acls" to "acl" in most cases

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/NotebooksController.java
@@ -190,7 +190,7 @@ public class NotebooksController implements NotebooksApiDelegate {
 
         Set<String> workspaceUsers =
             workspaceAuthService
-                .getFirecloudWorkspaceAcls(workspaceNamespace, workspaceName)
+                .getFirecloudWorkspaceAcl(workspaceNamespace, workspaceName)
                 .keySet();
 
         response.lastLockedBy(

--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -274,7 +274,7 @@ public class UserMetricsController implements UserMetricsApiDelegate {
       DbWorkspace dbWorkspace) {
     Set<String> workspaceUsers =
         workspaceAuthService
-            .getFirecloudWorkspaceAcls(
+            .getFirecloudWorkspaceAcl(
                 dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName())
             .keySet();
     return workspaceResourceMapper.fromDbUserRecentlyModifiedResource(

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -580,19 +580,19 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     // a 500 to the user if this block of code fails since the workspace is already
     // committed to the database in an earlier call
     if (Boolean.TRUE.equals(body.getIncludeUserRoles())) {
-      var fcAcls =
-          workspaceAuthService.getFirecloudWorkspaceAcls(
+      var fromAcl =
+          workspaceAuthService.getFirecloudWorkspaceAcl(
               fromWorkspace.getWorkspaceNamespace(), fromWorkspace.getFirecloudName());
 
-      var collaborators =
+      var toAcl =
           Maps.transformEntries(
-              fcAcls,
+              fromAcl,
               (username, accessEntry) ->
                   username.equals(user.getUsername())
                       ? WorkspaceAccessLevel.OWNER
                       : WorkspaceAccessLevel.fromValue(accessEntry.getAccessLevel()));
 
-      dbWorkspace = workspaceAuthService.patchWorkspaceAcls(dbWorkspace, collaborators);
+      dbWorkspace = workspaceAuthService.patchWorkspaceAcl(dbWorkspace, toAcl);
     }
 
     dbWorkspace = workspaceDao.saveWithLastModified(dbWorkspace, user);
@@ -701,7 +701,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       }
     }
 
-    dbWorkspace = workspaceAuthService.patchWorkspaceAcls(dbWorkspace, aclsByEmail);
+    dbWorkspace = workspaceAuthService.patchWorkspaceAcl(dbWorkspace, aclsByEmail);
     resp.setWorkspaceEtag(Etags.fromVersion(dbWorkspace.getVersion()));
 
     List<UserRole> userRolesAfterShare =

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -120,7 +120,7 @@ public class NotebooksServiceImpl implements NotebooksService {
   public List<FileDetail> getNotebooksAsService(
       String bucketName, String workspaceNamespace, String workspaceName) {
     Set<String> workspaceUsers =
-        workspaceAuthService.getFirecloudWorkspaceAcls(workspaceNamespace, workspaceName).keySet();
+        workspaceAuthService.getFirecloudWorkspaceAcl(workspaceNamespace, workspaceName).keySet();
     return cloudStorageClient
         .getBlobPageForPrefix(bucketName, NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY)
         .stream()

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -392,7 +392,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
         publish ? WorkspaceAccessLevel.READER : WorkspaceAccessLevel.NO_ACCESS;
 
     // Enable all users in RT or higher tiers to see all published workspaces regardless of tier
-    // Note: keep in sync with WorkspaceAuthService.updateWorkspaceAcl.
+    // Note: keep in sync with WorkspaceAuthService.patchWorkspaceAcl.
     final DbAccessTier dbAccessTier = accessTierService.getRegisteredTierOrThrow();
     final String registeredTierGroupEmail = dbAccessTier.getAuthDomainGroupEmail();
 

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -392,7 +392,6 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
         publish ? WorkspaceAccessLevel.READER : WorkspaceAccessLevel.NO_ACCESS;
 
     // Enable all users in RT or higher tiers to see all published workspaces regardless of tier
-    // Note: keep in sync with WorkspaceAuthService.patchWorkspaceAcl.
     final DbAccessTier dbAccessTier = accessTierService.getRegisteredTierOrThrow();
     final String registeredTierGroupEmail = dbAccessTier.getAuthDomainGroupEmail();
 

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -342,7 +342,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
             .getWorkspace()
             .getBucketName();
     Set<String> workspaceUsers =
-        workspaceAuthService.getFirecloudWorkspaceAcls(workspaceNamespace, workspaceName).keySet();
+        workspaceAuthService.getFirecloudWorkspaceAcl(workspaceNamespace, workspaceName).keySet();
     return cloudStorageClient.getBlobPage(bucketName).stream()
         .map(blob -> cloudStorageClient.blobToFileDetail(blob, bucketName, workspaceUsers))
         .collect(Collectors.toList());
@@ -392,7 +392,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
         publish ? WorkspaceAccessLevel.READER : WorkspaceAccessLevel.NO_ACCESS;
 
     // Enable all users in RT or higher tiers to see all published workspaces regardless of tier
-    // Note: keep in sync with WorkspaceAuthService.updateWorkspaceAcls.
+    // Note: keep in sync with WorkspaceAuthService.updateWorkspaceAcl.
     final DbAccessTier dbAccessTier = accessTierService.getRegisteredTierOrThrow();
     final String registeredTierGroupEmail = dbAccessTier.getAuthDomainGroupEmail();
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -245,7 +245,7 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
   @Override
   public List<UserRole> getFirecloudUserRoles(String workspaceNamespace, String firecloudName) {
     Map<String, RawlsWorkspaceAccessEntry> emailToRole =
-        workspaceAuthService.getFirecloudWorkspaceAcls(workspaceNamespace, firecloudName);
+        workspaceAuthService.getFirecloudWorkspaceAcl(workspaceNamespace, firecloudName);
 
     List<UserRole> userRoles = new ArrayList<>();
     for (Map.Entry<String, RawlsWorkspaceAccessEntry> entry : emailToRole.entrySet()) {

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
@@ -200,7 +200,7 @@ public class WorkspaceAuditorTest {
 
   @Test
   public void testFiresCollaborateAction() {
-    final ImmutableMap<Long, String> aclsByUserId =
+    final ImmutableMap<Long, String> aclByUserId =
         ImmutableMap.of(
             ActionAuditTestConfig.ADMINISTRATOR_USER_ID,
             WorkspaceAccessLevel.OWNER.toString(),
@@ -208,12 +208,12 @@ public class WorkspaceAuditorTest {
             WorkspaceAccessLevel.NO_ACCESS.toString(),
             ADDED_USER_ID,
             WorkspaceAccessLevel.READER.toString());
-    workspaceAuditor.fireCollaborateAction(dbWorkspace1.getWorkspaceId(), aclsByUserId);
+    workspaceAuditor.fireCollaborateAction(dbWorkspace1.getWorkspaceId(), aclByUserId);
     verify(mockActionAuditService).send(eventCollectionCaptor.capture());
     Collection<ActionAuditEvent> eventsSent = eventCollectionCaptor.getValue();
 
     // 1 workspace + N user COLLABORATE events
-    final int expectedEvents = 1 + aclsByUserId.size();
+    final int expectedEvents = 1 + aclByUserId.size();
     assertThat(eventsSent).hasSize(expectedEvents);
 
     Map<String, Long> countByTargetType =

--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -603,7 +603,7 @@ public class NotebooksControllerTest {
     stubGetWorkspace(fcWorkspace, WorkspaceAccessLevel.OWNER);
     stubFcGetWorkspaceACL(acl);
 
-    when(mockWorkspaceAuthService.getFirecloudWorkspaceAcls(anyString(), anyString()))
+    when(mockWorkspaceAuthService.getFirecloudWorkspaceAcl(anyString(), anyString()))
         .thenReturn(FirecloudTransforms.extractAclResponse(acl));
 
     final String testNotebookPath = NotebookUtils.withNotebookPath(testNotebook);

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -2198,7 +2198,7 @@ public class WorkspacesControllerTest {
                 new UserRole().email(writer.getUsername()).role(WorkspaceAccessLevel.WRITER)));
 
     stubFcUpdateWorkspaceACL();
-    RawlsWorkspaceACL workspaceAclsFromCloned =
+    RawlsWorkspaceACL workspaceAclFromCloned =
         createWorkspaceACL(
             new JSONObject()
                 .put(
@@ -2208,7 +2208,7 @@ public class WorkspacesControllerTest {
                         .put("canCompute", true)
                         .put("canShare", true)));
 
-    RawlsWorkspaceACL workspaceAclsFromOriginal =
+    RawlsWorkspaceACL workspaceAclFromOriginal =
         createWorkspaceACL(
             new JSONObject()
                 .put(
@@ -2237,9 +2237,9 @@ public class WorkspacesControllerTest {
                         .put("canShare", true)));
 
     when(fireCloudService.getWorkspaceAclAsService("cloned-ns", "cloned"))
-        .thenReturn(workspaceAclsFromCloned);
+        .thenReturn(workspaceAclFromCloned);
     when(fireCloudService.getWorkspaceAclAsService(workspace.getNamespace(), workspace.getName()))
-        .thenReturn(workspaceAclsFromOriginal);
+        .thenReturn(workspaceAclFromOriginal);
 
     currentUser = cloner;
 
@@ -2551,8 +2551,8 @@ public class WorkspacesControllerTest {
     Workspace workspace = createWorkspace();
     workspace = workspacesController.createWorkspace(workspace).getBody();
 
-    // Mock firecloud ACLs
-    RawlsWorkspaceACL workspaceACLs =
+    // Mock firecloud ACL
+    RawlsWorkspaceACL workspaceACL =
         createWorkspaceACL(
             new JSONObject()
                 .put(
@@ -2573,7 +2573,7 @@ public class WorkspacesControllerTest {
                         .put("accessLevel", "READER")
                         .put("canCompute", false)
                         .put("canShare", false)));
-    when(fireCloudService.getWorkspaceAclAsService(any(), any())).thenReturn(workspaceACLs);
+    when(fireCloudService.getWorkspaceAclAsService(any(), any())).thenReturn(workspaceACL);
 
     fakeClock.increment(1000);
     stubFcUpdateWorkspaceACL();

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceAuthServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceAuthServiceTest.java
@@ -163,7 +163,7 @@ public class WorkspaceAuthServiceTest {
 
   // Arguments are (original Workspace ACL), (ACL updates to make), (expected result Workspace ACL),
   // (expected remove BP from owner count), (expected add BP to owner count)
-  private static Stream<Arguments> patchWorkspaceAcls() {
+  private static Stream<Arguments> patchWorkspaceAcl() {
     return Stream.of(
         // trivial case: do nothing to empty ACL
         Arguments.of(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), 0, 0),
@@ -230,8 +230,8 @@ public class WorkspaceAuthServiceTest {
   }
 
   @ParameterizedTest
-  @MethodSource("patchWorkspaceAcls")
-  public void test_patchWorkspaceAcls(
+  @MethodSource("patchWorkspaceAcl")
+  public void test_patchWorkspaceAcl(
       Map<String, WorkspaceAccessLevel> originalAcl,
       Map<String, WorkspaceAccessLevel> updates,
       Map<String, WorkspaceAccessLevel> expectedFcUpdates,
@@ -245,7 +245,7 @@ public class WorkspaceAuthServiceTest {
     stubFcGetAcl(namespace, fcName, originalAcl);
     DbWorkspace workspace = stubDaoGetRequired(namespace, fcName, BillingStatus.ACTIVE);
 
-    workspaceAuthService.patchWorkspaceAcls(workspace, updates);
+    workspaceAuthService.patchWorkspaceAcl(workspace, updates);
     verify(mockFireCloudService)
         .updateWorkspaceACL(namespace, fcName, buildAclUpdates(expectedFcUpdates));
     verify(mockFireCloudService, times(expectedBpRemovals))

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/CreateWgsCohortExtractionBillingProjectWorkspace.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/CreateWgsCohortExtractionBillingProjectWorkspace.java
@@ -156,7 +156,7 @@ public class CreateWgsCohortExtractionBillingProjectWorkspace extends Tool {
           rawlsApiClientFactory.workspacesApi().createWorkspace(workspaceIngest);
 
       log.info("Updating Workspace ACL");
-      List<RawlsWorkspaceACLUpdate> acls =
+      List<RawlsWorkspaceACLUpdate> acl =
           Stream.concat(
                   Arrays.stream(opts.getOptionValue(ownersOpt.getLongOpt()).split(",")),
                   Arrays.stream(new String[] {workspace.getCreatedBy()}))
@@ -164,7 +164,7 @@ public class CreateWgsCohortExtractionBillingProjectWorkspace extends Tool {
               .collect(Collectors.toList());
       rawlsApiClientFactory
           .workspacesApi()
-          .updateACL(acls, workspace.getNamespace(), workspace.getName(), false);
+          .updateACL(acl, workspace.getNamespace(), workspace.getName(), false);
 
       String proxyGroup =
           firecloudApiClientFactory.profileApi().getProxyGroup(workspace.getCreatedBy());


### PR DESCRIPTION
An Access Control List is... a list of access controls.  We generally care about a single **ACL** rather than multiple **ACLs**, but we often name them in the plural because lists _feel like_ they should be plural.  But no.

No functional changes expected.  I'm making a change to an ACL and I wanted to separate this PR from the actual change I wanted to make.

Tested by running local API+UI, and observing that unsharing a workspace does not affect its published status.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
