### PR TITLE
[DT-538][risk=no] Implement has_ehr_data for cohort builder criteria

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -117,7 +117,8 @@
     "ccSupportWhenAdminLocking": false,
     "enableRStudioGKEApp": true,
     "enableSasGKEApp": true,
-    "enableDataExplorer": true
+    "enableDataExplorer": true,
+    "enableHasEhrData": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-local",

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -117,7 +117,8 @@
     "ccSupportWhenAdminLocking": true,
     "enableRStudioGKEApp": true,
     "enableSasGKEApp": false,
-    "enableDataExplorer": false
+    "enableDataExplorer": false,
+    "enableHasEhrData": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-preprod",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -117,7 +117,8 @@
     "ccSupportWhenAdminLocking": true,
     "enableRStudioGKEApp": false,
     "enableSasGKEApp": false,
-    "enableDataExplorer": false
+    "enableDataExplorer": false,
+    "enableHasEhrData": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-prod",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -117,7 +117,8 @@
     "ccSupportWhenAdminLocking": false,
     "enableRStudioGKEApp": false,
     "enableSasGKEApp": false,
-    "enableDataExplorer": false
+    "enableDataExplorer": false,
+    "enableHasEhrData": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-stable",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -117,7 +117,8 @@
     "ccSupportWhenAdminLocking": false,
     "enableRStudioGKEApp": true,
     "enableSasGKEApp": false,
-    "enableDataExplorer": false
+    "enableDataExplorer": false,
+    "enableHasEhrData": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-staging",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -117,7 +117,8 @@
     "ccSupportWhenAdminLocking": false,
     "enableRStudioGKEApp": true,
     "enableSasGKEApp": true,
-    "enableDataExplorer": false
+    "enableDataExplorer": false,
+    "enableHasEhrData": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/db-cdr/generate-cdr/build-cb-criteria-menu.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-menu.sh
@@ -104,6 +104,7 @@ insertCriteriaMenu "
 ($((++ID)),1,'Program Data','PERSON','GENDER','Gender Identity',0,4),
 ($((++ID)),1,'Program Data','PERSON','RACE','Race',0,5),
 ($((++ID)),1,'Program Data','PERSON','SEX','Sex Assigned at Birth',0,6),
+($((++ID)),1,'Program Data','PERSON','HAS_EHR_DATA','Has EHR data',0,7),
 ($((++ID)),2,'Program Data','SURVEY','PPI','All Surveys',0,1)"
 
 echo "Adding surveys"

--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -159,10 +159,8 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
     workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
     if (workbenchConfigProvider.get().featureFlags.enableHasEhrData) {
-      CriteriaMenuListResponse response =
-          new CriteriaMenuListResponse()
-              .items(cohortBuilderService.findCriteriaMenuByParentId(parentId));
-      return ResponseEntity.ok(response);
+      return ResponseEntity.ok(new CriteriaMenuListResponse()
+          .items(cohortBuilderService.findCriteriaMenuByParentId(parentId)));
     } else {
       return ResponseEntity.ok(
           new CriteriaMenuListResponse()

--- a/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CohortBuilderController.java
@@ -159,8 +159,9 @@ public class CohortBuilderController implements CohortBuilderApiDelegate {
     workspaceAuthService.getWorkspaceEnforceAccessLevelAndSetCdrVersion(
         workspaceNamespace, workspaceId, WorkspaceAccessLevel.READER);
     if (workbenchConfigProvider.get().featureFlags.enableHasEhrData) {
-      return ResponseEntity.ok(new CriteriaMenuListResponse()
-          .items(cohortBuilderService.findCriteriaMenuByParentId(parentId)));
+      return ResponseEntity.ok(
+          new CriteriaMenuListResponse()
+              .items(cohortBuilderService.findCriteriaMenuByParentId(parentId)));
     } else {
       return ResponseEntity.ok(
           new CriteriaMenuListResponse()

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
@@ -353,6 +353,8 @@ public final class SearchGroupItemQueryBuilder {
             + String.format(DEMO_IN_SQL, DEMO_COLUMN_SQL_MAP.get(criteriaType), namedParameter);
       case DECEASED:
         return DEMO_BASE + DEC_SQL;
+      case HAS_EHR_DATA:
+        return String.format(HAS_DATA_SQL, "has_ehr_data");
       default:
         throw new BadRequestException(
             "Search unsupported for demographics type " + param.getType());

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -323,6 +323,8 @@ public class WorkbenchConfig {
     public boolean enableSasGKEApp;
     // If true, enable visual data explorer
     public boolean enableDataExplorer;
+    // If true, enable has EHR data
+    public boolean enableHasEhrData;
   }
 
   public static class ActionAuditConfig {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -73,5 +73,6 @@ public interface WorkbenchConfigMapper {
   @Mapping(target = "enableRStudioGKEApp", source = "config.featureFlags.enableRStudioGKEApp")
   @Mapping(target = "enableSasGKEApp", source = "config.featureFlags.enableSasGKEApp")
   @Mapping(target = "enableDataExplorer", source = "config.featureFlags.enableDataExplorer")
+  @Mapping(target = "enableHasEhrData", source = "config.featureFlags.enableHasEhrData")
   ConfigResponse toModel(WorkbenchConfig config, List<DbAccessModule> accessModules);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4863,7 +4863,7 @@ definitions:
       enableRStudioGKEApp:
         type: boolean
         default: false
-        description: Whether users are able to use the RStudio GKE app./criteria
+        description: Whether users are able to use the RStudio GKE app.
       enableSasGKEApp:
         type: boolean
         default: false

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4872,6 +4872,10 @@ definitions:
         type: boolean
         default: false
         description: Whether to enable visual data explorer.
+      enableHasEhrData:
+        type: boolean
+        default: false
+        description: Whether to enable has ehr data.
       tanagraBaseUrl:
         type: string
         description: The tanagra base url

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4863,7 +4863,7 @@ definitions:
       enableRStudioGKEApp:
         type: boolean
         default: false
-        description: Whether users are able to use the RStudio GKE app.
+        description: Whether users are able to use the RStudio GKE app./criteria
       enableSasGKEApp:
         type: boolean
         default: false
@@ -9137,6 +9137,7 @@ definitions:
     - SNOMED
     - VISIT
     - NONE
+    - HAS_EHR_DATA
   CriteriaSubType:
     type: string
     description: possible criteria types

--- a/ui/src/app/pages/data/cohort/cohort-search.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-search.tsx
@@ -360,7 +360,7 @@ export const CohortSearch = fp.flow(
         parentId: null,
         parameterId: '',
         type: CriteriaType.HAS_EHR_DATA.toString(),
-        name: 'Deceased',
+        name: 'Has EHR Data',
         group: false,
         domainId: Domain.PERSON.toString(),
         hasAttributes: false,

--- a/ui/src/app/pages/data/cohort/cohort-search.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-search.tsx
@@ -204,7 +204,9 @@ export const CohortSearch = fp.flow(
       } = this.props;
       // JSON stringify and parse prevents changes to selections from being passed to the cohortContext
       const selections = JSON.parse(JSON.stringify(item.searchParameters));
-      if (type === CriteriaType.DECEASED) {
+      if (type === CriteriaType.HAS_EHR_DATA) {
+        this.selectHasEhrData();
+      } else if (type === CriteriaType.DECEASED) {
         this.selectDeceased();
       } else if (domain.includes(Domain.FITBIT.toString())) {
         this.selectFitbit(domain, name);
@@ -351,6 +353,23 @@ export const CohortSearch = fp.flow(
       );
       this.setState({ toastVisible: true });
     };
+
+    selectHasEhrData() {
+      const param = {
+        id: null,
+        parentId: null,
+        parameterId: '',
+        type: CriteriaType.HAS_EHR_DATA.toString(),
+        name: 'Deceased',
+        group: false,
+        domainId: Domain.PERSON.toString(),
+        hasAttributes: false,
+        selectable: true,
+        attributes: [],
+      } as Selection;
+      AnalyticsTracker.CohortBuilder.SelectDemographics('Select Has EHR Data');
+      saveCriteria([param]);
+    }
 
     selectDeceased() {
       const param = {

--- a/ui/src/app/pages/data/cohort/utils.ts
+++ b/ui/src/app/pages/data/cohort/utils.ts
@@ -159,6 +159,9 @@ export function typeToTitle(_type: string): string {
     case CriteriaType[CriteriaType.SEX]:
       _type = 'Sex Assigned at Birth';
       break;
+    case CriteriaType[CriteriaType.HAS_EHR_DATA]:
+      _type = 'Has EHR Data';
+      break;
   }
   return _type;
 }


### PR DESCRIPTION
---
- Implemented `has_ehr_data` selection under `Demographics`
- Added SQL to get counts for  `has_ehr_data`
- Indexing build nedds to be run in test environment after this PR is merged
- I have manually tested the change to `cd_criteria_menu` in local docker environment  with
  - `"enableHasEhrData": true` 
https://github.com/all-of-us/workbench/assets/4452480/49cb466c-8bbc-4f50-8fd2-220fb16456dd
  - `"enableHasEhrData": false`
  

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
