### PR TITLE
[DT-489][risk=no] adding static tables for pfhh mappings

### DIFF
--- a/api/db-cdr/generate-cdr/bq-schemas/prep_pfhh_mapping.json
+++ b/api/db-cdr/generate-cdr/bq-schemas/prep_pfhh_mapping.json
@@ -1,0 +1,17 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "pfhh_answer_concept_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "pfhh_question_concept_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "historic_question_concept_id",
+    "type": "INTEGER"
+  }
+]

--- a/api/db-cdr/generate-cdr/bq-schemas/prep_pfhh_non_answer.json
+++ b/api/db-cdr/generate-cdr/bq-schemas/prep_pfhh_non_answer.json
@@ -1,0 +1,17 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "pfhh_answer_concept_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "pfhh_question_concept_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "historic_question_concept_id",
+    "type": "INTEGER"
+  }
+]

--- a/api/db-cdr/generate-cdr/bq-schemas/prep_pfhh_remove_from_index.json
+++ b/api/db-cdr/generate-cdr/bq-schemas/prep_pfhh_remove_from_index.json
@@ -1,0 +1,12 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "value",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "concept_id",
+    "type": "INTEGER"
+  }
+]

--- a/api/db-cdr/generate-cdr/build-search-all-events.sh
+++ b/api/db-cdr/generate-cdr/build-search-all-events.sh
@@ -304,7 +304,7 @@ then
           , survey_concept_id
           , cati_concept_id
       )
-  SELECT
+  SELECT DISTINCT
         b.person_id
       , a.observation_date as entry_date
       , a.observation_datetime as entry_datetime
@@ -352,7 +352,7 @@ else
           , survey_concept_id
           , cati_concept_id
       )
-  SELECT
+  SELECT DISTINCT
         b.person_id
       , a.observation_date as entry_date
       , a.observation_datetime as entry_datetime


### PR DESCRIPTION
Adding static tables for pfhh mappings. This PR will pull csv files during the indexing build from all-of-us-workbench-private-cloudsql bucket:

1. prep_pfhh_mapping.csv
2. prep_pfhh_non_answer.csv
3. prep_pfhh_remove_from_index.csv

Also added a distinct keyword when inserting observation data into cb_search_all_events to remove duplicates.