### PR TITLE
[risk=no][no ticket] Remove unnecessary E2E coverage

### DIFF
--- a/e2e/tests/datasets/dataset-export-r-notebook.spec.ts
+++ b/e2e/tests/datasets/dataset-export-r-notebook.spec.ts
@@ -1,8 +1,7 @@
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
-import { makeWorkspaceName, makeRandomName } from 'utils/str-utils';
+import { makeRandomName, makeWorkspaceName } from 'utils/str-utils';
 import { findOrCreateDataset, findOrCreateWorkspace, openTab, signInWithAccessToken } from 'utils/test-utils';
 import { Language, ResourceCard, Tabs } from 'app/text-labels';
-import { getPropValue } from 'utils/element-utils';
 import WorkspaceAnalysisPage from 'app/page/workspace-analysis-page';
 import DatasetBuildPage from 'app/page/dataset-build-page';
 import { logger } from 'libs/logger';
@@ -63,17 +62,6 @@ describe('Export Dataset to Notebook Test', () => {
     const lastCell = await notebookPage.findLastCell();
     // Verify run output: Cell output format should be html table. Log error if failed.
     await lastCell.findRenderedHtmlElementHandle(2000).catch(() => lastCell.getOutputError());
-
-    // Verify workspace name is in notebook page.
-    const workspaceLink = await notebookPage.getWorkspaceLink().asElementHandle();
-    expect(await getPropValue<string>(workspaceLink, 'textContent')).toEqual(workspaceName);
-
-    // Verify notebook name is visible in notebook page.
-    const notebookLinkXpath =
-      `//a[contains(@href, "/${workspaceName.toLowerCase()}/notebooks/${notebookName.toLowerCase()}.ipynb")` +
-      `and text()="${notebookName.toLowerCase()}"]`;
-    const notebookLink = await page.waitForXPath(notebookLinkXpath, { visible: true });
-    expect(notebookLink.asElement()).toBeTruthy();
 
     // Navigate to Workspace Data page.
     await notebookPage.goDataPage();


### PR DESCRIPTION
Removes unnecessary E2E coverage.

This test was consistently failing in [a recent PR](https://github.com/all-of-us/workbench/pull/7759) of mine. However, the failing section doesn't seem relevant for this particular test so I investigated removing it instead of spending the afternoon debugging it.

We have [unit tests](https://github.com/all-of-us/workbench/blob/2446b9dc4f5adf3e392db0cba968716b2e8186db/ui/src/app/components/breadcrumb.spec.tsx#L42) that check the notebook name breadcrumb, although the coverage seems light. If we don't think that coverage is sufficient, we can add a new unit test specifically for notebook names.

The workspace link doesn't seem relevant for this test. Regardless, the line `await notebookPage.goDataPage();` [leverages the workspace link](https://github.com/all-of-us/workbench/blob/2446b9dc4f5adf3e392db0cba968716b2e8186db/e2e/app/page/notebook-page.ts#L106), so if that link stops working this test will still fail.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.