### PR TITLE
[RW-10827][risk=no] Remove pandas from snippet menu

### DIFF
--- a/api/snippets-menu/aou-snippets-menu.js.template
+++ b/api/snippets-menu/aou-snippets-menu.js.template
@@ -44,11 +44,6 @@ define([
          'sub-menu': [...customMenus, ...menus[0]['sub-menu']]
       };
 
-      menus[0] = {
-         ...menus[0],
-         'sub-menu': [...customMenus, ...menus[0]['sub-menu']]
-      };
-
       // Include custom menu content from the nbconfigurator UI extension, if any.
       // We primarily expect this to be used for manual testing of
       // workbench-snippets code, so prefix it to differentiate from the menus

--- a/api/snippets-menu/aou-snippets-menu.js.template
+++ b/api/snippets-menu/aou-snippets-menu.js.template
@@ -33,6 +33,17 @@ define([
       // Avoid mutating the original default_menus to reduce side-effects.
       snippets_menu.options['menus'] = [...snippets_menu.default_menus];
       const menus = snippets_menu.options['menus'];
+
+      // Remove pandas because it is broken by https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/1636
+      // How to remove snippets: https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/snippets_menu#deleting-menu-items
+      // TODO(RW-10914): Bring pandas back.
+      menus[0]['sub-menu'].splice(4, 1);
+
+      menus[0] = {
+         ...menus[0],
+         'sub-menu': [...customMenus, ...menus[0]['sub-menu']]
+      };
+
       menus[0] = {
          ...menus[0],
          'sub-menu': [...customMenus, ...menus[0]['sub-menu']]


### PR DESCRIPTION
snippet menu is broken by pandas menu due to https://github.com/ipython-contrib/jupyter_contrib_nbextensions/commit/d0fb8668c1158fd17a803ebd3fda0b01014b7021

Support is okay with just remove it for now.

![Screenshot 2023-09-14 at 10 30 26 AM](https://github.com/all-of-us/workbench/assets/6351731/0661173b-f747-4ebb-bfcf-f28d6c64f229)


**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
