### PR TITLE
[risk=low][no ticket] Break the simple parts of admin-workspace into components

### DIFF
--- a/ui/src/app/pages/admin/workspace/basic-information.tsx
+++ b/ui/src/app/pages/admin/workspace/basic-information.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+import { Workspace } from 'generated/fetch';
+
+import { isUsingFreeTierBillingAccount } from 'app/utils/workspace-utils';
+
+import { WorkspaceInfoField } from './workspace-info-field';
+
+interface Props {
+  workspace: Workspace;
+}
+export const BasicInformation = ({ workspace }: Props) => (
+  <>
+    <h3>Basic Information</h3>
+    <div className='basic-info' style={{ marginTop: '1.5rem' }}>
+      <WorkspaceInfoField labelText='Workspace Name'>
+        {workspace.name}
+      </WorkspaceInfoField>
+      <WorkspaceInfoField labelText='Workspace Namespace'>
+        {workspace.namespace}
+      </WorkspaceInfoField>
+      <WorkspaceInfoField labelText='Access Tier'>
+        {workspace.accessTierShortName?.toUpperCase()}
+      </WorkspaceInfoField>
+      <WorkspaceInfoField labelText='Google Project Id'>
+        {workspace.googleProject}
+      </WorkspaceInfoField>
+      <WorkspaceInfoField labelText='Billing Status'>
+        {workspace.billingStatus}
+      </WorkspaceInfoField>
+      <WorkspaceInfoField labelText='Billing Account Type'>
+        {isUsingFreeTierBillingAccount(workspace)
+          ? 'Initial credits'
+          : 'User provided'}
+      </WorkspaceInfoField>
+      <WorkspaceInfoField labelText='Creation Time'>
+        {new Date(workspace.creationTime).toDateString()}
+      </WorkspaceInfoField>
+      <WorkspaceInfoField labelText='Last Modified Time'>
+        {new Date(workspace.lastModifiedTime).toDateString()}
+      </WorkspaceInfoField>
+      <WorkspaceInfoField labelText='Workspace Published'>
+        {workspace.published ? 'Yes' : 'No'}
+      </WorkspaceInfoField>
+      <WorkspaceInfoField labelText='Audit'>
+        {
+          <Link to={`/admin/workspace-audit/${workspace.namespace}`}>
+            Audit History
+          </Link>
+        }
+      </WorkspaceInfoField>
+    </div>
+  </>
+);

--- a/ui/src/app/pages/admin/workspace/cloud-storage-objects.tsx
+++ b/ui/src/app/pages/admin/workspace/cloud-storage-objects.tsx
@@ -13,43 +13,40 @@ interface Props {
 }
 export const CloudStorageObjects = ({
   workspaceNamespace,
-  cloudStorage,
-}: Props) => {
-  const {
+  cloudStorage: {
     storageBucketPath,
     notebookFileCount,
     nonNotebookFileCount,
     storageBytesUsed,
-  } = cloudStorage;
-  return (
-    <>
-      <h3>Cloud Storage Objects</h3>
-      <div className='cloud-storage-objects' style={{ marginTop: '1.5rem' }}>
-        <div
-          style={{
-            color: colors.warning,
-            fontWeight: 'bold',
-            maxWidth: '1000px',
-          }}
-        >
-          NOTE: if there are more than ~1000 files in the bucket, these counts
-          and the table below may be incomplete because we process only a single
-          page of storage list results.
-        </div>
-        <WorkspaceInfoField labelText='GCS bucket path'>
-          {storageBucketPath}
-        </WorkspaceInfoField>
-        <WorkspaceInfoField labelText='# of Workbench-managed notebook files'>
-          {notebookFileCount}
-        </WorkspaceInfoField>
-        <WorkspaceInfoField labelText='# of other files'>
-          {nonNotebookFileCount}
-        </WorkspaceInfoField>
-        <WorkspaceInfoField labelText='Storage used (MB)'>
-          {formatMB(storageBytesUsed)}
-        </WorkspaceInfoField>
+  },
+}: Props) => (
+  <>
+    <h3>Cloud Storage Objects</h3>
+    <div className='cloud-storage-objects' style={{ marginTop: '1.5rem' }}>
+      <div
+        style={{
+          color: colors.warning,
+          fontWeight: 'bold',
+          maxWidth: '1000px',
+        }}
+      >
+        NOTE: if there are more than ~1000 files in the bucket, these counts and
+        the table below may be incomplete because we process only a single page
+        of storage list results.
       </div>
-      <FileTable {...{ workspaceNamespace, storageBucketPath }} />
-    </>
-  );
-};
+      <WorkspaceInfoField labelText='GCS bucket path'>
+        {storageBucketPath}
+      </WorkspaceInfoField>
+      <WorkspaceInfoField labelText='# of Workbench-managed notebook files'>
+        {notebookFileCount}
+      </WorkspaceInfoField>
+      <WorkspaceInfoField labelText='# of other files'>
+        {nonNotebookFileCount}
+      </WorkspaceInfoField>
+      <WorkspaceInfoField labelText='Storage used (MB)'>
+        {formatMB(storageBytesUsed)}
+      </WorkspaceInfoField>
+    </div>
+    <FileTable {...{ workspaceNamespace, storageBucketPath }} />
+  </>
+);

--- a/ui/src/app/pages/admin/workspace/cloud-storage-objects.tsx
+++ b/ui/src/app/pages/admin/workspace/cloud-storage-objects.tsx
@@ -4,7 +4,7 @@ import { AdminWorkspaceCloudStorageCounts } from 'generated/fetch';
 
 import colors from 'app/styles/colors';
 
-import { FileDetailsTable, formatMB } from './file-table';
+import { FileTable, formatMB } from './file-table';
 import { WorkspaceInfoField } from './workspace-info-field';
 
 interface Props {
@@ -49,10 +49,7 @@ export const CloudStorageObjects = ({
           {formatMB(storageBytesUsed)}
         </WorkspaceInfoField>
       </div>
-      <FileDetailsTable
-        {...{ workspaceNamespace }}
-        bucket={storageBucketPath}
-      />
+      <FileTable {...{ workspaceNamespace }} bucket={storageBucketPath} />
     </>
   );
 };

--- a/ui/src/app/pages/admin/workspace/cloud-storage-objects.tsx
+++ b/ui/src/app/pages/admin/workspace/cloud-storage-objects.tsx
@@ -49,7 +49,7 @@ export const CloudStorageObjects = ({
           {formatMB(storageBytesUsed)}
         </WorkspaceInfoField>
       </div>
-      <FileTable {...{ workspaceNamespace }} bucket={storageBucketPath} />
+      <FileTable {...{ workspaceNamespace, storageBucketPath }} />
     </>
   );
 };

--- a/ui/src/app/pages/admin/workspace/cloud-storage-objects.tsx
+++ b/ui/src/app/pages/admin/workspace/cloud-storage-objects.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+
+import { AdminWorkspaceCloudStorageCounts } from 'generated/fetch';
+
+import colors from 'app/styles/colors';
+
+import { FileDetailsTable, formatMB } from './file-table';
+import { WorkspaceInfoField } from './workspace-info-field';
+
+interface Props {
+  workspaceNamespace: string;
+  cloudStorage: AdminWorkspaceCloudStorageCounts;
+}
+export const CloudStorageObjects = ({
+  workspaceNamespace,
+  cloudStorage,
+}: Props) => {
+  const {
+    storageBucketPath,
+    notebookFileCount,
+    nonNotebookFileCount,
+    storageBytesUsed,
+  } = cloudStorage;
+  return (
+    <>
+      <h3>Cloud Storage Objects</h3>
+      <div className='cloud-storage-objects' style={{ marginTop: '1.5rem' }}>
+        <div
+          style={{
+            color: colors.warning,
+            fontWeight: 'bold',
+            maxWidth: '1000px',
+          }}
+        >
+          NOTE: if there are more than ~1000 files in the bucket, these counts
+          and the table below may be incomplete because we process only a single
+          page of storage list results.
+        </div>
+        <WorkspaceInfoField labelText='GCS bucket path'>
+          {storageBucketPath}
+        </WorkspaceInfoField>
+        <WorkspaceInfoField labelText='# of Workbench-managed notebook files'>
+          {notebookFileCount}
+        </WorkspaceInfoField>
+        <WorkspaceInfoField labelText='# of other files'>
+          {nonNotebookFileCount}
+        </WorkspaceInfoField>
+        <WorkspaceInfoField labelText='Storage used (MB)'>
+          {formatMB(storageBytesUsed)}
+        </WorkspaceInfoField>
+      </div>
+      <FileDetailsTable
+        {...{ workspaceNamespace }}
+        bucket={storageBucketPath}
+      />
+    </>
+  );
+};

--- a/ui/src/app/pages/admin/workspace/cloud-storage-traffic-chart.tsx
+++ b/ui/src/app/pages/admin/workspace/cloud-storage-traffic-chart.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import * as HighCharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+
+import { CloudStorageTraffic, TimeSeriesPoint } from 'generated/fetch';
+
+import moment from 'moment';
+
+const customOptions: HighCharts.Options = {
+  time: {
+    useUTC: false,
+  },
+  lang: {
+    decimalPoint: '.',
+    thousandsSep: ',',
+  },
+};
+
+const getHighChartsReactOptions = (receivedBytes: TimeSeriesPoint[]) => ({
+  animation: false,
+  chart: {
+    animation: false,
+    height: '150px',
+  },
+  credits: {
+    enabled: false,
+  },
+  legend: {
+    enabled: false,
+  },
+  title: {
+    text: undefined,
+  },
+  tooltip: {
+    xDateFormat: '%A, %b %e, %H:%M',
+    valueDecimals: 0,
+  },
+  xAxis: {
+    min: moment().subtract(6, 'hours').valueOf(),
+    max: moment().valueOf(),
+    title: {
+      enabled: false,
+    },
+    type: 'datetime',
+    zoomEnabled: false,
+  },
+  yAxis: {
+    title: {
+      enabled: false,
+    },
+    zoomEnabled: false,
+  },
+  series: [
+    {
+      data: receivedBytes?.map((x) => [x.timestamp, x.value]),
+      lineWidth: 0.5,
+      name: 'GCS received bytes',
+    },
+  ],
+});
+
+interface Props {
+  cloudStorageTraffic: CloudStorageTraffic;
+}
+export const CloudStorageTrafficChart = ({ cloudStorageTraffic }: Props) => {
+  HighCharts.setOptions(customOptions);
+  return (
+    <div>
+      <h2>Cloud Storage Traffic</h2>
+      <div>
+        Cloud Storage <i>received_bytes_count</i> over the past 6 hours.
+      </div>
+      <div style={{ width: '500px', zIndex: 1001 }}>
+        <HighchartsReact
+          highcharts={HighCharts}
+          options={getHighChartsReactOptions(
+            cloudStorageTraffic?.receivedBytes
+          )}
+        />
+      </div>
+    </div>
+  );
+};

--- a/ui/src/app/pages/admin/workspace/cohort-builder.tsx
+++ b/ui/src/app/pages/admin/workspace/cohort-builder.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+import { AdminWorkspaceObjectsCounts } from 'generated/fetch';
+
+import { WorkspaceInfoField } from './workspace-info-field';
+
+interface Props {
+  workspaceObjects: AdminWorkspaceObjectsCounts;
+}
+export const CohortBuilder = ({ workspaceObjects }: Props) => {
+  const { cohortCount, conceptSetCount, datasetCount } = workspaceObjects;
+  return (
+    <>
+      <h3>Cohort Builder</h3>
+      <div className='cohort-builder' style={{ marginTop: '1.5rem' }}>
+        <WorkspaceInfoField labelText='# of Cohorts'>
+          {cohortCount}
+        </WorkspaceInfoField>
+        <WorkspaceInfoField labelText='# of Concept Sets'>
+          {conceptSetCount}
+        </WorkspaceInfoField>
+        <WorkspaceInfoField labelText='# of Data Sets'>
+          {datasetCount}
+        </WorkspaceInfoField>
+      </div>
+    </>
+  );
+};

--- a/ui/src/app/pages/admin/workspace/collaborators.tsx
+++ b/ui/src/app/pages/admin/workspace/collaborators.tsx
@@ -9,10 +9,8 @@ export const Collaborators = ({ collaborators }: Props) => (
   <>
     <h3>Collaborators</h3>
     <div className='collaborators' style={{ marginTop: '1.5rem' }}>
-      {collaborators.map((workspaceUserAdminView, i) => (
-        <div key={i}>
-          {`${workspaceUserAdminView.userModel.userName}: ${workspaceUserAdminView.role}`}
-        </div>
+      {collaborators.map((c, i) => (
+        <div key={i}>{`${c.userModel.userName}: ${c.role}`}</div>
       ))}
     </div>
   </>

--- a/ui/src/app/pages/admin/workspace/collaborators.tsx
+++ b/ui/src/app/pages/admin/workspace/collaborators.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+import { WorkspaceUserAdminView } from 'generated/fetch';
+
+interface Props {
+  collaborators: WorkspaceUserAdminView[];
+}
+export const Collaborators = ({ collaborators }: Props) => (
+  <>
+    <h3>Collaborators</h3>
+    <div className='collaborators' style={{ marginTop: '1.5rem' }}>
+      {collaborators.map((workspaceUserAdminView, i) => (
+        <div key={i}>
+          {`${workspaceUserAdminView.userModel.userName}: ${workspaceUserAdminView.role}`}
+        </div>
+      ))}
+    </div>
+  </>
+);

--- a/ui/src/app/pages/admin/workspace/file-table.tsx
+++ b/ui/src/app/pages/admin/workspace/file-table.tsx
@@ -126,10 +126,10 @@ const NameCell = (props: NameCellProps) => {
 
 interface Props {
   workspaceNamespace: string;
-  bucket: string;
+  storageBucketPath: string;
 }
 export const FileTable = (props: Props) => {
-  const { workspaceNamespace, bucket } = props;
+  const { workspaceNamespace, storageBucketPath } = props;
 
   interface TableEntry {
     location: string;
@@ -150,12 +150,12 @@ export const FileTable = (props: Props) => {
     return fileDetails
       .map((file) => {
         return {
-          location: parseLocation(file, bucket),
+          location: parseLocation(file, storageBucketPath),
           rawName: file.name,
           nameCell: (
             <NameCell
               file={file}
-              bucket={bucket}
+              bucket={storageBucketPath}
               workspaceNamespace={workspaceNamespace}
               accessReason={accessReason}
             />

--- a/ui/src/app/pages/admin/workspace/file-table.tsx
+++ b/ui/src/app/pages/admin/workspace/file-table.tsx
@@ -123,12 +123,12 @@ const NameCell = (props: NameCellProps) => {
     filenameSpan
   );
 };
-interface FileDetailsProps {
+
+interface Props {
   workspaceNamespace: string;
   bucket: string;
 }
-
-export const FileDetailsTable = (props: FileDetailsProps) => {
+export const FileTable = (props: Props) => {
   const { workspaceNamespace, bucket } = props;
 
   interface TableEntry {

--- a/ui/src/app/pages/admin/workspace/file-table.tsx
+++ b/ui/src/app/pages/admin/workspace/file-table.tsx
@@ -12,10 +12,11 @@ import { FlexColumn, FlexRow } from 'app/components/flex';
 import { TextArea } from 'app/components/inputs';
 import { TooltipTrigger } from 'app/components/popups';
 import { Spinner } from 'app/components/spinners';
-import { PurpleLabel } from 'app/pages/admin/workspace/admin-workspace';
 import { workspaceAdminApi } from 'app/services/swagger-fetch-clients';
 import { reactStyles } from 'app/utils';
 import { useNavigation } from 'app/utils/navigation';
+
+import { PurpleLabel } from './workspace-info-field';
 
 const MAX_NOTEBOOK_READ_SIZE_BYTES = 5 * 1000 * 1000; // see NotebooksServiceImpl
 

--- a/ui/src/app/pages/admin/workspace/research-purpose-section.tsx
+++ b/ui/src/app/pages/admin/workspace/research-purpose-section.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+
+import { ResearchPurpose } from 'generated/fetch';
+
+import {
+  getSelectedPopulations,
+  getSelectedPrimaryPurposeItems,
+} from 'app/utils/research-purpose';
+
+import { WorkspaceInfoField } from './workspace-info-field';
+
+interface Props {
+  researchPurpose: ResearchPurpose;
+}
+
+export const ResearchPurposeSection = ({ researchPurpose }: Props) => {
+  const {
+    reasonForAllOfUs,
+    intendedStudy,
+    anticipatedFindings,
+    populationDetails,
+  } = researchPurpose;
+  return (
+    <>
+      <h3>Research Purpose</h3>
+      <div className='research-purpose' style={{ marginTop: '1.5rem' }}>
+        <WorkspaceInfoField labelText='Primary purpose of project'>
+          {getSelectedPrimaryPurposeItems(researchPurpose).map(
+            (researchPurposeItem, i) => (
+              <div key={i}>{researchPurposeItem}</div>
+            )
+          )}
+        </WorkspaceInfoField>
+        <WorkspaceInfoField labelText='Reason for choosing All of Us'>
+          {reasonForAllOfUs}
+        </WorkspaceInfoField>
+        <WorkspaceInfoField labelText='Area of intended study'>
+          {intendedStudy}
+        </WorkspaceInfoField>
+        <WorkspaceInfoField labelText='Anticipated findings'>
+          {anticipatedFindings}
+        </WorkspaceInfoField>
+        {populationDetails.length > 0 && (
+          <WorkspaceInfoField labelText='Population area(s) of focus'>
+            {getSelectedPopulations(researchPurpose)}
+          </WorkspaceInfoField>
+        )}
+      </div>
+    </>
+  );
+};

--- a/ui/src/app/pages/admin/workspace/workspace-info-field.tsx
+++ b/ui/src/app/pages/admin/workspace/workspace-info-field.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import { FlexRow } from 'app/components/flex';
+import colors from 'app/styles/colors';
+import { reactStyles } from 'app/utils';
+
+const styles = reactStyles({
+  infoRow: {
+    width: '80%',
+    maxWidth: '1000px',
+  },
+  infoLabel: {
+    width: '300px',
+    minWidth: '180px',
+    textAlign: 'right',
+    marginRight: '1.5rem',
+  },
+  infoValue: {
+    flex: 1,
+    wordWrap: 'break-word',
+  },
+});
+
+interface LabelProps {
+  style?: React.CSSProperties;
+  children: any;
+}
+export const PurpleLabel = ({ style, children }: LabelProps) => {
+  return <label style={{ color: colors.primary, ...style }}>{children}</label>;
+};
+
+interface InfoProps {
+  labelText: string;
+  children: any;
+}
+export const WorkspaceInfoField = ({ labelText, children }: InfoProps) => {
+  return (
+    <FlexRow style={styles.infoRow}>
+      <PurpleLabel style={styles.infoLabel}>{labelText}</PurpleLabel>
+      <div style={styles.infoValue}>{children}</div>
+    </FlexRow>
+  );
+};


### PR DESCRIPTION
I'm working on some updates to workspace-admin, and my first step is to refactor the page to make it easier to update.  However, that is proving to be a larger task than I expected, so I'm splitting it into smaller pieces.

This PR takes the simple (minimal-logic) display sections and converts them to components.  No changes are expected here, and the new components are simple enough that I don't think adding tests would be useful.

Tested locally - works the same as the existing page

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
