### PR TITLE
[risk=no][RW-10361] Track compliance training verification system

### DIFF
--- a/api/db/changelog/db.changelog-226-compliance-training-verification.xml
+++ b/api/db/changelog/db.changelog-226-compliance-training-verification.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="Peter-Lavigne" id="db.changelog-226-compliance-training-verification">
+    <createTable tableName="compliance_training_verification">
+      <column name="compliance_training_verification_id" type="bigint" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="user_access_module_id" type="bigint">
+        <constraints nullable="false"
+                     foreignKeyName="fk_compliance_training_verification_access_module"
+                     references="user_access_module(user_access_module_id)"
+                     deleteCascade="true"/>
+      </column>
+      <column name="compliance_training_verification_system" type="ENUM('MOODLE','ABSORB')">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <sql>
+      INSERT INTO compliance_training_verification (user_access_module_id, compliance_training_verification_system)
+        SELECT uam.user_access_module_id, 'MOODLE'
+        FROM user_access_module AS uam
+        INNER JOIN access_module AS am
+            ON am.access_module_id = uam.access_module_id
+        WHERE am.name = 'RT_COMPLIANCE_TRAINING'
+            AND uam.completion_time IS NOT NULL;
+
+      INSERT INTO compliance_training_verification (user_access_module_id, compliance_training_verification_system)
+      SELECT uam.user_access_module_id, 'MOODLE'
+      FROM user_access_module AS uam
+             INNER JOIN access_module AS am
+                        ON am.access_module_id = uam.access_module_id
+      WHERE am.name = 'CT_COMPLIANCE_TRAINING'
+        AND uam.completion_time IS NOT NULL;
+    </sql>
+
+    <rollback>
+      <dropTable tableName="compliance_training_verification"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -233,6 +233,7 @@
   <include file="changelog/db.changelog-223-modify-egress-bypass-window-datatype.xml"/>
   <include file="changelog/db.changelog-224-cdr-version-tanagra-enabled.xml"/>
   <include file="changelog/db.changelog-225-add-user-discovery-source.xml"/>
+  <include file="changelog/db.changelog-226-compliance-training-verification.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.model.AccessBypassRequest;
 import org.pmiops.workbench.model.AccessModuleStatus;
 
@@ -18,8 +19,12 @@ public interface AccessModuleService {
   /** Updates bypass times for all modules in the environment. */
   void updateAllBypassTimes(long userId);
 
-  /** Update module status to complete for a user. */
-  void updateCompletionTime(
+  /**
+   * Update module status to complete for a user.
+   *
+   * @return the updated {@link DbUserAccessModule}
+   */
+  DbUserAccessModule updateCompletionTime(
       DbUser dbUser, DbAccessModuleName accessModuleName, Timestamp timestamp);
 
   /** Retrieves all {@link AccessModuleStatus} for a user. */

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
@@ -108,17 +108,19 @@ public class AccessModuleServiceImpl implements AccessModuleService {
   }
 
   @Override
-  public void updateCompletionTime(
+  public DbUserAccessModule updateCompletionTime(
       DbUser dbUser, DbAccessModuleName accessModuleName, @Nullable Timestamp timestamp) {
     DbAccessModule dbAccessModule =
         getDbAccessModuleOrThrow(dbAccessModulesProvider.get(), accessModuleName);
     DbUserAccessModule userAccessModuleToUpdate =
         retrieveUserAccessModuleOrCreate(dbUser, dbAccessModule);
-    userAccessModuleDao.save(userAccessModuleToUpdate.setCompletionTime(timestamp));
+    userAccessModuleToUpdate =
+        userAccessModuleDao.save(userAccessModuleToUpdate.setCompletionTime(timestamp));
     if (accessModuleName.equals(DbAccessModuleName.RAS_ID_ME)
         || accessModuleName.equals(DbAccessModuleName.RAS_LOGIN_GOV)) {
       updateCompletionTime(dbUser, DbAccessModuleName.IDENTITY, timestamp);
     }
+    return userAccessModuleToUpdate;
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -153,6 +153,9 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
             var updatedUserAccessModule =
                 accessModuleService.updateCompletionTime(
                     dbUser, accessModuleName, timestamp.orElse(null));
+            // This is null, for example:
+            // - If the user has not completed any trainings yet
+            // - For CT if the user has just completed RT
             if (updatedUserAccessModule.getCompletionTime() != null) {
               var verification = retrieveVerificationOrCreate(updatedUserAccessModule);
               verification.setComplianceTrainingVerificationSystem(

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -19,6 +19,7 @@ import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbComplianceTrainingVerification;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.model.AccessModuleStatus;
 import org.pmiops.workbench.moodle.MoodleService;
@@ -153,12 +154,9 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
                 accessModuleService.updateCompletionTime(
                     dbUser, accessModuleName, timestamp.orElse(null));
             if (updatedUserAccessModule.getCompletionTime() != null) {
-              var verification =
-                  new DbComplianceTrainingVerification()
-                      .setComplianceTrainingVerificationSystem(
-                          DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem
-                              .MOODLE)
-                      .setUserAccessModule(updatedUserAccessModule);
+              var verification = retrieveVerificationOrCreate(updatedUserAccessModule);
+              verification.setComplianceTrainingVerificationSystem(
+                  DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.MOODLE);
               complianceTrainingVerificationDao.save(verification);
             }
           });
@@ -183,5 +181,12 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
 
   private Timestamp clockNow() {
     return new Timestamp(clock.instant().toEpochMilli());
+  }
+
+  private DbComplianceTrainingVerification retrieveVerificationOrCreate(
+      DbUserAccessModule userAccessModule) {
+    return complianceTrainingVerificationDao
+        .getByUserAccessModule(userAccessModule)
+        .orElse(new DbComplianceTrainingVerification().setUserAccessModule(userAccessModule));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ComplianceTrainingVerificationDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ComplianceTrainingVerificationDao.java
@@ -1,0 +1,11 @@
+package org.pmiops.workbench.db.dao;
+
+import java.util.Optional;
+import org.pmiops.workbench.db.model.DbComplianceTrainingVerification;
+import org.pmiops.workbench.db.model.DbUserAccessModule;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ComplianceTrainingVerificationDao
+    extends CrudRepository<DbComplianceTrainingVerification, Long> {
+  Optional<DbComplianceTrainingVerification> getByUserAccessModule(DbUserAccessModule uam);
+}

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbComplianceTrainingVerification.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbComplianceTrainingVerification.java
@@ -1,0 +1,61 @@
+package org.pmiops.workbench.db.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "compliance_training_verification")
+public class DbComplianceTrainingVerification {
+  private long complianceTrainingVerificationId;
+  private DbUserAccessModule userAccessModule;
+  private DbComplianceTrainingVerificationSystem complianceTrainingVerificationSystem;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "compliance_training_verification_id")
+  public long getComplianceTrainingVerificationId() {
+    return complianceTrainingVerificationId;
+  }
+
+  public DbComplianceTrainingVerification setComplianceTrainingVerificationId(
+      long userAccessModuleId) {
+    this.complianceTrainingVerificationId = userAccessModuleId;
+    return this;
+  }
+
+  @ManyToOne
+  @JoinColumn(name = "user_access_module_id", nullable = false)
+  public DbUserAccessModule getUserAccessModule() {
+    return userAccessModule;
+  }
+
+  public DbComplianceTrainingVerification setUserAccessModule(DbUserAccessModule accessModule) {
+    this.userAccessModule = accessModule;
+    return this;
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "compliance_training_verification_system", nullable = false)
+  public DbComplianceTrainingVerificationSystem getComplianceTrainingVerificationSystem() {
+    return complianceTrainingVerificationSystem;
+  }
+
+  public DbComplianceTrainingVerification setComplianceTrainingVerificationSystem(
+      DbComplianceTrainingVerificationSystem identityVerificationSystem) {
+    this.complianceTrainingVerificationSystem = identityVerificationSystem;
+    return this;
+  }
+
+  public enum DbComplianceTrainingVerificationSystem {
+    MOODLE,
+    ABSORB,
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
@@ -36,6 +36,7 @@ import org.pmiops.workbench.db.dao.UserTermsOfServiceDao;
 import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
+import org.pmiops.workbench.db.model.DbComplianceTrainingVerification;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
@@ -190,8 +191,9 @@ public class ComplianceTrainingServiceTest {
   }
 
   @Test
-  public void testSyncComplianceTrainingStatusV2_UpdatesComplianceTrainingVerificationIfComplete()
-      throws Exception {
+  public void
+      testSyncComplianceTrainingStatusV2_UpdatesComplianceTrainingVerificationToMoodleIfComplete()
+          throws Exception {
     long issued = fakeClock.instant().getEpochSecond() - 100;
     Map<BadgeName, BadgeDetailsV2> userBadgesByName =
         ImmutableMap.<BadgeName, BadgeDetailsV2>builder()
@@ -217,6 +219,8 @@ public class ComplianceTrainingServiceTest {
     var rtVerification =
         complianceTrainingVerificationDao.getByUserAccessModule(rtUserAccessModule);
     assertThat(rtVerification.isPresent()).isTrue();
+    assertThat(rtVerification.get().getComplianceTrainingVerificationSystem())
+        .isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.MOODLE);
 
     // CT is incomplete, so there should not be a verification record.
     var ctAccessModule =


### PR DESCRIPTION
Track the system we used to verify a user's compliance training status. Currently, this is always Moodle. This will be used as we transition to Absorb to determine whether a user has already used Moodle or not. Once all users are using Moodle, it's possible we may remove this table.

Schema:
```
MariaDB [workbench]> desc compliance_training_verification;
+-----------------------------------------+-------------------------+------+-----+---------+----------------+
| Field                                   | Type                    | Null | Key | Default | Extra          |
+-----------------------------------------+-------------------------+------+-----+---------+----------------+
| compliance_training_verification_id     | bigint(20)              | NO   | PRI | NULL    | auto_increment |
| user_access_module_id                   | bigint(20)              | NO   | MUL | NULL    |                |
| compliance_training_verification_system | enum('MOODLE','ABSORB') | NO   |     | NULL    |                |
+-----------------------------------------+-------------------------+------+-----+---------+----------------+
```

This mirrors the [approach used for ID verification](https://github.com/all-of-us/workbench/pull/7840). Like that work, this table only tracks completed (not bypassed) compliance training verification. Unlike that work, this is [tracking two access modules](https://pmi-engteam.slack.com/archives/C0150CWF6FP/p1693945359881869?thread_ts=1693944511.104739&cid=C0150CWF6FP) (RT and CT), so we point at `user_access_module_id` instead of `user`. Alternatively, we could store `user` and `access_module` information, but this seems simpler.

I manually tested this by syncing training using my local user which has completed RT but not CT. As expected, exactly one entry pointing to RT was populated in the table.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [x] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.