### PR TITLE
[risk=low][no ticket] Add runtime creators to workspace admin page

### DIFF
--- a/ui/src/app/pages/admin/workspace/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/workspace/admin-workspace.tsx
@@ -35,6 +35,7 @@ import {
   getSelectedPopulations,
   getSelectedPrimaryPurposeItems,
 } from 'app/utils/research-purpose';
+import { getCreator } from 'app/utils/runtime-utils';
 import { MatchParams } from 'app/utils/stores';
 import { isUsingFreeTierBillingAccount } from 'app/utils/workspace-utils';
 import moment from 'moment';
@@ -479,7 +480,7 @@ export class AdminWorkspaceImpl extends React.Component<Props, State> {
                   Runtime Name
                 </PurpleLabel>
                 <PurpleLabel style={styles.narrowWithMargin}>
-                  Google Project
+                  Creator
                 </PurpleLabel>
                 <PurpleLabel style={styles.narrowWithMargin}>
                   Created Time
@@ -497,7 +498,7 @@ export class AdminWorkspaceImpl extends React.Component<Props, State> {
                     {runtime.runtimeName}
                   </div>
                   <div style={styles.narrowWithMargin}>
-                    {runtime.googleProject}
+                    {getCreator(runtime)}
                   </div>
                   <div style={styles.narrowWithMargin}>
                     {new Date(runtime.createdDate).toDateString()}

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -7,6 +7,7 @@ import {
   DiskType,
   ErrorCode,
   GpuConfig,
+  ListRuntimeResponse,
   PersistentDiskRequest,
   Runtime,
   RuntimeConfigurationType,
@@ -1279,3 +1280,6 @@ export const isVisible = (status: RuntimeStatus) =>
 // is the runtime in a state where the user can take action?
 export const isActionable = (status: RuntimeStatus) =>
   [RuntimeStatus.Running, RuntimeStatus.Stopped].includes(status);
+
+export const getCreator = (runtime: ListRuntimeResponse): string | undefined =>
+  runtime?.labels?.creator;


### PR DESCRIPTION
I was looking at a workspace for an oncall ticket where there were several users' runtimes in a workspace.  It occurred to me that it would be useful to be able to distinguish these.


Before (include redundant Google Project info)
<img width="1432" alt="Old runtimes" src="https://github.com/all-of-us/workbench/assets/2701406/4aa5f05b-8134-4928-b665-8b397f096029">


After
<img width="1433" alt="New runtimes" src="https://github.com/all-of-us/workbench/assets/2701406/ccee7d5b-0a35-4fea-a181-7061f98c921d">



---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
