### PR TITLE
[risk=no][RW-10361] Add Absorb API spec

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -170,6 +170,7 @@ swaggerSources {
     notebooks swagger3JavaClient("notebooks.yaml", "notebooks")
     jira swagger3JavaClient("jira.yaml", "jira")
     mandrill swagger3JavaClient("mandrill.yaml", "mandrill")
+    absorb swagger3JavaClient("absorb.yaml", "absorb")
     moodle swagger3JavaClient("moodle.yaml", "moodle")
     rdr swagger3JavaClient("rdr.yaml", "rdr", [
             '--model-name-prefix', 'Rdr'

--- a/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
@@ -1,0 +1,57 @@
+package org.pmiops.workbench;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.pmiops.workbench.absorb.api.AuthenticateApi;
+import org.pmiops.workbench.absorb.api.EnrollmentsApi;
+import org.pmiops.workbench.absorb.api.UsersApi;
+import org.pmiops.workbench.absorb.model.AuthenticationRequest;
+import org.pmiops.workbench.google.CloudStorageClient;
+import org.pmiops.workbench.google.DirectoryServiceImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+
+public class AbsorbAcceptanceTest extends BaseIntegrationTest {
+  @Autowired private CloudStorageClient cloudStorageClient;
+
+  @TestConfiguration
+  @ComponentScan(basePackageClasses = DirectoryServiceImpl.class)
+  static class Configuration {}
+
+  @Test
+  public void testGetCertificates() throws Exception {
+    // Setup: A user with this email exists and has completed both Absorb trainings in the
+    // test environment.
+    var email = "absorb_acceptance_test@fake-research-aou.org";
+
+    var config = cloudStorageClient.getAbsorbCredentials();
+    var apiKey = config.getString("apiKey");
+
+    // Obtain an access token
+    var accessToken =
+        new AuthenticateApi()
+            .restAuthenticationAuthenticate(
+                new AuthenticationRequest()
+                    .password(config.getString("password"))
+                    .username(config.getString("username"))
+                    .privateKey(apiKey),
+                apiKey);
+
+    // Find the user id
+    var users = new UsersApi().usersGetUsers(apiKey, accessToken, "username eq '" + email + "'");
+    assertThat(users.getUsers().size()).isEqualTo(1);
+    assertThat(users.getUsers().get(0).getUsername()).isEqualTo(email);
+
+    // Validate the user has completed two courses
+    var enrollments =
+        new EnrollmentsApi()
+            .enrollmentsGetUserEnrollments(
+                apiKey, accessToken, users.getUsers().get(0).getId(), null);
+    assertThat(enrollments.getEnrollments().size()).isEqualTo(2);
+    for (var enrollment : enrollments.getEnrollments()) {
+      assertThat(enrollment.getDateCompleted()).isNotNull();
+    }
+  }
+}

--- a/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.absorb.api.AuthenticateApi;
 import org.pmiops.workbench.absorb.api.EnrollmentsApi;
@@ -21,6 +22,7 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
   static class Configuration {}
 
   @Test
+  @Disabled("RW-11039")
   public void testGetCertificates() throws Exception {
     // Setup: A user with this email exists and has completed both Absorb trainings in the
     // test environment.

--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageClient.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageClient.java
@@ -50,6 +50,8 @@ public interface CloudStorageClient {
 
   void deleteBlob(BlobId blobId);
 
+  JSONObject getAbsorbCredentials();
+
   String getMoodleApiKey();
 
   String getCaptchaServerKey();

--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageClientImpl.java
@@ -39,6 +39,11 @@ public class CloudStorageClientImpl implements CloudStorageClient {
   }
 
   @Override
+  public JSONObject getAbsorbCredentials() {
+    return getCredentialsBucketJSON("absorb-credentials.json");
+  }
+
+  @Override
   public String getMoodleApiKey() {
     return getCredentialsBucketString(configProvider.get().moodle.credentialsKeyV2);
   }

--- a/api/src/main/resources/absorb.yaml
+++ b/api/src/main/resources/absorb.yaml
@@ -1,0 +1,255 @@
+# This spec is mostly manually adapted from the Swagger 2 spec corresponding to each
+# page of the docs. These can be found through Chrome's network tab while loading
+# one of the pages.
+# Example: https://aoudev.myabsorb.com/Areas/ApiDocumentation/V15/Data/RestAuthentication.json
+# However, these specs were imperfect and needed to be manually edited.
+
+openapi: 3.0.1
+info:
+  title: Absorb
+  description: "Service for Absorb Interactions. API documentation can be found at https://aoudev.myabsorb.com/v1_5-doc"
+  version: "1.0"
+servers:
+  - url: https://rest.myabsorb.com
+
+paths:
+  /authenticate:
+    post:
+      tags:
+        - "Authenticate"
+      summary: "Authenticates the user and provides an API token to use in subsequent API calls."
+      operationId: "RestAuthentication_Authenticate"
+      parameters:
+        - $ref: "#/components/parameters/ApiKey"
+      requestBody:
+        description: "The credentials required to authenticate with the API."
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthenticationRequest"
+      responses:
+        200:
+          description: "A unique authentication token used to make subsequent requests, valid for a limited time from when it was created."
+          content:
+            application/json:
+              schema:
+                type: "string"
+        400:
+          description: "The required body paramaters were not included."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericErrorResponse"
+        403:
+          description: "Portal disabled."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericErrorResponse"
+  /users:
+    get:
+      tags:
+        - "Users"
+      summary: "List users."
+      description: "Lists all selected LMS users that are available to the current, authenticated administrator."
+      operationId: "Users_GetUsers"
+      parameters:
+        - $ref: "#/components/parameters/ApiKey"
+        - $ref: "#/components/parameters/AccessToken"
+        - $ref: "#/components/parameters/Filter"
+      responses:
+        200:
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsersResource"
+        422:
+          description: "A validation error occured with the provided parameters."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericErrorResponse"
+  /users/{userId}/enrollments:
+    get:
+      tags:
+        - "Enrollments"
+      summary: "List course enrollments for specific user."
+      description: "Supports pagination, filtering, and sorting."
+      operationId: "Enrollments_GetUserEnrollments"
+      parameters:
+        - $ref: "#/components/parameters/ApiKey"
+        - $ref: "#/components/parameters/AccessToken"
+        - name: "userId"
+          schema:
+            type: "string"
+            format: "guid"
+          in: "path"
+          required: true
+          description: "The user ID."
+        - $ref: "#/components/parameters/Filter"
+      responses:
+        200:
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserCourseEnrollmentsResource"
+        404:
+          description: "User not found."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericErrorResponse"
+        422:
+          description: "A validation error occured with the provided parameters."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericErrorResponse"
+
+components:
+  parameters:
+    ApiKey:
+      name: "x-api-key"
+      in: "header"
+      schema:
+        type: "string"
+      required: true
+    AccessToken:
+      name: "Authorization"
+      in: "header"
+      schema:
+        type: "string"
+      required: true
+    Filter:
+      name: "_filter"
+      in: "query"
+      schema:
+        type: "string"
+      description: "One or more filter operations to be performed on the collection. The referenced fields must allow filtering. See the respective report's schema for which fields can be filtered. Supports most of the [OData filter syntax](http://docs.oasis-open.org/odata/odata/v4.01/cs01/part2-url-conventions/odata-v4.01-cs01-part2-url-conventions.html#sec_SystemQueryOptionfilter). Supported operations: eq, ne, gt, ge, lt, le, and, or, not, (). Supported functions: substringof('value',fieldName), endswith(fieldName,'value'), startswith(fieldName,'value'), tolower(fieldName), toupper(fieldName). Examples: _filter=`firstname eq 'Jeffrey'`, _filter=`id eq guid'a14c149a-2ce0-41d4-b532-02189ad3cb22'`, _filter=`startsWith(lastname,'leb') or dateAdded ge datetime'1998-03-06T20:38:07Z'`"
+  schemas:
+    GenericErrorResponse:
+      type: "object"
+      description: "The return type for non-200 responses"
+      properties:
+        validations:
+          type: "array"
+          description: "The validations (if any) which caused the error."
+          items:
+            type: "string"
+        code:
+          description: "The status code returned."
+          allOf:
+            - type: "integer"
+        message:
+          type: "string"
+          description: "The error message."
+        term:
+          type: "string"
+          description: "The general error term."
+        _meta:
+          type: "object"
+          description: "A list of meta data (if any). "
+          additionalProperties:
+            type: "string"
+    AuthenticationRequest:
+      type: "object"
+      required:
+        - "username"
+        - "password"
+        - "privateKey"
+      properties:
+        username:
+          type: "string"
+          description: "The login username of the user."
+          minLength: 1
+        password:
+          type: "string"
+          description: "The login password of the user."
+          minLength: 1
+        privateKey:
+          type: "string"
+          description: "A unique key identifying the client. System owners can request their key."
+          format: "guid"
+          minLength: 1
+    UsersResource:
+      type: "object"
+      properties:
+        totalItems:
+          type: "integer"
+          description: "The total number of items returned"
+          format: "int32"
+        limit:
+          type: "integer"
+          description: "The page size."
+          format: "int32"
+        offset:
+          type: "integer"
+          description: "The page number."
+          format: "int32"
+        returnedItems:
+          type: "integer"
+          description: "The number of items returned."
+          format: "int32"
+        users:
+          type: "array"
+          description: "The paged collection of resources."
+          items:
+            $ref: "#/components/schemas/UserResource"
+    UserResource:
+      type: object
+      properties:
+        id:
+          type: "string"
+          description: '`Filterable` \n\nThe unique user identifier.'
+          format: "guid"
+        username:
+          type: "string"
+          description: '`Default Sort` `Sortable` `Filterable` \n\nThe unique username.'
+    UserCourseEnrollmentsResource:
+      type: "object"
+      description: "Represents a collection of UserCourseEnrollmentResource."
+      properties:
+        totalItems:
+          type: "integer"
+          description: "The total number of items in the unbounded collection"
+          format: "int32"
+        returnedItems:
+          type: "integer"
+          description: "The number of items in the bound collection being returned"
+          format: "int32"
+        limit:
+          type: "integer"
+          description: "The current page size for the collection"
+          format: "int32"
+        offset:
+          type: "integer"
+          description: "The current offset for the collection"
+          format: "int32"
+        enrollments:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/UserCourseEnrollmentResource"
+    UserCourseEnrollmentResource:
+      type: "object"
+      description: "Represents information about a course enrollment."
+      properties:
+        id:
+          type: "string"
+          description: "`Filterable` \n\nEnrollment identifier."
+          format: "guid"
+        courseId:
+          type: "string"
+          description: "`Filterable` \n\nCourse identifier."
+          format: "guid"
+        courseName:
+          type: "string"
+          description: "`Default Sort` `Sortable` `Filterable` \n\nName of the course."
+        dateCompleted:
+          type: "string"
+          description: "`Sortable` `Filterable` \n\nThe date the enrollment was completed."
+        isActive:
+          type: "boolean"
+          description: "`Sortable` `Filterable` \n\nIndicates if the enrollment is the current (active) enrollment or a historical enrollment."


### PR DESCRIPTION
Add Absorb API spec.

This will be used to query for course completion information instead of Moodle. As of now, it is unused.

This also adds an acceptance test for Absorb that hits actual Absorb endpoints, which I used while creating the spec. If this seems unnecessary, unhelpful, or likely to flake, then I will remove it.

I found the fastest development loop here to be:
- Change absorb.yaml
- Run `./gradlew generateSwaggerCodeAbsorb`
- Run the acceptance test

Notes from a session with the Absorb API support team:
- We should use "enrollments," not completion "certificates."
  - Certificates map to enrollments, not courses, provide no additional information that we would use.
  - Enrollments make re-enrollments clearer (see below)
  - Certificates have a delay and are tied to enrollments, not courses
- When a user retakes a course a new enrollment will be created. The new enrollment "isActive" and the "historic" enrollment becomes not "isActive." There can only be one enrollment marked as active per course.
- There is always at least one active enrollment, if there are any enrollments for a course
- There was confusion over the behavior or the “get enrollment (singular) for course” endpoint. They claimed it may return a list if the user has multiple enrollments (active and historic), but that would be a massive violation of the swagger contract so I'm not sure their interpretation was correct. However, the docs do not specify which enrollment is returned. We agreed that using the "list enrollments" endpoint with an "isActive" filter would be sufficient for our use case.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.