### PR TITLE
[DT-465][risk=no]bug in dataset builder surveys

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -641,6 +641,57 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
+  public void testGenerateCodePrepackagedCohortSurveyBasics() {
+    final String expectedConceptId = "concept_id IN (1586134)";
+    String code =
+        joinCodeCells(
+            dataSetService.generateCodeCells(
+                new DataSetExportRequest()
+                    .kernelType(KernelTypeEnum.PYTHON)
+                    .dataSetRequest(
+                        createDataSetRequest(
+                            ImmutableList.of(),
+                            ImmutableList.of(dbCohort1),
+                            ImmutableList.of(Domain.SURVEY),
+                            false,
+                            ImmutableList.of(PrePackagedConceptSetEnum.SURVEY_BASICS))),
+                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+
+    assertThat(code.replaceAll("[ \\s]",""))
+        .contains(expectedConceptId.replaceAll(" ",""));
+  }
+
+  @Test
+  public void testGenerateCodePrepackagedCohortAllIndividualSurveysExceptPfhhInOrder() {
+    final ImmutableList<PrePackagedConceptSetEnum> prePackagedConceptSetEnumList = ImmutableList.of(
+        PrePackagedConceptSetEnum.SURVEY_BASICS,
+        PrePackagedConceptSetEnum.SURVEY_LIFESTYLE,
+        PrePackagedConceptSetEnum.SURVEY_OVERALL_HEALTH,
+        PrePackagedConceptSetEnum.SURVEY_HEALTHCARE_ACCESS_UTILIZATION,
+        PrePackagedConceptSetEnum.SURVEY_COPE,
+        PrePackagedConceptSetEnum.SURVEY_SDOH,
+        PrePackagedConceptSetEnum.SURVEY_COVID_VACCINE);
+
+    final String expectedConceptId = "concept_id IN (1586134,1585855,1585710,43528895,1333342,40192389,1741006)";
+    String code =
+        joinCodeCells(
+            dataSetService.generateCodeCells(
+                new DataSetExportRequest()
+                    .kernelType(KernelTypeEnum.PYTHON)
+                    .dataSetRequest(
+                        createDataSetRequest(
+                            ImmutableList.of(),
+                            ImmutableList.of(dbCohort1),
+                            ImmutableList.of(Domain.SURVEY),
+                            false,
+                            prePackagedConceptSetEnumList)),
+                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+
+    assertThat(code.replaceAll("[ \\s]",""))
+        .contains(expectedConceptId.replaceAll(" ",""));
+  }
+
+  @Test
   public void testGenerateCodePrepackagedConceptSetFitBit() {
     addFitbitInfoToDsLinkingTable();
 

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -657,22 +657,23 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             ImmutableList.of(PrePackagedConceptSetEnum.SURVEY_BASICS))),
                 workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
-    assertThat(code.replaceAll("[ \\s]",""))
-        .contains(expectedConceptId.replaceAll(" ",""));
+    assertThat(code.replaceAll("[ \\s]", "")).contains(expectedConceptId.replaceAll(" ", ""));
   }
 
   @Test
   public void testGenerateCodePrepackagedCohortAllIndividualSurveysExceptPfhhInOrder() {
-    final ImmutableList<PrePackagedConceptSetEnum> prePackagedConceptSetEnumList = ImmutableList.of(
-        PrePackagedConceptSetEnum.SURVEY_BASICS,
-        PrePackagedConceptSetEnum.SURVEY_LIFESTYLE,
-        PrePackagedConceptSetEnum.SURVEY_OVERALL_HEALTH,
-        PrePackagedConceptSetEnum.SURVEY_HEALTHCARE_ACCESS_UTILIZATION,
-        PrePackagedConceptSetEnum.SURVEY_COPE,
-        PrePackagedConceptSetEnum.SURVEY_SDOH,
-        PrePackagedConceptSetEnum.SURVEY_COVID_VACCINE);
+    final ImmutableList<PrePackagedConceptSetEnum> prePackagedConceptSetEnumList =
+        ImmutableList.of(
+            PrePackagedConceptSetEnum.SURVEY_BASICS,
+            PrePackagedConceptSetEnum.SURVEY_LIFESTYLE,
+            PrePackagedConceptSetEnum.SURVEY_OVERALL_HEALTH,
+            PrePackagedConceptSetEnum.SURVEY_HEALTHCARE_ACCESS_UTILIZATION,
+            PrePackagedConceptSetEnum.SURVEY_COPE,
+            PrePackagedConceptSetEnum.SURVEY_SDOH,
+            PrePackagedConceptSetEnum.SURVEY_COVID_VACCINE);
 
-    final String expectedConceptId = "concept_id IN (1586134,1585855,1585710,43528895,1333342,40192389,1741006)";
+    final String expectedConceptId =
+        "concept_id IN (1586134,1585855,1585710,43528895,1333342,40192389,1741006)";
     String code =
         joinCodeCells(
             dataSetService.generateCodeCells(
@@ -687,8 +688,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             prePackagedConceptSetEnumList)),
                 workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
-    assertThat(code.replaceAll("[ \\s]",""))
-        .contains(expectedConceptId.replaceAll(" ",""));
+    assertThat(code.replaceAll("[ \\s]", "")).contains(expectedConceptId.replaceAll(" ", ""));
   }
 
   @Test

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -661,6 +661,29 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
+  public void testGenerateCodePrepackagedCohortSurveyBasicsAndFitbitHeartRate() {
+    addFitbitInfoToDsLinkingTable();
+    final String expectedConceptId = "concept_id IN (1586134)";// for survey_basics
+    final String expectedFitbitHrLevel = ".heart_rate_minute_level";
+    String code =
+        joinCodeCells(
+            dataSetService.generateCodeCells(
+                new DataSetExportRequest()
+                    .kernelType(KernelTypeEnum.PYTHON)
+                    .dataSetRequest(
+                        createDataSetRequest(
+                            ImmutableList.of(),
+                            ImmutableList.of(),
+                            ImmutableList.of(Domain.SURVEY, Domain.FITBIT_HEART_RATE_LEVEL),
+                            true,
+                            ImmutableList.of(PrePackagedConceptSetEnum.SURVEY_BASICS, PrePackagedConceptSetEnum.FITBIT_HEART_RATE_LEVEL))),
+                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+
+    assertThat(code.replaceAll("[ \\s]", "")).contains(expectedConceptId.replaceAll(" ", ""));
+    assertThat(code).contains(expectedFitbitHrLevel);
+  }
+
+  @Test
   public void testGenerateCodePrepackagedCohortAllIndividualSurveysExceptPfhhInOrder() {
     final ImmutableList<PrePackagedConceptSetEnum> prePackagedConceptSetEnumList =
         ImmutableList.of(

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -1691,7 +1691,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
 
   private DbConceptSet buildPrePackagedAllSurveyConceptSet() {
     final DbConceptSet surveyConceptSet = new DbConceptSet();
-    surveyConceptSet.setName("All Surveys");
+    surveyConceptSet.setName("SURVEY");
     surveyConceptSet.setDomain(DbStorageEnums.domainToStorage(Domain.SURVEY));
     return surveyConceptSet;
   }

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -1708,10 +1708,11 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
         || prePackagedConceptSet.contains(PrePackagedConceptSetEnum.BOTH)) {
       return ImmutableList.of(createSurveyDbConceptSet(SURVEY));
     }
-    List<DbConceptSet> returnList = prePackagedConceptSet.stream()
-        .filter(d-> PRE_PACKAGED_SURVEY_CONCEPT_IDS.containsKey(d))
-        .map(this::createSurveyDbConceptSet)
-        .collect(Collectors.toList());
+    List<DbConceptSet> returnList =
+        prePackagedConceptSet.stream()
+            .filter(d -> PRE_PACKAGED_SURVEY_CONCEPT_IDS.containsKey(d))
+            .map(this::createSurveyDbConceptSet)
+            .collect(Collectors.toList());
     return returnList;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -819,7 +819,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
       if (prePackagedSurveyConceptSet(dbConceptSets)) {
         surveyConceptIds.addAll(
             dbConceptSets.stream()
-                .filter(d -> d.getConceptSetId() == 0)
+                .filter(d -> d.getConceptSetId() == 0 && Domain.SURVEY.equals(d.getDomainEnum()))
                 .filter(d -> !d.getName().equals(PrePackagedConceptSetEnum.SURVEY_PFHH.toString()))
                 .map(
                     d ->
@@ -1708,9 +1708,11 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
         || prePackagedConceptSet.contains(PrePackagedConceptSetEnum.BOTH)) {
       return ImmutableList.of(createSurveyDbConceptSet(SURVEY));
     }
-    return prePackagedConceptSet.stream()
+    List<DbConceptSet> returnList = prePackagedConceptSet.stream()
+        .filter(d-> PRE_PACKAGED_SURVEY_CONCEPT_IDS.containsKey(d))
         .map(this::createSurveyDbConceptSet)
         .collect(Collectors.toList());
+    return returnList;
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -390,7 +390,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                 findDomainConceptIds(request.getDomain(), request.getConceptSetIds()));
             List<Long> prePackagedSurveyConceptIds =
                 request.getPrePackagedConceptSet().stream()
-                    .map(p -> PRE_PACKAGED_SURVEY_CONCEPT_IDS.get(p))
+                    .map(PRE_PACKAGED_SURVEY_CONCEPT_IDS::get)
                     .collect(Collectors.toList());
 
             // add selected prePackaged survey question concept ids
@@ -580,8 +580,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     final ImmutableList.Builder<DbConceptSet> selectedConceptSetsBuilder = ImmutableList.builder();
     selectedConceptSetsBuilder.addAll(initialSelectedConceptSets);
 
-    if (prePackagedConceptSet.stream()
-        .anyMatch(PRE_PACKAGED_SURVEY_CONCEPT_IDS::containsKey)
+    if (prePackagedConceptSet.stream().anyMatch(PRE_PACKAGED_SURVEY_CONCEPT_IDS::containsKey)
         || prePackagedConceptSet.contains(PrePackagedConceptSetEnum.BOTH)) {
       selectedConceptSetsBuilder.addAll(buildPrePackagedSurveyConceptSets(prePackagedConceptSet));
     } else {
@@ -1710,7 +1709,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
       return ImmutableList.of(createSurveyDbConceptSet(SURVEY));
     }
     return prePackagedConceptSet.stream()
-        .map(s -> createSurveyDbConceptSet(s))
+        .map(this::createSurveyDbConceptSet)
         .collect(Collectors.toList());
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -332,6 +332,7 @@ public class DataSetControllerTest {
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
     workbenchConfig.billing.accountId = "free-tier";
     workbenchConfig.featureFlags.enableGenomicExtraction = true;
+    workbenchConfig.featureFlags.enableDataExplorer = true;
 
     DbUser user = new DbUser();
     user.setUsername(USER_EMAIL);

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -332,7 +332,6 @@ public class DataSetControllerTest {
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
     workbenchConfig.billing.accountId = "free-tier";
     workbenchConfig.featureFlags.enableGenomicExtraction = true;
-    workbenchConfig.featureFlags.enableDataExplorer = true;
 
     DbUser user = new DbUser();
     user.setUsername(USER_EMAIL);

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -584,7 +584,7 @@ describe('DataSetPage', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(
       wrapper.find('[data-test-id="prePackage-concept-set-item"]').length
-    ).toBe(7);
+    ).toBe(15);
 
     cdrVersionTiersResponse.tiers[0].versions[0].hasWgsData = false;
     wrapper = component();
@@ -618,7 +618,7 @@ describe('DataSetPage', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(
       wrapper.find('[data-test-id="prePackage-concept-set-item"]').length
-    ).toBe(7);
+    ).toBe(15);
 
     serverConfigStore.set({
       config: { enableGenomicExtraction: false, gsuiteDomain: '' },

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -591,7 +591,7 @@ describe('DataSetPage', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(
       wrapper.find('[data-test-id="prePackage-concept-set-item"]').length
-    ).toBe(6);
+    ).toBe(14);
 
     cdrVersionTiersResponse.tiers[0].versions[0].hasFitbitData = false;
     cdrVersionTiersResponse.tiers[0].versions[0].hasWgsData = true;
@@ -599,7 +599,7 @@ describe('DataSetPage', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(
       wrapper.find('[data-test-id="prePackage-concept-set-item"]').length
-    ).toBe(3);
+    ).toBe(11);
 
     cdrVersionTiersResponse.tiers[0].versions[0].hasFitbitData = false;
     cdrVersionTiersResponse.tiers[0].versions[0].hasWgsData = false;
@@ -607,7 +607,7 @@ describe('DataSetPage', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(
       wrapper.find('[data-test-id="prePackage-concept-set-item"]').length
-    ).toBe(2);
+    ).toBe(10);
   });
 
   it('should display Pre packaged concept set per genomics extraction flag', async () => {
@@ -627,7 +627,7 @@ describe('DataSetPage', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(
       wrapper.find('[data-test-id="prePackage-concept-set-item"]').length
-    ).toBe(6);
+    ).toBe(14);
   });
 
   it('should open Export modal if Analyze is clicked and WGS concept is not selected', async () => {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -829,16 +829,14 @@ export const DatasetPage = fp.flow(
         workspace,
         cdrVersionTiersResponse
       );
-      if (serverConfigStore.get().config.enableDataExplorer) {
-        PREPACKAGED_DOMAINS = {
-          ...PREPACKAGED_DOMAINS,
-          ...PREPACKAGED_SURVEY_DOMAINS,
-        };
-        prepackagedConceptSetToString = {
-          ...prepackagedConceptSetToString,
-          ...prepackagedSurveyConceptSetToString,
-        };
-      }
+      PREPACKAGED_DOMAINS = {
+        ...PREPACKAGED_DOMAINS,
+        ...PREPACKAGED_SURVEY_DOMAINS,
+      };
+      prepackagedConceptSetToString = {
+        ...prepackagedConceptSetToString,
+        ...prepackagedSurveyConceptSetToString,
+      };
       if (hasFitbitData) {
         PREPACKAGED_DOMAINS = {
           ...PREPACKAGED_DOMAINS,


### PR DESCRIPTION
---
- Fixed bug in code when selecting individual-survey and another pre-paackaged concept set
**Bug**
- go to data set builder **Datasets**
  - Under **Select Cohorts** Select `All Participants`
  - Under **Select Concept Sets** Select `The Basics` 
- Click **CREATE DATASET**
- Click **ANALYZE**
- In the popup Click **SEE CODE PREVIEW**
Breaks with  and logs would show NullPointerException

This is fixed and works as expected:
<img width="1086" alt="image" src="https://github.com/all-of-us/workbench/assets/4452480/095ae8d8-eacc-4142-b035-1d6a618f659a">
Correct SQL is generated in the notebook:
<img width="802" alt="image" src="https://github.com/all-of-us/workbench/assets/4452480/c71626ac-c485-4931-969e-4fbb27cf8ad6">


---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
