### PR TITLE
[DT-474][risk=no] Tanagra authz new AoU endpoint to get workspace access level

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -436,6 +436,15 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   }
 
   @Override
+  public ResponseEntity<String> getWorkspaceAccess(String workspaceNamespace) {
+    DbWorkspace workspace = workspaceService.lookupWorkspaceByNamespace(workspaceNamespace);
+    WorkspaceAccessLevel accessLevel =
+        workspaceAuthService.getWorkspaceAccessLevel(
+            workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
+    return ResponseEntity.ok(accessLevel.toString());
+  }
+
+  @Override
   public ResponseEntity<WorkspaceResponse> getWorkspace(
       String workspaceNamespace, String workspaceId) {
     return ResponseEntity.ok(workspaceService.getWorkspace(workspaceNamespace, workspaceId));

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -35,6 +35,7 @@ import org.pmiops.workbench.exceptions.FailedPreconditionException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.exceptions.TooManyRequestsException;
+import org.pmiops.workbench.exceptions.UnauthorizedException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.iam.IamService;
 import org.pmiops.workbench.model.ArchivalStatus;
@@ -67,6 +68,7 @@ import org.pmiops.workbench.workspaces.WorkspaceOperationMapper;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.pmiops.workbench.workspaces.resources.WorkspaceResourcesService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -437,11 +439,19 @@ public class WorkspacesController implements WorkspacesApiDelegate {
 
   @Override
   public ResponseEntity<String> getWorkspaceAccess(String workspaceNamespace) {
-    DbWorkspace workspace = workspaceService.lookupWorkspaceByNamespace(workspaceNamespace);
-    WorkspaceAccessLevel accessLevel =
-        workspaceAuthService.getWorkspaceAccessLevel(
-            workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
-    return ResponseEntity.ok(accessLevel.toString());
+    try {
+      DbWorkspace workspace = workspaceService.lookupWorkspaceByNamespace(workspaceNamespace);
+      return ResponseEntity.ok(
+          workspaceAuthService
+              .getWorkspaceAccessLevel(
+                  workspace.getWorkspaceNamespace(), workspace.getFirecloudName())
+              .toString());
+    } catch (NotFoundException nfe) {
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(HttpStatus.NOT_FOUND.toString());
+    } catch (UnauthorizedException uae) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+          .body(HttpStatus.UNAUTHORIZED.toString());
+    }
   }
 
   @Override

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1181,6 +1181,21 @@ paths:
           description: Returns true if the notebooks have been copied to the workspace
           schema:
             type: boolean
+  "/v1/workspaces/access/{workspaceNamespace}":
+    parameters:
+      - "$ref": "#/parameters/workspaceNamespace"
+    get:
+      tags:
+        - workspaces
+      description: Returns the WorkspaceAccessLevel Enum as String for  workspace namespace
+      operationId: getWorkspaceAccess
+      responses:
+        200:
+          description: A workspace access level string
+          schema:
+            type: string
+        403:
+          description: Forbidden
   "/v1/workspaces/{workspaceNamespace}/{workspaceId}":
     parameters:
     - "$ref": "#/parameters/workspaceNamespace"

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -1031,7 +1031,7 @@ public class WorkspacesControllerTest {
   @Test
   public void testGetWorkspaceAccessNotFound() {
     assertThat(workspacesController.getWorkspaceAccess("none").getBody())
-        .isEqualTo("404 NOT_FOUND");
+        .startsWith("Workspace not found");
   }
 
   @ParameterizedTest(name = "testGetWorkspaceAccess({0} user access, expected access {1})")

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -1028,6 +1028,12 @@ public class WorkspacesControllerTest {
     assertThat(operation3.getWorkspace().getName()).isEqualTo(workspace.getName());
   }
 
+  @Test
+  public void testGetWorkspaceAccessNotFound() {
+    assertThat(workspacesController.getWorkspaceAccess("none").getBody())
+        .isEqualTo("404 NOT_FOUND");
+  }
+
   @ParameterizedTest(name = "testGetWorkspaceAccess({0} user access, expected access {1})")
   @MethodSource("workspaceAccessLevels")
   public void testGetWorkspaceAccess(RawlsWorkspaceAccessLevel accessLevel, String expected) {

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -1041,7 +1041,7 @@ public class WorkspacesControllerTest {
     workspace = workspacesController.createWorkspace(workspace).getBody();
     stubFcGetWorkspace(workspace.getNamespace(), workspace.getId(), accessLevel);
     assertThat(workspacesController.getWorkspaceAccess(workspace.getNamespace()).getBody())
-        .isEqualTo(expected);
+        .startsWith(expected);
   }
 
   private void stubFcGetWorkspace(
@@ -1058,7 +1058,9 @@ public class WorkspacesControllerTest {
         Arguments.of(RawlsWorkspaceAccessLevel.OWNER, "OWNER"),
         Arguments.of(RawlsWorkspaceAccessLevel.WRITER, "WRITER"),
         Arguments.of(RawlsWorkspaceAccessLevel.READER, "READER"),
-        Arguments.of(RawlsWorkspaceAccessLevel.NO_ACCESS, "NO ACCESS"));
+        Arguments.of(
+            RawlsWorkspaceAccessLevel.NO_ACCESS,
+            "You do not have sufficient permissions to access workspace"));
   }
 
   @Test


### PR DESCRIPTION
---
- Added new api endpoint for tanagra to call and get workspace access level for workspaceNamespace given user's Bearer Token
- Tested the api call locally through postman
---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
