### PR TITLE
[DT-298][risk=no] Update style, navigation for Tanagra iframe

### DIFF
--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4564,6 +4564,7 @@ definitions:
     - name
     - accessTierShortName
     - creationTime
+    - bigqueryDataset
     properties:
       cdrVersionId:
         type: string
@@ -4589,6 +4590,8 @@ definitions:
         type: boolean
       hasSurveyConductData:
         type: boolean
+      bigqueryDataset:
+        type: string
   DomainCard:
     type: object
     required:

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
     "build-terra-deps": "./src/terraui/build.sh",
     "deps": "yarn run codegen && yarn run build-terra-deps",
     "start": "BROWSER='none' PORT=4200 react-app-rewired start",
-    "start-tanagra": "npm install --prefix ../tanagra/ui && npm run codegen --prefix ../tanagra/ui && BROWSER='none' npm start --prefix ../tanagra/ui",
+    "start-tanagra": "npm install --prefix ../tanagra/ui && npm run codegen --prefix ../tanagra/ui && BROWSER='none' REACT_APP_POST_MESSAGE_ORIGIN=http://localhost:4200 npm start --prefix ../tanagra/ui",
     "dev-up": "yarn && yarn run deps && yarn start",
     "dev-up-test": "yarn && yarn run deps && REACT_APP_ENVIRONMENT=localtest yarn start",
     "dev-up-local": "yarn && yarn run deps && REACT_APP_ENVIRONMENT=local yarn start",

--- a/ui/src/app/pages/tanagra-dev/tanagra-dev.tsx
+++ b/ui/src/app/pages/tanagra-dev/tanagra-dev.tsx
@@ -1,30 +1,83 @@
 import * as React from 'react';
 
+import { Button } from 'app/components/buttons';
+import { SpinnerOverlay } from 'app/components/spinners';
 import { withSpinnerOverlay } from 'app/components/with-spinner-overlay';
 
-const { useEffect } = React;
+const { useCallback, useEffect, useState } = React;
+
+const tanagraUrl = 'http://localhost:3000';
+
+export function useExitActionListener(callback: () => void) {
+  const listener = useCallback(
+    (event: MessageEvent) => {
+      if (
+        event.origin !== tanagraUrl ||
+        typeof event.data !== 'object' ||
+        event.data.message !== 'CLOSE'
+      ) {
+        return;
+      }
+      callback();
+    },
+    [callback]
+  );
+
+  useEffect(() => {
+    window.addEventListener('message', listener);
+    return () => {
+      window.removeEventListener('message', listener);
+    };
+  }, [listener]);
+}
 
 export const TanagraDev = withSpinnerOverlay()(({ hideSpinner }) => {
+  const [loadingIframe, setLoadingIframe] = useState(false);
+  const [showIframe, setShowIframe] = useState(false);
   useEffect(() => {
     hideSpinner();
   }, []);
 
-  return (
+  useExitActionListener(() => {
+    setShowIframe(false);
+  });
+
+  // Temporary variable to hardcode existing study ids until we have a link between workspaces and studies
+  const studyId =
+    process.env.REACT_APP_ENVIRONMENT === 'local' ? 'tqmXfZ4qzu' : 'UslvvbIYxk';
+
+  return showIframe ? (
     <div
       style={{
-        height: '25rem',
-        margin: '2rem auto',
-        width: '98%',
+        height: '95vh',
       }}
     >
+      {loadingIframe && <SpinnerOverlay />}
       <iframe
+        onLoad={() => setLoadingIframe(false)}
         style={{
           border: 0,
           height: '100%',
           width: '100%',
         }}
-        src='http://localhost:3000/#/'
+        src={`${tanagraUrl}/#/tanagra/underlays/SR2022Q4R6/studies/${studyId}/export`}
       />
+    </div>
+  ) : (
+    <div style={{ padding: '2rem' }}>
+      <div style={{ marginBottom: '1rem' }}>
+        This is a temporary interface to demonstrate the transition from the
+        Workbench to Tanagra and back. This transition will eventually take
+        place on the Data tab page.
+      </div>
+      <Button
+        onClick={() => {
+          setLoadingIframe(true);
+          setShowIframe(true);
+        }}
+      >
+        Show Tanagra iframe
+      </Button>
     </div>
   );
 });

--- a/ui/src/app/pages/tanagra-dev/tanagra-dev.tsx
+++ b/ui/src/app/pages/tanagra-dev/tanagra-dev.tsx
@@ -7,7 +7,6 @@ import { serverConfigStore } from 'app/utils/stores';
 
 const { useCallback, useEffect, useState } = React;
 
-
 export function useExitActionListener(callback: () => void) {
   const listener = useCallback(
     (event: MessageEvent) => {
@@ -69,8 +68,8 @@ export const TanagraDev = withSpinnerOverlay()(({ hideSpinner }) => {
     <div style={{ padding: '2rem' }}>
       <div style={{ marginBottom: '1rem' }}>
         This is a temporary interface to demonstrate the transition from the
-        Workbench to the Tanagra iframe and back. This transition will eventually take
-        place on the Data tab page.
+        Workbench to the Tanagra iframe and back. This transition will
+        eventually take place on the Data tab page.
       </div>
       <Button
         onClick={() => {

--- a/ui/src/app/pages/tanagra-dev/tanagra-dev.tsx
+++ b/ui/src/app/pages/tanagra-dev/tanagra-dev.tsx
@@ -7,11 +7,11 @@ import { serverConfigStore } from 'app/utils/stores';
 
 const { useCallback, useEffect, useState } = React;
 
-const tanagraUrl = serverConfigStore.get().config.tanagraBaseUrl;
 
 export function useExitActionListener(callback: () => void) {
   const listener = useCallback(
     (event: MessageEvent) => {
+      const tanagraUrl = serverConfigStore.get().config.tanagraBaseUrl;
       if (
         event.origin !== tanagraUrl ||
         typeof event.data !== 'object' ||
@@ -47,6 +47,7 @@ export const TanagraDev = withSpinnerOverlay()(({ hideSpinner }) => {
   const studyId =
     process.env.REACT_APP_ENVIRONMENT === 'local' ? 'tqmXfZ4qzu' : 'UslvvbIYxk';
 
+  const tanagraUrl = serverConfigStore.get().config.tanagraBaseUrl;
   return showIframe ? (
     <div
       style={{

--- a/ui/src/app/pages/tanagra-dev/tanagra-dev.tsx
+++ b/ui/src/app/pages/tanagra-dev/tanagra-dev.tsx
@@ -3,10 +3,11 @@ import * as React from 'react';
 import { Button } from 'app/components/buttons';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { withSpinnerOverlay } from 'app/components/with-spinner-overlay';
+import { serverConfigStore } from 'app/utils/stores';
 
 const { useCallback, useEffect, useState } = React;
 
-const tanagraUrl = 'http://localhost:3000';
+const tanagraUrl = serverConfigStore.get().config.tanagraBaseUrl;
 
 export function useExitActionListener(callback: () => void) {
   const listener = useCallback(
@@ -67,7 +68,7 @@ export const TanagraDev = withSpinnerOverlay()(({ hideSpinner }) => {
     <div style={{ padding: '2rem' }}>
       <div style={{ marginBottom: '1rem' }}>
         This is a temporary interface to demonstrate the transition from the
-        Workbench to Tanagra and back. This transition will eventually take
+        Workbench to the Tanagra iframe and back. This transition will eventually take
         place on the Data tab page.
       </div>
       <Button

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -75,6 +75,7 @@ const defaultServerConfig: ConfigResponse = {
   accessModules: defaultAccessModuleConfig,
   currentDuccVersions: [3, 4],
   enableRStudioGKEApp: true,
+  tanagraBaseUrl: 'https://aou-tanagra.dev.pmi-ops.org',
 };
 
 export default defaultServerConfig;

--- a/ui/src/testing/stubs/cdr-versions-api-stub.ts
+++ b/ui/src/testing/stubs/cdr-versions-api-stub.ts
@@ -39,6 +39,7 @@ export const cdrVersionTiersResponse: CdrVersionTiersResponse = {
           hasFitbitSleepData: false,
           hasWgsData: true,
           creationTime: 0,
+          bigqueryDataset: '',
         },
         {
           name: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION,
@@ -49,6 +50,7 @@ export const cdrVersionTiersResponse: CdrVersionTiersResponse = {
           hasFitbitSleepData: false,
           hasWgsData: false,
           creationTime: 0,
+          bigqueryDataset: '',
         },
       ],
     },
@@ -68,6 +70,7 @@ export const cdrVersionTiersResponse: CdrVersionTiersResponse = {
           hasFitbitSleepData: false,
           hasWgsData: true,
           creationTime: 0,
+          bigqueryDataset: '',
         },
       ],
     },


### PR DESCRIPTION
- Listen for events from `postMessage` api to hide Tanagra iframe
- Get correct Tanagra url from `serverConfigStore`
- Update iframe styles for a smoother transition to and from the workbench
- Add property `bigqueryDataset` to the `CdrVersion` object in `CdrVersionTiersResponse` to use as the Tanagra underlay

https://github.com/all-of-us/workbench/assets/40036095/908df294-25aa-4011-9fa6-00871d6ab259

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
