### PR TITLE
[risk=low][no ticket] Fully remove enableResearchReviewPrompt and needsReviewPrompt

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -113,7 +113,6 @@
   "featureFlags": {
     "unsafeAllowDeleteUser": true,
     "enableEventDateModifier": false,
-    "enableResearchPurposePrompt": false,
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableRStudioGKEApp": true,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -113,7 +113,6 @@
   "featureFlags": {
     "unsafeAllowDeleteUser": false,
     "enableEventDateModifier": false,
-    "enableResearchPurposePrompt": false,
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": true,
     "enableRStudioGKEApp": true,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -113,7 +113,6 @@
   "featureFlags": {
     "unsafeAllowDeleteUser": false,
     "enableEventDateModifier": false,
-    "enableResearchPurposePrompt": false,
     "enablePrivateDataprocWorker": false,
     "ccSupportWhenAdminLocking": true,
     "enableRStudioGKEApp": false,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -113,7 +113,6 @@
   "featureFlags": {
     "unsafeAllowDeleteUser": false,
     "enableEventDateModifier": false,
-    "enableResearchPurposePrompt": false,
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableRStudioGKEApp": false,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -113,7 +113,6 @@
   "featureFlags": {
     "unsafeAllowDeleteUser": false,
     "enableEventDateModifier": false,
-    "enableResearchPurposePrompt": false,
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableRStudioGKEApp": true,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -113,7 +113,6 @@
   "featureFlags": {
     "unsafeAllowDeleteUser": true,
     "enableEventDateModifier": false,
-    "enableResearchPurposePrompt": false,
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableRStudioGKEApp": true,

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -313,11 +313,6 @@ public class WorkbenchConfig {
     public boolean unsafeAllowDeleteUser;
     // Flag to indicate whether to show the Event Date modifier in cohort builder
     public boolean enableEventDateModifier;
-    // DEPRECATED - now always false
-    // Flag to indicate whether to show the Update Research Purpose prompt one year after
-    // workspace creation
-    @Deprecated(forRemoval = true)
-    public boolean enableResearchPurposePrompt;
     // If true, ask Leo to set dataproc worker VMs not having internet access.
     public boolean enablePrivateDataprocWorker;
     // If true, copy the support staff when sending Admin Locking emails.

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -38,9 +38,6 @@ public interface WorkbenchConfigMapper {
 
   AccessModuleConfig mapAccessModule(DbAccessModule accessModule);
 
-  // false in all environments: hard-code for imminent deletion
-  @Mapping(target = "enableResearchReviewPrompt", constant = "false")
-
   // handled by mapRuntimeImages()
   @Mapping(target = "runtimeImages", ignore = true)
   @Mapping(target = "accessRenewalLookback", source = "config.access.renewal.lookbackPeriod")

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -101,8 +101,6 @@ public interface WorkspaceMapper {
         .collect(Collectors.toList());
   }
 
-  // always false: hard-code for imminent deletion
-  @Mapping(target = "needsReviewPrompt", constant = "false")
   @Mapping(target = "timeReviewed", ignore = true)
   @Mapping(target = "populationDetails", source = "specificPopulationsEnum")
   @Mapping(target = "researchOutcomeList", source = "researchOutcomeEnumSet")

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4836,10 +4836,6 @@ definitions:
         type: boolean
         default: false
         description: Whether to show the Event Date modifier in cohort builder
-      enableResearchReviewPrompt:
-        type: boolean
-        default: false
-        description: Whether user should see a prompt if Workspace Research Purpose needs Review
       enableRasIdMeLinking:
         type: boolean
         default: false
@@ -5437,9 +5433,6 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/ResearchOutcomeEnum"
-      needsReviewPrompt:
-        type: boolean
-        default: false
   SpecificPopulationEnum:
     type: string
     description: Short parsable descriptions of specific population categories


### PR DESCRIPTION
Remove all code references to 
* FF enableResearchPurposePrompt (API) / enableResearchReviewPrompt (UI)
* workspace.needsReviewPrompt

#7874 has been released, so we can now merge this.  Tested locally by updating a workspace.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
