### PR TITLE
[risk=low][RW-9754] App selector for RStudio opens config panel

### DIFF
--- a/e2ev2/tests/workspace-analysis.test.js
+++ b/e2ev2/tests/workspace-analysis.test.js
@@ -29,7 +29,7 @@ browserTest('create an application', async browser => {
 
   await page.waitForSelector('#application-list-dropdown').then(eh => eh.evaluate(e => e.click()))
 
-  const jupyterOption = await page.waitForSelector('li[role="option"][aria-label="JUPYTER"]')
+  const jupyterOption = await page.waitForSelector('li[role="option"][aria-label="Jupyter"]')
   await jupyterOption.click()
   await nextButton.click()
 

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -2,16 +2,10 @@ import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import * as fp from 'lodash/fp';
 
-import {
-  AppStatus,
-  BillingStatus,
-  Runtime,
-  RuntimeStatus,
-} from 'generated/fetch';
+import { BillingStatus, Runtime, RuntimeStatus } from 'generated/fetch';
 
-import { findApp, UIAppType } from 'app/components/apps-panel/utils';
+import { UIAppType } from 'app/components/apps-panel/utils';
 import { IconButton } from 'app/components/buttons';
-import { rstudioConfigIconId } from 'app/components/help-sidebar-icons';
 import { ClrIcon, PlaygroundIcon } from 'app/components/icons';
 import { TooltipTrigger } from 'app/components/popups';
 import { RuntimeInitializerModal } from 'app/components/runtime-initializer-modal';
@@ -30,10 +24,7 @@ import {
 } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { InitialRuntimeNotFoundError } from 'app/utils/leo-runtime-initializer';
-import {
-  NavigationProps,
-  setSidebarActiveIconStore,
-} from 'app/utils/navigation';
+import { NavigationProps } from 'app/utils/navigation';
 import {
   ComputeSecuritySuspendedError,
   maybeInitializeRuntime,
@@ -49,7 +40,7 @@ import {
   UserAppsStore,
 } from 'app/utils/stores';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
-import { openRStudio } from 'app/utils/user-apps-utils';
+import { openRStudioOrConfigPanel } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
@@ -553,12 +544,7 @@ export const InteractiveNotebook = fp.flow(
         if (!this.notebookInUse) {
           if (appType === UIAppType.RSTUDIO) {
             const { userApps } = this.props.userAppsStore;
-            const userApp = findApp(userApps, UIAppType.RSTUDIO);
-            if (userApp && userApp.status === AppStatus.RUNNING) {
-              openRStudio(ns, userApp);
-            } else {
-              setSidebarActiveIconStore.next(rstudioConfigIconId);
-            }
+            openRStudioOrConfigPanel(ns, userApps);
           } else {
             this.runRuntime(() => {
               this.navigateEditMode();

--- a/ui/src/app/pages/appAnalysis/app-selector-modal.tsx
+++ b/ui/src/app/pages/appAnalysis/app-selector-modal.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { Dropdown } from 'primereact/dropdown';
+
+import { UIAppType } from 'app/components/apps-panel/utils';
+import { Button } from 'app/components/buttons';
+import {
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalTitle,
+} from 'app/components/modals';
+import colors from 'app/styles/colors';
+import { reactStyles } from 'app/utils';
+
+export const APP_LIST = [UIAppType.JUPYTER, UIAppType.RSTUDIO];
+
+const styles = reactStyles({
+  appsLabel: {
+    color: colors.primary,
+    fontWeight: 600,
+    fontSize: '14px',
+    lineHeight: '24px',
+    paddingBottom: '0.75rem',
+  },
+});
+
+interface AppSelectorModalProps {
+  selectedApp: UIAppType;
+  setSelectedApp: (UIAppType) => void;
+  onNext: () => void;
+  onClose: () => void;
+}
+export const AppSelectorModal = (props: AppSelectorModalProps) => {
+  const { selectedApp, setSelectedApp, onNext, onClose } = props;
+  return (
+    <Modal
+      data-test-id='select-application-modal'
+      aria={{
+        label: 'Select Applications Modal',
+      }}
+    >
+      <ModalTitle>Analyze Data</ModalTitle>
+      <ModalBody>
+        <div style={styles.appsLabel}>Select an application</div>
+        <Dropdown
+          id='application-list-dropdown'
+          data-test-id='application-list-dropdown'
+          ariaLabel='Application List Dropdown'
+          value={selectedApp}
+          appendTo='self'
+          options={APP_LIST}
+          placeholder='Choose One'
+          onChange={(e) => setSelectedApp(e.value)}
+          style={{ width: '13.5rem' }}
+        />
+      </ModalBody>
+      <ModalFooter style={{ paddingTop: '3rem' }}>
+        <Button
+          style={{ marginRight: '3rem' }}
+          type='secondary'
+          aria-label='close'
+          onClick={onClose}
+        >
+          Close
+        </Button>
+        <Button
+          data-test-id='next-btn'
+          type='primary'
+          aria-label='next'
+          onClick={onNext}
+          disabled={!selectedApp}
+        >
+          Next
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/ui/src/app/pages/appAnalysis/app-selector.spec.tsx
+++ b/ui/src/app/pages/appAnalysis/app-selector.spec.tsx
@@ -16,7 +16,8 @@ import {
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
 import { workspaceDataStub } from 'testing/stubs/workspaces';
 
-import { APP_LIST, AppSelector } from './app-selector';
+import { AppSelector } from './app-selector';
+import { APP_LIST } from './app-selector-modal';
 
 describe('App Selector', () => {
   const startButton = (wrapper) => {

--- a/ui/src/app/pages/appAnalysis/app-selector.spec.tsx
+++ b/ui/src/app/pages/appAnalysis/app-selector.spec.tsx
@@ -5,8 +5,8 @@ import { mount } from 'enzyme';
 
 import { NotebooksApi, WorkspaceAccessLevel } from 'generated/fetch';
 
+import { UIAppType } from 'app/components/apps-panel/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
-import { APP_LIST, JUPYTER_APP } from 'app/utils/constants';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 
 import {
@@ -16,7 +16,7 @@ import {
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
 import { workspaceDataStub } from 'testing/stubs/workspaces';
 
-import { AppSelector } from './app-selector';
+import { APP_LIST, AppSelector } from './app-selector';
 
 describe('App Selector', () => {
   const startButton = (wrapper) => {
@@ -93,7 +93,7 @@ describe('App Selector', () => {
 
     // Application Drop down List should have Jupyter as an option
     expect(applicationListDropDownWrapper(wrapper).prop('options')).toContain(
-      JUPYTER_APP
+      UIAppType.JUPYTER
     );
 
     // Next button should be disabled by default
@@ -104,7 +104,7 @@ describe('App Selector', () => {
       await simulateComponentChange(
         wrapper,
         applicationListDropDown,
-        JUPYTER_APP
+        UIAppType.JUPYTER
       );
     });
 

--- a/ui/src/app/pages/appAnalysis/app-selector.tsx
+++ b/ui/src/app/pages/appAnalysis/app-selector.tsx
@@ -38,11 +38,12 @@ const styles = reactStyles({
 
 export const APP_LIST = [UIAppType.JUPYTER, UIAppType.RSTUDIO];
 
-const enum VisiblePanel {
+const enum VisibleModal {
   None = 'None',
-  Selector = 'Selector',
+  SelectAnApp = 'SelectAnApp',
   Jupyter = 'Jupyter',
-  RStudio = 'RStudio',
+  // TODO will we need this?
+  // RStudio = 'RStudio'
 }
 
 interface AppSelectorProps {
@@ -51,7 +52,7 @@ interface AppSelectorProps {
 
 export const AppSelector = (props: AppSelectorProps) => {
   const { workspace } = props;
-  const [visiblePanel, setVisiblePanel] = useState(VisiblePanel.None);
+  const [visibleModal, setVisibleModal] = useState(VisibleModal.None);
   const [selectedApp, setSelectedApp] = useState<UIAppType>(undefined);
 
   const canCreateApps =
@@ -60,18 +61,18 @@ export const AppSelector = (props: AppSelectorProps) => {
 
   const onClose = () => {
     setSelectedApp(undefined);
-    setVisiblePanel(VisiblePanel.None);
+    setVisibleModal(VisibleModal.None);
   };
 
   const onNext = () => {
     switch (selectedApp) {
       case UIAppType.JUPYTER:
         AnalyticsTracker.Notebooks.OpenCreateModal();
-        setVisiblePanel(VisiblePanel.Jupyter);
+        setVisibleModal(VisibleModal.Jupyter);
         break;
       case UIAppType.RSTUDIO:
         // TODO do something more interesting?
-        setVisiblePanel(VisiblePanel.None);
+        setVisibleModal(VisibleModal.None);
         setSidebarActiveIconStore.next(rstudioConfigIconId);
         break;
     }
@@ -84,13 +85,13 @@ export const AppSelector = (props: AppSelectorProps) => {
         data-test-id='start-button'
         style={styles.startButton}
         onClick={() => {
-          setVisiblePanel(VisiblePanel.Selector);
+          setVisibleModal(VisibleModal.SelectAnApp);
         }}
         disabled={!canCreateApps}
       >
         <div style={{ width: '9rem', paddingLeft: '1rem' }}>Choose an App</div>
       </Button>
-      {visiblePanel === VisiblePanel.Selector && (
+      {visibleModal === VisibleModal.SelectAnApp && (
         <Modal
           data-test-id='select-application-modal'
           aria={{
@@ -133,13 +134,13 @@ export const AppSelector = (props: AppSelectorProps) => {
           </ModalFooter>
         </Modal>
       )}
-      {visiblePanel === VisiblePanel.Jupyter && (
+      {visibleModal === VisibleModal.Jupyter && (
         <NewJupyterNotebookModal
           {...{ workspace, onClose }}
           data-test-id='jupyter-modal'
           existingNameList={null}
           onBack={() => {
-            setVisiblePanel(VisiblePanel.Selector);
+            setVisibleModal(VisibleModal.SelectAnApp);
           }}
         />
       )}

--- a/ui/src/app/pages/appAnalysis/app-selector.tsx
+++ b/ui/src/app/pages/appAnalysis/app-selector.tsx
@@ -5,12 +5,12 @@ import { BillingStatus } from 'generated/fetch';
 
 import { UIAppType } from 'app/components/apps-panel/utils';
 import { Button } from 'app/components/buttons';
-import { rstudioConfigIconId } from 'app/components/help-sidebar-icons';
 import { NewJupyterNotebookModal } from 'app/pages/analysis/new-jupyter-notebook-modal';
 import colors from 'app/styles/colors';
 import { reactStyles, switchCase } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
-import { setSidebarActiveIconStore } from 'app/utils/navigation';
+import { userAppsStore, useStore } from 'app/utils/stores';
+import { openRStudioOrConfigPanel } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
 
@@ -28,8 +28,6 @@ const enum VisibleModal {
   None = 'None',
   SelectAnApp = 'SelectAnApp',
   Jupyter = 'Jupyter',
-  // TODO will we need this?
-  // RStudio = 'RStudio'
 }
 
 interface AppSelectorProps {
@@ -38,6 +36,7 @@ interface AppSelectorProps {
 
 export const AppSelector = (props: AppSelectorProps) => {
   const { workspace } = props;
+  const { userApps } = useStore(userAppsStore);
   const [selectedApp, setSelectedApp] = useState<UIAppType>(undefined);
   const [visibleModal, setVisibleModal] = useState(VisibleModal.None);
 
@@ -58,8 +57,7 @@ export const AppSelector = (props: AppSelectorProps) => {
         break;
       case UIAppType.RSTUDIO:
         setVisibleModal(VisibleModal.None);
-        // TODO iterate on what is the best action here
-        setSidebarActiveIconStore.next(rstudioConfigIconId);
+        openRStudioOrConfigPanel(workspace.namespace, userApps);
         break;
     }
   };

--- a/ui/src/app/pages/appAnalysis/app-selector.tsx
+++ b/ui/src/app/pages/appAnalysis/app-selector.tsx
@@ -38,8 +38,8 @@ interface AppSelectorProps {
 
 export const AppSelector = (props: AppSelectorProps) => {
   const { workspace } = props;
-  const [visibleModal, setVisibleModal] = useState(VisibleModal.None);
   const [selectedApp, setSelectedApp] = useState<UIAppType>(undefined);
+  const [visibleModal, setVisibleModal] = useState(VisibleModal.None);
 
   const canCreateApps =
     workspace.billingStatus === BillingStatus.ACTIVE &&
@@ -57,8 +57,8 @@ export const AppSelector = (props: AppSelectorProps) => {
         setVisibleModal(VisibleModal.Jupyter);
         break;
       case UIAppType.RSTUDIO:
-        // TODO do something more interesting?
         setVisibleModal(VisibleModal.None);
+        // TODO iterate on what is the best action here
         setSidebarActiveIconStore.next(rstudioConfigIconId);
         break;
     }

--- a/ui/src/app/pages/appAnalysis/app-selector.tsx
+++ b/ui/src/app/pages/appAnalysis/app-selector.tsx
@@ -8,7 +8,7 @@ import { Button } from 'app/components/buttons';
 import { rstudioConfigIconId } from 'app/components/help-sidebar-icons';
 import { NewJupyterNotebookModal } from 'app/pages/analysis/new-jupyter-notebook-modal';
 import colors from 'app/styles/colors';
-import { reactStyles } from 'app/utils';
+import { reactStyles, switchCase } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { WorkspaceData } from 'app/utils/workspace-data';
@@ -77,20 +77,29 @@ export const AppSelector = (props: AppSelectorProps) => {
       >
         <div style={{ width: '9rem', paddingLeft: '1rem' }}>Choose an App</div>
       </Button>
-      {visibleModal === VisibleModal.SelectAnApp && (
-        <AppSelectorModal
-          {...{ selectedApp, setSelectedApp, onNext, onClose }}
-        />
-      )}
-      {visibleModal === VisibleModal.Jupyter && (
-        <NewJupyterNotebookModal
-          {...{ workspace, onClose }}
-          data-test-id='jupyter-modal'
-          existingNameList={null}
-          onBack={() => {
-            setVisibleModal(VisibleModal.SelectAnApp);
-          }}
-        />
+      {switchCase(
+        visibleModal,
+        [
+          VisibleModal.SelectAnApp,
+          () => (
+            <AppSelectorModal
+              {...{ selectedApp, setSelectedApp, onNext, onClose }}
+            />
+          ),
+        ],
+        [
+          VisibleModal.Jupyter,
+          () => (
+            <NewJupyterNotebookModal
+              {...{ workspace, onClose }}
+              data-test-id='jupyter-modal'
+              existingNameList={null}
+              onBack={() => {
+                setVisibleModal(VisibleModal.SelectAnApp);
+              }}
+            />
+          ),
+        ]
       )}
     </>
   );

--- a/ui/src/app/pages/appAnalysis/app-selector.tsx
+++ b/ui/src/app/pages/appAnalysis/app-selector.tsx
@@ -1,18 +1,11 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { Dropdown } from 'primereact/dropdown';
 
 import { BillingStatus } from 'generated/fetch';
 
 import { UIAppType } from 'app/components/apps-panel/utils';
 import { Button } from 'app/components/buttons';
 import { rstudioConfigIconId } from 'app/components/help-sidebar-icons';
-import {
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalTitle,
-} from 'app/components/modals';
 import { NewJupyterNotebookModal } from 'app/pages/analysis/new-jupyter-notebook-modal';
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
@@ -21,22 +14,15 @@ import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
 
+import { AppSelectorModal } from './app-selector-modal';
+
 const styles = reactStyles({
   startButton: {
     paddingLeft: '0.75rem',
     height: '3rem',
     backgroundColor: colors.secondary,
   },
-  appsLabel: {
-    color: colors.primary,
-    fontWeight: 600,
-    fontSize: '14px',
-    lineHeight: '24px',
-    paddingBottom: '0.75rem',
-  },
 });
-
-export const APP_LIST = [UIAppType.JUPYTER, UIAppType.RSTUDIO];
 
 const enum VisibleModal {
   None = 'None',
@@ -92,47 +78,9 @@ export const AppSelector = (props: AppSelectorProps) => {
         <div style={{ width: '9rem', paddingLeft: '1rem' }}>Choose an App</div>
       </Button>
       {visibleModal === VisibleModal.SelectAnApp && (
-        <Modal
-          data-test-id='select-application-modal'
-          aria={{
-            label: 'Select Applications Modal',
-          }}
-        >
-          <ModalTitle>Analyze Data</ModalTitle>
-          <ModalBody>
-            <div style={styles.appsLabel}>Select an application</div>
-            <Dropdown
-              id='application-list-dropdown'
-              data-test-id='application-list-dropdown'
-              ariaLabel='Application List Dropdown'
-              value={selectedApp}
-              appendTo='self'
-              options={APP_LIST}
-              placeholder='Choose One'
-              onChange={(e) => setSelectedApp(e.value)}
-              style={{ width: '13.5rem' }}
-            />
-          </ModalBody>
-          <ModalFooter style={{ paddingTop: '3rem' }}>
-            <Button
-              style={{ marginRight: '3rem' }}
-              type='secondary'
-              aria-label='close'
-              onClick={onClose}
-            >
-              Close
-            </Button>
-            <Button
-              data-test-id='next-btn'
-              type='primary'
-              aria-label='next'
-              onClick={onNext}
-              disabled={!selectedApp}
-            >
-              Next
-            </Button>
-          </ModalFooter>
-        </Modal>
+        <AppSelectorModal
+          {...{ selectedApp, setSelectedApp, onNext, onClose }}
+        />
       )}
       {visibleModal === VisibleModal.Jupyter && (
         <NewJupyterNotebookModal

--- a/ui/src/app/utils/constants.tsx
+++ b/ui/src/app/utils/constants.tsx
@@ -84,10 +84,6 @@ export const STATE_CODE_MAPPING = {
   WYOMING: 'WY',
 };
 
-// ANALYSIS (NEW): APPS LIST
-export const JUPYTER_APP = 'JUPYTER';
-export const APP_LIST = [JUPYTER_APP];
-
 export const JUPYTER_FILE_EXT = '.ipynb';
 export const RMD_FILE_EXT = '.Rmd';
 export const R_FILE_EXT = '.R';

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -3,12 +3,16 @@ import {
   AppType,
   CreateAppRequest,
   Disk,
+  ListAppsResponse,
   UserAppEnvironment,
 } from 'generated/fetch';
 
+import { findApp, UIAppType } from 'app/components/apps-panel/utils';
+import { rstudioConfigIconId } from 'app/components/help-sidebar-icons';
 import { leoAppsApi } from 'app/services/notebooks-swagger-fetch-clients';
 import { appsApi } from 'app/services/swagger-fetch-clients';
 
+import { setSidebarActiveIconStore } from './navigation';
 import { userAppsStore } from './stores';
 
 export const appTypeToString: Record<AppType, string> = {
@@ -104,7 +108,10 @@ export function unattachedDiskExists(
   return !app && disk !== undefined;
 }
 
-export const openRStudio = (workspaceNamespace, userApp) => {
+export const openRStudio = (
+  workspaceNamespace: string,
+  userApp: UserAppEnvironment
+) => {
   localizeUserApp(
     workspaceNamespace,
     userApp.appName,
@@ -113,4 +120,16 @@ export const openRStudio = (workspaceNamespace, userApp) => {
     false
   );
   window.open(userApp.proxyUrls['rstudio-service'], '_blank').focus();
+};
+
+export const openRStudioOrConfigPanel = (
+  workspaceNamespace: string,
+  userApps: ListAppsResponse
+) => {
+  const userApp = findApp(userApps, UIAppType.RSTUDIO);
+  if (userApp?.status === AppStatus.RUNNING) {
+    openRStudio(workspaceNamespace, userApp);
+  } else {
+    setSidebarActiveIconStore.next(rstudioConfigIconId);
+  }
 };


### PR DESCRIPTION
Thinking about the remaining steps before launching to Preprod to gain user feedback, I felt that the Choose an App modal should allow another choice besides Jupyter - otherwise why have it?

The action taken is the same as the Edit button on the R-file preview page:
* Open Config Panel if RStudio is not currently running
* Open RStudio in a new tab if RStudio is currently running

Not running:
![Select RStudio](https://github.com/all-of-us/workbench/assets/2701406/c7f3d8da-d43f-4a50-bc41-ba4a51cd9a9d)

Running:
![Open_RStudio](https://github.com/all-of-us/workbench/assets/2701406/b6a6aa24-630c-4d2e-9357-df0027915342)

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
