### PR TITLE
[risk=low][RW-10794] Set analysisConfig in Runtime panel in useEffect()

### DIFF
--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -481,8 +481,10 @@ describe('RuntimeConfigurationPanel', () => {
   });
 
   it('should disable controls when runtime has a non-actionable status', async () => {
-    runtimeApiStub.runtime.status = RuntimeStatus.Stopping;
-    runtimeStoreStub.runtime = runtimeApiStub.runtime;
+    setCurrentRuntime({
+      ...runtimeApiStub.runtime,
+      status: RuntimeStatus.Stopping,
+    });
 
     // sanity check
     expect(isActionable(runtimeApiStub.runtime.status)).toBeFalsy();

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -222,7 +222,7 @@ const PanelMain = fp.flow(
     );
 
     const [analysisConfig, setAnalysisConfig] = useState(
-      existingAnalysisConfig
+      withAnalysisConfigDefaults(existingAnalysisConfig, gcePersistentDisk)
     );
 
     // TODO: simplify the state logic here!  At least, try to understand why this is happening.

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -226,7 +226,7 @@ const PanelMain = fp.flow(
     );
 
     // TODO: simplify the state logic here!  At least, try to understand why this is happening.
-    // Somehow, setting the analysisConfig in the above useState() step means that
+    // Somehow, only setting the analysisConfig in the above useState() step means that
     // a gcePersistentDisk update from the diskStore does not always cause analysisConfig to be updated.
     // So we must set this explicit dependency trigger instead.
     useEffect(

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -232,7 +232,7 @@ const PanelMain = fp.flow(
     useEffect(
       () =>
         setAnalysisConfig(
-          withAnalysisConfigDefaults(existingAnalysisConfig, gcePersistentDisk)
+          withAnalysisConfigDefaults(analysisConfig, gcePersistentDisk)
         ),
       [gcePersistentDisk]
     );

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -222,8 +222,21 @@ const PanelMain = fp.flow(
     );
 
     const [analysisConfig, setAnalysisConfig] = useState(
-      withAnalysisConfigDefaults(existingAnalysisConfig, gcePersistentDisk)
+      existingAnalysisConfig
     );
+
+    // TODO: simplify the state logic here!  At least, try to understand why this is happening.
+    // Somehow, setting the analysisConfig in the above useState() step means that
+    // a gcePersistentDisk update from the diskStore does not always cause analysisConfig to be updated.
+    // So we must set this explicit dependency trigger instead.
+    useEffect(
+      () =>
+        setAnalysisConfig(
+          withAnalysisConfigDefaults(existingAnalysisConfig, gcePersistentDisk)
+        ),
+      [gcePersistentDisk]
+    );
+
     const requestAnalysisConfig = (config: AnalysisConfig) =>
       setRuntimeRequest({
         runtime: fromAnalysisConfig(config),


### PR DESCRIPTION
Add a `setAnalysisConfig()` call in a `useEffect()` to ensure it is triggered when `gcePersistentDisk` changes.

I don't know why this is necessary, or how to write a test for it.

To manually test
* create a GCE runtime
* delete it but keep the PD
* refresh the UI
* open the Runtime Config Panel
* create a new runtime (which will implicitly use the existing PD)
* observe that it succeeds - and specifically that it does so by calling create-runtime with a named Persistent Disk instead of null

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
