### PR TITLE
[RW-10520][risk=no] Add default config for access modules in UI

### DIFF
--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -342,15 +342,10 @@ export const maybeDaysRemaining = (
   profile: Profile,
   accessTier: AccessTierShortNames = AccessTierShortNames.Registered
 ): number | undefined => {
-  const tierFilter = (status: AccessModuleStatus): boolean => {
-    const x =
-      accessTier === AccessTierShortNames.Registered
-        ? getAccessModuleConfig(status.moduleName).requiredForRTAccess
-        : getAccessModuleConfig(status.moduleName).requiredForCTAccess;
-    console.log('Name: ', status.moduleName);
-    console.log('config: ', x);
-    return x;
-  };
+  const tierFilter = (status: AccessModuleStatus): boolean =>
+    accessTier === AccessTierShortNames.Registered
+      ? getAccessModuleConfig(status.moduleName).requiredForRTAccess
+      : getAccessModuleConfig(status.moduleName).requiredForCTAccess;
 
   const earliestExpiration: number = fp.flow(
     fp.get(['accessModules', 'modules']),

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -34,7 +34,7 @@ import {
   getWholeDaysFromNow,
   MILLIS_PER_DAY,
 } from './dates';
-import { cond, switchCase } from './index';
+import { cond, DEFAULT, switchCase } from './index';
 
 export enum AccessRenewalStatus {
   NEVER_EXPIRES = 'Complete (Never Expires)',
@@ -310,6 +310,12 @@ export const getAccessModuleConfig = (
         adminPageTitle: 'Report any publications',
         renewalTimeEstimate: 5,
       }),
+    ],
+    [
+      DEFAULT,
+      () => ({
+        ...apiConfig,
+      }),
     ]
   );
 };
@@ -336,10 +342,15 @@ export const maybeDaysRemaining = (
   profile: Profile,
   accessTier: AccessTierShortNames = AccessTierShortNames.Registered
 ): number | undefined => {
-  const tierFilter = (status: AccessModuleStatus): boolean =>
-    accessTier === AccessTierShortNames.Registered
-      ? getAccessModuleConfig(status.moduleName).requiredForRTAccess
-      : getAccessModuleConfig(status.moduleName).requiredForCTAccess;
+  const tierFilter = (status: AccessModuleStatus): boolean => {
+    const x =
+      accessTier === AccessTierShortNames.Registered
+        ? getAccessModuleConfig(status.moduleName).requiredForRTAccess
+        : getAccessModuleConfig(status.moduleName).requiredForCTAccess;
+    console.log('Name: ', status.moduleName);
+    console.log('config: ', x);
+    return x;
+  };
 
   const earliestExpiration: number = fp.flow(
     fp.get(['accessModules', 'modules']),


### PR DESCRIPTION
This change allows for api configuration to be loaded in the UI without having a corresponding value specified. This allows to implement new access modules more safely.

In order to test this, delete an existing module from  getAccessModuleConfig and add a print statement to getAccessModuleConfig to print the resulting config. Ensure that the values for requiredForRTAccess and requiredForCTAccess match the values that you would expect for the deleted module.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
