### PR TITLE
[risk=low][RW-9836] Rename GKE app creation inside-panel components to "create"

### DIFF
--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -28,7 +28,7 @@ import {
   GkeAppConfigurationPanelProps,
   GKEAppPanelContent,
 } from './gke-app-configuration-panel';
-import { DEFAULT_PROPS as RSTUDIO_DEFAULT_PROPS } from './rstudio-configuration-panel.spec';
+import { defaultProps as rstudioDefaultProps } from './gke-app-configuration-panels/create-rstudio.spec';
 
 // component text for selectors
 
@@ -71,7 +71,7 @@ describe(GKEAppConfigurationPanel.name, () => {
       .mockImplementation((): Promise<any> => Promise.resolve([]));
   });
 
-  const DEFAULT_PROPS: GkeAppConfigurationPanelProps = {
+  const defaultProps: GkeAppConfigurationPanelProps = {
     appType: AppType.RSTUDIO,
     workspaceNamespace: 'aou-rw-1234',
     onClose: jest.fn(),
@@ -79,15 +79,15 @@ describe(GKEAppConfigurationPanel.name, () => {
     creatorFreeCreditsRemaining: 300,
 
     // Use RSTUDIO_DEFAULT_PROPS for the rest of the props since they shouldn't affect this test
-    workspace: RSTUDIO_DEFAULT_PROPS.workspace,
-    profileState: RSTUDIO_DEFAULT_PROPS.profileState,
+    workspace: rstudioDefaultProps.workspace,
+    profileState: rstudioDefaultProps.profileState,
   };
 
   const createWrapper = (
     propOverrides: Partial<GkeAppConfigurationPanelProps> = {}
   ) => {
     const props = {
-      ...DEFAULT_PROPS,
+      ...defaultProps,
       ...propOverrides,
     };
     return render(<GKEAppConfigurationPanel {...props} />);

--- a/ui/src/app/components/gke-app-configuration-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.tsx
@@ -32,13 +32,6 @@ export enum GKEAppPanelContent {
   DELETE_GKE_APP,
 }
 
-const CreateGKEAppPanel = ({ appType, ...props }: CreateGkeAppProps) =>
-  switchCase(
-    appType,
-    [AppType.CROMWELL, () => <CreateCromwell {...props} />],
-    [AppType.RSTUDIO, () => <CreateRStudio {...props} />]
-  );
-
 export const GKEAppConfigurationPanel = ({
   appType,
   workspaceNamespace,
@@ -133,18 +126,38 @@ export const GKEAppConfigurationPanel = ({
     panelContent,
     [
       GKEAppPanelContent.CREATE,
-      () => (
-        <CreateGKEAppPanel
-          {...{
-            ...props,
-            appType,
-            app,
-            disk,
-            onClickDeleteUnattachedPersistentDisk,
-            onClose,
-          }}
-        />
-      ),
+      () =>
+        switchCase(
+          appType,
+          [
+            AppType.CROMWELL,
+            () => (
+              <CreateCromwell
+                {...{
+                  ...props,
+                  app,
+                  disk,
+                  onClickDeleteUnattachedPersistentDisk,
+                  onClose,
+                }}
+              />
+            ),
+          ],
+          [
+            AppType.RSTUDIO,
+            () => (
+              <CreateRStudio
+                {...{
+                  ...props,
+                  app,
+                  disk,
+                  onClickDeleteUnattachedPersistentDisk,
+                  onClose,
+                }}
+              />
+            ),
+          ]
+        ),
     ],
     [
       GKEAppPanelContent.DELETE_UNATTACHED_PD,

--- a/ui/src/app/components/gke-app-configuration-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.tsx
@@ -10,9 +10,9 @@ import { notificationStore } from 'app/utils/stores';
 import { deleteUserApp, findDisk } from 'app/utils/user-apps-utils';
 
 import { findApp, toUIAppType } from './apps-panel/utils';
-import { CromwellConfigurationPanel } from './cromwell-configuration-panel';
-import { CreateGKEAppPanelPropsWithAppType } from './gke-app-configuration-panels/create-gke-app-panel';
-import { RStudioConfigurationPanel } from './rstudio-configuration-panel';
+import { CreateCromwell } from './gke-app-configuration-panels/create-cromwell';
+import { CreateGkeAppProps } from './gke-app-configuration-panels/create-gke-app';
+import { CreateRStudio } from './gke-app-configuration-panels/create-rstudio';
 import { ConfirmDelete } from './runtime-configuration-panel/confirm-delete';
 import { ConfirmDeleteEnvironmentWithPD } from './runtime-configuration-panel/confirm-delete-environment-with-pd';
 import { ConfirmDeleteUnattachedPD } from './runtime-configuration-panel/confirm-delete-unattached-pd';
@@ -24,7 +24,7 @@ export type GkeAppConfigurationPanelProps = {
   workspaceNamespace: string;
   onClose: () => void;
   initialPanelContent: GKEAppPanelContent | null;
-} & Omit<CreateGKEAppPanelPropsWithAppType, InjectedProps>;
+} & Omit<CreateGkeAppProps, InjectedProps>;
 
 export enum GKEAppPanelContent {
   CREATE,
@@ -32,14 +32,11 @@ export enum GKEAppPanelContent {
   DELETE_GKE_APP,
 }
 
-const CreateGKEAppPanel = ({
-  appType,
-  ...props
-}: CreateGKEAppPanelPropsWithAppType) =>
+const CreateGKEAppPanel = ({ appType, ...props }: CreateGkeAppProps) =>
   switchCase(
     appType,
-    [AppType.CROMWELL, () => <CromwellConfigurationPanel {...props} />],
-    [AppType.RSTUDIO, () => <RStudioConfigurationPanel {...props} />]
+    [AppType.CROMWELL, () => <CreateCromwell {...props} />],
+    [AppType.RSTUDIO, () => <CreateRStudio {...props} />]
   );
 
 export const GKEAppConfigurationPanel = ({

--- a/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
@@ -6,6 +6,7 @@ import { DisksApi, WorkspaceAccessLevel } from 'generated/fetch';
 import { AppsApi } from 'generated/fetch/api';
 
 import { render, screen, waitFor } from '@testing-library/react';
+import { defaultCromwellConfig } from 'app/components/apps-panel/utils';
 import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
 import { serverConfigStore } from 'app/utils/stores';
 
@@ -23,15 +24,14 @@ import {
   WorkspaceStubVariables,
 } from 'testing/stubs/workspaces';
 
-import { defaultCromwellConfig } from './apps-panel/utils';
-import { CromwellConfigurationPanel } from './cromwell-configuration-panel';
-import { CreateGKEAppPanelProps } from './gke-app-configuration-panels/create-gke-app-panel';
+import { CreateCromwell } from './create-cromwell';
+import { CommonCreateGkeAppProps } from './create-gke-app';
 
-describe(CromwellConfigurationPanel.name, () => {
+describe(CreateCromwell.name, () => {
   const onClose = jest.fn();
   const freeTierBillingAccountId = 'freetier';
 
-  const DEFAULT_PROPS: CreateGKEAppPanelProps = {
+  const defaultProps: CommonCreateGkeAppProps = {
     onClose,
     creatorFreeCreditsRemaining: null,
     workspace: {
@@ -53,10 +53,8 @@ describe(CromwellConfigurationPanel.name, () => {
 
   let disksApiStub: DisksApiStub;
 
-  const component = async (propOverrides?: Partial<CreateGKEAppPanelProps>) =>
-    render(
-      <CromwellConfigurationPanel {...{ ...DEFAULT_PROPS, ...propOverrides }} />
-    );
+  const component = async (propOverrides?: Partial<CommonCreateGkeAppProps>) =>
+    render(<CreateCromwell {...{ ...defaultProps, ...propOverrides }} />);
 
   beforeEach(async () => {
     disksApiStub = new DisksApiStub();

--- a/ui/src/app/components/gke-app-configuration-panels/create-cromwell.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-cromwell.tsx
@@ -3,17 +3,14 @@ import * as React from 'react';
 import { AppType } from 'generated/fetch';
 
 import { WarningMessage } from 'app/components/messages';
+import { styles } from 'app/components/runtime-configuration-panel/styles';
 import {
   CROMWELL_INFORMATION_LINK,
   CROMWELL_INTRO_LINK,
   WORKFLOW_AND_WDL_LINK,
 } from 'app/utils/aou_external_links';
 
-import {
-  CreateGKEAppPanel,
-  CreateGKEAppPanelProps,
-} from './gke-app-configuration-panels/create-gke-app-panel';
-import { styles } from './runtime-configuration-panel/styles';
+import { CommonCreateGkeAppProps, CreateGkeApp } from './create-gke-app';
 
 const cromwellSupportArticles = [
   {
@@ -81,8 +78,8 @@ const CreateAppText = () => (
   </div>
 );
 
-export const CromwellConfigurationPanel = (props: CreateGKEAppPanelProps) => (
-  <CreateGKEAppPanel
+export const CreateCromwell = (props: CommonCreateGkeAppProps) => (
+  <CreateGkeApp
     {...{
       ...props,
       introText,

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
@@ -5,7 +5,7 @@ import { AppStatus } from 'generated/fetch';
 import { render, screen, waitFor } from '@testing-library/react';
 import { defaultCromwellConfig } from 'app/components/apps-panel/utils';
 import {
-  CreateGKEAppButton,
+  CreateGkeAppButton,
   CreateGKEAppButtonProps,
 } from 'app/components/gke-app-configuration-panels/create-gke-app-button';
 
@@ -16,8 +16,8 @@ import {
 import { createListAppsCromwellResponse } from 'testing/stubs/apps-api-stub';
 import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
 
-describe(CreateGKEAppButton.name, () => {
-  const DEFAULT_PROPS: CreateGKEAppButtonProps = {
+describe(CreateGkeAppButton.name, () => {
+  const defaultProps: CreateGKEAppButtonProps = {
     createAppRequest: defaultCromwellConfig,
     existingApp: null,
     workspaceNamespace: 'aou-rw-test-1',
@@ -27,8 +27,8 @@ describe(CreateGKEAppButton.name, () => {
   const component = async (
     propOverrides?: Partial<CreateGKEAppButtonProps>
   ) => {
-    const allProps = { ...DEFAULT_PROPS, ...propOverrides };
-    return render(<CreateGKEAppButton {...allProps} />);
+    const allProps = { ...defaultProps, ...propOverrides };
+    return render(<CreateGkeAppButton {...allProps} />);
   };
 
   const createEnabledStatuses = [AppStatus.DELETED, null, undefined];

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
@@ -16,7 +16,7 @@ export interface CreateGKEAppButtonProps {
   onDismiss: () => void;
 }
 
-export function CreateGKEAppButton({
+export function CreateGkeAppButton({
   createAppRequest,
   existingApp,
   workspaceNamespace,

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
@@ -26,14 +26,15 @@ import {
 } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
-import { CreateGKEAppButton } from './create-gke-app-button';
+import { CreateGkeAppButton } from './create-gke-app-button';
 import { DisabledCloudComputeProfile } from './disabled-cloud-compute-profile';
 
 const defaultIntroText =
   'Your analysis environment consists of an application and compute resources. ' +
   'Your cloud environment is unique to this workspace and not shared with other users.';
 
-export interface CreateGKEAppPanelProps {
+export interface CreateGkeAppProps {
+  appType: AppType;
   onClose: () => void;
   creatorFreeCreditsRemaining: number | null;
   workspace: WorkspaceData;
@@ -41,20 +42,23 @@ export interface CreateGKEAppPanelProps {
   app: UserAppEnvironment | undefined;
   disk: Disk | undefined;
   onClickDeleteUnattachedPersistentDisk: () => void;
-}
-
-export type CreateGKEAppPanelPropsWithAppType = {
-  appType: AppType;
-} & CreateGKEAppPanelProps;
-
-type Props = {
   introText?: string;
   CostNote?: React.FunctionComponent;
   SupportNote?: React.FunctionComponent;
   CreateAppText?: React.FunctionComponent;
-} & CreateGKEAppPanelPropsWithAppType;
+}
 
-export const CreateGKEAppPanel = ({
+type ToOmit =
+  | 'appType'
+  | 'introText'
+  | 'CostNote'
+  | 'SupportNote'
+  | 'CreateAppText';
+
+// for use by the individual gke app creation components, e.g. CreateCromwell
+export type CommonCreateGkeAppProps = Omit<CreateGkeAppProps, ToOmit>;
+
+export const CreateGkeApp = ({
   appType,
   onClose,
   creatorFreeCreditsRemaining,
@@ -67,7 +71,7 @@ export const CreateGKEAppPanel = ({
   CostNote = () => null,
   SupportNote = () => null,
   CreateAppText = () => null,
-}: Props) => {
+}: CreateGkeAppProps) => {
   const { profile } = profileState;
 
   const onDismiss = () => {
@@ -131,7 +135,7 @@ export const CreateGKEAppPanel = ({
           />
         )}
         <CreateAppText />
-        <CreateGKEAppButton
+        <CreateGkeAppButton
           {...{ createAppRequest, onDismiss }}
           existingApp={app}
           workspaceNamespace={workspace.namespace}

--- a/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
@@ -6,6 +6,7 @@ import { DisksApi, WorkspaceAccessLevel } from 'generated/fetch';
 import { AppsApi } from 'generated/fetch/api';
 
 import { render, screen, waitFor } from '@testing-library/react';
+import { defaultRStudioConfig } from 'app/components/apps-panel/utils';
 import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
 import { serverConfigStore } from 'app/utils/stores';
 
@@ -23,13 +24,12 @@ import {
   WorkspaceStubVariables,
 } from 'testing/stubs/workspaces';
 
-import { defaultRStudioConfig } from './apps-panel/utils';
-import { CreateGKEAppPanelProps } from './gke-app-configuration-panels/create-gke-app-panel';
-import { RStudioConfigurationPanel } from './rstudio-configuration-panel';
+import { CommonCreateGkeAppProps } from './create-gke-app';
+import { CreateRStudio } from './create-rstudio';
 
 const onClose = jest.fn();
 const freeTierBillingAccountId = 'freetier';
-export const DEFAULT_PROPS: CreateGKEAppPanelProps = {
+export const defaultProps: CommonCreateGkeAppProps = {
   onClose,
   creatorFreeCreditsRemaining: null,
   workspace: {
@@ -49,13 +49,11 @@ export const DEFAULT_PROPS: CreateGKEAppPanelProps = {
   onClickDeleteUnattachedPersistentDisk: jest.fn(),
 };
 
-describe(RStudioConfigurationPanel.name, () => {
+describe(CreateRStudio.name, () => {
   let disksApiStub: DisksApiStub;
 
-  const component = async (propOverrides?: Partial<CreateGKEAppPanelProps>) =>
-    render(
-      <RStudioConfigurationPanel {...{ ...DEFAULT_PROPS, ...propOverrides }} />
-    );
+  const component = async (propOverrides?: Partial<CommonCreateGkeAppProps>) =>
+    render(<CreateRStudio {...{ ...defaultProps, ...propOverrides }} />);
 
   beforeEach(async () => {
     disksApiStub = new DisksApiStub();

--- a/ui/src/app/components/gke-app-configuration-panels/create-rstudio.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-rstudio.tsx
@@ -4,10 +4,7 @@ import { AppType } from 'generated/fetch';
 
 import { InfoMessage } from 'app/components/messages';
 
-import {
-  CreateGKEAppPanel,
-  CreateGKEAppPanelProps,
-} from './gke-app-configuration-panels/create-gke-app-panel';
+import { CommonCreateGkeAppProps, CreateGkeApp } from './create-gke-app';
 
 const SupportNote = () => (
   <InfoMessage>
@@ -22,8 +19,8 @@ const SupportNote = () => (
   </InfoMessage>
 );
 
-export const RStudioConfigurationPanel = (props: CreateGKEAppPanelProps) => (
-  <CreateGKEAppPanel
+export const CreateRStudio = (props: CommonCreateGkeAppProps) => (
+  <CreateGkeApp
     {...{
       ...props,
       SupportNote,


### PR DESCRIPTION
This is a followup to https://github.com/all-of-us/workbench/pull/7921

GkeAppConfigurationPanel is a *container* for various types of panel content.  The default content for all GKE Apps is "create" so more appropriate names for the these panel content components are **CreateCromwell** and **CreateRStudio**.

Tested by observing these panels on Local->Test

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
