### PR TITLE
[RW-10626] [risk=low] Backend change to upload user creation questions into WDR BQ

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryService.java
@@ -14,6 +14,8 @@ import org.pmiops.workbench.model.ReportingDatasetDomainIdValue;
 import org.pmiops.workbench.model.ReportingInstitution;
 import org.pmiops.workbench.model.ReportingNewUserSatisfactionSurvey;
 import org.pmiops.workbench.model.ReportingUser;
+import org.pmiops.workbench.model.ReportingUserGeneralDiscoverySource;
+import org.pmiops.workbench.model.ReportingUserPartnerDiscoverySource;
 import org.pmiops.workbench.model.ReportingWorkspace;
 import org.pmiops.workbench.model.ReportingWorkspaceFreeTierUsage;
 
@@ -35,7 +37,9 @@ public interface ReportingQueryService {
 
   List<ReportingWorkspace> getWorkspaceBatch(long limit, long offset);
 
-  int getWorkspaceCount();
+  List<ReportingUserGeneralDiscoverySource> getUserGeneralDiscoverySource(long limit, long offset);
+
+  List<ReportingUserPartnerDiscoverySource> getUserPartnerDiscoverySource(long limit, long offset);
 
   default Stream<List<ReportingWorkspace>> getBatchedWorkspaceStream() {
     return getBatchedStream(this::getWorkspaceBatch);
@@ -47,15 +51,11 @@ public interface ReportingQueryService {
     return getBatchedStream(this::getUserBatch);
   }
 
-  int getUserCount();
-
   List<ReportingCohort> getCohortBatch(long limit, long offset);
 
   default Stream<List<ReportingCohort>> getBatchedCohortStream() {
     return getBatchedStream(this::getCohortBatch);
   }
-
-  int getCohortCount();
 
   List<ReportingNewUserSatisfactionSurvey> getNewUserSatisfactionSurveyBatch(
       long limit, long offset);
@@ -64,8 +64,6 @@ public interface ReportingQueryService {
       getBatchedNewUserSatisfactionSurveyStream() {
     return getBatchedStream(this::getNewUserSatisfactionSurveyBatch);
   }
-
-  int getNewUserSatisfactionSurveyCount();
 
   default <T> List<T> getBatchByIndex(BiFunction<Long, Long, List<T>> getter, long batchIndex) {
     final long offset = getQueryBatchSize() * batchIndex;
@@ -130,4 +128,6 @@ public interface ReportingQueryService {
     final Iterable<List<T>> iterable = () -> batchIterator;
     return StreamSupport.stream(iterable.spliterator(), false);
   }
+
+  int getTableRowCount(String tableName);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryService.java
@@ -37,10 +37,6 @@ public interface ReportingQueryService {
 
   List<ReportingWorkspace> getWorkspaceBatch(long limit, long offset);
 
-  List<ReportingUserGeneralDiscoverySource> getUserGeneralDiscoverySource(long limit, long offset);
-
-  List<ReportingUserPartnerDiscoverySource> getUserPartnerDiscoverySource(long limit, long offset);
-
   default Stream<List<ReportingWorkspace>> getBatchedWorkspaceStream() {
     return getBatchedStream(this::getWorkspaceBatch);
   }
@@ -63,6 +59,22 @@ public interface ReportingQueryService {
   default Stream<List<ReportingNewUserSatisfactionSurvey>>
       getBatchedNewUserSatisfactionSurveyStream() {
     return getBatchedStream(this::getNewUserSatisfactionSurveyBatch);
+  }
+
+  List<ReportingUserGeneralDiscoverySource> getUserGeneralDiscoverySourceBatch(
+      long limit, long offset);
+
+  default Stream<List<ReportingUserGeneralDiscoverySource>>
+      getBatchedUserGeneralDiscoverySourceStream() {
+    return getBatchedStream(this::getUserGeneralDiscoverySourceBatch);
+  }
+
+  List<ReportingUserPartnerDiscoverySource> getUserPartnerDiscoverySourceBatch(
+      long limit, long offset);
+
+  default Stream<List<ReportingUserPartnerDiscoverySource>>
+      getBatchedUserPartnerDiscoverySourceStream() {
+    return getBatchedStream(this::getUserPartnerDiscoverySourceBatch);
   }
 
   default <T> List<T> getBatchByIndex(BiFunction<Long, Long, List<T>> getter, long batchIndex) {
@@ -130,4 +142,6 @@ public interface ReportingQueryService {
   }
 
   int getTableRowCount(String tableName);
+
+  int getWorkspaceCount();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -32,6 +32,8 @@ import org.pmiops.workbench.model.ReportingDatasetDomainIdValue;
 import org.pmiops.workbench.model.ReportingInstitution;
 import org.pmiops.workbench.model.ReportingNewUserSatisfactionSurvey;
 import org.pmiops.workbench.model.ReportingUser;
+import org.pmiops.workbench.model.ReportingUserGeneralDiscoverySource;
+import org.pmiops.workbench.model.ReportingUserPartnerDiscoverySource;
 import org.pmiops.workbench.model.ReportingWorkspace;
 import org.pmiops.workbench.model.ReportingWorkspaceFreeTierUsage;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
@@ -95,6 +97,50 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 .satisfaction(
                     NewUserSatisfactionSurveySatisfaction.valueOf(rs.getString("satisfaction")))
                 .additionalInfo(rs.getString("additional_info")));
+  }
+
+  @Override
+  public List<ReportingUserGeneralDiscoverySource> getUserGeneralDiscoverySource(long limit,
+      long offset) {
+    return jdbcTemplate.query(
+        String.format(
+            "SELECT\n"
+                + "  us.user_id as user_id,\n"
+                + "  us.source as answer,\n"
+                + "  u.user_general_discovery_source_other_text as other_text,\n"
+                + "FROM user_general_discovery_source us\n"
+                + " JOIN user u\n"
+                + "   ON us.user_id = u.user_id\n"
+                + "  LIMIT %d\n"
+                + "  OFFSET %d",
+            limit, offset),
+        (rs, unused) ->
+            new ReportingUserGeneralDiscoverySource()
+                .userId(rs.getLong("user_id"))
+                .answer(rs.getString("answer"))
+                .otherText(rs.getString("other_text")));
+  }
+
+  @Override
+  public List<ReportingUserPartnerDiscoverySource> getUserPartnerDiscoverySource(long limit,
+      long offset) {
+    return jdbcTemplate.query(
+        String.format(
+            "SELECT\n"
+                + "  us.user_id as user_id,\n"
+                + "  us.source as answer,\n"
+                + "  u.user_partner_discovery_source_other_text as other_text,\n"
+                + "FROM user_partner_discovery_source us\n"
+                + " JOIN user u\n"
+                + "   ON us.user_id = u.user_id\n"
+                + "  LIMIT %d\n"
+                + "  OFFSET %d",
+            limit, offset),
+        (rs, unused) ->
+            new ReportingUserPartnerDiscoverySource()
+                .userId(rs.getLong("user_id"))
+                .answer(rs.getString("answer"))
+                .otherText(rs.getString("other_text")));
   }
 
   @Override
@@ -514,28 +560,11 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
   }
 
   @Override
-  public int getWorkspaceCount() {
+  public int getTableRowCount(String tableName) {
     return jdbcTemplate.queryForObject(
-        "SELECT count(*) FROM workspace WHERE active_status = "
-            + workspaceActiveStatusToStorage(WorkspaceActiveStatus.ACTIVE),
-        Integer.class);
+        "SELECT count(*) FROM " + tableName, Integer.class);
   }
 
-  @Override
-  public int getUserCount() {
-    return jdbcTemplate.queryForObject("SELECT count(*) FROM user", Integer.class);
-  }
-
-  @Override
-  public int getCohortCount() {
-    return jdbcTemplate.queryForObject("SELECT count(*) FROM cohort", Integer.class);
-  }
-
-  @Override
-  public int getNewUserSatisfactionSurveyCount() {
-    return jdbcTemplate.queryForObject(
-        "SELECT count(*) FROM new_user_satisfaction_survey", Integer.class);
-  }
 
   /** Converts aggregated storage enums to String value. e.g. 0. 8 -> BA, MS. */
   private static String convertListEnumFromStorage(

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -136,7 +136,7 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
             "SELECT\n"
                 + "  us.user_id as user_id,\n"
                 + "  us.source as answer,\n"
-                + "  u.user_partner_discovery_source_other_text as other_text,\n"
+                + "  u.user_partner_discovery_source_other_text as other_text\n"
                 + "FROM user_partner_discovery_source us\n"
                 + " JOIN user u\n"
                 + "   ON us.user_id = u.user_id\n"

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
@@ -9,6 +9,8 @@ import org.pmiops.workbench.model.ReportingSnapshot;
 import org.pmiops.workbench.reporting.insertion.CohortColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.NewUserSatisfactionSurveyColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.UserColumnValueExtractor;
+import org.pmiops.workbench.reporting.insertion.UserGeneralDiscoverySourceColumnValueExtractor;
+import org.pmiops.workbench.reporting.insertion.UserPartnerDiscoverySourceColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.WorkspaceColumnValueExtractor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,7 +38,9 @@ public class ReportingServiceImpl implements ReportingService {
           CohortColumnValueExtractor.TABLE_NAME,
           WorkspaceColumnValueExtractor.TABLE_NAME,
           UserColumnValueExtractor.TABLE_NAME,
-          NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME);
+          NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME,
+          UserGeneralDiscoverySourceColumnValueExtractor.TABLE_NAME,
+          UserPartnerDiscoverySourceColumnValueExtractor.TABLE_NAME);
 
   public ReportingServiceImpl(
       ReportingQueryService reportingQueryService,

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
@@ -72,6 +72,14 @@ public class ReportingServiceImpl implements ReportingService {
         .getBatchedNewUserSatisfactionSurveyStream()
         .forEach(
             b -> reportingUploadService.uploadNewUserSatisfactionSurveyBatch(b, captureTimestamp));
+    reportingQueryService
+        .getBatchedUserGeneralDiscoverySourceStream()
+        .forEach(
+            b -> reportingUploadService.uploadUserGeneralDiscoverySourceBatch(b, captureTimestamp));
+    reportingQueryService
+        .getBatchedUserPartnerDiscoverySourceStream()
+        .forEach(
+            b -> reportingUploadService.uploadUserPartnerDiscoverySourceBatch(b, captureTimestamp));
 
     // Third: Verify the count.
     boolean batchUploadSuccess =

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadService.java
@@ -5,6 +5,8 @@ import org.pmiops.workbench.model.ReportingCohort;
 import org.pmiops.workbench.model.ReportingNewUserSatisfactionSurvey;
 import org.pmiops.workbench.model.ReportingSnapshot;
 import org.pmiops.workbench.model.ReportingUser;
+import org.pmiops.workbench.model.ReportingUserGeneralDiscoverySource;
+import org.pmiops.workbench.model.ReportingUserPartnerDiscoverySource;
 import org.pmiops.workbench.model.ReportingWorkspace;
 
 /**
@@ -23,6 +25,12 @@ public interface ReportingUploadService {
 
   void uploadNewUserSatisfactionSurveyBatch(
       List<ReportingNewUserSatisfactionSurvey> batch, long captureTimestamp);
+
+  void uploadUserGeneralDiscoverySourceBatch(
+      List<ReportingUserGeneralDiscoverySource> batch, long captureTimestamp);
+
+  void uploadUserPartnerDiscoverySourceBatch(
+      List<ReportingUserPartnerDiscoverySource> batch, long captureTimestamp);
 
   /** Uploads a record into VerifiedSnapshot table if upload result is verified. */
   void uploadVerifiedSnapshot(long captureTimestamp);

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
@@ -27,6 +27,8 @@ import org.pmiops.workbench.model.ReportingInstitution;
 import org.pmiops.workbench.model.ReportingNewUserSatisfactionSurvey;
 import org.pmiops.workbench.model.ReportingSnapshot;
 import org.pmiops.workbench.model.ReportingUser;
+import org.pmiops.workbench.model.ReportingUserGeneralDiscoverySource;
+import org.pmiops.workbench.model.ReportingUserPartnerDiscoverySource;
 import org.pmiops.workbench.model.ReportingWorkspace;
 import org.pmiops.workbench.model.ReportingWorkspaceFreeTierUsage;
 import org.pmiops.workbench.reporting.insertion.CohortColumnValueExtractor;
@@ -38,6 +40,8 @@ import org.pmiops.workbench.reporting.insertion.InsertAllRequestPayloadTransform
 import org.pmiops.workbench.reporting.insertion.InstitutionColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.NewUserSatisfactionSurveyColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.UserColumnValueExtractor;
+import org.pmiops.workbench.reporting.insertion.UserGeneralDiscoverySourceColumnValueExtractor;
+import org.pmiops.workbench.reporting.insertion.UserPartnerDiscoverySourceColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.WorkspaceColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.WorkspaceFreeTierUsageColumnValueExtractor;
 import org.pmiops.workbench.utils.LogFormatters;
@@ -67,6 +71,14 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
   private static final InsertAllRequestPayloadTransformer<ReportingNewUserSatisfactionSurvey>
       newUserSatisfactionSurveyRequestBuilder =
           NewUserSatisfactionSurveyColumnValueExtractor::values;
+
+  private static final InsertAllRequestPayloadTransformer<ReportingUserGeneralDiscoverySource>
+      userGeneralDiscoverySourceRequestBuilder =
+      UserGeneralDiscoverySourceColumnValueExtractor::values;
+
+  private static final InsertAllRequestPayloadTransformer<ReportingUserPartnerDiscoverySource>
+      userPartnerDiscoverySourceRequestBuilder =
+      UserPartnerDiscoverySourceColumnValueExtractor::values;
 
   /**
    * The verified–snapshot BigQuery name. It has no row other than the default snapshot_timestamp,
@@ -148,6 +160,26 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
     uploadBatchTable(
         newUserSatisfactionSurveyRequestBuilder.build(
             getTableId(NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME),
+            batch,
+            getFixedValues(captureTimestamp)));
+  }
+
+  @Override
+  public void uploadUserGeneralDiscoverySourceBatch(List<ReportingUserGeneralDiscoverySource> batch,
+      long captureTimestamp) {
+    uploadBatchTable(
+        userGeneralDiscoverySourceRequestBuilder.build(
+            getTableId(UserGeneralDiscoverySourceColumnValueExtractor.TABLE_NAME),
+            batch,
+            getFixedValues(captureTimestamp)));
+  }
+
+  @Override
+  public void uploadUserPartnerDiscoverySourceBatch(List<ReportingUserPartnerDiscoverySource> batch,
+      long captureTimestamp) {
+    uploadBatchTable(
+        userPartnerDiscoverySourceRequestBuilder.build(
+            getTableId(UserPartnerDiscoverySourceColumnValueExtractor.TABLE_NAME),
             batch,
             getFixedValues(captureTimestamp)));
   }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
@@ -74,11 +74,11 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
 
   private static final InsertAllRequestPayloadTransformer<ReportingUserGeneralDiscoverySource>
       userGeneralDiscoverySourceRequestBuilder =
-      UserGeneralDiscoverySourceColumnValueExtractor::values;
+          UserGeneralDiscoverySourceColumnValueExtractor::values;
 
   private static final InsertAllRequestPayloadTransformer<ReportingUserPartnerDiscoverySource>
       userPartnerDiscoverySourceRequestBuilder =
-      UserPartnerDiscoverySourceColumnValueExtractor::values;
+          UserPartnerDiscoverySourceColumnValueExtractor::values;
 
   /**
    * The verified–snapshot BigQuery name. It has no row other than the default snapshot_timestamp,
@@ -165,8 +165,8 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
   }
 
   @Override
-  public void uploadUserGeneralDiscoverySourceBatch(List<ReportingUserGeneralDiscoverySource> batch,
-      long captureTimestamp) {
+  public void uploadUserGeneralDiscoverySourceBatch(
+      List<ReportingUserGeneralDiscoverySource> batch, long captureTimestamp) {
     uploadBatchTable(
         userGeneralDiscoverySourceRequestBuilder.build(
             getTableId(UserGeneralDiscoverySourceColumnValueExtractor.TABLE_NAME),
@@ -175,8 +175,8 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
   }
 
   @Override
-  public void uploadUserPartnerDiscoverySourceBatch(List<ReportingUserPartnerDiscoverySource> batch,
-      long captureTimestamp) {
+  public void uploadUserPartnerDiscoverySourceBatch(
+      List<ReportingUserPartnerDiscoverySource> batch, long captureTimestamp) {
     uploadBatchTable(
         userPartnerDiscoverySourceRequestBuilder.build(
             getTableId(UserPartnerDiscoverySourceColumnValueExtractor.TABLE_NAME),

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.StreamSupport;
@@ -93,18 +92,27 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
         List.of(
             Map.entry(
                 WorkspaceColumnValueExtractor.TABLE_NAME,
-                reportingQueryService.getTableRowCount(WorkspaceColumnValueExtractor.TABLE_NAME)),
-            Map.entry(UserColumnValueExtractor.TABLE_NAME, reportingQueryService.getTableRowCount(NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME)),
-            Map.entry(CohortColumnValueExtractor.TABLE_NAME, reportingQueryService.getTableRowCount(NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME)),
+                reportingQueryService.getWorkspaceCount()),
+            Map.entry(
+                UserColumnValueExtractor.TABLE_NAME,
+                reportingQueryService.getTableRowCount(
+                    NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME)),
+            Map.entry(
+                CohortColumnValueExtractor.TABLE_NAME,
+                reportingQueryService.getTableRowCount(
+                    NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME)),
             Map.entry(
                 NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME,
-                reportingQueryService.getTableRowCount(NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME)),
+                reportingQueryService.getTableRowCount(
+                    NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME)),
             Map.entry(
                 UserGeneralDiscoverySourceColumnValueExtractor.TABLE_NAME,
-                reportingQueryService.getTableRowCount(UserGeneralDiscoverySourceColumnValueExtractor.TABLE_NAME)),
+                reportingQueryService.getTableRowCount(
+                    UserGeneralDiscoverySourceColumnValueExtractor.TABLE_NAME)),
             Map.entry(
                 UserPartnerDiscoverySourceColumnValueExtractor.TABLE_NAME,
-                reportingQueryService.getTableRowCount(UserPartnerDiscoverySourceColumnValueExtractor.TABLE_NAME)));
+                reportingQueryService.getTableRowCount(
+                    UserPartnerDiscoverySourceColumnValueExtractor.TABLE_NAME)));
 
     // fails-fast due to allMatch() so logs may be incomplete on failure
     boolean verified =

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
@@ -27,6 +27,8 @@ import org.pmiops.workbench.reporting.insertion.DatasetDomainColumnValueExtracto
 import org.pmiops.workbench.reporting.insertion.InstitutionColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.NewUserSatisfactionSurveyColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.UserColumnValueExtractor;
+import org.pmiops.workbench.reporting.insertion.UserGeneralDiscoverySourceColumnValueExtractor;
+import org.pmiops.workbench.reporting.insertion.UserPartnerDiscoverySourceColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.WorkspaceColumnValueExtractor;
 import org.pmiops.workbench.reporting.insertion.WorkspaceFreeTierUsageColumnValueExtractor;
 import org.pmiops.workbench.utils.FieldValues;
@@ -87,15 +89,22 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
     sb.append("Table\tSource\tDestination\tDifference(%)\n");
 
     // alt: this could be a Map, but we don't need to reference it in that way
-    List<Map.Entry<String, Supplier<Integer>>> tableCounters =
+    List<Map.Entry<String, Integer>> tableCounters =
         List.of(
             Map.entry(
-                WorkspaceColumnValueExtractor.TABLE_NAME, reportingQueryService::getWorkspaceCount),
-            Map.entry(UserColumnValueExtractor.TABLE_NAME, reportingQueryService::getUserCount),
-            Map.entry(CohortColumnValueExtractor.TABLE_NAME, reportingQueryService::getCohortCount),
+                WorkspaceColumnValueExtractor.TABLE_NAME,
+                reportingQueryService.getTableRowCount(WorkspaceColumnValueExtractor.TABLE_NAME)),
+            Map.entry(UserColumnValueExtractor.TABLE_NAME, reportingQueryService.getTableRowCount(NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME)),
+            Map.entry(CohortColumnValueExtractor.TABLE_NAME, reportingQueryService.getTableRowCount(NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME)),
             Map.entry(
                 NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME,
-                reportingQueryService::getNewUserSatisfactionSurveyCount));
+                reportingQueryService.getTableRowCount(NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME)),
+            Map.entry(
+                UserGeneralDiscoverySourceColumnValueExtractor.TABLE_NAME,
+                reportingQueryService.getTableRowCount(UserGeneralDiscoverySourceColumnValueExtractor.TABLE_NAME)),
+            Map.entry(
+                UserPartnerDiscoverySourceColumnValueExtractor.TABLE_NAME,
+                reportingQueryService.getTableRowCount(UserPartnerDiscoverySourceColumnValueExtractor.TABLE_NAME)));
 
     // fails-fast due to allMatch() so logs may be incomplete on failure
     boolean verified =
@@ -103,7 +112,7 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
             .allMatch(
                 entry -> {
                   final String tableName = entry.getKey();
-                  long sourceCount = entry.getValue().get();
+                  long sourceCount = entry.getValue();
                   long actualCount = getActualRowCount(tableName, captureSnapshotTime);
                   return verifyCount(tableName, sourceCount, actualCount, sb);
                 });

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserGeneralDiscoverySourceColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserGeneralDiscoverySourceColumnValueExtractor.java
@@ -10,9 +10,7 @@ import org.pmiops.workbench.model.ReportingUserGeneralDiscoverySource;
 public enum UserGeneralDiscoverySourceColumnValueExtractor
     implements ColumnValueExtractor<ReportingUserGeneralDiscoverySource> {
   USER_ID("user_id", ReportingUserGeneralDiscoverySource::getUserId),
-  ANSWER(
-      "answer",
-      ReportingUserGeneralDiscoverySource::getAnswer),
+  ANSWER("answer", ReportingUserGeneralDiscoverySource::getAnswer),
   OTHER_TEXT("otherText", ReportingUserGeneralDiscoverySource::getOtherText);
 
   public static final String TABLE_NAME = "user_general_discovery_source";

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserGeneralDiscoverySourceColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserGeneralDiscoverySourceColumnValueExtractor.java
@@ -1,0 +1,39 @@
+package org.pmiops.workbench.reporting.insertion;
+
+import java.util.function.Function;
+import org.pmiops.workbench.model.ReportingUserGeneralDiscoverySource;
+
+/*
+ * Column data and metadata convertors for BigQuery user_general_discovery_source table in reporting
+ * dataset.
+ */
+public enum UserGeneralDiscoverySourceColumnValueExtractor
+    implements ColumnValueExtractor<ReportingUserGeneralDiscoverySource> {
+  USER_ID("user_id", ReportingUserGeneralDiscoverySource::getUserId),
+  ANSWER(
+      "answer",
+      ReportingUserGeneralDiscoverySource::getAnswer),
+  OTHER_TEXT("otherText", ReportingUserGeneralDiscoverySource::getOtherText);
+
+  public static final String TABLE_NAME = "user_general_discovery_source";
+
+  private final String parameterName;
+  private final Function<ReportingUserGeneralDiscoverySource, Object> rowToInsertValueFunction;
+
+  UserGeneralDiscoverySourceColumnValueExtractor(
+      String parameterName,
+      Function<ReportingUserGeneralDiscoverySource, Object> rowToInsertValueFunction) {
+    this.parameterName = parameterName;
+    this.rowToInsertValueFunction = rowToInsertValueFunction;
+  }
+
+  @Override
+  public String getParameterName() {
+    return parameterName;
+  }
+
+  @Override
+  public Function<ReportingUserGeneralDiscoverySource, Object> getRowToInsertValueFunction() {
+    return rowToInsertValueFunction;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserPartnerDiscoverySourceColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserPartnerDiscoverySourceColumnValueExtractor.java
@@ -1,0 +1,39 @@
+package org.pmiops.workbench.reporting.insertion;
+
+import java.util.function.Function;
+import org.pmiops.workbench.model.ReportingUserPartnerDiscoverySource;
+
+/*
+ * Column data and metadata convertors for BigQuery user_partner_discovery_source table in reporting
+ * dataset.
+ */
+public enum UserPartnerDiscoverySourceColumnValueExtractor
+    implements ColumnValueExtractor<ReportingUserPartnerDiscoverySource> {
+  USER_ID("user_id", ReportingUserPartnerDiscoverySource::getUserId),
+  ANSWER(
+      "answer",
+      ReportingUserPartnerDiscoverySource::getAnswer),
+  OTHER_TEXT("otherText", ReportingUserPartnerDiscoverySource::getOtherText);
+
+  public static final String TABLE_NAME = "user_partner_discovery_source";
+
+  private final String parameterName;
+  private final Function<ReportingUserPartnerDiscoverySource, Object> rowToInsertValueFunction;
+
+  UserPartnerDiscoverySourceColumnValueExtractor(
+      String parameterName,
+      Function<ReportingUserPartnerDiscoverySource, Object> rowToInsertValueFunction) {
+    this.parameterName = parameterName;
+    this.rowToInsertValueFunction = rowToInsertValueFunction;
+  }
+
+  @Override
+  public String getParameterName() {
+    return parameterName;
+  }
+
+  @Override
+  public Function<ReportingUserPartnerDiscoverySource, Object> getRowToInsertValueFunction() {
+    return rowToInsertValueFunction;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserPartnerDiscoverySourceColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/UserPartnerDiscoverySourceColumnValueExtractor.java
@@ -10,9 +10,7 @@ import org.pmiops.workbench.model.ReportingUserPartnerDiscoverySource;
 public enum UserPartnerDiscoverySourceColumnValueExtractor
     implements ColumnValueExtractor<ReportingUserPartnerDiscoverySource> {
   USER_ID("user_id", ReportingUserPartnerDiscoverySource::getUserId),
-  ANSWER(
-      "answer",
-      ReportingUserPartnerDiscoverySource::getAnswer),
+  ANSWER("answer", ReportingUserPartnerDiscoverySource::getAnswer),
   OTHER_TEXT("otherText", ReportingUserPartnerDiscoverySource::getOtherText);
 
   public static final String TABLE_NAME = "user_partner_discovery_source";

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9774,6 +9774,14 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/ReportingNewUserSatisfactionSurvey"
+      userGeneralDiscoverySource:
+        type: array
+        items:
+          "$ref": "#/definitions/ReportingUserGeneralDiscoverySource"
+      userPartnerDiscoverySource:
+        type: array
+        items:
+          "$ref": "#/definitions/ReportingUserPartnerDiscoverySource"
       workspaceFreeTierUsage:
         type: array
         items:
@@ -10290,6 +10298,34 @@ definitions:
       additionalInfo:
         type: string
         description: Additional information regarding the satisfaction score.
+
+  ReportingUserGeneralDiscoverySource:
+    type: object
+    properties:
+      userId:
+        type: integer
+        format: int64
+        description: ID of the user who created the survey response.
+      answer:
+        type: string
+        description: Answer for How did you learn about the All of Us Researcher question when signup.
+      otherText:
+        type: string
+        description: User input when choosing Other
+
+  ReportingUserPartnerDiscoverySource:
+    type: object
+    properties:
+      userId:
+        type: integer
+        format: int64
+        description: ID of the user who created the survey response.
+      answer:
+        type: string
+        description: Answer for Did you learn about the All of Us Researcher Workbench from any of these program partners.
+      otherText:
+        type: string
+        description: User input when choosing Other
 
   ReportingDataset:
     x-aou-note: |-

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
@@ -16,6 +16,7 @@ import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableResult;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -39,6 +40,8 @@ import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.jdbc.ReportingQueryServiceImpl;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUser.DbGeneralDiscoverySource;
+import org.pmiops.workbench.db.model.DbUser.DbPartnerDiscoverySource;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.testconfig.ReportingTestConfig;
@@ -125,6 +128,12 @@ public class ReportingVerificationServiceTest {
     String expectedNewUserSatisfactionSurveyLogPart =
         "new_user_satisfaction_survey\t2\t2\t0 (0.000%)";
     assertThat(getTestCapturedLog().contains(expectedNewUserSatisfactionSurveyLogPart)).isTrue();
+    String expectedUserGeneralDiscoverySourceLogPart =
+        "user_general_discovery_source\t2\t2\t0 (0.000%)";
+    assertThat(getTestCapturedLog().contains(expectedUserGeneralDiscoverySourceLogPart)).isTrue();
+    String expectedUserPartnerDiscoverySourceLogPart =
+        "user_partner_discovery_source\t2\t2\t0 (0.000%)";
+    assertThat(getTestCapturedLog().contains(expectedUserPartnerDiscoverySourceLogPart)).isTrue();
   }
 
   @Test
@@ -155,6 +164,8 @@ public class ReportingVerificationServiceTest {
 
     for (int i = 0; i < count; ++i) {
       DbUser user = new DbUser();
+      user.setGeneralDiscoverySources(ImmutableSet.of(DbGeneralDiscoverySource.OTHER_WEBSITE));
+      user.setPartnerDiscoverySources(ImmutableSet.of(DbPartnerDiscoverySource.ALL_OF_US_EVENINGS_WITH_GENETICS_RESEARCH_PROGRAM));
       userDao.save(user);
       DbWorkspace dbworkspace = workspaceDao.save(createDbWorkspace(user, cdrVersion));
       cohortDao.save(createDbCohort(user, dbworkspace));

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
@@ -165,7 +165,9 @@ public class ReportingVerificationServiceTest {
     for (int i = 0; i < count; ++i) {
       DbUser user = new DbUser();
       user.setGeneralDiscoverySources(ImmutableSet.of(DbGeneralDiscoverySource.OTHER_WEBSITE));
-      user.setPartnerDiscoverySources(ImmutableSet.of(DbPartnerDiscoverySource.ALL_OF_US_EVENINGS_WITH_GENETICS_RESEARCH_PROGRAM));
+      user.setPartnerDiscoverySources(
+          ImmutableSet.of(
+              DbPartnerDiscoverySource.ALL_OF_US_EVENINGS_WITH_GENETICS_RESEARCH_PROGRAM));
       userDao.save(user);
       DbWorkspace dbworkspace = workspaceDao.save(createDbWorkspace(user, cdrVersion));
       cohortDao.save(createDbCohort(user, dbworkspace));


### PR DESCRIPTION
Tested the query using prod DB and the query works for me. 
One thing to hightlight is in ReportingQueryService, we only populate `otherText` field when choosing `OTHER` enum. 
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
