### PR TITLE
[noTicket][risk=no] Use free fortawesome icons vs pro

### DIFF
--- a/ui/src/app/pages/admin/user/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-profile.tsx
@@ -4,7 +4,7 @@ import * as fp from 'lodash/fp';
 import { Column } from 'primereact/column';
 import { DataTable } from 'primereact/datatable';
 import validate from 'validate.js';
-import { faLink } from '@fortawesome/pro-solid-svg-icons';
+import { faLink } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import {

--- a/ui/src/app/pages/analysis/notebook-list.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {
   faExclamationTriangle,
   faPlusCircle,
-} from '@fortawesome/pro-solid-svg-icons';
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { BillingStatus, FileDetail } from 'generated/fetch';

--- a/ui/src/app/pages/profile/profile-component.tsx
+++ b/ui/src/app/pages/profile/profile-component.tsx
@@ -3,7 +3,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import * as fp from 'lodash/fp';
 import { Dropdown } from 'primereact/dropdown';
 import validate from 'validate.js';
-import { faCircleInfo } from '@fortawesome/pro-solid-svg-icons';
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import {


### PR DESCRIPTION
Replaced Icons:

1. **faCircleInfo**: (used in profile page)

**Change**: 
<img width="135" alt="Screenshot 2023-09-22 at 2 25 53 PM" src="https://github.com/all-of-us/workbench/assets/34481816/c1cbb044-9eb7-48b0-8936-1386e8db5bb0">

**Original**
<img width="108" alt="Screenshot 2023-09-22 at 2 26 21 PM" src="https://github.com/all-of-us/workbench/assets/34481816/9c34923d-6f2e-4b20-8328-bfd946ef2868">


2. **falink** ( used in user admin)
change
<img width="388" alt="Screenshot 2023-09-22 at 2 28 11 PM" src="https://github.com/all-of-us/workbench/assets/34481816/e54d977a-ad45-4906-a90a-42dfac90c3b5">

original:
<img width="390" alt="Screenshot 2023-09-22 at 2 28 39 PM" src="https://github.com/all-of-us/workbench/assets/34481816/2aa0651a-4008-4fa1-bdb9-a2c6dba13837">


4. faExclamationTriangle:
change:
<img width="566" alt="Screenshot 2023-09-22 at 3 28 26 PM" src="https://github.com/all-of-us/workbench/assets/34481816/b72307ca-37ee-4949-9823-bd73a344bfc4">

original:
<img width="551" alt="Screenshot 2023-09-22 at 3 31 01 PM" src="https://github.com/all-of-us/workbench/assets/34481816/1b63e3e5-2aa0-4ca9-97c8-a436602d9c78">


5. faPlusCircle
change:
<img width="349" alt="Screenshot 2023-09-22 at 3 27 32 PM" src="https://github.com/all-of-us/workbench/assets/34481816/485afea4-06c8-49d8-837c-3788d9f49385">

original
<img width="327" alt="Screenshot 2023-09-22 at 3 29 25 PM" src="https://github.com/all-of-us/workbench/assets/34481816/d5518591-7292-4578-a8f1-6a6d5d96c4b1">


There are just two pro icons left in our code base:

1. faLockAlt: 

> The alternative in free is slightly different. 

> It is used in workspace card and workspace admin page for locked workspaces

6. faLocationCircle:

> Does not have a free version

> Used in genomics extraction



<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
