### PR TITLE
[RW-10520][risk=no] Replaced Login.gov fields with Identity fields for the WRD.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -226,8 +226,9 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "  u.disabled,\n"
                 + "  uame.era_commons_bypass_time,\n"
                 + "  uame.era_commons_completion_time,\n"
-                + "  uaml.ras_login_gov_bypass_time,\n"
-                + "  uaml.ras_login_gov_completion_time,\n"
+                + "  uami.identity_bypass_time,\n"
+                + "  uami.identity_completion_time,\n"
+                + "  iv.identity_verification_system,\n"
                 + "  u.family_name,\n"
                 // temporary solution for RW-6566
                 + "  uat.first_enabled AS first_registration_completion_time,\n"
@@ -329,8 +330,9 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "      uam.completion_time AS ras_login_gov_completion_time "
                 + "    FROM user_access_module uam "
                 + "    JOIN access_module am ON am.access_module_id=uam.access_module_id "
-                + "    WHERE am.name = 'RAS_LOGIN_GOV' "
-                + "  ) uaml ON u.user_id = uaml.user_id "
+                + "    WHERE am.name = 'IDENTITY' "
+                + "  ) uami ON u.user_id = uami.user_id "
+                + "  LEFT OUTER JOIN identity_verification AS iv on u.user_id = iv.user_id\n"
                 + "  LEFT OUTER JOIN ( "
                 + "    SELECT uam.user_id, "
                 + "      uam.bypass_time AS two_factor_auth_bypass_time, "
@@ -378,10 +380,12 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 .eraCommonsBypassTime(offsetDateTimeUtc(rs.getTimestamp("era_commons_bypass_time")))
                 .eraCommonsCompletionTime(
                     offsetDateTimeUtc(rs.getTimestamp("era_commons_completion_time")))
-                .rasLoginGovBypassTime(
-                    offsetDateTimeUtc(rs.getTimestamp("ras_login_gov_bypass_time")))
-                .rasLoginGovCompletionTime(
-                    offsetDateTimeUtc(rs.getTimestamp("ras_login_gov_completion_time")))
+                .identityBypassTime(
+                    offsetDateTimeUtc(rs.getTimestamp("identity_bypass_time")))
+                .identityCompletionTime(
+                    offsetDateTimeUtc(rs.getTimestamp("identity_completion_time")))
+                .identityVerificationSystem(
+                    rs.getString("identity_verification_system"))
                 .familyName(rs.getString("family_name"))
                 .firstRegistrationCompletionTime(
                     offsetDateTimeUtc(rs.getTimestamp("first_registration_completion_time")))

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserColumnValueExtractor.java
@@ -34,10 +34,10 @@ public enum UserColumnValueExtractor implements ColumnValueExtractor<ReportingUs
       "era_commons_bypass_time", u -> toInsertRowString(u.getEraCommonsBypassTime())),
   ERA_COMMONS_COMPLETION_TIME(
       "era_commons_completion_time", u -> toInsertRowString(u.getEraCommonsCompletionTime())),
-  RAS_LOGIN_GOV_BYPASS_TIME(
-      "ras_login_gov_bypass_time", u -> toInsertRowString(u.getRasLoginGovBypassTime())),
-  RAS_LOGIN_GOV_COMPLETION_TIME(
-      "ras_login_gov_completion_time", u -> toInsertRowString(u.getRasLoginGovCompletionTime())),
+  IDENTITY_BYPASS_TIME(
+      "identity_bypass_time", u -> toInsertRowString(u.getIdentityBypassTime())),
+  IDENTITY_COMPLETION_TIME(
+      "identity_completion_time", u -> toInsertRowString(u.getIdentityBypassTime())),
   FAMILY_NAME("family_name", ReportingUser::getFamilyName),
   FIRST_REGISTRATION_COMPLETION_TIME(
       "first_registration_completion_time",

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9879,14 +9879,17 @@ definitions:
       professionalUrl:
         type: string
         description: User's URL at primary place of work.
-      rasLoginGovBypassTime:
+      identityBypassTime:
         type: string
         format: date-time
-        description: Time an administrator bypassed the RAS Login.gov requirement for this user.
-      rasLoginGovCompletionTime:
+        description: Time an administrator bypassed the identity requirement for this user.
+      identityCompletionTime:
         type: string
         format: date-time
-        description: Time user completed the RAS Login.gov account link.
+        description: Time user completed the identity requirement.
+      identityVerificationSystem:
+        type: string
+        description: The system that the user used to complete identity verification.
       twoFactorAuthBypassTime:
         type: string
         format: date-time

--- a/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
@@ -8,11 +8,11 @@ import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__DATA_USER_CODE_OF_CONDUCT_COMPLETION_TIME;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__ERA_COMMONS_BYPASS_TIME;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__ERA_COMMONS_COMPLETION_TIME;
+import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__IDENTITY_BYPASS_TIME;
+import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__IDENTITY_COMPLETION_TIME;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__INSTITUTIONAL_ROLE_ENUM;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__INSTITUTIONAL_ROLE_OTHER_TEXT;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__INSTITUTION_ID;
-import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__RAS_LOGIN_GOV_BYPASS_TIME;
-import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__RAS_LOGIN_GOV_COMPLETION_TIME;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__TWO_FACTOR_AUTH_BYPASS_TIME;
 import static org.pmiops.workbench.testconfig.fixtures.ReportingUserFixture.USER__TWO_FACTOR_AUTH_COMPLETION_TIME;
 import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
@@ -135,7 +135,7 @@ public class ReportingQueryServiceTest {
   private DbAccessModule twoFactorAuthModule;
   private DbAccessModule rtTrainingModule;
   private DbAccessModule eRACommonsModule;
-  private DbAccessModule rasLoginGovModule;
+  private DbAccessModule identityModule;
   private DbAccessModule duccModule;
 
   @BeforeEach
@@ -148,7 +148,7 @@ public class ReportingQueryServiceTest {
     rtTrainingModule =
         accessModuleDao.findOneByName(DbAccessModuleName.RT_COMPLIANCE_TRAINING).get();
     eRACommonsModule = accessModuleDao.findOneByName(DbAccessModuleName.ERA_COMMONS).get();
-    rasLoginGovModule = accessModuleDao.findOneByName(DbAccessModuleName.RAS_LOGIN_GOV).get();
+    identityModule = accessModuleDao.findOneByName(DbAccessModuleName.IDENTITY).get();
     duccModule = accessModuleDao.findOneByName(DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT).get();
   }
 
@@ -595,9 +595,9 @@ public class ReportingQueryServiceTest {
           user, eRACommonsModule, USER__ERA_COMMONS_BYPASS_TIME, USER__ERA_COMMONS_COMPLETION_TIME);
       addUserAccessModule(
           user,
-          rasLoginGovModule,
-          USER__RAS_LOGIN_GOV_BYPASS_TIME,
-          USER__RAS_LOGIN_GOV_COMPLETION_TIME);
+          identityModule,
+          USER__IDENTITY_BYPASS_TIME,
+          USER__IDENTITY_COMPLETION_TIME);
       addUserAccessModule(
           user,
           duccModule,

--- a/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/fixtures/ReportingUserFixture.java
@@ -42,10 +42,6 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
   //  type in the model class. An example of such a manual fix is the following:
   // .duccSignedVersion(USER__DATA_USER_CODE_OF_CONDUCT_SIGNED_VERSION.longValue())
 
-  // This code was generated using reporting-wizard.rb at 2020-09-23T15:56:47-04:00.
-  // Manual modification should be avoided if possible as this is a one-time generation
-  // and does not run on every build and updates must be merged manually for now.
-
   public static final String USER__AREA_OF_RESEARCH = "foo_1";
   public static final Timestamp USER__COMPLIANCE_TRAINING_BYPASS_TIME =
       Timestamp.from(Instant.parse("2015-05-07T00:00:00.00Z"));
@@ -68,9 +64,9 @@ public class ReportingUserFixture implements ReportingTestFixture<DbUser, Report
       Timestamp.from(Instant.parse("2015-05-19T00:00:00.00Z"));
   public static final Timestamp USER__ERA_COMMONS_COMPLETION_TIME =
       Timestamp.from(Instant.parse("2015-05-20T00:00:00.00Z"));
-  public static final Timestamp USER__RAS_LOGIN_GOV_BYPASS_TIME =
+  public static final Timestamp USER__IDENTITY_BYPASS_TIME =
       Timestamp.from(Instant.parse("2015-05-21T00:00:00.00Z"));
-  public static final Timestamp USER__RAS_LOGIN_GOV_COMPLETION_TIME =
+  public static final Timestamp USER__IDENTITY_COMPLETION_TIME =
       Timestamp.from(Instant.parse("2015-05-22T00:00:00.00Z"));
   public static final String USER__FAMILY_NAME = "foo_16";
   public static final Timestamp USER__FIRST_SIGN_IN_TIME =


### PR DESCRIPTION
Login.gov completion and bypass times are no longer relevant to our system. They have been replaced with equivalents for identity module plus the identity_verification_system in order to distinguish the system being called.

In the words of @jmthibault79:
We will not be dropping these fields from the BigQuery tables in the WRD (because we can't!) 

BQ Terraform module change (descriptions only): TBD
TODO: terraform application in all environments

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
