### PR TITLE
Use random workspace name

### DIFF
--- a/e2e/tests/notebook/notebook-writer-clone-workspace.spec.ts
+++ b/e2e/tests/notebook/notebook-writer-clone-workspace.spec.ts
@@ -6,7 +6,7 @@ import { Language, ResourceCard, Tabs, WorkspaceAccessLevel } from 'app/text-lab
 import { config } from 'resources/workbench-config';
 import { findOrCreateWorkspace, openTab, signInWithAccessToken } from 'utils/test-utils';
 import NotebookPreviewPage from 'app/page/notebook-preview-page';
-import { makeRandomName } from 'utils/str-utils';
+import { makeWorkspaceName, makeRandomName } from 'utils/str-utils';
 import expect from 'expect';
 
 // 30 minutes.
@@ -14,7 +14,7 @@ jest.setTimeout(30 * 60 * 1000);
 
 describe('WRITER clone workspace and notebook tests', () => {
   const notebookName = makeRandomName('notebookWriterTest-Py3');
-  const workspaceName = 'e2eNotebookWriterCloneWorkspaceTest';
+  const workspaceName = makeWorkspaceName();
   const writerWorkspaceName = 'e2eNotebookTestWriterWorkspace2';
 
   test('WRITER create workspace', async () => {


### PR DESCRIPTION
Similar to https://github.com/all-of-us/workbench/pull/7755/files
we reuse the same workspace name for that test an cleanup daily. The ran time stuck in ERROR state this moring, and it breaks all following tests
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
