### PR TITLE
[risk=low][no ticket] Constify notebooks path in the UI

### DIFF
--- a/e2e/tests/datasets/dataset-export-py-notebook.spec.ts
+++ b/e2e/tests/datasets/dataset-export-py-notebook.spec.ts
@@ -37,7 +37,7 @@ describe('Export Dataset to Notebook Test', () => {
 
     // Verify notebook created successfully. Not going to start notebook runtime.
     const currentPageUrl = page.url();
-    expect(currentPageUrl).toContain(`notebooks/preview/${notebookName}.ipynb`);
+    expect(currentPageUrl).toContain(`preview/${notebookName}.ipynb`);
 
     // Delete notebook.
     const analysisPage = await notebookPreviewPage.goAnalysisPage();

--- a/e2e/tests/nightly/notebook/dataset-export-r-notebook.spec.ts
+++ b/e2e/tests/nightly/notebook/dataset-export-r-notebook.spec.ts
@@ -42,7 +42,7 @@ describe('Export Dataset to Notebook Test', () => {
     const notebookPreviewPage = new NotebookPreviewPage(page);
     await notebookPreviewPage.waitForLoad();
     const currentPageUrl = page.url();
-    expect(currentPageUrl).toContain(`notebooks/preview/${notebookName}.ipynb`);
+    expect(currentPageUrl).toContain(`preview/${notebookName}.ipynb`);
 
     previewCodeLines = await notebookPreviewPage.getFormattedCode();
     // Verify few randomly selected code snippet

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -115,7 +115,10 @@ export const getTrail = (
           conceptSet,
           params
         ),
-        new BreadcrumbData('Notebooks', `${prefix}/${NOTEBOOKS_TAB_NAME}`),
+        new BreadcrumbData(
+          fp.upperFirst(NOTEBOOKS_TAB_NAME),
+          `${prefix}/${NOTEBOOKS_TAB_NAME}`
+        ),
         new BreadcrumbData(
           nbName && dropJupyterNotebookFileSuffix(decodeURIComponent(nbName)),
           `${prefix}/${NOTEBOOKS_TAB_NAME}/${nbName}`

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -18,6 +18,7 @@ import {
   withCurrentConceptSet,
   withCurrentWorkspace,
 } from 'app/utils';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import {
   MatchParams,
   RouteDataStore,
@@ -114,10 +115,10 @@ export const getTrail = (
           conceptSet,
           params
         ),
-        new BreadcrumbData('Notebooks', `${prefix}/notebooks`),
+        new BreadcrumbData('Notebooks', `${prefix}/${NOTEBOOKS_TAB_NAME}`),
         new BreadcrumbData(
           nbName && dropJupyterNotebookFileSuffix(decodeURIComponent(nbName)),
-          `${prefix}/notebooks/${nbName}`
+          `${prefix}/${NOTEBOOKS_TAB_NAME}/${nbName}`
         ),
       ];
     case BreadcrumbType.ConceptSet:
@@ -321,10 +322,10 @@ export const Breadcrumb = fp.flow(
       const { pid = '' } = participantMatch ? participantMatch.params : {};
 
       const notebookMatch = matchPath<MatchParams>(location.pathname, {
-        path: '/workspaces/:ns/:wsid/notebooks/:nbName',
+        path: `/workspaces/:ns/:wsid/${NOTEBOOKS_TAB_NAME}/:nbName`,
       });
       const notebookPreviewMatch = matchPath<MatchParams>(location.pathname, {
-        path: '/workspaces/:ns/:wsid/notebooks/preview/:nbName',
+        path: `/workspaces/:ns/:wsid/${NOTEBOOKS_TAB_NAME}/preview/:nbName`,
       });
       const nbName = notebookMatch
         ? notebookMatch.params.nbName
@@ -338,7 +339,7 @@ export const Breadcrumb = fp.flow(
         this.props.cohort,
         this.props.cohortReview,
         this.props.conceptSet,
-        { ns: ns, wsid: wsid, cid: cid, csid: csid, pid: pid, nbName: nbName }
+        { ns, wsid, cid, csid, pid, nbName }
       );
     }
 

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -23,6 +23,7 @@ import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { cond, reactStyles, withCdrVersions } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { NavigationProps } from 'app/utils/navigation';
 import { toDisplay } from 'app/utils/resources';
 import { WorkspacePermissions } from 'app/utils/workspace-permissions';
@@ -37,7 +38,7 @@ enum RequestState {
 }
 
 const ResourceTypeHomeTabs = new Map()
-  .set(ResourceType.NOTEBOOK, 'notebooks')
+  .set(ResourceType.NOTEBOOK, NOTEBOOKS_TAB_NAME)
   .set(ResourceType.COHORT, 'data')
   .set(ResourceType.CONCEPTSET, 'data')
   .set(ResourceType.DATASET, 'data');

--- a/ui/src/app/components/resource-list.tsx
+++ b/ui/src/app/components/resource-list.tsx
@@ -24,7 +24,10 @@ import {
 import colors from 'app/styles/colors';
 import { reactStyles, withCdrVersions } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
-import { ROWS_PER_PAGE_RESOURCE_TABLE } from 'app/utils/constants';
+import {
+  NOTEBOOKS_TAB_NAME,
+  ROWS_PER_PAGE_RESOURCE_TABLE,
+} from 'app/utils/constants';
 import { displayDate, displayDateWithoutHours } from 'app/utils/dates';
 import {
   getDisplayName,
@@ -71,7 +74,7 @@ const WorkspaceNavigation = (props: NavProps) => {
     resource,
     style,
   } = props;
-  const tab = isNotebook(resource) ? 'notebooks' : 'data';
+  const tab = isNotebook(resource) ? NOTEBOOKS_TAB_NAME : 'data';
   const url = `/workspaces/${namespace}/${id}/${tab}`;
 
   return (

--- a/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
@@ -8,6 +8,7 @@ import userEvent from '@testing-library/user-event';
 import { UserEvent } from '@testing-library/user-event/setup/setup';
 import { rstudioConfigIconId } from 'app/components/help-sidebar-icons';
 import * as swaggerClients from 'app/services/swagger-fetch-clients';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import {
   currentWorkspaceStore,
   setSidebarActiveIconStore,
@@ -47,10 +48,12 @@ const renderInteractiveNotebook = (pathParameters) =>
   render(
     <MemoryRouter
       initialEntries={[
-        '/workspaces/sampleNameSpace/sampleWorkspace/notebooks/preview/example.Rmd',
+        `/workspaces/sampleNameSpace/sampleWorkspace/${NOTEBOOKS_TAB_NAME}/preview/example.Rmd`,
       ]}
     >
-      <Route path='/workspaces/:ns/:wsid/notebooks/preview/:nbName'>
+      <Route
+        path={`/workspaces/:ns/:wsid/${NOTEBOOKS_TAB_NAME}/preview/:nbName`}
+      >
         <InteractiveNotebook hideSpinner={() => {}} match={pathParameters} />
       </Route>
     </MemoryRouter>

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -23,6 +23,7 @@ import {
   withCurrentWorkspace,
 } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { InitialRuntimeNotFoundError } from 'app/utils/leo-runtime-initializer';
 import { NavigationProps } from 'app/utils/navigation';
 import {
@@ -273,7 +274,7 @@ export const InteractiveNotebook = fp.flow(
           'workspaces',
           this.props.match.params.ns,
           this.props.match.params.wsid,
-          'notebooks',
+          NOTEBOOKS_TAB_NAME,
           this.props.match.params.nbName,
         ],
         { queryParams: queryParams }
@@ -319,7 +320,7 @@ export const InteractiveNotebook = fp.flow(
             'workspaces',
             ns,
             wsid,
-            'notebooks',
+            NOTEBOOKS_TAB_NAME,
             encodeURIComponent(notebook.name),
           ]);
         });

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
@@ -25,6 +25,7 @@ import {
 } from 'app/pages/analysis/leonardo-app-launcher';
 import { registerApiClient as registerApiClientNotebooks } from 'app/services/notebooks-swagger-fetch-clients';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 import { ComputeSecuritySuspendedError } from 'app/utils/runtime-utils';
 import {
@@ -72,13 +73,13 @@ describe('NotebookLauncher', () => {
 
   let runtimeStub;
 
-  const notebookInitialUrl = '/workspaces/namespace/id/notebooks/wharrgarbl';
+  const notebookInitialUrl = `/workspaces/namespace/id/${NOTEBOOKS_TAB_NAME}/wharrgarbl`;
   const history = createMemoryHistory({ initialEntries: [notebookInitialUrl] });
 
   const notebookComponent = async () => {
     const c = mount(
       <Router history={history}>
-        <Route path='/workspaces/:ns/:wsid/notebooks/:nbName'>
+        <Route path={`/workspaces/:ns/:wsid/${NOTEBOOKS_TAB_NAME}/:nbName`}>
           <LeonardoAppLauncher
             hideSpinner={() => {}}
             showSpinner={() => {}}
@@ -550,7 +551,7 @@ describe('TerminalLauncher', () => {
       'workspaces',
       'defaultNamespace',
       '1',
-      'notebooks',
+      NOTEBOOKS_TAB_NAME,
     ]);
   });
 });

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -27,6 +27,7 @@ import {
   withCurrentWorkspace,
   withUserProfile,
 } from 'app/utils';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { InitialRuntimeNotFoundError } from 'app/utils/leo-runtime-initializer';
 import { NavigationProps } from 'app/utils/navigation';
 import { Kernels } from 'app/utils/notebook-kernels';
@@ -508,7 +509,7 @@ export const LeonardoAppLauncher = fp.flow(
           workspace.namespace,
           workspace.id,
           // navigate will encode the notebook name automatically
-          'notebooks',
+          NOTEBOOKS_TAB_NAME,
           ...(this.props.leoAppType === LeoApplicationType.Notebook
             ? ['preview', this.getFullJupyterNotebookName()]
             : []),
@@ -577,12 +578,9 @@ export const LeonardoAppLauncher = fp.flow(
         window.history.replaceState(
           {},
           'Notebook',
-          'workspaces/' +
-            namespace +
-            '/' +
-            id +
-            '/notebooks/' +
-            encodeURIComponent(this.getFullJupyterNotebookName())
+          `workspaces/${namespace}/${id}/${NOTEBOOKS_TAB_NAME}/${encodeURIComponent(
+            this.getFullJupyterNotebookName()
+          )}`
         );
       }
       if (this.isOpeningTerminal()) {

--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -18,6 +18,7 @@ import { getExistingNotebookNames } from 'app/pages/analysis/util';
 import { userMetricsApi } from 'app/services/swagger-fetch-clients';
 import { summarizeErrors } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { useNavigation } from 'app/utils/navigation';
 import { Kernels } from 'app/utils/notebook-kernels';
 import { nameValidationFormat } from 'app/utils/resources';
@@ -71,7 +72,7 @@ export const NewJupyterNotebookModal = (props: Props) => {
         'workspaces',
         workspace.namespace,
         workspace.id,
-        'notebooks',
+        NOTEBOOKS_TAB_NAME,
         encodeURIComponent(name),
       ],
       { queryParams: { kernelType: kernel, creating: true } }

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -24,8 +24,6 @@ import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
 
 import { NotebookList } from './notebook-list';
 
-const NOTEBOOK_HREF_LOCATION = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${NOTEBOOKS_TAB_NAME}/preview/mockFile.ipynb`;
-
 describe('NotebookList', () => {
   beforeEach(() => {
     registerApiClient(WorkspacesApi, new WorkspacesApiStub());
@@ -76,18 +74,19 @@ describe('NotebookList', () => {
     );
     await waitOneTickAndUpdate(wrapper);
 
+    const expected = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${NOTEBOOKS_TAB_NAME}/preview/mockFile.ipynb`;
     expect(
       resourceTableColumns(wrapper)
         .at(RESOURCE_TYPE_COLUMN_NUMBER)
         .find('a')
         .prop('href')
-    ).toBe(NOTEBOOK_HREF_LOCATION);
+    ).toBe(expected);
 
     expect(
       resourceTableColumns(wrapper)
         .at(NAME_COLUMN_NUMBER)
         .find('a')
         .prop('href')
-    ).toBe(NOTEBOOK_HREF_LOCATION);
+    ).toBe(expected);
   });
 });

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -12,6 +12,7 @@ import {
   resourceTableColumns,
 } from 'app/components/resource-list.spec';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 
@@ -23,7 +24,7 @@ import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
 
 import { NotebookList } from './notebook-list';
 
-const NOTEBOOK_HREF_LOCATION = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/notebooks/preview/mockFile.ipynb`;
+const NOTEBOOK_HREF_LOCATION = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${NOTEBOOKS_TAB_NAME}/preview/mockFile.ipynb`;
 
 describe('NotebookList', () => {
   beforeEach(() => {

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -17,6 +17,7 @@ import { NotebookResourceCard } from 'app/pages/analysis/notebook-resource-card'
 import { getAppInfoFromFileName, listNotebooks } from 'app/pages/analysis/util';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCurrentWorkspace } from 'app/utils';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { convertToResources } from 'app/utils/resources';
 import { WorkspaceData } from 'app/utils/workspace-data';
@@ -111,7 +112,7 @@ export const AppFilesList = withCurrentWorkspace()(
         workspace: { namespace, id },
       } = props;
       const { name } = row;
-      const url = `/workspaces/${namespace}/${id}/notebooks/preview/${name}`;
+      const url = `/workspaces/${namespace}/${id}/${NOTEBOOKS_TAB_NAME}/preview/${name}`;
       return (
         <Clickable>
           <RouterLink to={url} data-test-id='notebook-navigation'>

--- a/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
+++ b/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
@@ -14,8 +14,6 @@ import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
 import { workspaceDataStub } from 'testing/stubs/workspaces';
 import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
-
-const NOTEBOOK_HREF_LOCATION = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${NOTEBOOKS_TAB_NAME}/preview/mockFile.ipynb`;
 const appsFilesTable = (wrapper) =>
   wrapper.find('[data-test-id="apps-file-list"]').find('tbody');
 const appsFilesTableColumns = (wrapper) => appsFilesTable(wrapper).find('td');
@@ -86,11 +84,12 @@ describe('AppsList', () => {
     );
     await waitOneTickAndUpdate(wrapper);
 
+    const expected = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${NOTEBOOKS_TAB_NAME}/preview/mockFile.ipynb`;
     expect(
       appsFilesTableColumns(wrapper)
         .at(NAME_COLUMN_NUMBER)
         .find('a')
         .prop('href')
-    ).toBe(NOTEBOOK_HREF_LOCATION);
+    ).toBe(expected);
   });
 });

--- a/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
+++ b/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
@@ -6,6 +6,7 @@ import { NotebooksApi, WorkspacesApi } from 'generated/fetch';
 
 import { AppFilesList } from 'app/pages/appAnalysis/app-files-list';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 
@@ -14,7 +15,7 @@ import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
 import { workspaceDataStub } from 'testing/stubs/workspaces';
 import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
 
-const NOTEBOOK_HREF_LOCATION = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/notebooks/preview/mockFile.ipynb`;
+const NOTEBOOK_HREF_LOCATION = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${NOTEBOOKS_TAB_NAME}/preview/mockFile.ipynb`;
 const appsFilesTable = (wrapper) =>
   wrapper.find('[data-test-id="apps-file-list"]').find('tbody');
 const appsFilesTableColumns = (wrapper) => appsFilesTable(wrapper).find('td');

--- a/ui/src/app/pages/data/cohort/cohort-actions.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-actions.tsx
@@ -19,6 +19,7 @@ import {
   withCurrentCohort,
   withCurrentWorkspace,
 } from 'app/utils';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
@@ -161,7 +162,7 @@ export const CohortActions = fp.flow(
           url += `data/cohorts/${cohort.id}/reviews`;
           break;
         case 'notebook':
-          url += 'notebooks';
+          url += NOTEBOOKS_TAB_NAME;
           break;
         case 'dataSet':
           url += 'data/data-sets';

--- a/ui/src/app/pages/data/cohort/overview.tsx
+++ b/ui/src/app/pages/data/cohort/overview.tsx
@@ -39,6 +39,7 @@ import {
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCdrVersions, withCurrentWorkspace } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { isAbortError } from 'app/utils/errors';
 import { currentWorkspaceStore, NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
@@ -444,7 +445,7 @@ export const ListOverview = fp.flow(
       switch (action) {
         case 'notebook':
           AnalyticsTracker.CohortBuilder.CohortAction('Export to notebook');
-          url += 'notebooks';
+          url += NOTEBOOKS_TAB_NAME;
           break;
         case 'review':
           AnalyticsTracker.CohortBuilder.CohortAction('Review cohort');

--- a/ui/src/app/pages/data/concept/concept-set-actions.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-actions.tsx
@@ -18,6 +18,7 @@ import {
   withCurrentConceptSet,
   withCurrentWorkspace,
 } from 'app/utils';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { conceptSetUpdating, NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
@@ -156,7 +157,7 @@ export const ConceptSetActions = fp.flow(
           url += 'data/concepts';
           break;
         case 'notebook':
-          url += 'notebooks';
+          url += NOTEBOOKS_TAB_NAME;
           break;
         case 'dataSet':
           url += 'data/data-sets';

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -35,6 +35,7 @@ import { dataSetApi, notebooksApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { reactStyles, summarizeErrors } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { encodeURIComponentStrict, useNavigation } from 'app/utils/navigation';
 import { nameValidationFormat } from 'app/utils/resources';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
@@ -123,7 +124,7 @@ export const ExportDatasetModal = ({
         createExportDatasetRequest()
       );
       const notebookUrl =
-        `/workspaces/${workspace.namespace}/${workspace.id}/notebooks/preview/` +
+        `/workspaces/${workspace.namespace}/${workspace.id}/${NOTEBOOKS_TAB_NAME}/preview/` +
         encodeURIComponentStrict(
           appendJupyterNotebookFileSuffix(notebookNameWithoutSuffix)
         );

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -3,7 +3,6 @@ import { MemoryRouter, Route } from 'react-router-dom';
 import { mount } from 'enzyme';
 import { mockNavigate } from 'setupTests';
 
-import { environment } from 'environments/environment';
 import { WorkspaceNavBar } from 'app/pages/workspace/workspace-nav-bar';
 import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { currentWorkspaceStore } from 'app/utils/navigation';

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -3,7 +3,9 @@ import { MemoryRouter, Route } from 'react-router-dom';
 import { mount } from 'enzyme';
 import { mockNavigate } from 'setupTests';
 
+import { environment } from 'environments/environment';
 import { WorkspaceNavBar } from 'app/pages/workspace/workspace-nav-bar';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 import { cdrVersionStore, serverConfigStore } from 'app/utils/stores';
 
@@ -68,7 +70,7 @@ describe('WorkspaceNavBar', () => {
       'workspaces',
       workspaceDataStub.namespace,
       workspaceDataStub.id,
-      'notebooks',
+      NOTEBOOKS_TAB_NAME,
     ]);
 
     wrapper.find({ 'data-test-id': 'Data' }).first().simulate('click');
@@ -119,7 +121,7 @@ describe('WorkspaceNavBar', () => {
       'workspaces',
       workspaceDataStub.namespace,
       workspaceDataStub.id,
-      'notebooks',
+      NOTEBOOKS_TAB_NAME,
     ]);
   });
 
@@ -141,7 +143,7 @@ describe('WorkspaceNavBar', () => {
       'workspaces',
       workspaceDataStub.namespace,
       workspaceDataStub.id,
-      'notebooks',
+      NOTEBOOKS_TAB_NAME,
     ]);
   });
 

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -16,6 +16,7 @@ import {
   getDefaultCdrVersionForTier,
   hasDefaultCdrVersion,
 } from 'app/utils/cdr-versions';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { useNavigation } from 'app/utils/navigation';
 import { MatchParams, serverConfigStore } from 'app/utils/stores';
 
@@ -142,8 +143,10 @@ const CdrVersion = (props: {
 
 const tabs = [
   { name: 'Data', link: 'data' },
-  { name: 'Analysis', link: 'notebooks' },
-  // { name: 'Analysis (New)', link: 'apps' },
+  {
+    name: 'Analysis',
+    link: NOTEBOOKS_TAB_NAME,
+  },
   { name: 'About', link: 'about' },
 ];
 
@@ -190,7 +193,7 @@ export const WorkspaceNavBar = fp.flow(
     }
   }, []);
 
-  const appsTabStyle = (selected) => {
+  const experimentalTabStyle = (selected) => {
     return selected
       ? { backgroundColor: colorWithWhiteness(colors.danger, 0.3) }
       : { backgroundColor: colors.danger };
@@ -214,7 +217,7 @@ export const WorkspaceNavBar = fp.flow(
             ...(selected ? styles.active : {}),
             ...(disabled ? styles.disabled : {}),
             ...(['apps', 'data-explorer', 'tanagra'].includes(link)
-              ? appsTabStyle(selected)
+              ? experimentalTabStyle(selected)
               : {}),
           }}
           onClick={() => navigate(['workspaces', ns, wsid, link])}

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -7,8 +7,10 @@ import { BreadcrumbType } from 'app/components/breadcrumb-type';
 import { LEONARDO_APP_PAGE_KEY } from 'app/components/help-sidebar';
 import { withRoutingSpinner } from 'app/components/with-routing-spinner';
 import { InteractiveNotebook } from 'app/pages/analysis/interactive-notebook';
-import { LeonardoAppLauncher } from 'app/pages/analysis/leonardo-app-launcher';
-import { LeoApplicationType } from 'app/pages/analysis/leonardo-app-launcher';
+import {
+  LeoApplicationType,
+  LeonardoAppLauncher,
+} from 'app/pages/analysis/leonardo-app-launcher';
 import { NotebookList } from 'app/pages/analysis/notebook-list';
 import { AppFilesList } from 'app/pages/appAnalysis/app-files-list';
 import { CohortActions } from 'app/pages/data/cohort/cohort-actions';
@@ -29,6 +31,7 @@ import {
   WorkspaceEditMode,
 } from 'app/pages/workspace/workspace-edit';
 import { adminLockedGuard, tempAppsAnalysisGuard } from 'app/routing/guards';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { MatchParams, withParamsKey } from 'app/utils/stores';
 
 const CohortPagePage = fp.flow(withRouteData, withRoutingSpinner)(CohortPage);
@@ -159,15 +162,15 @@ export const WorkspaceRoutes = () => {
         <NotebookListPage
           routeData={{
             title: 'View Notebooks',
-            pageKey: 'notebooks',
-            workspaceNavBarTab: 'notebooks',
+            pageKey: NOTEBOOKS_TAB_NAME,
+            workspaceNavBarTab: NOTEBOOKS_TAB_NAME,
             breadcrumb: BreadcrumbType.Workspace,
           }}
         />
       </AppRoute>
       <AppRoute
         exact
-        path={`${path}/notebooks/preview/:nbName`}
+        path={`${path}/${NOTEBOOKS_TAB_NAME}/preview/:nbName`}
         guards={[adminLockedGuard(ns, wsid)]}
       >
         <InteractiveNotebookPage
@@ -175,14 +178,14 @@ export const WorkspaceRoutes = () => {
             pathElementForTitle: 'nbName',
             breadcrumb: BreadcrumbType.Notebook,
             pageKey: LEONARDO_APP_PAGE_KEY,
-            workspaceNavBarTab: 'notebooks',
+            workspaceNavBarTab: NOTEBOOKS_TAB_NAME,
             minimizeChrome: true,
           }}
         />
       </AppRoute>
       <AppRoute
         exact
-        path={`${path}/notebooks/:nbName`}
+        path={`${path}/${NOTEBOOKS_TAB_NAME}/:nbName`}
         guards={[adminLockedGuard(ns, wsid)]}
       >
         <LeonardoAppRedirectPage
@@ -195,7 +198,7 @@ export const WorkspaceRoutes = () => {
             // Setting this flag sets the container to 100% so that no content is clipped.
             contentFullHeightOverride: true,
             pageKey: LEONARDO_APP_PAGE_KEY,
-            workspaceNavBarTab: 'notebooks',
+            workspaceNavBarTab: NOTEBOOKS_TAB_NAME,
             minimizeChrome: true,
           }}
           leoAppType={LeoApplicationType.Notebook}
@@ -212,7 +215,7 @@ export const WorkspaceRoutes = () => {
             breadcrumb: BreadcrumbType.Workspace,
             pageKey: LEONARDO_APP_PAGE_KEY,
             contentFullHeightOverride: true,
-            workspaceNavBarTab: 'notebooks',
+            workspaceNavBarTab: NOTEBOOKS_TAB_NAME,
             minimizeChrome: true,
           }}
           leoAppType={LeoApplicationType.Terminal}
@@ -228,7 +231,7 @@ export const WorkspaceRoutes = () => {
             breadcrumb: BreadcrumbType.Workspace,
             pageKey: LEONARDO_APP_PAGE_KEY,
             contentFullHeightOverride: true,
-            workspaceNavBarTab: 'notebooks',
+            workspaceNavBarTab: NOTEBOOKS_TAB_NAME,
             minimizeChrome: true,
           }}
           leoAppType={LeoApplicationType.SparkConsole}

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -156,7 +156,7 @@ export const WorkspaceRoutes = () => {
       </AppRoute>
       <AppRoute
         exact
-        path={`${path}/notebooks`}
+        path={`${path}/${NOTEBOOKS_TAB_NAME}`}
         guards={[adminLockedGuard(ns, wsid)]}
       >
         <NotebookListPage

--- a/ui/src/app/utils/constants.tsx
+++ b/ui/src/app/utils/constants.tsx
@@ -87,3 +87,6 @@ export const STATE_CODE_MAPPING = {
 export const JUPYTER_FILE_EXT = '.ipynb';
 export const RMD_FILE_EXT = '.Rmd';
 export const R_FILE_EXT = '.R';
+
+// name of the tab for accessing notebooks and runtimes, also used to construct URLs
+export const NOTEBOOKS_TAB_NAME = 'notebooks';

--- a/ui/src/app/utils/resources.spec.tsx
+++ b/ui/src/app/utils/resources.spec.tsx
@@ -12,6 +12,7 @@ import { exampleCohortStubs } from 'testing/stubs/cohorts-api-stub';
 import { stubResource } from 'testing/stubs/resources-stub';
 import { WorkspaceStubVariables } from 'testing/stubs/workspaces';
 
+import { NOTEBOOKS_TAB_NAME } from './constants';
 import { stringifyUrl } from './navigation';
 import {
   getDescription,
@@ -186,7 +187,7 @@ describe('resources.tsx', () => {
     const EXPECTED_COHORT_REVIEW_URL = `${WORKSPACE_URL_PREFIX}/data/cohorts/${COHORT_REVIEW_COHORT_ID}/reviews/${COHORT_REVIEW_ID}`;
     const EXPECTED_CONCEPT_SET_URL = `${WORKSPACE_URL_PREFIX}/data/concepts/sets/${CONCEPT_SET_ID}`;
     const EXPECTED_DATA_SET_URL = `${WORKSPACE_URL_PREFIX}/data/data-sets/${DATA_SET_ID}`;
-    const EXPECTED_NOTEBOOK_URL = `${WORKSPACE_URL_PREFIX}/notebooks/preview/${NOTEBOOK_NAME}`;
+    const EXPECTED_NOTEBOOK_URL = `${WORKSPACE_URL_PREFIX}/${NOTEBOOKS_TAB_NAME}/preview/${NOTEBOOK_NAME}`;
 
     expect(stringifyUrl(getResourceUrl(testCohort))).toBe(EXPECTED_COHORT_URL);
     expect(stringifyUrl(getResourceUrl(testCohortReview))).toBe(

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -11,6 +11,7 @@ import {
   WorkspaceResource,
 } from 'generated/fetch';
 
+import { NOTEBOOKS_TAB_NAME } from './constants';
 import { encodeURIComponentStrict, UrlObj } from './navigation';
 import { WorkspaceData } from './workspace-data';
 
@@ -100,7 +101,7 @@ export function getResourceUrl(resource: WorkspaceResource): UrlObj {
     [
       isNotebook,
       (r) => ({
-        url: `${workspacePrefix}/notebooks/preview/${encodeURIComponentStrict(
+        url: `${workspacePrefix}/${NOTEBOOKS_TAB_NAME}/preview/${encodeURIComponentStrict(
           r.notebook.name
         )}`,
       }),


### PR DESCRIPTION
Motivation: as part of the replacement of the old analysis tab, I'm considering a renaming of the tab and URL element from **notebooks** to something like **appFiles** or **analysis** because the Analysis tab will no longer be strictly dealing with notebooks.  This will be easier if there's a single constant to update.  So: as a first step, I'm making the "notebooks" tab name and UI url path element a constant (TODO: should these be coupled?) 

Possible future work: do the same for other tabs?

To test: change `NOTEBOOKS_TAB_NAME` from 'notebooks'  to something else and run it as Local->Test (make sure to hard-refresh your browser)
* do you see your string in the URL when you interact with notebooks and R files (preview only)?
* does everything still work?

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
