### PR TITLE
[risk=low][RW-9836] Make Cromwell and Rstudio config panels generic

### DIFF
--- a/ui/src/app/components/configuration-panel.spec.tsx
+++ b/ui/src/app/components/configuration-panel.spec.tsx
@@ -7,15 +7,12 @@ import {
   WorkspacesApi,
 } from 'generated/fetch';
 
+import { render, screen } from '@testing-library/react';
 import { UIAppType } from 'app/components/apps-panel/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 import { clearCompoundRuntimeOperations } from 'app/utils/stores';
 
-import {
-  mountWithRouter,
-  waitOneTickAndUpdate,
-} from 'testing/react-test-helpers';
 import { CdrVersionsStubVariables } from 'testing/stubs/cdr-versions-api-stub';
 import { workspaceStubs } from 'testing/stubs/workspaces';
 import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
@@ -30,12 +27,8 @@ describe('ConfigurationPanel', () => {
   let workspacesApiStub: WorkspacesApiStub;
   let onClose: () => void;
 
-  const component = async (propOverrides?: object) => {
-    const allProps = { ...defaultProps, ...propOverrides };
-    const c = mountWithRouter(<ConfigurationPanel {...allProps} />);
-    await waitOneTickAndUpdate(c);
-    return c;
-  };
+  const component = async (propOverrides?: object) =>
+    render(<ConfigurationPanel {...{ ...defaultProps, ...propOverrides }} />);
 
   beforeEach(async () => {
     workspacesApiStub = new WorkspacesApiStub();
@@ -63,12 +56,12 @@ describe('ConfigurationPanel', () => {
       billingStatus: BillingStatus.INACTIVE,
       cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     });
-    const wrapper = await component();
+    await component();
 
-    const disabledPanel = wrapper.find({
-      'data-test-id': 'environment-disabled-panel',
-    });
-    expect(disabledPanel.exists()).toBeTruthy();
+    const disabledPanel = screen.queryByText(
+      'Cloud services are disabled for this workspace.'
+    );
+    expect(disabledPanel).not.toBeNull();
   });
 
   it('should not render disabled panel when creator billing is enabled', async () => {
@@ -78,11 +71,10 @@ describe('ConfigurationPanel', () => {
       billingStatus: BillingStatus.ACTIVE,
       cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     });
-    const wrapper = await component();
-
-    const disabledPanel = wrapper.find({
-      'data-test-id': 'environment-disabled-panel',
-    });
-    expect(disabledPanel.exists()).toBeFalsy();
+    await component();
+    const disabledPanel = screen.queryByText(
+      'Cloud services are disabled for this workspace.'
+    );
+    expect(disabledPanel).toBeNull();
   });
 });

--- a/ui/src/app/components/configuration-panel.spec.tsx
+++ b/ui/src/app/components/configuration-panel.spec.tsx
@@ -44,7 +44,7 @@ describe('ConfigurationPanel', () => {
     onClose = jest.fn();
     defaultProps = {
       onClose,
-      type: UIAppType.JUPYTER,
+      appType: UIAppType.JUPYTER,
     };
 
     jest.useFakeTimers();

--- a/ui/src/app/components/configuration-panel.tsx
+++ b/ui/src/app/components/configuration-panel.tsx
@@ -23,7 +23,7 @@ import { DisabledPanel } from './runtime-configuration-panel/disabled-panel';
 
 export interface ConfigurationPanelProps {
   onClose: () => void;
-  type: UIAppType;
+  appType: UIAppType;
   runtimeConfPanelInitialState?: RuntimeConfigurationPanelProps['initialPanelContent'];
   gkeAppConfPanelInitialState?: GkeAppConfigurationPanelProps['initialPanelContent'];
 }
@@ -35,7 +35,7 @@ export const ConfigurationPanel = fp.flow(
   ({
     onClose,
     workspace,
-    type,
+    appType,
     runtimeConfPanelInitialState = null,
     gkeAppConfPanelInitialState = null,
     profileState,
@@ -74,7 +74,7 @@ export const ConfigurationPanel = fp.flow(
             () => <DisabledPanel />,
           ],
           [
-            type === UIAppType.JUPYTER,
+            appType === UIAppType.JUPYTER,
             () => (
               <div>
                 <RuntimeConfigurationPanel
@@ -88,7 +88,7 @@ export const ConfigurationPanel = fp.flow(
           () => (
             <GKEAppConfigurationPanel
               {...{
-                appType: toAppType[type],
+                appType: toAppType[appType],
                 onClose,
                 creatorFreeCreditsRemaining,
                 workspace,

--- a/ui/src/app/components/configuration-panel.tsx
+++ b/ui/src/app/components/configuration-panel.tsx
@@ -88,7 +88,7 @@ export const ConfigurationPanel = fp.flow(
           () => (
             <GKEAppConfigurationPanel
               {...{
-                type: toAppType[type],
+                appType: toAppType[type],
                 onClose,
                 creatorFreeCreditsRemaining,
                 workspace,

--- a/ui/src/app/components/cromwell-configuration-panel.spec.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.spec.tsx
@@ -1,16 +1,16 @@
+import '@testing-library/jest-dom';
+
 import * as React from 'react';
 
 import { DisksApi, WorkspaceAccessLevel } from 'generated/fetch';
 import { AppsApi } from 'generated/fetch/api';
 
+import { render, screen, waitFor } from '@testing-library/react';
 import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
 import { serverConfigStore } from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
-import {
-  mountWithRouter,
-  waitOneTickAndUpdate,
-} from 'testing/react-test-helpers';
+import { expectButtonElementEnabled } from 'testing/react-test-helpers';
 import {
   AppsApiStub,
   createListAppsCromwellResponse,
@@ -27,7 +27,7 @@ import { defaultCromwellConfig } from './apps-panel/utils';
 import { CromwellConfigurationPanel } from './cromwell-configuration-panel';
 import { CreateGKEAppPanelProps } from './gke-app-configuration-panels/create-gke-app-panel';
 
-describe('CromwellConfigurationPanel', () => {
+describe(CromwellConfigurationPanel.name, () => {
   const onClose = jest.fn();
   const freeTierBillingAccountId = 'freetier';
 
@@ -53,12 +53,10 @@ describe('CromwellConfigurationPanel', () => {
 
   let disksApiStub: DisksApiStub;
 
-  const component = async (propOverrides?: Partial<CreateGKEAppPanelProps>) => {
-    const allProps = { ...DEFAULT_PROPS, ...propOverrides };
-    const c = mountWithRouter(<CromwellConfigurationPanel {...allProps} />);
-    await waitOneTickAndUpdate(c);
-    return c;
-  };
+  const component = async (propOverrides?: Partial<CreateGKEAppPanelProps>) =>
+    render(
+      <CromwellConfigurationPanel {...{ ...DEFAULT_PROPS, ...propOverrides }} />
+    );
 
   beforeEach(async () => {
     disksApiStub = new DisksApiStub();
@@ -83,97 +81,105 @@ describe('CromwellConfigurationPanel', () => {
   });
 
   it('start button should create cromwell and close panel', async () => {
-    const wrapper = await component({
+    await component({
       app: undefined,
       disk: undefined,
     });
-    await waitOneTickAndUpdate(wrapper);
 
     const spyCreateApp = jest
       .spyOn(appsApi(), 'createApp')
       .mockImplementation((): Promise<any> => Promise.resolve());
-    const startButton = wrapper
-      .find('#Cromwell-cloud-environment-create-button')
-      .first();
 
-    startButton.simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-    expect(spyCreateApp).toHaveBeenCalledTimes(1);
-    expect(spyCreateApp).toHaveBeenCalledWith(
-      WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-      defaultCromwellConfig
+    const startButton = screen.getByLabelText(
+      'Cromwell cloud environment create button'
     );
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expectButtonElementEnabled(startButton);
+    startButton.click();
+
+    await waitFor(() => {
+      expect(spyCreateApp).toHaveBeenCalledTimes(1);
+      expect(spyCreateApp).toHaveBeenCalledWith(
+        WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+        defaultCromwellConfig
+      );
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('should use the existing PD when creating', async () => {
     const disk = stubDisk();
-    const wrapper = await component({
+    await component({
       app: undefined,
       disk,
     });
-    await waitOneTickAndUpdate(wrapper);
 
     const spyCreateApp = jest
       .spyOn(appsApi(), 'createApp')
       .mockImplementation((): Promise<any> => Promise.resolve());
-    const startButton = wrapper
-      .find('#Cromwell-cloud-environment-create-button')
-      .first();
 
-    startButton.simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-    expect(spyCreateApp).toHaveBeenCalledTimes(1);
-    expect(spyCreateApp.mock.calls[0][1].persistentDiskRequest).toEqual(disk);
-    expect(onClose).toHaveBeenCalledTimes(1);
+    const startButton = screen.getByLabelText(
+      'Cromwell cloud environment create button'
+    );
+    expectButtonElementEnabled(startButton);
+    startButton.click();
+
+    await waitFor(() => {
+      expect(spyCreateApp).toHaveBeenCalledTimes(1);
+      expect(spyCreateApp.mock.calls[0][1].persistentDiskRequest).toEqual(disk);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('should display a cost of $0.40 per hour when running and $0.20 per hour when paused', async () => {
-    const wrapper = await component();
-
-    const costEstimator = (w) => w.find('[data-test-id="cost-estimator"]');
-    const runningCost = (w) =>
-      costEstimator(w).find('[data-test-id="running-cost"]');
-    const pausedCost = (w) =>
-      costEstimator(w).find('[data-test-id="paused-cost"]');
-
-    expect(costEstimator(wrapper).exists()).toBeTruthy();
-    expect(runningCost(wrapper).text()).toEqual('$0.40 per hour');
-    expect(pausedCost(wrapper).text()).toEqual('$0.20 per hour');
+    await component();
+    expect(screen.queryByLabelText('cost while running')).toHaveTextContent(
+      '$0.40 per hour'
+    );
+    expect(screen.queryByLabelText('cost while paused')).toHaveTextContent(
+      '$0.20 per hour'
+    );
   });
 
   it('should render a DeletePersistentDiskButton when a disk is present but no app', async () => {
     const disk = stubDisk();
     const onClickDeleteUnattachedPersistentDisk = jest.fn();
-    const wrapper = await component({
+
+    await component({
       app: undefined,
       disk,
       onClickDeleteUnattachedPersistentDisk,
     });
-    const deleteButton = wrapper.find('DeletePersistentDiskButton');
-    expect(deleteButton.exists()).toBeTruthy();
 
-    // validate that onClickDeleteUnattachedPersistentDisk is passed correctly
-    deleteButton.simulate('click');
-    expect(onClickDeleteUnattachedPersistentDisk).toHaveBeenCalledTimes(1);
+    const deleteButton = screen.getByLabelText('Delete Persistent Disk');
+    expect(deleteButton).not.toBeNull();
+
+    expectButtonElementEnabled(deleteButton);
+    deleteButton.click();
+
+    await waitFor(() => {
+      expect(onClickDeleteUnattachedPersistentDisk).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('should not render a DeletePersistentDiskButton when an app is present', async () => {
     const disk = stubDisk();
-    const wrapper = await component({
+
+    await component({
       app: createListAppsCromwellResponse(),
       disk,
     });
-    const deleteButton = wrapper.find('DeletePersistentDiskButton');
-    expect(deleteButton.exists()).toBeFalsy();
+
+    const deleteButton = screen.queryByLabelText('Delete Persistent Disk');
+    expect(deleteButton).toBeNull();
   });
 
   it('should not render a DeletePersistentDiskButton no disk is present', async () => {
-    const wrapper = await component({
+    await component({
       app: undefined,
       disk: undefined,
     });
-    const deleteButton = wrapper.find('DeletePersistentDiskButton');
-    expect(deleteButton.exists()).toBeFalsy();
+
+    const deleteButton = screen.queryByLabelText('Delete Persistent Disk');
+    expect(deleteButton).toBeNull();
   });
 });

--- a/ui/src/app/components/cromwell-configuration-panel.spec.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.spec.tsx
@@ -3,10 +3,6 @@ import * as React from 'react';
 import { DisksApi, WorkspaceAccessLevel } from 'generated/fetch';
 import { AppsApi } from 'generated/fetch/api';
 
-import {
-  CromwellConfigurationPanel,
-  CromwellConfigurationPanelProps,
-} from 'app/components/cromwell-configuration-panel';
 import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
 import { serverConfigStore } from 'app/utils/stores';
 
@@ -28,12 +24,14 @@ import {
 } from 'testing/stubs/workspaces';
 
 import { defaultCromwellConfig } from './apps-panel/utils';
+import { CromwellConfigurationPanel } from './cromwell-configuration-panel';
+import { CreateGKEAppPanelProps } from './gke-app-configuration-panels/create-gke-app-panel';
 
 describe('CromwellConfigurationPanel', () => {
   const onClose = jest.fn();
   const freeTierBillingAccountId = 'freetier';
 
-  const DEFAULT_PROPS: CromwellConfigurationPanelProps = {
+  const DEFAULT_PROPS: CreateGKEAppPanelProps = {
     onClose,
     creatorFreeCreditsRemaining: null,
     workspace: {
@@ -55,9 +53,7 @@ describe('CromwellConfigurationPanel', () => {
 
   let disksApiStub: DisksApiStub;
 
-  const component = async (
-    propOverrides?: Partial<CromwellConfigurationPanelProps>
-  ) => {
+  const component = async (propOverrides?: Partial<CreateGKEAppPanelProps>) => {
     const allProps = { ...DEFAULT_PROPS, ...propOverrides };
     const c = mountWithRouter(<CromwellConfigurationPanel {...allProps} />);
     await waitOneTickAndUpdate(c);

--- a/ui/src/app/components/cromwell-configuration-panel.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.tsx
@@ -30,16 +30,12 @@ const cromwellSupportArticles = [
   },
 ];
 
-const IntroText = () => (
-  <div>
-    A cloud environment consists of an application configuration, cloud compute
-    and persistent disk(s). Cromwell is a workflow execution engine. You will
-    need to create a Jupyter terminal environment in order to interact with
-    Cromwell.
-  </div>
-);
+const introTextOverride =
+  'A cloud environment consists of an application configuration, cloud compute, and persistent disk(s). ' +
+  'Cromwell is a workflow execution engine. ' +
+  'You will need to create a Jupyter terminal environment in order to interact with Cromwell.';
 
-const PostCost = () => (
+const CostNote = () => (
   <WarningMessage>
     This cost is only for running the Cromwell Engine. There will be additional
     cost for interactions with the workflow.
@@ -62,7 +58,7 @@ const PostCost = () => (
   </WarningMessage>
 );
 
-const PostCompute = () => (
+const SupportNote = () => (
   <div style={{ ...styles.controlSection }}>
     <div style={{ fontWeight: 'bold' }}>Cromwell support articles</div>
     {cromwellSupportArticles.map((article, index) => (
@@ -89,9 +85,9 @@ export const CromwellConfigurationPanel = (props: CreateGKEAppPanelProps) => (
   <CreateGKEAppPanel
     {...{
       ...props,
-      IntroText,
-      PostCost,
-      PostCompute,
+      introTextOverride,
+      CostNote,
+      SupportNote,
       CreateAppText,
     }}
     appType={AppType.CROMWELL}

--- a/ui/src/app/components/cromwell-configuration-panel.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.tsx
@@ -30,7 +30,7 @@ const cromwellSupportArticles = [
   },
 ];
 
-const introTextOverride =
+const introText =
   'A cloud environment consists of an application configuration, cloud compute, and persistent disk(s). ' +
   'Cromwell is a workflow execution engine. ' +
   'You will need to create a Jupyter terminal environment in order to interact with Cromwell.';
@@ -85,7 +85,7 @@ export const CromwellConfigurationPanel = (props: CreateGKEAppPanelProps) => (
   <CreateGKEAppPanel
     {...{
       ...props,
-      introTextOverride,
+      introText,
       CostNote,
       SupportNote,
       CreateAppText,

--- a/ui/src/app/components/cromwell-configuration-panel.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.tsx
@@ -41,7 +41,7 @@ const IntroText = () => (
 
 const PostCost = () => (
   <WarningMessage>
-    This cost is only for running the Cromwell Engine, there will be additional
+    This cost is only for running the Cromwell Engine. There will be additional
     cost for interactions with the workflow.
     <a
       style={{ marginLeft: '0.25rem' }}

--- a/ui/src/app/components/cromwell-configuration-panel.tsx
+++ b/ui/src/app/components/cromwell-configuration-panel.tsx
@@ -1,33 +1,19 @@
 import * as React from 'react';
 
-import {
-  AppType,
-  CreateAppRequest,
-  Disk,
-  UserAppEnvironment,
-} from 'generated/fetch';
+import { AppType } from 'generated/fetch';
 
-import { DeletePersistentDiskButton } from 'app/components/delete-persistent-disk-button';
-import { FlexColumn, FlexRow } from 'app/components/flex';
-import { CreateGKEAppButton } from 'app/components/gke-app-configuration-panels/create-gke-app-button';
-import { DisabledCloudComputeProfile } from 'app/components/gke-app-configuration-panels/disabled-cloud-compute-profile';
 import { WarningMessage } from 'app/components/messages';
-import { styles } from 'app/components/runtime-configuration-panel/styles';
 import {
   CROMWELL_INFORMATION_LINK,
   CROMWELL_INTRO_LINK,
   WORKFLOW_AND_WDL_LINK,
 } from 'app/utils/aou_external_links';
-import { setSidebarActiveIconStore } from 'app/utils/navigation';
-import { ProfileStore } from 'app/utils/stores';
-import { unattachedDiskExists } from 'app/utils/user-apps-utils';
-import { WorkspaceData } from 'app/utils/workspace-data';
 
 import {
-  createAppRequestToAnalysisConfig,
-  defaultCromwellConfig,
-} from './apps-panel/utils';
-import { EnvironmentInformedActionPanel } from './environment-informed-action-panel';
+  CreateGKEAppPanel,
+  CreateGKEAppPanelProps,
+} from './gke-app-configuration-panels/create-gke-app-panel';
+import { styles } from './runtime-configuration-panel/styles';
 
 const cromwellSupportArticles = [
   {
@@ -44,129 +30,70 @@ const cromwellSupportArticles = [
   },
 ];
 
-export interface CromwellConfigurationPanelProps {
-  onClose: () => void;
-  creatorFreeCreditsRemaining: number | null;
-  workspace: WorkspaceData;
-  profileState: ProfileStore;
-  app: UserAppEnvironment | undefined;
-  disk: Disk | undefined;
-  onClickDeleteUnattachedPersistentDisk: () => void;
-}
+const IntroText = () => (
+  <div>
+    A cloud environment consists of an application configuration, cloud compute
+    and persistent disk(s). Cromwell is a workflow execution engine. You will
+    need to create a Jupyter terminal environment in order to interact with
+    Cromwell.
+  </div>
+);
 
-export const CromwellConfigurationPanel = ({
-  onClose,
-  creatorFreeCreditsRemaining,
-  workspace,
-  profileState,
-  app,
-  disk,
-  onClickDeleteUnattachedPersistentDisk,
-}: CromwellConfigurationPanelProps) => {
-  const { profile } = profileState;
-
-  const onDismiss = () => {
-    onClose();
-    setTimeout(() => setSidebarActiveIconStore.next('apps'), 3000);
-  };
-
-  const cromwellConfig: CreateAppRequest = {
-    ...defaultCromwellConfig,
-    persistentDiskRequest:
-      disk !== undefined ? disk : defaultCromwellConfig.persistentDiskRequest,
-  };
-  const analysisConfig = createAppRequestToAnalysisConfig(cromwellConfig);
-
-  return (
-    <FlexColumn
-      id='cromwell-configuration-panel'
-      style={{ height: '100%', rowGap: '1rem' }}
+const PostCost = () => (
+  <WarningMessage>
+    This cost is only for running the Cromwell Engine, there will be additional
+    cost for interactions with the workflow.
+    <a
+      style={{ marginLeft: '0.25rem' }}
+      href={CROMWELL_INFORMATION_LINK}
+      target={'_blank'}
     >
-      <div>
-        A cloud environment consists of an application configuration, cloud
-        compute and persistent disk(s). Cromwell is a workflow execution engine.
-        You will need to create a Jupyter terminal environment in order to
-        interact with Cromwell.
+      Learn more{' '}
+    </a>
+    <i
+      className='pi pi-external-link'
+      style={{
+        marginLeft: '0.25rem',
+        fontSize: '0.75rem',
+        color: '#6fb4ff',
+        cursor: 'pointer',
+      }}
+    />
+  </WarningMessage>
+);
+
+const PostCompute = () => (
+  <div style={{ ...styles.controlSection }}>
+    <div style={{ fontWeight: 'bold' }}>Cromwell support articles</div>
+    {cromwellSupportArticles.map((article, index) => (
+      <div key={index} style={{ display: 'block' }}>
+        <a href={article.link} target='_blank'>
+          {index + 1}. {article.text}
+        </a>
       </div>
-      <div style={{ ...styles.controlSection }}>
-        <EnvironmentInformedActionPanel
-          {...{
-            creatorFreeCreditsRemaining,
-            profile,
-            workspace,
-            analysisConfig,
-          }}
-          status={app?.status}
-          onPause={Promise.resolve()}
-          onResume={Promise.resolve()}
-          appType={AppType.CROMWELL}
-        />
-        <WarningMessage>
-          This cost is only for running the Cromwell Engine, there will be
-          additional cost for interactions with the workflow.
-          <a
-            style={{ marginLeft: '0.25rem' }}
-            href={CROMWELL_INFORMATION_LINK}
-            target={'_blank'}
-          >
-            Learn more{' '}
-          </a>
-          <i
-            className='pi pi-external-link'
-            style={{
-              marginLeft: '0.25rem',
-              fontSize: '0.75rem',
-              color: '#6fb4ff',
-              cursor: 'pointer',
-            }}
-          />
-        </WarningMessage>
-      </div>
-      <div style={{ ...styles.controlSection }}>
-        <DisabledCloudComputeProfile
-          cpu={analysisConfig.machine.cpu}
-          memory={analysisConfig.machine.memory}
-          persistentDiskRequestSize={cromwellConfig.persistentDiskRequest.size}
-          appType={AppType.CROMWELL}
-        />
-      </div>
-      <div style={{ ...styles.controlSection }}>
-        <div style={{ fontWeight: 'bold' }}>Cromwell support articles</div>
-        {cromwellSupportArticles.map((article, index) => (
-          <div key={index} style={{ display: 'block' }}>
-            <a href={article.link} target='_blank'>
-              {index + 1}. {article.text}
-            </a>
-          </div>
-        ))}
-      </div>
-      <FlexRow
-        style={{
-          alignItems: 'center',
-          justifyContent: 'flex-end',
-          gap: '2rem',
-        }}
-      >
-        {unattachedDiskExists(app, disk) && (
-          <DeletePersistentDiskButton
-            onClick={onClickDeleteUnattachedPersistentDisk}
-            style={{ flexShrink: 0 }}
-          />
-        )}
-        <div style={{ flexGrow: 1 }}>
-          <div style={{ fontWeight: 'bold' }}>Next Steps:</div>
-          <div>
-            You can interact with the workflow by using the Cromshell in Jupyter
-            Terminal or Jupyter notebook
-          </div>
-        </div>
-        <CreateGKEAppButton
-          createAppRequest={cromwellConfig}
-          existingApp={app}
-          workspaceNamespace={workspace.namespace}
-          onDismiss={onDismiss}
-        />
-      </FlexRow>
-    </FlexColumn>
-  );
-};
+    ))}
+  </div>
+);
+
+const CreateAppText = () => (
+  <div style={{ flexGrow: 1 }}>
+    <div style={{ fontWeight: 'bold' }}>Next Steps:</div>
+    <div>
+      You can interact with the workflow by using the Cromshell in Jupyter
+      Terminal or Jupyter notebook
+    </div>
+  </div>
+);
+
+export const CromwellConfigurationPanel = (props: CreateGKEAppPanelProps) => (
+  <CreateGKEAppPanel
+    {...{
+      ...props,
+      IntroText,
+      PostCost,
+      PostCompute,
+      CreateAppText,
+    }}
+    appType={AppType.CROMWELL}
+  />
+);

--- a/ui/src/app/components/environment-cost-estimator.tsx
+++ b/ui/src/app/components/environment-cost-estimator.tsx
@@ -96,7 +96,11 @@ export const EnvironmentCostEstimator = ({
             </div>
           }
         >
-          <div style={costStyle} data-test-id='running-cost'>
+          <div
+            style={costStyle}
+            data-test-id='running-cost'
+            aria-label='cost while running'
+          >
             <div style={styles.costValue}>{formatUsd(runningCost)}</div>
             <div style={styles.costPeriod}>{` per hour`}</div>
           </div>
@@ -116,7 +120,11 @@ export const EnvironmentCostEstimator = ({
             </div>
           }
         >
-          <div style={costStyle} data-test-id='paused-cost'>
+          <div
+            style={costStyle}
+            data-test-id='paused-cost'
+            aria-label='cost while paused'
+          >
             <div style={styles.costValue}>{formatUsd(pausedCost)}</div>
             <div style={styles.costPeriod}>{` per hour`}</div>
           </div>

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -9,16 +9,6 @@ import {
   UserAppEnvironment,
 } from 'generated/fetch';
 
-import { CromwellConfigurationPanel } from 'app/components/cromwell-configuration-panel';
-import {
-  GKEAppConfigurationPanel,
-  GkeAppConfigurationPanelProps,
-  GKEAppPanelContent,
-} from 'app/components/gke-app-configuration-panel';
-import { RStudioConfigurationPanel } from 'app/components/rstudio-configuration-panel';
-import { DEFAULT_PROPS as RSTUDIO_DEFAULT_PROPS } from 'app/components/rstudio-configuration-panel.spec';
-import { ConfirmDeleteEnvironmentWithPD } from 'app/components/runtime-configuration-panel/confirm-delete-environment-with-pd';
-import { ConfirmDeleteUnattachedPD } from 'app/components/runtime-configuration-panel/confirm-delete-unattached-pd';
 import { Spinner } from 'app/components/spinners';
 import {
   appsApi,
@@ -36,7 +26,17 @@ import {
 } from 'testing/stubs/apps-api-stub';
 import { DisksApiStub, stubDisk } from 'testing/stubs/disks-api-stub';
 
+import { CromwellConfigurationPanel } from './cromwell-configuration-panel';
+import {
+  GKEAppConfigurationPanel,
+  GkeAppConfigurationPanelProps,
+  GKEAppPanelContent,
+} from './gke-app-configuration-panel';
+import { RStudioConfigurationPanel } from './rstudio-configuration-panel';
+import { DEFAULT_PROPS as RSTUDIO_DEFAULT_PROPS } from './rstudio-configuration-panel.spec';
 import { ConfirmDelete } from './runtime-configuration-panel/confirm-delete';
+import { ConfirmDeleteEnvironmentWithPD } from './runtime-configuration-panel/confirm-delete-environment-with-pd';
+import { ConfirmDeleteUnattachedPD } from './runtime-configuration-panel/confirm-delete-unattached-pd';
 
 async function validateInitialLoadingSpinner(wrapper: ReactWrapper) {
   expect(wrapper.childAt(0).is(Spinner)).toBeTruthy();

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -272,11 +272,12 @@ describe(GKEAppConfigurationPanel.name, () => {
     expectButtonElementEnabled(deleteButton);
     deleteButton.click();
 
+    const deletePDSelected = true;
     await waitFor(() => {
       expect(deleteAppStub).toHaveBeenCalledWith(
         workspaceNamespace,
         app.appName,
-        true /* deletePDSelected */
+        deletePDSelected
       );
       expect(onCloseStub).toHaveBeenCalled();
     });
@@ -318,11 +319,12 @@ describe(GKEAppConfigurationPanel.name, () => {
     expectButtonElementEnabled(deleteButton);
     deleteButton.click();
 
+    const deletePDSelected = false;
     await waitFor(() => {
       expect(deleteAppStub).toHaveBeenCalledWith(
         workspaceNamespace,
         app.appName,
-        false /* deletePDSelected */
+        deletePDSelected
       );
 
       expect(onCloseStub).toHaveBeenCalled();

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -68,7 +68,7 @@ describe(GKEAppConfigurationPanel.name, () => {
   });
 
   const DEFAULT_PROPS: GkeAppConfigurationPanelProps = {
-    type: AppType.RSTUDIO,
+    appType: AppType.RSTUDIO,
     workspaceNamespace: 'aou-rw-1234',
     onClose: jest.fn(),
     initialPanelContent: null,
@@ -158,7 +158,7 @@ describe(GKEAppConfigurationPanel.name, () => {
 
     const wrapper = createWrapper({
       workspaceNamespace,
-      type: AppType.CROMWELL,
+      appType: AppType.CROMWELL,
     });
     await waitOneTickAndUpdate(wrapper);
 
@@ -182,7 +182,7 @@ describe(GKEAppConfigurationPanel.name, () => {
 
     const wrapper = createWrapper({
       workspaceNamespace,
-      type: AppType.CROMWELL,
+      appType: AppType.CROMWELL,
     });
     await waitOneTickAndUpdate(wrapper);
 
@@ -202,7 +202,7 @@ describe(GKEAppConfigurationPanel.name, () => {
 
     const wrapper = createWrapper({
       workspaceNamespace,
-      type: AppType.CROMWELL,
+      appType: AppType.CROMWELL,
     });
     await waitOneTickAndUpdate(wrapper);
 
@@ -214,7 +214,7 @@ describe(GKEAppConfigurationPanel.name, () => {
 
   it('should display the CREATE panel if no initial panel is passed', async () => {
     const wrapper = createWrapper({
-      type: AppType.CROMWELL,
+      appType: AppType.CROMWELL,
       initialPanelContent: null,
     });
     await waitOneTickAndUpdate(wrapper);
@@ -234,7 +234,7 @@ describe(GKEAppConfigurationPanel.name, () => {
       .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
       .mockImplementation((): Promise<any> => Promise.resolve([cromwellDisk]));
     const wrapper = createWrapper({
-      type: AppType.CROMWELL,
+      appType: AppType.CROMWELL,
       initialPanelContent: GKEAppPanelContent.DELETE_GKE_APP,
     });
     await waitOneTickAndUpdate(wrapper);
@@ -244,7 +244,7 @@ describe(GKEAppConfigurationPanel.name, () => {
 
   it('should display the Cromwell panel when the type is Cromwell', async () => {
     const wrapper = createWrapper({
-      type: AppType.CROMWELL,
+      appType: AppType.CROMWELL,
     });
     await waitOneTickAndUpdate(wrapper);
 
@@ -256,7 +256,7 @@ describe(GKEAppConfigurationPanel.name, () => {
 
   it('should display the RStudio panel when the type is RStudio', async () => {
     const wrapper = createWrapper({
-      type: AppType.RSTUDIO,
+      appType: AppType.RSTUDIO,
     });
     await waitOneTickAndUpdate(wrapper);
 
@@ -268,7 +268,7 @@ describe(GKEAppConfigurationPanel.name, () => {
 
   it('should change panels from CREATE to DELETE_UNATTACHED_PD after clicking the delete PD button', async () => {
     const wrapper = createWrapper({
-      type: AppType.CROMWELL,
+      appType: AppType.CROMWELL,
     });
     await waitOneTickAndUpdate(wrapper);
 
@@ -304,7 +304,7 @@ describe(GKEAppConfigurationPanel.name, () => {
       .mockImplementation((): Promise<any> => Promise.resolve([app]));
     const wrapper = createWrapper({
       onClose: onCloseStub,
-      type: AppType.CROMWELL,
+      appType: AppType.CROMWELL,
       workspaceNamespace,
       initialPanelContent: GKEAppPanelContent.DELETE_GKE_APP,
     });
@@ -348,7 +348,7 @@ describe(GKEAppConfigurationPanel.name, () => {
     const workspaceNamespace = 'aou-rw-1234';
     const wrapper = createWrapper({
       onClose: onCloseStub,
-      type: AppType.CROMWELL,
+      appType: AppType.CROMWELL,
       workspaceNamespace,
       initialPanelContent: GKEAppPanelContent.DELETE_GKE_APP,
     });
@@ -388,7 +388,7 @@ describe(GKEAppConfigurationPanel.name, () => {
       .mockImplementation((): Promise<any> => Promise.resolve([app]));
     const wrapper = createWrapper({
       onClose: onCloseStub,
-      type: AppType.CROMWELL,
+      appType: AppType.CROMWELL,
       workspaceNamespace,
       initialPanelContent: GKEAppPanelContent.DELETE_GKE_APP,
     });
@@ -415,7 +415,7 @@ describe(GKEAppConfigurationPanel.name, () => {
       .mockImplementation((): Promise<any> => Promise.resolve([disk]));
     const wrapper = createWrapper({
       onClose: onCloseStub,
-      type: AppType.CROMWELL,
+      appType: AppType.CROMWELL,
       workspaceNamespace,
     });
     await waitOneTickAndUpdate(wrapper);
@@ -446,7 +446,7 @@ describe(GKEAppConfigurationPanel.name, () => {
       .mockImplementation((): Promise<any> => Promise.reject());
 
     const wrapper = createWrapper({
-      type: AppType.CROMWELL,
+      appType: AppType.CROMWELL,
     });
     await waitOneTickAndUpdate(wrapper);
     // Start with the DELETE_UNATTACHED_PD panel
@@ -468,7 +468,7 @@ describe(GKEAppConfigurationPanel.name, () => {
 
   it('should change panels from DELETE_UNATTACHED_PD to CREATE after cancelling delete PD', async () => {
     const wrapper = createWrapper({
-      type: AppType.CROMWELL,
+      appType: AppType.CROMWELL,
     });
     await waitOneTickAndUpdate(wrapper);
     // Start with the DELETE_UNATTACHED_PD panel

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import { act } from 'react-dom/test-utils';
-import { mount, ReactWrapper } from 'enzyme';
 
 import {
   AppsApi,
@@ -9,7 +7,7 @@ import {
   UserAppEnvironment,
 } from 'generated/fetch';
 
-import { Spinner } from 'app/components/spinners';
+import { render, screen, waitFor } from '@testing-library/react';
 import {
   appsApi,
   disksApi,
@@ -18,33 +16,39 @@ import {
 import { notificationStore, serverConfigStore } from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
-import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
+import { expectButtonElementEnabled } from 'testing/react-test-helpers';
 import {
   AppsApiStub,
   createListAppsCromwellResponse,
-  createListAppsRStudioResponse,
 } from 'testing/stubs/apps-api-stub';
 import { DisksApiStub, stubDisk } from 'testing/stubs/disks-api-stub';
 
-import { CromwellConfigurationPanel } from './cromwell-configuration-panel';
 import {
   GKEAppConfigurationPanel,
   GkeAppConfigurationPanelProps,
   GKEAppPanelContent,
 } from './gke-app-configuration-panel';
-import { RStudioConfigurationPanel } from './rstudio-configuration-panel';
 import { DEFAULT_PROPS as RSTUDIO_DEFAULT_PROPS } from './rstudio-configuration-panel.spec';
-import { ConfirmDelete } from './runtime-configuration-panel/confirm-delete';
-import { ConfirmDeleteEnvironmentWithPD } from './runtime-configuration-panel/confirm-delete-environment-with-pd';
-import { ConfirmDeleteUnattachedPD } from './runtime-configuration-panel/confirm-delete-unattached-pd';
 
-async function validateInitialLoadingSpinner(wrapper: ReactWrapper) {
-  expect(wrapper.childAt(0).is(Spinner)).toBeTruthy();
+// component text for selectors
 
-  await waitOneTickAndUpdate(wrapper);
+const cromwellIntroTextRegex = /Cromwell is a workflow execution engine/;
+const defaultIntroTextRegex =
+  /Your cloud environment is unique to this workspace and not shared with other users/;
+const rstudioIntroTextRegex = defaultIntroTextRegex;
+const deleteUnattachedPdRegex =
+  /Deletes your persistent disk, which will also delete all files/;
+const confirmDeleteGkeAppText =
+  'You’re about to delete your cloud analysis environment.';
+const confirmDeleteGkeAppWithPdText =
+  'Keep persistent disk, delete environment';
 
-  expect(wrapper.childAt(0).is(Spinner)).toBeFalsy();
-}
+const validateInitialLoadingSpinner = async () => {
+  expect(screen.queryByLabelText('Please Wait')).not.toBeNull();
+  return waitFor(() => {
+    expect(screen.queryByLabelText('Please Wait')).toBeNull();
+  });
+};
 
 describe(GKEAppConfigurationPanel.name, () => {
   beforeEach(() => {
@@ -72,10 +76,9 @@ describe(GKEAppConfigurationPanel.name, () => {
     workspaceNamespace: 'aou-rw-1234',
     onClose: jest.fn(),
     initialPanelContent: null,
+    creatorFreeCreditsRemaining: 300,
 
     // Use RSTUDIO_DEFAULT_PROPS for the rest of the props since they shouldn't affect this test
-    creatorFreeCreditsRemaining:
-      RSTUDIO_DEFAULT_PROPS.creatorFreeCreditsRemaining,
     workspace: RSTUDIO_DEFAULT_PROPS.workspace,
     profileState: RSTUDIO_DEFAULT_PROPS.profileState,
   };
@@ -87,21 +90,23 @@ describe(GKEAppConfigurationPanel.name, () => {
       ...DEFAULT_PROPS,
       ...propOverrides,
     };
-    return mount(<GKEAppConfigurationPanel {...props} />);
+    return render(<GKEAppConfigurationPanel {...props} />);
   };
 
   it('should show a loading spinner while waiting for the list apps API call to return', async () => {
     jest
       .spyOn(appsApi(), 'listAppsInWorkspace')
       .mockImplementation((): Promise<any> => Promise.resolve([]));
-    await validateInitialLoadingSpinner(createWrapper());
+    createWrapper();
+    await validateInitialLoadingSpinner();
   });
 
   it('should show a loading spinner while waiting for the list disks API call to return', async () => {
     jest
       .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
       .mockImplementation((): Promise<any> => Promise.resolve([]));
-    await validateInitialLoadingSpinner(createWrapper());
+    createWrapper();
+    await validateInitialLoadingSpinner();
   });
 
   it('should show an error if the list apps API call fails', async () => {
@@ -111,11 +116,11 @@ describe(GKEAppConfigurationPanel.name, () => {
 
     expect(notificationStore.get()).toBeNull();
 
-    const wrapper = createWrapper();
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(notificationStore.get().title).toBeTruthy();
-    expect(notificationStore.get().message).toBeTruthy();
+    createWrapper();
+    await waitFor(() => {
+      expect(notificationStore.get().title).toBeTruthy();
+      expect(notificationStore.get().message).toBeTruthy();
+    });
   });
 
   it('should show an error if the list disks API call fails', async () => {
@@ -125,11 +130,11 @@ describe(GKEAppConfigurationPanel.name, () => {
 
     expect(notificationStore.get()).toBeNull();
 
-    const wrapper = createWrapper();
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(notificationStore.get().title).toBeTruthy();
-    expect(notificationStore.get().message).toBeTruthy();
+    createWrapper();
+    await waitFor(() => {
+      expect(notificationStore.get().title).toBeTruthy();
+      expect(notificationStore.get().message).toBeTruthy();
+    });
   });
 
   it('should not show an error if both fetch API calls succeed', async () => {
@@ -142,84 +147,21 @@ describe(GKEAppConfigurationPanel.name, () => {
 
     expect(notificationStore.get()).toBeNull();
 
-    const wrapper = createWrapper();
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(notificationStore.get()).toBeNull();
-  });
-
-  it('should pass the relevant user app to the specific app component when the API call succeeds', async () => {
-    const workspaceNamespace = 'aou-rw-1234';
-    const cromwellApp = createListAppsCromwellResponse();
-    const apps = [cromwellApp, createListAppsRStudioResponse()];
-    const listAppsStub = jest
-      .spyOn(appsApi(), 'listAppsInWorkspace')
-      .mockImplementation((): Promise<any> => Promise.resolve(apps));
-
-    const wrapper = createWrapper({
-      workspaceNamespace,
-      appType: AppType.CROMWELL,
+    createWrapper();
+    await waitFor(() => {
+      expect(notificationStore.get()).toBeNull();
     });
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(listAppsStub).toHaveBeenCalledWith(workspaceNamespace);
-    const cromwellPanel = wrapper.find(CromwellConfigurationPanel);
-    expect(cromwellPanel.exists()).toBeTruthy();
-    expect(cromwellPanel.prop('app')).toEqual(cromwellApp);
   });
 
-  it('should pass the relevant disk to the specific app if available', async () => {
-    const workspaceNamespace = 'aou-rw-1234';
-    const cromwellDisk = stubDisk();
-    cromwellDisk.appType = AppType.CROMWELL;
-    const rstudioDisk = stubDisk();
-    rstudioDisk.appType = AppType.RSTUDIO;
-    const listDisksStub = jest
-      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
-      .mockImplementation(
-        (): Promise<any> => Promise.resolve([cromwellDisk, rstudioDisk])
-      );
-
-    const wrapper = createWrapper({
-      workspaceNamespace,
-      appType: AppType.CROMWELL,
-    });
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(listDisksStub).toHaveBeenCalledWith(workspaceNamespace);
-    const cromwellPanel = wrapper.find(CromwellConfigurationPanel);
-    expect(cromwellPanel.exists()).toBeTruthy();
-    expect(cromwellPanel.prop('disk')).toEqual(cromwellDisk);
-  });
-
-  it('should pass no disk to the specific app component if no relevant disk is available', async () => {
-    const workspaceNamespace = 'aou-rw-1234';
-    const rstudioDisk = stubDisk();
-    rstudioDisk.appType = AppType.RSTUDIO;
-    const listDisksStub = jest
-      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
-      .mockImplementation((): Promise<any> => Promise.resolve([rstudioDisk]));
-
-    const wrapper = createWrapper({
-      workspaceNamespace,
-      appType: AppType.CROMWELL,
-    });
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(listDisksStub).toHaveBeenCalledWith(workspaceNamespace);
-    const cromwellPanel = wrapper.find(CromwellConfigurationPanel);
-    expect(cromwellPanel.exists()).toBeTruthy();
-    expect(cromwellPanel.prop('disk')).toEqual(undefined);
-  });
-
-  it('should display the CREATE panel if no initial panel is passed', async () => {
-    const wrapper = createWrapper({
+  it('should display the Cromwell creation panel if no initial panel is passed', async () => {
+    createWrapper({
       appType: AppType.CROMWELL,
       initialPanelContent: null,
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    expect(wrapper.find(CromwellConfigurationPanel).exists()).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByText(cromwellIntroTextRegex)).not.toBeNull();
+    });
   });
 
   it('should display the initial panel if an initial panel is passed', async () => {
@@ -233,56 +175,63 @@ describe(GKEAppConfigurationPanel.name, () => {
     jest
       .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
       .mockImplementation((): Promise<any> => Promise.resolve([cromwellDisk]));
-    const wrapper = createWrapper({
+    createWrapper({
       appType: AppType.CROMWELL,
       initialPanelContent: GKEAppPanelContent.DELETE_GKE_APP,
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    expect(wrapper.find(ConfirmDeleteEnvironmentWithPD).exists()).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByText(confirmDeleteGkeAppWithPdText)).not.toBeNull();
+    });
   });
 
   it('should display the Cromwell panel when the type is Cromwell', async () => {
-    const wrapper = createWrapper({
+    createWrapper({
       appType: AppType.CROMWELL,
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    const cromwellPanel = wrapper.find(CromwellConfigurationPanel);
-    expect(cromwellPanel.exists()).toBeTruthy();
-    // check that an arbitrary CromwellConfigurationPanelProps prop is passed through
-    expect(cromwellPanel.prop('onClose')).toEqual(DEFAULT_PROPS.onClose);
+    await waitFor(() => {
+      expect(screen.queryByText(cromwellIntroTextRegex)).not.toBeNull();
+      expect(screen.queryByText(rstudioIntroTextRegex)).toBeNull();
+    });
   });
 
   it('should display the RStudio panel when the type is RStudio', async () => {
-    const wrapper = createWrapper({
+    createWrapper({
       appType: AppType.RSTUDIO,
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    const rstudioPanel = wrapper.find(RStudioConfigurationPanel);
-    expect(rstudioPanel.exists()).toBeTruthy();
-    // check that an arbitrary RStudioConfigurationPanelProps prop is passed through
-    expect(rstudioPanel.prop('onClose')).toEqual(DEFAULT_PROPS.onClose);
+    await waitFor(() => {
+      expect(screen.queryByText(rstudioIntroTextRegex)).not.toBeNull();
+      expect(screen.queryByText(cromwellIntroTextRegex)).toBeNull();
+    });
   });
 
   it('should change panels from CREATE to DELETE_UNATTACHED_PD after clicking the delete PD button', async () => {
-    const wrapper = createWrapper({
+    // add an unattached PD
+    const disk = stubDisk();
+    disk.appType = AppType.CROMWELL;
+    jest
+      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.resolve([disk]));
+
+    createWrapper({
       appType: AppType.CROMWELL,
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    const cromwellPanel = wrapper.find(CromwellConfigurationPanel);
-    expect(cromwellPanel.exists()).toBeTruthy();
-    expect(wrapper.find(ConfirmDeleteUnattachedPD).exists()).toBeFalsy();
-
-    act(() => {
-      cromwellPanel.prop('onClickDeleteUnattachedPersistentDisk')();
+    await waitFor(() => {
+      expect(screen.queryByText(cromwellIntroTextRegex)).not.toBeNull();
+      expect(screen.queryByText(deleteUnattachedPdRegex)).toBeNull();
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    expect(wrapper.find(CromwellConfigurationPanel).exists()).toBeFalsy();
-    expect(wrapper.find(ConfirmDeleteUnattachedPD).exists()).toBeTruthy();
+    const deleteButton = screen.getByLabelText('Delete Persistent Disk');
+    expectButtonElementEnabled(deleteButton);
+    deleteButton.click();
+
+    await waitFor(() => {
+      expect(screen.queryByText(deleteUnattachedPdRegex)).not.toBeNull();
+      expect(screen.queryByText(cromwellIntroTextRegex)).toBeNull();
+    });
   });
 
   it('should call the delete GKE app api after confirming deleting a GKE app', async () => {
@@ -302,28 +251,35 @@ describe(GKEAppConfigurationPanel.name, () => {
     jest
       .spyOn(appsApi(), 'listAppsInWorkspace')
       .mockImplementation((): Promise<any> => Promise.resolve([app]));
-    const wrapper = createWrapper({
+    createWrapper({
       onClose: onCloseStub,
       appType: AppType.CROMWELL,
       workspaceNamespace,
       initialPanelContent: GKEAppPanelContent.DELETE_GKE_APP,
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    const deletePDSelected = true;
-    act(() => {
-      wrapper.find(ConfirmDeleteEnvironmentWithPD).prop('onConfirm')(
-        deletePDSelected
-      );
+    // confirm that the correct panel is visible
+    await waitFor(() => {
+      expect(screen.queryByText(confirmDeleteGkeAppWithPdText)).not.toBeNull();
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    expect(deleteAppStub).toHaveBeenCalledWith(
-      workspaceNamespace,
-      app.appName,
-      deletePDSelected
-    );
-    expect(onCloseStub).toHaveBeenCalled();
+    const deletePDRadioButton = screen.getByRole('radio', {
+      name: 'Delete persistent disk and environment',
+    });
+    deletePDRadioButton.click();
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+    expectButtonElementEnabled(deleteButton);
+    deleteButton.click();
+
+    await waitFor(() => {
+      expect(deleteAppStub).toHaveBeenCalledWith(
+        workspaceNamespace,
+        app.appName,
+        true /* deletePDSelected */
+      );
+      expect(onCloseStub).toHaveBeenCalled();
+    });
   });
 
   it('should open the ConfirmDelete (without PD) panel when deleting a GKE app with no PD', async () => {
@@ -346,30 +302,31 @@ describe(GKEAppConfigurationPanel.name, () => {
       .mockImplementation((): Promise<any> => Promise.resolve([app]));
 
     const workspaceNamespace = 'aou-rw-1234';
-    const wrapper = createWrapper({
+    createWrapper({
       onClose: onCloseStub,
       appType: AppType.CROMWELL,
       workspaceNamespace,
       initialPanelContent: GKEAppPanelContent.DELETE_GKE_APP,
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    const confirmDeletePanel = wrapper.find(ConfirmDelete);
-    expect(confirmDeletePanel.exists()).toBeTruthy();
-
-    act(() => {
-      confirmDeletePanel.prop('onConfirm')();
+    // confirm that the correct panel is visible
+    await waitFor(() => {
+      expect(screen.queryByText(confirmDeleteGkeAppText)).not.toBeNull();
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    const deletePDSelected = false;
-    expect(deleteAppStub).toHaveBeenCalledWith(
-      workspaceNamespace,
-      app.appName,
-      deletePDSelected
-    );
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+    expectButtonElementEnabled(deleteButton);
+    deleteButton.click();
 
-    expect(onCloseStub).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(deleteAppStub).toHaveBeenCalledWith(
+        workspaceNamespace,
+        app.appName,
+        false /* deletePDSelected */
+      );
+
+      expect(onCloseStub).toHaveBeenCalled();
+    });
   });
 
   it('should close the panel after cancelling deleting a GKE app', async () => {
@@ -386,18 +343,24 @@ describe(GKEAppConfigurationPanel.name, () => {
     jest
       .spyOn(appsApi(), 'listAppsInWorkspace')
       .mockImplementation((): Promise<any> => Promise.resolve([app]));
-    const wrapper = createWrapper({
+    createWrapper({
       onClose: onCloseStub,
       appType: AppType.CROMWELL,
       workspaceNamespace,
       initialPanelContent: GKEAppPanelContent.DELETE_GKE_APP,
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    wrapper.find(ConfirmDeleteEnvironmentWithPD).prop('onCancel')();
-    await waitOneTickAndUpdate(wrapper);
+    await waitFor(() => {
+      expect(screen.queryByText(confirmDeleteGkeAppWithPdText)).not.toBeNull();
+    });
 
-    expect(onCloseStub).toHaveBeenCalled();
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    expectButtonElementEnabled(cancelButton);
+    cancelButton.click();
+
+    await waitFor(() => {
+      expect(onCloseStub).toHaveBeenCalled();
+    });
   });
 
   it('should call the delete PD api after confirming deleting PD', async () => {
@@ -413,31 +376,45 @@ describe(GKEAppConfigurationPanel.name, () => {
     jest
       .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
       .mockImplementation((): Promise<any> => Promise.resolve([disk]));
-    const wrapper = createWrapper({
+    createWrapper({
       onClose: onCloseStub,
       appType: AppType.CROMWELL,
       workspaceNamespace,
     });
-    await waitOneTickAndUpdate(wrapper);
-    // Start with the DELETE_UNATTACHED_PD panel
-    act(() => {
-      wrapper
-        .find(CromwellConfigurationPanel)
-        .prop('onClickDeleteUnattachedPersistentDisk')();
+
+    await waitFor(() => {
+      expect(screen.queryByText(cromwellIntroTextRegex)).not.toBeNull();
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    wrapper.find(ConfirmDeleteUnattachedPD).prop('onConfirm')();
-    await waitOneTickAndUpdate(wrapper);
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete Persistent Disk',
+    });
+    expectButtonElementEnabled(deleteButton);
+    deleteButton.click();
 
-    expect(deleteUnattachedPDStub).toHaveBeenCalledWith(
-      workspaceNamespace,
-      disk.name
-    );
-    expect(onCloseStub).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByText(deleteUnattachedPdRegex)).not.toBeNull();
+    });
 
-    // Validate there is no error modal if the call succeeds
-    expect(notificationStore.get()).toBeNull();
+    const deletePDRadioButton = screen.getByRole('radio', {
+      name: 'Delete persistent disk',
+    });
+    deletePDRadioButton.click();
+
+    const confirmDeleteButton = screen.getByRole('button', { name: 'Delete' });
+    expectButtonElementEnabled(confirmDeleteButton);
+    confirmDeleteButton.click();
+
+    await waitFor(() => {
+      expect(deleteUnattachedPDStub).toHaveBeenCalledWith(
+        workspaceNamespace,
+        disk.name
+      );
+      expect(onCloseStub).toHaveBeenCalled();
+
+      // Validate there is no error modal if the call succeeds
+      expect(notificationStore.get()).toBeNull();
+    });
   });
 
   it('should show an error modal if the delete PD API call fails', async () => {
@@ -445,52 +422,85 @@ describe(GKEAppConfigurationPanel.name, () => {
       .spyOn(disksApi(), 'deleteDisk')
       .mockImplementation((): Promise<any> => Promise.reject());
 
-    const wrapper = createWrapper({
+    const disk = stubDisk();
+    disk.appType = AppType.CROMWELL;
+    jest
+      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.resolve([disk]));
+
+    createWrapper({
       appType: AppType.CROMWELL,
     });
-    await waitOneTickAndUpdate(wrapper);
-    // Start with the DELETE_UNATTACHED_PD panel
-    act(() => {
-      wrapper
-        .find(CromwellConfigurationPanel)
-        .prop('onClickDeleteUnattachedPersistentDisk')();
+
+    await waitFor(() => {
+      expect(screen.queryByText(cromwellIntroTextRegex)).not.toBeNull();
+      expect(notificationStore.get()).toBeNull(); // no errors
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    expect(notificationStore.get()).toBeNull();
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete Persistent Disk',
+    });
+    expectButtonElementEnabled(deleteButton);
+    deleteButton.click();
 
-    wrapper.find(ConfirmDeleteUnattachedPD).prop('onConfirm')();
-    await waitOneTickAndUpdate(wrapper);
+    await waitFor(() => {
+      expect(screen.queryByText(deleteUnattachedPdRegex)).not.toBeNull();
+    });
 
-    expect(notificationStore.get().title).toBeTruthy();
-    expect(notificationStore.get().message).toBeTruthy();
+    const deletePDRadioButton = screen.getByRole('radio', {
+      name: 'Delete persistent disk',
+    });
+    deletePDRadioButton.click();
+
+    const confirmDeleteButton = screen.getByRole('button', { name: 'Delete' });
+    expectButtonElementEnabled(confirmDeleteButton);
+    confirmDeleteButton.click();
+
+    await waitFor(() => {
+      expect(notificationStore.get().title).toBeTruthy();
+      expect(notificationStore.get().message).toBeTruthy();
+    });
   });
 
   it('should change panels from DELETE_UNATTACHED_PD to CREATE after cancelling delete PD', async () => {
-    const wrapper = createWrapper({
+    // Setup: A Cromwell disk exists and the current app is Cromwell
+    const workspaceNamespace = 'aou-rw-1234';
+    const disk = stubDisk();
+    disk.appType = AppType.CROMWELL;
+    jest
+      .spyOn(disksApi(), 'listOwnedDisksInWorkspace')
+      .mockImplementation((): Promise<any> => Promise.resolve([disk]));
+    createWrapper({
       appType: AppType.CROMWELL,
+      workspaceNamespace,
     });
-    await waitOneTickAndUpdate(wrapper);
-    // Start with the DELETE_UNATTACHED_PD panel
-    act(() => {
-      wrapper
-        .find(CromwellConfigurationPanel)
-        .prop('onClickDeleteUnattachedPersistentDisk')();
+
+    await waitFor(() => {
+      expect(screen.queryByText(cromwellIntroTextRegex)).not.toBeNull();
     });
-    await waitOneTickAndUpdate(wrapper);
 
-    expect(wrapper.find(CromwellConfigurationPanel).exists()).toBeFalsy();
-    const confirmDeleteUnattachedPDPanel = wrapper.find(
-      ConfirmDeleteUnattachedPD
-    );
-    expect(confirmDeleteUnattachedPDPanel.exists()).toBeTruthy();
-
-    act(() => {
-      confirmDeleteUnattachedPDPanel.prop('onCancel')();
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete Persistent Disk',
     });
-    await waitOneTickAndUpdate(wrapper);
+    expectButtonElementEnabled(deleteButton);
+    deleteButton.click();
 
-    expect(wrapper.find(CromwellConfigurationPanel).exists()).toBeTruthy();
-    expect(wrapper.find(ConfirmDeleteUnattachedPD).exists()).toBeFalsy();
+    await waitFor(() => {
+      expect(screen.queryByText(deleteUnattachedPdRegex)).not.toBeNull();
+    });
+
+    const deletePDRadioButton = screen.getByRole('radio', {
+      name: 'Delete persistent disk',
+    });
+    deletePDRadioButton.click();
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    expectButtonElementEnabled(cancelButton);
+    cancelButton.click();
+
+    await waitFor(() => {
+      expect(screen.queryByText(cromwellIntroTextRegex)).not.toBeNull();
+      expect(screen.queryByText(deleteUnattachedPdRegex)).toBeNull();
+    });
   });
 });

--- a/ui/src/app/components/gke-app-configuration-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.tsx
@@ -5,14 +5,8 @@ import { AppType, Disk, UserAppEnvironment } from 'generated/fetch';
 
 import { switchCase } from '@terra-ui-packages/core-utils';
 import { findApp, toUIAppType } from 'app/components/apps-panel/utils';
-import {
-  CromwellConfigurationPanel,
-  CromwellConfigurationPanelProps,
-} from 'app/components/cromwell-configuration-panel';
-import {
-  RStudioConfigurationPanel,
-  RStudioConfigurationPanelProps,
-} from 'app/components/rstudio-configuration-panel';
+import { CromwellConfigurationPanel } from 'app/components/cromwell-configuration-panel';
+import { RStudioConfigurationPanel } from 'app/components/rstudio-configuration-panel';
 import { ConfirmDeleteEnvironmentWithPD } from 'app/components/runtime-configuration-panel/confirm-delete-environment-with-pd';
 import { ConfirmDeleteUnattachedPD } from 'app/components/runtime-configuration-panel/confirm-delete-unattached-pd';
 import { Spinner } from 'app/components/spinners';
@@ -20,16 +14,17 @@ import { appsApi, disksApi } from 'app/services/swagger-fetch-clients';
 import { notificationStore } from 'app/utils/stores';
 import { deleteUserApp, findDisk } from 'app/utils/user-apps-utils';
 
+import { CreateGKEAppPanelPropsWithAppType } from './gke-app-configuration-panels/create-gke-app-panel';
 import { ConfirmDelete } from './runtime-configuration-panel/confirm-delete';
 
 type InjectedProps = 'app' | 'disk' | 'onClickDeleteUnattachedPersistentDisk';
 
 export type GkeAppConfigurationPanelProps = {
-  type: AppType;
+  appType: AppType;
   workspaceNamespace: string;
   onClose: () => void;
   initialPanelContent: GKEAppPanelContent | null;
-} & Omit<CreateGKEAppPanelProps, InjectedProps>;
+} & Omit<CreateGKEAppPanelPropsWithAppType, InjectedProps>;
 
 export enum GKEAppPanelContent {
   CREATE,
@@ -37,20 +32,18 @@ export enum GKEAppPanelContent {
   DELETE_GKE_APP,
 }
 
-type CreateGKEAppPanelProps = {
-  type: AppType;
-} & CromwellConfigurationPanelProps &
-  RStudioConfigurationPanelProps;
-
-const CreateGKEAppPanel = ({ type, ...props }: CreateGKEAppPanelProps) =>
+const CreateGKEAppPanel = ({
+  appType,
+  ...props
+}: CreateGKEAppPanelPropsWithAppType) =>
   switchCase(
-    type,
+    appType,
     [AppType.CROMWELL, () => <CromwellConfigurationPanel {...props} />],
     [AppType.RSTUDIO, () => <RStudioConfigurationPanel {...props} />]
   );
 
 export const GKEAppConfigurationPanel = ({
-  type,
+  appType,
   workspaceNamespace,
   onClose,
   initialPanelContent,
@@ -107,8 +100,8 @@ export const GKEAppConfigurationPanel = ({
     return <Spinner />;
   }
 
-  const app = findApp(gkeAppsInWorkspace, toUIAppType[type]);
-  const disk = findDisk(ownedDisksInWorkspace, type);
+  const app = findApp(gkeAppsInWorkspace, toUIAppType[appType]);
+  const disk = findDisk(ownedDisksInWorkspace, appType);
 
   const onClickDeleteUnattachedPersistentDisk = () => {
     setPanelContent(GKEAppPanelContent.DELETE_UNATTACHED_PD);
@@ -147,7 +140,7 @@ export const GKEAppConfigurationPanel = ({
         <CreateGKEAppPanel
           {...{
             ...props,
-            type,
+            appType,
             app,
             disk,
             onClickDeleteUnattachedPersistentDisk,

--- a/ui/src/app/components/gke-app-configuration-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.tsx
@@ -3,19 +3,18 @@ import { useEffect, useState } from 'react';
 
 import { AppType, Disk, UserAppEnvironment } from 'generated/fetch';
 
-import { switchCase } from '@terra-ui-packages/core-utils';
-import { findApp, toUIAppType } from 'app/components/apps-panel/utils';
-import { CromwellConfigurationPanel } from 'app/components/cromwell-configuration-panel';
-import { RStudioConfigurationPanel } from 'app/components/rstudio-configuration-panel';
-import { ConfirmDeleteEnvironmentWithPD } from 'app/components/runtime-configuration-panel/confirm-delete-environment-with-pd';
-import { ConfirmDeleteUnattachedPD } from 'app/components/runtime-configuration-panel/confirm-delete-unattached-pd';
 import { Spinner } from 'app/components/spinners';
 import { appsApi, disksApi } from 'app/services/swagger-fetch-clients';
 import { notificationStore } from 'app/utils/stores';
 import { deleteUserApp, findDisk } from 'app/utils/user-apps-utils';
 
+import { findApp, toUIAppType } from './apps-panel/utils';
+import { CromwellConfigurationPanel } from './cromwell-configuration-panel';
 import { CreateGKEAppPanelPropsWithAppType } from './gke-app-configuration-panels/create-gke-app-panel';
+import { RStudioConfigurationPanel } from './rstudio-configuration-panel';
 import { ConfirmDelete } from './runtime-configuration-panel/confirm-delete';
+import { ConfirmDeleteEnvironmentWithPD } from './runtime-configuration-panel/confirm-delete-environment-with-pd';
+import { ConfirmDeleteUnattachedPD } from './runtime-configuration-panel/confirm-delete-unattached-pd';
 
 type InjectedProps = 'app' | 'disk' | 'onClickDeleteUnattachedPersistentDisk';
 

--- a/ui/src/app/components/gke-app-configuration-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 
 import { AppType, Disk, UserAppEnvironment } from 'generated/fetch';
 
+import { switchCase } from '@terra-ui-packages/core-utils';
 import { Spinner } from 'app/components/spinners';
 import { appsApi, disksApi } from 'app/services/swagger-fetch-clients';
 import { notificationStore } from 'app/utils/stores';

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
 
 import { AppStatus } from 'generated/fetch';
 
+import { render, screen, waitFor } from '@testing-library/react';
 import { defaultCromwellConfig } from 'app/components/apps-panel/utils';
-import { Button } from 'app/components/buttons';
 import {
   CreateGKEAppButton,
   CreateGKEAppButtonProps,
 } from 'app/components/gke-app-configuration-panels/create-gke-app-button';
-import { TooltipTrigger } from 'app/components/popups';
 
+import {
+  expectButtonElementDisabled,
+  expectButtonElementEnabled,
+} from 'testing/react-test-helpers';
 import { createListAppsCromwellResponse } from 'testing/stubs/apps-api-stub';
 import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
 
@@ -26,7 +28,7 @@ describe(CreateGKEAppButton.name, () => {
     propOverrides?: Partial<CreateGKEAppButtonProps>
   ) => {
     const allProps = { ...DEFAULT_PROPS, ...propOverrides };
-    return shallow(<CreateGKEAppButton {...allProps} />);
+    return render(<CreateGKEAppButton {...allProps} />);
   };
 
   const createEnabledStatuses = [AppStatus.DELETED, null, undefined];
@@ -37,23 +39,31 @@ describe(CreateGKEAppButton.name, () => {
 
   describe('should allow creating a GKE app for certain app statuses', () => {
     test.each(createEnabledStatuses)('Status %s', async (appStatus) => {
-      const wrapper = await component({
+      await component({
         createAppRequest: defaultCromwellConfig,
         existingApp: createListAppsCromwellResponse({ status: appStatus }),
       });
-      expect(wrapper.find(TooltipTrigger).prop('disabled')).toBeTruthy();
-      expect(wrapper.find(Button).prop('disabled')).toBeFalsy();
+      await waitFor(() => {
+        const createButton = screen.getByRole('button', {
+          name: 'Cromwell cloud environment create button',
+        });
+        expectButtonElementEnabled(createButton);
+      });
     });
   });
 
-  describe('should not allow creating an RStudio app for certain app statuses', () => {
+  describe('should not allow creating a GKE app for certain app statuses', () => {
     test.each(createDisabledStatuses)('Status %s', async (appStatus) => {
-      const wrapper = await component({
+      await component({
         createAppRequest: defaultCromwellConfig,
         existingApp: createListAppsCromwellResponse({ status: appStatus }),
       });
-      expect(wrapper.find(TooltipTrigger).prop('disabled')).toBeFalsy();
-      expect(wrapper.find(Button).prop('disabled')).toBeTruthy();
+      await waitFor(() => {
+        const createButton = screen.getByRole('button', {
+          name: 'Cromwell cloud environment create button',
+        });
+        expectButtonElementDisabled(createButton);
+      });
     });
   });
 });

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
@@ -45,7 +45,7 @@ export function CreateGKEAppButton({
   return (
     <TooltipTrigger
       disabled={createEnabled}
-      content={`An ${appTypeString} app exists or is being created`}
+      content={`A ${appTypeString} app exists or is being created`}
     >
       {/* tooltip trigger needs a div for some reason */}
       <div>

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-panel.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+
+import {
+  AppType,
+  CreateAppRequest,
+  Disk,
+  PersistentDiskRequest,
+  UserAppEnvironment,
+} from 'generated/fetch';
+
+import {
+  createAppRequestToAnalysisConfig,
+  defaultCromwellConfig,
+  defaultRStudioConfig,
+} from 'app/components/apps-panel/utils';
+import { DeletePersistentDiskButton } from 'app/components/delete-persistent-disk-button';
+import { EnvironmentInformedActionPanel } from 'app/components/environment-informed-action-panel';
+import { FlexColumn, FlexRow } from 'app/components/flex';
+import { styles } from 'app/components/runtime-configuration-panel/styles';
+import { switchCase } from 'app/utils';
+import { setSidebarActiveIconStore } from 'app/utils/navigation';
+import { ProfileStore } from 'app/utils/stores';
+import {
+  appTypeToString,
+  unattachedDiskExists,
+} from 'app/utils/user-apps-utils';
+import { WorkspaceData } from 'app/utils/workspace-data';
+
+import { CreateGKEAppButton } from './create-gke-app-button';
+import { DisabledCloudComputeProfile } from './disabled-cloud-compute-profile';
+
+export interface CreateGKEAppPanelProps {
+  onClose: () => void;
+  creatorFreeCreditsRemaining: number | null;
+  workspace: WorkspaceData;
+  profileState: ProfileStore;
+  app: UserAppEnvironment | undefined;
+  disk: Disk | undefined;
+  onClickDeleteUnattachedPersistentDisk: () => void;
+}
+
+export type CreateGKEAppPanelPropsWithAppType = {
+  appType: AppType;
+} & CreateGKEAppPanelProps;
+
+type Props = {
+  IntroText?: () => JSX.Element;
+  PostCost?: () => JSX.Element;
+  PostCompute?: () => JSX.Element;
+  CreateAppText?: () => JSX.Element;
+} & CreateGKEAppPanelPropsWithAppType;
+
+export const CreateGKEAppPanel = ({
+  appType,
+  onClose,
+  creatorFreeCreditsRemaining,
+  workspace,
+  profileState,
+  app,
+  disk,
+  onClickDeleteUnattachedPersistentDisk,
+  IntroText = () => null,
+  PostCost = () => null,
+  PostCompute = () => null,
+  CreateAppText = () => null,
+}: Props) => {
+  const { profile } = profileState;
+
+  const onDismiss = () => {
+    onClose();
+    setTimeout(() => setSidebarActiveIconStore.next('apps'), 3000);
+  };
+
+  const defaultConfig = switchCase(
+    appType,
+    [AppType.CROMWELL, () => defaultCromwellConfig],
+    [AppType.RSTUDIO, () => defaultRStudioConfig]
+  );
+
+  const persistentDiskRequest: Disk | PersistentDiskRequest =
+    disk !== undefined ? disk : defaultConfig.persistentDiskRequest;
+  const createAppRequest: CreateAppRequest = {
+    ...defaultConfig,
+    persistentDiskRequest,
+  };
+  const analysisConfig = createAppRequestToAnalysisConfig(createAppRequest);
+  const { machine } = analysisConfig;
+
+  return (
+    <FlexColumn
+      id={`${appTypeToString[appType]}-configuration-panel`}
+      style={{ height: '100%', rowGap: '1rem' }}
+    >
+      <IntroText />
+      <div style={{ ...styles.controlSection }}>
+        <EnvironmentInformedActionPanel
+          {...{
+            appType,
+            creatorFreeCreditsRemaining,
+            profile,
+            workspace,
+            analysisConfig,
+          }}
+          status={app?.status}
+          onPause={Promise.resolve()}
+          onResume={Promise.resolve()}
+        />
+        <PostCost />
+      </div>
+      <div style={{ ...styles.controlSection }}>
+        <DisabledCloudComputeProfile
+          {...{ appType, machine, persistentDiskRequest }}
+        />
+      </div>
+      <PostCompute />
+      <FlexRow
+        style={{
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          gap: '2rem', // cromwell-only?
+        }}
+      >
+        {unattachedDiskExists(app, disk) && (
+          <DeletePersistentDiskButton
+            onClick={onClickDeleteUnattachedPersistentDisk}
+            style={{ flexShrink: 0 }} // rstudio wants this instead {{ flexGrow: 1 }}?
+          />
+        )}
+        <CreateAppText />
+        <CreateGKEAppButton
+          {...{ createAppRequest, onDismiss }}
+          existingApp={app}
+          workspaceNamespace={workspace.namespace}
+        />
+      </FlexRow>
+    </FlexColumn>
+  );
+};

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-panel.tsx
@@ -81,8 +81,8 @@ export const CreateGKEAppPanel = ({
     [AppType.RSTUDIO, () => defaultRStudioConfig]
   );
 
-  const persistentDiskRequest: Disk | PersistentDiskRequest =
-    disk !== undefined ? disk : defaultConfig.persistentDiskRequest;
+  const persistentDiskRequest: PersistentDiskRequest =
+    disk ?? defaultConfig.persistentDiskRequest;
   const createAppRequest: CreateAppRequest = {
     ...defaultConfig,
     persistentDiskRequest,
@@ -121,13 +121,13 @@ export const CreateGKEAppPanel = ({
         style={{
           alignItems: 'center',
           justifyContent: 'flex-end',
-          gap: '2rem', // cromwell-only?
+          gap: '2rem',
         }}
       >
         {unattachedDiskExists(app, disk) && (
           <DeletePersistentDiskButton
             onClick={onClickDeleteUnattachedPersistentDisk}
-            style={{ flexShrink: 0 }} // rstudio wants this instead {{ flexGrow: 1 }}?
+            style={{ flexShrink: 0 }}
           />
         )}
         <CreateAppText />

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-panel.tsx
@@ -44,10 +44,10 @@ export type CreateGKEAppPanelPropsWithAppType = {
 } & CreateGKEAppPanelProps;
 
 type Props = {
-  IntroText?: () => JSX.Element;
-  PostCost?: () => JSX.Element;
-  PostCompute?: () => JSX.Element;
-  CreateAppText?: () => JSX.Element;
+  IntroText?: React.FunctionComponent;
+  PostCost?: React.FunctionComponent;
+  PostCompute?: React.FunctionComponent;
+  CreateAppText?: React.FunctionComponent;
 } & CreateGKEAppPanelPropsWithAppType;
 
 export const CreateGKEAppPanel = ({

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-panel.tsx
@@ -29,6 +29,10 @@ import { WorkspaceData } from 'app/utils/workspace-data';
 import { CreateGKEAppButton } from './create-gke-app-button';
 import { DisabledCloudComputeProfile } from './disabled-cloud-compute-profile';
 
+const defaultIntroText =
+  'Your analysis environment consists of an application and compute resources. ' +
+  'Your cloud environment is unique to this workspace and not shared with other users.';
+
 export interface CreateGKEAppPanelProps {
   onClose: () => void;
   creatorFreeCreditsRemaining: number | null;
@@ -44,7 +48,7 @@ export type CreateGKEAppPanelPropsWithAppType = {
 } & CreateGKEAppPanelProps;
 
 type Props = {
-  introTextOverride?: string;
+  introText?: string;
   CostNote?: React.FunctionComponent;
   SupportNote?: React.FunctionComponent;
   CreateAppText?: React.FunctionComponent;
@@ -59,7 +63,7 @@ export const CreateGKEAppPanel = ({
   app,
   disk,
   onClickDeleteUnattachedPersistentDisk,
-  introTextOverride,
+  introText = defaultIntroText,
   CostNote = () => null,
   SupportNote = () => null,
   CreateAppText = () => null,
@@ -70,10 +74,6 @@ export const CreateGKEAppPanel = ({
     onClose();
     setTimeout(() => setSidebarActiveIconStore.next('apps'), 3000);
   };
-
-  const defaultIntroText =
-    'Your analysis environment consists of an application and compute resources. ' +
-    'Your cloud environment is unique to this workspace and not shared with other users.';
 
   const defaultConfig = switchCase(
     appType,
@@ -95,7 +95,7 @@ export const CreateGKEAppPanel = ({
       id={`${appTypeToString[appType]}-configuration-panel`}
       style={{ height: '100%', rowGap: '1rem' }}
     >
-      <div>{introTextOverride ?? defaultIntroText}</div>
+      <div>{introText}</div>
       <div style={{ ...styles.controlSection }}>
         <EnvironmentInformedActionPanel
           {...{

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-panel.tsx
@@ -8,6 +8,7 @@ import {
   UserAppEnvironment,
 } from 'generated/fetch';
 
+import { switchCase } from '@terra-ui-packages/core-utils';
 import {
   createAppRequestToAnalysisConfig,
   defaultCromwellConfig,
@@ -17,7 +18,6 @@ import { DeletePersistentDiskButton } from 'app/components/delete-persistent-dis
 import { EnvironmentInformedActionPanel } from 'app/components/environment-informed-action-panel';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { styles } from 'app/components/runtime-configuration-panel/styles';
-import { switchCase } from 'app/utils';
 import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { ProfileStore } from 'app/utils/stores';
 import {

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-panel.tsx
@@ -44,9 +44,9 @@ export type CreateGKEAppPanelPropsWithAppType = {
 } & CreateGKEAppPanelProps;
 
 type Props = {
-  IntroText?: React.FunctionComponent;
-  PostCost?: React.FunctionComponent;
-  PostCompute?: React.FunctionComponent;
+  introTextOverride?: string;
+  CostNote?: React.FunctionComponent;
+  SupportNote?: React.FunctionComponent;
   CreateAppText?: React.FunctionComponent;
 } & CreateGKEAppPanelPropsWithAppType;
 
@@ -59,9 +59,9 @@ export const CreateGKEAppPanel = ({
   app,
   disk,
   onClickDeleteUnattachedPersistentDisk,
-  IntroText = () => null,
-  PostCost = () => null,
-  PostCompute = () => null,
+  introTextOverride,
+  CostNote = () => null,
+  SupportNote = () => null,
   CreateAppText = () => null,
 }: Props) => {
   const { profile } = profileState;
@@ -70,6 +70,10 @@ export const CreateGKEAppPanel = ({
     onClose();
     setTimeout(() => setSidebarActiveIconStore.next('apps'), 3000);
   };
+
+  const defaultIntroText =
+    'Your analysis environment consists of an application and compute resources. ' +
+    'Your cloud environment is unique to this workspace and not shared with other users.';
 
   const defaultConfig = switchCase(
     appType,
@@ -91,7 +95,7 @@ export const CreateGKEAppPanel = ({
       id={`${appTypeToString[appType]}-configuration-panel`}
       style={{ height: '100%', rowGap: '1rem' }}
     >
-      <IntroText />
+      <div>{introTextOverride ?? defaultIntroText}</div>
       <div style={{ ...styles.controlSection }}>
         <EnvironmentInformedActionPanel
           {...{
@@ -105,14 +109,14 @@ export const CreateGKEAppPanel = ({
           onPause={Promise.resolve()}
           onResume={Promise.resolve()}
         />
-        <PostCost />
+        <CostNote />
       </div>
       <div style={{ ...styles.controlSection }}>
         <DisabledCloudComputeProfile
           {...{ appType, machine, persistentDiskRequest }}
         />
       </div>
-      <PostCompute />
+      <SupportNote />
       <FlexRow
         style={{
           alignItems: 'center',

--- a/ui/src/app/components/gke-app-configuration-panels/disabled-cloud-compute-profile.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/disabled-cloud-compute-profile.tsx
@@ -1,38 +1,34 @@
 import * as React from 'react';
 
-import { AppType } from 'generated/fetch';
+import { AppType, Disk, PersistentDiskRequest } from 'generated/fetch';
 
 import { FlexRow } from 'app/components/flex';
 import { TooltipTrigger } from 'app/components/popups';
 import { styles } from 'app/components/runtime-configuration-panel/styles';
+import { Machine } from 'app/utils/machines';
 import { appTypeToString } from 'app/utils/user-apps-utils';
 
-interface DisabledCloudComputeProfileProps {
-  cpu: number;
-  memory: number;
-  persistentDiskRequestSize: number;
+interface Props {
+  machine: Machine;
+  persistentDiskRequest: Disk | PersistentDiskRequest;
   appType: AppType;
 }
-
-export function DisabledCloudComputeProfile({
-  cpu,
-  memory,
-  persistentDiskRequestSize,
+export const DisabledCloudComputeProfile = ({
+  machine: { cpu, memory },
+  persistentDiskRequest: { size },
   appType,
-}: DisabledCloudComputeProfileProps) {
-  return (
-    <FlexRow style={{ alignItems: 'center' }}>
-      <div style={{ fontWeight: 'bold', marginRight: '0.5rem' }}>
-        Cloud compute profile
+}: Props) => (
+  <FlexRow style={{ alignItems: 'center' }}>
+    <div style={{ fontWeight: 'bold', marginRight: '0.5rem' }}>
+      Cloud compute profile
+    </div>
+    <TooltipTrigger
+      content={`The cloud compute profile for ${appTypeToString[appType]} beta is non-configurable.`}
+      side={'right'}
+    >
+      <div style={styles.disabledCloudProfile}>
+        {`${cpu} CPUS, ${memory}GB RAM, ${size}GB disk`}
       </div>
-      <TooltipTrigger
-        content={`The cloud compute profile for ${appTypeToString[appType]} beta is non-configurable.`}
-        side={'right'}
-      >
-        <div style={styles.disabledCloudProfile}>
-          {`${cpu} CPUS, ${memory}GB RAM, ${persistentDiskRequestSize}GB disk`}
-        </div>
-      </TooltipTrigger>
-    </FlexRow>
-  );
-}
+    </TooltipTrigger>
+  </FlexRow>
+);

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -527,7 +527,7 @@ export const HelpSidebar = fp.flow(
               <ConfigurationPanel
                 {...{ runtimeConfPanelInitialState }}
                 onClose={() => this.setActiveIcon(null)}
-                type={UIAppType.JUPYTER}
+                appType={UIAppType.JUPYTER}
               />
             ),
             showFooter: false,
@@ -581,7 +581,7 @@ export const HelpSidebar = fp.flow(
             ),
             renderBody: () => (
               <ConfigurationPanel
-                type={UIAppType.CROMWELL}
+                appType={UIAppType.CROMWELL}
                 onClose={() => this.setActiveIcon(null)}
                 gkeAppConfPanelInitialState={gkeAppConfPanelInitialState}
               />
@@ -613,7 +613,7 @@ export const HelpSidebar = fp.flow(
             ),
             renderBody: () => (
               <ConfigurationPanel
-                type={UIAppType.RSTUDIO}
+                appType={UIAppType.RSTUDIO}
                 onClose={() => this.setActiveIcon(null)}
                 gkeAppConfPanelInitialState={gkeAppConfPanelInitialState}
               />

--- a/ui/src/app/components/rstudio-configuration-panel.spec.tsx
+++ b/ui/src/app/components/rstudio-configuration-panel.spec.tsx
@@ -24,14 +24,12 @@ import {
 } from 'testing/stubs/workspaces';
 
 import { defaultRStudioConfig } from './apps-panel/utils';
-import {
-  RStudioConfigurationPanel,
-  RStudioConfigurationPanelProps,
-} from './rstudio-configuration-panel';
+import { CreateGKEAppPanelProps } from './gke-app-configuration-panels/create-gke-app-panel';
+import { RStudioConfigurationPanel } from './rstudio-configuration-panel';
 
 const onClose = jest.fn();
 const freeTierBillingAccountId = 'freetier';
-export const DEFAULT_PROPS: RStudioConfigurationPanelProps = {
+export const DEFAULT_PROPS: CreateGKEAppPanelProps = {
   onClose,
   creatorFreeCreditsRemaining: null,
   workspace: {
@@ -54,9 +52,7 @@ export const DEFAULT_PROPS: RStudioConfigurationPanelProps = {
 describe('RStudioConfigurationPanel', () => {
   let disksApiStub: DisksApiStub;
 
-  const component = async (
-    propOverrides?: Partial<RStudioConfigurationPanelProps>
-  ) => {
+  const component = async (propOverrides?: Partial<CreateGKEAppPanelProps>) => {
     const allProps = { ...DEFAULT_PROPS, ...propOverrides };
     const c = mountWithRouter(<RStudioConfigurationPanel {...allProps} />);
     await waitOneTickAndUpdate(c);

--- a/ui/src/app/components/rstudio-configuration-panel.tsx
+++ b/ui/src/app/components/rstudio-configuration-panel.tsx
@@ -1,123 +1,42 @@
 import * as React from 'react';
 
-import {
-  AppType,
-  CreateAppRequest,
-  Disk,
-  UserAppEnvironment,
-} from 'generated/fetch';
+import { AppType } from 'generated/fetch';
 
-import { DeletePersistentDiskButton } from 'app/components/delete-persistent-disk-button';
-import { FlexColumn, FlexRow } from 'app/components/flex';
-import { CreateGKEAppButton } from 'app/components/gke-app-configuration-panels/create-gke-app-button';
-import { DisabledCloudComputeProfile } from 'app/components/gke-app-configuration-panels/disabled-cloud-compute-profile';
 import { InfoMessage } from 'app/components/messages';
-import { styles } from 'app/components/runtime-configuration-panel/styles';
-import { setSidebarActiveIconStore } from 'app/utils/navigation';
-import { ProfileStore } from 'app/utils/stores';
-import { unattachedDiskExists } from 'app/utils/user-apps-utils';
-import { WorkspaceData } from 'app/utils/workspace-data';
 
 import {
-  createAppRequestToAnalysisConfig,
-  defaultRStudioConfig,
-} from './apps-panel/utils';
-import { EnvironmentInformedActionPanel } from './environment-informed-action-panel';
+  CreateGKEAppPanel,
+  CreateGKEAppPanelProps,
+} from './gke-app-configuration-panels/create-gke-app-panel';
 
-export interface RStudioConfigurationPanelProps {
-  onClose: () => void;
-  creatorFreeCreditsRemaining: number | null;
-  workspace: WorkspaceData;
-  profileState: ProfileStore;
-  app: UserAppEnvironment | undefined;
-  disk: Disk | undefined;
-  onClickDeleteUnattachedPersistentDisk: () => void;
-}
+const IntroText = () => (
+  <div>
+    Your analysis environment consists of an application and compute resources.
+    Your cloud environment is unique to this workspace and not shared with other
+    users.
+  </div>
+);
 
-export const RStudioConfigurationPanel = ({
-  onClose,
-  creatorFreeCreditsRemaining,
-  workspace,
-  profileState,
-  app,
-  disk,
-  onClickDeleteUnattachedPersistentDisk,
-}: RStudioConfigurationPanelProps) => {
-  const { profile } = profileState;
+const PostCompute = () => (
+  <InfoMessage>
+    <h4 style={{ marginTop: 0, fontSize: '1rem' }}>
+      How to create RStudio artifacts:
+    </h4>
+    <p style={{ marginTop: '0.5rem' }}>
+      You can create R and RMD files within RStudio’s menu bar. Saved files will
+      appear in the analysis tab and be stored in the workspace bucket. Access
+      your files in RStudio through the Output pane.
+    </p>
+  </InfoMessage>
+);
 
-  const onDismiss = () => {
-    onClose();
-    setTimeout(() => setSidebarActiveIconStore.next('apps'), 3000);
-  };
-
-  const rstudioConfig: CreateAppRequest = {
-    ...defaultRStudioConfig,
-    persistentDiskRequest:
-      disk !== undefined ? disk : defaultRStudioConfig.persistentDiskRequest,
-  };
-  const analysisConfig = createAppRequestToAnalysisConfig(rstudioConfig);
-
-  return (
-    <FlexColumn
-      id='rstudio-configuration-panel'
-      style={{ height: '100%', rowGap: '1rem' }}
-    >
-      <div>
-        Your analysis environment consists of an application and compute
-        resources. Your cloud environment is unique to this workspace and not
-        shared with other users.
-      </div>
-      <div style={{ ...styles.controlSection }}>
-        <EnvironmentInformedActionPanel
-          {...{
-            creatorFreeCreditsRemaining,
-            profile,
-            workspace,
-            analysisConfig,
-          }}
-          status={app?.status}
-          onPause={Promise.resolve()}
-          onResume={Promise.resolve()}
-          appType={AppType.RSTUDIO}
-        />
-      </div>
-      <div style={{ ...styles.controlSection }}>
-        <DisabledCloudComputeProfile
-          cpu={analysisConfig.machine.cpu}
-          memory={analysisConfig.machine.memory}
-          persistentDiskRequestSize={rstudioConfig.persistentDiskRequest.size}
-          appType={AppType.RSTUDIO}
-        />
-      </div>
-      <InfoMessage>
-        <h4 style={{ marginTop: 0, fontSize: '1rem' }}>
-          How to create RStudio artifacts:
-        </h4>
-        <p style={{ marginTop: '0.5rem' }}>
-          You can create R and RMD files within RStudio’s menu bar. Saved files
-          will appear in the analysis tab and be stored in the workspace bucket.
-          Access your files in RStudio through the Output pane.
-        </p>
-      </InfoMessage>
-      <FlexRow
-        style={{
-          alignItems: 'center',
-          justifyContent: 'flex-end',
-        }}
-      >
-        {unattachedDiskExists(app, disk) && (
-          <DeletePersistentDiskButton
-            onClick={onClickDeleteUnattachedPersistentDisk}
-            style={{ flexGrow: 1 }}
-          />
-        )}
-        <CreateGKEAppButton
-          createAppRequest={rstudioConfig}
-          existingApp={app}
-          workspaceNamespace={workspace.namespace}
-          onDismiss={onDismiss}
-        />
-      </FlexRow>
-    </FlexColumn>
-  );
-};
+export const RStudioConfigurationPanel = (props: CreateGKEAppPanelProps) => (
+  <CreateGKEAppPanel
+    {...{
+      ...props,
+      IntroText,
+      PostCompute,
+    }}
+    appType={AppType.RSTUDIO}
+  />
+);

--- a/ui/src/app/components/rstudio-configuration-panel.tsx
+++ b/ui/src/app/components/rstudio-configuration-panel.tsx
@@ -9,15 +9,7 @@ import {
   CreateGKEAppPanelProps,
 } from './gke-app-configuration-panels/create-gke-app-panel';
 
-const IntroText = () => (
-  <div>
-    Your analysis environment consists of an application and compute resources.
-    Your cloud environment is unique to this workspace and not shared with other
-    users.
-  </div>
-);
-
-const PostCompute = () => (
+const SupportNote = () => (
   <InfoMessage>
     <h4 style={{ marginTop: 0, fontSize: '1rem' }}>
       How to create RStudio artifacts:
@@ -34,8 +26,7 @@ export const RStudioConfigurationPanel = (props: CreateGKEAppPanelProps) => (
   <CreateGKEAppPanel
     {...{
       ...props,
-      IntroText,
-      PostCompute,
+      SupportNote,
     }}
     appType={AppType.RSTUDIO}
   />

--- a/ui/src/app/components/runtime-configuration-panel/confirm-delete-environment-with-pd.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/confirm-delete-environment-with-pd.tsx
@@ -98,8 +98,11 @@ export const ConfirmDeleteEnvironmentWithPD = ({
               style={{ marginRight: '0.375rem' }}
               onChange={() => setDeletePDSelected(true)}
               checked={deletePDSelected}
+              aria-labelledby='delete-environment-and-pd'
             />
-            <label>Delete persistent disk and environment</label>
+            <label id='delete-environment-and-pd'>
+              Delete persistent disk and environment
+            </label>
           </div>
         </h3>
         <p style={{ ...styles.confirmWarningText, gridColumn: 1, gridRow: 2 }}>
@@ -204,7 +207,7 @@ export const ConfirmDeleteEnvironmentWithPD = ({
           Cancel
         </Button>
         <Button
-          aria-label={'Delete'}
+          aria-label='Delete'
           disabled={deleting}
           onClick={async () => {
             setDeleting(true);

--- a/ui/src/app/components/runtime-configuration-panel/confirm-delete-unattached-pd.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/confirm-delete-unattached-pd.tsx
@@ -53,8 +53,11 @@ export const ConfirmDeleteUnattachedPD = ({
               style={{ marginRight: '0.375rem' }}
               onChange={() => setDeleting(true)}
               checked={deleting === true}
+              aria-labelledby='delete-unattached-pd-radio'
             />
-            <label>Delete persistent disk</label>
+            <label id='delete-unattached-pd-radio'>
+              Delete persistent disk
+            </label>
           </div>
         </h3>
         <p style={{ ...styles.confirmWarningText, gridColumn: 1, gridRow: 2 }}>
@@ -71,14 +74,14 @@ export const ConfirmDeleteUnattachedPD = ({
       <FlexRow style={{ justifyContent: 'flex-end' }}>
         <Button
           type='secondaryLight'
-          aria-label={'Cancel'}
+          aria-label='Cancel'
           style={{ marginRight: '.9rem' }}
           onClick={() => onCancel()}
         >
           Cancel
         </Button>
         <Button
-          aria-label={'Delete'}
+          aria-label='Delete'
           disabled={!deleting}
           onClick={async () => {
             setDeleting(true);

--- a/ui/src/app/components/runtime-configuration-panel/confirm-delete.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/confirm-delete.tsx
@@ -54,7 +54,7 @@ export const ConfirmDelete = ({ onCancel, onConfirm }) => {
           Cancel
         </Button>
         <Button
-          aria-label={'Delete'}
+          aria-label='Delete'
           disabled={deleting}
           onClick={async () => {
             setDeleting(true);

--- a/ui/src/app/components/spinners.tsx
+++ b/ui/src/app/components/spinners.tsx
@@ -31,6 +31,7 @@ const styles = reactStyles({
 export const Spinner = ({ dark = false, size = 72, style = {}, ...props }) => {
   return (
     <svg
+      aria-label='Please Wait'
       xmlns='http://www.w3.org/2000/svg'
       viewBox='0 0 72 72'
       width={size}


### PR DESCRIPTION
Move the bulk of the Cromwell and RStudio configuration panels to a new component CreateGKEAppPanel, in preparation for adding SAS.  Tested locally by running Local->Test

Also convert the relevant UI UTs from Enzyme to RTL.

Naming suggestions welcome.

Does not complete RW-9836 because this does not add SAS!


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
