### PR TITLE
[risk=low][RW-9416][RW-9754] Set enableRStudioGKEApp and showNewAnalysisTab to true in Preprod

### DIFF
--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -118,7 +118,7 @@
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": true,
     "enableCromwellGKEApp": true,
-    "enableRStudioGKEApp": false,
+    "enableRStudioGKEApp": true,
     "enableDataExplorer": false,
     "enableTanagra": false
   },

--- a/ui/src/environments/environment.preprod.ts
+++ b/ui/src/environments/environment.preprod.ts
@@ -18,5 +18,5 @@ export const environment: Environment = {
   inactivityTimeoutSeconds: 30 * 60,
   inactivityWarningBeforeSeconds: 5 * 60,
   allowTestAccessTokenOverride: false,
-  showNewAnalysisTab: false,
+  showNewAnalysisTab: true,
 };


### PR DESCRIPTION
This will launch RStudio and the new analysis tab in Preprod when it's included in a release.

No changes will be made to Prod.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
