### PR TITLE
[RW-10520][risk=no] Updated reporting to not handle deleted workspaces.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -510,7 +510,8 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
 
   @Override
   public int getWorkspacesCount() {
-    return jdbcTemplate.queryForObject("SELECT count(*) FROM workspace WHERE active_status = 0", Integer.class);
+    return jdbcTemplate.queryForObject(
+        "SELECT count(*) FROM workspace WHERE active_status = 0", Integer.class);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -10,6 +10,7 @@ import static org.pmiops.workbench.db.model.DbStorageEnums.institutionalRoleFrom
 import static org.pmiops.workbench.db.model.DbStorageEnums.organizationTypeFromStorage;
 import static org.pmiops.workbench.db.model.DbStorageEnums.raceFromStorage;
 import static org.pmiops.workbench.db.model.DbStorageEnums.sexAtBirthFromStorage;
+import static org.pmiops.workbench.db.model.DbStorageEnums.workspaceActiveStatusToStorage;
 import static org.pmiops.workbench.utils.mappers.CommonMappers.offsetDateTimeUtc;
 import static org.pmiops.workbench.workspaces.WorkspaceUtils.getBillingAccountType;
 
@@ -464,7 +465,7 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "  JOIN cdr_version c ON w.cdr_version_id = c.cdr_version_id\n"
                 + "  JOIN access_tier a ON c.access_tier = a.access_tier_id\n"
                 + "WHERE active_status = "
-                + WorkspaceActiveStatus.ACTIVE.ordinal()
+                + workspaceActiveStatusToStorage(WorkspaceActiveStatus.ACTIVE)
                 + "\n"
                 + "ORDER BY workspace_id\n"
                 + "LIMIT %d\n"
@@ -516,7 +517,7 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
   public int getWorkspacesCount() {
     return jdbcTemplate.queryForObject(
         "SELECT count(*) FROM workspace WHERE active_status = "
-            + WorkspaceActiveStatus.ACTIVE.ordinal(),
+            + workspaceActiveStatusToStorage(WorkspaceActiveStatus.ACTIVE),
         Integer.class);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -33,6 +33,7 @@ import org.pmiops.workbench.model.ReportingNewUserSatisfactionSurvey;
 import org.pmiops.workbench.model.ReportingUser;
 import org.pmiops.workbench.model.ReportingWorkspace;
 import org.pmiops.workbench.model.ReportingWorkspaceFreeTierUsage;
+import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
@@ -462,11 +463,14 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "FROM workspace w\n"
                 + "  JOIN cdr_version c ON w.cdr_version_id = c.cdr_version_id\n"
                 + "  JOIN access_tier a ON c.access_tier = a.access_tier_id\n"
-                + "WHERE active_status = 0\n"
+                + "WHERE active_status = "
+                + WorkspaceActiveStatus.ACTIVE.ordinal()
+                + "\n"
                 + "ORDER BY workspace_id\n"
                 + "LIMIT %d\n"
                 + "OFFSET %d",
-            limit, offset),
+            limit,
+            offset),
         (rs, unused) ->
             new ReportingWorkspace()
                 .accessTierShortName(rs.getString("access_tier_short_name"))
@@ -511,7 +515,9 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
   @Override
   public int getWorkspacesCount() {
     return jdbcTemplate.queryForObject(
-        "SELECT count(*) FROM workspace WHERE active_status = 0", Integer.class);
+        "SELECT count(*) FROM workspace WHERE active_status = "
+            + WorkspaceActiveStatus.ACTIVE.ordinal(),
+        Integer.class);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -462,6 +462,7 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "FROM workspace w\n"
                 + "  JOIN cdr_version c ON w.cdr_version_id = c.cdr_version_id\n"
                 + "  JOIN access_tier a ON c.access_tier = a.access_tier_id\n"
+                + "WHERE active_status = 0\n"
                 + "ORDER BY workspace_id\n"
                 + "LIMIT %d\n"
                 + "OFFSET %d",
@@ -509,7 +510,7 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
 
   @Override
   public int getWorkspacesCount() {
-    return jdbcTemplate.queryForObject("SELECT count(*) FROM workspace", Integer.class);
+    return jdbcTemplate.queryForObject("SELECT count(*) FROM workspace WHERE active_status = 0", Integer.class);
   }
 
   @Override

--- a/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
@@ -342,11 +342,12 @@ public class ReportingQueryServiceTest {
   public void testWorkspaceIteratorStream_withDeleted() {
     final int numWorkspaces = 5;
     List<DbWorkspace> workspaces = createWorkspaces(numWorkspaces);
-    workspaceDao.save(workspaces.get(0).setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED));
+    workspaceDao.save(
+        workspaces.get(0).setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED));
     entityManager.flush();
 
     final int totalRows = reportingQueryService.getWorkspacesStream().mapToInt(List::size).sum();
-    assertThat(totalRows).isEqualTo(numWorkspaces-1);
+    assertThat(totalRows).isEqualTo(numWorkspaces - 1);
 
     final long totalBatches = reportingQueryService.getWorkspacesStream().count();
     assertThat(totalBatches).isEqualTo((long) Math.ceil(1.0 * numWorkspaces / BATCH_SIZE));
@@ -358,7 +359,7 @@ public class ReportingQueryServiceTest {
             .flatMap(List::stream)
             .map(ReportingWorkspace::getWorkspaceId)
             .collect(ImmutableSet.toImmutableSet());
-    assertThat(ids).hasSize(numWorkspaces-1);
+    assertThat(ids).hasSize(numWorkspaces - 1);
   }
 
   @Test
@@ -380,7 +381,8 @@ public class ReportingQueryServiceTest {
   @Test
   public void testWorkspaceCount_withDeleted() {
     List<DbWorkspace> workspaces = createWorkspaces(5);
-    workspaceDao.save(workspaces.get(0).setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED));
+    workspaceDao.save(
+        workspaces.get(0).setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED));
     entityManager.flush();
     assertThat(reportingQueryService.getWorkspacesCount()).isEqualTo(4);
   }


### PR DESCRIPTION
The reporting cron for testing has not been running, because it has been taking too long. In an attempt at addressing this, I am changing our workspace reporting to only contain workspaces that are active (not deleted).

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
