### PR TITLE
[risk=low][RW-10290] Add Delete Environment links to GKE App Configuration Panels

### DIFF
--- a/ui/src/app/components/apps-panel/utils.tsx
+++ b/ui/src/app/components/apps-panel/utils.tsx
@@ -59,7 +59,7 @@ export const appAssets: AppAssets[] = [
   },
 ];
 
-// TODO replace with better defaults
+// TODO replace with better defaults?
 export const defaultCromwellConfig: CreateAppRequest = {
   appType: AppType.CROMWELL,
   kubernetesRuntimeConfig: {
@@ -73,6 +73,7 @@ export const defaultCromwellConfig: CreateAppRequest = {
   },
 };
 
+// TODO replace with better defaults?
 export const defaultRStudioConfig: CreateAppRequest = {
   appType: AppType.RSTUDIO,
   kubernetesRuntimeConfig: {
@@ -86,6 +87,7 @@ export const defaultRStudioConfig: CreateAppRequest = {
   },
 };
 
+// TODO replace with better defaults?
 export const defaultSASConfig: CreateAppRequest = {
   appType: AppType.SAS,
   kubernetesRuntimeConfig: {

--- a/ui/src/app/components/configuration-panel.tsx
+++ b/ui/src/app/components/configuration-panel.tsx
@@ -78,9 +78,8 @@ export const ConfigurationPanel = fp.flow(
             () => (
               <div>
                 <RuntimeConfigurationPanel
-                  {...{ onClose, creatorFreeCreditsRemaining }}
+                  {...{ onClose, profileState, creatorFreeCreditsRemaining }}
                   initialPanelContent={runtimeConfPanelInitialState}
-                  profileState={profileState}
                 />
               </div>
             ),

--- a/ui/src/app/components/configuration-panel.tsx
+++ b/ui/src/app/components/configuration-panel.tsx
@@ -12,9 +12,11 @@ import {
 } from 'app/components/gke-app-configuration-panel';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import { withCurrentWorkspace, withUserProfile } from 'app/utils';
+import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { ProfileStore } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
+import { SidebarIconId } from './help-sidebar-icons';
 import {
   RuntimeConfigurationPanel,
   RuntimeConfigurationPanelProps,
@@ -88,14 +90,22 @@ export const ConfigurationPanel = fp.flow(
           () => (
             <GKEAppConfigurationPanel
               {...{
-                appType: toAppType[appType],
                 onClose,
                 creatorFreeCreditsRemaining,
                 workspace,
                 profileState,
-                workspaceNamespace: workspace.namespace,
-                initialPanelContent: gkeAppConfPanelInitialState,
               }}
+              appType={toAppType[appType]}
+              workspaceNamespace={workspace.namespace}
+              initialPanelContent={gkeAppConfPanelInitialState}
+              onClickDeleteGkeApp={
+                (sidebarIcon: SidebarIconId) =>
+                  setSidebarActiveIconStore.next(sidebarIcon)
+                // openGkeAppConfigWithState(
+                //   sidebarIcon,
+                //   GKEAppPanelContent.DELETE_GKE_APP
+                // )
+              }
             />
           )
         )}

--- a/ui/src/app/components/configuration-panel.tsx
+++ b/ui/src/app/components/configuration-panel.tsx
@@ -12,11 +12,9 @@ import {
 } from 'app/components/gke-app-configuration-panel';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import { withCurrentWorkspace, withUserProfile } from 'app/utils';
-import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { ProfileStore } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
-import { SidebarIconId } from './help-sidebar-icons';
 import {
   RuntimeConfigurationPanel,
   RuntimeConfigurationPanelProps,

--- a/ui/src/app/components/configuration-panel.tsx
+++ b/ui/src/app/components/configuration-panel.tsx
@@ -98,14 +98,6 @@ export const ConfigurationPanel = fp.flow(
               appType={toAppType[appType]}
               workspaceNamespace={workspace.namespace}
               initialPanelContent={gkeAppConfPanelInitialState}
-              onClickDeleteGkeApp={
-                (sidebarIcon: SidebarIconId) =>
-                  setSidebarActiveIconStore.next(sidebarIcon)
-                // openGkeAppConfigWithState(
-                //   sidebarIcon,
-                //   GKEAppPanelContent.DELETE_GKE_APP
-                // )
-              }
             />
           )
         )}

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -73,7 +73,6 @@ describe(GKEAppConfigurationPanel.name, () => {
     appType: AppType.RSTUDIO,
     workspaceNamespace: 'aou-rw-1234',
     onClose: jest.fn(),
-    onClickDeleteGkeApp: jest.fn(),
     initialPanelContent: null,
     creatorFreeCreditsRemaining: 300,
 

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -73,6 +73,7 @@ describe(GKEAppConfigurationPanel.name, () => {
     appType: AppType.RSTUDIO,
     workspaceNamespace: 'aou-rw-1234',
     onClose: jest.fn(),
+    onClickDeleteGkeApp: jest.fn(),
     initialPanelContent: null,
     creatorFreeCreditsRemaining: 300,
 

--- a/ui/src/app/components/gke-app-configuration-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.tsx
@@ -18,7 +18,11 @@ import { ConfirmDelete } from './runtime-configuration-panel/confirm-delete';
 import { ConfirmDeleteEnvironmentWithPD } from './runtime-configuration-panel/confirm-delete-environment-with-pd';
 import { ConfirmDeleteUnattachedPD } from './runtime-configuration-panel/confirm-delete-unattached-pd';
 
-type InjectedProps = 'app' | 'disk' | 'onClickDeleteUnattachedPersistentDisk';
+type InjectedProps =
+  | 'app'
+  | 'disk'
+  | 'onClickDeleteUnattachedPersistentDisk'
+  | 'onClickDeleteGkeApp';
 
 export type GkeAppConfigurationPanelProps = {
   appType: AppType;
@@ -114,6 +118,9 @@ export const GKEAppConfigurationPanel = ({
     }
   };
 
+  const onClickDeleteGkeApp = () =>
+    setPanelContent(GKEAppPanelContent.DELETE_GKE_APP);
+
   const onCancelDeleteUnattachedPersistentDisk = () => {
     setPanelContent(GKEAppPanelContent.CREATE);
   };
@@ -123,6 +130,14 @@ export const GKEAppConfigurationPanel = ({
     onClose();
   };
 
+  const createAppProps = {
+    ...props,
+    app,
+    disk,
+    onClose,
+    onClickDeleteGkeApp,
+    onClickDeleteUnattachedPersistentDisk,
+  };
   return switchCase(
     panelContent,
     [
@@ -130,48 +145,9 @@ export const GKEAppConfigurationPanel = ({
       () =>
         switchCase(
           appType,
-          [
-            AppType.CROMWELL,
-            () => (
-              <CreateCromwell
-                {...{
-                  ...props,
-                  app,
-                  disk,
-                  onClickDeleteUnattachedPersistentDisk,
-                  onClose,
-                }}
-              />
-            ),
-          ],
-          [
-            AppType.RSTUDIO,
-            () => (
-              <CreateRStudio
-                {...{
-                  ...props,
-                  app,
-                  disk,
-                  onClickDeleteUnattachedPersistentDisk,
-                  onClose,
-                }}
-              />
-            ),
-          ],
-          [
-            AppType.SAS,
-            () => (
-              <CreateSAS
-                {...{
-                  ...props,
-                  app,
-                  disk,
-                  onClickDeleteUnattachedPersistentDisk,
-                  onClose,
-                }}
-              />
-            ),
-          ]
+          [AppType.CROMWELL, () => <CreateCromwell {...createAppProps} />],
+          [AppType.RSTUDIO, () => <CreateRStudio {...createAppProps} />],
+          [AppType.SAS, () => <CreateSAS {...createAppProps} />]
         ),
     ],
     [

--- a/ui/src/app/components/gke-app-configuration-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.tsx
@@ -21,8 +21,8 @@ import { ConfirmDeleteUnattachedPD } from './runtime-configuration-panel/confirm
 type InjectedProps =
   | 'app'
   | 'disk'
-  | 'onClickDeleteUnattachedPersistentDisk'
-  | 'onClickDeleteGkeApp';
+  | 'onClickDeleteGkeApp'
+  | 'onClickDeleteUnattachedPersistentDisk';
 
 export type GkeAppConfigurationPanelProps = {
   appType: AppType;
@@ -98,6 +98,14 @@ export const GKEAppConfigurationPanel = ({
   const app = findApp(gkeAppsInWorkspace, toUIAppType[appType]);
   const disk = findDisk(ownedDisksInWorkspace, appType);
 
+  const onClickDeleteGkeApp = () =>
+    setPanelContent(GKEAppPanelContent.DELETE_GKE_APP);
+
+  const onConfirmDeleteGKEApp = async (deletePDSelected) => {
+    await deleteUserApp(workspaceNamespace, app.appName, deletePDSelected);
+    onClose();
+  };
+
   const onClickDeleteUnattachedPersistentDisk = () => {
     setPanelContent(GKEAppPanelContent.DELETE_UNATTACHED_PD);
   };
@@ -118,16 +126,8 @@ export const GKEAppConfigurationPanel = ({
     }
   };
 
-  const onClickDeleteGkeApp = () =>
-    setPanelContent(GKEAppPanelContent.DELETE_GKE_APP);
-
   const onCancelDeleteUnattachedPersistentDisk = () => {
     setPanelContent(GKEAppPanelContent.CREATE);
-  };
-
-  const onConfirmDeleteGKEApp = async (deletePDSelected) => {
-    await deleteUserApp(workspaceNamespace, app.appName, deletePDSelected);
-    onClose();
   };
 
   const createAppProps = {
@@ -163,8 +163,6 @@ export const GKEAppConfigurationPanel = ({
     [
       GKEAppPanelContent.DELETE_GKE_APP,
       () =>
-        // currently (July 2023) we do not expose detaching PDs to users, but it's possible to get into
-        // an error state where the disk is missing, so we need to account for this
         disk ? (
           <ConfirmDeleteEnvironmentWithPD
             onConfirm={onConfirmDeleteGKEApp}

--- a/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
@@ -15,6 +15,7 @@ import { expectButtonElementEnabled } from 'testing/react-test-helpers';
 import {
   AppsApiStub,
   createListAppsCromwellResponse,
+  createListAppsRStudioResponse,
 } from 'testing/stubs/apps-api-stub';
 import { CdrVersionsStubVariables } from 'testing/stubs/cdr-versions-api-stub';
 import { DisksApiStub, stubDisk } from 'testing/stubs/disks-api-stub';
@@ -133,7 +134,33 @@ describe(CreateCromwell.name, () => {
     );
   });
 
-  it('should render a DeletePersistentDiskButton when a disk is present but no app', async () => {
+  it('should allow deleting the environment when an app is running', async () => {
+    const disk = stubDisk();
+    const onClickDeleteGkeApp = jest.fn();
+
+    await component({
+      app: createListAppsCromwellResponse(),
+      disk,
+      onClickDeleteGkeApp,
+    });
+
+    const deleteButton = screen.queryByLabelText('Delete Environment');
+    expectButtonElementEnabled(deleteButton);
+    deleteButton.click();
+
+    await waitFor(() => {
+      expect(onClickDeleteGkeApp).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should not render a Delete Environment link when no app is present', async () => {
+    await component();
+
+    const deleteButton = screen.queryByLabelText('Delete Environment');
+    expect(deleteButton).not.toBeInTheDocument();
+  });
+
+  it('should allow deletion of a Persistent Disk when a disk is present but no app', async () => {
     const disk = stubDisk();
     const onClickDeleteUnattachedPersistentDisk = jest.fn();
 
@@ -154,7 +181,7 @@ describe(CreateCromwell.name, () => {
     });
   });
 
-  it('should not render a DeletePersistentDiskButton when an app is present', async () => {
+  it('should not render a Delete Persistent Disk link when an app is present', async () => {
     const disk = stubDisk();
 
     await component({
@@ -166,7 +193,7 @@ describe(CreateCromwell.name, () => {
     expect(deleteButton).toBeNull();
   });
 
-  it('should not render a DeletePersistentDiskButton no disk is present', async () => {
+  it('should not render a Delete Persistent Disk Button when no disk is present', async () => {
     await component({
       app: undefined,
       disk: undefined,

--- a/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
@@ -29,10 +29,12 @@ import { CommonCreateGkeAppProps } from './create-gke-app';
 
 describe(CreateCromwell.name, () => {
   const onClose = jest.fn();
+  const onClickDeleteGkeApp = jest.fn();
   const freeTierBillingAccountId = 'freetier';
 
   const defaultProps: CommonCreateGkeAppProps = {
     onClose,
+    onClickDeleteGkeApp,
     creatorFreeCreditsRemaining: null,
     workspace: {
       ...workspaceStubs[0],

--- a/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
@@ -29,12 +29,10 @@ import { CommonCreateGkeAppProps } from './create-gke-app';
 
 describe(CreateCromwell.name, () => {
   const onClose = jest.fn();
-  const onClickDeleteGkeApp = jest.fn();
   const freeTierBillingAccountId = 'freetier';
 
   const defaultProps: CommonCreateGkeAppProps = {
     onClose,
-    onClickDeleteGkeApp,
     creatorFreeCreditsRemaining: null,
     workspace: {
       ...workspaceStubs[0],
@@ -50,6 +48,7 @@ describe(CreateCromwell.name, () => {
     },
     app: undefined,
     disk: undefined,
+    onClickDeleteGkeApp: jest.fn(),
     onClickDeleteUnattachedPersistentDisk: jest.fn(),
   };
 

--- a/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
@@ -15,7 +15,6 @@ import { expectButtonElementEnabled } from 'testing/react-test-helpers';
 import {
   AppsApiStub,
   createListAppsCromwellResponse,
-  createListAppsRStudioResponse,
 } from 'testing/stubs/apps-api-stub';
 import { CdrVersionsStubVariables } from 'testing/stubs/cdr-versions-api-stub';
 import { DisksApiStub, stubDisk } from 'testing/stubs/disks-api-stub';

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
@@ -1,0 +1,232 @@
+import '@testing-library/jest-dom';
+
+import * as React from 'react';
+
+import {
+  AppType,
+  DisksApi,
+  UserAppEnvironment,
+  WorkspaceAccessLevel,
+} from 'generated/fetch';
+import { AppsApi } from 'generated/fetch/api';
+
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+  defaultCromwellConfig,
+  defaultRStudioConfig,
+  defaultSASConfig,
+} from 'app/components/apps-panel/utils';
+import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
+import { serverConfigStore } from 'app/utils/stores';
+import { appTypeToString } from 'app/utils/user-apps-utils';
+
+import defaultServerConfig from 'testing/default-server-config';
+import { expectButtonElementEnabled } from 'testing/react-test-helpers';
+import {
+  AppsApiStub,
+  createListAppsCromwellResponse,
+  createListAppsRStudioResponse,
+  createListAppsSASResponse,
+} from 'testing/stubs/apps-api-stub';
+import { CdrVersionsStubVariables } from 'testing/stubs/cdr-versions-api-stub';
+import { DisksApiStub, stubDisk } from 'testing/stubs/disks-api-stub';
+import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
+import {
+  workspaceStubs,
+  WorkspaceStubVariables,
+} from 'testing/stubs/workspaces';
+
+import {
+  CommonCreateGkeAppProps,
+  CreateGkeApp,
+  CreateGkeAppProps,
+} from './create-gke-app';
+
+const onClose = jest.fn();
+const freeTierBillingAccountId = 'freetier';
+export const defaultProps: CommonCreateGkeAppProps = {
+  onClose,
+  creatorFreeCreditsRemaining: null,
+  workspace: {
+    ...workspaceStubs[0],
+    accessLevel: WorkspaceAccessLevel.WRITER,
+    billingAccountName: 'billingAccounts/' + freeTierBillingAccountId,
+    cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
+  },
+  profileState: {
+    profile: ProfileStubVariables.PROFILE_STUB,
+    load: jest.fn(),
+    reload: jest.fn(),
+    updateCache: jest.fn(),
+  },
+  app: undefined,
+  disk: undefined,
+  onClickDeleteGkeApp: jest.fn(),
+  onClickDeleteUnattachedPersistentDisk: jest.fn(),
+};
+
+// tests for behavior common to all GKE Apps.  For app-specific tests, see e.g. create-cromwell-spec
+describe(CreateGkeApp.name, () => {
+  let disksApiStub: DisksApiStub;
+
+  const component = async (
+    appType: AppType,
+    propOverrides?: Partial<CreateGkeAppProps>
+  ) =>
+    render(
+      <CreateGkeApp {...{ ...defaultProps, appType, ...propOverrides }} />
+    );
+
+  beforeEach(async () => {
+    disksApiStub = new DisksApiStub();
+    registerApiClient(DisksApi, disksApiStub);
+
+    serverConfigStore.set({
+      config: {
+        ...defaultServerConfig,
+        freeTierBillingAccountId: freeTierBillingAccountId,
+        defaultFreeCreditsDollarLimit: 100.0,
+        gsuiteDomain: '',
+      },
+    });
+
+    registerApiClient(AppsApi, new AppsApiStub());
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  describe.each([
+    [AppType.CROMWELL, defaultCromwellConfig, createListAppsCromwellResponse],
+    [AppType.RSTUDIO, defaultRStudioConfig, createListAppsRStudioResponse],
+    [AppType.SAS, defaultSASConfig, createListAppsSASResponse],
+  ])(
+    '%s',
+    (
+      appType: AppType,
+      appConfig: UserAppEnvironment,
+      listAppsResponse: () => UserAppEnvironment
+    ) => {
+      const startButtonText = `${appTypeToString[appType]} cloud environment create button`;
+
+      it('Should create an app and close the panel when the create button is clicked', async () => {
+        await component(appType, {
+          app: undefined,
+          disk: undefined,
+        });
+
+        const spyCreateApp = jest
+          .spyOn(appsApi(), 'createApp')
+          .mockImplementation((): Promise<any> => Promise.resolve());
+
+        const startButton = screen.getByLabelText(startButtonText);
+        expectButtonElementEnabled(startButton);
+        startButton.click();
+
+        await waitFor(() => {
+          expect(spyCreateApp).toHaveBeenCalledTimes(1);
+          expect(spyCreateApp).toHaveBeenCalledWith(
+            WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+            appConfig
+          );
+          expect(onClose).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      it('should use the existing PD when creating', async () => {
+        const disk = stubDisk();
+        await component(appType, {
+          app: undefined,
+          disk,
+        });
+
+        const spyCreateApp = jest
+          .spyOn(appsApi(), 'createApp')
+          .mockImplementation((): Promise<any> => Promise.resolve());
+
+        const startButton = screen.getByLabelText(startButtonText);
+        expectButtonElementEnabled(startButton);
+        startButton.click();
+
+        await waitFor(() => {
+          expect(spyCreateApp).toHaveBeenCalledTimes(1);
+          expect(spyCreateApp.mock.calls[0][1].persistentDiskRequest).toEqual(
+            disk
+          );
+          expect(onClose).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      it('should allow deleting the environment when an app is running', async () => {
+        const disk = stubDisk();
+        const onClickDeleteGkeApp = jest.fn();
+
+        await component(appType, {
+          app: listAppsResponse(),
+          disk,
+          onClickDeleteGkeApp,
+        });
+
+        const deleteButton = screen.queryByLabelText('Delete Environment');
+        expectButtonElementEnabled(deleteButton);
+        deleteButton.click();
+
+        await waitFor(() => {
+          expect(onClickDeleteGkeApp).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      it('should not render a Delete Environment link when no app is present', async () => {
+        await component(appType);
+        const deleteButton = screen.queryByLabelText('Delete Environment');
+        expect(deleteButton).not.toBeInTheDocument();
+      });
+
+      it('should allow deletion of a Persistent Disk when a disk is present but no app', async () => {
+        const disk = stubDisk();
+        const onClickDeleteUnattachedPersistentDisk = jest.fn();
+
+        await component(appType, {
+          app: undefined,
+          disk,
+          onClickDeleteUnattachedPersistentDisk,
+        });
+
+        const deleteButton = screen.queryByLabelText('Delete Persistent Disk');
+        expectButtonElementEnabled(deleteButton);
+        deleteButton.click();
+
+        await waitFor(() => {
+          expect(onClickDeleteUnattachedPersistentDisk).toHaveBeenCalledTimes(
+            1
+          );
+        });
+      });
+
+      it('should not render a Delete Persistent Disk link when an app is present', async () => {
+        const disk = stubDisk();
+
+        await component(appType, {
+          app: createListAppsSASResponse(),
+          disk,
+        });
+
+        const deleteButton = screen.queryByLabelText('Delete Persistent Disk');
+        expect(deleteButton).toBeNull();
+      });
+
+      it('should not render a Delete Persistent Disk link when no disk is present', async () => {
+        await component(appType, {
+          app: undefined,
+          disk: undefined,
+        });
+
+        const deleteButton = screen.queryByLabelText('Delete Persistent Disk');
+        expect(deleteButton).toBeNull();
+      });
+    }
+  );
+});

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
@@ -91,12 +91,6 @@ describe(CreateGkeApp.name, () => {
     });
 
     registerApiClient(AppsApi, new AppsApiStub());
-    jest.useFakeTimers();
-  });
-
-  afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
   });
 
   describe.each([

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
@@ -131,7 +131,7 @@ export const CreateGkeApp = ({
       <FlexRow
         style={{
           alignItems: 'center',
-          justifyContent: 'flex-end',
+          justifyContent: 'space-between',
           gap: '2rem',
         }}
       >
@@ -143,7 +143,7 @@ export const CreateGkeApp = ({
         )}
         {canDeleteApp(app) && (
           <LinkButton
-            style={styles.deleteLink}
+            style={{ ...styles.deleteLink, flexShrink: 0 }}
             aria-label='Delete Environment'
             onClick={onClickDeleteGkeApp}
           >

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
@@ -10,14 +10,17 @@ import {
 
 import { switchCase } from '@terra-ui-packages/core-utils';
 import {
+  canDeleteApp,
   createAppRequestToAnalysisConfig,
   defaultCromwellConfig,
   defaultRStudioConfig,
   defaultSASConfig,
 } from 'app/components/apps-panel/utils';
+import { LinkButton } from 'app/components/buttons';
 import { DeletePersistentDiskButton } from 'app/components/delete-persistent-disk-button';
 import { EnvironmentInformedActionPanel } from 'app/components/environment-informed-action-panel';
 import { FlexColumn, FlexRow } from 'app/components/flex';
+import { SidebarIconId } from 'app/components/help-sidebar-icons';
 import { styles } from 'app/components/runtime-configuration-panel/styles';
 import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { ProfileStore } from 'app/utils/stores';
@@ -42,6 +45,7 @@ export interface CreateGkeAppProps {
   profileState: ProfileStore;
   app: UserAppEnvironment | undefined;
   disk: Disk | undefined;
+  onClickDeleteGkeApp: (sidebarIcon: SidebarIconId) => void;
   onClickDeleteUnattachedPersistentDisk: () => void;
   introText?: string;
   CostNote?: React.FunctionComponent;
@@ -67,6 +71,7 @@ export const CreateGkeApp = ({
   profileState,
   app,
   disk,
+  onClickDeleteGkeApp,
   onClickDeleteUnattachedPersistentDisk,
   introText = defaultIntroText,
   CostNote = () => null,
@@ -135,6 +140,15 @@ export const CreateGkeApp = ({
             onClick={onClickDeleteUnattachedPersistentDisk}
             style={{ flexShrink: 0 }}
           />
+        )}
+        {canDeleteApp(app) && (
+          <LinkButton
+            style={styles.deleteLink}
+            aria-label='Delete Environment'
+            onClick={onClickDeleteGkeApp}
+          >
+            Delete Environment
+          </LinkButton>
         )}
         <CreateAppText />
         <CreateGkeAppButton

--- a/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
@@ -5,24 +5,16 @@ import * as React from 'react';
 import { DisksApi, WorkspaceAccessLevel } from 'generated/fetch';
 import { AppsApi } from 'generated/fetch/api';
 
-import { render, screen, waitFor } from '@testing-library/react';
-import { defaultRStudioConfig } from 'app/components/apps-panel/utils';
-import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
+import { render, screen } from '@testing-library/react';
+import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { serverConfigStore } from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
-import { expectButtonElementEnabled } from 'testing/react-test-helpers';
-import {
-  AppsApiStub,
-  createListAppsRStudioResponse,
-} from 'testing/stubs/apps-api-stub';
+import { AppsApiStub } from 'testing/stubs/apps-api-stub';
 import { CdrVersionsStubVariables } from 'testing/stubs/cdr-versions-api-stub';
-import { DisksApiStub, stubDisk } from 'testing/stubs/disks-api-stub';
+import { DisksApiStub } from 'testing/stubs/disks-api-stub';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
-import {
-  workspaceStubs,
-  WorkspaceStubVariables,
-} from 'testing/stubs/workspaces';
+import { workspaceStubs } from 'testing/stubs/workspaces';
 
 import { CommonCreateGkeAppProps } from './create-gke-app';
 import { CreateRStudio } from './create-rstudio';
@@ -50,6 +42,7 @@ export const defaultProps: CommonCreateGkeAppProps = {
   onClickDeleteUnattachedPersistentDisk: jest.fn(),
 };
 
+// tests for behavior specific to RStudio.  For behavior common to all GKE Apps, see create-gke-app.spec
 describe(CreateRStudio.name, () => {
   let disksApiStub: DisksApiStub;
 
@@ -72,56 +65,6 @@ describe(CreateRStudio.name, () => {
     registerApiClient(AppsApi, new AppsApiStub());
   });
 
-  it('start button should create rstudio and close panel', async () => {
-    await component({
-      app: undefined,
-      disk: undefined,
-    });
-
-    const spyCreateApp = jest
-      .spyOn(appsApi(), 'createApp')
-      .mockImplementation((): Promise<any> => Promise.resolve());
-
-    const startButton = screen.getByLabelText(
-      'RStudio cloud environment create button'
-    );
-    expectButtonElementEnabled(startButton);
-    startButton.click();
-
-    await waitFor(() => {
-      expect(spyCreateApp).toHaveBeenCalledTimes(1);
-      expect(spyCreateApp).toHaveBeenCalledWith(
-        WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-        defaultRStudioConfig
-      );
-      expect(onClose).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it('should use the existing PD when creating', async () => {
-    const disk = stubDisk();
-    await component({
-      app: undefined,
-      disk,
-    });
-
-    const spyCreateApp = jest
-      .spyOn(appsApi(), 'createApp')
-      .mockImplementation((): Promise<any> => Promise.resolve());
-
-    const startButton = screen.getByLabelText(
-      'RStudio cloud environment create button'
-    );
-    expectButtonElementEnabled(startButton);
-    startButton.click();
-
-    await waitFor(() => {
-      expect(spyCreateApp).toHaveBeenCalledTimes(1);
-      expect(spyCreateApp.mock.calls[0][1].persistentDiskRequest).toEqual(disk);
-      expect(onClose).toHaveBeenCalledTimes(1);
-    });
-  });
-
   it('should display a cost of $0.40 per hour when running and $0.21 per hour when paused', async () => {
     await component();
     expect(screen.queryByLabelText('cost while running')).toHaveTextContent(
@@ -130,72 +73,5 @@ describe(CreateRStudio.name, () => {
     expect(screen.queryByLabelText('cost while paused')).toHaveTextContent(
       '$0.21 per hour'
     );
-  });
-
-  it('should allow deleting the environment when an app is running', async () => {
-    const disk = stubDisk();
-    const onClickDeleteGkeApp = jest.fn();
-
-    await component({
-      app: createListAppsRStudioResponse(),
-      disk,
-      onClickDeleteGkeApp,
-    });
-
-    const deleteButton = screen.queryByLabelText('Delete Environment');
-    expectButtonElementEnabled(deleteButton);
-    deleteButton.click();
-
-    await waitFor(() => {
-      expect(onClickDeleteGkeApp).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it('should not render a Delete Environment link when no app is present', async () => {
-    await component();
-
-    const deleteButton = screen.queryByLabelText('Delete Environment');
-    expect(deleteButton).not.toBeInTheDocument();
-  });
-
-  it('should allow deleting a persistent disk when a disk is present but no app', async () => {
-    const disk = stubDisk();
-    const onClickDeleteUnattachedPersistentDisk = jest.fn();
-
-    await component({
-      app: undefined,
-      disk,
-      onClickDeleteUnattachedPersistentDisk,
-    });
-
-    const deleteButton = screen.queryByLabelText('Delete Persistent Disk');
-    expectButtonElementEnabled(deleteButton);
-    deleteButton.click();
-
-    await waitFor(() => {
-      expect(onClickDeleteUnattachedPersistentDisk).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it('should not render a Delete Persistent Disk link when an app is present', async () => {
-    const disk = stubDisk();
-
-    await component({
-      app: createListAppsRStudioResponse(),
-      disk,
-    });
-
-    const deleteButton = screen.queryByLabelText('Delete Persistent Disk');
-    expect(deleteButton).not.toBeInTheDocument();
-  });
-
-  it('should not render a Delete Persistent Disk link when no disk is present', async () => {
-    await component({
-      app: undefined,
-      disk: undefined,
-    });
-
-    const deleteButton = screen.queryByLabelText('Delete Persistent Disk');
-    expect(deleteButton).not.toBeInTheDocument();
   });
 });

--- a/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
@@ -132,7 +132,33 @@ describe(CreateRStudio.name, () => {
     );
   });
 
-  it('should render a DeletePersistentDiskButton when a disk is present but no app', async () => {
+  it('should allow deleting the environment when an app is running', async () => {
+    const disk = stubDisk();
+    const onClickDeleteGkeApp = jest.fn();
+
+    await component({
+      app: createListAppsRStudioResponse(),
+      disk,
+      onClickDeleteGkeApp,
+    });
+
+    const deleteButton = screen.queryByLabelText('Delete Environment');
+    expectButtonElementEnabled(deleteButton);
+    deleteButton.click();
+
+    await waitFor(() => {
+      expect(onClickDeleteGkeApp).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should not render a Delete Environment link when no app is present', async () => {
+    await component();
+
+    const deleteButton = screen.queryByLabelText('Delete Environment');
+    expect(deleteButton).not.toBeInTheDocument();
+  });
+
+  it('should allow deleting a persistent disk when a disk is present but no app', async () => {
     const disk = stubDisk();
     const onClickDeleteUnattachedPersistentDisk = jest.fn();
 
@@ -151,7 +177,7 @@ describe(CreateRStudio.name, () => {
     });
   });
 
-  it('should not render a DeletePersistentDiskButton when an app is present', async () => {
+  it('should not render a Delete Persistent Disk link when an app is present', async () => {
     const disk = stubDisk();
 
     await component({
@@ -160,16 +186,16 @@ describe(CreateRStudio.name, () => {
     });
 
     const deleteButton = screen.queryByLabelText('Delete Persistent Disk');
-    expect(deleteButton).toBeNull();
+    expect(deleteButton).not.toBeInTheDocument();
   });
 
-  it('should not render a DeletePersistentDiskButton no disk is present', async () => {
+  it('should not render a Delete Persistent Disk link when no disk is present', async () => {
     await component({
       app: undefined,
       disk: undefined,
     });
 
     const deleteButton = screen.queryByLabelText('Delete Persistent Disk');
-    expect(deleteButton).toBeNull();
+    expect(deleteButton).not.toBeInTheDocument();
   });
 });

--- a/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
@@ -28,11 +28,9 @@ import { CommonCreateGkeAppProps } from './create-gke-app';
 import { CreateRStudio } from './create-rstudio';
 
 const onClose = jest.fn();
-const onClickDeleteGkeApp = jest.fn();
 const freeTierBillingAccountId = 'freetier';
 export const defaultProps: CommonCreateGkeAppProps = {
   onClose,
-  onClickDeleteGkeApp,
   creatorFreeCreditsRemaining: null,
   workspace: {
     ...workspaceStubs[0],
@@ -48,6 +46,7 @@ export const defaultProps: CommonCreateGkeAppProps = {
   },
   app: undefined,
   disk: undefined,
+  onClickDeleteGkeApp: jest.fn(),
   onClickDeleteUnattachedPersistentDisk: jest.fn(),
 };
 

--- a/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
@@ -28,9 +28,11 @@ import { CommonCreateGkeAppProps } from './create-gke-app';
 import { CreateRStudio } from './create-rstudio';
 
 const onClose = jest.fn();
+const onClickDeleteGkeApp = jest.fn();
 const freeTierBillingAccountId = 'freetier';
 export const defaultProps: CommonCreateGkeAppProps = {
   onClose,
+  onClickDeleteGkeApp,
   creatorFreeCreditsRemaining: null,
   workspace: {
     ...workspaceStubs[0],

--- a/ui/src/app/components/gke-app-configuration-panels/create-sas.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-sas.spec.tsx
@@ -28,11 +28,9 @@ import { CommonCreateGkeAppProps } from './create-gke-app';
 import { CreateSAS } from './create-sas';
 
 const onClose = jest.fn();
-const onClickDeleteGkeApp = jest.fn();
 const freeTierBillingAccountId = 'freetier';
 export const defaultProps: CommonCreateGkeAppProps = {
   onClose,
-  onClickDeleteGkeApp,
   creatorFreeCreditsRemaining: null,
   workspace: {
     ...workspaceStubs[0],
@@ -48,6 +46,7 @@ export const defaultProps: CommonCreateGkeAppProps = {
   },
   app: undefined,
   disk: undefined,
+  onClickDeleteGkeApp: jest.fn(),
   onClickDeleteUnattachedPersistentDisk: jest.fn(),
 };
 

--- a/ui/src/app/components/gke-app-configuration-panels/create-sas.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-sas.spec.tsx
@@ -28,9 +28,11 @@ import { CommonCreateGkeAppProps } from './create-gke-app';
 import { CreateSAS } from './create-sas';
 
 const onClose = jest.fn();
+const onClickDeleteGkeApp = jest.fn();
 const freeTierBillingAccountId = 'freetier';
 export const defaultProps: CommonCreateGkeAppProps = {
   onClose,
+  onClickDeleteGkeApp,
   creatorFreeCreditsRemaining: null,
   workspace: {
     ...workspaceStubs[0],

--- a/ui/src/app/components/gke-app-configuration-panels/create-sas.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-sas.spec.tsx
@@ -132,7 +132,33 @@ describe(CreateSAS.name, () => {
     );
   });
 
-  it('should render a DeletePersistentDiskButton when a disk is present but no app', async () => {
+  it('should allow deleting the environment when an app is running', async () => {
+    const disk = stubDisk();
+    const onClickDeleteGkeApp = jest.fn();
+
+    await component({
+      app: createListAppsSASResponse(),
+      disk,
+      onClickDeleteGkeApp,
+    });
+
+    const deleteButton = screen.queryByLabelText('Delete Environment');
+    expectButtonElementEnabled(deleteButton);
+    deleteButton.click();
+
+    await waitFor(() => {
+      expect(onClickDeleteGkeApp).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should not render a Delete Environment link when no app is present', async () => {
+    await component();
+
+    const deleteButton = screen.queryByLabelText('Delete Environment');
+    expect(deleteButton).not.toBeInTheDocument();
+  });
+
+  it('should allow deletion of a Persistent Disk when a disk is present but no app', async () => {
     const disk = stubDisk();
     const onClickDeleteUnattachedPersistentDisk = jest.fn();
 
@@ -151,7 +177,7 @@ describe(CreateSAS.name, () => {
     });
   });
 
-  it('should not render a DeletePersistentDiskButton when an app is present', async () => {
+  it('should not render a Delete Persistent Disk link when an app is present', async () => {
     const disk = stubDisk();
 
     await component({
@@ -163,7 +189,7 @@ describe(CreateSAS.name, () => {
     expect(deleteButton).toBeNull();
   });
 
-  it('should not render a DeletePersistentDiskButton no disk is present', async () => {
+  it('should not render a Delete Persistent Disk link when no disk is present', async () => {
     await component({
       app: undefined,
       disk: undefined,

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -530,8 +530,8 @@ export const HelpSidebar = fp.flow(
             renderBody: () => (
               <ConfigurationPanel
                 {...{ runtimeConfPanelInitialState }}
-                onClose={() => this.setActiveIcon(null)}
                 appType={UIAppType.JUPYTER}
+                onClose={() => this.setActiveIcon(null)}
               />
             ),
             showFooter: false,

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -585,9 +585,9 @@ export const HelpSidebar = fp.flow(
             ),
             renderBody: () => (
               <ConfigurationPanel
+                {...{ gkeAppConfPanelInitialState }}
                 appType={UIAppType.CROMWELL}
                 onClose={() => this.setActiveIcon(null)}
-                gkeAppConfPanelInitialState={gkeAppConfPanelInitialState}
               />
             ),
           };
@@ -617,9 +617,9 @@ export const HelpSidebar = fp.flow(
             ),
             renderBody: () => (
               <ConfigurationPanel
+                {...{ gkeAppConfPanelInitialState }}
                 appType={UIAppType.RSTUDIO}
                 onClose={() => this.setActiveIcon(null)}
-                gkeAppConfPanelInitialState={gkeAppConfPanelInitialState}
               />
             ),
           };
@@ -649,9 +649,9 @@ export const HelpSidebar = fp.flow(
             ),
             renderBody: () => (
               <ConfigurationPanel
+                {...{ gkeAppConfPanelInitialState }}
                 appType={UIAppType.SAS}
                 onClose={() => this.setActiveIcon(null)}
-                gkeAppConfPanelInitialState={gkeAppConfPanelInitialState}
               />
             ),
           };


### PR DESCRIPTION
I got increasingly frustrated by needing to go to the Apps Panel to delete apps while testing SAS.  As I recall, users often had that confusion as well.  Now we match Jupyter behavior by having a link in the configuration panel itself.

![Delete_Env](https://github.com/all-of-us/workbench/assets/2701406/e7b10f23-f3ba-4a42-8cba-763c6246a24d)


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
