### PR TITLE
[risk=no][no ticket] Bump version of typescript

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -84,7 +84,7 @@
     "stackdriver-errors-js": "^0.4.0",
     "stacktrace-js": "^2.0.0",
     "swr": "^1.3.0",
-    "typescript": "^4.7.3",
+    "typescript": "^4.9.5",
     "validate.js": "^0.12.0",
     "yarn": "^1.22.0"
   },

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9855,7 +9855,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.7.3:
+typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==


### PR DESCRIPTION
I was attempting to fix something else and found another way, but decided to proceed with this change anyway.

Tested by building and running locally and just clicking around a bit.

Our yarn.lock file already selects the indicated version, so this change acts like a comment and should have no effect on functionality.

---
**PR checklist**

- [X] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [X] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [X] I have manually tested this change and my testing process is described above.
- [X] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [X] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [X] None of the above apply to this change.
