### PR TITLE
[risk=low][RW-10991] Extract and test throwRuntimeNotFound() to better understand runtime logic

### DIFF
--- a/ui/src/app/utils/leo-runtime-initializer.spec.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.spec.tsx
@@ -375,7 +375,7 @@ describe('RuntimeInitializer', () => {
 
 // intended to document the current behavior of this peculiar method
 describe(throwRuntimeNotFound.name, () => {
-  it('should throw the preset default if targetRuntime and currentRuntime both do not exist', () => {
+  it('should use the preset default if targetRuntime and currentRuntime both do not exist', () => {
     const currentRuntime = undefined;
     const gcePersistentDisk = undefined;
 

--- a/ui/src/app/utils/leo-runtime-initializer.spec.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.spec.tsx
@@ -19,7 +19,7 @@ import {
   InitialRuntimeNotFoundError,
   LeoRuntimeInitializer,
   LeoRuntimeInitializerOptions,
-  throwIfTargetRuntimeNotFound,
+  throwRuntimeNotFound,
 } from 'app/utils/leo-runtime-initializer';
 import { serverConfigStore } from 'app/utils/stores';
 import { RuntimesApi as LeoRuntimesApi } from 'notebooks-generated/fetch';
@@ -374,32 +374,14 @@ describe('RuntimeInitializer', () => {
 });
 
 // intended to document the current behavior of this peculiar method
-describe(throwIfTargetRuntimeNotFound.name, () => {
-  it('should not throw if targetRuntime exists', () => {
-    const targetRuntime = defaultRuntimeWithPd();
-    const currentRuntime = undefined;
-    const gcePersistentDisk = undefined;
-    expect(() =>
-      throwIfTargetRuntimeNotFound(
-        targetRuntime,
-        currentRuntime,
-        gcePersistentDisk
-      )
-    ).not.toThrow();
-  });
-
+describe(throwRuntimeNotFound.name, () => {
   it('should throw the preset default if targetRuntime and currentRuntime both do not exist', () => {
-    const targetRuntime = undefined;
     const currentRuntime = undefined;
     const gcePersistentDisk = undefined;
 
     try {
       const callSucceeded = true;
-      throwIfTargetRuntimeNotFound(
-        targetRuntime,
-        currentRuntime,
-        gcePersistentDisk
-      );
+      throwRuntimeNotFound(currentRuntime, gcePersistentDisk);
       expect(callSucceeded).toBeFalsy();
     } catch (e) {
       expect(e).toBeInstanceOf(InitialRuntimeNotFoundError);
@@ -410,7 +392,6 @@ describe(throwIfTargetRuntimeNotFound.name, () => {
   });
 
   it('should apply a preset override if targetRuntime does not exist but currentRuntime exists and is not DELETED', () => {
-    const targetRuntime = undefined;
     const currentRuntime = {
       ...defaultRuntimeWithPd(),
       gceWithPdConfig: {
@@ -446,11 +427,7 @@ describe(throwIfTargetRuntimeNotFound.name, () => {
 
     try {
       const callSucceeded = true;
-      throwIfTargetRuntimeNotFound(
-        targetRuntime,
-        currentRuntime,
-        gcePersistentDisk
-      );
+      throwRuntimeNotFound(currentRuntime, gcePersistentDisk);
       expect(callSucceeded).toBeFalsy();
     } catch (e) {
       expect(e).toBeInstanceOf(InitialRuntimeNotFoundError);
@@ -473,7 +450,6 @@ describe(throwIfTargetRuntimeNotFound.name, () => {
     'should apply a preset override and connect an existing disk when: ' +
       'targetRuntime does not exist, currentRuntime exists, currentRuntime is DELETED',
     () => {
-      const targetRuntime = undefined;
       const currentRuntime = {
         ...defaultRuntime(),
         status: RuntimeStatus.DELETED,
@@ -505,11 +481,7 @@ describe(throwIfTargetRuntimeNotFound.name, () => {
 
       try {
         const callSucceeded = true;
-        throwIfTargetRuntimeNotFound(
-          targetRuntime,
-          currentRuntime,
-          gcePersistentDisk
-        );
+        throwRuntimeNotFound(currentRuntime, gcePersistentDisk);
         expect(callSucceeded).toBeFalsy();
       } catch (e) {
         expect(e).toBeInstanceOf(InitialRuntimeNotFoundError);
@@ -538,7 +510,6 @@ describe(throwIfTargetRuntimeNotFound.name, () => {
     'should apply a preset override with an undefined persistent disk name when: ' +
       'targetRuntime does not exist, currentRuntime exists, currentRuntime is DELETED, gcePersistentDisk does not exist',
     () => {
-      const targetRuntime = undefined;
       const currentRuntime = {
         ...defaultRuntime(),
         status: RuntimeStatus.DELETED,
@@ -570,11 +541,7 @@ describe(throwIfTargetRuntimeNotFound.name, () => {
 
       try {
         const callSucceeded = true;
-        throwIfTargetRuntimeNotFound(
-          targetRuntime,
-          currentRuntime,
-          gcePersistentDisk
-        );
+        throwRuntimeNotFound(currentRuntime, gcePersistentDisk);
         expect(callSucceeded).toBeFalsy();
       } catch (e) {
         expect(e).toBeInstanceOf(InitialRuntimeNotFoundError);

--- a/ui/src/app/utils/runtime-presets.ts
+++ b/ui/src/app/utils/runtime-presets.ts
@@ -70,7 +70,7 @@ export const applyPresetOverride = (runtime) => {
     return {
       ...runtime,
       gceConfig,
-      // restore the original PD name, which will cause a creation request to attach it to the new runtime
+      // restore the original PD name if it exists, which will cause a creation request to attach it to the new runtime
       gceWithPdConfig:
         gceWithPdConfig &&
         fp.set(

--- a/ui/src/testing/stubs/runtime-api-stub.ts
+++ b/ui/src/testing/stubs/runtime-api-stub.ts
@@ -1,6 +1,7 @@
 import {
   DataprocConfig,
   GceConfig,
+  GceWithPdConfig,
   Runtime,
   RuntimeApi,
   RuntimeConfigurationType,
@@ -25,6 +26,11 @@ export const defaultGceConfig = (): GceConfig => ({
   machineType: 'n1-standard-4',
 });
 
+export const defaultGceWithPdConfig = (): GceWithPdConfig => ({
+  machineType: 'n1-standard-4',
+  persistentDisk: stubDisk(),
+});
+
 export const defaultDataprocConfig = (): DataprocConfig => ({
   masterMachineType: 'n1-standard-4',
   masterDiskSize: DATAPROC_MIN_DISK_SIZE_GB,
@@ -44,6 +50,12 @@ export const defaultRuntime = (): Runtime => ({
   configurationType: RuntimeConfigurationType.GENERAL_ANALYSIS,
   gceConfig: defaultGceConfig(),
   errors: [],
+});
+
+export const defaultRuntimeWithPd = (): Runtime => ({
+  ...defaultRuntime(),
+  gceConfig: undefined,
+  gceWithPdConfig: defaultGceWithPdConfig(),
 });
 
 export class RuntimeApiStub extends RuntimeApi {


### PR DESCRIPTION
This is part of my effort to understand runtime logic, as well as fixing the bug which can create GCE VMs without PD.  This will probably make more sense in the context of that change, which is coming soon.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
