### PR TITLE
[risk=low][no ticket] Set prepackaged concept set IDs to undefined instead of null

### DIFF
--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -1041,7 +1041,7 @@ export const DatasetPage = fp.flow(
           }
           const updateIndex = domainsWithConceptSetIds.findIndex(
             (dc) =>
-              dc.conceptSetId !== null &&
+              dc.conceptSetId !== undefined &&
               dc.conceptSetId === domainWithConceptSetId.conceptSetId
           );
           if (updateIndex > -1) {
@@ -1177,12 +1177,12 @@ export const DatasetPage = fp.flow(
             if (
               (PREPACKAGED_DOMAINS[prepackaged] === Domain.SURVEY &&
                 domainWithConceptSetId.domain === Domain.SURVEY &&
-                domainWithConceptSetId.conceptSetId === null &&
+                domainWithConceptSetId.conceptSetId === undefined &&
                 !Array.from(updatedPrepackaged).some((domain) =>
                   domain.toString().includes('SURVEY')
                 )) ||
               (PREPACKAGED_DOMAINS[prepackaged] !== Domain.SURVEY &&
-                domainWithConceptSetId.conceptSetId === null &&
+                domainWithConceptSetId.conceptSetId === undefined &&
                 domainWithConceptSetId.domain ===
                   PREPACKAGED_DOMAINS[prepackaged])
             ) {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -762,7 +762,7 @@ function domainValuePairsToLowercase(domainValuePairs: DomainValuePair[]) {
 
 interface DomainWithConceptSetId {
   domain: Domain;
-  conceptSetId: number;
+  conceptSetId?: number;
 }
 
 interface DataSetPreviewInfo {
@@ -897,20 +897,19 @@ export const DatasetPage = fp.flow(
       conceptSets: ConceptSet[],
       prepackagedConceptSets: PrePackagedConceptSetEnum[]
     ): DomainWithConceptSetId[] => {
-      return conceptSets
-        .map((cs) => ({
+      return (
+        conceptSets.map((cs) => ({
           conceptSetId: cs.id,
           domain:
             cs.domain === Domain.PHYSICAL_MEASUREMENT
               ? Domain.MEASUREMENT
               : cs.domain,
+        })) as DomainWithConceptSetId[]
+      ).concat(
+        prepackagedConceptSets.map((p) => ({
+          domain: PREPACKAGED_DOMAINS[p],
         }))
-        .concat(
-          prepackagedConceptSets.map((p) => ({
-            conceptSetId: null,
-            domain: PREPACKAGED_DOMAINS[p],
-          }))
-        );
+      );
     };
 
     const getDomainsWithConceptSetIdsFromDataSet = (d: DataSet) => {
@@ -1142,7 +1141,6 @@ export const DatasetPage = fp.flow(
       if (selected) {
         updatedPrepackaged.add(prepackaged);
         updatedDomainsWithConceptSetIds.add({
-          conceptSetId: null,
           domain: PREPACKAGED_DOMAINS[prepackaged],
         });
         // check surveys
@@ -1215,7 +1213,6 @@ export const DatasetPage = fp.flow(
           domainValueSetIsLoading.add(PREPACKAGED_DOMAINS[prepackaged])
         );
         loadValueSetForDomain({
-          conceptSetId: null,
           domain: PREPACKAGED_DOMAINS[prepackaged],
         });
       }


### PR DESCRIPTION
This changes calls to `getValuesFromDomain()` from setting a query parameter `conceptSetId=null` where the ID is null to leaving out the parameter entirely.

The new syntax caused the API to respond with 500s when creating datasets with Prepackaged Concept Sets with the underlying error of 
```
MethodArgumentTypeMismatchException: Failed to convert value of type 'java.lang.String' to required type 'java.lang.Long'; nested exception is java.lang.NumberFormatException: For input string: "null"
````

My guess is that this behavior changed with https://github.com/all-of-us/workbench/pull/7953.

The old syntax (which we can observe on Staging+, which continues to work) is `conceptSetID=`

Tested on Local->Test by creating Datasets with Prepackaged and standard Concept Sets.


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
