### PR TITLE
[risk=no][no ticket] Add option to use local code for deploy

### DIFF
--- a/deploy/bootstrap-docker.sh
+++ b/deploy/bootstrap-docker.sh
@@ -6,6 +6,11 @@ if [[ -z "${WORKBENCH_VERSION}" ]]; then
   exit 1
 fi
 
+if [[ "$WORKBENCH_VERSION" = 'local-source' ]]; then
+  cd /mnt/local-source
+  exec "$@"
+fi
+
 if [[ ! -d ~/workbench/.git ]]; then
   git clone https://github.com/all-of-us/workbench ~/workbench
 fi

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - workbench:/home/circleci/workbench
       - yarn-cache:/home/circleci/.cache/yarn
       - ./bootstrap-docker.sh:/bootstrap-docker.sh
-
+      - ..:/mnt/local-source
 volumes:
   workbench:
   gradle-cache:

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
       - workbench:/home/circleci/workbench
       - yarn-cache:/home/circleci/.cache/yarn
       - ./bootstrap-docker.sh:/bootstrap-docker.sh
+      # Unconditionally mount the local repo into the container. Used conditionally
+      # within bootstrap-docker.sh.
       - ..:/mnt/local-source
 volumes:
   workbench:


### PR DESCRIPTION
To test:
```
deploy/project.rb deploy \
  --project=foo \
  --account=deploy@bar.gserviceaccount.com \
  --git-version=local-source
```
The `local-source` version avoids the standard "clone from known version" behavior.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [X] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
