### PR TITLE
[risk=no][RW-10361] Redirect users to Absorb for initial training

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -90,6 +90,11 @@
   "zendesk": {
     "host": "https:\/\/aousupporthelp1634849601.zendesk.com"
   },
+  "absorb": {
+    "enabledForNewUsers": false,
+    "samlIdentityProviderId": "C03q5hexf",
+    "samlServiceProviderId": "133137951028"
+  },
   "moodle": {
     "host": "aoudev.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -90,6 +90,11 @@
   "zendesk": {
     "host": "https:\/\/aoupreprodsupporthelp.zendesk.com"
   },
+  "absorb": {
+    "enabledForNewUsers": false,
+    "samlIdentityProviderId": "TODO",
+    "samlServiceProviderId": "TODO"
+  },
   "moodle": {
     "host": "aou.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -90,6 +90,11 @@
   "zendesk": {
     "host": "https:\/\/aousupporthelp.zendesk.com"
   },
+  "absorb": {
+    "enabledForNewUsers": false,
+    "samlIdentityProviderId": "TODO",
+    "samlServiceProviderId": "TODO"
+  },
   "moodle": {
     "host": "aou.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -90,6 +90,11 @@
   "zendesk": {
     "host": "https:\/\/aousupporthelp1634849601.zendesk.com"
   },
+  "absorb": {
+    "enabledForNewUsers": false,
+    "samlIdentityProviderId": "C03q5hexf",
+    "samlServiceProviderId": "133137951028"
+  },
   "moodle": {
     "host": "aou.nnlm.gov",
     "credentialsKeyV2": "moodle-prod-key-v2.txt"

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -90,6 +90,11 @@
   "zendesk": {
     "host": "https:\/\/aousupporthelp1634849601.zendesk.com"
   },
+  "absorb": {
+    "enabledForNewUsers": false,
+    "samlIdentityProviderId": "C03q5hexf",
+    "samlServiceProviderId": "133137951028"
+  },
   "moodle": {
     "host": "aoudev.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -90,6 +90,11 @@
   "zendesk": {
     "host": "https:\/\/aousupporthelp1634849601.zendesk.com"
   },
+  "absorb": {
+    "enabledForNewUsers": false,
+    "samlIdentityProviderId": "C03q5hexf",
+    "samlServiceProviderId": "133137951028"
+  },
   "moodle": {
     "host": "aoudev.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -368,6 +368,11 @@ public class ProfileController implements ProfileApiDelegate {
   }
 
   @Override
+  public ResponseEntity<Boolean> useAbsorb() {
+    return ResponseEntity.ok(complianceTrainingService.useAbsorb());
+  }
+
+  @Override
   public ResponseEntity<Profile> syncEraCommonsStatus() {
     userService.syncEraCommonsStatus();
     return getProfileResponse(userProvider.get());

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingService.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingService.java
@@ -6,4 +6,6 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 public interface ComplianceTrainingService {
   public DbUser syncComplianceTrainingStatus()
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException;
+
+  public boolean useAbsorb();
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -23,6 +23,7 @@ public class WorkbenchConfig {
   public ServerConfig server;
   public AdminConfig admin;
   public MandrillConfig mandrill;
+  public AbsorbConfig absorb;
   public MoodleConfig moodle;
   public TanagraConfig tanagra;
   public ZendeskConfig zendesk;
@@ -59,6 +60,7 @@ public class WorkbenchConfig {
     config.googleCloudStorageService = new GoogleCloudStorageServiceConfig();
     config.googleDirectoryService = new GoogleDirectoryServiceConfig();
     config.mandrill = new MandrillConfig();
+    config.absorb = new AbsorbConfig();
     config.moodle = new MoodleConfig();
     config.offlineBatch = new OfflineBatchConfig();
     config.ras = new RasConfig();
@@ -252,6 +254,12 @@ public class WorkbenchConfig {
   public static class MandrillConfig {
     public String fromEmail;
     public int sendRetries;
+  }
+
+  public static class AbsorbConfig {
+    public boolean enabledForNewUsers;
+    public String samlIdentityProviderId;
+    public String samlServiceProviderId;
   }
 
   public static class MoodleConfig {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -53,6 +53,8 @@ public interface WorkbenchConfigMapper {
       source = "config.billing.defaultFreeCreditsDollarLimit")
   @Mapping(target = "enableComplianceTraining", source = "config.access.enableComplianceTraining")
   @Mapping(target = "complianceTrainingHost", source = "config.moodle.host")
+  @Mapping(target = "absorbSamlIdentityProviderId", source = "config.absorb.samlIdentityProviderId")
+  @Mapping(target = "absorbSamlServiceProviderId", source = "config.absorb.samlServiceProviderId")
   @Mapping(
       target = "complianceTrainingRenewalLookback",
       source = "config.access.renewal.trainingLookbackPeriod")

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -534,6 +534,17 @@ paths:
           description: Internal Error
           schema:
             "$ref": "#/definitions/ErrorResponse"
+  "/v1/account/use-absorb":
+    get:
+      tags:
+        - profile
+      summary: Whether the user should use Absorb for compliance training
+      operationId: useAbsorb
+      responses:
+        200:
+          description: Whether the user should use Absorb for compliance training
+          schema:
+            type: boolean
   "/v1/account/sync-era-commons-status":
     post:
       tags:
@@ -4815,6 +4826,12 @@ definitions:
       complianceTrainingHost:
         type: string
         description: The hostname for constructing the compliance training URL.
+      absorbSamlIdentityProviderId:
+        type: string
+        description: The SAML identity provider ID for Absorb.
+      absorbSamlServiceProviderId:
+        type: string
+        description: The SAML service provider ID for Absorb.
       enableEraCommons:
         type: boolean
         default: false

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -1,12 +1,12 @@
 import {
   AccessModule,
   AdminTableUser,
+  AdminUserListResponse,
   InstitutionalRole,
   Profile,
   ProfileApi,
   UsernameTakenResponse,
 } from 'generated/fetch';
-import { AdminUserListResponse } from 'generated/fetch';
 
 import { AccessTierShortNames } from 'app/utils/access-tiers';
 
@@ -154,5 +154,9 @@ export class ProfileApiStub extends ProfileApi {
     return Promise.resolve({
       isTaken: false,
     });
+  }
+
+  public useAbsorb() {
+    return Promise.resolve(false);
   }
 }


### PR DESCRIPTION
Redirect users to Absorb for initial training.

This PR only implements redirecting users to the right place, **not** the full flow. Support for the synchronization endpoint will be added in a future PR.

This can be manually tested by clicking on either training access module when the feature flag is set to true and the user has no training modules completed. To actually access Absorb, if desired, there are currently some additional steps: See "To manually test this..." in https://github.com/all-of-us/workbench/pull/7968.

I have `This change modifies the UI` unchecked because the feature flag is disabled in all environments.

This PR does not indicate which course a user should take. Ideally, we would link directly to courses, however, this has proven difficult to combine with SSO. If we cannot find a way to link to courses, we can explain to users what course they need to take (comparable to our ID.me approach), though that's less preferred. This PR allows for either approach and I plan on implementing that as a follow-up after a conversation with PM/UX.

[Feature flag removal ticket](https://precisionmedicineinitiative.atlassian.net/browse/RW-11040). Enabling this is mentioned in the [prod ticket](https://precisionmedicineinitiative.atlassian.net/browse/RW-10906).

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [x] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [x] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.