### PR TITLE
[risk=no][RW-10895] Configure Absorb department external IDs for new users

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -91,6 +91,7 @@
     "host": "https:\/\/aousupporthelp1634849601.zendesk.com"
   },
   "absorb": {
+    "externalDepartmentId": "Development",
     "enabledForNewUsers": false,
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"
@@ -98,9 +99,6 @@
   "moodle": {
     "host": "aoudev.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
-  },
-  "absorb": {
-    "externalDepartmentId": "Development"
   },
   "access": {
     "enableComplianceTraining": true,

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -99,6 +99,9 @@
     "host": "aoudev.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
   },
+  "absorb": {
+    "externalDepartmentId": "Development"
+  },
   "access": {
     "enableComplianceTraining": true,
     "enableEraCommons": true,

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -92,6 +92,7 @@
   },
   "absorb": {
     "externalDepartmentId": "Development",
+    "externalDepartmentIdPopulatedForNewUsers": true,
     "enabledForNewUsers": false,
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -92,6 +92,7 @@
   },
   "absorb": {
     "externalDepartmentId": "Researchers",
+    "externalDepartmentIdPopulatedForNewUsers": true,
     "enabledForNewUsers": false,
     "samlIdentityProviderId": "TODO",
     "samlServiceProviderId": "TODO"

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -99,6 +99,9 @@
     "host": "aou.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
   },
+  "absorb": {
+    "externalDepartmentId": "Researchers"
+  },
   "access": {
     "enableComplianceTraining": false,
     "enableEraCommons": false,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -91,6 +91,7 @@
     "host": "https:\/\/aoupreprodsupporthelp.zendesk.com"
   },
   "absorb": {
+    "externalDepartmentId": "Researchers",
     "enabledForNewUsers": false,
     "samlIdentityProviderId": "TODO",
     "samlServiceProviderId": "TODO"
@@ -98,9 +99,6 @@
   "moodle": {
     "host": "aou.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
-  },
-  "absorb": {
-    "externalDepartmentId": "Researchers"
   },
   "access": {
     "enableComplianceTraining": false,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -91,6 +91,7 @@
     "host": "https:\/\/aousupporthelp.zendesk.com"
   },
   "absorb": {
+    "externalDepartmentId": "Researchers",
     "enabledForNewUsers": false,
     "samlIdentityProviderId": "TODO",
     "samlServiceProviderId": "TODO"
@@ -98,9 +99,6 @@
   "moodle": {
     "host": "aou.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
-  },
-  "absorb": {
-    "externalDepartmentId": "Researchers"
   },
   "access": {
     "enableComplianceTraining": true,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -92,6 +92,7 @@
   },
   "absorb": {
     "externalDepartmentId": "Researchers",
+    "externalDepartmentIdPopulatedForNewUsers": false,
     "enabledForNewUsers": false,
     "samlIdentityProviderId": "TODO",
     "samlServiceProviderId": "TODO"

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -99,6 +99,9 @@
     "host": "aou.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
   },
+  "absorb": {
+    "externalDepartmentId": "Researchers"
+  },
   "access": {
     "enableComplianceTraining": true,
     "enableEraCommons": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -91,6 +91,7 @@
     "host": "https:\/\/aousupporthelp1634849601.zendesk.com"
   },
   "absorb": {
+    "externalDepartmentId": "Development",
     "enabledForNewUsers": false,
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"
@@ -98,9 +99,6 @@
   "moodle": {
     "host": "aou.nnlm.gov",
     "credentialsKeyV2": "moodle-prod-key-v2.txt"
-  },
-  "absorb": {
-    "externalDepartmentId": "Development"
   },
   "access": {
     "enableComplianceTraining": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -92,6 +92,7 @@
   },
   "absorb": {
     "externalDepartmentId": "Development",
+    "externalDepartmentIdPopulatedForNewUsers": true,
     "enabledForNewUsers": false,
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -99,6 +99,9 @@
     "host": "aou.nnlm.gov",
     "credentialsKeyV2": "moodle-prod-key-v2.txt"
   },
+  "absorb": {
+    "externalDepartmentId": "Development"
+  },
   "access": {
     "enableComplianceTraining": true,
     "enableEraCommons": true,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -99,6 +99,9 @@
     "host": "aoudev.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
   },
+  "absorb": {
+    "externalDepartmentId": "Development"
+  },
   "access": {
     "enableComplianceTraining": false,
     "enableEraCommons": true,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -92,6 +92,7 @@
   },
   "absorb": {
     "externalDepartmentId": "Development",
+    "externalDepartmentIdPopulatedForNewUsers": true,
     "enabledForNewUsers": false,
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -91,6 +91,7 @@
     "host": "https:\/\/aousupporthelp1634849601.zendesk.com"
   },
   "absorb": {
+    "externalDepartmentId": "Development",
     "enabledForNewUsers": false,
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"
@@ -98,9 +99,6 @@
   "moodle": {
     "host": "aoudev.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
-  },
-  "absorb": {
-    "externalDepartmentId": "Development"
   },
   "access": {
     "enableComplianceTraining": false,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -91,6 +91,7 @@
     "host": "https:\/\/aousupporthelp1634849601.zendesk.com"
   },
   "absorb": {
+    "externalDepartmentId": "Development",
     "enabledForNewUsers": false,
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"
@@ -98,9 +99,6 @@
   "moodle": {
     "host": "aoudev.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
-  },
-  "absorb": {
-    "externalDepartmentId": "Development"
   },
   "access": {
     "enableComplianceTraining": true,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -99,6 +99,9 @@
     "host": "aoudev.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
   },
+  "absorb": {
+    "externalDepartmentId": "Development"
+  },
   "access": {
     "enableComplianceTraining": true,
     "enableEraCommons": true,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -92,6 +92,7 @@
   },
   "absorb": {
     "externalDepartmentId": "Development",
+    "externalDepartmentIdPopulatedForNewUsers": true,
     "enabledForNewUsers": false,
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"

--- a/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
@@ -58,6 +58,8 @@ public class DirectoryServiceImplIntegrationTest extends BaseIntegrationTest {
                 });
     // Ensure our two custom schema fields are correctly set & re-fetched from GSuite.
     assertThat(aouMeta).containsEntry("Institution", "All of Us Research Workbench");
+    assertThat(aouMeta)
+        .containsEntry("Absorb_department_external_ID", config.absorb.externalDepartmentId);
     assertThat(service.getContactEmail(username)).hasValue("notasecret@gmail.com");
 
     retryTemplate()

--- a/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/google/DirectoryServiceImplIntegrationTest.java
@@ -40,6 +40,7 @@ public class DirectoryServiceImplIntegrationTest extends BaseIntegrationTest {
     String userPrefix = String.format("integration.test.%d", Clock.systemUTC().millis());
     String username = userPrefix + "@" + config.googleDirectoryService.gSuiteDomain;
     service.createUser("Integration", "Test", username, "notasecret@gmail.com");
+    config.absorb.externalDepartmentIdPopulatedForNewUsers = true;
     boolean userNameTaken = retryTemplate().execute(c -> service.isUsernameTaken(userPrefix));
     assertThat(userNameTaken).isTrue();
 
@@ -59,7 +60,7 @@ public class DirectoryServiceImplIntegrationTest extends BaseIntegrationTest {
     // Ensure our two custom schema fields are correctly set & re-fetched from GSuite.
     assertThat(aouMeta).containsEntry("Institution", "All of Us Research Workbench");
     assertThat(aouMeta)
-        .containsEntry("Absorb_department_external_ID", config.absorb.externalDepartmentId);
+        .containsEntry("Absorb_external_department_ID", config.absorb.externalDepartmentId);
     assertThat(service.getContactEmail(username)).hasValue("notasecret@gmail.com");
 
     retryTemplate()

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -258,6 +258,7 @@ public class WorkbenchConfig {
 
   public static class AbsorbConfig {
     public String externalDepartmentId;
+    public boolean externalDepartmentIdPopulatedForNewUsers;
     public boolean enabledForNewUsers;
     public String samlIdentityProviderId;
     public String samlServiceProviderId;

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -25,6 +25,7 @@ public class WorkbenchConfig {
   public MandrillConfig mandrill;
   public AbsorbConfig absorb;
   public MoodleConfig moodle;
+  public AbsorbConfig absorb;
   public TanagraConfig tanagra;
   public ZendeskConfig zendesk;
   public AccessConfig access;
@@ -265,6 +266,10 @@ public class WorkbenchConfig {
   public static class MoodleConfig {
     public String host;
     public String credentialsKeyV2;
+  }
+
+  public static class AbsorbConfig {
+    public String externalDepartmentId;
   }
 
   public static class TanagraConfig {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -25,7 +25,6 @@ public class WorkbenchConfig {
   public MandrillConfig mandrill;
   public AbsorbConfig absorb;
   public MoodleConfig moodle;
-  public AbsorbConfig absorb;
   public TanagraConfig tanagra;
   public ZendeskConfig zendesk;
   public AccessConfig access;
@@ -258,6 +257,7 @@ public class WorkbenchConfig {
   }
 
   public static class AbsorbConfig {
+    public String externalDepartmentId;
     public boolean enabledForNewUsers;
     public String samlIdentityProviderId;
     public String samlServiceProviderId;
@@ -266,10 +266,6 @@ public class WorkbenchConfig {
   public static class MoodleConfig {
     public String host;
     public String credentialsKeyV2;
-  }
-
-  public static class AbsorbConfig {
-    public String externalDepartmentId;
   }
 
   public static class TanagraConfig {

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -64,6 +64,10 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
   // Name of the "institution" custom field, whose value is the same for all Workbench users.
   private static final String GSUITE_FIELD_INSTITUTION = "Institution";
   private static final String INSTITUTION_FIELD_VALUE = "All of Us Research Workbench";
+  // A GSuite "custom field" required by Absorb for SSO via SAML.
+  // Details: https://docs.google.com/document/d/1xgcvow0xPL6K4vxyM3PVlW-1E5Ye3X1Y5wZSD5rrPlc
+  private static final String GSUITE_FIELD_ABSORB_EXTERNAL_DEPARTMENT_ID =
+      "Absorb_external_department_ID";
   private static final int MAX_USERS_LIST_PAGE_SIZE = 500;
   private static final String EMAIL_USER_FIELD = "email";
   private static final String USER_VIEW_TYPE = "domain_public";
@@ -220,7 +224,7 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
                         .get(GSUITE_FIELD_CONTACT_EMAIL));
   }
 
-  public static void addCustomSchemaAndEmails(User user, String username, String contactEmail) {
+  public void addCustomSchemaAndEmails(User user, String username, String contactEmail) {
     // GSuite custom fields for Workbench user accounts.
     // See the Moodle integration doc (broad.io/aou-moodle) for more details, as this
     // was primarily set up for Moodle SSO integration.
@@ -229,6 +233,13 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
     // Since this value is unlikely to ever change, we use a hard-coded constant rather than an env
     // variable.
     aouCustomFields.put(GSUITE_FIELD_INSTITUTION, INSTITUTION_FIELD_VALUE);
+
+    // The value of this field must match one of the manually-configured values in the
+    // Absorb installation.
+    // See https://docs.google.com/document/d/1xgcvow0xPL6K4vxyM3PVlW-1E5Ye3X1Y5wZSD5rrPlc
+    aouCustomFields.put(
+        GSUITE_FIELD_ABSORB_EXTERNAL_DEPARTMENT_ID,
+        configProvider.get().absorb.externalDepartmentId);
 
     if (contactEmail != null) {
       // This gives us a structured place to store researchers' contact email addresses, in
@@ -261,7 +272,7 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
             .setName(new UserName().setGivenName(givenName).setFamilyName(familyName))
             .setChangePasswordAtNextLogin(true)
             .setOrgUnitPath(GSUITE_WORKBENCH_ORG_UNIT_PATH);
-    addCustomSchemaAndEmails(user, username, contactEmail);
+    this.addCustomSchemaAndEmails(user, username, contactEmail);
 
     retryHandler.run((context) -> getGoogleDirectoryService().users().insert(user).execute());
     return user;

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -234,12 +234,14 @@ public class DirectoryServiceImpl implements DirectoryService, GaugeDataCollecto
     // variable.
     aouCustomFields.put(GSUITE_FIELD_INSTITUTION, INSTITUTION_FIELD_VALUE);
 
-    // The value of this field must match one of the manually-configured values in the
-    // Absorb installation.
-    // See https://docs.google.com/document/d/1xgcvow0xPL6K4vxyM3PVlW-1E5Ye3X1Y5wZSD5rrPlc
-    aouCustomFields.put(
-        GSUITE_FIELD_ABSORB_EXTERNAL_DEPARTMENT_ID,
-        configProvider.get().absorb.externalDepartmentId);
+    if (configProvider.get().absorb.externalDepartmentIdPopulatedForNewUsers) {
+      // The value of this field must match one of the manually-configured values in the
+      // Absorb installation.
+      // See https://docs.google.com/document/d/1xgcvow0xPL6K4vxyM3PVlW-1E5Ye3X1Y5wZSD5rrPlc
+      aouCustomFields.put(
+          GSUITE_FIELD_ABSORB_EXTERNAL_DEPARTMENT_ID,
+          configProvider.get().absorb.externalDepartmentId);
+    }
 
     if (contactEmail != null) {
       // This gives us a structured place to store researchers' contact email addresses, in


### PR DESCRIPTION
When a new user is created, this adds "Absorb_external_department_ID" as a custom GSuite field.

The need for this is outlined in [this section of the Absorb SSO setup docs](https://docs.google.com/document/d/1xgcvow0xPL6K4vxyM3PVlW-1E5Ye3X1Y5wZSD5rrPlc/edit?resourcekey=0-q_6-vFevph2piD88EfX-1g#bookmark=id.ekjh4jia8c6). In addition to reviewing this PR, I ask that the reviewing developer also reviews that document in it's entirety to gain context.

This PR builds on the [comparable work done for Moodle](https://docs.google.com/document/d/1J87xu7xSTm2q02Xaxb_XPfSBYPd-Ok1hIdg9jl2kUBg/edit#bookmark=id.bryj4yqqvh4f).

To manually test this, create a new user and follow [these instructions](https://docs.google.com/document/d/1xgcvow0xPL6K4vxyM3PVlW-1E5Ye3X1Y5wZSD5rrPlc/edit?resourcekey=0-q_6-vFevph2piD88EfX-1g#bookmark=id.wesss7shr9s3). Additionally, I manually ensured the value was populated in GSuite.

**As-is, this would break prod on release**. This is because the custom field does not yet exist in the prod GSuite, and setting a custom field that does not exist causes an error. To unblock this, we should create a PD ticket to allow the change and determine who should make this change. Currently, I do not have the right permissions to make the change. When this was done for Moodle [we gave a developer access](https://precisionmedicineinitiative.atlassian.net/browse/PD-3105), but it's been several years so it's worth asking again. I'm waiting to start this conversation until another developer reviews this work.

Additionally, work still needs to be done to backfill existing users. However, this requires writing a tool [like this one for Moodle](https://github.com/all-of-us/workbench/pull/1803). I started writing it and got it running locally. However, in non-local environments our tools use the configuration in the running environment. Since the tool depends on configuration (the Absorb external ID), the config needs to be merged and released before the tool can be run. While I wanted to make this all in one PR I think it will be easier to test the tool once the configuration change here has released to the test environment.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [x] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [x] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.