### PR TITLE
[risk=low][no ticket] Rename R "Notebook" and "File" to R "Script"

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebookUtils.java
@@ -9,7 +9,7 @@ public class NotebookUtils {
   public static String NOTEBOOKS_WORKSPACE_DIRECTORY = "notebooks";
   public static String JUPYTER_NOTEBOOK_EXTENSION = ".ipynb";
   public static String R_MARKDOWN_NOTEBOOK_EXTENSION = ".Rmd";
-  public static String R_NOTEBOOK_EXTENSION = ".R";
+  public static String R_SCRIPT_EXTENSION = ".R";
 
   // Pattern matches directory and the file type, e.g. notebooks/file.ipynb
   public static final Pattern JUPYTER_NOTEBOOK_WITH_DIRECTORY_PATTERN =
@@ -18,24 +18,24 @@ public class NotebookUtils {
   public static final Pattern R_MARKDOWN_NOTEBOOK_WITH_DIRECTORY_PATTERN =
       Pattern.compile(NOTEBOOKS_WORKSPACE_DIRECTORY + "/[^/]+(\\.(?i)(Rmd))$");
 
-  public static final Pattern R_NOTEBOOK_WITH_DIRECTORY_PATTERN =
+  public static final Pattern R_SCRIPT_WITH_DIRECTORY_PATTERN =
       Pattern.compile(NOTEBOOKS_WORKSPACE_DIRECTORY + "/[^/]+(\\.(?i)(R))$");
 
   public static boolean isJupyterNotebookWithDirectory(String nameWithFileExtension) {
     return JUPYTER_NOTEBOOK_WITH_DIRECTORY_PATTERN.matcher(nameWithFileExtension).matches();
   }
 
-  public static boolean isRNotebookWithDirectory(String nameWithFileExtension) {
-    return R_NOTEBOOK_WITH_DIRECTORY_PATTERN.matcher(nameWithFileExtension).matches();
-  }
-
   public static boolean isRMarkDownNotebookWithDirectory(String nameWithFileExtension) {
     return R_MARKDOWN_NOTEBOOK_WITH_DIRECTORY_PATTERN.matcher(nameWithFileExtension).matches();
   }
 
+  public static boolean isRScriptWithDirectory(String nameWithFileExtension) {
+    return R_SCRIPT_WITH_DIRECTORY_PATTERN.matcher(nameWithFileExtension).matches();
+  }
+
   public static boolean isRStudioFileWithDirectory(String nameWithFileExtension) {
     return isRMarkDownNotebookWithDirectory(nameWithFileExtension)
-        || isRNotebookWithDirectory(nameWithFileExtension);
+        || isRScriptWithDirectory(nameWithFileExtension);
   }
 
   public static boolean isJupyterNotebook(String nameWithFileExtension) {
@@ -46,12 +46,12 @@ public class NotebookUtils {
     return nameWithFileExtension.endsWith(R_MARKDOWN_NOTEBOOK_EXTENSION);
   }
 
-  public static boolean isRStudioFile(String nameWithFileExtension) {
-    return isRmdNotebook(nameWithFileExtension) || isRNotebook(nameWithFileExtension);
+  public static boolean isRScriptFile(String nameWithFileExtension) {
+    return nameWithFileExtension.endsWith(R_SCRIPT_EXTENSION);
   }
 
-  public static boolean isRNotebook(String nameWithFileExtension) {
-    return nameWithFileExtension.endsWith(R_NOTEBOOK_EXTENSION);
+  public static boolean isRStudioFile(String nameWithFileExtension) {
+    return isRmdNotebook(nameWithFileExtension) || isRScriptFile(nameWithFileExtension);
   }
 
   public static String withJupyterNotebookExtension(String notebookName) {

--- a/ui/src/app/components/rename-modal.spec.tsx
+++ b/ui/src/app/components/rename-modal.spec.tsx
@@ -35,24 +35,24 @@ describe('should show error if new name already exist', () => {
     ['123.Rmd', '123'],
     ['123.Rmd', '123.Rmd'],
   ])(
-    'Old notebook name %s, new notebook name %s',
-    async (oldNotebookName, newNotebookName) => {
+    'Old analysis file name %s, new analysis file name %s',
+    async (oldFilename, newFilename) => {
       const wrapper = mount(
         <RenameModal
           onRename={() => {}}
           resourceType={ResourceType.NOTEBOOK}
           onCancel={() => {}}
-          oldName={oldNotebookName}
-          existingNames={[oldNotebookName]}
+          oldName={oldFilename}
+          existingNames={[oldFilename]}
           nameFormat={(name) =>
-            appendAnalysisFileSuffixByOldName(name, oldNotebookName)
+            appendAnalysisFileSuffixByOldName(name, oldFilename)
           }
         />
       );
       wrapper
         .find('[data-test-id="rename-new-name-input"]')
         .first()
-        .simulate('change', { target: { value: newNotebookName } });
+        .simulate('change', { target: { value: newFilename } });
       await waitOneTickAndUpdate(wrapper);
       expect(
         wrapper.find('[data-test-id="rename-new-name-invalid"]').first().text()

--- a/ui/src/app/components/rename-modal.spec.tsx
+++ b/ui/src/app/components/rename-modal.spec.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 
 import { ResourceType } from 'generated/fetch';
 
-import { appendNotebookFileSuffixByOldName } from 'app/pages/analysis/util';
+import { appendAnalysisFileSuffixByOldName } from 'app/pages/analysis/util';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 
@@ -45,7 +45,7 @@ describe('should show error if new name already exist', () => {
           oldName={oldNotebookName}
           existingNames={[oldNotebookName]}
           nameFormat={(name) =>
-            appendNotebookFileSuffixByOldName(name, oldNotebookName)
+            appendAnalysisFileSuffixByOldName(name, oldNotebookName)
           }
         />
       );

--- a/ui/src/app/components/rename-modal.tsx
+++ b/ui/src/app/components/rename-modal.tsx
@@ -73,7 +73,7 @@ export class RenameModal extends React.Component<Props, States> {
     const errors = validate(
       {
         newName:
-          // Append .ipynb or .Rmd file based on the oldName format
+          // Append .ipynb, .Rmd, or .R to the filename (if needed) based on the oldName format
           resourceType === ResourceType.NOTEBOOK
             ? appendAnalysisFileSuffixByOldName(newName?.trim(), oldName)
             : newName?.trim(),

--- a/ui/src/app/components/rename-modal.tsx
+++ b/ui/src/app/components/rename-modal.tsx
@@ -13,7 +13,7 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
-import { appendNotebookFileSuffixByOldName } from 'app/pages/analysis/util';
+import { appendAnalysisFileSuffixByOldName } from 'app/pages/analysis/util';
 import colors from 'app/styles/colors';
 import { reactStyles, summarizeErrors } from 'app/utils';
 import { nameValidationFormat, toDisplay } from 'app/utils/resources';
@@ -75,7 +75,7 @@ export class RenameModal extends React.Component<Props, States> {
         newName:
           // Append .ipynb or .Rmd file based on the oldName format
           resourceType === ResourceType.NOTEBOOK
-            ? appendNotebookFileSuffixByOldName(newName?.trim(), oldName)
+            ? appendAnalysisFileSuffixByOldName(newName?.trim(), oldName)
             : newName?.trim(),
       },
       {

--- a/ui/src/app/pages/analysis/notebook-resource-card.tsx
+++ b/ui/src/app/pages/analysis/notebook-resource-card.tsx
@@ -26,7 +26,7 @@ import {
   withSpinnerOverlay,
   WithSpinnerOverlayProps,
 } from 'app/components/with-spinner-overlay';
-import { appendNotebookFileSuffixByOldName } from 'app/pages/analysis/util';
+import { appendAnalysisFileSuffixByOldName } from 'app/pages/analysis/util';
 import { notebooksApi } from 'app/services/swagger-fetch-clients';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { getDisplayName, getType } from 'app/utils/resources';
@@ -122,7 +122,7 @@ export const NotebookResourceCard = fp.flow(
           resource.workspaceFirecloudName,
           {
             name: resource.notebook.name,
-            newName: appendNotebookFileSuffixByOldName(newName, oldName),
+            newName: appendAnalysisFileSuffixByOldName(newName, oldName),
           }
         )
         .then(() => this.props.onUpdate())
@@ -217,7 +217,7 @@ export const NotebookResourceCard = fp.flow(
               hideDescription={true}
               oldName={oldName}
               nameFormat={(name) =>
-                appendNotebookFileSuffixByOldName(name, oldName)
+                appendAnalysisFileSuffixByOldName(name, oldName)
               }
               existingNames={existingNameList}
             />

--- a/ui/src/app/pages/analysis/util.spec.tsx
+++ b/ui/src/app/pages/analysis/util.spec.tsx
@@ -1,20 +1,20 @@
-import { appendNotebookFileSuffixByOldName } from './util';
+import { appendAnalysisFileSuffixByOldName } from './util';
 
 describe('NotebookUtil', () => {
   it('should append Rmd if old file is Rmd file', () => {
-    expect(appendNotebookFileSuffixByOldName('test', 'old.Rmd')).toEqual(
+    expect(appendAnalysisFileSuffixByOldName('test', 'old.Rmd')).toEqual(
       'test.Rmd'
     );
   });
 
   it('should append ipynb if old file is ipynb file', () => {
-    expect(appendNotebookFileSuffixByOldName('test', 'old.ipynb')).toEqual(
+    expect(appendAnalysisFileSuffixByOldName('test', 'old.ipynb')).toEqual(
       'test.ipynb'
     );
   });
 
   it('should not append anything if old file neither ipynb nor Rmd file', () => {
-    expect(appendNotebookFileSuffixByOldName('test', 'old.random')).toEqual(
+    expect(appendAnalysisFileSuffixByOldName('test', 'old.random')).toEqual(
       'test'
     );
   });

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -25,7 +25,7 @@ export function appendJupyterNotebookFileSuffix(filename: string) {
   return filename;
 }
 
-export function appendRstudioNotebookFileSuffix(filename: string) {
+export function appendRStudioNotebookFileSuffix(filename: string) {
   if (filename && !filename.endsWith(RMD_FILE_EXT)) {
     return filename + RMD_FILE_EXT;
   }
@@ -41,7 +41,7 @@ export function appendRScriptSuffix(filename: string) {
   return filename;
 }
 
-export function appendNotebookFileSuffixByOldName(
+export function appendAnalysisFileSuffixByOldName(
   filename: string,
   oldFileName: string
 ) {
@@ -52,7 +52,7 @@ export function appendNotebookFileSuffixByOldName(
     ],
     [
       oldFileName.endsWith(RMD_FILE_EXT),
-      () => appendRstudioNotebookFileSuffix(filename),
+      () => appendRStudioNotebookFileSuffix(filename),
     ],
     [oldFileName.endsWith(R_SCRIPT_EXT), () => appendRScriptSuffix(filename)],
     () => filename

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -5,7 +5,7 @@ import { notebooksApi } from 'app/services/swagger-fetch-clients';
 import { cond } from 'app/utils';
 import {
   JUPYTER_FILE_EXT,
-  R_FILE_EXT,
+  R_SCRIPT_EXT,
   RMD_FILE_EXT,
 } from 'app/utils/constants';
 
@@ -33,9 +33,9 @@ export function appendRstudioNotebookFileSuffix(filename: string) {
   return filename;
 }
 
-export function appendRNotebookFileSuffix(filename: string) {
-  if (filename && !filename.endsWith(R_FILE_EXT)) {
-    return filename + R_FILE_EXT;
+export function appendRScriptSuffix(filename: string) {
+  if (filename && !filename.endsWith(R_SCRIPT_EXT)) {
+    return filename + R_SCRIPT_EXT;
   }
 
   return filename;
@@ -54,10 +54,7 @@ export function appendNotebookFileSuffixByOldName(
       oldFileName.endsWith(RMD_FILE_EXT),
       () => appendRstudioNotebookFileSuffix(filename),
     ],
-    [
-      oldFileName.endsWith(R_FILE_EXT),
-      () => appendRNotebookFileSuffix(filename),
-    ],
+    [oldFileName.endsWith(R_SCRIPT_EXT), () => appendRScriptSuffix(filename)],
     () => filename
   );
 }
@@ -86,7 +83,7 @@ const appsExtensionMap = [
     canPlayground: false,
   },
   {
-    extension: R_FILE_EXT,
+    extension: R_SCRIPT_EXT,
     appType: UIAppType.RSTUDIO,
     canPlayground: false,
   },

--- a/ui/src/app/utils/constants.tsx
+++ b/ui/src/app/utils/constants.tsx
@@ -86,4 +86,4 @@ export const STATE_CODE_MAPPING = {
 
 export const JUPYTER_FILE_EXT = '.ipynb';
 export const RMD_FILE_EXT = '.Rmd';
-export const R_FILE_EXT = '.R';
+export const R_SCRIPT_EXT = '.R';


### PR DESCRIPTION
No functional changes - just renaming some code structures.

The RStudio application uses "notebook" to refer to .Rmd files and "script" to .R files.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
