### PR TITLE
[risk=low][no ticket] Remove logic for the obsolete case where Cromwell is not enabled

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -56,10 +56,8 @@ public class AppsController implements AppsApiDelegate {
     DbWorkspace dbWorkspace = workspaceService.lookupWorkspaceByNamespace(workspaceNamespace);
     workspaceAuthService.validateActiveBilling(workspaceNamespace, dbWorkspace.getFirecloudName());
     validateCanPerformApiAction(dbWorkspace);
-    if ((createAppRequest.getAppType() == AppType.RSTUDIO
-            && !configProvider.get().featureFlags.enableRStudioGKEApp)
-        || (createAppRequest.getAppType() == AppType.CROMWELL
-            && !configProvider.get().featureFlags.enableCromwellGKEApp)) {
+    if (createAppRequest.getAppType() == AppType.RSTUDIO
+        && !configProvider.get().featureFlags.enableRStudioGKEApp) {
       throw new UnsupportedOperationException("API not supported.");
     }
 

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -40,6 +40,8 @@ public interface WorkbenchConfigMapper {
 
   // handled by mapRuntimeImages()
   @Mapping(target = "runtimeImages", ignore = true)
+  // always true, soon to be removed
+  @Mapping(target = "enableCromwellGKEApp", constant = "true")
   @Mapping(target = "accessRenewalLookback", source = "config.access.renewal.lookbackPeriod")
   @Mapping(target = "gsuiteDomain", source = "config.googleDirectoryService.gSuiteDomain")
   @Mapping(target = "projectId", source = "config.server.projectId")
@@ -75,7 +77,6 @@ public interface WorkbenchConfigMapper {
   @Mapping(target = "freeTierBillingAccountId", source = "config.billing.accountId")
   @Mapping(target = "currentDuccVersions", source = "config.access.currentDuccVersions")
   @Mapping(target = "enableCaptcha", source = "config.captcha.enableCaptcha")
-  @Mapping(target = "enableCromwellGKEApp", source = "config.featureFlags.enableCromwellGKEApp")
   @Mapping(target = "enableRStudioGKEApp", source = "config.featureFlags.enableRStudioGKEApp")
   @Mapping(target = "enableDataExplorer", source = "config.featureFlags.enableDataExplorer")
   @Mapping(target = "enableTanagra", source = "config.featureFlags.enableTanagra")

--- a/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
@@ -98,8 +98,7 @@ public class AppsControllerTest {
   }
 
   @Test
-  public void testCreateAppSuccess() throws Exception {
-    config.featureFlags.enableCromwellGKEApp = true;
+  public void testCreateAppSuccess() {
     config.featureFlags.enableRStudioGKEApp = true;
 
     controller.createApp(WORKSPACE_NS, createAppRequest);
@@ -108,7 +107,6 @@ public class AppsControllerTest {
 
   @Test
   public void testCreateAppFail_validateActiveBilling() {
-    config.featureFlags.enableCromwellGKEApp = true;
     config.featureFlags.enableRStudioGKEApp = true;
 
     doThrow(ForbiddenException.class)
@@ -120,29 +118,14 @@ public class AppsControllerTest {
   }
 
   @Test
-  public void testCreateCromwellAppSuccess_featureEnabled() {
-    config.featureFlags.enableCromwellGKEApp = true;
-    config.featureFlags.enableRStudioGKEApp = true;
+  public void testCreateCromwellAppSuccess() {
     CreateAppRequest createCromwellAppRequest = new CreateAppRequest().appType(AppType.CROMWELL);
-
     controller.createApp(WORKSPACE_NS, createCromwellAppRequest);
-
     verify(mockLeonardoApiClient).createApp(createCromwellAppRequest, testWorkspace);
   }
 
   @Test
-  public void testCreateCromwellAppFail_featureNotEnabled() throws Exception {
-    config.featureFlags.enableCromwellGKEApp = false;
-    config.featureFlags.enableRStudioGKEApp = true;
-    CreateAppRequest createCromwellAppRequest = new CreateAppRequest().appType(AppType.CROMWELL);
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> controller.createApp(WORKSPACE_NS, createCromwellAppRequest));
-  }
-
-  @Test
   public void testCreateRStudioAppSuccess_featureEnabled() {
-    config.featureFlags.enableCromwellGKEApp = true;
     config.featureFlags.enableRStudioGKEApp = true;
     CreateAppRequest createRStudioAppRequest = new CreateAppRequest().appType(AppType.RSTUDIO);
 
@@ -152,8 +135,7 @@ public class AppsControllerTest {
   }
 
   @Test
-  public void testCreateRStudioAppFail_featureNotEnabled() throws Exception {
-    config.featureFlags.enableCromwellGKEApp = true;
+  public void testCreateRStudioAppFail_featureNotEnabled() {
     config.featureFlags.enableRStudioGKEApp = false;
     CreateAppRequest createRStudioAppRequest = new CreateAppRequest().appType(AppType.RSTUDIO);
     assertThrows(

--- a/ui/src/app/components/apps-panel.spec.tsx
+++ b/ui/src/app/components/apps-panel.spec.tsx
@@ -65,7 +65,7 @@ describe('AppsPanel', () => {
   const leoAppsStub = new LeoAppsApiStub();
   beforeEach(() => {
     serverConfigStore.set({
-      config: { ...defaultServerConfig, enableCromwellGKEApp: true },
+      config: defaultServerConfig,
     });
     registerApiClient(AppsApi, appsStub);
     registerApiClient(NotebooksApi, new NotebooksApiStub());
@@ -124,19 +124,13 @@ describe('AppsPanel', () => {
     expect(findAvailableApps(wrapper, false).exists()).toBeFalsy();
   });
 
-  test.each([
-    [true, true],
-    [true, false],
-    [false, true],
-    [false, false],
-  ])(
-    'should / should not show apps when the feature flags are Rstudio=%s, Cromwell=%s',
-    async (enableRStudioGKEApp, enableCromwellGKEApp) => {
+  test.each([true, false])(
+    'should / should not show apps when the RStudio feature flag is %s',
+    async (enableRStudioGKEApp) => {
       serverConfigStore.set({
         config: {
           ...defaultServerConfig,
           enableRStudioGKEApp,
-          enableCromwellGKEApp,
         },
       });
       appsStub.listAppsResponse = [];
@@ -147,9 +141,7 @@ describe('AppsPanel', () => {
       expect(findUnexpandedApp(wrapper, 'RStudio').exists()).toEqual(
         enableRStudioGKEApp
       );
-      expect(findUnexpandedApp(wrapper, 'Cromwell').exists()).toEqual(
-        enableCromwellGKEApp
-      );
+      expect(findUnexpandedApp(wrapper, 'Cromwell').exists()).toBeTruthy();
     }
   );
 });

--- a/ui/src/app/components/apps-panel.spec.tsx
+++ b/ui/src/app/components/apps-panel.spec.tsx
@@ -138,10 +138,12 @@ describe('AppsPanel', () => {
       const wrapper = await component();
       await waitOneTickAndUpdate(wrapper);
 
+      // Cromwell is always available
+      expect(findUnexpandedApp(wrapper, 'Cromwell').exists()).toBeTruthy();
+
       expect(findUnexpandedApp(wrapper, 'RStudio').exists()).toEqual(
         enableRStudioGKEApp
       );
-      expect(findUnexpandedApp(wrapper, 'Cromwell').exists()).toBeTruthy();
     }
   );
 });

--- a/ui/src/app/components/apps-panel.tsx
+++ b/ui/src/app/components/apps-panel.tsx
@@ -81,7 +81,7 @@ export const AppsPanel = (props: {
   const appsToDisplay = [
     UIAppType.JUPYTER,
     ...(config.enableRStudioGKEApp ? [UIAppType.RSTUDIO] : []),
-    ...(config.enableCromwellGKEApp ? [UIAppType.CROMWELL] : []),
+    UIAppType.CROMWELL,
   ];
 
   useEffect(() => {

--- a/ui/src/app/components/apps-panel/utils.tsx
+++ b/ui/src/app/components/apps-panel/utils.tsx
@@ -3,7 +3,6 @@ import * as fp from 'lodash/fp';
 import {
   AppStatus,
   AppType,
-  ConfigResponse,
   CreateAppRequest,
   DiskType,
   Runtime,
@@ -190,10 +189,6 @@ export const toUserEnvironmentStatusByAppType = (
   appType === UIAppType.JUPYTER
     ? fromRuntimeStatus(status as RuntimeStatus)
     : fromUserAppStatus(status as AppStatus);
-
-export const showAppsPanel = (config: ConfigResponse) => {
-  return config.enableCromwellGKEApp || config.enableRStudioGKEApp;
-};
 
 export interface AppDisplayState {
   appType: UIAppType;

--- a/ui/src/app/components/confirm-workspace-delete-modal.tsx
+++ b/ui/src/app/components/confirm-workspace-delete-modal.tsx
@@ -24,18 +24,17 @@ export const ConfirmWorkspaceDeleteModal = ({
   workspaceName,
   workspaceNamespace,
 }: ConfirmWorkspaceDeleteModalProps) => {
-  const [loading, setLoading] = useState<boolean>(false);
-  const [deleteDisabled, setDeleteDisabled] = useState<boolean>(true);
-  const [checkingForUserApps, setCheckingForUserApps] = useState<boolean>(true);
-  const [appsExistForWorkspace, setAppsExistForWorkspace] =
-    useState<boolean>(false);
+  const [loading, setLoading] = useState(false);
+  const [deleteDisabled, setDeleteDisabled] = useState(true);
+  const [checkingForUserApps, setCheckingForUserApps] = useState(true);
+  const [appsExist, setAppsExist] = useState(false);
 
   useEffect(() => {
     setCheckingForUserApps(true);
     appsApi()
       .listAppsInWorkspace(workspaceNamespace)
       .then((userApps) => {
-        setAppsExistForWorkspace(userApps?.length > 0);
+        setAppsExist(userApps?.length > 0);
         setCheckingForUserApps(false);
       })
       .finally(() => {
@@ -52,7 +51,7 @@ export const ConfirmWorkspaceDeleteModal = ({
     setDeleteDisabled(!event.toLowerCase().match('delete'));
   };
 
-  const displayUserInput = !checkingForUserApps && !appsExistForWorkspace;
+  const displayUserInput = !checkingForUserApps && !appsExist;
 
   return (
     <Modal loading={loading}>
@@ -86,7 +85,7 @@ export const ConfirmWorkspaceDeleteModal = ({
               Checking for any existing User Apps....
             </div>
           )}
-          {appsExistForWorkspace && (
+          {appsExist && (
             <WarningMessage>
               You cannot delete the workspace as there are Apps you must delete
               first
@@ -105,10 +104,7 @@ export const ConfirmWorkspaceDeleteModal = ({
         <Button
           aria-label='Confirm Delete'
           disabled={
-            loading ||
-            deleteDisabled ||
-            checkingForUserApps ||
-            appsExistForWorkspace
+            loading || deleteDisabled || checkingForUserApps || appsExist
           }
           style={{ marginLeft: '0.75rem' }}
           data-test-id='confirm-delete'

--- a/ui/src/app/components/confirm-workspace-delete-modal.tsx
+++ b/ui/src/app/components/confirm-workspace-delete-modal.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 
-import { showAppsPanel } from 'app/components/apps-panel/utils';
 import { Button } from 'app/components/buttons';
 import { TextInput } from 'app/components/inputs';
 import { WarningMessage } from 'app/components/messages';
@@ -12,7 +11,6 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { appsApi } from 'app/services/swagger-fetch-clients';
-import { serverConfigStore, useStore } from 'app/utils/stores';
 
 export interface ConfirmWorkspaceDeleteModalProps {
   closeFunction: Function;
@@ -28,26 +26,21 @@ export const ConfirmWorkspaceDeleteModal = ({
 }: ConfirmWorkspaceDeleteModalProps) => {
   const [loading, setLoading] = useState<boolean>(false);
   const [deleteDisabled, setDeleteDisabled] = useState<boolean>(true);
-  const { config } = useStore(serverConfigStore);
-  const [checkingForUserApps, setCheckingForUserApps] = useState<boolean>(
-    showAppsPanel(config)
-  );
+  const [checkingForUserApps, setCheckingForUserApps] = useState<boolean>(true);
   const [appsExistForWorkspace, setAppsExistForWorkspace] =
     useState<boolean>(false);
 
   useEffect(() => {
-    if (showAppsPanel(config)) {
-      setCheckingForUserApps(true);
-      appsApi()
-        .listAppsInWorkspace(workspaceNamespace)
-        .then((userApps) => {
-          setAppsExistForWorkspace(userApps?.length > 0);
-          setCheckingForUserApps(false);
-        })
-        .finally(() => {
-          setCheckingForUserApps(false);
-        });
-    }
+    setCheckingForUserApps(true);
+    appsApi()
+      .listAppsInWorkspace(workspaceNamespace)
+      .then((userApps) => {
+        setAppsExistForWorkspace(userApps?.length > 0);
+        setCheckingForUserApps(false);
+      })
+      .finally(() => {
+        setCheckingForUserApps(false);
+      });
   }, []);
 
   const emitDelete = () => {

--- a/ui/src/app/components/help-sidebar-icons.spec.tsx
+++ b/ui/src/app/components/help-sidebar-icons.spec.tsx
@@ -10,7 +10,6 @@ import {
   RuntimeIcon,
 } from 'app/components/help-sidebar-icons';
 import { serverConfigStore, userAppsStore } from 'app/utils/stores';
-import thunderstorm from 'assets/icons/thunderstorm-solid.svg';
 import cromwellIcon from 'assets/images/Cromwell-icon.png';
 import jupyterIcon from 'assets/images/Jupyter-icon.png';
 import rstudioIcon from 'assets/images/RStudio-icon.png';
@@ -109,22 +108,10 @@ describe('CompoundIcons', () => {
     expect(statusIndicator.exists()).toBeTruthy();
   });
 
-  test.each([
-    [true, jupyterIcon],
-    [false, thunderstorm],
-  ])('RuntimeIcon renders when appsPanel is %s', (enableAppsPanel, icon) => {
+  test('RuntimeIcon renders', () => {
     const iconId = 'runtimeConfig';
     const label = 'Jupyter Icon';
     const iconConfig = getIconConfig(iconId, label);
-
-    if (enableAppsPanel) {
-      serverConfigStore.set({
-        config: {
-          ...serverConfigStore.get().config,
-          enableCromwellGKEApp: enableAppsPanel,
-        },
-      });
-    }
 
     const wrapper = mount(
       <RuntimeIcon
@@ -134,7 +121,12 @@ describe('CompoundIcons', () => {
       />
     );
 
-    verifySidebarIcon(wrapper, `help-sidebar-icon-${iconId}`, icon, label);
+    verifySidebarIcon(
+      wrapper,
+      `help-sidebar-icon-${iconId}`,
+      jupyterIcon,
+      label
+    );
 
     const statusIndicator = wrapper.find(
       `[data-test-id="runtime-status-icon-container"]`

--- a/ui/src/app/components/help-sidebar-icons.tsx
+++ b/ui/src/app/components/help-sidebar-icons.tsx
@@ -81,6 +81,12 @@ const styles = reactStyles({
     textAlign: 'center',
     verticalAlign: 'middle',
   },
+  compoundStyle: { width: '36px', position: 'absolute' },
+  compoundContainerStyle: {
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'space-around',
+  },
 });
 
 const iconStyles = reactStyles({
@@ -133,22 +139,14 @@ const CompoundIcon = ({
   iconConfig,
   children,
 }: CompoundIconProps) => {
-  const iconStyle: CSSProperties = { width: '36px', position: 'absolute' };
-
-  const containerStyle: CSSProperties = {
-    height: '100%',
-    alignItems: 'center',
-    justifyContent: 'space-around',
-  };
-
   // For most runtime statuses (Deleting and Unknown currently excepted), we will show a small
   // overlay icon in the bottom right of the tab showing the runtime status.
   return (
-    <FlexRow style={containerStyle}>
+    <FlexRow style={styles.compoundContainerStyle}>
       <img
         src={iconPath}
         alt={iconConfig.label}
-        style={iconStyle}
+        style={styles.compoundStyle}
         data-test-id={'help-sidebar-icon-' + iconConfig.id}
       />
       {children}

--- a/ui/src/app/components/help-sidebar-icons.tsx
+++ b/ui/src/app/components/help-sidebar-icons.tsx
@@ -40,12 +40,7 @@ import moment from 'moment/moment';
 
 import { RouteLink } from './app-router';
 import { AppStatusIndicator } from './app-status-indicator';
-import {
-  appAssets,
-  findApp,
-  showAppsPanel,
-  UIAppType,
-} from './apps-panel/utils';
+import { appAssets, findApp, UIAppType } from './apps-panel/utils';
 import { FlexRow } from './flex';
 import { TooltipTrigger } from './popups';
 import { RuntimeStatusIndicator } from './runtime-status-indicator';
@@ -138,10 +133,7 @@ const CompoundIcon = ({
   iconConfig,
   children,
 }: CompoundIconProps) => {
-  const { config } = useStore(serverConfigStore);
-  const iconStyle: CSSProperties = showAppsPanel(config)
-    ? { width: '36px', position: 'absolute' }
-    : { width: '22px', position: 'absolute' };
+  const iconStyle: CSSProperties = { width: '36px', position: 'absolute' };
 
   const containerStyle: CSSProperties = {
     height: '100%',
@@ -194,11 +186,9 @@ export const RuntimeIcon = (props: {
     (aa) => aa.appType === UIAppType.JUPYTER
   );
 
-  const iconPath = showAppsPanel(config) ? jupyterAssets.icon : thunderstorm;
-
-  // We always want to show the thunderstorm or Jupyter icon.
+  // We always want to show the Jupyter icon.
   return (
-    <CompoundIcon {...{ config, iconConfig, iconPath }}>
+    <CompoundIcon {...{ config, iconConfig }} iconPath={jupyterAssets.icon}>
       <RuntimeStatusIndicator
         {...{ workspaceNamespace, userSuspended }}
         style={styles.statusIconContainer}
@@ -701,12 +691,7 @@ export const HelpSidebarIcons = (props: HelpSidebarIconsProps) => {
   );
 
   if (WorkspacePermissionsUtil.canWrite(workspace.accessLevel)) {
-    if (showAppsPanel(config)) {
-      keys.push('apps');
-    }
-    if (config.enableCromwellGKEApp) {
-      keys.push(cromwellConfigIconId);
-    }
+    keys.push('apps', cromwellConfigIconId);
     if (config.enableRStudioGKEApp) {
       keys.push(rstudioConfigIconId);
     }

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -355,7 +355,7 @@ describe('HelpSidebar', () => {
     ).toBe(0);
   });
 
-  it('should display apps icon for writable workspaces when Cromwell is enabled', async () => {
+  it('should display apps icon for writable workspaces', async () => {
     currentWorkspaceStore.next({
       ...currentWorkspaceStore.value,
       accessLevel: WorkspaceAccessLevel.WRITER,
@@ -363,50 +363,14 @@ describe('HelpSidebar', () => {
     serverConfigStore.set({
       config: {
         ...defaultServerConfig,
-        enableCromwellGKEApp: true,
         enableRStudioGKEApp: false,
       },
     });
+
     const wrapper = await component();
     expect(
       wrapper.find({ 'data-test-id': 'help-sidebar-icon-apps' }).length
     ).toBe(1);
-  });
-
-  it('should display apps icon for writable workspaces when RStudio is enabled', async () => {
-    currentWorkspaceStore.next({
-      ...currentWorkspaceStore.value,
-      accessLevel: WorkspaceAccessLevel.WRITER,
-    });
-    serverConfigStore.set({
-      config: {
-        ...defaultServerConfig,
-        enableCromwellGKEApp: false,
-        enableRStudioGKEApp: true,
-      },
-    });
-    const wrapper = await component();
-    expect(
-      wrapper.find({ 'data-test-id': 'help-sidebar-icon-apps' }).length
-    ).toBe(1);
-  });
-
-  it('should not display apps icon for writable workspaces when no apps are enabled', async () => {
-    currentWorkspaceStore.next({
-      ...currentWorkspaceStore.value,
-      accessLevel: WorkspaceAccessLevel.WRITER,
-    });
-    serverConfigStore.set({
-      config: {
-        ...defaultServerConfig,
-        enableCromwellGKEApp: false,
-        enableRStudioGKEApp: false,
-      },
-    });
-    const wrapper = await component();
-    expect(
-      wrapper.find({ 'data-test-id': 'help-sidebar-icon-apps' }).length
-    ).toBe(0);
   });
 
   it('should display dynamic runtime status icon', async () => {
@@ -652,22 +616,9 @@ describe('HelpSidebar', () => {
     expect(wrapper.text()).toContain('Cromwell Cloud Environment');
   });
 
-  it('should not show the Cromwell icon if Cromwell is disabled', async () => {
-    serverConfigStore.set({
-      config: { ...defaultServerConfig, enableCromwellGKEApp: false },
-    });
-    const wrapper = await component();
-
-    expect(
-      wrapper
-        .find({ 'data-test-id': 'help-sidebar-icon-cromwellConfig' })
-        .exists()
-    ).toBeFalsy();
-  });
-
   it('should open the Cromwell config panel after clicking the Cromwell icon', async () => {
     serverConfigStore.set({
-      config: { ...defaultServerConfig, enableCromwellGKEApp: true },
+      config: defaultServerConfig,
     });
     const wrapper = await component();
 

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -617,9 +617,6 @@ describe('HelpSidebar', () => {
   });
 
   it('should open the Cromwell config panel after clicking the Cromwell icon', async () => {
-    serverConfigStore.set({
-      config: defaultServerConfig,
-    });
     const wrapper = await component();
 
     const cromwellIcon = wrapper.find({

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -74,7 +74,6 @@ const defaultServerConfig: ConfigResponse = {
   freeTierBillingAccountId: 'freetier',
   accessModules: defaultAccessModuleConfig,
   currentDuccVersions: [3, 4],
-  // enableCromwellGKEApp: true,
   enableRStudioGKEApp: true,
 };
 

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -74,7 +74,7 @@ const defaultServerConfig: ConfigResponse = {
   freeTierBillingAccountId: 'freetier',
   accessModules: defaultAccessModuleConfig,
   currentDuccVersions: [3, 4],
-  enableCromwellGKEApp: true,
+  // enableCromwellGKEApp: true,
   enableRStudioGKEApp: true,
 };
 


### PR DESCRIPTION
One step in removing the `enableCromwellGKEApp` feature flag which is now always true: remove logic where it is set to false.

Tested by running locally with no obvious problems.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [x] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
