### PR TITLE
[risk=no][RW-10815] Repair all instances of .npmrc usage and update some Readme files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,9 +282,12 @@ commands:
           key: v5-ui-cache-{{ .Branch }}-{{ checksum "~/workbench/ui/yarn.lock" }}
       - gcloud-auth-login
       - run:
-          name: "Download .npmrc file with Fontawesome Pro license key so FA icon SVG packages can be installed"
+          name: "Download Fontawesome Pro license key"
           working_directory: ~/workbench
-          command: gsutil cp gs://all-of-us-workbench-test-credentials/.npmrc .
+          command: |
+            gsutil cat \
+              gs://all-of-us-workbench-test-credentials/dot-npmrc-fontawesome-creds-line.txt \
+              >> ~/.npmrc
       - run:
           working_directory: ~/workbench/ui
           command: yarn install --verbose --frozen-lockfile --non-interactive

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The `status` column enum values can be found in `org.pmiops.workbench.db.model.S
 
 ### UI
 
-See [ui/README.md].
+See [ui/README.md]().
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -103,48 +103,7 @@ The `status` column enum values can be found in `org.pmiops.workbench.db.model.S
 
 ### UI
 
-In the UI, we use some [Fontawesome](https://fontawesome.com/) Pro icons. In order to install the Fontawesome Pro packages, you will need to download an `.npmrc` file with a Fontawesome license token. Copy it into the workbench root directory:
-```
-workbench$ gsutil cp gs://all-of-us-workbench-test-credentials/.npmrc .
-```
-
-Before launching or testing the UI, yarn must first install the neccessary packages. From the `ui/` directory:
-```Shell
-yarn install
-```
-
-To launch the local UI:
-```Shell
-yarn dev-up-local
-```
-
-You can view your local UI server at http://localhost:4200/.  
-
-This connects the UI server to your local API server, If you wish to connect
-your UI server to the test API server, you need to start your UI server using:
-
-```
-yarn dev-up-test
-```
-
-Alternatively, you can specify which environment to connect to by setting `REACT_APP_ENVIRONMENT` variable. For example to connect to the test API server you can use
-```
-REACT_APP_ENVIRONMENT=localtest yarn dev-up
-```
-
-To run react UI tests:
-```Shell
-yarn test
-```
-
-Other useful yarn commands:
-```Shell
-# To upgrade yarn packages:
-yarn
-
-# To lint the UI and automatically fix issues:
-yarn lint --fix
-```
+See [ui/README.md].
 
 ## Deploying
 

--- a/api/docs/developer-system-initialization.md
+++ b/api/docs/developer-system-initialization.md
@@ -57,13 +57,6 @@ cd workbench
 git submodule update -f --init --recursive
 ```
 
-## .npmrc
-
-In the UI, we use some [Fontawesome](https://fontawesome.com/) Pro icons. In order to install the Fontawesome Pro packages, you will need to download an `.npmrc` file with a Fontawesome license token. Copy it into the workbench root directory:
-```
-workbench$ gsutil cp gs://all-of-us-workbench-test-credentials/.npmrc .
-```
-
 ## git-secrets
 
 ### Setup

--- a/ui/README.md
+++ b/ui/README.md
@@ -30,6 +30,14 @@ To run the UI locally against the test API:
 
 By default, this runs the server at: http://localhost:4200/.
 
+To automatically fix lint errors:
+
+`yarn lint --fix`
+
+Other useful helper scripts are available. To get a list of all available scripts:
+
+`yarn run`
+
 ## Fontawesome
 
 We use some [Fontawesome](https://fontawesome.com/) Pro icons. Fontawesome requires a license during a fresh `yarn install`. Delete `node_modules` and `yarn.lock` before running `yarn install` to test. If a license isn't found, `yarn install` will fail with the error message:

--- a/ui/README.md
+++ b/ui/README.md
@@ -36,7 +36,21 @@ To automatically fix lint errors:
 
 Other useful helper scripts are available. To get a list of all available scripts:
 
-`yarn run`
+```
+$ yarn run
+...
+   - deps
+      yarn run codegen && yarn run build-terra-deps
+   - dev-up
+      yarn && yarn run deps && yarn start
+   - dev-up-local
+      yarn && yarn run deps && REACT_APP_ENVIRONMENT=local yarn start
+   - dev-up-tanagra-local
+      yarn && concurrently "yarn run start-tanagra" "yarn run dev-up-local"
+   - dev-up-test
+      yarn && yarn run deps && REACT_APP_ENVIRONMENT=localtest yarn start
+...
+```
 
 ## Fontawesome
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -24,9 +24,15 @@ To regenerate TypeScript APIs after you've changed them in Swagger:
 
 `yarn codegen`
 
+To run the UI locally against the test API:
+
+`REACT_APP_ENVIRONMENT=test yarn dev-up`
+
+By default, this runs the server at: http://localhost:4200/.
+
 ## Fontawesome
 
-Fontawesome requires a license during a fresh `yarn install`. Delete `node_modules` and `yarn.lock` before running `yarn install` to test. If a license isn't found, `yarn install` will fail with the error message:
+We use some [Fontawesome](https://fontawesome.com/) Pro icons. Fontawesome requires a license during a fresh `yarn install`. Delete `node_modules` and `yarn.lock` before running `yarn install` to test. If a license isn't found, `yarn install` will fail with the error message:
 ```
 error An unexpected error occurred: "https://npm.fontawesome.com/@fortawesome%2ffontawesome-free: authentication required".
 ```

--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -33,7 +33,8 @@ def build(cmd_name, args)
 
   common = Common.new
 
-  common.run_inline %W{gsutil cp gs://all-of-us-workbench-test-credentials/.npmrc ..}
+  fontawesomeCredsLineFilePath = "gs://all-of-us-workbench-test-credentials/dot-npmrc-fontawesome-creds-line.txt"
+  common.run_inline "gsutil cp #{fontawesomeCredsLinePath} >> ~/.npmrc"
   common.run_inline %W{yarn install --frozen-lockfile}
   common.run_inline %W{yarn run deps}
 

--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -34,7 +34,7 @@ def build(cmd_name, args)
   common = Common.new
 
   fontawesomeCredsLineFilePath = "gs://all-of-us-workbench-test-credentials/dot-npmrc-fontawesome-creds-line.txt"
-  common.run_inline "gsutil cat #{fontawesomeCredsLinePath} >> ~/.npmrc"
+  common.run_inline "gsutil cat #{fontawesomeCredsLineFilePath} >> ~/.npmrc"
   common.run_inline %W{yarn install --frozen-lockfile}
   common.run_inline %W{yarn run deps}
 

--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -34,7 +34,7 @@ def build(cmd_name, args)
   common = Common.new
 
   fontawesomeCredsLineFilePath = "gs://all-of-us-workbench-test-credentials/dot-npmrc-fontawesome-creds-line.txt"
-  common.run_inline "gsutil cp #{fontawesomeCredsLinePath} >> ~/.npmrc"
+  common.run_inline "gsutil cat #{fontawesomeCredsLinePath} >> ~/.npmrc"
   common.run_inline %W{yarn install --frozen-lockfile}
   common.run_inline %W{yarn run deps}
 


### PR DESCRIPTION
Narrows all usage of the Fontawesome license to use the key only rather than downloading a whole .npmrc file.

Not testing locally since CircleCI was primary failure mode.

Readme files updated and merged where appropriate.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
