### PR TITLE
[risk=no][RW-9703][RW-9762] Update RStudio buttons

### DIFF
--- a/e2e/app/sidebar/apps-panel.ts
+++ b/e2e/app/sidebar/apps-panel.ts
@@ -63,4 +63,13 @@ export default class AppsPanel extends BaseEnvironmentPanel {
     );
     return isDeleted;
   }
+
+  async clickUnexpandedApp(appNameSelector: string): Promise<void> {
+    await this.open();
+    const unexpandedXPath = `${this.getXpath()}//*[@data-test-id="${appNameSelector}-unexpanded"]`;
+    const unexpanded = new Button(page, unexpandedXPath);
+
+    expect(await unexpanded.exists()).toBeTruthy();
+    await unexpanded.click();
+  }
 }

--- a/e2e/app/sidebar/cromwell-configuration-panel.ts
+++ b/e2e/app/sidebar/cromwell-configuration-panel.ts
@@ -14,12 +14,7 @@ export default class CromwellConfigurationPanel extends BaseEnvironmentPanel {
   async startCromwellGkeApp(): Promise<void> {
     // Cromwell is not running, so it appears in unexpanded mode
     const appsPanel = new AppsPanel(page);
-    await appsPanel.open();
-    const unexpandedCromwellXPath = `${appsPanel.getXpath()}//*[@data-test-id="Cromwell-unexpanded"]`;
-    const unexpandedCromwell = new Button(page, unexpandedCromwellXPath);
-
-    expect(await unexpandedCromwell.exists()).toBeTruthy();
-    await unexpandedCromwell.click();
+    await appsPanel.clickUnexpandedApp('Cromwell');
 
     const configPanel = new CromwellConfigurationPanel(page);
     await configPanel.isVisible();

--- a/e2e/app/sidebar/rstudio-configuration-panel.ts
+++ b/e2e/app/sidebar/rstudio-configuration-panel.ts
@@ -1,0 +1,31 @@
+import { Page } from 'puppeteer';
+import { SideBarLink } from 'app/text-labels';
+import BaseEnvironmentPanel from './base-environment-panel';
+import Button from '../element/button';
+import AppsPanel from './apps-panel';
+
+const defaultXpath = '//*[@id="rstudio-configuration-panel"]';
+
+export default class RStudioConfigurationPanel extends BaseEnvironmentPanel {
+  constructor(page: Page) {
+    super(page, defaultXpath, SideBarLink.RStudioConfiguration);
+  }
+
+  async startRStudioGkeApp(): Promise<void> {
+    // RStudio is not running, so it appears in unexpanded mode
+    const appsPanel = new AppsPanel(page);
+    await appsPanel.clickUnexpandedApp('RStudio');
+
+    const configPanel = new RStudioConfigurationPanel(page);
+    await configPanel.isVisible();
+
+    // now we can create a RStudio app by clicking the button on this page
+
+    const createXPath = `${configPanel.getXpath()}//*[@id="RStudio-cloud-environment-create-button"]`;
+    const createButton = new Button(page, createXPath);
+    expect(await createButton.exists()).toBeTruthy();
+    await createButton.click();
+
+    return;
+  }
+}

--- a/e2e/tests/nightly/gke-apps/rstudio.spec.ts
+++ b/e2e/tests/nightly/gke-apps/rstudio.spec.ts
@@ -34,7 +34,7 @@ describe('RStudio GKE App', () => {
     const expandedRStudioXpath = `${appsPanel.getXpath()}//*[@data-test-id="RStudio-expanded"]`;
     await page.waitForXPath(expandedRStudioXpath);
 
-    const createXPath = `${expandedRStudioXpath}//*[@data-test-id="apps-panel-button-Create"]`;
+    const createXPath = `${expandedRStudioXpath}//*[@data-test-id="apps-panel-button-Open-RStudio"]`;
     const createButton = new Button(page, createXPath);
     expect(await createButton.exists()).toBeTruthy();
 

--- a/ui/src/app/components/apps-panel.spec.tsx
+++ b/ui/src/app/components/apps-panel.spec.tsx
@@ -79,7 +79,7 @@ describe('AppsPanel', () => {
     });
   });
 
-  it('should allow a user to expand Jupyter and RStudio', async () => {
+  it('should allow a user to expand Jupyter', async () => {
     // initial state: no apps exist
 
     runtimeStub.runtime.status = undefined;
@@ -102,18 +102,8 @@ describe('AppsPanel', () => {
     expect(findUnexpandedApp(wrapper, 'Jupyter').exists()).toBeFalsy();
     expect(findExpandedApp(wrapper, 'Jupyter').exists()).toBeTruthy();
 
-    // Click unexpanded RStudio app
-
-    expect(findUnexpandedApp(wrapper, 'RStudio').exists()).toBeTruthy();
-    const clickRStudio = findUnexpandedApp(wrapper, 'RStudio').prop('onClick');
-    await clickRStudio();
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(findUnexpandedApp(wrapper, 'RStudio').exists()).toBeFalsy();
-    expect(findExpandedApp(wrapper, 'RStudio').exists()).toBeTruthy();
-
     // the overall apps panel state doesn't change: there are still no ActiveApps
-    // the newly expanded apps are in the AvailableApps section
+    // the newly expanded app is in the AvailableApps section
 
     expect(findActiveApps(wrapper).exists()).toBeFalsy();
     expect(findAvailableApps(wrapper, false).exists()).toBeTruthy();

--- a/ui/src/app/components/apps-panel.tsx
+++ b/ui/src/app/components/apps-panel.tsx
@@ -7,6 +7,7 @@ import { Clickable, CloseButton } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import {
   cromwellConfigIconId,
+  rstudioConfigIconId,
   SidebarIconId,
 } from 'app/components/help-sidebar-icons';
 import { DisabledPanel } from 'app/components/runtime-configuration-panel/disabled-panel';
@@ -149,6 +150,8 @@ export const AppsPanel = (props: {
                 onClick={() => {
                   if (availableApp.appType === UIAppType.CROMWELL) {
                     setSidebarActiveIconStore.next(cromwellConfigIconId);
+                  } else if (availableApp.appType === UIAppType.RSTUDIO) {
+                    setSidebarActiveIconStore.next(rstudioConfigIconId);
                   } else {
                     addToExpandedApps(availableApp.appType);
                   }

--- a/ui/src/app/components/apps-panel/apps-panel-button.tsx
+++ b/ui/src/app/components/apps-panel/apps-panel-button.tsx
@@ -65,7 +65,7 @@ export const AppsPanelButton = (props: Props) => {
       <Clickable
         {...{ disabled, onClick }}
         style={{ padding: '0.5em' }}
-        data-test-id={`apps-panel-button-${buttonText}`}
+        data-test-id={`apps-panel-button-${buttonText.replace(' ', '-')}`}
         propagateDataTestId
       >
         <FlexColumn

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -19,11 +19,7 @@ import {
   registerApiClient as leoRegisterApiClient,
 } from 'app/services/notebooks-swagger-fetch-clients';
 import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
-import {
-  notificationStore,
-  runtimeStore,
-  serverConfigStore,
-} from 'app/utils/stores';
+import { runtimeStore, serverConfigStore } from 'app/utils/stores';
 import {
   AppsApi as LeoAppsApi,
   ProxyApi,
@@ -45,7 +41,7 @@ import {
 import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
 
 import { ExpandedApp } from './expanded-app';
-import { defaultRStudioConfig, UIAppType } from './utils';
+import { UIAppType } from './utils';
 
 const googleProject = 'project-for-test';
 const workspace = {
@@ -402,77 +398,6 @@ describe('ExpandedApp', () => {
         });
         expect(launchButton.prop('disabled')).toBeTruthy();
       }
-    );
-  });
-
-  const createEnabledStatuses = [AppStatus.DELETED, null, undefined];
-  const createDisabledStatuses = minus(
-    ALL_GKE_APP_STATUSES,
-    createEnabledStatuses
-  );
-
-  describe('should allow creating an RStudio app for certain app statuses', () => {
-    test.each(createEnabledStatuses)('Status %s', async (appStatus) => {
-      const wrapper = await component(UIAppType.RSTUDIO, {
-        appName: 'my-app',
-        googleProject,
-        status: appStatus,
-      });
-      appsStub.createApp = jest.fn(() => Promise.resolve({}));
-
-      const createButton = () =>
-        wrapper.find({
-          'data-test-id': `RStudio-create-button`,
-        });
-      expect(createButton().exists()).toBeTruthy();
-      expect(createButton().prop('disabled')).toBeFalsy();
-      expect(createButton().prop('buttonText')).toEqual('Create');
-
-      createButton().simulate('click');
-      await waitOneTickAndUpdate(wrapper);
-
-      expect(appsStub.createApp).toHaveBeenCalledWith(
-        workspace.namespace,
-        defaultRStudioConfig
-      );
-      expect(createButton().prop('buttonText')).toEqual('Creating');
-      expect(createButton().prop('disabled')).toBeTruthy();
-    });
-  });
-
-  describe('should disable the RStudio create button for all other app statuses', () => {
-    test.each(createDisabledStatuses)('Status %s', async (appStatus) => {
-      const wrapper = await component(UIAppType.RSTUDIO, {
-        appName: 'my-app',
-        googleProject,
-        status: appStatus,
-      });
-
-      const createButton = wrapper.find({
-        'data-test-id': `RStudio-create-button`,
-      });
-      expect(createButton.exists()).toBeTruthy();
-      expect(createButton.prop('disabled')).toBeTruthy();
-    });
-  });
-
-  it('should show an error if the initial request to create RStudio fails', async () => {
-    const wrapper = await component(UIAppType.RSTUDIO, {
-      appName: 'my-app',
-      googleProject,
-      status: null,
-    });
-    appsStub.createApp = jest.fn(() => Promise.reject());
-
-    wrapper
-      .find({
-        'data-test-id': `RStudio-create-button`,
-      })
-      .simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(notificationStore.get().title).toEqual(
-      'Error Creating RStudio Environment'
     );
   });
 });

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -370,7 +370,7 @@ describe('ExpandedApp', () => {
       .mockReturnValue({ focus: focusStub } as any as Window);
 
     const launchButton = wrapper.find({
-      'data-test-id': 'RStudio-launch-button',
+      'data-test-id': 'open-RStudio-button',
     });
     expect(launchButton.exists()).toBeTruthy();
     expect(launchButton.prop('disabled')).toBeFalsy();
@@ -398,7 +398,7 @@ describe('ExpandedApp', () => {
         });
 
         const launchButton = wrapper.find({
-          'data-test-id': 'RStudio-launch-button',
+          'data-test-id': 'open-RStudio-button',
         });
         expect(launchButton.prop('disabled')).toBeTruthy();
       }

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useState } from 'react';
 import {
   faGear,
-  faPlay,
   faRocket,
   faTrashCan,
 } from '@fortawesome/free-solid-svg-icons';
@@ -19,7 +18,6 @@ import {
   rstudioConfigIconId,
   SidebarIconId,
 } from 'app/components/help-sidebar-icons';
-import { withErrorModal } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
 import { RuntimeStatusIndicator } from 'app/components/runtime-status-indicator';
 import colors from 'app/styles/colors';
@@ -32,7 +30,6 @@ import {
 } from 'app/utils/runtime-utils';
 import { runtimeStore, useStore } from 'app/utils/stores';
 import {
-  createUserApp,
   localizeUserApp,
   pauseUserApp,
   resumeUserApp,
@@ -44,9 +41,7 @@ import { NewNotebookButton } from './new-notebook-button';
 import { PauseResumeButton } from './pause-resume-button';
 import { RuntimeCost } from './runtime-cost';
 import {
-  canCreateApp,
   canDeleteApp,
-  defaultRStudioConfig,
   fromRuntimeStatus,
   fromUserAppStatus,
   fromUserAppStatusWithFallback,
@@ -159,20 +154,6 @@ const RStudioButtonRow = (props: {
   workspaceNamespace: string;
 }) => {
   const { userApp, workspaceNamespace } = props;
-  const [creating, setCreating] = useState(false);
-
-  const onClickCreate = withErrorModal(
-    {
-      title: 'Error Creating RStudio Environment',
-      message:
-        'Please wait a few minutes and try to create your RStudio Environment again.',
-      onDismiss: () => setCreating(false),
-    },
-    async () => {
-      setCreating(true);
-      await createUserApp(workspaceNamespace, defaultRStudioConfig);
-    }
-  );
 
   const onClickLaunch = async () => {
     await localizeUserApp(
@@ -185,26 +166,10 @@ const RStudioButtonRow = (props: {
     window.open(userApp.proxyUrls['rstudio-service'], '_blank').focus();
   };
 
-  const createButtonDisabled = creating || !canCreateApp(userApp);
   const launchButtonDisabled = userApp?.status !== AppStatus.RUNNING;
 
   return (
     <FlexRow>
-      <TooltipTrigger
-        disabled={!createButtonDisabled}
-        content='An RStudio app exists or is being created'
-      >
-        {/* tooltip trigger needs a div for some reason */}
-        <div>
-          <AppsPanelButton
-            disabled={createButtonDisabled}
-            onClick={onClickCreate}
-            icon={faPlay}
-            buttonText={creating ? 'Creating' : 'Create'}
-            data-test-id='RStudio-create-button'
-          />
-        </div>
-      </TooltipTrigger>
       <PauseUserAppButton {...{ userApp, workspaceNamespace }} />
       <TooltipTrigger
         disabled={!launchButtonDisabled}

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -170,6 +170,11 @@ const RStudioButtonRow = (props: {
 
   return (
     <FlexRow>
+      <SettingsButton
+        onClick={() => {
+          setSidebarActiveIconStore.next(rstudioConfigIconId);
+        }}
+      />
       <PauseUserAppButton {...{ userApp, workspaceNamespace }} />
       <TooltipTrigger
         disabled={!launchButtonDisabled}

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -216,8 +216,8 @@ const RStudioButtonRow = (props: {
             onClick={onClickLaunch}
             disabled={launchButtonDisabled}
             icon={faRocket}
-            buttonText='Launch'
-            data-test-id='RStudio-launch-button'
+            buttonText='Open RStudio'
+            data-test-id='open-RStudio-button'
           />
         </div>
       </TooltipTrigger>

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
@@ -9,6 +9,7 @@ import {
   CreateGKEAppButton,
   CreateGKEAppButtonProps,
 } from 'app/components/gke-app-configuration-panels/create-gke-app-button';
+import { TooltipTrigger } from 'app/components/popups';
 
 import { createListAppsCromwellResponse } from 'testing/stubs/apps-api-stub';
 import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
@@ -40,6 +41,7 @@ describe(CreateGKEAppButton.name, () => {
         createAppRequest: defaultCromwellConfig,
         existingApp: createListAppsCromwellResponse({ status: appStatus }),
       });
+      expect(wrapper.find(TooltipTrigger).prop('disabled')).toBeTruthy();
       expect(wrapper.find(Button).prop('disabled')).toBeFalsy();
     });
   });
@@ -50,6 +52,7 @@ describe(CreateGKEAppButton.name, () => {
         createAppRequest: defaultCromwellConfig,
         existingApp: createListAppsCromwellResponse({ status: appStatus }),
       });
+      expect(wrapper.find(TooltipTrigger).prop('disabled')).toBeFalsy();
       expect(wrapper.find(Button).prop('disabled')).toBeTruthy();
     });
   });

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
@@ -5,6 +5,7 @@ import { CreateAppRequest, UserAppEnvironment } from 'generated/fetch';
 
 import { canCreateApp } from 'app/components/apps-panel/utils';
 import { Button } from 'app/components/buttons';
+import { TooltipTrigger } from 'app/components/popups';
 import { ApiErrorResponse, fetchWithErrorModal } from 'app/utils/errors';
 import { appTypeToString, createUserApp } from 'app/utils/user-apps-utils';
 
@@ -42,13 +43,21 @@ export function CreateGKEAppButton({
   };
 
   return (
-    <Button
-      id={`${appTypeString}-cloud-environment-create-button`}
-      aria-label={`${appTypeString} cloud environment create button`}
-      onClick={onCreate}
-      disabled={!createEnabled}
+    <TooltipTrigger
+      disabled={createEnabled}
+      content={`An ${appTypeString} app exists or is being created`}
     >
-      Start
-    </Button>
+      {/* tooltip trigger needs a div for some reason */}
+      <div>
+        <Button
+          id={`${appTypeString}-cloud-environment-create-button`}
+          aria-label={`${appTypeString} cloud environment create button`}
+          onClick={onCreate}
+          disabled={!createEnabled}
+        >
+          Start
+        </Button>
+      </div>
+    </TooltipTrigger>
   );
 }


### PR DESCRIPTION
Replaces the RStudio "Create" button with a "Settings" button. Changes the wording of the "Launch" button to "Open RStudio." As a bonus, this moves existing tooltip logic from the create button to the config panel.

This fixes [a bug](https://pmi-engteam.slack.com/archives/C0150CWF6FP/p1686073620949159?thread_ts=1686072650.884329&cid=C0150CWF6FP) with the in-progress story, RW-9762: RStudio apps with detached PDs could not be re-created from the expanded app. I thought it was easier to complete RW-9703 than add the additional complexity to support re-attaching disks from that button.

[Relevant workbench-ux thread](https://pmi-engteam.slack.com/archives/C02MWP2RN5P/p1686164080573979).

I have manually run the Cromwell and RStudio create / delete e2e tests.

Demo:

https://github.com/all-of-us/workbench/assets/31020403/b63e1a84-e813-4ecb-8092-b73b172f38fa

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.