### PR TITLE
[risk=low][RW-10592] Remove 6 researcher address fields from the WRD

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -241,12 +241,6 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "  uamt.two_factor_auth_bypass_time,\n"
                 + "  uamt.two_factor_auth_completion_time,\n"
                 + "  u.email AS username,\n"
-                + "  a.city,\n"
-                + "  a.country,\n"
-                + "  a.state,\n"
-                + "  a.street_address_1,\n"
-                + "  a.street_address_2,\n"
-                + "  a.zip_code,\n"
                 + "  via.institution_id AS institution_id,\n"
                 + "  via.institutional_role_enum,\n"
                 + "  via.institutional_role_other_text,\n"
@@ -262,7 +256,6 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "  dm.sex_at_birth,\n"
                 + "  t.access_tier_short_names\n"
                 + "FROM user u"
-                + "  LEFT OUTER JOIN address AS a ON u.user_id = a.user_id\n"
                 + "  LEFT OUTER JOIN user_verified_institutional_affiliation AS via on u.user_id = via.user_id\n"
                 + "  LEFT OUTER JOIN user_code_of_conduct_agreement AS ducc on u.user_id = ducc.user_id\n"
                 + "  LEFT OUTER JOIN "
@@ -401,12 +394,6 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                     offsetDateTimeUtc(rs.getTimestamp("two_factor_auth_completion_time")))
                 .userId(rs.getLong("user_id"))
                 .username(rs.getString("username"))
-                .city(rs.getString("city"))
-                .country(rs.getString("country"))
-                .state(rs.getString("state"))
-                .streetAddress1(rs.getString("street_address_1"))
-                .streetAddress2(rs.getString("street_address_2"))
-                .zipCode(rs.getString("zip_code"))
                 .institutionId(rs.getLong("institution_id"))
                 .institutionalRoleEnum(
                     institutionalRoleFromStorage(rs.getShort("institutional_role_enum")))

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
@@ -62,12 +62,6 @@ public enum UserColumnValueExtractor implements ColumnValueExtractor<ReportingUs
       u -> toInsertRowString(u.getTwoFactorAuthCompletionTime())),
   USER_ID("user_id", ReportingUser::getUserId),
   USERNAME("username", ReportingUser::getUsername),
-  CITY("city", ReportingUser::getCity),
-  COUNTRY("country", ReportingUser::getCountry),
-  STATE("state", ReportingUser::getState),
-  STREET_ADDRESS_1("street_address_1", ReportingUser::getStreetAddress1),
-  STREET_ADDRESS_2("street_address_2", ReportingUser::getStreetAddress2),
-  ZIP_CODE("zip_code", ReportingUser::getZipCode),
   INSTITUTION_ID("institution_id", ReportingUser::getInstitutionId),
   INSTITUTIONAL_ROLE_ENUM(
       "institutional_role_enum", u -> enumToString(u.getInstitutionalRoleEnum())),

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9910,25 +9910,6 @@ definitions:
         description: |-
           User's GSuite username, including appropriate domain for this environment. Uniquely describes a
           user account (but not constrained to be unique by BigQuery).
-      city:
-        type: string
-        description: User-reported city of residence.
-      country:
-        type: string
-        description: User-reported country of residence.
-      state:
-        type: string
-        description: User-reported state or province. Not guaranteed to match official
-          abbreviations or spellings.
-      streetAddress1:
-        type: string
-        description: First line of user street address.
-      streetAddress2:
-        type: string
-        description: Second line of user street address.
-      zipCode:
-        type: string
-        description: Up to 10-digit zip code for use residence.
       institutionId:
         type: integer
         format: int64

--- a/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
@@ -87,12 +87,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
   public static final Long USER__USER_ID = 26L;
   public static final String USER__USERNAME = "foo_27";
   // Address fields - manually renamed
-  public static final String USER__CITY = "foo_0";
-  public static final String USER__COUNTRY = "foo_1";
-  public static final String USER__STATE = "foo_2";
-  public static final String USER__STREET_ADDRESS_1 = "foo_3";
-  public static final String USER__STREET_ADDRESS_2 = "foo_4";
-  public static final String USER__ZIP_CODE = "foo_5";
   public static final Long USER__INSTITUTION_ID = 0L;
   public static final InstitutionalRole USER__INSTITUTIONAL_ROLE_ENUM =
       InstitutionalRole.UNDERGRADUATE;
@@ -216,12 +210,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
         .twoFactorAuthCompletionTime(offsetDateTimeUtc(USER__TWO_FACTOR_AUTH_COMPLETION_TIME))
         .userId(USER__USER_ID)
         .username(USER__USERNAME)
-        .city(USER__CITY)
-        .country(USER__COUNTRY)
-        .state(USER__STATE)
-        .streetAddress1(USER__STREET_ADDRESS_1)
-        .streetAddress2(USER__STREET_ADDRESS_2)
-        .zipCode(USER__ZIP_CODE)
         .institutionId(USER__INSTITUTION_ID)
         .institutionalRoleEnum(USER__INSTITUTIONAL_ROLE_ENUM)
         .institutionalRoleOtherText(USER__INSTITUTIONAL_ROLE_OTHER_TEXT)

--- a/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
@@ -86,7 +86,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
       Timestamp.from(Instant.parse("2015-05-30T00:00:00.00Z"));
   public static final Long USER__USER_ID = 26L;
   public static final String USER__USERNAME = "foo_27";
-  // Address fields - manually renamed
   public static final Long USER__INSTITUTION_ID = 0L;
   public static final InstitutionalRole USER__INSTITUTIONAL_ROLE_ENUM =
       InstitutionalRole.UNDERGRADUATE;


### PR DESCRIPTION
No downstream team needs us to send them this sensitive information about researchers, so let's stop adding it to the WRD.

We will not be dropping these fields from the BigQuery tables in the WRD (because we can't!) so it's safe to apply the API and BQ changes in any order.

BQ Terraform module change (descriptions only): https://github.com/all-of-us/workbench-terraform-modules/pull/43
TODO: terraform application in all environments

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
