### PR TITLE
[DT-448][risk=no] Fix clearing of attributes between concepts

### DIFF
--- a/ui/src/app/pages/data/cohort/attributes-page.tsx
+++ b/ui/src/app/pages/data/cohort/attributes-page.tsx
@@ -322,11 +322,12 @@ export const AttributesPage = fp.flow(
     cohortBuilderApi()
       .findCriteriaAttributeByConceptId(namespace, id, conceptId)
       .then((resp) => {
+        const newAttributes = { numAttributes: [], catAttributes: [] };
         resp.items.forEach((attr) => {
           if (attr.type === AttrName[AttrName.NUM]) {
             // NUM attributes set the min and max range for the number inputs in the attributes form
-            if (!numAttributes.length) {
-              numAttributes.push({
+            if (!newAttributes.numAttributes.length) {
+              newAttributes.numAttributes.push({
                 name: AttrName.NUM,
                 operator: isSurvey() ? 'ANY' : null,
                 operands: [],
@@ -334,7 +335,9 @@ export const AttributesPage = fp.flow(
                 [attr.conceptName]: parseFloat(attr.estCount),
               });
             } else {
-              numAttributes[0][attr.conceptName] = parseFloat(attr.estCount);
+              newAttributes.numAttributes[0][attr.conceptName] = parseFloat(
+                attr.estCount
+              );
             }
           } else {
             // CAT attributes are displayed as checkboxes in the attributes form
@@ -343,13 +346,13 @@ export const AttributesPage = fp.flow(
               // TODO RW-5572 confirm proper behavior and fix
               // eslint-disable-next-line @typescript-eslint/dot-notation
               attr['checked'] = false;
-              catAttributes.push(attr);
+              newAttributes.catAttributes.push(attr);
             }
           }
         });
         setAttributeCount(null);
-        setCatAttributes(catAttributes);
-        setNumAttributes(numAttributes);
+        setCatAttributes(newAttributes.catAttributes);
+        setNumAttributes(newAttributes.numAttributes);
         setLoading(false);
       });
   };


### PR DESCRIPTION
Attributes in state are not getting cleared between concepts, resulting in duplicated and/or incorrect options if multiple concepts are selected without closing the sidebar.

<img width="561" alt="Screenshot 2023-06-27 at 9 29 50 PM" src="https://github.com/all-of-us/workbench/assets/40036095/b2033505-9aab-4a11-95fc-5119b88f5d63">
