### PR TITLE
[DT-467][risk=no] Adding Tanagra API call to save a study after an AoU workspace is created

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -193,7 +193,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     final Workspace createdWorkspace = workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace);
     workspaceAuditor.fireCreateAction(createdWorkspace, dbWorkspace.getWorkspaceId());
 
-    if (!cdrVersion.getTanagraEnabled()) {
+    if (cdrVersion.getTanagraEnabled()) {
       try {
         workspaceService.createTanagraStudy(
             createdWorkspace.getNamespace(), createdWorkspace.getName());

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -193,12 +193,17 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     final Workspace createdWorkspace = workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace);
     workspaceAuditor.fireCreateAction(createdWorkspace, dbWorkspace.getWorkspaceId());
 
-    if (cdrVersion.getTanagraEnabled()) {
+    if (!cdrVersion.getTanagraEnabled()) {
       try {
         workspaceService.createTanagraStudy(
             createdWorkspace.getNamespace(), createdWorkspace.getName());
       } catch (Exception e) {
-        log.log(Level.SEVERE, "Could not create a Tanagra Study.", e);
+        log.log(
+            Level.SEVERE,
+            String.format(
+                "Could not create a Tanagra study for workspace namespace: %s, name: %s",
+                createdWorkspace.getNamespace(), createdWorkspace.getName()),
+            e);
       }
     }
     return ResponseEntity.ok(createdWorkspace);

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -195,7 +195,8 @@ public class WorkspacesController implements WorkspacesApiDelegate {
 
     if (cdrVersion.getTanagraEnabled()) {
       try {
-        workspaceService.createTanagraStudy(createdWorkspace.getNamespace(), createdWorkspace.getName());
+        workspaceService.createTanagraStudy(
+            createdWorkspace.getNamespace(), createdWorkspace.getName());
       } catch (Exception e) {
         log.log(Level.SEVERE, "Could not create a Tanagra Study.", e);
       }

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -193,10 +193,12 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     final Workspace createdWorkspace = workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace);
     workspaceAuditor.fireCreateAction(createdWorkspace, dbWorkspace.getWorkspaceId());
 
-    try {
-      workspaceService.createTanagraStudy(createdWorkspace.getNamespace(), createdWorkspace.getName());
-    } catch (Exception e) {
-      log.log(Level.SEVERE, "Could not create a Tanagra Study.", e);
+    if (cdrVersion.getTanagraEnabled()) {
+      try {
+        workspaceService.createTanagraStudy(createdWorkspace.getNamespace(), createdWorkspace.getName());
+      } catch (Exception e) {
+        log.log(Level.SEVERE, "Could not create a Tanagra Study.", e);
+      }
     }
     return ResponseEntity.ok(createdWorkspace);
   }

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -192,6 +192,12 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     }
     final Workspace createdWorkspace = workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace);
     workspaceAuditor.fireCreateAction(createdWorkspace, dbWorkspace.getWorkspaceId());
+
+    try {
+      workspaceService.createTanagraStudy(createdWorkspace.getNamespace(), createdWorkspace.getName());
+    } catch (Exception e) {
+      log.log(Level.SEVERE, "Could not create a Tanagra Study.", e);
+    }
     return ResponseEntity.ok(createdWorkspace);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/tanagra/TanagraConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/tanagra/TanagraConfig.java
@@ -5,6 +5,7 @@ import org.pmiops.workbench.tanagra.api.TanagraApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.context.annotation.RequestScope;
 
 @Configuration
@@ -16,6 +17,7 @@ public class TanagraConfig {
     TanagraApi api = new TanagraApi();
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(workbenchConfig.tanagra.baseUrl);
+    apiClient.setApiKey("Bearer " + SecurityContextHolder.getContext().getAuthentication().getCredentials().toString());
     api.setApiClient(apiClient);
     return api;
   }

--- a/api/src/main/java/org/pmiops/workbench/tanagra/TanagraConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/tanagra/TanagraConfig.java
@@ -17,7 +17,9 @@ public class TanagraConfig {
     TanagraApi api = new TanagraApi();
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(workbenchConfig.tanagra.baseUrl);
-    apiClient.setApiKey("Bearer " + SecurityContextHolder.getContext().getAuthentication().getCredentials().toString());
+    apiClient.setApiKey(
+        "Bearer "
+            + SecurityContextHolder.getContext().getAuthentication().getCredentials().toString());
     api.setApiClient(apiClient);
     return api;
   }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -7,6 +7,8 @@ import org.pmiops.workbench.db.model.DbUserRecentWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.model.WorkspaceResponse;
+import org.pmiops.workbench.tanagra.ApiException;
+import org.pmiops.workbench.tanagra.model.Study;
 
 /*
  * WorkspaceService is primarily an interface for coordinating the three Workspace models.
@@ -58,4 +60,10 @@ public interface WorkspaceService {
   Map<String, DbWorkspace> getWorkspacesByGoogleProject(Set<String> keySet);
 
   DbWorkspace lookupWorkspaceByNamespace(String workspaceNamespace);
+
+  /**
+   * This call will create a Study in the Tanagra application. A Tanagra Study is equivalent to a
+   * AoU workspace.
+   */
+  Study createTanagraStudy(String workspaceNamespace, String workspaceName) throws ApiException;
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceFakeImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceFakeImpl.java
@@ -76,7 +76,8 @@ public class WorkspaceServiceFakeImpl implements WorkspaceService {
   }
 
   @Override
-  public Study createTanagraStudy(String workspaceNamespace, String workspaceName) throws ApiException {
+  public Study createTanagraStudy(String workspaceNamespace, String workspaceName)
+      throws ApiException {
     return null;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceFakeImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceFakeImpl.java
@@ -8,6 +8,8 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.model.WorkspaceResponse;
+import org.pmiops.workbench.tanagra.ApiException;
+import org.pmiops.workbench.tanagra.model.Study;
 
 public class WorkspaceServiceFakeImpl implements WorkspaceService {
 
@@ -70,6 +72,11 @@ public class WorkspaceServiceFakeImpl implements WorkspaceService {
   @Override
   public DbWorkspace lookupWorkspaceByNamespace(String workspaceNamespace)
       throws NotFoundException {
+    return null;
+  }
+
+  @Override
+  public Study createTanagraStudy(String workspaceNamespace, String workspaceName) throws ApiException {
     return null;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -54,10 +54,15 @@ import org.pmiops.workbench.monitoring.views.GaugeMetric;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessEntry;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceDetails;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceResponse;
+import org.pmiops.workbench.tanagra.ApiException;
+import org.pmiops.workbench.tanagra.api.TanagraApi;
+import org.pmiops.workbench.tanagra.model.Study;
+import org.pmiops.workbench.tanagra.model.StudyCreateInfo;
 import org.pmiops.workbench.utils.mappers.FirecloudMapper;
 import org.pmiops.workbench.utils.mappers.UserMapper;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -91,6 +96,7 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
   private final WorkspaceDao workspaceDao;
   private final WorkspaceMapper workspaceMapper;
   private final WorkspaceAuthService workspaceAuthService;
+  private final Provider<TanagraApi> tanagraApiProvider;
 
   @Autowired
   public WorkspaceServiceImpl(
@@ -111,7 +117,8 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
       UserRecentWorkspaceDao userRecentWorkspaceDao,
       WorkspaceDao workspaceDao,
       WorkspaceMapper workspaceMapper,
-      WorkspaceAuthService workspaceAuthService) {
+      WorkspaceAuthService workspaceAuthService,
+      Provider<TanagraApi> tanagraApiProvider) {
     this.accessTierService = accessTierService;
     this.cloudBillingClient = cloudBillingClient;
     this.billingProjectAuditor = billingProjectAuditor;
@@ -130,6 +137,7 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
     this.workspaceDao = workspaceDao;
     this.workspaceMapper = workspaceMapper;
     this.workspaceAuthService = workspaceAuthService;
+    this.tanagraApiProvider = tanagraApiProvider;
   }
 
   @Override
@@ -469,5 +477,12 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
     return workspaceDao
         .getByNamespace(workspaceNamespace)
         .orElseThrow(() -> new NotFoundException("Workspace not found: " + workspaceNamespace));
+  }
+
+  @Override
+  public Study createTanagraStudy(String workspaceNamespace, String workspaceName) throws ApiException {
+    StudyCreateInfo studyCreateInfo =
+        new StudyCreateInfo().displayName(workspaceName);
+    return tanagraApiProvider.get().createStudy(studyCreateInfo);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -62,7 +62,6 @@ import org.pmiops.workbench.utils.mappers.FirecloudMapper;
 import org.pmiops.workbench.utils.mappers.UserMapper;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -480,9 +479,9 @@ public class WorkspaceServiceImpl implements WorkspaceService, GaugeDataCollecto
   }
 
   @Override
-  public Study createTanagraStudy(String workspaceNamespace, String workspaceName) throws ApiException {
-    StudyCreateInfo studyCreateInfo =
-        new StudyCreateInfo().displayName(workspaceName);
+  public Study createTanagraStudy(String workspaceNamespace, String workspaceName)
+      throws ApiException {
+    StudyCreateInfo studyCreateInfo = new StudyCreateInfo().displayName(workspaceName);
     return tanagraApiProvider.get().createStudy(studyCreateInfo);
   }
 }

--- a/api/src/main/resources/tanagra.yaml
+++ b/api/src/main/resources/tanagra.yaml
@@ -23,13 +23,12 @@ paths:
         - Tanagra
       summary: Save a Study(equivalent to AoU workspace) in Tanagra.
       operationId: createStudy
-      parameters:
-        - in: body
-          description: Format of the response which will be json for AoU
-          name: body
-          required: true
-          schema:
-            $ref: '#/components/schemas/StudyCreateInfo'
+      requestBody:
+        description: Format of the response which will be json for AoU
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StudyCreateInfo'
       responses:
         200:
           description: Newly created Study / Error response
@@ -42,13 +41,18 @@ paths:
 ## COMPONENTS
 ##########################################################################################
 components:
+  securitySchemes:
+    oauth:
+      type: apiKey
+      in: header
+      name: Authorization
   schemas:
     StudyCreateInfo:
       type: object
       properties:
         id:
           type: string
-          description: Unique identifier for this studay
+          description: Unique identifier for this study
         displayName:
           type: string
           description: Human readable name of the study
@@ -71,3 +75,5 @@ components:
         lastModified:
           type: string
           format: date-time
+security:
+  - oauth: []


### PR DESCRIPTION
Adding Tanagra API call to save a study after an AoU workspace is created. 

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
