### PR TITLE
[risk=no][no ticket] Show the time of egress bypass windows, not just the date

### DIFF
--- a/ui/src/app/pages/admin/user/admin-user-egress-bypass.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-egress-bypass.tsx
@@ -15,7 +15,7 @@ import { TextAreaWithLengthValidationMessage } from 'app/components/inputs';
 import { TooltipTrigger } from 'app/components/popups';
 import { userAdminApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
-import { formatDate, isDateValid, maybeToSingleDate } from 'app/utils/dates';
+import { displayDate, isDateValid, maybeToSingleDate } from 'app/utils/dates';
 const MIN_BYPASS_DESCRIPTION = 10;
 const MAX_BYPASS_DESCRIPTION = 4000;
 
@@ -89,7 +89,9 @@ export const AdminUserEgressBypass = (props: Props) => {
   };
 
   const displayTime = (row, opt) => {
-    return <div style={{ width: '7rem' }}>{formatDate(row[opt.field])}</div>;
+    const value: number | undefined = row[opt.field];
+    const display: string = value ? displayDate(value) : 'N/A';
+    return <div style={{ width: '7rem' }}>{display}</div>;
   };
 
   return (

--- a/ui/src/app/pages/admin/user/admin-user-egress-bypass.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-egress-bypass.tsx
@@ -88,12 +88,6 @@ export const AdminUserEgressBypass = (props: Props) => {
       });
   };
 
-  const displayTime = (row, opt) => {
-    const value: number | undefined = row[opt.field];
-    const display: string = value ? displayDate(value) : 'N/A';
-    return <div style={{ width: '7rem' }}>{display}</div>;
-  };
-
   return (
     <FlexRow style={{ minWidth: '100rem' }}>
       <FlexColumn style={{ width: '60%', justifyContent: 'space-between' }}>
@@ -138,8 +132,8 @@ export const AdminUserEgressBypass = (props: Props) => {
               paddingBottom: '0.45rem',
             }}
           >
-            Bypass starting date and time. (end date is 48 hours after starting
-            time)
+            <div>Bypass starting date and time (in your local time zone)</div>
+            <div>Note: the end time is 48 hours after the start time.</div>
           </div>
         </FlexRow>
         <FlexRow>
@@ -169,19 +163,19 @@ export const AdminUserEgressBypass = (props: Props) => {
           </TooltipTrigger>
         </FlexRow>
         <FlexRow>
-          <h3>Large File Download Requests</h3>
+          <h3>Large File Download Requests (all times local)</h3>
         </FlexRow>
-        <FlexRow style={{ paddingTop: '1rem' }}>
+        <FlexRow style={{ paddingTop: '1rem', paddingBottom: '1rem' }}>
           <DataTable value={bypassWindowsList}>
             <Column
-              field={'startTime'}
-              header={'Start Time'}
-              body={(date, opt) => displayTime(date, opt)}
+              field='startTime'
+              header='Start Time'
+              body={(row, opt) => <div>{displayDate(row[opt.field])}</div>}
             />
             <Column
-              field={'endTime'}
-              header={'End Time'}
-              body={(date, opt) => displayTime(date, opt)}
+              field='endTime'
+              header='End Time'
+              body={(row, opt) => <div>{displayDate(row[opt.field])}</div>}
             />
             <Column field={'description'} header={'Description'} />
           </DataTable>


### PR DESCRIPTION
When handling [this egress ticket](https://precisionmedicineinitiative.atlassian.net/browse/RW-10671) I needed to know the *time* of the end of the window, not just the date.  I was able to find that in the DB, but it will be much easier on this page.

Also updated some text and formatting.

Tested by running local UI, as seen here:

<img width="793" alt="Egress Window Time" src="https://github.com/all-of-us/workbench/assets/2701406/9aabdd92-54a4-4cdb-b062-5ed20dcff660">


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
