### PR TITLE
[DT-490][risk=no] Remove old code for PFHH survey

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
@@ -8,14 +8,11 @@ import com.google.cloud.bigquery.QueryParameterValue;
 import com.google.cloud.bigquery.TableResult;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.pmiops.workbench.api.BigQueryService;
-import org.pmiops.workbench.cohortbuilder.CohortBuilderService;
 import org.pmiops.workbench.db.model.DbConceptSetConceptId;
 import org.pmiops.workbench.model.Domain;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,107 +22,53 @@ import org.springframework.stereotype.Service;
 public class ConceptBigQueryService {
 
   private final BigQueryService bigQueryService;
-  private final CohortBuilderService cohortBuilderService;
   private static final ImmutableList<Domain> CHILD_LOOKUP_DOMAINS =
       ImmutableList.of(Domain.CONDITION, Domain.PROCEDURE, Domain.MEASUREMENT, Domain.DRUG);
 
   @Autowired
   public ConceptBigQueryService(
-      BigQueryService bigQueryService, CohortBuilderService cohortBuilderService) {
+      BigQueryService bigQueryService) {
     this.bigQueryService = bigQueryService;
-    this.cohortBuilderService = cohortBuilderService;
   }
 
   public int getParticipantCountForConcepts(
       Domain domain, Set<DbConceptSetConceptId> dbConceptSetConceptIds) {
-    List<Long> dbCriteriaAnswerIds = new ArrayList<>();
+    Map<Boolean, List<DbConceptSetConceptId>> partitionSourceAndStandard =
+            dbConceptSetConceptIds.stream()
+                    .collect(Collectors.partitioningBy(DbConceptSetConceptId::getStandard));
+    List<Long> standardList =
+            partitionSourceAndStandard.get(true).stream()
+                    .map(DbConceptSetConceptId::getConceptId)
+                    .collect(Collectors.toList());
+    List<Long> sourceList =
+            partitionSourceAndStandard.get(false).stream()
+                    .map(DbConceptSetConceptId::getConceptId)
+                    .collect(Collectors.toList());
     StringBuilder innerSql = new StringBuilder();
     ImmutableMap.Builder<String, QueryParameterValue> paramMap = ImmutableMap.builder();
-    Set<DbConceptSetConceptId> dbNonPFHHSurveyQuestions = new HashSet<>();
-    if (domain.equals(Domain.SURVEY)) {
-      List<Long> questionConceptIds =
-          dbConceptSetConceptIds.stream()
-              .map(DbConceptSetConceptId::getConceptId)
-              .collect(Collectors.toList());
-      // find any questions that belong to PFHH survey. The PFHH survey should
-      // only use answer ids when looking up participants.
-      List<Long> pfhhSurveyQuestionIds =
-          cohortBuilderService.findPFHHSurveyQuestionIds(questionConceptIds);
-      // need to filter out PFHH survey questions for other survey questions
-      dbNonPFHHSurveyQuestions =
-          dbConceptSetConceptIds.stream()
-              .filter(cid -> !pfhhSurveyQuestionIds.contains(cid.getConceptId()))
-              .collect(Collectors.toSet());
-      if (!pfhhSurveyQuestionIds.isEmpty()) {
-        // find all answers for the questions
-        dbCriteriaAnswerIds = cohortBuilderService.findPFHHSurveyAnswerIds(pfhhSurveyQuestionIds);
-      }
+    if (!standardList.isEmpty()) {
       innerSql.append("SELECT person_id\n");
       innerSql.append("FROM `${projectId}.${dataSetId}.cb_search_all_events`\n");
-      innerSql.append("WHERE is_standard = 0 AND ");
-      StringBuilder sqlFragment = new StringBuilder();
-      if (!dbNonPFHHSurveyQuestions.isEmpty()) {
-        String questionIdsParam = "questionConceptIds";
-        paramMap.put(
-            questionIdsParam,
-            QueryParameterValue.array(
-                dbNonPFHHSurveyQuestions.stream()
-                    .map(DbConceptSetConceptId::getConceptId)
-                    .toArray(Long[]::new),
-                Long.class));
-        sqlFragment.append("concept_id IN UNNEST(@").append(questionIdsParam).append(")");
-      }
-      if (!dbCriteriaAnswerIds.isEmpty()) {
-        if (sqlFragment.toString().contains("concept_id IN UNNEST")) {
-          sqlFragment.append(" OR ");
-        }
-        String answerIdsParam = "answerConceptIds";
-        paramMap.put(
-            answerIdsParam,
-            QueryParameterValue.array(dbCriteriaAnswerIds.toArray(new Long[0]), Long.class));
-        sqlFragment
-            .append("value_source_concept_id IN UNNEST(@")
-            .append(answerIdsParam)
-            .append(")");
-      }
-      innerSql.append("(").append(sqlFragment).append(")");
-    } else {
-      Map<Boolean, List<DbConceptSetConceptId>> partitionSourceAndStandard =
-          dbConceptSetConceptIds.stream()
-              .collect(Collectors.partitioningBy(DbConceptSetConceptId::getStandard));
-      List<Long> standardList =
-          partitionSourceAndStandard.get(true).stream()
-              .map(DbConceptSetConceptId::getConceptId)
-              .collect(Collectors.toList());
-      List<Long> sourceList =
-          partitionSourceAndStandard.get(false).stream()
-              .map(DbConceptSetConceptId::getConceptId)
-              .collect(Collectors.toList());
-
-      if (!standardList.isEmpty()) {
-        innerSql.append("SELECT person_id\n");
-        innerSql.append("FROM `${projectId}.${dataSetId}.cb_search_all_events`\n");
-        generateParentChildLookupSql(
-            innerSql, domain, "standardConceptIds", 1, standardList, paramMap);
-        innerSql.append("\n");
-        if (!sourceList.isEmpty()) {
-          innerSql.append(" UNION DISTINCT\n");
-        }
-      }
+      generateParentChildLookupSql(
+              innerSql, domain, "standardConceptIds", 1, standardList, paramMap);
+      innerSql.append("\n");
       if (!sourceList.isEmpty()) {
-        innerSql.append("SELECT person_id\n");
-        innerSql.append("FROM `${projectId}.${dataSetId}.cb_search_all_events`\n");
-        generateParentChildLookupSql(innerSql, domain, "sourceConceptIds", 0, sourceList, paramMap);
+        innerSql.append(" UNION ALL\n");
       }
+    }
+    if (!sourceList.isEmpty()) {
+      innerSql.append("SELECT person_id\n");
+      innerSql.append("FROM `${projectId}.${dataSetId}.cb_search_all_events`\n");
+      generateParentChildLookupSql(innerSql, domain, "sourceConceptIds", 0, sourceList, paramMap);
     }
     String finalSql = "SELECT COUNT(DISTINCT person_id) person_count FROM (\n" + innerSql + ")";
     QueryJobConfiguration jobConfiguration =
-        QueryJobConfiguration.newBuilder(finalSql)
-            .setNamedParameters(paramMap.build())
-            .setUseLegacySql(false)
-            .build();
+            QueryJobConfiguration.newBuilder(finalSql)
+                    .setNamedParameters(paramMap.build())
+                    .setUseLegacySql(false)
+                    .build();
     TableResult result =
-        bigQueryService.executeQuery(bigQueryService.filterBigQueryConfig(jobConfiguration));
+            bigQueryService.executeQuery(bigQueryService.filterBigQueryConfig(jobConfiguration));
     return (int) result.iterateAll().iterator().next().get(0).getLongValue();
   }
 
@@ -149,7 +92,7 @@ public class ConceptBigQueryService {
               "@" + conceptIdsParam,
               "@" + standardParam));
     } else {
-      sqlBuilder.append("UNNEST(@").append(conceptIdsParam).append(")");
+      sqlBuilder.append(" unnest(@" + conceptIdsParam + ")");
     }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/dao/CBCriteriaDao.java
@@ -447,23 +447,6 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomC
               + "join ( "
               + "      select cast(id as char) as id "
               + "      from cb_criteria "
-              + "      where concept_id in (1740639) "
-              + "      and domain_id = 'SURVEY' "
-              + "      ) a on (c.path like CONCAT('%', a.id, '.%')) "
-              + "where domain_id = 'SURVEY' "
-              + "and type = 'PPI' "
-              + "and subtype = 'QUESTION' "
-              + "and concept_id in (:conceptIds)",
-      nativeQuery = true)
-  List<Long> findPFHHSurveyQuestionIds(@Param("conceptIds") List<Long> conceptIds);
-
-  @Query(
-      value =
-          "select distinct concept_id "
-              + "from cb_criteria c "
-              + "join ( "
-              + "      select cast(id as char) as id "
-              + "      from cb_criteria "
               + "      where concept_id in (:surveyConceptIds) "
               + "      and domain_id = 'SURVEY' "
               + "      ) a on (c.path like CONCAT('%', a.id, '.%')) "
@@ -472,23 +455,6 @@ public interface CBCriteriaDao extends CrudRepository<DbCriteria, Long>, CustomC
               + "and subtype = 'QUESTION' ",
       nativeQuery = true)
   List<Long> findSurveyQuestionIds(@Param("surveyConceptIds") List<Long> surveyConceptIds);
-
-  @Query(
-      value =
-          "select distinct cast(value as signed) "
-              + "from cb_criteria c "
-              + "join ( "
-              + "      select cast(id as char) as id "
-              + "      from cb_criteria "
-              + "      where concept_id in (1740639) "
-              + "      and domain_id = 'SURVEY' "
-              + "      ) a on (c.path like CONCAT('%', a.id, '.%')) "
-              + "where domain_id = 'SURVEY' "
-              + "and type = 'PPI' "
-              + "and subtype = 'ANSWER' "
-              + "and concept_id in (:conceptIds)",
-      nativeQuery = true)
-  List<Long> findPFHHSurveyAnswerIds(@Param("conceptIds") List<Long> conceptIds);
 
   @Query(value = "SELECT * FROM INFORMATION_SCHEMA.INNODB_FT_DEFAULT_STOPWORD", nativeQuery = true)
   List<String> findMySQLStopWords();

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderService.java
@@ -77,10 +77,6 @@ public interface CohortBuilderService {
 
   List<Criteria> findVersionedSurveys();
 
-  List<Long> findPFHHSurveyQuestionIds(List<Long> conceptIds);
-
-  List<Long> findPFHHSurveyAnswerIds(List<Long> conceptIds);
-
   List<Criteria> findCriteriaByConceptIdsOrConceptCodes(List<String> conceptKeys);
 
   List<Long> findSurveyQuestionIds(List<Long> surveyConceptIds);

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortBuilderServiceImpl.java
@@ -582,16 +582,6 @@ public class CohortBuilderServiceImpl implements CohortBuilderService {
   }
 
   @Override
-  public List<Long> findPFHHSurveyQuestionIds(List<Long> conceptIds) {
-    return cbCriteriaDao.findPFHHSurveyQuestionIds(conceptIds);
-  }
-
-  @Override
-  public List<Long> findPFHHSurveyAnswerIds(List<Long> conceptIds) {
-    return cbCriteriaDao.findPFHHSurveyAnswerIds(conceptIds);
-  }
-
-  @Override
   public List<Long> findSurveyQuestionIds(List<Long> surveyConceptIds) {
     return cbCriteriaDao.findSurveyQuestionIds(surveyConceptIds);
   }

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
@@ -119,7 +119,7 @@ public final class SearchGroupItemQueryBuilder {
           + "WHERE is_standard = %s\n"
           + "AND is_selectable = 1) b ON (ca.ancestor_id = b.concept_id))";
   public static final String QUESTION_LOOKUP_SQL =
-      "(SELECT DISTINCT concept_id\n"
+      "question_concept_id IN (SELECT DISTINCT concept_id\n"
           + "FROM `${projectId}.${dataSetId}.cb_criteria` c\n"
           + "JOIN (select cast(cr.id as string) as id\n"
           + "FROM `${projectId}.${dataSetId}.cb_criteria` cr\n"

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
@@ -201,7 +201,7 @@ public final class SearchGroupItemQueryBuilder {
   private static final String HAS_DATA_SQL =
       "SELECT person_id\n" + "FROM `${projectId}.${dataSetId}.cb_search_person` p\nWHERE %s = 1\n";
   private static final String CB_SEARCH_ALL_EVENTS_WHERE =
-          "SELECT person_id FROM `${projectId}.${dataSetId}.cb_search_all_events`\nWHERE ";
+      "SELECT person_id FROM `${projectId}.${dataSetId}.cb_search_all_events`\nWHERE ";
   private static final String PERSON_ID_IN = "person_id IN (";
   private static final String VARIANT_SQL =
       "SELECT person_id\n"
@@ -281,13 +281,13 @@ public final class SearchGroupItemQueryBuilder {
 
     String queryPartsSql;
     if (SOURCE_STANDARD_DOMAINS.contains(domain)
-            && !sourceSearchParameters.isEmpty()
-            && !standardSearchParameters.isEmpty()) {
+        && !sourceSearchParameters.isEmpty()
+        && !standardSearchParameters.isEmpty()) {
       queryPartsSql =
-              PERSON_ID_IN
-                      + CB_SEARCH_ALL_EVENTS_WHERE
-                      + String.join(UNION_TEMPLATE + CB_SEARCH_ALL_EVENTS_WHERE, queryParts)
-                      + ")";
+          PERSON_ID_IN
+              + CB_SEARCH_ALL_EVENTS_WHERE
+              + String.join(UNION_TEMPLATE + CB_SEARCH_ALL_EVENTS_WHERE, queryParts)
+              + ")";
     } else {
       queryPartsSql = "(" + String.join(OR + "\n", queryParts) + ")";
     }
@@ -708,7 +708,7 @@ public final class SearchGroupItemQueryBuilder {
           QueryParameterUtil.addQueryParameterValue(
               queryParams, QueryParameterValue.int64(standardOrSource));
       List<Long> conceptIds =
-              searchParameters.stream().map(SearchParameter::getConceptId).collect(Collectors.toList());
+          searchParameters.stream().map(SearchParameter::getConceptId).collect(Collectors.toList());
 
       Map<Boolean, List<SearchParameter>> parentsAndChildren =
           searchParameters.stream().collect(Collectors.partitioningBy(SearchParameter::getGroup));
@@ -718,9 +718,8 @@ public final class SearchGroupItemQueryBuilder {
               .collect(Collectors.toList());
 
       String conceptIdsParam =
-              QueryParameterUtil.addQueryParameterValue(
-                      queryParams,
-                      QueryParameterValue.array(conceptIds.toArray(new Long[0]), Long.class));
+          QueryParameterUtil.addQueryParameterValue(
+              queryParams, QueryParameterValue.array(conceptIds.toArray(new Long[0]), Long.class));
       if (!parents.isEmpty() || Domain.DRUG.toString().equals(domain)) {
         // Lookup child nodes
         queryParts.add(
@@ -732,7 +731,7 @@ public final class SearchGroupItemQueryBuilder {
       } else {
         // Children only
         queryParts.add(
-                String.format(STANDARD_OR_SOURCE_SQL, conceptIdsParam, standardOrSourceParam));
+            String.format(STANDARD_OR_SOURCE_SQL, conceptIdsParam, standardOrSourceParam));
       }
     }
   }

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -384,23 +384,23 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
       if (domain == Domain.SURVEY) {
         if (!isPrepackagedAllSurveys(request)) {
           dbConceptSetConceptIds.addAll(
-                  findDomainConceptIds(request.getDomain(), request.getConceptSetIds()));
+              findDomainConceptIds(request.getDomain(), request.getConceptSetIds()));
           List<Long> prePackagedSurveyConceptIds =
-                  request.getPrePackagedConceptSet().stream()
-                          .map(PRE_PACKAGED_SURVEY_CONCEPT_IDS::get)
-                          .collect(Collectors.toList());
+              request.getPrePackagedConceptSet().stream()
+                  .map(PRE_PACKAGED_SURVEY_CONCEPT_IDS::get)
+                  .collect(Collectors.toList());
 
           // add selected prePackaged survey question concept ids
           if (!prePackagedSurveyConceptIds.isEmpty()) {
             dbConceptSetConceptIds.addAll(
-                    findSurveyQuestionConceptIds(prePackagedSurveyConceptIds));
+                findSurveyQuestionConceptIds(prePackagedSurveyConceptIds));
           }
         }
       } else {
         // Get all source concepts and check to see if they cross this domain. Please see:
         // https://precisionmedicineinitiative.atlassian.net/browse/RW-7657
         dbConceptSetConceptIds.addAll(
-                findMultipleDomainConceptIds(request.getDomain(), request.getConceptSetIds()));
+            findMultipleDomainConceptIds(request.getDomain(), request.getConceptSetIds()));
       }
       Map<Boolean, List<DbConceptSetConceptId>> partitionSourceAndStandard =
           dbConceptSetConceptIds.stream()
@@ -772,8 +772,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
       dbConceptSetConceptIds.addAll(findMultipleDomainConceptIds(domain, dbConceptSetIds));
     }
 
-    if (dbConceptSetConceptIds.isEmpty()
-        && surveyConceptIds.isEmpty()) {
+    if (dbConceptSetConceptIds.isEmpty() && surveyConceptIds.isEmpty()) {
       return Optional.empty();
     } else {
       StringBuilder queryBuilder = new StringBuilder();

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -381,48 +381,26 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
 
     if (supportsConceptSets(domain)) {
       Set<DbConceptSetConceptId> dbConceptSetConceptIds = new HashSet<>();
-      List<Long> dbCriteriaAnswerIds = new ArrayList<>();
-      switch (domain) {
-        case SURVEY:
-          if (!isPrepackagedAllSurveys(request)) {
-            dbConceptSetConceptIds.addAll(
-                findDomainConceptIds(request.getDomain(), request.getConceptSetIds()));
-            List<Long> prePackagedSurveyConceptIds =
-                request.getPrePackagedConceptSet().stream()
-                    .map(PRE_PACKAGED_SURVEY_CONCEPT_IDS::get)
-                    .collect(Collectors.toList());
-
-            // add selected prePackaged survey question concept ids
-            if (!prePackagedSurveyConceptIds.isEmpty()) {
-              dbConceptSetConceptIds.addAll(
-                  findSurveyQuestionConceptIds(prePackagedSurveyConceptIds));
-            }
-          }
-          List<Long> questionConceptIds =
-              dbConceptSetConceptIds.stream()
-                  .map(DbConceptSetConceptId::getConceptId)
-                  .collect(Collectors.toList());
-
-          // find any questions that belong to PFHH survey. The PFHH survey should
-          // only use answer ids when looking up participants.
-          List<Long> pfhhSurveyQuestionIds = findPFHHSurveyQuestionIds(questionConceptIds);
-          if (!pfhhSurveyQuestionIds.isEmpty()) {
-            // need to filter out PFHH survey questions for other survey questions
-            Set<DbConceptSetConceptId> dbNonPFHHSurveyQuestions =
-                dbConceptSetConceptIds.stream()
-                    .filter(cid -> !pfhhSurveyQuestionIds.contains(cid.getConceptId()))
-                    .collect(Collectors.toSet());
-            dbConceptSetConceptIds = dbNonPFHHSurveyQuestions;
-            // find all answers for the questions
-            dbCriteriaAnswerIds = findPFHHSurveyAnswerIds(pfhhSurveyQuestionIds);
-          }
-          break;
-        default:
-          // Get all source concepts and check to see if they cross this domain. Please see:
-          // https://precisionmedicineinitiative.atlassian.net/browse/RW-7657
+      if (domain == Domain.SURVEY) {
+        if (!isPrepackagedAllSurveys(request)) {
           dbConceptSetConceptIds.addAll(
-              findMultipleDomainConceptIds(request.getDomain(), request.getConceptSetIds()));
-          break;
+                  findDomainConceptIds(request.getDomain(), request.getConceptSetIds()));
+          List<Long> prePackagedSurveyConceptIds =
+                  request.getPrePackagedConceptSet().stream()
+                          .map(PRE_PACKAGED_SURVEY_CONCEPT_IDS::get)
+                          .collect(Collectors.toList());
+
+          // add selected prePackaged survey question concept ids
+          if (!prePackagedSurveyConceptIds.isEmpty()) {
+            dbConceptSetConceptIds.addAll(
+                    findSurveyQuestionConceptIds(prePackagedSurveyConceptIds));
+          }
+        }
+      } else {
+        // Get all source concepts and check to see if they cross this domain. Please see:
+        // https://precisionmedicineinitiative.atlassian.net/browse/RW-7657
+        dbConceptSetConceptIds.addAll(
+                findMultipleDomainConceptIds(request.getDomain(), request.getConceptSetIds()));
       }
       Map<Boolean, List<DbConceptSetConceptId>> partitionSourceAndStandard =
           dbConceptSetConceptIds.stream()
@@ -448,15 +426,6 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
           queryBuilder.append(" OR ");
         }
         queryBuilder.append(BigQueryDataSetTableInfo.getConceptIdIn(domain, false));
-      }
-      if (Domain.SURVEY.equals(request.getDomain()) && !dbCriteriaAnswerIds.isEmpty()) {
-        mergedQueryParameterValues.put(
-            "answerConceptIds",
-            QueryParameterValue.array(dbCriteriaAnswerIds.toArray(new Long[0]), Long.class));
-        if (queryBuilder.toString().contains("question_concept_id IN unnest(@sourceConceptIds)")) {
-          queryBuilder.append(" OR ");
-        }
-        queryBuilder.append("answer_concept_id IN unnest(@answerConceptIds)");
       }
       if (queryBuilder.toString().endsWith("WHERE (")) {
         queryBuilder.append(" 1 = 1 ");
@@ -782,7 +751,6 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
         conceptSets.stream().map(DbConceptSet::getConceptSetId).collect(Collectors.toList());
     Set<DbConceptSetConceptId> dbConceptSetConceptIds = new HashSet<>();
     List<Long> surveyConceptIds = new ArrayList<>();
-    List<Long> dbCriteriaAnswerIds = new ArrayList<>();
     if (domain.equals(Domain.SURVEY)) {
       if (prePackagedAllSurveyConceptSet(dbConceptSets)) {
         return Optional.empty();
@@ -790,36 +758,10 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
       if (userSurveyConceptSet(dbConceptSets)) {
         dbConceptSetConceptIds.addAll(findDomainConceptIds(domain, dbConceptSetIds));
       }
-      // handle prepackaged PFHH
-      if (prePackagedPfhhSurveyConceptSet(dbConceptSets)) {
-        dbConceptSetConceptIds.addAll(
-            findSurveyQuestionConceptIds(
-                ImmutableList.of(
-                    PRE_PACKAGED_SURVEY_CONCEPT_IDS.get(PrePackagedConceptSetEnum.SURVEY_PFHH))));
-      }
-      // Resolve PFHH question_concept_ids to answer_concept_ids
-      List<Long> questionConceptIds =
-          dbConceptSetConceptIds.stream()
-              .map(DbConceptSetConceptId::getConceptId)
-              .collect(Collectors.toList());
-      // find any questions that belong to PFHH survey. The PFHH survey should
-      // only use answer ids when looking up participants.
-      List<Long> pfhhSurveyQuestionIds = findPFHHSurveyQuestionIds(questionConceptIds);
-      if (!pfhhSurveyQuestionIds.isEmpty()) {
-        // need to filter out PFHH survey questions for other survey questions
-        Set<DbConceptSetConceptId> dbNonPFHHSurveyQuestions =
-            dbConceptSetConceptIds.stream()
-                .filter(cid -> !pfhhSurveyQuestionIds.contains(cid.getConceptId()))
-                .collect(Collectors.toSet());
-        dbConceptSetConceptIds = dbNonPFHHSurveyQuestions;
-        // find all answers for the questions
-        dbCriteriaAnswerIds = findPFHHSurveyAnswerIds(pfhhSurveyQuestionIds);
-      }
       if (prePackagedSurveyConceptSet(dbConceptSets)) {
         surveyConceptIds.addAll(
             dbConceptSets.stream()
                 .filter(d -> d.getConceptSetId() == 0 && Domain.SURVEY.equals(d.getDomainEnum()))
-                .filter(d -> !d.getName().equals(PrePackagedConceptSetEnum.SURVEY_PFHH.toString()))
                 .map(
                     d ->
                         PRE_PACKAGED_SURVEY_CONCEPT_IDS.get(
@@ -831,7 +773,6 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     }
 
     if (dbConceptSetConceptIds.isEmpty()
-        && dbCriteriaAnswerIds.isEmpty()
         && surveyConceptIds.isEmpty()) {
       return Optional.empty();
     } else {
@@ -865,22 +806,9 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
                 .replaceAll("(@sourceConceptIds)", sourceConceptIds));
       }
       if (Domain.SURVEY.equals(domain)) {
-        if (!dbCriteriaAnswerIds.isEmpty()) {
-          String answerConceptIds =
-              dbCriteriaAnswerIds.stream().map(Object::toString).collect(Collectors.joining(","));
+        if (!surveyConceptIds.isEmpty()) {
           if (queryBuilder.toString().contains("question_concept_id IN (")) {
             queryBuilder.append(" OR ");
-          }
-          queryBuilder.append(
-              "answer_concept_id IN (@answerConceptIds)"
-                  .replaceAll("@answerConceptIds", answerConceptIds));
-        }
-        if (!surveyConceptIds.isEmpty()) {
-          if (queryBuilder.toString().contains("question_concept_id IN (")
-              || queryBuilder.toString().contains("answer_concept_id IN (")) {
-            queryBuilder.append(" OR question_concept_id IN ");
-          } else {
-            queryBuilder.append("question_concept_id IN ");
           }
           queryBuilder.append(
               QUESTION_LOOKUP_SQL.replaceAll(
@@ -911,15 +839,6 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
   private boolean prePackagedSurveyConceptSet(List<DbConceptSet> dbConceptSets) {
     return dbConceptSets.stream()
         .anyMatch(c -> c.getConceptSetId() == 0 && Domain.SURVEY.equals(c.getDomainEnum()));
-  }
-
-  private boolean prePackagedPfhhSurveyConceptSet(List<DbConceptSet> dbConceptSets) {
-    return dbConceptSets.stream()
-        .anyMatch(
-            c ->
-                c.getConceptSetId() == 0
-                    && Domain.SURVEY.equals(c.getDomainEnum())
-                    && c.getName().equals(PrePackagedConceptSetEnum.SURVEY_PFHH.toString()));
   }
 
   private QueryJobConfiguration buildQueryJobConfiguration(
@@ -1773,16 +1692,6 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
         .filter(cs -> cs.getDomainEnum().equals(domain))
         .flatMap(cs -> cs.getConceptSetConceptIds().stream())
         .collect(Collectors.toList());
-  }
-
-  @NotNull
-  private List<Long> findPFHHSurveyQuestionIds(List<Long> conceptIds) {
-    return cohortBuilderService.findPFHHSurveyQuestionIds(conceptIds);
-  }
-
-  @NotNull
-  private List<Long> findPFHHSurveyAnswerIds(List<Long> conceptIds) {
-    return cohortBuilderService.findPFHHSurveyAnswerIds(conceptIds);
   }
 
   @NotNull

--- a/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/cdr/dao/CBCriteriaDaoTest.java
@@ -34,9 +34,6 @@ public class CBCriteriaDaoTest {
   @Autowired private CBCriteriaDao cbCriteriaDao;
   @Autowired private JdbcTemplate jdbcTemplate;
   private DbCriteria surveyCriteria;
-  private DbCriteria pfhhSurveyQuestion;
-
-  private DbCriteria pfhhSurveyAnswer;
   private DbCriteria sourceCriteria;
   private DbCriteria standardCriteria;
   private DbCriteria icd9Criteria;
@@ -81,60 +78,6 @@ public class CBCriteriaDaoTest {
             .addPath(String.valueOf(surveyCriteria.getId()))
             .addFullText("term[survey_rank1]")
             .build());
-    // adding pfhh survey module
-    DbCriteria pfhhSurveyModule =
-        cbCriteriaDao.save(
-            DbCriteria.builder()
-                .addDomainId(Domain.SURVEY.toString())
-                .addType(CriteriaType.PPI.toString())
-                .addSubtype(CriteriaSubType.SURVEY.toString())
-                .addGroup(true)
-                .addConceptId("1740639")
-                .addStandard(false)
-                .addSelectable(true)
-                .addName("Personal and Family Health History")
-                .build());
-    // adding pfhh survey module path
-    pfhhSurveyModule.setPath(String.valueOf(pfhhSurveyModule.getId()));
-    cbCriteriaDao.save(pfhhSurveyModule);
-    // adding pfhh survey question
-    pfhhSurveyQuestion =
-        cbCriteriaDao.save(
-            DbCriteria.builder()
-                .addDomainId(Domain.SURVEY.toString())
-                .addType(CriteriaType.PPI.toString())
-                .addSubtype(CriteriaSubType.QUESTION.toString())
-                .addGroup(true)
-                .addConceptId("43530446")
-                .addStandard(false)
-                .addSelectable(true)
-                .addName("Question")
-                .build());
-    // setting the correct path on pfhh question
-    pfhhSurveyQuestion.setPath(pfhhSurveyModule.getId() + "." + pfhhSurveyQuestion.getId());
-    pfhhSurveyQuestion = cbCriteriaDao.save(pfhhSurveyQuestion);
-    // adding a pfhh survey answer
-    pfhhSurveyAnswer =
-        cbCriteriaDao.save(
-            DbCriteria.builder()
-                .addDomainId(Domain.SURVEY.toString())
-                .addType(CriteriaType.PPI.toString())
-                .addSubtype(CriteriaSubType.ANSWER.toString())
-                .addGroup(false)
-                .addConceptId("43530446")
-                .addStandard(false)
-                .addSelectable(true)
-                .addName("Answer")
-                .addValue("1385558")
-                .build());
-    // setting the correct path on pfhh answer
-    pfhhSurveyAnswer.setPath(
-        pfhhSurveyModule.getId()
-            + "."
-            + pfhhSurveyQuestion.getId()
-            + "."
-            + pfhhSurveyAnswer.getId());
-    cbCriteriaDao.save(pfhhSurveyAnswer);
 
     sourceCriteria =
         cbCriteriaDao.save(
@@ -551,21 +494,6 @@ public class CBCriteriaDaoTest {
     assertThat(dbCriteria).hasSize(1);
     assertThat(dbCriteria).containsExactly(versionedSurvey);
     jdbcTemplate.execute("drop table cb_survey_version");
-  }
-
-  @Test
-  public void findPFHHSurveyQuestionIds() {
-    List<Long> pfhhSurveyQuestionIds =
-        cbCriteriaDao.findPFHHSurveyQuestionIds(ImmutableList.of(43530446L));
-    assertThat(Long.parseLong(pfhhSurveyQuestion.getConceptId()))
-        .isEqualTo(pfhhSurveyQuestionIds.get(0));
-  }
-
-  @Test
-  public void findPFHHSurveyAnswerIds() {
-    List<Long> pfhhSurveyAnswerIds =
-        cbCriteriaDao.findPFHHSurveyAnswerIds(ImmutableList.of(43530446L));
-    assertThat(Long.parseLong(pfhhSurveyAnswer.getValue())).isEqualTo(pfhhSurveyAnswerIds.get(0));
   }
 
   @Test

--- a/ui/src/app/pages/data/cohort/tree-node.tsx
+++ b/ui/src/app/pages/data/cohort/tree-node.tsx
@@ -15,7 +15,6 @@ import { Spinner } from 'app/components/spinners';
 import { PREDEFINED_ATTRIBUTES } from 'app/pages/data/cohort/constant';
 import {
   ppiQuestions,
-  ppiSurveys,
 } from 'app/pages/data/cohort/search-state.service';
 import { domainToTitle } from 'app/pages/data/cohort/utils';
 import { cohortBuilderApi } from 'app/services/swagger-fetch-clients';
@@ -33,7 +32,6 @@ import {
 export const COPE_SURVEY_GROUP_NAME =
   'COVID-19 Participant Experience (COPE) Survey';
 export const MINUTE_SURVEY_GROUP_NAME = 'COVID-19 Vaccine Survey';
-const PFHH_SURVEY_CONCEPT_ID = 1740639;
 const styles = reactStyles({
   code: {
     color: colors.dark,
@@ -316,16 +314,6 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
       .includes(this.props.node.subtype);
   }
 
-  get isPFHHSurvey() {
-    return (
-      ppiSurveys
-        .getValue()
-        [currentWorkspaceStore.getValue().cdrVersionId]?.find(
-          (survey) => survey.conceptId === PFHH_SURVEY_CONCEPT_ID
-        )?.id === +this.props.node.path.split('.')[0]
-    );
-  }
-
   get showCount() {
     const {
       node: { code, count, group, selectable, subtype, type },
@@ -367,13 +355,6 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
           operands: [value],
         });
       } else if (domainId === Domain.SURVEY.toString()) {
-        if (this.isPFHHSurvey) {
-          attributes.push({
-            name: AttrName.PERSONALFAMILYHEALTHHISTORY,
-            operator: Operator.IN,
-            operands: [PFHH_SURVEY_CONCEPT_ID.toString()],
-          });
-        }
         if (!group) {
           const question = ppiQuestions.getValue()[parentId];
           if (question) {

--- a/ui/src/app/pages/data/cohort/tree-node.tsx
+++ b/ui/src/app/pages/data/cohort/tree-node.tsx
@@ -13,9 +13,7 @@ import { ClrIcon } from 'app/components/icons';
 import { TooltipTrigger } from 'app/components/popups';
 import { Spinner } from 'app/components/spinners';
 import { PREDEFINED_ATTRIBUTES } from 'app/pages/data/cohort/constant';
-import {
-  ppiQuestions,
-} from 'app/pages/data/cohort/search-state.service';
+import { ppiQuestions } from 'app/pages/data/cohort/search-state.service';
 import { domainToTitle } from 'app/pages/data/cohort/utils';
 import { cohortBuilderApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';


### PR DESCRIPTION
Remove old code for PFHH surveys. The index is now completely updated and added all the non-answers so we can now query this survey just like all the other surveys.

NOTE: will not merge this PR until release goes out this week.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
