### PR TITLE
[risk=low][no ticket] Hide the "hide" button and text on Cloud Environments

### DIFF
--- a/ui/src/app/pages/runtimes-list.tsx
+++ b/ui/src/app/pages/runtimes-list.tsx
@@ -84,6 +84,7 @@ const css =
         display: none !important
     }
     
+    /* hides a warning banner which is only appropriate for Terra UI */
     div[style*="z-index: 2"]:has(>div>svg) {
         display: none !important
     }

--- a/ui/src/app/pages/runtimes-list.tsx
+++ b/ui/src/app/pages/runtimes-list.tsx
@@ -81,12 +81,22 @@ const css =
       .join(',\n')
   ) +
   ` {
-         display: none !important
-        }
-      
-       div[style*="z-index: 2"]:has(>div>svg) {
-          display: none !important
-        }`;
+        display: none !important
+    }
+    
+    div[style*="z-index: 2"]:has(>div>svg) {
+        display: none !important
+    }
+    
+    /* hides the "Hide resources you did not create" checkbox, which does not do anything */
+    [role=checkbox] {
+        display: none !important
+    }
+
+    /* hides the text after the checkbox above */
+    [role=checkbox] ~ span {
+        display: none !important
+    }`;
 
 interface RuntimesListProps
   extends WithSpinnerOverlayProps,


### PR DESCRIPTION
After https://github.com/all-of-us/workbench/pull/7736 the "Hide resources you did not create" checkbox doesn't do anything.  This PR removes it from view.

Tested by viewing the Cloud Environments page as the same user on Test and Local->Test and observing that removing this checkbox was the only change.

Before
<img width="695" alt="With-Hide" src="https://github.com/all-of-us/workbench/assets/2701406/dd0234bf-c87e-4fec-a9a3-bda112102817">

After
<img width="836" alt="Without-Hide" src="https://github.com/all-of-us/workbench/assets/2701406/b51f86ee-4f30-4fe5-b07a-f489764710af">


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
