### PR TITLE
[risk=no][RW-9965] Add multi-region bucket cost banner

### DIFF
--- a/ui/src/app/pages/workspace/workspace-wrapper.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.spec.tsx
@@ -1,0 +1,71 @@
+import '@testing-library/jest-dom';
+
+import * as React from 'react';
+import { MemoryRouter } from 'react-router';
+
+import { AppsApi, RuntimeApi, WorkspacesApi } from 'generated/fetch';
+
+import { screen } from '@testing-library/dom';
+import { render, waitForElementToBeRemoved } from '@testing-library/react';
+import { WorkspaceWrapper } from 'app/pages/workspace/workspace-wrapper';
+import { registerApiClient } from 'app/services/swagger-fetch-clients';
+import { cdrVersionStore, serverConfigStore } from 'app/utils/stores';
+
+import defaultServerConfig from 'testing/default-server-config';
+import { AppsApiStub } from 'testing/stubs/apps-api-stub';
+import { cdrVersionTiersResponse } from 'testing/stubs/cdr-versions-api-stub';
+import { RuntimeApiStub } from 'testing/stubs/runtime-api-stub';
+import { workspaceDataStub } from 'testing/stubs/workspaces';
+import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
+
+describe(WorkspaceWrapper.name, () => {
+  let workspaceData: typeof workspaceDataStub = null;
+
+  beforeEach(() => {
+    workspaceData = { ...workspaceDataStub };
+    serverConfigStore.set({ config: defaultServerConfig });
+    cdrVersionStore.set(cdrVersionTiersResponse);
+    registerApiClient(RuntimeApi, new RuntimeApiStub());
+    registerApiClient(AppsApi, new AppsApiStub());
+
+    const workspacesApi = new WorkspacesApiStub();
+    registerApiClient(WorkspacesApi, workspacesApi);
+    workspacesApi.getWorkspace = jest
+      .fn()
+      .mockResolvedValue({ workspace: workspaceData });
+  });
+
+  const createWrapperAndWaitForLoad = async () => {
+    render(
+      <MemoryRouter>
+        <WorkspaceWrapper hideSpinner={() => {}} />
+      </MemoryRouter>
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByTitle('loading workspaces spinner')
+    );
+  };
+
+  it('should show the multi-region workspace notification for workspaces created before 6/15/2022', async () => {
+    workspaceData.creationTime = new Date(2022, 5, 14).getTime();
+    await createWrapperAndWaitForLoad();
+    expect(
+      screen.queryByText(
+        'Workspaces created before 6/15/2022 use multi-region buckets',
+        { exact: false }
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('should not show the multi-region workspace notification for workspaces created during or after 6/15/2022', async () => {
+    workspaceData.creationTime = new Date(2022, 5, 15).getTime();
+    await createWrapperAndWaitForLoad();
+    expect(
+      screen.queryByText(
+        'Workspaces created before 6/15/2022 use multi-region buckets',
+        { exact: false }
+      )
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Adds a multi-region bucket cost banner.

How I determined the exact cutoff date:
- [This PR](https://github.com/all-of-us/workbench/pull/6761) implements the update
- [This release tag](https://github.com/all-of-us/workbench/tree/v7-14-rc1) marks the PR for release
- [This slack message](https://pmi-engteam.slack.com/archives/C66DX9FD0/p1655213641787859) indicates the release was completed
- Then, I added one day since the release happened mid-day.

I manually tested this by modifying the creation time of a workspace.

[Relevant workbench-ux thread](https://pmi-engteam.slack.com/archives/C02MWP2RN5P/p1686686866796819).

Screenshot:
<img width="1286" alt="image" src="https://github.com/all-of-us/workbench/assets/31020403/e5c61659-82f7-4cac-b47f-4ef1b2823a5a">

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.