### PR TITLE
[risk=low][RW-9501] Don't publish cloned workspaces

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -601,6 +601,9 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       dbWorkspace = workspaceAuthService.patchWorkspaceAcl(dbWorkspace, toAcl);
     }
 
+    // RW-9501: cloned workspaces should not be published
+    dbWorkspace = dbWorkspace.setPublished(false);
+    
     dbWorkspace = workspaceDao.saveWithLastModified(dbWorkspace, user);
     final Workspace savedWorkspace = workspaceMapper.toApiWorkspace(dbWorkspace, toFcWorkspace);
 

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -603,7 +603,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
 
     // RW-9501: cloned workspaces should not be published
     dbWorkspace = dbWorkspace.setPublished(false);
-    
+
     dbWorkspace = workspaceDao.saveWithLastModified(dbWorkspace, user);
     final Workspace savedWorkspace = workspaceMapper.toApiWorkspace(dbWorkspace, toFcWorkspace);
 

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -10,7 +10,6 @@ import jakarta.mail.MessagingException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -60,7 +59,6 @@ import org.pmiops.workbench.model.WorkspaceAuditLogQueryResponse;
 import org.pmiops.workbench.model.WorkspaceUserAdminView;
 import org.pmiops.workbench.notebooks.NotebookUtils;
 import org.pmiops.workbench.notebooks.NotebooksService;
-import org.pmiops.workbench.rawls.model.RawlsWorkspaceACLUpdate;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceDetails;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
 import org.pmiops.workbench.utils.mappers.UserMapper;
@@ -386,14 +384,12 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     final WorkspaceAccessLevel accessLevel =
         publish ? WorkspaceAccessLevel.READER : WorkspaceAccessLevel.NO_ACCESS;
 
-    final RawlsWorkspaceACLUpdate aclUpdate =
+    var aclUpdate =
         FirecloudTransforms.buildAclUpdate(
             workspaceService.getPublishedWorkspacesGroupEmail(), accessLevel);
 
     fireCloudService.updateWorkspaceACL(
-        dbWorkspace.getWorkspaceNamespace(),
-        dbWorkspace.getFirecloudName(),
-        Collections.singletonList(aclUpdate));
+        dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName(), List.of(aclUpdate));
 
     dbWorkspace.setPublished(publish);
     return workspaceDao.saveWithLastModified(dbWorkspace, userProvider.get());

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -32,6 +32,12 @@ public interface WorkspaceService {
 
   List<WorkspaceResponse> getPublishedWorkspaces();
 
+  /**
+   * Return the email associated with the group that we use to indicate that a workspace is
+   * published. (implementation detail: it's the RT auth domain group email)
+   */
+  String getPublishedWorkspacesGroupEmail();
+
   void deleteWorkspace(DbWorkspace dbWorkspace);
 
   /*

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceFakeImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceFakeImpl.java
@@ -27,6 +27,11 @@ public class WorkspaceServiceFakeImpl implements WorkspaceService {
   }
 
   @Override
+  public String getPublishedWorkspacesGroupEmail() {
+    return null;
+  }
+
+  @Override
   public void deleteWorkspace(DbWorkspace dbWorkspace) {}
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -158,11 +158,17 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
 
   @Override
   public String getPublishedWorkspacesGroupEmail() {
-    // All users with CT access also have RT access.  This means that all users who have access to
-    // workspaces (in both tiers) are members of the RT, and hence its Auth Domain Group.  Assigning
-    // workspace access to this group thus means we are assigning this access to all users.
+    // All users with CT access also have RT access, so we know that any user with access to
+    // workspaces will be a member of the RT Auth Domain Group.  Therefore, we can use this group
+    // to assign access to all relevant users at once.
     //
-    // We implement the concept of a "Published" workspace by assigning READER access to this group
+    // We implement the "Publishing" of workspaces by assigning READER access to this group.
+    //
+    // Controlled Tier note: our intention for RT-only users is that they have -*awareness of*- but
+    // not -*access to*- Published workspaces in the CT.  Our UI special-cases Published workspaces
+    // to make this possible, and any user attempting to gain access to these will find that they
+    // are blocked.  Despite having nominal "READER" access, their level is actually "NO ACCESS"
+    // specifically because they are not members of the Controlled Tier Auth Domain.
     return accessTierService.getRegisteredTierOrThrow().getAuthDomainGroupEmail();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -156,6 +156,16 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
         .collect(Collectors.toList());
   }
 
+  @Override
+  public String getPublishedWorkspacesGroupEmail() {
+    // All users with CT access also have RT access.  This means that all users who have access to
+    // workspaces (in both tiers) are members of the RT, and hence its Auth Domain Group.  Assigning
+    // workspace access to this group thus means we are assigning this access to all users.
+    //
+    // We implement the concept of a "Published" workspace by assigning READER access to this group
+    return accessTierService.getRegisteredTierOrThrow().getAuthDomainGroupEmail();
+  }
+
   @Transactional
   @Override
   public WorkspaceResponse getWorkspace(String workspaceNamespace, String workspaceId) {

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -2205,7 +2205,7 @@ public class WorkspacesControllerTest {
                         .put("canShare", false))
                 // this is how we indicate that a workspace has been published
                 .put(
-                    registeredTier.getAuthDomainGroupEmail(),
+                    workspaceService.getPublishedWorkspacesGroupEmail(),
                     new JSONObject()
                         .put("accessLevel", "READER")
                         .put("canCompute", false)
@@ -2242,14 +2242,17 @@ public class WorkspacesControllerTest {
     when(fireCloudService.getWorkspaceAclAsService("cloned-ns", "cloned"))
         .thenReturn(clonedAclBeforeUpdate);
 
-    // does not contain an entry for the "published" group
+    // cloner is now OWNER, and it does not contain an entry for the "published" group
     List<RawlsWorkspaceACLUpdate> expectedCollaboratorsAfterUpdate =
         convertUserRolesToUpdateAclRequestList(
             List.of(
                 new UserRole().email(cloner.getUsername()).role(WorkspaceAccessLevel.OWNER),
                 new UserRole().email(LOGGED_IN_USER_EMAIL).role(WorkspaceAccessLevel.OWNER),
                 new UserRole().email(reader.getUsername()).role(WorkspaceAccessLevel.READER),
-                new UserRole().email(writer.getUsername()).role(WorkspaceAccessLevel.WRITER)));
+                new UserRole().email(writer.getUsername()).role(WorkspaceAccessLevel.WRITER),
+                new UserRole()
+                    .email(workspaceService.getPublishedWorkspacesGroupEmail())
+                    .role(WorkspaceAccessLevel.NO_ACCESS)));
 
     currentUser = cloner;
 

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -732,21 +732,14 @@ public class WorkspacesControllerTest {
     Workspace workspace = createWorkspace();
     workspace.setCdrVersionId(archivedCdrVersionId);
     assertThrows(
-        FailedPreconditionException.class,
-        () -> {
-          workspacesController.createWorkspace(workspace);
-        });
+        FailedPreconditionException.class, () -> workspacesController.createWorkspace(workspace));
   }
 
   @Test
   public void testCreateWorkspace_noResearchPurposeThrows() {
     Workspace workspace = createWorkspace();
     workspace.setResearchPurpose(null);
-    assertThrows(
-        BadRequestException.class,
-        () -> {
-          workspacesController.createWorkspace(workspace);
-        });
+    assertThrows(BadRequestException.class, () -> workspacesController.createWorkspace(workspace));
   }
 
   // we do not actually use the accessTierShortName of the Workspace passed to
@@ -778,9 +771,7 @@ public class WorkspacesControllerTest {
     workspace.setCdrVersionId(archivedCdrVersionId);
     assertThrows(
         FailedPreconditionException.class,
-        () -> {
-          workspacesController.createWorkspaceAsync(workspace);
-        });
+        () -> workspacesController.createWorkspaceAsync(workspace));
   }
 
   @Test
@@ -788,10 +779,7 @@ public class WorkspacesControllerTest {
     Workspace workspace = createWorkspace();
     workspace.setResearchPurpose(null);
     assertThrows(
-        BadRequestException.class,
-        () -> {
-          workspacesController.createWorkspaceAsync(workspace);
-        });
+        BadRequestException.class, () -> workspacesController.createWorkspaceAsync(workspace));
   }
 
   @Test
@@ -824,9 +812,7 @@ public class WorkspacesControllerTest {
     workspace.setCdrVersionId(archivedCdrVersionId);
     assertThrows(
         FailedPreconditionException.class,
-        () -> {
-          workspacesController.duplicateWorkspaceAsync("foo", "bar", request);
-        });
+        () -> workspacesController.duplicateWorkspaceAsync("foo", "bar", request));
   }
 
   @Test
@@ -837,9 +823,7 @@ public class WorkspacesControllerTest {
     workspace.setResearchPurpose(null);
     assertThrows(
         BadRequestException.class,
-        () -> {
-          workspacesController.duplicateWorkspaceAsync("foo", "bar", request);
-        });
+        () -> workspacesController.duplicateWorkspaceAsync("foo", "bar", request));
   }
 
   @Test
@@ -2645,10 +2629,9 @@ public class WorkspacesControllerTest {
 
     assertThrows(
         BadRequestException.class,
-        () -> {
-          workspacesController.shareWorkspacePatch(
-              workspace.getNamespace(), workspace.getName(), shareWorkspaceRequest);
-        });
+        () ->
+            workspacesController.shareWorkspacePatch(
+                workspace.getNamespace(), workspace.getName(), shareWorkspaceRequest));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -2193,8 +2193,8 @@ public class WorkspacesControllerTest {
                     "cloner@gmail.com",
                     new JSONObject()
                         .put("accessLevel", "READER")
-                        .put("canCompute", true)
-                        .put("canShare", true))
+                        .put("canCompute", false)
+                        .put("canShare", false))
                 .put(
                     "reader@gmail.com",
                     new JSONObject()

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -2233,12 +2233,13 @@ public class WorkspacesControllerTest {
     when(fireCloudService.getWorkspaceAclAsService("cloned-ns", "cloned"))
         .thenReturn(clonedAclBeforeUpdate);
 
-    List<UserRole> expectedCollaboratorsAfterUpdate =
-        List.of(
-            new UserRole().email(cloner.getUsername()).role(WorkspaceAccessLevel.OWNER),
-            new UserRole().email(LOGGED_IN_USER_EMAIL).role(WorkspaceAccessLevel.OWNER),
-            new UserRole().email(reader.getUsername()).role(WorkspaceAccessLevel.READER),
-            new UserRole().email(writer.getUsername()).role(WorkspaceAccessLevel.WRITER));
+    List<RawlsWorkspaceACLUpdate> expectedCollaboratorsAfterUpdate =
+        convertUserRolesToUpdateAclRequestList(
+            List.of(
+                new UserRole().email(cloner.getUsername()).role(WorkspaceAccessLevel.OWNER),
+                new UserRole().email(LOGGED_IN_USER_EMAIL).role(WorkspaceAccessLevel.OWNER),
+                new UserRole().email(reader.getUsername()).role(WorkspaceAccessLevel.READER),
+                new UserRole().email(writer.getUsername()).role(WorkspaceAccessLevel.WRITER)));
 
     currentUser = cloner;
 
@@ -2270,11 +2271,7 @@ public class WorkspacesControllerTest {
             eq("cloned"),
             // Accept the ACL update list in any order.
             argThat(
-                arg ->
-                    new HashSet<>(
-                            convertUserRolesToUpdateAclRequestList(
-                                expectedCollaboratorsAfterUpdate))
-                        .equals(new HashSet<>(arg))));
+                arg -> new HashSet<>(expectedCollaboratorsAfterUpdate).equals(new HashSet<>(arg))));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -2242,10 +2242,10 @@ public class WorkspacesControllerTest {
     when(fireCloudService.getWorkspaceAclAsService("cloned-ns", "cloned"))
         .thenReturn(clonedAclBeforeUpdate);
 
-    // cloner is now OWNER, and it does not contain an entry for the "published" group
+    // cloner is now OWNER, and the "published" group has NO_ACCESS
     List<RawlsWorkspaceACLUpdate> expectedCollaboratorsAfterUpdate =
         convertUserRolesToUpdateAclRequestList(
-            List.of(
+            Set.of(
                 new UserRole().email(cloner.getUsername()).role(WorkspaceAccessLevel.OWNER),
                 new UserRole().email(LOGGED_IN_USER_EMAIL).role(WorkspaceAccessLevel.OWNER),
                 new UserRole().email(reader.getUsername()).role(WorkspaceAccessLevel.READER),


### PR DESCRIPTION
Add WorkspaceService.getPublishedWorkspacesGroupEmail()

Tested manually by:
1. creating workspaces shared with the published-group and other users
2. duplicating these workspaces in the UI with "share with same collaborators" checked
3. observing that the duplicates were shared with the **user** collaborators but not the published group

I considered taking this opportunity to migrate a piece of controller business logic to a service, but I think I'll do it in a separate PR instead.

Whether or not this completes RW-9501 is an open discussion - but I think this change is worthwhile regardless.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
