### PR TITLE
[risk=low][no ticket] Fix non-notebook count for WS admin page

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageClientImpl.java
@@ -7,7 +7,6 @@ import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.CopyRequest;
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.List;
@@ -51,19 +50,17 @@ public class CloudStorageClientImpl implements CloudStorageClient {
 
   @Override
   public List<Blob> getBlobPage(String bucketName) {
-    Iterable<Blob> blobList = storageProvider.get().get(bucketName).list().getValues();
-    return ImmutableList.copyOf(blobList);
+    return storageProvider.get().get(bucketName).list().streamValues().collect(Collectors.toList());
   }
 
   @Override
   public List<Blob> getBlobPageForPrefix(String bucketName, String directory) {
-    Iterable<Blob> blobList =
-        storageProvider
-            .get()
-            .get(bucketName)
-            .list(Storage.BlobListOption.prefix(directory))
-            .getValues();
-    return ImmutableList.copyOf(blobList);
+    return storageProvider
+        .get()
+        .get(bucketName)
+        .list(Storage.BlobListOption.prefix(directory))
+        .streamValues()
+        .collect(Collectors.toList());
   }
 
   private String getCredentialsBucketName() {

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
@@ -22,6 +22,7 @@ public interface NotebooksService {
    * Is this a notebook file which is managed (localized and delocalized) by the Workbench?
    *
    * @return TRUE only if it has a supported file extension and resides in the supported directory
+   *     (and not a subdirectory)
    */
   boolean isManagedNotebookBlob(Blob blob);
 

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
@@ -18,7 +18,12 @@ public interface NotebooksService {
   List<FileDetail> getNotebooksAsService(
       String bucketName, String workspaceNamespace, String workspaceName);
 
-  boolean isNotebookBlob(Blob blob);
+  /**
+   * Is this a notebook file which is managed (localized and delocalized) by the Workbench?
+   *
+   * @return TRUE only if it has a supported file extension and resides in the supported directory
+   */
+  boolean isManagedNotebookBlob(Blob blob);
 
   FileDetail copyNotebook(
       String fromWorkspaceNamespace,

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -125,13 +125,13 @@ public class NotebooksServiceImpl implements NotebooksService {
     return cloudStorageClient
         .getBlobPageForPrefix(bucketName, NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY)
         .stream()
-        .filter(this::isNotebookBlob)
+        .filter(this::isManagedNotebookBlob)
         .map(blob -> cloudStorageClient.blobToFileDetail(blob, bucketName, workspaceUsers))
         .collect(Collectors.toList());
   }
 
   @Override
-  public boolean isNotebookBlob(Blob blob) {
+  public boolean isManagedNotebookBlob(Blob blob) {
     // Blobs have notebooks/ directory
     return NotebookUtils.isJupyterNotebookWithDirectory(blob.getName())
         || NotebookUtils.isRMarkDownNotebookWithDirectory(blob.getName());

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -57,7 +57,6 @@ import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceAdminView;
 import org.pmiops.workbench.model.WorkspaceAuditLogQueryResponse;
 import org.pmiops.workbench.model.WorkspaceUserAdminView;
-import org.pmiops.workbench.notebooks.NotebookUtils;
 import org.pmiops.workbench.notebooks.NotebooksService;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceDetails;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
@@ -398,10 +397,8 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
   // NOTE: may be an undercount since we only retrieve the first Page of Storage List results
   private int getNonNotebookFileCount(String bucketName) {
     return (int)
-        cloudStorageClient
-            .getBlobPageForPrefix(bucketName, NotebookUtils.NOTEBOOKS_WORKSPACE_DIRECTORY)
-            .stream()
-            .filter(((Predicate<Blob>) notebooksService::isNotebookBlob).negate())
+        cloudStorageClient.getBlobPage(bucketName).stream()
+            .filter(((Predicate<Blob>) notebooksService::isManagedNotebookBlob).negate())
             .count();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -654,9 +654,25 @@ public class NotebooksServiceTest {
   }
 
   @Test
-  public void testIsNotebookBlob_negative() {
-    when(mockBlob.getName()).thenReturn(NotebookUtils.withNotebookPath("test.txt"));
-    assertThat(notebooksService.isNotebookBlob(mockBlob)).isEqualTo(false);
+  public void testIsManagedNotebookBlob_positive() {
+    String managedNotebookFile =
+        NotebookUtils.withNotebookPath(NotebookUtils.withJupyterNotebookExtension("test"));
+    when(mockBlob.getName()).thenReturn(managedNotebookFile);
+    assertThat(notebooksService.isManagedNotebookBlob(mockBlob)).isEqualTo(true);
+  }
+
+  @Test
+  public void testIsManagedNotebookBlob_negative_path() {
+    String unmanagedNotebookFile = NotebookUtils.withJupyterNotebookExtension("test");
+    when(mockBlob.getName()).thenReturn(unmanagedNotebookFile);
+    assertThat(notebooksService.isManagedNotebookBlob(mockBlob)).isEqualTo(false);
+  }
+
+  @Test
+  public void testIsManagedNotebookBlob_negative_filename() {
+    String unmanagedOtherFileInNotebookDir = NotebookUtils.withNotebookPath("test.txt");
+    when(mockBlob.getName()).thenReturn(unmanagedOtherFileInNotebookDir);
+    assertThat(notebooksService.isManagedNotebookBlob(mockBlob)).isEqualTo(false);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -663,7 +663,8 @@ public class NotebooksServiceTest {
 
   @Test
   public void testIsManagedNotebookBlob_negative_path() {
-    String unmanagedNotebookFile = NotebookUtils.withJupyterNotebookExtension("test");
+    String unmanagedNotebookFile =
+        NotebookUtils.withJupyterNotebookExtension("some_other_dir/test");
     when(mockBlob.getName()).thenReturn(unmanagedNotebookFile);
     assertThat(notebooksService.isManagedNotebookBlob(mockBlob)).isEqualTo(false);
   }


### PR DESCRIPTION
I noticed the "# of other files" on the Workspace Admin page was always wrong: that's because we were only looking in the notebooks directory.  Now we look in all directories.

This screenshot shows correct counting and categorization for 6 files in a bucket, 2 managed notebooks and 4 other files:
1. `text.txt` in the root directory is not a notebook file
2. `anomaly.txt` in the `notebooks` directory is not a notebook file
3. `simple1.ipynb` is a notebook file in the right location, so it is a workbench-managed file 
4. `simple2.ipynb` is a notebook file in the right location, so it is a workbench-managed file 
5. `another.txt` in `notebooks/folder1` is not a notebook file
6. `Inside.ipynb` in `notebooks/folder1` is a notebook file, but it **isn't previewable or counted as workbench-managed** because it's in the wrong folder. 

<img width="1012" alt="File Count" src="https://github.com/all-of-us/workbench/assets/2701406/8dd77d1c-3ded-4dca-a647-b0f4d9803f1a">


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
