### PR TITLE
[risk=low][no ticket] Allow deletion of GKE apps without PDs

### DIFF
--- a/ui/src/app/components/gke-app-configuration-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.tsx
@@ -20,6 +20,8 @@ import { switchCase } from 'app/utils';
 import { notificationStore } from 'app/utils/stores';
 import { deleteUserApp, findDisk } from 'app/utils/user-apps-utils';
 
+import { ConfirmDelete } from './runtime-configuration-panel/confirm-delete';
+
 type InjectedProps = 'app' | 'disk' | 'onClickDeleteUnattachedPersistentDisk';
 
 export type GkeAppConfigurationPanelProps = {
@@ -165,15 +167,20 @@ export const GKEAppConfigurationPanel = ({
     ],
     [
       GKEAppPanelContent.DELETE_GKE_APP,
-      () => (
-        <ConfirmDeleteEnvironmentWithPD
-          onConfirm={onConfirmDeleteGKEApp}
-          onCancel={onClose}
-          appType={toUIAppType[app.appType]}
-          usingDataproc={false}
-          disk={disk}
-        />
-      ),
+      () =>
+        // currently (July 2023) we do not expose detaching PDs to users, but it's possible to get into
+        // an error state where the disk is missing, so we need to account for this
+        disk ? (
+          <ConfirmDeleteEnvironmentWithPD
+            onConfirm={onConfirmDeleteGKEApp}
+            onCancel={onClose}
+            appType={toUIAppType[app.appType]}
+            usingDataproc={false}
+            disk={disk}
+          />
+        ) : (
+          <ConfirmDelete onCancel={onClose} onConfirm={onConfirmDeleteGKEApp} />
+        ),
     ]
   );
 };

--- a/ui/src/app/components/gke-app-configuration-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.tsx
@@ -179,7 +179,12 @@ export const GKEAppConfigurationPanel = ({
             disk={disk}
           />
         ) : (
-          <ConfirmDelete onCancel={onClose} onConfirm={onConfirmDeleteGKEApp} />
+          <ConfirmDelete
+            onCancel={onClose}
+            onConfirm={() =>
+              onConfirmDeleteGKEApp(false /* deletePdSelected */)
+            }
+          />
         ),
     ]
   );

--- a/ui/src/app/components/runtime-configuration-panel/confirm-delete-environment-with-pd.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/confirm-delete-environment-with-pd.tsx
@@ -43,7 +43,7 @@ export const ConfirmDeleteEnvironmentWithPD = ({
     [DEFAULT, () => null]
   );
 
-  const standardvmDeleteOption = (
+  const gceDeleteOption = (
     <div>
       <div style={styles.confirmWarning}>
         <h3
@@ -191,7 +191,7 @@ export const ConfirmDeleteEnvironmentWithPD = ({
           Delete environment options
         </h3>
       </div>
-      {usingDataproc ? dataprocDeleteOption : standardvmDeleteOption}
+      {usingDataproc ? dataprocDeleteOption : gceDeleteOption}
       <BackupFilesHelpSection appType={appType} />
       <FlexRow style={{ justifyContent: 'flex-end' }}>
         <Button


### PR DESCRIPTION
While it **shouldn't** (currently) happen that we ever see a GKE app without an attached PD, it **does** happen in error scenarios.  This causes the app to crash when we load the "Confirm deletion with PD" panel with a missing disk.

Instead, call up the "Confirm deletion without PD" panel in all cases when a disk is missing.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
