### PR TITLE
[RW-10348][risk=low] Support create SAS app in RW

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -117,6 +117,7 @@
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableRStudioGKEApp": true,
+    "enableSasGKEApp": true,
     "enableDataExplorer": true
   },
   "actionAudit": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -117,6 +117,7 @@
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": true,
     "enableRStudioGKEApp": true,
+    "enableSasGKEApp": false,
     "enableDataExplorer": false
   },
   "actionAudit": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -117,6 +117,7 @@
     "enablePrivateDataprocWorker": false,
     "ccSupportWhenAdminLocking": true,
     "enableRStudioGKEApp": false,
+    "enableSasGKEApp": false,
     "enableDataExplorer": false
   },
   "actionAudit": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -117,6 +117,7 @@
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableRStudioGKEApp": false,
+    "enableSasGKEApp": false,
     "enableDataExplorer": false
   },
   "actionAudit": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -117,6 +117,7 @@
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableRStudioGKEApp": true,
+    "enableSasGKEApp": false,
     "enableDataExplorer": false
   },
   "actionAudit": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -117,6 +117,7 @@
     "enablePrivateDataprocWorker": true,
     "ccSupportWhenAdminLocking": false,
     "enableRStudioGKEApp": true,
+    "enableSasGKEApp": true,
     "enableDataExplorer": false
   },
   "actionAudit": {

--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -60,6 +60,10 @@ public class AppsController implements AppsApiDelegate {
         && !configProvider.get().featureFlags.enableRStudioGKEApp) {
       throw new UnsupportedOperationException("API not supported.");
     }
+    if (createAppRequest.getAppType() == AppType.SAS
+        && !configProvider.get().featureFlags.enableSasGKEApp) {
+      throw new UnsupportedOperationException("API not supported.");
+    }
 
     leonardoApiClient.createApp(createAppRequest, dbWorkspace);
     return ResponseEntity.ok(new EmptyResponse());

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -324,6 +324,8 @@ public class WorkbenchConfig {
     public boolean ccSupportWhenAdminLocking;
     // If true, enable user creation of RStudio GKE apps
     public boolean enableRStudioGKEApp;
+    // If true, enable user creation of SAS GKE apps
+    public boolean enableSasGKEApp;
     // If true, enable visual data explorer
     public boolean enableDataExplorer;
   }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -74,6 +74,7 @@ public interface WorkbenchConfigMapper {
   @Mapping(target = "currentDuccVersions", source = "config.access.currentDuccVersions")
   @Mapping(target = "enableCaptcha", source = "config.captcha.enableCaptcha")
   @Mapping(target = "enableRStudioGKEApp", source = "config.featureFlags.enableRStudioGKEApp")
+  @Mapping(target = "enableSasGKEApp", source = "config.featureFlags.enableSasGKEApp")
   @Mapping(target = "enableDataExplorer", source = "config.featureFlags.enableDataExplorer")
   ConfigResponse toModel(WorkbenchConfig config, List<DbAccessModule> accessModules);
 }

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -574,6 +574,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
 
     leonardoCreateAppRequest
         .appType(leonardoMapper.toLeonardoAppType(appType))
+        .allowedChartName(leonardoMapper.toLeonardoAllowedChartName(appType))
         .kubernetesRuntimeConfig(
             leonardoMapper.toLeonardoKubernetesRuntimeConfig(kubernetesRuntimeConfig))
         .diskConfig(diskRequest)

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoLabelHelper.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoLabelHelper.java
@@ -34,7 +34,7 @@ public class LeonardoLabelHelper {
   // a limitation in the Leo Swagger client code generation means that the labels come in as Object
   // rather than their true type of Map<String, String>
   @SuppressWarnings("unchecked")
-  public static Optional<AppType> maybeMapDiskLabelsToGkeApp(@Nullable Object diskLabels) {
+  public static Optional<AppType> maybeMapLeonardoLabelsToGkeApp(@Nullable Object diskLabels) {
     return Optional.ofNullable((Map<String, String>) diskLabels)
         .flatMap(m -> Optional.ofNullable(m.get(LEONARDO_LABEL_APP_TYPE)))
         .map(LeonardoLabelHelper::labelValueToAppType);

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -289,7 +289,7 @@ public class MailServiceImpl implements MailService {
   }
 
   private String getEnvironmentType(Object labels) {
-    return LeonardoLabelHelper.maybeMapDiskLabelsToGkeApp(labels)
+    return LeonardoLabelHelper.maybeMapLeonardoLabelsToGkeApp(labels)
         .map(appType -> CaseUtils.toCamelCase(appType.toString(), true))
         .orElse("Jupyter");
   }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -10,11 +10,13 @@ import javax.annotation.Nullable;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 import org.mapstruct.ValueMapping;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.leonardo.LeonardoLabelHelper;
+import org.pmiops.workbench.leonardo.model.LeonardoAllowedChartName;
 import org.pmiops.workbench.leonardo.model.LeonardoAppType;
 import org.pmiops.workbench.leonardo.model.LeonardoCloudContext;
 import org.pmiops.workbench.leonardo.model.LeonardoCloudProvider;
@@ -247,6 +249,11 @@ public interface LeonardoMapper {
   @ValueMapping(source = "RSTUDIO", target = "ALLOWED") // we don't support Galaxy
   @ValueMapping(source = "SAS", target = "ALLOWED") // we don't support CUSTOM apps
   LeonardoAppType toLeonardoAppType(AppType appType);
+
+  @ValueMapping(source = "RSTUDIO", target = "RSTUDIO_CHART")
+  @ValueMapping(source = "SAS", target = "SAS_CHART")
+  @ValueMapping(source = "CROMWELL", target = MappingConstants.NULL)
+  LeonardoAllowedChartName toLeonardoAllowedChartName(AppType appType);
 
   @AfterMapping
   default void listAppsAfterMapper(

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -1498,6 +1498,11 @@ components:
         - GALAXY
         - RSTUDIO
         - ALLOWED
+    AllowedChartName:
+      type: string
+      enum:
+        - aou-rstudio-chart
+        - aou-sas-chart
     AppStatus:
       type: string
       enum:
@@ -2463,6 +2468,8 @@ components:
           $ref: '#/components/schemas/PersistentDiskRequest'
         appType:
           $ref: '#/components/schemas/AppType'
+        allowedChartName:
+          $ref: '#/components/schemas/AllowedChartName'
         kubernetesRuntimeConfig:
           $ref: '#/components/schemas/KubernetesRuntimeConfig'
         labels:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4886,6 +4886,10 @@ definitions:
         type: boolean
         default: false
         description: Whether users are able to use the RStudio GKE app.
+      enableSasGKEApp:
+        type: boolean
+        default: false
+        description: Whether users are able to use the SAS GKE app.
       enableDataExplorer:
         type: boolean
         default: false

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6519,6 +6519,7 @@ definitions:
     enum:
       - CROMWELL
       - RSTUDIO
+      - SAS
   DiskStatus:
     type: string
     enum:

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -228,7 +228,7 @@ public class LeonardoApiClientTest {
     customEnvironmentVariables.put("OWNER_EMAIL", user.getUsername());
     LeonardoCreateAppRequest expectedAppRequest =
         new LeonardoCreateAppRequest()
-            .appType(LeonardoAppType.RSTUDIO)
+            .appType(LeonardoAppType.ALLOWED)
             .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig)
             .labels(appLabels)
             .diskConfig(leonardoPersistentDiskRequest.labels(diskLabels).name("pd-name"))

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -32,6 +32,7 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.leonardo.api.AppsApi;
 import org.pmiops.workbench.leonardo.api.DisksApi;
+import org.pmiops.workbench.leonardo.model.LeonardoAllowedChartName;
 import org.pmiops.workbench.leonardo.model.LeonardoAppType;
 import org.pmiops.workbench.leonardo.model.LeonardoCloudContext;
 import org.pmiops.workbench.leonardo.model.LeonardoCloudProvider;
@@ -230,6 +231,7 @@ public class LeonardoApiClientTest {
         new LeonardoCreateAppRequest()
             .appType(LeonardoAppType.ALLOWED)
             .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig)
+            .allowedChartName(LeonardoAllowedChartName.RSTUDIO_CHART)
             .labels(appLabels)
             .diskConfig(leonardoPersistentDiskRequest.labels(diskLabels).name("pd-name"))
             .customEnvironmentVariables(customEnvironmentVariables);

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -238,7 +238,7 @@ public class LeonardoApiClientTest {
 
     assertThat(createAppRequest).isEqualTo(expectedAppRequest);
   }
-  https://604508422.jupyter-dev.firecloud.org
+
   @Test
   public void testCreateAppSuccess_newPd() throws Exception {
     stubGetFcWorkspace(WorkspaceAccessLevel.OWNER);

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -238,7 +238,7 @@ public class LeonardoApiClientTest {
 
     assertThat(createAppRequest).isEqualTo(expectedAppRequest);
   }
-
+  https://604508422.jupyter-dev.firecloud.org
   @Test
   public void testCreateAppSuccess_newPd() throws Exception {
     stubGetFcWorkspace(WorkspaceAccessLevel.OWNER);

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pmiops.workbench.leonardo.LeonardoLabelHelper;
+import org.pmiops.workbench.leonardo.model.LeonardoAllowedChartName;
 import org.pmiops.workbench.leonardo.model.LeonardoAppStatus;
 import org.pmiops.workbench.leonardo.model.LeonardoAppType;
 import org.pmiops.workbench.leonardo.model.LeonardoAuditInfo;
@@ -142,6 +143,15 @@ public class LeonardoMapperTest {
     assertThat(mapper.toLeonardoAppType(AppType.RSTUDIO)).isEqualTo(LeonardoAppType.ALLOWED);
     assertThat(mapper.toLeonardoAppType(AppType.SAS)).isEqualTo(LeonardoAppType.ALLOWED);
     assertThat(mapper.toLeonardoAppType(AppType.CROMWELL)).isEqualTo(LeonardoAppType.CROMWELL);
+  }
+
+  @Test
+  public void testToLeonardoAllowedAppChart() {
+    assertThat(mapper.toLeonardoAllowedChartName(AppType.RSTUDIO))
+        .isEqualTo(LeonardoAllowedChartName.RSTUDIO_CHART);
+    assertThat(mapper.toLeonardoAllowedChartName(AppType.SAS))
+        .isEqualTo(LeonardoAllowedChartName.SAS_CHART);
+    assertThat(mapper.toLeonardoAllowedChartName(AppType.CROMWELL)).isNull();
   }
 
   @ParameterizedTest(name = "appType {0} can be mapped for getApp call")


### PR DESCRIPTION
```
curl -X 'POST' \
  'http://localhost:8081/v1/workspaces/aou-rw-local1-a605b797/apps' \
  -H 'accept: */*' \
  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
  -H 'Content-Type: application/json' \
  -d '{
  "kubernetesRuntimeConfig": {
    "autoscalingEnabled": "false",
    "machineType": "n1-standard-4",
    "numNodes": "1"
  },
  "appType": "SAS",
  "persistentDiskRequest": {
    "diskType": "pd-standard",
    "size": 100
  }
}'

List App response:

![Screenshot 2023-08-29 at 9 33 17 AM](https://github.com/all-of-us/workbench/assets/6351731/05f424d3-ca9d-4fa0-bfd7-bd10add22ab0)

```
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
