### PR TITLE
[risk=no][no ticket] Bump detachable-disk timeout to 45min and add a few timeout constants

### DIFF
--- a/e2e/app/page/notebook-preview-page.ts
+++ b/e2e/app/page/notebook-preview-page.ts
@@ -6,6 +6,7 @@ import WorkspaceAnalysisPage from './workspace-analysis-page';
 import { waitWhileLoading } from 'utils/waits-utils';
 import { initializeRuntimeIfModalPresented } from 'utils/runtime-utils';
 import { getFormattedPreviewCode, waitForPreviewCellsRendered } from 'utils/notebook-preview-utils';
+import { environmentTimeout } from 'utils/timeout-constants';
 
 const Selector = {
   editLink: '//div[contains(normalize-space(text()), "Edit")]',
@@ -40,7 +41,7 @@ export default class NotebookPreviewPage extends AuthenticatedPage {
     await initializeRuntimeIfModalPresented(this.page);
 
     // Restarting notebook server may take a while.
-    await waitWhileLoading(this.page, { timeout: 15 * 60 * 1000 });
+    await waitWhileLoading(this.page, { timeout: environmentTimeout });
 
     const notebookPage = new NotebookPage(this.page, notebookName);
     await notebookPage.waitForLoad();

--- a/e2e/app/page/workspace-analysis-page.ts
+++ b/e2e/app/page/workspace-analysis-page.ts
@@ -12,6 +12,7 @@ import { initializeRuntimeIfModalPresented } from 'utils/runtime-utils';
 import { logger } from 'libs/logger';
 import Button from 'app/element/button';
 import SelectMenu from 'app/component/select-menu';
+import { environmentTimeout } from 'utils/timeout-constants';
 
 const PageTitle = 'View Analysis Files';
 
@@ -85,8 +86,8 @@ export default class WorkspaceAnalysisPage extends WorkspaceBase {
       this.page.waitForXPath(redirectingTextsXpath, { visible: true })
     ]);
 
-    // Waiting up to 15 minutes
-    await waitWhileLoading(this.page, { timeout: 15 * 60 * 1000 });
+    // Waiting up to 15 minutes for runtime
+    await waitWhileLoading(this.page, { timeout: environmentTimeout });
     const notebook = new NotebookPage(this.page, notebookName);
     await notebook.waitForLoad();
     return notebook;

--- a/e2e/tests/nightly/detachable-disk.spec.ts
+++ b/e2e/tests/nightly/detachable-disk.spec.ts
@@ -3,8 +3,9 @@ import RuntimePanel from 'app/sidebar/runtime-panel';
 import { makeRandomName } from 'utils/str-utils';
 import { createWorkspace, signInWithAccessToken } from 'utils/test-utils';
 import path from 'path';
+import { twoRuntimesTimeout } from 'utils/timeout-constants';
 
-jest.setTimeout(30 * 60 * 1000);
+jest.setTimeout(twoRuntimesTimeout);
 
 describe('Updating runtime status', () => {
   // Notebooks to run before/after reattaching a PD.

--- a/e2e/tests/nightly/gke-apps/cromwell.spec.ts
+++ b/e2e/tests/nightly/gke-apps/cromwell.spec.ts
@@ -7,6 +7,7 @@ import WorkspaceDataPage from 'app/page/workspace-data-page';
 import { makeRandomName } from 'utils/str-utils';
 import { Language } from 'app/text-labels';
 import path from 'path';
+import { environmentTimeout } from 'utils/timeout-constants';
 
 // Cluster provisioning can take a while, so set a 20 min timeout
 jest.setTimeout(20 * 60 * 1000);
@@ -63,7 +64,7 @@ describe('Cromwell GKE App', () => {
     console.log('Cromwell status: PROVISIONING');
 
     // Poll until cromwell is running
-    await appsPanel.pollForStatus(expandedCromwellXpath, 'Running', 15 * 60e3);
+    await appsPanel.pollForStatus(expandedCromwellXpath, 'Running', environmentTimeout);
 
     // Cromwell is running, now lets delete it
     const isDeleted = await appsPanel.deleteCromwellGkeApp();
@@ -166,7 +167,7 @@ describe('Cromwell GKE App', () => {
         return cromshellJobStatus.includes('Succeeded');
       },
       20e3, // every 20 sec
-      15 * 60e3 // with a 15 min timeout
+      environmentTimeout // with a 15 min timeout
     );
 
     expect(succeededStatus).toBeTruthy();

--- a/e2e/tests/nightly/gke-apps/rstudio.spec.ts
+++ b/e2e/tests/nightly/gke-apps/rstudio.spec.ts
@@ -5,6 +5,7 @@ import { waitForFn } from 'utils/waits-utils';
 import ConfirmDeleteEnvironmentWithPdPanel from 'app/sidebar/confirm-delete-environment-with-pd-panel';
 import { SideBarLink } from 'app/text-labels';
 import RStudioConfigurationPanel from 'app/sidebar/rstudio-configuration-panel';
+import { environmentTimeout } from 'utils/timeout-constants';
 
 // Cluster provisioning can take a while, so set a 20 min timeout
 jest.setTimeout(20 * 60 * 1000);
@@ -36,7 +37,7 @@ describe('RStudio GKE App', () => {
 
     await appsPanel.pollForStatus(expandedRStudioXpath, 'PROVISIONING');
 
-    await appsPanel.pollForStatus(expandedRStudioXpath, 'Running', 15 * 60e3);
+    await appsPanel.pollForStatus(expandedRStudioXpath, 'Running', environmentTimeout);
 
     const deleteXPath = `${expandedRStudioXpath}//*[@data-test-id="RStudio-delete-button"]`;
     const deleteButton = new Button(page, deleteXPath);

--- a/e2e/utils/timeout-constants.ts
+++ b/e2e/utils/timeout-constants.ts
@@ -1,0 +1,7 @@
+const oneMinute = 60 * 1000; // in milliseconds
+
+// a timeout appropriate for environment creation
+export const environmentTimeout = 15 * oneMinute;
+
+// a timeout appropriate for tests which need to create two Jupyter runtimes but also do other things
+export const twoRuntimesTimeout = 3 * environmentTimeout;


### PR DESCRIPTION
The nightly test `nightly/detachable-disk.spec.ts` frequently times out after 30min because that's not really long enough for a test to create a Jupyter runtime twice.  Increased that test to 45 min.

Also started a new pattern for making the reasoning behind timeouts more explicit, by naming those timeouts.  Replaced a few instances of 15-min environment creation timeout with this new `environmentTimeout`

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
