### PR TITLE
[risk=low][no ticket] rm references to constant config/FFs in rdrExport

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -32,8 +32,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class TaskQueueService {
   private static final String BASE_PATH = "/v1/cloudTask";
-  private static final String EXPORT_RESEARCHER_PATH = BASE_PATH + "/exportResearcherData";
-  private static final String EXPORT_WORKSPACE_PATH = BASE_PATH + "/exportWorkspaceData";
+  private static final String RDR_EXPORT_QUEUE_NAME = "rdrExportQueue";
+  private static final String RDR_EXPORT_RESEARCHER_PATH = BASE_PATH + "/exportResearcherData";
+  private static final String RDR_EXPORT_WORKSPACE_PATH = BASE_PATH + "/exportWorkspaceData";
   private static final String AUDIT_PROJECTS_PATH = BASE_PATH + "/auditProjectAccess";
   private static final String SYNCHRONIZE_ACCESS_PATH = BASE_PATH + "/synchronizeUserAccess";
   private static final String EGRESS_EVENT_PATH = BASE_PATH + "/processEgressEvent";
@@ -71,19 +72,19 @@ public class TaskQueueService {
   }
 
   public void groupAndPushRdrWorkspaceTasks(List<Long> workspaceIds) {
-    groupAndPushRdrTasks(workspaceIds, EXPORT_WORKSPACE_PATH, false);
+    groupAndPushRdrTasks(workspaceIds, RDR_EXPORT_WORKSPACE_PATH, false);
   }
 
   public void groupAndPushRdrWorkspaceTasks(List<Long> workspaceIds, boolean backfill) {
-    groupAndPushRdrTasks(workspaceIds, EXPORT_WORKSPACE_PATH, backfill);
+    groupAndPushRdrTasks(workspaceIds, RDR_EXPORT_WORKSPACE_PATH, backfill);
   }
 
   public void groupAndPushRdrResearcherTasks(List<Long> userIds) {
-    groupAndPushRdrTasks(userIds, EXPORT_RESEARCHER_PATH, false);
+    groupAndPushRdrTasks(userIds, RDR_EXPORT_RESEARCHER_PATH, false);
   }
 
   public void groupAndPushRdrResearcherTasks(List<Long> userIds, boolean backfill) {
-    groupAndPushRdrTasks(userIds, EXPORT_RESEARCHER_PATH, backfill);
+    groupAndPushRdrTasks(userIds, RDR_EXPORT_RESEARCHER_PATH, backfill);
   }
 
   public void groupAndPushRdrTasks(List<Long> ids, String pathBase, boolean backfill) {
@@ -96,7 +97,7 @@ public class TaskQueueService {
     String path = backfill ? pathBase + "?backfill=true" : pathBase;
 
     CloudTasksUtils.partitionList(ids, rdrConfig.exportObjectsPerTask)
-        .forEach(batch -> createAndPushTask(rdrConfig.queueName, path, batch));
+        .forEach(batch -> createAndPushTask(RDR_EXPORT_QUEUE_NAME, path, batch));
   }
 
   public void groupAndPushAuditProjectsTasks(List<Long> userIds) {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -363,6 +363,7 @@ public class WorkbenchConfig {
     // Number of ids per task
     public Integer exportObjectsPerTask;
     // feature flag: do we export V2 of the Demographic Survey to RDR
+    @Deprecated(forRemoval = true) // always true - will remove soon
     public Boolean exportDemoSurveyV2;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -356,9 +356,10 @@ public class WorkbenchConfig {
   }
 
   public static class RdrExportConfig {
-    // RDR Host to connect to to export data
+    // RDR Host to connect to for exporting data
     public String host;
-    // Google cloud Queue name to which the task will be pushed to
+    // Google cloud Queue name where tasks are pushed
+    @Deprecated(forRemoval = true) // hardcoded to RDR_EXPORT_QUEUE_NAME
     public String queueName;
     // Number of ids per task
     public Integer exportObjectsPerTask;

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -210,10 +210,9 @@ public class RdrExportServiceImpl implements RdrExportService {
 
   private RdrResearcher toRdrResearcher(long userId) {
     DbUser dbUser = userDao.findUserByUserId(userId);
-    return rdrMapper.toRdrResearcher(
-        dbUser,
-        accessTierService.getAccessTiersForUser(dbUser),
-        verifiedInstitutionalAffiliationDao.findFirstByUser(dbUser).orElse(null));
+    var tiers = accessTierService.getAccessTiersForUser(dbUser);
+    var maybeAffiliation = verifiedInstitutionalAffiliationDao.findFirstByUser(dbUser);
+    return rdrMapper.toRdrResearcher(dbUser, tiers, maybeAffiliation.orElse(null));
   }
 
   @Nullable

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -7,7 +7,6 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -212,9 +211,9 @@ public class RdrExportServiceImpl implements RdrExportService {
   private RdrResearcher toRdrResearcher(long userId) {
     DbUser dbUser = userDao.findUserByUserId(userId);
     return rdrMapper.toRdrResearcher(
-            dbUser,
-            accessTierService.getAccessTiersForUser(dbUser),
-            verifiedInstitutionalAffiliationDao.findFirstByUser(dbUser).orElse(null));
+        dbUser,
+        accessTierService.getAccessTiersForUser(dbUser),
+        verifiedInstitutionalAffiliationDao.findFirstByUser(dbUser).orElse(null));
   }
 
   @Nullable

--- a/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/rdr/RdrExportServiceImpl.java
@@ -211,15 +211,10 @@ public class RdrExportServiceImpl implements RdrExportService {
 
   private RdrResearcher toRdrResearcher(long userId) {
     DbUser dbUser = userDao.findUserByUserId(userId);
-    RdrResearcher researcher =
-        rdrMapper.toRdrResearcher(
+    return rdrMapper.toRdrResearcher(
             dbUser,
             accessTierService.getAccessTiersForUser(dbUser),
             verifiedInstitutionalAffiliationDao.findFirstByUser(dbUser).orElse(null));
-    return Optional.ofNullable(workbenchConfigProvider.get().rdrExport.exportDemoSurveyV2)
-            .orElse(false)
-        ? researcher
-        : researcher.demographicSurveyV2(null);
   }
 
   @Nullable

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -236,7 +236,6 @@ public class RdrExportServiceImplTest {
 
   @Test
   public void exportUsers_DemoSurveyV2Export() throws ApiException {
-    workbenchConfig.rdrExport.exportDemoSurveyV2 = true;
     boolean backfill = false;
 
     dbUserWithEmail =
@@ -259,33 +258,7 @@ public class RdrExportServiceImplTest {
   }
 
   @Test
-  public void exportUsers_DemoSurveyV2NoExport() throws ApiException {
-    workbenchConfig.rdrExport.exportDemoSurveyV2 = false;
-    boolean backfill = false;
-
-    dbUserWithEmail =
-        userDao.save(
-            dbUserWithEmail.setDemographicSurveyV2(
-                new DbDemographicSurveyV2()
-                    .setUser(dbUserWithEmail)
-                    .setEducation(DbEducationV2.DOCTORATE)));
-
-    List<Long> userIds = Collections.singletonList(dbUserWithEmail.getUserId());
-    rdrExportService.exportUsers(userIds, backfill);
-
-    RdrResearcher expectedNoSurvey =
-        rdrMapper
-            .toRdrResearcher(dbUserWithEmail, Collections.emptyList(), null)
-            .demographicSurveyV2(null);
-    // test sanity check
-    assertThat(expectedNoSurvey.getDemographicSurveyV2()).isNull();
-
-    verify(rdrExportService, times(1)).updateDbRdrExport(RdrEntity.USER, userIds);
-    verify(mockRdrApi).exportResearchers(Collections.singletonList(expectedNoSurvey), backfill);
-  }
-
-  @Test
-  public void exportUsers_DemoSurveyV2NoExport_nullBoolean() throws ApiException {
+  public void exportUsers_DemoSurveyV2NoExport_nullBoolean() {
     boolean backfill = false;
 
     dbUserWithEmail =

--- a/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/rdr/RdrExportServiceImplTest.java
@@ -258,30 +258,6 @@ public class RdrExportServiceImplTest {
   }
 
   @Test
-  public void exportUsers_DemoSurveyV2NoExport_nullBoolean() {
-    boolean backfill = false;
-
-    dbUserWithEmail =
-        userDao.save(
-            dbUserWithEmail.setDemographicSurveyV2(
-                new DbDemographicSurveyV2()
-                    .setUser(dbUserWithEmail)
-                    .setEducation(DbEducationV2.DOCTORATE)));
-
-    List<Long> userIds = Collections.singletonList(dbUserWithEmail.getUserId());
-    rdrExportService.exportUsers(userIds, backfill);
-
-    RdrResearcher expectedNoSurvey =
-        rdrMapper
-            .toRdrResearcher(dbUserWithEmail, Collections.emptyList(), null)
-            .demographicSurveyV2(null);
-    // test sanity check
-    assertThat(expectedNoSurvey.getDemographicSurveyV2()).isNull();
-
-    verify(rdrExportService, times(1)).updateDbRdrExport(RdrEntity.USER, userIds);
-  }
-
-  @Test
   public void exportWorkspace() throws ApiException {
     RdrWorkspace rdrWorkspace = toDefaultRdrWorkspace(workspace);
     rdrExportService.exportWorkspaces(ImmutableList.of(workspace.getWorkspaceId()), NO_BACKFILL);


### PR DESCRIPTION
`exportDemoSurveyV2` is always true, and `queueName` is always `rdrExportQueue`

Tested by running locally and calling the rdrExport cron job on users with and without demographic surveys.

We can fully remove these after one release cycle: #7896

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [x] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
