### PR TITLE
[risk=low][RW-10998][RW-10934] Use the correct delocalization pattern for SAS and enable in UI

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -116,6 +116,7 @@ public class AppsController implements AppsApiDelegate {
                 interactiveAnalysisService.localize(
                     workspaceNamespace,
                     appName,
+                    body.getAppType(),
                     body.getFileNames(),
                     body.getPlaygroundMode(),
                     false)));

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -26,6 +26,7 @@ import org.pmiops.workbench.leonardo.model.LeonardoClusterError;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeStatus;
+import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.Disk;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.GceWithPdConfig;
@@ -275,13 +276,14 @@ public class RuntimeController implements RuntimeApiDelegate {
     workspaceAuthService.validateActiveBilling(
         dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
 
+    AppType appType = null; // Jupyter uses GCE, so it doesn't have a GKE App Type
     return ResponseEntity.ok(
         new RuntimeLocalizeResponse()
             .runtimeLocalDirectory(
                 interactiveAnalysisService.localize(
                     workspaceNamespace,
                     userProvider.get().getRuntimeName(),
-                    null,
+                    appType,
                     body.getNotebookNames(),
                     body.getPlaygroundMode(),
                     true)));

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -281,6 +281,7 @@ public class RuntimeController implements RuntimeApiDelegate {
                 interactiveAnalysisService.localize(
                     workspaceNamespace,
                     userProvider.get().getRuntimeName(),
+                    null,
                     body.getNotebookNames(),
                     body.getPlaygroundMode(),
                     true)));

--- a/api/src/main/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisService.java
+++ b/api/src/main/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisService.java
@@ -58,7 +58,7 @@ public class InteractiveAnalysisService {
   @VisibleForTesting static final String JUPYTER_DELOC_PATTERN = "\\.ipynb$";
 
   @VisibleForTesting static final String RSTUDIO_DELOC_PATTERN = "\\.(Rmd|R)$";
-  @VisibleForTesting static final String SAS_DELOC_PATTERN = "\\.(sas)$";
+  @VisibleForTesting static final String SAS_DELOC_PATTERN = "\\.sas$";
 
   @Autowired
   public InteractiveAnalysisService(

--- a/api/src/main/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisService.java
+++ b/api/src/main/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisService.java
@@ -7,7 +7,6 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -133,7 +132,8 @@ public class InteractiveAnalysisService {
     } else {
       throw new NotImplementedException(
           String.format(
-              "Localizing is not yet supported for app type %s", Optional.ofNullable(appType)));
+              "Localizing is not yet supported for app type %s",
+              appType == null ? "[null]" : appType.toString()));
     }
 
     if (isGceRuntime) {

--- a/api/src/main/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisService.java
+++ b/api/src/main/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisService.java
@@ -132,7 +132,8 @@ public class InteractiveAnalysisService {
       storageLink.setPattern(SAS_DELOC_PATTERN);
     } else {
       throw new NotImplementedException(
-          String.format("Localizing is not yet supported for app type %s", Optional.ofNullable(appType)));
+          String.format(
+              "Localizing is not yet supported for app type %s", Optional.ofNullable(appType)));
     }
 
     if (isGceRuntime) {

--- a/api/src/main/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisService.java
+++ b/api/src/main/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisService.java
@@ -59,6 +59,9 @@ public class InteractiveAnalysisService {
   @VisibleForTesting static final String RSTUDIO_DELOC_PATTERN = "\\.(Rmd|R)$";
   @VisibleForTesting static final String SAS_DELOC_PATTERN = "\\.sas$";
 
+  static final Map<AppType, String> GKE_DELOC_PATTERNS =
+      Map.of(AppType.RSTUDIO, RSTUDIO_DELOC_PATTERN, AppType.SAS, SAS_DELOC_PATTERN);
+
   @Autowired
   public InteractiveAnalysisService(
       WorkspaceService workspaceService,
@@ -125,15 +128,16 @@ public class InteractiveAnalysisService {
 
     if (isGceRuntime) {
       storageLink.setPattern(JUPYTER_DELOC_PATTERN);
-    } else if (AppType.RSTUDIO.equals(appType)) {
-      storageLink.setPattern(RSTUDIO_DELOC_PATTERN);
-    } else if (AppType.SAS.equals(appType)) {
-      storageLink.setPattern(SAS_DELOC_PATTERN);
     } else {
-      throw new NotImplementedException(
-          String.format(
-              "Localizing is not yet supported for app type %s",
-              appType == null ? "[null]" : appType.toString()));
+      var pattern = GKE_DELOC_PATTERNS.get(appType);
+      if (pattern == null) {
+        throw new NotImplementedException(
+            String.format(
+                "Localizing is not yet supported for app type %s",
+                appType == null ? "[null]" : appType.toString()));
+      } else {
+        storageLink.setPattern(pattern);
+      }
     }
 
     if (isGceRuntime) {

--- a/api/src/main/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisService.java
+++ b/api/src/main/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisService.java
@@ -128,6 +128,7 @@ public class InteractiveAnalysisService {
 
     if (isGceRuntime) {
       storageLink.setPattern(JUPYTER_DELOC_PATTERN);
+      leonardoNotebooksClient.createStorageLinkForRuntime(googleProjectId, appName, storageLink);
     } else {
       var pattern = GKE_DELOC_PATTERNS.get(appType);
       if (pattern == null) {
@@ -137,15 +138,8 @@ public class InteractiveAnalysisService {
                 appType == null ? "[null]" : appType.toString()));
       } else {
         storageLink.setPattern(pattern);
+        leonardoNotebooksClient.createStorageLinkForApp(googleProjectId, appName, storageLink);
       }
-    }
-
-    if (isGceRuntime) {
-      leonardoNotebooksClient.createStorageLinkForRuntime(googleProjectId, appName, storageLink);
-    } else {
-      // For now if the request is not for GCE runtime, that would be RStudio. When supporting more
-      // apps, consider to use AppType.
-      leonardoNotebooksClient.createStorageLinkForApp(googleProjectId, appName, storageLink);
     }
 
     // Always localize config files; usually a no-op after the first call.

--- a/api/src/test/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisServiceTest.java
@@ -1,11 +1,14 @@
 package org.pmiops.workbench.interactiveanalysis;
 
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.interactiveanalysis.InteractiveAnalysisService.JUPYTER_DELOC_PATTERN;
 import static org.pmiops.workbench.interactiveanalysis.InteractiveAnalysisService.RSTUDIO_DELOC_PATTERN;
+import static org.pmiops.workbench.interactiveanalysis.InteractiveAnalysisService.SAS_DELOC_PATTERN;
 import static org.pmiops.workbench.interactiveanalysis.InteractiveAnalysisService.aouConfigDataUri;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,8 +18,10 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.exceptions.NotImplementedException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
+import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.notebooks.model.StorageLink;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceDetails;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceResponse;
@@ -146,7 +151,7 @@ public class InteractiveAnalysisServiceTest {
   }
 
   @Test
-  public void testLocalize_gkeApp_editMode() {
+  public void testLocalize_RStudio_editMode() {
     String editDir = "";
     String playgroundDir = "workspaces_playground";
     List<String> notebookLists = List.of("foo.Rmd");
@@ -161,14 +166,15 @@ public class InteractiveAnalysisServiceTest {
     expectedLocalizeMap.put(playgroundDir + "/.all_of_us_config.json", aouConfigDataUri);
     expectedLocalizeMap.put("foo.Rmd", NOTEBOOK_DIR + "/foo.Rmd");
 
-    interactiveAnalysisService.localize(WORKSPACE_NS, APP_NAME, notebookLists, false, false);
+    interactiveAnalysisService.localize(
+        WORKSPACE_NS, APP_NAME, AppType.RSTUDIO, notebookLists, false, false);
     verify(mockLeonardoApiClient)
         .createStorageLinkForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedStorageLink);
     verify(mockLeonardoApiClient).localizeForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedLocalizeMap);
   }
 
   @Test
-  public void testLocalize_gkeApp_playground() {
+  public void testLocalize_RStudio_playground() {
     String editDir = "";
     String playgroundDir = "workspaces_playground";
     List<String> notebookLists = List.of("foo.Rmd");
@@ -183,9 +189,65 @@ public class InteractiveAnalysisServiceTest {
     expectedLocalizeMap.put(playgroundDir + "/.all_of_us_config.json", aouConfigDataUri);
     expectedLocalizeMap.put(playgroundDir + "/foo.Rmd", NOTEBOOK_DIR + "/foo.Rmd");
 
-    interactiveAnalysisService.localize(WORKSPACE_NS, APP_NAME, notebookLists, true, false);
+    interactiveAnalysisService.localize(
+        WORKSPACE_NS, APP_NAME, AppType.RSTUDIO, notebookLists, true, false);
     verify(mockLeonardoApiClient)
         .createStorageLinkForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedStorageLink);
     verify(mockLeonardoApiClient).localizeForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedLocalizeMap);
+  }
+
+  @Test
+  public void testLocalize_SAS_editMode() {
+    String editDir = "";
+    String playgroundDir = "workspaces_playground";
+    List<String> notebookLists = List.of("foo.sas");
+    StorageLink expectedStorageLink =
+        new StorageLink()
+            .cloudStorageDirectory(NOTEBOOK_DIR)
+            .localBaseDirectory(editDir)
+            .localSafeModeBaseDirectory(playgroundDir)
+            .pattern(SAS_DELOC_PATTERN);
+    Map<String, String> expectedLocalizeMap = new HashMap<>();
+    expectedLocalizeMap.put(".all_of_us_config.json", aouConfigDataUri);
+    expectedLocalizeMap.put(playgroundDir + "/.all_of_us_config.json", aouConfigDataUri);
+    expectedLocalizeMap.put("foo.sas", NOTEBOOK_DIR + "/foo.sas");
+
+    interactiveAnalysisService.localize(
+        WORKSPACE_NS, APP_NAME, AppType.SAS, notebookLists, false, false);
+    verify(mockLeonardoApiClient)
+        .createStorageLinkForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedStorageLink);
+    verify(mockLeonardoApiClient).localizeForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedLocalizeMap);
+  }
+
+  @Test
+  public void testLocalize_SAS_playground() {
+    String editDir = "";
+    String playgroundDir = "workspaces_playground";
+    List<String> notebookLists = List.of("foo.sas");
+    StorageLink expectedStorageLink =
+        new StorageLink()
+            .cloudStorageDirectory(NOTEBOOK_DIR)
+            .localBaseDirectory(editDir)
+            .localSafeModeBaseDirectory(playgroundDir)
+            .pattern(RSTUDIO_DELOC_PATTERN);
+    Map<String, String> expectedLocalizeMap = new HashMap<>();
+    expectedLocalizeMap.put(".all_of_us_config.json", aouConfigDataUri);
+    expectedLocalizeMap.put(playgroundDir + "/.all_of_us_config.json", aouConfigDataUri);
+    expectedLocalizeMap.put(playgroundDir + "/foo.sas", NOTEBOOK_DIR + "/foo.sas");
+
+    interactiveAnalysisService.localize(
+        WORKSPACE_NS, APP_NAME, AppType.SAS, notebookLists, true, false);
+    verify(mockLeonardoApiClient)
+        .createStorageLinkForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedStorageLink);
+    verify(mockLeonardoApiClient).localizeForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedLocalizeMap);
+  }
+
+  @Test
+  public void testLocalize_appType_not_supported() {
+    assertThrows(
+        NotImplementedException.class,
+        () ->
+            interactiveAnalysisService.localize(
+                WORKSPACE_NS, APP_NAME, AppType.CROMWELL, Collections.emptyList(), false, false));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisServiceTest.java
@@ -247,10 +247,11 @@ public class InteractiveAnalysisServiceTest {
 
   @Test
   public void testLocalize_appType_not_supported() {
+    var unsupportedAppType = AppType.CROMWELL;
     assertThrows(
         NotImplementedException.class,
         () ->
             interactiveAnalysisService.localize(
-                WORKSPACE_NS, APP_NAME, AppType.CROMWELL, Collections.emptyList(), false, false));
+                WORKSPACE_NS, APP_NAME, unsupportedAppType, Collections.emptyList(), false, false));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisServiceTest.java
@@ -120,7 +120,9 @@ public class InteractiveAnalysisServiceTest {
     expectedLocalizeMap.put(playgroundDir + "/.all_of_us_config.json", aouConfigDataUri);
     expectedLocalizeMap.put(editDir + "/foo.ipynb", NOTEBOOK_DIR + "/foo.ipynb");
 
-    interactiveAnalysisService.localize(WORKSPACE_NS, APP_NAME, notebookLists, false, true);
+    AppType appType = null; // Jupyter uses GCE, so it doesn't have a GKE App Type
+    interactiveAnalysisService.localize(
+        WORKSPACE_NS, APP_NAME, appType, notebookLists, false, true);
     verify(mockLeonardoApiClient)
         .createStorageLinkForRuntime(GOOGLE_PROJECT_ID, APP_NAME, expectedStorageLink);
     verify(mockLeonardoApiClient)
@@ -143,7 +145,8 @@ public class InteractiveAnalysisServiceTest {
     expectedLocalizeMap.put(playgroundDir + "/.all_of_us_config.json", aouConfigDataUri);
     expectedLocalizeMap.put(playgroundDir + "/foo.ipynb", NOTEBOOK_DIR + "/foo.ipynb");
 
-    interactiveAnalysisService.localize(WORKSPACE_NS, APP_NAME, notebookLists, true, true);
+    AppType appType = null; // Jupyter uses GCE, so it doesn't have a GKE App Type
+    interactiveAnalysisService.localize(WORKSPACE_NS, APP_NAME, appType, notebookLists, true, true);
     verify(mockLeonardoApiClient)
         .createStorageLinkForRuntime(GOOGLE_PROJECT_ID, APP_NAME, expectedStorageLink);
     verify(mockLeonardoApiClient)
@@ -229,7 +232,7 @@ public class InteractiveAnalysisServiceTest {
             .cloudStorageDirectory(NOTEBOOK_DIR)
             .localBaseDirectory(editDir)
             .localSafeModeBaseDirectory(playgroundDir)
-            .pattern(RSTUDIO_DELOC_PATTERN);
+            .pattern(SAS_DELOC_PATTERN);
     Map<String, String> expectedLocalizeMap = new HashMap<>();
     expectedLocalizeMap.put(".all_of_us_config.json", aouConfigDataUri);
     expectedLocalizeMap.put(playgroundDir + "/.all_of_us_config.json", aouConfigDataUri);

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -348,18 +348,15 @@ describe('ExpandedApp', () => {
         launchButton.click();
 
         await waitFor(() => {
-          // RW-10934 SAS localization throws a 500 error
-          if (appType !== UIAppType.SAS) {
-            expect(localizeSpy).toHaveBeenCalledWith(
-              WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-              appName,
-              {
-                appType: toAppType[appType],
-                fileNames: [],
-                playgroundMode: false,
-              }
-            );
-          }
+          expect(localizeSpy).toHaveBeenCalledWith(
+            WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+            appName,
+            {
+              appType: toAppType[appType],
+              fileNames: [],
+              playgroundMode: false,
+            }
+          );
 
           expect(windowOpenSpy).toHaveBeenCalledWith(proxyUrl, '_blank');
           expect(focusStub).toHaveBeenCalled();

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -131,14 +131,15 @@ export const openSAS = (
   workspaceNamespace: string,
   userApp: UserAppEnvironment
 ) => {
-  // RW-10934 SAS localization throws a 500 error
-  // fetchWithErrorModal(() => localizeUserApp(
-  //   workspaceNamespace,
-  //   userApp.appName,
-  //   userApp.appType,
-  //   [],
-  //   false
-  // ));
+  fetchWithErrorModal(() =>
+    localizeUserApp(
+      workspaceNamespace,
+      userApp.appName,
+      userApp.appType,
+      [],
+      false
+    )
+  );
   window.open(userApp.proxyUrls[GKE_APP_PROXY_PATH_SUFFIX], '_blank').focus();
 };
 


### PR DESCRIPTION
Use the SAS localization pattern (for `.sas`) instead of using RStudio's for all GKE apps, and call the localization endpoint when opening a SAS app.

Tested locally by saving SAS files in the app and observing they appear in the Analysis tab (after some delay), as well as adding files to the bucket and observing that they are copied into the SAS app VM

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
