### PR TITLE
[risk=low][RW-9754] Replace old analysis tab with new tab when FF is true

### DIFF
--- a/e2e/app/page/notebook-page.ts
+++ b/e2e/app/page/notebook-page.ts
@@ -76,18 +76,12 @@ export default class NotebookPage extends NotebookFrame {
     return true;
   }
 
-  async getNotebookName(): Promise<string> {
-    const iframe = await this.getIFrame();
-    const element = await iframe.waitForSelector(CssSelector.notebookName, { visible: true });
-    return getPropValue<string>(element, 'innerText');
-  }
-
   /**
-   * Click "Notebook" link, goto Workspace Analysis page.
+   * Click "Analysis" link, goto Workspace Analysis page.
    * This function does not handle Unsaved Changes confirmation.
    */
   async goAnalysisPage(): Promise<WorkspaceAnalysisPage> {
-    const selector = '//a[text()="Notebooks"]';
+    const selector = '//a[text()="Analysis"]';
     const navPromise = this.page.waitForNavigation({ waitUntil: ['load', 'domcontentloaded', 'networkidle0'] });
     await this.page.waitForXPath(selector, { visible: true }).then((link) => link.click());
     await navPromise;

--- a/e2e/app/page/notebook-preview-page.ts
+++ b/e2e/app/page/notebook-preview-page.ts
@@ -68,8 +68,8 @@ export default class NotebookPreviewPage extends AuthenticatedPage {
    * This function does not handle Unsaved Changes confirmation.
    */
   async goAnalysisPage(): Promise<WorkspaceAnalysisPage> {
-    const notebooksLink = Link.findByName(this.page, { name: 'Analysis' });
-    await notebooksLink.clickAndWait();
+    const analysisLink = Link.findByName(this.page, { name: 'Analysis' });
+    await analysisLink.clickAndWait();
     await waitWhileLoading(this.page);
 
     const analysisPage = new WorkspaceAnalysisPage(this.page);

--- a/e2e/app/page/notebook-preview-page.ts
+++ b/e2e/app/page/notebook-preview-page.ts
@@ -64,11 +64,11 @@ export default class NotebookPreviewPage extends AuthenticatedPage {
   }
 
   /**
-   * Click "Notebook" link, goto Workspace Analysis page.
+   * Click "Analysis" link, goto Workspace Analysis page.
    * This function does not handle Unsaved Changes confirmation.
    */
   async goAnalysisPage(): Promise<WorkspaceAnalysisPage> {
-    const notebooksLink = Link.findByName(this.page, { name: 'Notebooks' });
+    const notebooksLink = Link.findByName(this.page, { name: 'Analysis' });
     await notebooksLink.clickAndWait();
     await waitWhileLoading(this.page);
 

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -100,8 +100,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
   }
 
   createNewNotebookLink(): Link {
-    const xpath = '//*[local-name()="svg" and @data-icon="circle-plus"]';
-    return new Link(this.page, xpath);
+    throw new Error('not implemented for new analysis tab');
   }
 
   /**

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -10,6 +10,8 @@ import NotebookPage from './notebook-page';
 import WorkspaceBase from './workspace-base';
 import { initializeRuntimeIfModalPresented } from 'utils/runtime-utils';
 import { logger } from 'libs/logger';
+import Button from 'app/element/button';
+import SelectMenu from 'app/component/select-menu';
 
 const PageTitle = 'View Analysis Files';
 
@@ -19,41 +21,32 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
   }
 
   async isLoaded(): Promise<boolean> {
-    await Promise.all([waitForDocumentTitle(this.page, PageTitle), this.createNewNotebookLink().waitUntilEnabled()]);
+    await waitForDocumentTitle(this.page, PageTitle);
     await waitWhileLoading(this.page);
     return true;
   }
 
   /**
    * Create a new notebook.
-   * - Click "Create a New Notebook" link in Analysis page.
+   * - Click the "Choose an App" button on the Analysis page.
+   * - Choose "Jupyter" from the selection in the App Selector Modal.
+   * - Click the "Next" button on the App Selector Modal.
    * - Fill in Notebook name and choose language in New Notebook modal.
    * - Wait for Jupyter notebook page load.
    * @param {string} notebookName New notebook name.
    * @param {Language} language Notebook language.
    */
   async createNotebook(notebookName: string, language: Language = Language.Python): Promise<NotebookPage> {
-    const modal = new NewNotebookModal(this.page);
-    let maxRetries = 3;
-    const clickCreateButtonWithRetries = async (): Promise<void> => {
-      const link = this.createNewNotebookLink();
-      await link.click();
-      try {
-        await modal.waitForLoad();
-        return;
-      } catch (err) {
-        if (maxRetries < 1) {
-          throw new Error(`Click link "Create a New Notebook" failed after trying ${maxRetries} times.\n${err}`);
-        }
-      }
-      if (maxRetries < 1) {
-        throw new Error('Investigate why waitForLoad() did not throw error. It should not happen.');
-      }
-      maxRetries--;
-      await this.page.waitForTimeout(2000).then(() => clickCreateButtonWithRetries());
-    };
+    const appSelectorButton = Button.findByName(this.page, { normalizeSpace: 'Choose an App' });
+    await appSelectorButton.click();
 
-    await clickCreateButtonWithRetries();
+    const appSelectorOptions = SelectMenu.findByName(this.page, { normalizeSpace: 'Choose One' });
+    await appSelectorOptions.select('Jupyter');
+
+    const nextButton = Button.findByName(this.page, { name: 'Next' });
+    await nextButton.click();
+
+    const modal = new NewNotebookModal(this.page);
     await modal.fillInModal(notebookName, language);
 
     // Log notebook page heading.
@@ -99,6 +92,7 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
     return notebook;
   }
 
+  // the only remaining test references to this are skipped
   createNewNotebookLink(): Link {
     throw new Error('not implemented for new analysis tab');
   }

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -11,7 +11,7 @@ import WorkspaceBase from './workspace-base';
 import { initializeRuntimeIfModalPresented } from 'utils/runtime-utils';
 import { logger } from 'libs/logger';
 
-const PageTitle = 'View Notebooks';
+const PageTitle = 'View Analysis Files';
 
 export default class WorkspaceAnalysisPage extends WorkspaceBase {
   constructor(page: Page) {

--- a/e2ev2/tests/workspace-analysis.test.js
+++ b/e2ev2/tests/workspace-analysis.test.js
@@ -11,7 +11,7 @@ const navigateToNewAnalysisPage = async (browser) => {
   await utils.dismissLeoAuthErrorModal(page);
   await page.goto(config.urlRoot()+'/workspaces/aou-rw-test-53ff4756/mohstest/data')
   await utils.dismissLeoAuthErrorModal(page);
-  const newAnalysisTab = await page.waitForSelector('div[role="button"][aria-label="Analysis (New)"]')
+  const newAnalysisTab = await page.waitForSelector('div[role="button"][aria-label="Analysis"]')
   await newAnalysisTab.click()
   return page
 }

--- a/e2ev2/tests/workspace-analysis.test.js
+++ b/e2ev2/tests/workspace-analysis.test.js
@@ -4,20 +4,20 @@ const utils = require("../src/utils");
 
 const browserTest = tu.browserTest(__filename)
 
-const navigateToNewAnalysisPage = async (browser) => {
+const navigateToAnalysisTab = async (browser) => {
   const page = browser.initialPage
   await tu.useApiProxy(page)
   await tu.fakeSignIn(page)
   await utils.dismissLeoAuthErrorModal(page);
   await page.goto(config.urlRoot()+'/workspaces/aou-rw-test-53ff4756/mohstest/data')
   await utils.dismissLeoAuthErrorModal(page);
-  const newAnalysisTab = await page.waitForSelector('div[role="button"][aria-label="Analysis"]')
-  await newAnalysisTab.click()
+  const analysisTab = await page.waitForSelector('div[role="button"][aria-label="Analysis"]')
+  await analysisTab.click()
   return page
 }
 
 browserTest('create an application', async browser => {
-  const page = await navigateToNewAnalysisPage(browser)
+  const page = await navigateToAnalysisTab(browser)
 
   const startButton = await page.waitForSelector('div[role="button"][aria-label="start"]')
   await startButton.click()
@@ -39,7 +39,7 @@ browserTest('create an application', async browser => {
 }, 10e3)
 
 browserTest('Cancel the creation of an application', async browser => {
-  const page = await navigateToNewAnalysisPage(browser)
+  const page = await navigateToAnalysisTab(browser)
 
   const startButton = await page.waitForSelector('div[role="button"][aria-label="start"]')
   await startButton.click()

--- a/ui/src/app/components/breadcrumb-type.tsx
+++ b/ui/src/app/components/breadcrumb-type.tsx
@@ -3,7 +3,7 @@ export enum BreadcrumbType {
   Workspace = 'Workspace',
   WorkspaceEdit = 'WorkspaceEdit',
   WorkspaceDuplicate = 'WorkspaceDuplicate',
-  AppFile = 'AppFile',
+  Analysis = 'Analysis',
   ConceptSet = 'ConceptSet',
   Cohort = 'Cohort',
   CohortReview = 'CohortReview',

--- a/ui/src/app/components/breadcrumb-type.tsx
+++ b/ui/src/app/components/breadcrumb-type.tsx
@@ -3,7 +3,7 @@ export enum BreadcrumbType {
   Workspace = 'Workspace',
   WorkspaceEdit = 'WorkspaceEdit',
   WorkspaceDuplicate = 'WorkspaceDuplicate',
-  Notebook = 'Notebook',
+  AppFile = 'AppFile',
   ConceptSet = 'ConceptSet',
   Cohort = 'Cohort',
   CohortReview = 'CohortReview',

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -24,7 +24,7 @@ import {
   routeDataStore,
   withStore,
 } from 'app/utils/stores';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { BreadcrumbType } from './breadcrumb-type';
@@ -116,12 +116,12 @@ export const getTrail = (
           params
         ),
         new BreadcrumbData(
-          fp.upperFirst(NOTEBOOKS_TAB_NAME),
-          `${prefix}/${NOTEBOOKS_TAB_NAME}`
+          fp.upperFirst(appFilesTabName),
+          `${prefix}/${appFilesTabName}`
         ),
         new BreadcrumbData(
           nbName && dropJupyterNotebookFileSuffix(decodeURIComponent(nbName)),
-          `${prefix}/${NOTEBOOKS_TAB_NAME}/${nbName}`
+          `${prefix}/${appFilesTabName}/${nbName}`
         ),
       ];
     case BreadcrumbType.ConceptSet:
@@ -325,10 +325,10 @@ export const Breadcrumb = fp.flow(
       const { pid = '' } = participantMatch ? participantMatch.params : {};
 
       const notebookMatch = matchPath<MatchParams>(location.pathname, {
-        path: `/workspaces/:ns/:wsid/${NOTEBOOKS_TAB_NAME}/:nbName`,
+        path: `/workspaces/:ns/:wsid/${appFilesTabName}/:nbName`,
       });
       const notebookPreviewMatch = matchPath<MatchParams>(location.pathname, {
-        path: `/workspaces/:ns/:wsid/${NOTEBOOKS_TAB_NAME}/preview/:nbName`,
+        path: `/workspaces/:ns/:wsid/${appFilesTabName}/preview/:nbName`,
       });
       const nbName = notebookMatch
         ? notebookMatch.params.nbName

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -324,16 +324,16 @@ export const Breadcrumb = fp.flow(
       });
       const { pid = '' } = participantMatch ? participantMatch.params : {};
 
-      const appFileMatch = matchPath<MatchParams>(location.pathname, {
+      const analysisMatch = matchPath<MatchParams>(location.pathname, {
         path: `/workspaces/:ns/:wsid/${analysisTabName}/:nbName`,
       });
-      const appFilePreviewMatch = matchPath<MatchParams>(location.pathname, {
+      const analysisPreviewMatch = matchPath<MatchParams>(location.pathname, {
         path: `/workspaces/:ns/:wsid/${analysisTabName}/preview/:nbName`,
       });
-      const appFileName = appFileMatch
-        ? appFileMatch.params.nbName
-        : appFilePreviewMatch
-        ? appFilePreviewMatch.params.nbName
+      const analysisFileName = analysisMatch
+        ? analysisMatch.params.nbName
+        : analysisPreviewMatch
+        ? analysisPreviewMatch.params.nbName
         : undefined;
 
       return getTrail(
@@ -342,7 +342,7 @@ export const Breadcrumb = fp.flow(
         this.props.cohort,
         this.props.cohortReview,
         this.props.conceptSet,
-        { ns, wsid, cid, csid, pid, nbName: appFileName }
+        { ns, wsid, cid, csid, pid, nbName: analysisFileName }
       );
     }
 

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -105,7 +105,7 @@ export const getTrail = (
         ),
         new BreadcrumbData('Duplicate Workspace', `${prefix}/duplicate`),
       ];
-    case BreadcrumbType.Notebook:
+    case BreadcrumbType.AppFile:
       return [
         ...getTrail(
           BreadcrumbType.Workspace,
@@ -324,16 +324,16 @@ export const Breadcrumb = fp.flow(
       });
       const { pid = '' } = participantMatch ? participantMatch.params : {};
 
-      const notebookMatch = matchPath<MatchParams>(location.pathname, {
+      const appFileMatch = matchPath<MatchParams>(location.pathname, {
         path: `/workspaces/:ns/:wsid/${appFilesTabName}/:nbName`,
       });
-      const notebookPreviewMatch = matchPath<MatchParams>(location.pathname, {
+      const appFilePreviewMatch = matchPath<MatchParams>(location.pathname, {
         path: `/workspaces/:ns/:wsid/${appFilesTabName}/preview/:nbName`,
       });
-      const nbName = notebookMatch
-        ? notebookMatch.params.nbName
-        : notebookPreviewMatch
-        ? notebookPreviewMatch.params.nbName
+      const appFileName = appFileMatch
+        ? appFileMatch.params.nbName
+        : appFilePreviewMatch
+        ? appFilePreviewMatch.params.nbName
         : undefined;
 
       return getTrail(
@@ -342,7 +342,7 @@ export const Breadcrumb = fp.flow(
         this.props.cohort,
         this.props.cohortReview,
         this.props.conceptSet,
-        { ns, wsid, cid, csid, pid, nbName }
+        { ns, wsid, cid, csid, pid, nbName: appFileName }
       );
     }
 

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -24,7 +24,7 @@ import {
   routeDataStore,
   withStore,
 } from 'app/utils/stores';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { BreadcrumbType } from './breadcrumb-type';
@@ -116,12 +116,12 @@ export const getTrail = (
           params
         ),
         new BreadcrumbData(
-          fp.upperFirst(appFilesTabName),
-          `${prefix}/${appFilesTabName}`
+          fp.upperFirst(analysisTabName),
+          `${prefix}/${analysisTabName}`
         ),
         new BreadcrumbData(
           nbName && dropJupyterNotebookFileSuffix(decodeURIComponent(nbName)),
-          `${prefix}/${appFilesTabName}/${nbName}`
+          `${prefix}/${analysisTabName}/${nbName}`
         ),
       ];
     case BreadcrumbType.ConceptSet:
@@ -325,10 +325,10 @@ export const Breadcrumb = fp.flow(
       const { pid = '' } = participantMatch ? participantMatch.params : {};
 
       const appFileMatch = matchPath<MatchParams>(location.pathname, {
-        path: `/workspaces/:ns/:wsid/${appFilesTabName}/:nbName`,
+        path: `/workspaces/:ns/:wsid/${analysisTabName}/:nbName`,
       });
       const appFilePreviewMatch = matchPath<MatchParams>(location.pathname, {
-        path: `/workspaces/:ns/:wsid/${appFilesTabName}/preview/:nbName`,
+        path: `/workspaces/:ns/:wsid/${analysisTabName}/preview/:nbName`,
       });
       const appFileName = appFileMatch
         ? appFileMatch.params.nbName

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -18,13 +18,13 @@ import {
   withCurrentConceptSet,
   withCurrentWorkspace,
 } from 'app/utils';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import {
   MatchParams,
   RouteDataStore,
   routeDataStore,
   withStore,
 } from 'app/utils/stores';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { BreadcrumbType } from './breadcrumb-type';

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -105,7 +105,7 @@ export const getTrail = (
         ),
         new BreadcrumbData('Duplicate Workspace', `${prefix}/duplicate`),
       ];
-    case BreadcrumbType.AppFile:
+    case BreadcrumbType.Analysis:
       return [
         ...getTrail(
           BreadcrumbType.Workspace,

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -25,7 +25,7 @@ import { cond, reactStyles, withCdrVersions } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
 import { NavigationProps } from 'app/utils/navigation';
 import { toDisplay } from 'app/utils/resources';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 import { WorkspacePermissions } from 'app/utils/workspace-permissions';
 
 import { FlexRow } from './flex';
@@ -38,7 +38,7 @@ enum RequestState {
 }
 
 const ResourceTypeHomeTabs = new Map()
-  .set(ResourceType.NOTEBOOK, NOTEBOOKS_TAB_NAME)
+  .set(ResourceType.NOTEBOOK, appFilesTabName)
   .set(ResourceType.COHORT, 'data')
   .set(ResourceType.CONCEPTSET, 'data')
   .set(ResourceType.DATASET, 'data');

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -23,9 +23,9 @@ import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { cond, reactStyles, withCdrVersions } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { NavigationProps } from 'app/utils/navigation';
 import { toDisplay } from 'app/utils/resources';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 import { WorkspacePermissions } from 'app/utils/workspace-permissions';
 
 import { FlexRow } from './flex';

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -25,7 +25,7 @@ import { cond, reactStyles, withCdrVersions } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
 import { NavigationProps } from 'app/utils/navigation';
 import { toDisplay } from 'app/utils/resources';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 import { WorkspacePermissions } from 'app/utils/workspace-permissions';
 
 import { FlexRow } from './flex';
@@ -38,7 +38,7 @@ enum RequestState {
 }
 
 const ResourceTypeHomeTabs = new Map()
-  .set(ResourceType.NOTEBOOK, appFilesTabName)
+  .set(ResourceType.NOTEBOOK, analysisTabName)
   .set(ResourceType.COHORT, 'data')
   .set(ResourceType.CONCEPTSET, 'data')
   .set(ResourceType.DATASET, 'data');

--- a/ui/src/app/components/resource-list.tsx
+++ b/ui/src/app/components/resource-list.tsx
@@ -24,10 +24,7 @@ import {
 import colors from 'app/styles/colors';
 import { reactStyles, withCdrVersions } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
-import {
-  NOTEBOOKS_TAB_NAME,
-  ROWS_PER_PAGE_RESOURCE_TABLE,
-} from 'app/utils/constants';
+import { ROWS_PER_PAGE_RESOURCE_TABLE } from 'app/utils/constants';
 import { displayDate, displayDateWithoutHours } from 'app/utils/dates';
 import {
   getDisplayName,
@@ -35,6 +32,7 @@ import {
   getTypeString,
   isNotebook,
 } from 'app/utils/resources';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 const styles = reactStyles({

--- a/ui/src/app/components/resource-list.tsx
+++ b/ui/src/app/components/resource-list.tsx
@@ -32,7 +32,7 @@ import {
   getTypeString,
   isNotebook,
 } from 'app/utils/resources';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 const styles = reactStyles({
@@ -72,7 +72,7 @@ const WorkspaceNavigation = (props: NavProps) => {
     resource,
     style,
   } = props;
-  const tab = isNotebook(resource) ? NOTEBOOKS_TAB_NAME : 'data';
+  const tab = isNotebook(resource) ? appFilesTabName : 'data';
   const url = `/workspaces/${namespace}/${id}/${tab}`;
 
   return (

--- a/ui/src/app/components/resource-list.tsx
+++ b/ui/src/app/components/resource-list.tsx
@@ -32,7 +32,7 @@ import {
   getTypeString,
   isNotebook,
 } from 'app/utils/resources';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 const styles = reactStyles({
@@ -72,7 +72,7 @@ const WorkspaceNavigation = (props: NavProps) => {
     resource,
     style,
   } = props;
-  const tab = isNotebook(resource) ? appFilesTabName : 'data';
+  const tab = isNotebook(resource) ? analysisTabName : 'data';
   const url = `/workspaces/${namespace}/${id}/${tab}`;
 
   return (

--- a/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
@@ -13,7 +13,7 @@ import {
   setSidebarActiveIconStore,
 } from 'app/utils/navigation';
 import { userAppsStore } from 'app/utils/stores';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 
 import { createListAppsRStudioResponse } from 'testing/stubs/apps-api-stub';
 import { workspaceStubs } from 'testing/stubs/workspaces';
@@ -48,10 +48,10 @@ const renderInteractiveNotebook = (pathParameters) =>
   render(
     <MemoryRouter
       initialEntries={[
-        `/workspaces/sampleNameSpace/sampleWorkspace/${appFilesTabName}/preview/example.Rmd`,
+        `/workspaces/sampleNameSpace/sampleWorkspace/${analysisTabName}/preview/example.Rmd`,
       ]}
     >
-      <Route path={`/workspaces/:ns/:wsid/${appFilesTabName}/preview/:nbName`}>
+      <Route path={`/workspaces/:ns/:wsid/${analysisTabName}/preview/:nbName`}>
         <InteractiveNotebook hideSpinner={() => {}} match={pathParameters} />
       </Route>
     </MemoryRouter>

--- a/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
@@ -13,7 +13,7 @@ import {
   setSidebarActiveIconStore,
 } from 'app/utils/navigation';
 import { userAppsStore } from 'app/utils/stores';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 
 import { createListAppsRStudioResponse } from 'testing/stubs/apps-api-stub';
 import { workspaceStubs } from 'testing/stubs/workspaces';
@@ -48,12 +48,10 @@ const renderInteractiveNotebook = (pathParameters) =>
   render(
     <MemoryRouter
       initialEntries={[
-        `/workspaces/sampleNameSpace/sampleWorkspace/${NOTEBOOKS_TAB_NAME}/preview/example.Rmd`,
+        `/workspaces/sampleNameSpace/sampleWorkspace/${appFilesTabName}/preview/example.Rmd`,
       ]}
     >
-      <Route
-        path={`/workspaces/:ns/:wsid/${NOTEBOOKS_TAB_NAME}/preview/:nbName`}
-      >
+      <Route path={`/workspaces/:ns/:wsid/${appFilesTabName}/preview/:nbName`}>
         <InteractiveNotebook hideSpinner={() => {}} match={pathParameters} />
       </Route>
     </MemoryRouter>

--- a/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
@@ -8,12 +8,12 @@ import userEvent from '@testing-library/user-event';
 import { UserEvent } from '@testing-library/user-event/setup/setup';
 import { rstudioConfigIconId } from 'app/components/help-sidebar-icons';
 import * as swaggerClients from 'app/services/swagger-fetch-clients';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import {
   currentWorkspaceStore,
   setSidebarActiveIconStore,
 } from 'app/utils/navigation';
 import { userAppsStore } from 'app/utils/stores';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 
 import { createListAppsRStudioResponse } from 'testing/stubs/apps-api-stub';
 import { workspaceStubs } from 'testing/stubs/workspaces';

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -40,7 +40,7 @@ import {
   UserAppsStore,
 } from 'app/utils/stores';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
-import { NOTEBOOKS_TAB_NAME, openRStudioOrConfigPanel } from 'app/utils/user-apps-utils';
+import { appFilesTabName, openRStudioOrConfigPanel } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
@@ -273,7 +273,7 @@ export const InteractiveNotebook = fp.flow(
           'workspaces',
           this.props.match.params.ns,
           this.props.match.params.wsid,
-          NOTEBOOKS_TAB_NAME,
+          appFilesTabName,
           this.props.match.params.nbName,
         ],
         { queryParams: queryParams }
@@ -319,7 +319,7 @@ export const InteractiveNotebook = fp.flow(
             'workspaces',
             ns,
             wsid,
-            NOTEBOOKS_TAB_NAME,
+            appFilesTabName,
             encodeURIComponent(notebook.name),
           ]);
         });

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -40,7 +40,10 @@ import {
   UserAppsStore,
 } from 'app/utils/stores';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
-import { appFilesTabName, openRStudioOrConfigPanel } from 'app/utils/user-apps-utils';
+import {
+  analysisTabName,
+  openRStudioOrConfigPanel,
+} from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
@@ -273,7 +276,7 @@ export const InteractiveNotebook = fp.flow(
           'workspaces',
           this.props.match.params.ns,
           this.props.match.params.wsid,
-          appFilesTabName,
+          analysisTabName,
           this.props.match.params.nbName,
         ],
         { queryParams: queryParams }
@@ -319,7 +322,7 @@ export const InteractiveNotebook = fp.flow(
             'workspaces',
             ns,
             wsid,
-            appFilesTabName,
+            analysisTabName,
             encodeURIComponent(notebook.name),
           ]);
         });

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -23,7 +23,6 @@ import {
   withCurrentWorkspace,
 } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { InitialRuntimeNotFoundError } from 'app/utils/leo-runtime-initializer';
 import { NavigationProps } from 'app/utils/navigation';
 import {
@@ -41,7 +40,7 @@ import {
   UserAppsStore,
 } from 'app/utils/stores';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
-import { openRStudioOrConfigPanel } from 'app/utils/user-apps-utils';
+import { NOTEBOOKS_TAB_NAME, openRStudioOrConfigPanel } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
@@ -32,7 +32,7 @@ import {
   runtimeStore,
   serverConfigStore,
 } from 'app/utils/stores';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 import {
   JupyterApi,
   ProxyApi,
@@ -73,13 +73,13 @@ describe('NotebookLauncher', () => {
 
   let runtimeStub;
 
-  const notebookInitialUrl = `/workspaces/namespace/id/${NOTEBOOKS_TAB_NAME}/wharrgarbl`;
+  const notebookInitialUrl = `/workspaces/namespace/id/${appFilesTabName}/wharrgarbl`;
   const history = createMemoryHistory({ initialEntries: [notebookInitialUrl] });
 
   const notebookComponent = async () => {
     const c = mount(
       <Router history={history}>
-        <Route path={`/workspaces/:ns/:wsid/${NOTEBOOKS_TAB_NAME}/:nbName`}>
+        <Route path={`/workspaces/:ns/:wsid/${appFilesTabName}/:nbName`}>
           <LeonardoAppLauncher
             hideSpinner={() => {}}
             showSpinner={() => {}}
@@ -551,7 +551,7 @@ describe('TerminalLauncher', () => {
       'workspaces',
       'defaultNamespace',
       '1',
-      NOTEBOOKS_TAB_NAME,
+      appFilesTabName,
     ]);
   });
 });

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
@@ -25,7 +25,6 @@ import {
 } from 'app/pages/analysis/leonardo-app-launcher';
 import { registerApiClient as registerApiClientNotebooks } from 'app/services/notebooks-swagger-fetch-clients';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 import { ComputeSecuritySuspendedError } from 'app/utils/runtime-utils';
 import {
@@ -33,6 +32,7 @@ import {
   runtimeStore,
   serverConfigStore,
 } from 'app/utils/stores';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 import {
   JupyterApi,
   ProxyApi,

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
@@ -32,7 +32,7 @@ import {
   runtimeStore,
   serverConfigStore,
 } from 'app/utils/stores';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 import {
   JupyterApi,
   ProxyApi,
@@ -73,13 +73,13 @@ describe('NotebookLauncher', () => {
 
   let runtimeStub;
 
-  const notebookInitialUrl = `/workspaces/namespace/id/${appFilesTabName}/wharrgarbl`;
+  const notebookInitialUrl = `/workspaces/namespace/id/${analysisTabName}/wharrgarbl`;
   const history = createMemoryHistory({ initialEntries: [notebookInitialUrl] });
 
   const notebookComponent = async () => {
     const c = mount(
       <Router history={history}>
-        <Route path={`/workspaces/:ns/:wsid/${appFilesTabName}/:nbName`}>
+        <Route path={`/workspaces/:ns/:wsid/${analysisTabName}/:nbName`}>
           <LeonardoAppLauncher
             hideSpinner={() => {}}
             showSpinner={() => {}}
@@ -551,7 +551,7 @@ describe('TerminalLauncher', () => {
       'workspaces',
       'defaultNamespace',
       '1',
-      appFilesTabName,
+      analysisTabName,
     ]);
   });
 });

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -40,7 +40,7 @@ import {
   withRuntimeStore,
 } from 'app/utils/runtime-utils';
 import { MatchParams, RuntimeStore } from 'app/utils/stores';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -510,7 +510,7 @@ export const LeonardoAppLauncher = fp.flow(
           workspace.namespace,
           workspace.id,
           // navigate will encode the notebook name automatically
-          appFilesTabName,
+          analysisTabName,
           ...(this.props.leoAppType === LeoApplicationType.Notebook
             ? ['preview', this.getFullJupyterNotebookName()]
             : []),
@@ -579,7 +579,7 @@ export const LeonardoAppLauncher = fp.flow(
         window.history.replaceState(
           {},
           'Notebook',
-          `workspaces/${namespace}/${id}/${appFilesTabName}/${encodeURIComponent(
+          `workspaces/${namespace}/${id}/${analysisTabName}/${encodeURIComponent(
             this.getFullJupyterNotebookName()
           )}`
         );

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -27,7 +27,6 @@ import {
   withCurrentWorkspace,
   withUserProfile,
 } from 'app/utils';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { InitialRuntimeNotFoundError } from 'app/utils/leo-runtime-initializer';
 import { NavigationProps } from 'app/utils/navigation';
 import { Kernels } from 'app/utils/notebook-kernels';
@@ -41,6 +40,7 @@ import {
   withRuntimeStore,
 } from 'app/utils/runtime-utils';
 import { MatchParams, RuntimeStore } from 'app/utils/stores';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -40,7 +40,7 @@ import {
   withRuntimeStore,
 } from 'app/utils/runtime-utils';
 import { MatchParams, RuntimeStore } from 'app/utils/stores';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -510,7 +510,7 @@ export const LeonardoAppLauncher = fp.flow(
           workspace.namespace,
           workspace.id,
           // navigate will encode the notebook name automatically
-          NOTEBOOKS_TAB_NAME,
+          appFilesTabName,
           ...(this.props.leoAppType === LeoApplicationType.Notebook
             ? ['preview', this.getFullJupyterNotebookName()]
             : []),
@@ -579,7 +579,7 @@ export const LeonardoAppLauncher = fp.flow(
         window.history.replaceState(
           {},
           'Notebook',
-          `workspaces/${namespace}/${id}/${NOTEBOOKS_TAB_NAME}/${encodeURIComponent(
+          `workspaces/${namespace}/${id}/${appFilesTabName}/${encodeURIComponent(
             this.getFullJupyterNotebookName()
           )}`
         );

--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -21,7 +21,7 @@ import { AnalyticsTracker } from 'app/utils/analytics';
 import { useNavigation } from 'app/utils/navigation';
 import { Kernels } from 'app/utils/notebook-kernels';
 import { nameValidationFormat } from 'app/utils/resources';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 
 import { appendJupyterNotebookFileSuffix } from './util';
 
@@ -72,7 +72,7 @@ export const NewJupyterNotebookModal = (props: Props) => {
         'workspaces',
         workspace.namespace,
         workspace.id,
-        appFilesTabName,
+        analysisTabName,
         encodeURIComponent(name),
       ],
       { queryParams: { kernelType: kernel, creating: true } }

--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -21,7 +21,7 @@ import { AnalyticsTracker } from 'app/utils/analytics';
 import { useNavigation } from 'app/utils/navigation';
 import { Kernels } from 'app/utils/notebook-kernels';
 import { nameValidationFormat } from 'app/utils/resources';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 
 import { appendJupyterNotebookFileSuffix } from './util';
 
@@ -72,7 +72,7 @@ export const NewJupyterNotebookModal = (props: Props) => {
         'workspaces',
         workspace.namespace,
         workspace.id,
-        NOTEBOOKS_TAB_NAME,
+        appFilesTabName,
         encodeURIComponent(name),
       ],
       { queryParams: { kernelType: kernel, creating: true } }

--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -18,10 +18,10 @@ import { getExistingNotebookNames } from 'app/pages/analysis/util';
 import { userMetricsApi } from 'app/services/swagger-fetch-clients';
 import { summarizeErrors } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { useNavigation } from 'app/utils/navigation';
 import { Kernels } from 'app/utils/notebook-kernels';
 import { nameValidationFormat } from 'app/utils/resources';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 
 import { appendJupyterNotebookFileSuffix } from './util';
 

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -14,7 +14,7 @@ import {
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -12,9 +12,9 @@ import {
   resourceTableColumns,
 } from 'app/components/resource-list.spec';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -14,7 +14,7 @@ import {
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
@@ -74,7 +74,7 @@ describe('NotebookList', () => {
     );
     await waitOneTickAndUpdate(wrapper);
 
-    const expected = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${appFilesTabName}/preview/mockFile.ipynb`;
+    const expected = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${analysisTabName}/preview/mockFile.ipynb`;
     expect(
       resourceTableColumns(wrapper)
         .at(RESOURCE_TYPE_COLUMN_NUMBER)

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -74,7 +74,7 @@ describe('NotebookList', () => {
     );
     await waitOneTickAndUpdate(wrapper);
 
-    const expected = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${NOTEBOOKS_TAB_NAME}/preview/mockFile.ipynb`;
+    const expected = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${appFilesTabName}/preview/mockFile.ipynb`;
     expect(
       resourceTableColumns(wrapper)
         .at(RESOURCE_TYPE_COLUMN_NUMBER)

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -9,7 +9,6 @@ import {
   RMD_FILE_EXT,
 } from 'app/utils/constants';
 
-// todo generically drop suffix when previewing?
 export function dropJupyterNotebookFileSuffix(filename: string) {
   if (filename?.endsWith(JUPYTER_FILE_EXT)) {
     return filename.substring(0, filename.length - JUPYTER_FILE_EXT.length);

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -9,6 +9,7 @@ import {
   RMD_FILE_EXT,
 } from 'app/utils/constants';
 
+// todo generically drop suffix when previewing?
 export function dropJupyterNotebookFileSuffix(filename: string) {
   if (filename?.endsWith(JUPYTER_FILE_EXT)) {
     return filename.substring(0, filename.length - JUPYTER_FILE_EXT.length);

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -17,9 +17,9 @@ import { NotebookResourceCard } from 'app/pages/analysis/notebook-resource-card'
 import { getAppInfoFromFileName, listNotebooks } from 'app/pages/analysis/util';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCurrentWorkspace } from 'app/utils';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { convertToResources } from 'app/utils/resources';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { AppSelector } from './app-selector';

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -19,7 +19,7 @@ import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCurrentWorkspace } from 'app/utils';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { convertToResources } from 'app/utils/resources';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { AppSelector } from './app-selector';
@@ -112,7 +112,7 @@ export const AppFilesList = withCurrentWorkspace()(
         workspace: { namespace, id },
       } = props;
       const { name } = row;
-      const url = `/workspaces/${namespace}/${id}/${NOTEBOOKS_TAB_NAME}/preview/${name}`;
+      const url = `/workspaces/${namespace}/${id}/${appFilesTabName}/preview/${name}`;
       return (
         <Clickable>
           <RouterLink to={url} data-test-id='notebook-navigation'>

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -19,7 +19,7 @@ import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCurrentWorkspace } from 'app/utils';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { convertToResources } from 'app/utils/resources';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { AppSelector } from './app-selector';
@@ -112,7 +112,7 @@ export const AppFilesList = withCurrentWorkspace()(
         workspace: { namespace, id },
       } = props;
       const { name } = row;
-      const url = `/workspaces/${namespace}/${id}/${appFilesTabName}/preview/${name}`;
+      const url = `/workspaces/${namespace}/${id}/${analysisTabName}/preview/${name}`;
       return (
         <Clickable>
           <RouterLink to={url} data-test-id='notebook-navigation'>

--- a/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
+++ b/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
@@ -6,9 +6,9 @@ import { NotebooksApi, WorkspacesApi } from 'generated/fetch';
 
 import { AppFilesList } from 'app/pages/appAnalysis/app-files-list';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';

--- a/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
+++ b/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
@@ -8,12 +8,13 @@ import { AppFilesList } from 'app/pages/appAnalysis/app-files-list';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
 import { workspaceDataStub } from 'testing/stubs/workspaces';
 import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
+
 const appsFilesTable = (wrapper) =>
   wrapper.find('[data-test-id="apps-file-list"]').find('tbody');
 const appsFilesTableColumns = (wrapper) => appsFilesTable(wrapper).find('td');

--- a/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
+++ b/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
@@ -85,7 +85,7 @@ describe('AppsList', () => {
     );
     await waitOneTickAndUpdate(wrapper);
 
-    const expected = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${NOTEBOOKS_TAB_NAME}/preview/mockFile.ipynb`;
+    const expected = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${appFilesTabName}/preview/mockFile.ipynb`;
     expect(
       appsFilesTableColumns(wrapper)
         .at(NAME_COLUMN_NUMBER)

--- a/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
+++ b/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
@@ -8,7 +8,7 @@ import { AppFilesList } from 'app/pages/appAnalysis/app-files-list';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
@@ -85,7 +85,7 @@ describe('AppsList', () => {
     );
     await waitOneTickAndUpdate(wrapper);
 
-    const expected = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${appFilesTabName}/preview/mockFile.ipynb`;
+    const expected = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${analysisTabName}/preview/mockFile.ipynb`;
     expect(
       appsFilesTableColumns(wrapper)
         .at(NAME_COLUMN_NUMBER)

--- a/ui/src/app/pages/data/cohort/cohort-actions.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-actions.tsx
@@ -21,7 +21,7 @@ import {
 } from 'app/utils';
 import { NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -162,7 +162,7 @@ export const CohortActions = fp.flow(
           url += `data/cohorts/${cohort.id}/reviews`;
           break;
         case 'notebook':
-          url += appFilesTabName;
+          url += analysisTabName;
           break;
         case 'dataSet':
           url += 'data/data-sets';

--- a/ui/src/app/pages/data/cohort/cohort-actions.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-actions.tsx
@@ -19,9 +19,9 @@ import {
   withCurrentCohort,
   withCurrentWorkspace,
 } from 'app/utils';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 

--- a/ui/src/app/pages/data/cohort/cohort-actions.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-actions.tsx
@@ -21,7 +21,7 @@ import {
 } from 'app/utils';
 import { NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -162,7 +162,7 @@ export const CohortActions = fp.flow(
           url += `data/cohorts/${cohort.id}/reviews`;
           break;
         case 'notebook':
-          url += NOTEBOOKS_TAB_NAME;
+          url += appFilesTabName;
           break;
         case 'dataSet':
           url += 'data/data-sets';

--- a/ui/src/app/pages/data/cohort/overview.tsx
+++ b/ui/src/app/pages/data/cohort/overview.tsx
@@ -42,7 +42,7 @@ import { AnalyticsTracker } from 'app/utils/analytics';
 import { isAbortError } from 'app/utils/errors';
 import { currentWorkspaceStore, NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -445,7 +445,7 @@ export const ListOverview = fp.flow(
       switch (action) {
         case 'notebook':
           AnalyticsTracker.CohortBuilder.CohortAction('Export to notebook');
-          url += NOTEBOOKS_TAB_NAME;
+          url += appFilesTabName;
           break;
         case 'review':
           AnalyticsTracker.CohortBuilder.CohortAction('Review cohort');

--- a/ui/src/app/pages/data/cohort/overview.tsx
+++ b/ui/src/app/pages/data/cohort/overview.tsx
@@ -39,10 +39,10 @@ import {
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCdrVersions, withCurrentWorkspace } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { isAbortError } from 'app/utils/errors';
 import { currentWorkspaceStore, NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 

--- a/ui/src/app/pages/data/cohort/overview.tsx
+++ b/ui/src/app/pages/data/cohort/overview.tsx
@@ -42,7 +42,7 @@ import { AnalyticsTracker } from 'app/utils/analytics';
 import { isAbortError } from 'app/utils/errors';
 import { currentWorkspaceStore, NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -445,7 +445,7 @@ export const ListOverview = fp.flow(
       switch (action) {
         case 'notebook':
           AnalyticsTracker.CohortBuilder.CohortAction('Export to notebook');
-          url += appFilesTabName;
+          url += analysisTabName;
           break;
         case 'review':
           AnalyticsTracker.CohortBuilder.CohortAction('Review cohort');

--- a/ui/src/app/pages/data/concept/concept-set-actions.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-actions.tsx
@@ -20,7 +20,7 @@ import {
 } from 'app/utils';
 import { conceptSetUpdating, NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -157,7 +157,7 @@ export const ConceptSetActions = fp.flow(
           url += 'data/concepts';
           break;
         case 'notebook':
-          url += NOTEBOOKS_TAB_NAME;
+          url += appFilesTabName;
           break;
         case 'dataSet':
           url += 'data/data-sets';

--- a/ui/src/app/pages/data/concept/concept-set-actions.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-actions.tsx
@@ -20,7 +20,7 @@ import {
 } from 'app/utils';
 import { conceptSetUpdating, NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -157,7 +157,7 @@ export const ConceptSetActions = fp.flow(
           url += 'data/concepts';
           break;
         case 'notebook':
-          url += appFilesTabName;
+          url += analysisTabName;
           break;
         case 'dataSet':
           url += 'data/data-sets';

--- a/ui/src/app/pages/data/concept/concept-set-actions.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-actions.tsx
@@ -18,9 +18,9 @@ import {
   withCurrentConceptSet,
   withCurrentWorkspace,
 } from 'app/utils';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { conceptSetUpdating, NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -35,10 +35,10 @@ import { dataSetApi, notebooksApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { reactStyles, summarizeErrors } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { encodeURIComponentStrict, useNavigation } from 'app/utils/navigation';
 import { nameValidationFormat } from 'app/utils/resources';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
 

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -38,7 +38,7 @@ import { AnalyticsTracker } from 'app/utils/analytics';
 import { encodeURIComponentStrict, useNavigation } from 'app/utils/navigation';
 import { nameValidationFormat } from 'app/utils/resources';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
 
@@ -124,7 +124,7 @@ export const ExportDatasetModal = ({
         createExportDatasetRequest()
       );
       const notebookUrl =
-        `/workspaces/${workspace.namespace}/${workspace.id}/${appFilesTabName}/preview/` +
+        `/workspaces/${workspace.namespace}/${workspace.id}/${analysisTabName}/preview/` +
         encodeURIComponentStrict(
           appendJupyterNotebookFileSuffix(notebookNameWithoutSuffix)
         );

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -38,7 +38,7 @@ import { AnalyticsTracker } from 'app/utils/analytics';
 import { encodeURIComponentStrict, useNavigation } from 'app/utils/navigation';
 import { nameValidationFormat } from 'app/utils/resources';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
 
@@ -124,7 +124,7 @@ export const ExportDatasetModal = ({
         createExportDatasetRequest()
       );
       const notebookUrl =
-        `/workspaces/${workspace.namespace}/${workspace.id}/${NOTEBOOKS_TAB_NAME}/preview/` +
+        `/workspaces/${workspace.namespace}/${workspace.id}/${appFilesTabName}/preview/` +
         encodeURIComponentStrict(
           appendJupyterNotebookFileSuffix(notebookNameWithoutSuffix)
         );

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -6,7 +6,7 @@ import { mockNavigate } from 'setupTests';
 import { WorkspaceNavBar } from 'app/pages/workspace/workspace-nav-bar';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 import { cdrVersionStore, serverConfigStore } from 'app/utils/stores';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 
 import {
   CdrVersionsStubVariables,
@@ -69,7 +69,7 @@ describe('WorkspaceNavBar', () => {
       'workspaces',
       workspaceDataStub.namespace,
       workspaceDataStub.id,
-      NOTEBOOKS_TAB_NAME,
+      appFilesTabName,
     ]);
 
     wrapper.find({ 'data-test-id': 'Data' }).first().simulate('click');
@@ -120,7 +120,7 @@ describe('WorkspaceNavBar', () => {
       'workspaces',
       workspaceDataStub.namespace,
       workspaceDataStub.id,
-      NOTEBOOKS_TAB_NAME,
+      appFilesTabName,
     ]);
   });
 
@@ -142,7 +142,7 @@ describe('WorkspaceNavBar', () => {
       'workspaces',
       workspaceDataStub.namespace,
       workspaceDataStub.id,
-      NOTEBOOKS_TAB_NAME,
+      appFilesTabName,
     ]);
   });
 

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -4,9 +4,9 @@ import { mount } from 'enzyme';
 import { mockNavigate } from 'setupTests';
 
 import { WorkspaceNavBar } from 'app/pages/workspace/workspace-nav-bar';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 import { cdrVersionStore, serverConfigStore } from 'app/utils/stores';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 
 import {
   CdrVersionsStubVariables,

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -6,7 +6,7 @@ import { mockNavigate } from 'setupTests';
 import { WorkspaceNavBar } from 'app/pages/workspace/workspace-nav-bar';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 import { cdrVersionStore, serverConfigStore } from 'app/utils/stores';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 
 import {
   CdrVersionsStubVariables,
@@ -69,7 +69,7 @@ describe('WorkspaceNavBar', () => {
       'workspaces',
       workspaceDataStub.namespace,
       workspaceDataStub.id,
-      appFilesTabName,
+      analysisTabName,
     ]);
 
     wrapper.find({ 'data-test-id': 'Data' }).first().simulate('click');
@@ -120,7 +120,7 @@ describe('WorkspaceNavBar', () => {
       'workspaces',
       workspaceDataStub.namespace,
       workspaceDataStub.id,
-      appFilesTabName,
+      analysisTabName,
     ]);
   });
 
@@ -142,7 +142,7 @@ describe('WorkspaceNavBar', () => {
       'workspaces',
       workspaceDataStub.namespace,
       workspaceDataStub.id,
-      appFilesTabName,
+      analysisTabName,
     ]);
   });
 

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -17,7 +17,7 @@ import {
 } from 'app/utils/cdr-versions';
 import { useNavigation } from 'app/utils/navigation';
 import { MatchParams, serverConfigStore } from 'app/utils/stores';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 
 import { CdrVersionUpgradeModal } from './cdr-version-upgrade-modal';
 
@@ -144,7 +144,7 @@ const tabs = [
   { name: 'Data', link: 'data' },
   {
     name: 'Analysis',
-    link: appFilesTabName,
+    link: analysisTabName,
   },
   { name: 'About', link: 'about' },
 ];

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -18,7 +18,7 @@ import {
 } from 'app/utils/cdr-versions';
 import { useNavigation } from 'app/utils/navigation';
 import { MatchParams, serverConfigStore } from 'app/utils/stores';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 
 import { CdrVersionUpgradeModal } from './cdr-version-upgrade-modal';
 
@@ -145,7 +145,7 @@ const tabs = [
   { name: 'Data', link: 'data' },
   {
     name: 'Analysis',
-    link: NOTEBOOKS_TAB_NAME,
+    link: appFilesTabName,
   },
   { name: 'About', link: 'about' },
 ];

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -5,7 +5,6 @@ import * as fp from 'lodash/fp';
 
 import { CdrVersionTiersResponse, Workspace } from 'generated/fetch';
 
-import { environment } from 'environments/environment';
 import { Clickable } from 'app/components/buttons';
 import { FlexRow } from 'app/components/flex';
 import { ClrIcon } from 'app/components/icons';
@@ -176,9 +175,6 @@ export const WorkspaceNavBar = fp.flow(
   const { ns, wsid } = useParams<MatchParams>();
 
   useEffect(() => {
-    if (environment.showNewAnalysisTab && tabs.length === 3) {
-      tabs.push({ name: 'Analysis (New)', link: 'apps' });
-    }
     if (
       serverConfigStore.get().config.enableDataExplorer &&
       !tabs.find((tab) => tab.name === 'Data Explorer')
@@ -216,7 +212,7 @@ export const WorkspaceNavBar = fp.flow(
             ...styles.tab,
             ...(selected ? styles.active : {}),
             ...(disabled ? styles.disabled : {}),
-            ...(['apps', 'data-explorer', 'tanagra'].includes(link)
+            ...(['data-explorer', 'tanagra'].includes(link)
               ? experimentalTabStyle(selected)
               : {}),
           }}

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -16,9 +16,9 @@ import {
   getDefaultCdrVersionForTier,
   hasDefaultCdrVersion,
 } from 'app/utils/cdr-versions';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { useNavigation } from 'app/utils/navigation';
 import { MatchParams, serverConfigStore } from 'app/utils/stores';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 
 import { CdrVersionUpgradeModal } from './cdr-version-upgrade-modal';
 

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -1,6 +1,5 @@
 import { AccessModule, Profile } from 'generated/fetch';
 
-import { environment } from 'environments/environment';
 import { Guard } from 'app/components/app-router';
 import { cond } from 'app/utils';
 import {
@@ -87,15 +86,6 @@ export const adminLockedGuard = (ns: string, wsid: string): Guard => {
   return {
     allowed: (): boolean => !currentWorkspaceStore.getValue().adminLocked,
     redirectPath: `/workspaces/${ns}/${wsid}/about`,
-  };
-};
-
-// Temp: Since the new analysis page is not ready yet, use the guard to prevent users to go to
-// new analysis page, if the flag is off
-export const tempAppsAnalysisGuard = (ns: string, wsid: string): Guard => {
-  return {
-    allowed: (): boolean => environment.showNewAnalysisTab,
-    redirectPath: `/workspaces/${ns}/${wsid}/data`,
   };
 };
 

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -149,7 +149,7 @@ export const WorkspaceRoutes = () => {
         {environment.showNewAnalysisTab ? (
           <AppsListPage
             routeData={{
-              title: 'View App Files',
+              title: 'View Analysis Files',
               pageKey: analysisTabName,
               workspaceNavBarTab: analysisTabName,
               breadcrumb: BreadcrumbType.Workspace,

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -174,7 +174,7 @@ export const WorkspaceRoutes = () => {
         <InteractiveNotebookPage
           routeData={{
             pathElementForTitle: 'nbName',
-            breadcrumb: BreadcrumbType.AppFile,
+            breadcrumb: BreadcrumbType.Analysis,
             pageKey: LEONARDO_APP_PAGE_KEY,
             workspaceNavBarTab: analysisTabName,
             minimizeChrome: true,
@@ -190,7 +190,7 @@ export const WorkspaceRoutes = () => {
           key='notebook'
           routeData={{
             pathElementForTitle: 'nbName',
-            breadcrumb: BreadcrumbType.AppFile,
+            breadcrumb: BreadcrumbType.Analysis,
             // The iframe we use to display the Jupyter notebook does something strange
             // to the height calculation of the container, which is normally set to auto.
             // Setting this flag sets the container to 100% so that no content is clipped.

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -98,6 +98,11 @@ const WorkspaceEditPage = fp.flow(
 const AppsListPage = fp.flow(withRouteData, withRoutingSpinner)(AppFilesList);
 const TanagraDevPage = fp.flow(withRouteData, withRoutingSpinner)(TanagraDev);
 
+// name of the tab for accessing apps and app files, also used to construct URLs
+export const appFilesTabName = environment.showNewAnalysisTab
+  ? 'app-files'
+  : 'notebooks';
+
 export const WorkspaceRoutes = () => {
   const { path } = useRouteMatch();
   const { ns, wsid } = useParams<MatchParams>();
@@ -140,34 +145,37 @@ export const WorkspaceRoutes = () => {
           workspaceEditMode={WorkspaceEditMode.Edit}
         />
       </AppRoute>
-      <AppRoute
-        exact
-        path={`${path}/apps`}
-        guards={[adminLockedGuard(ns, wsid), tempAppsAnalysisGuard(ns, wsid)]}
-      >
-        <AppsListPage
-          routeData={{
-            title: 'View Apps',
-            pageKey: 'apps',
-            workspaceNavBarTab: 'apps',
-            breadcrumb: BreadcrumbType.Workspace,
-          }}
-        />
-      </AppRoute>
-      <AppRoute
-        exact
-        path={`${path}/${NOTEBOOKS_TAB_NAME}`}
-        guards={[adminLockedGuard(ns, wsid)]}
-      >
-        <NotebookListPage
-          routeData={{
-            title: 'View Notebooks',
-            pageKey: appFilesTabName,
-            workspaceNavBarTab: appFilesTabName,
-            breadcrumb: BreadcrumbType.Workspace,
-          }}
-        />
-      </AppRoute>
+      {environment.showNewAnalysisTab ? (
+        <AppRoute
+          exact
+          path={`${path}/${appFilesTabName}`}
+          guards={[adminLockedGuard(ns, wsid), tempAppsAnalysisGuard(ns, wsid)]}
+        >
+          <AppsListPage
+            routeData={{
+              title: 'View App Files',
+              pageKey: appFilesTabName,
+              workspaceNavBarTab: appFilesTabName,
+              breadcrumb: BreadcrumbType.Workspace,
+            }}
+          />
+        </AppRoute>
+      ) : (
+        <AppRoute
+          exact
+          path={`${path}/${appFilesTabName}`}
+          guards={[adminLockedGuard(ns, wsid)]}
+        >
+          <NotebookListPage
+            routeData={{
+              title: 'View Notebooks',
+              pageKey: appFilesTabName,
+              workspaceNavBarTab: appFilesTabName,
+              breadcrumb: BreadcrumbType.Workspace,
+            }}
+          />
+        </AppRoute>
+      )}
       <AppRoute
         exact
         path={`${path}/${appFilesTabName}/preview/:nbName`}
@@ -176,7 +184,7 @@ export const WorkspaceRoutes = () => {
         <InteractiveNotebookPage
           routeData={{
             pathElementForTitle: 'nbName',
-            breadcrumb: BreadcrumbType.Notebook,
+            breadcrumb: BreadcrumbType.AppFile,
             pageKey: LEONARDO_APP_PAGE_KEY,
             workspaceNavBarTab: appFilesTabName,
             minimizeChrome: true,
@@ -192,7 +200,7 @@ export const WorkspaceRoutes = () => {
           key='notebook'
           routeData={{
             pathElementForTitle: 'nbName',
-            breadcrumb: BreadcrumbType.Notebook,
+            breadcrumb: BreadcrumbType.AppFile,
             // The iframe we use to display the Jupyter notebook does something strange
             // to the height calculation of the container, which is normally set to auto.
             // Setting this flag sets the container to 100% so that no content is clipped.

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -33,7 +33,7 @@ import {
 } from 'app/pages/workspace/workspace-edit';
 import { adminLockedGuard, tempAppsAnalysisGuard } from 'app/routing/guards';
 import { MatchParams, withParamsKey } from 'app/utils/stores';
-import { appFilesTabName } from 'app/utils/user-apps-utils';
+import { analysisTabName } from 'app/utils/user-apps-utils';
 
 const CohortPagePage = fp.flow(withRouteData, withRoutingSpinner)(CohortPage);
 const CohortActionsPage = fp.flow(
@@ -144,14 +144,14 @@ export const WorkspaceRoutes = () => {
       {environment.showNewAnalysisTab ? (
         <AppRoute
           exact
-          path={`${path}/${appFilesTabName}`}
+          path={`${path}/${analysisTabName}`}
           guards={[adminLockedGuard(ns, wsid), tempAppsAnalysisGuard(ns, wsid)]}
         >
           <AppsListPage
             routeData={{
               title: 'View App Files',
-              pageKey: appFilesTabName,
-              workspaceNavBarTab: appFilesTabName,
+              pageKey: analysisTabName,
+              workspaceNavBarTab: analysisTabName,
               breadcrumb: BreadcrumbType.Workspace,
             }}
           />
@@ -159,14 +159,14 @@ export const WorkspaceRoutes = () => {
       ) : (
         <AppRoute
           exact
-          path={`${path}/${appFilesTabName}`}
+          path={`${path}/${analysisTabName}`}
           guards={[adminLockedGuard(ns, wsid)]}
         >
           <NotebookListPage
             routeData={{
               title: 'View Notebooks',
-              pageKey: appFilesTabName,
-              workspaceNavBarTab: appFilesTabName,
+              pageKey: analysisTabName,
+              workspaceNavBarTab: analysisTabName,
               breadcrumb: BreadcrumbType.Workspace,
             }}
           />
@@ -174,7 +174,7 @@ export const WorkspaceRoutes = () => {
       )}
       <AppRoute
         exact
-        path={`${path}/${appFilesTabName}/preview/:nbName`}
+        path={`${path}/${analysisTabName}/preview/:nbName`}
         guards={[adminLockedGuard(ns, wsid)]}
       >
         <InteractiveNotebookPage
@@ -182,14 +182,14 @@ export const WorkspaceRoutes = () => {
             pathElementForTitle: 'nbName',
             breadcrumb: BreadcrumbType.AppFile,
             pageKey: LEONARDO_APP_PAGE_KEY,
-            workspaceNavBarTab: appFilesTabName,
+            workspaceNavBarTab: analysisTabName,
             minimizeChrome: true,
           }}
         />
       </AppRoute>
       <AppRoute
         exact
-        path={`${path}/${appFilesTabName}/:nbName`}
+        path={`${path}/${analysisTabName}/:nbName`}
         guards={[adminLockedGuard(ns, wsid)]}
       >
         <LeonardoAppRedirectPage
@@ -202,7 +202,7 @@ export const WorkspaceRoutes = () => {
             // Setting this flag sets the container to 100% so that no content is clipped.
             contentFullHeightOverride: true,
             pageKey: LEONARDO_APP_PAGE_KEY,
-            workspaceNavBarTab: appFilesTabName,
+            workspaceNavBarTab: analysisTabName,
             minimizeChrome: true,
           }}
           leoAppType={LeoApplicationType.Notebook}
@@ -219,7 +219,7 @@ export const WorkspaceRoutes = () => {
             breadcrumb: BreadcrumbType.Workspace,
             pageKey: LEONARDO_APP_PAGE_KEY,
             contentFullHeightOverride: true,
-            workspaceNavBarTab: appFilesTabName,
+            workspaceNavBarTab: analysisTabName,
             minimizeChrome: true,
           }}
           leoAppType={LeoApplicationType.Terminal}
@@ -235,7 +235,7 @@ export const WorkspaceRoutes = () => {
             breadcrumb: BreadcrumbType.Workspace,
             pageKey: LEONARDO_APP_PAGE_KEY,
             contentFullHeightOverride: true,
-            workspaceNavBarTab: appFilesTabName,
+            workspaceNavBarTab: analysisTabName,
             minimizeChrome: true,
           }}
           leoAppType={LeoApplicationType.SparkConsole}

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -32,7 +32,7 @@ import {
 } from 'app/pages/workspace/workspace-edit';
 import { adminLockedGuard, tempAppsAnalysisGuard } from 'app/routing/guards';
 import { MatchParams, withParamsKey } from 'app/utils/stores';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
+import { appFilesTabName } from 'app/utils/user-apps-utils';
 
 const CohortPagePage = fp.flow(withRouteData, withRoutingSpinner)(CohortPage);
 const CohortActionsPage = fp.flow(
@@ -162,15 +162,15 @@ export const WorkspaceRoutes = () => {
         <NotebookListPage
           routeData={{
             title: 'View Notebooks',
-            pageKey: NOTEBOOKS_TAB_NAME,
-            workspaceNavBarTab: NOTEBOOKS_TAB_NAME,
+            pageKey: appFilesTabName,
+            workspaceNavBarTab: appFilesTabName,
             breadcrumb: BreadcrumbType.Workspace,
           }}
         />
       </AppRoute>
       <AppRoute
         exact
-        path={`${path}/${NOTEBOOKS_TAB_NAME}/preview/:nbName`}
+        path={`${path}/${appFilesTabName}/preview/:nbName`}
         guards={[adminLockedGuard(ns, wsid)]}
       >
         <InteractiveNotebookPage
@@ -178,14 +178,14 @@ export const WorkspaceRoutes = () => {
             pathElementForTitle: 'nbName',
             breadcrumb: BreadcrumbType.Notebook,
             pageKey: LEONARDO_APP_PAGE_KEY,
-            workspaceNavBarTab: NOTEBOOKS_TAB_NAME,
+            workspaceNavBarTab: appFilesTabName,
             minimizeChrome: true,
           }}
         />
       </AppRoute>
       <AppRoute
         exact
-        path={`${path}/${NOTEBOOKS_TAB_NAME}/:nbName`}
+        path={`${path}/${appFilesTabName}/:nbName`}
         guards={[adminLockedGuard(ns, wsid)]}
       >
         <LeonardoAppRedirectPage
@@ -198,7 +198,7 @@ export const WorkspaceRoutes = () => {
             // Setting this flag sets the container to 100% so that no content is clipped.
             contentFullHeightOverride: true,
             pageKey: LEONARDO_APP_PAGE_KEY,
-            workspaceNavBarTab: NOTEBOOKS_TAB_NAME,
+            workspaceNavBarTab: appFilesTabName,
             minimizeChrome: true,
           }}
           leoAppType={LeoApplicationType.Notebook}
@@ -215,7 +215,7 @@ export const WorkspaceRoutes = () => {
             breadcrumb: BreadcrumbType.Workspace,
             pageKey: LEONARDO_APP_PAGE_KEY,
             contentFullHeightOverride: true,
-            workspaceNavBarTab: NOTEBOOKS_TAB_NAME,
+            workspaceNavBarTab: appFilesTabName,
             minimizeChrome: true,
           }}
           leoAppType={LeoApplicationType.Terminal}
@@ -231,7 +231,7 @@ export const WorkspaceRoutes = () => {
             breadcrumb: BreadcrumbType.Workspace,
             pageKey: LEONARDO_APP_PAGE_KEY,
             contentFullHeightOverride: true,
-            workspaceNavBarTab: NOTEBOOKS_TAB_NAME,
+            workspaceNavBarTab: appFilesTabName,
             minimizeChrome: true,
           }}
           leoAppType={LeoApplicationType.SparkConsole}

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -31,7 +31,7 @@ import {
   WorkspaceEdit,
   WorkspaceEditMode,
 } from 'app/pages/workspace/workspace-edit';
-import { adminLockedGuard, tempAppsAnalysisGuard } from 'app/routing/guards';
+import { adminLockedGuard } from 'app/routing/guards';
 import { MatchParams, withParamsKey } from 'app/utils/stores';
 import { analysisTabName } from 'app/utils/user-apps-utils';
 
@@ -141,12 +141,12 @@ export const WorkspaceRoutes = () => {
           workspaceEditMode={WorkspaceEditMode.Edit}
         />
       </AppRoute>
-      {environment.showNewAnalysisTab ? (
-        <AppRoute
-          exact
-          path={`${path}/${analysisTabName}`}
-          guards={[adminLockedGuard(ns, wsid), tempAppsAnalysisGuard(ns, wsid)]}
-        >
+      <AppRoute
+        exact
+        path={`${path}/${analysisTabName}`}
+        guards={[adminLockedGuard(ns, wsid)]}
+      >
+        {environment.showNewAnalysisTab ? (
           <AppsListPage
             routeData={{
               title: 'View App Files',
@@ -155,13 +155,7 @@ export const WorkspaceRoutes = () => {
               breadcrumb: BreadcrumbType.Workspace,
             }}
           />
-        </AppRoute>
-      ) : (
-        <AppRoute
-          exact
-          path={`${path}/${analysisTabName}`}
-          guards={[adminLockedGuard(ns, wsid)]}
-        >
+        ) : (
           <NotebookListPage
             routeData={{
               title: 'View Notebooks',
@@ -170,8 +164,8 @@ export const WorkspaceRoutes = () => {
               breadcrumb: BreadcrumbType.Workspace,
             }}
           />
-        </AppRoute>
-      )}
+        )}
+      </AppRoute>
       <AppRoute
         exact
         path={`${path}/${analysisTabName}/preview/:nbName`}

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Redirect, Switch, useParams, useRouteMatch } from 'react-router-dom';
 import * as fp from 'lodash/fp';
 
+import { environment } from 'environments/environment';
 import { AppRoute, withRouteData } from 'app/components/app-router';
 import { BreadcrumbType } from 'app/components/breadcrumb-type';
 import { LEONARDO_APP_PAGE_KEY } from 'app/components/help-sidebar';
@@ -97,11 +98,6 @@ const WorkspaceEditPage = fp.flow(
 )(WorkspaceEdit);
 const AppsListPage = fp.flow(withRouteData, withRoutingSpinner)(AppFilesList);
 const TanagraDevPage = fp.flow(withRouteData, withRoutingSpinner)(TanagraDev);
-
-// name of the tab for accessing apps and app files, also used to construct URLs
-export const appFilesTabName = environment.showNewAnalysisTab
-  ? 'app-files'
-  : 'notebooks';
 
 export const WorkspaceRoutes = () => {
   const { path } = useRouteMatch();

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -31,8 +31,8 @@ import {
   WorkspaceEditMode,
 } from 'app/pages/workspace/workspace-edit';
 import { adminLockedGuard, tempAppsAnalysisGuard } from 'app/routing/guards';
-import { NOTEBOOKS_TAB_NAME } from 'app/utils/constants';
 import { MatchParams, withParamsKey } from 'app/utils/stores';
+import { NOTEBOOKS_TAB_NAME } from 'app/utils/user-apps-utils';
 
 const CohortPagePage = fp.flow(withRouteData, withRoutingSpinner)(CohortPage);
 const CohortActionsPage = fp.flow(

--- a/ui/src/app/utils/constants.tsx
+++ b/ui/src/app/utils/constants.tsx
@@ -87,6 +87,3 @@ export const STATE_CODE_MAPPING = {
 export const JUPYTER_FILE_EXT = '.ipynb';
 export const RMD_FILE_EXT = '.Rmd';
 export const R_FILE_EXT = '.R';
-
-// name of the tab for accessing notebooks and runtimes, also used to construct URLs
-export const NOTEBOOKS_TAB_NAME = 'notebooks';

--- a/ui/src/app/utils/resources.spec.tsx
+++ b/ui/src/app/utils/resources.spec.tsx
@@ -12,7 +12,6 @@ import { exampleCohortStubs } from 'testing/stubs/cohorts-api-stub';
 import { stubResource } from 'testing/stubs/resources-stub';
 import { WorkspaceStubVariables } from 'testing/stubs/workspaces';
 
-import { NOTEBOOKS_TAB_NAME } from './constants';
 import { stringifyUrl } from './navigation';
 import {
   getDescription,
@@ -28,6 +27,7 @@ import {
   isNotebook,
   toDisplay,
 } from './resources';
+import { NOTEBOOKS_TAB_NAME } from './user-apps-utils';
 
 const COHORT_NAME = exampleCohortStubs[0].name;
 const COHORT_DESCRIPTION = exampleCohortStubs[0].description;

--- a/ui/src/app/utils/resources.spec.tsx
+++ b/ui/src/app/utils/resources.spec.tsx
@@ -27,7 +27,7 @@ import {
   isNotebook,
   toDisplay,
 } from './resources';
-import { appFilesTabName } from './user-apps-utils';
+import { analysisTabName } from './user-apps-utils';
 
 const COHORT_NAME = exampleCohortStubs[0].name;
 const COHORT_DESCRIPTION = exampleCohortStubs[0].description;
@@ -187,7 +187,7 @@ describe('resources.tsx', () => {
     const EXPECTED_COHORT_REVIEW_URL = `${WORKSPACE_URL_PREFIX}/data/cohorts/${COHORT_REVIEW_COHORT_ID}/reviews/${COHORT_REVIEW_ID}`;
     const EXPECTED_CONCEPT_SET_URL = `${WORKSPACE_URL_PREFIX}/data/concepts/sets/${CONCEPT_SET_ID}`;
     const EXPECTED_DATA_SET_URL = `${WORKSPACE_URL_PREFIX}/data/data-sets/${DATA_SET_ID}`;
-    const EXPECTED_NOTEBOOK_URL = `${WORKSPACE_URL_PREFIX}/${appFilesTabName}/preview/${NOTEBOOK_NAME}`;
+    const EXPECTED_NOTEBOOK_URL = `${WORKSPACE_URL_PREFIX}/${analysisTabName}/preview/${NOTEBOOK_NAME}`;
 
     expect(stringifyUrl(getResourceUrl(testCohort))).toBe(EXPECTED_COHORT_URL);
     expect(stringifyUrl(getResourceUrl(testCohortReview))).toBe(

--- a/ui/src/app/utils/resources.spec.tsx
+++ b/ui/src/app/utils/resources.spec.tsx
@@ -27,7 +27,7 @@ import {
   isNotebook,
   toDisplay,
 } from './resources';
-import { NOTEBOOKS_TAB_NAME } from './user-apps-utils';
+import { appFilesTabName } from './user-apps-utils';
 
 const COHORT_NAME = exampleCohortStubs[0].name;
 const COHORT_DESCRIPTION = exampleCohortStubs[0].description;
@@ -187,7 +187,7 @@ describe('resources.tsx', () => {
     const EXPECTED_COHORT_REVIEW_URL = `${WORKSPACE_URL_PREFIX}/data/cohorts/${COHORT_REVIEW_COHORT_ID}/reviews/${COHORT_REVIEW_ID}`;
     const EXPECTED_CONCEPT_SET_URL = `${WORKSPACE_URL_PREFIX}/data/concepts/sets/${CONCEPT_SET_ID}`;
     const EXPECTED_DATA_SET_URL = `${WORKSPACE_URL_PREFIX}/data/data-sets/${DATA_SET_ID}`;
-    const EXPECTED_NOTEBOOK_URL = `${WORKSPACE_URL_PREFIX}/${NOTEBOOKS_TAB_NAME}/preview/${NOTEBOOK_NAME}`;
+    const EXPECTED_NOTEBOOK_URL = `${WORKSPACE_URL_PREFIX}/${appFilesTabName}/preview/${NOTEBOOK_NAME}`;
 
     expect(stringifyUrl(getResourceUrl(testCohort))).toBe(EXPECTED_COHORT_URL);
     expect(stringifyUrl(getResourceUrl(testCohortReview))).toBe(

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -12,7 +12,7 @@ import {
 } from 'generated/fetch';
 
 import { encodeURIComponentStrict, UrlObj } from './navigation';
-import { appFilesTabName } from './user-apps-utils';
+import { analysisTabName } from './user-apps-utils';
 import { WorkspaceData } from './workspace-data';
 
 export const isCohort = (resource: WorkspaceResource): boolean =>
@@ -101,7 +101,7 @@ export function getResourceUrl(resource: WorkspaceResource): UrlObj {
     [
       isNotebook,
       (r) => ({
-        url: `${workspacePrefix}/${appFilesTabName}/preview/${encodeURIComponentStrict(
+        url: `${workspacePrefix}/${analysisTabName}/preview/${encodeURIComponentStrict(
           r.notebook.name
         )}`,
       }),

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -11,8 +11,8 @@ import {
   WorkspaceResource,
 } from 'generated/fetch';
 
-import { NOTEBOOKS_TAB_NAME } from './constants';
 import { encodeURIComponentStrict, UrlObj } from './navigation';
+import { NOTEBOOKS_TAB_NAME } from './user-apps-utils';
 import { WorkspaceData } from './workspace-data';
 
 export const isCohort = (resource: WorkspaceResource): boolean =>

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -12,7 +12,7 @@ import {
 } from 'generated/fetch';
 
 import { encodeURIComponentStrict, UrlObj } from './navigation';
-import { NOTEBOOKS_TAB_NAME } from './user-apps-utils';
+import { appFilesTabName } from './user-apps-utils';
 import { WorkspaceData } from './workspace-data';
 
 export const isCohort = (resource: WorkspaceResource): boolean =>
@@ -101,7 +101,7 @@ export function getResourceUrl(resource: WorkspaceResource): UrlObj {
     [
       isNotebook,
       (r) => ({
-        url: `${workspacePrefix}/${NOTEBOOKS_TAB_NAME}/preview/${encodeURIComponentStrict(
+        url: `${workspacePrefix}/${appFilesTabName}/preview/${encodeURIComponentStrict(
           r.notebook.name
         )}`,
       }),

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -135,4 +135,4 @@ export const openRStudioOrConfigPanel = (
 };
 
 // name of the tab for accessing notebooks and runtimes, also used to construct URLs
-export const NOTEBOOKS_TAB_NAME = 'notebooks';
+export const appFilesTabName = 'notebooks';

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -9,6 +9,7 @@ import {
 
 import { findApp, UIAppType } from 'app/components/apps-panel/utils';
 import { rstudioConfigIconId } from 'app/components/help-sidebar-icons';
+import { environment } from 'environments/environment';
 import { leoAppsApi } from 'app/services/notebooks-swagger-fetch-clients';
 import { appsApi } from 'app/services/swagger-fetch-clients';
 
@@ -135,7 +136,6 @@ export const openRStudioOrConfigPanel = (
 };
 
 // name of the tab for accessing apps and app files, also used to construct URLs
-export const appFilesTabName = 'joeltemp';
-// environment.showNewAnalysisTab
-//     ? 'app-files'
-//     : 'notebooks';
+export const appFilesTabName = environment.showNewAnalysisTab
+  ? 'app-files'
+  : 'notebooks';

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -7,9 +7,9 @@ import {
   UserAppEnvironment,
 } from 'generated/fetch';
 
+import { environment } from 'environments/environment';
 import { findApp, UIAppType } from 'app/components/apps-panel/utils';
 import { rstudioConfigIconId } from 'app/components/help-sidebar-icons';
-import { environment } from 'environments/environment';
 import { leoAppsApi } from 'app/services/notebooks-swagger-fetch-clients';
 import { appsApi } from 'app/services/swagger-fetch-clients';
 
@@ -135,7 +135,7 @@ export const openRStudioOrConfigPanel = (
   }
 };
 
-// name of the tab for accessing apps and app files, also used to construct URLs
-export const appFilesTabName = environment.showNewAnalysisTab
-  ? 'app-files'
+// internal name of the analysis tab, also used to construct URLs
+export const analysisTabName = environment.showNewAnalysisTab
+  ? 'analysis'
   : 'notebooks';

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -133,3 +133,6 @@ export const openRStudioOrConfigPanel = (
     setSidebarActiveIconStore.next(rstudioConfigIconId);
   }
 };
+
+// name of the tab for accessing notebooks and runtimes, also used to construct URLs
+export const NOTEBOOKS_TAB_NAME = 'notebooks';

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -134,5 +134,8 @@ export const openRStudioOrConfigPanel = (
   }
 };
 
-// name of the tab for accessing notebooks and runtimes, also used to construct URLs
-export const appFilesTabName = 'notebooks';
+// name of the tab for accessing apps and app files, also used to construct URLs
+export const appFilesTabName = 'joeltemp';
+// environment.showNewAnalysisTab
+//     ? 'app-files'
+//     : 'notebooks';


### PR DESCRIPTION
When the `showNewAnalysisTab` env-flag is true, use the "new" analysis tab instead of the old one.

Also change the URL path and breadcrumbs from "notebooks" to "analysis" to reflect the tab's new role for apps beyond Jupyter

Tested by running locally with both `showAnalysisTab` UI env flag states
* true -> the New Analysis Tab replaces the old one, and URL/Breadcrumbs say "analysis"
* false -> the old analysis tab remains.  URL/Breadcrumbs for notebooks say "notebooks"

---

Note that we are displaying the new analysis tab, not the old one.  Also the URL says `analysis` instead of `notebooks`

<img width="1248" alt="New Analysis" src="https://github.com/all-of-us/workbench/assets/2701406/b8ce9963-4d3f-41c5-ac87-0fc99006b5ba">

---

The breadcrumb also says Analysis instead of Notebooks

<img width="1102" alt="New Analysis Preview" src="https://github.com/all-of-us/workbench/assets/2701406/37def42a-5566-49e7-99e4-ae0b181a2a67">

---

The tab name is now **View Analysis Files** (sorry my tab is too small to show it)

<img width="252" alt="View Analysis Files" src="https://github.com/all-of-us/workbench/assets/2701406/d056f0ce-90b1-4494-baf7-bb73bf71906f">


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
