### PR TITLE
[risk=low][RW-11048][RW-10764] Update UI module date logic to treat the wrong DUCC version as incomplete

### DIFF
--- a/ui/src/app/components/data-user-code-of-conduct.tsx
+++ b/ui/src/app/components/data-user-code-of-conduct.tsx
@@ -157,7 +157,7 @@ const InitialsAgreement = (props: InitialsProps) => (
         onChange={props.onChange}
         placeholder='INITIALS'
         dataTestId='ducc-initials-input'
-        style={{ width: '4ex', textAlign: 'center', padding: 0 }}
+        style={{ width: '4rem', textAlign: 'center', padding: 0 }}
       />
     )}
     <div style={{ marginLeft: '0.75rem' }}>{props.children}</div>

--- a/ui/src/app/pages/access/controlled-tier-card.tsx
+++ b/ui/src/app/pages/access/controlled-tier-card.tsx
@@ -49,7 +49,7 @@ const ControlledTierEraModule = (props: {
   const status = getAccessModuleStatusByName(profile, moduleName);
 
   // module is not clickable if (user is ineligible for CT) or (user has completed/bypassed module already)
-  const active = eligible && !isCompliant(status);
+  const active = eligible && !isCompliant(status, profile.duccSignedVersion);
 
   return (
     <Module

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -436,7 +436,10 @@ const incompleteModules = (
 ): AccessModule[] =>
   modules.filter(
     (moduleName) =>
-      !isCompliant(getAccessModuleStatusByName(profile, moduleName)) ||
+      !isCompliant(
+        getAccessModuleStatusByName(profile, moduleName),
+        profile.duccSignedVersion
+      ) ||
       (pageMode === DARPageMode.ANNUAL_RENEWAL &&
         !isRenewalCompleteForModule(
           getAccessModuleStatusByNameOrEmpty(
@@ -644,12 +647,11 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
       pageMode
     );
 
+    const moduleStatus = getAccessModuleStatusByName(profile, ctModule);
     const ctNeedsRenewal =
       pageMode === DARPageMode.ANNUAL_RENEWAL &&
-      isCompliant(getAccessModuleStatusByName(profile, ctModule)) &&
-      !isRenewalCompleteForModule(
-        getAccessModuleStatusByName(profile, ctModule)
-      );
+      isCompliant(moduleStatus, profile.duccSignedVersion) &&
+      !isRenewalCompleteForModule(moduleStatus);
     const showCompletionBanner = profile && !nextRequired && !ctNeedsRenewal;
 
     const rtCard = (

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -445,7 +445,8 @@ const incompleteModules = (
           getAccessModuleStatusByNameOrEmpty(
             profile.accessModules.modules,
             moduleName
-          )
+          ),
+          profile.duccSignedVersion
         ))
   );
 
@@ -651,7 +652,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
     const ctNeedsRenewal =
       pageMode === DARPageMode.ANNUAL_RENEWAL &&
       isCompliant(moduleStatus, profile.duccSignedVersion) &&
-      !isRenewalCompleteForModule(moduleStatus);
+      !isRenewalCompleteForModule(moduleStatus, profile.duccSignedVersion);
     const showCompletionBanner = profile && !nextRequired && !ctNeedsRenewal;
 
     const rtCard = (

--- a/ui/src/app/pages/access/identity-help-text.tsx
+++ b/ui/src/app/pages/access/identity-help-text.tsx
@@ -45,7 +45,8 @@ export const IdentityHelpText = (props: {
 
   // don't return help text if complete or bypassed
   const needsHelp = !isCompliant(
-    getAccessModuleStatusByName(profile, AccessModule.IDENTITY)
+    getAccessModuleStatusByName(profile, AccessModule.IDENTITY),
+    profile.duccSignedVersion
   );
 
   if (!needsHelp) {

--- a/ui/src/app/pages/access/login-gov-help-text.tsx
+++ b/ui/src/app/pages/access/login-gov-help-text.tsx
@@ -39,7 +39,8 @@ export const LoginGovHelpText = (props: {
 
   // don't return help text if complete or bypassed
   const needsHelp = !isCompliant(
-    getAccessModuleStatusByName(profile, AccessModule.IDENTITY)
+    getAccessModuleStatusByName(profile, AccessModule.IDENTITY),
+    profile.duccSignedVersion
   );
 
   return (

--- a/ui/src/app/pages/access/module.tsx
+++ b/ui/src/app/pages/access/module.tsx
@@ -100,7 +100,7 @@ export const Module = (props: {
       >
         <ModuleIcon
           {...{ moduleName, eligible }}
-          completedOrBypassed={isCompliant(status)}
+          completedOrBypassed={isCompliant(status, profile.duccSignedVersion)}
         />
         <FlexColumn style={{ flex: 1 }}>
           <div
@@ -123,8 +123,10 @@ export const Module = (props: {
               }}
             />
           </div>
-          {isCompliant(status) && (
-            <div style={styles.moduleDate}>{getStatusText(status)}</div>
+          {isCompliant(status, profile.duccSignedVersion) && (
+            <div style={styles.moduleDate}>
+              {getStatusText(status, profile.duccSignedVersion)}
+            </div>
           )}
         </FlexColumn>
       </ModuleBox>

--- a/ui/src/app/pages/access/modules-for-annual-renewal.tsx
+++ b/ui/src/app/pages/access/modules-for-annual-renewal.tsx
@@ -19,6 +19,7 @@ import {
   computeRenewalDisplayDates,
   getAccessModuleConfig,
   getAccessModuleStatusByNameOrEmpty,
+  isBypassed,
   isRenewalCompleteForModule,
   redirectToControlledTraining,
   redirectToRegisteredTraining,
@@ -169,6 +170,7 @@ interface ActionButtonInterface {
   onClick: Function;
   disabled?: boolean;
   style?: React.CSSProperties;
+  duccSignedVersion: number;
 }
 
 const ActionButton = ({
@@ -178,12 +180,12 @@ const ActionButton = ({
   onClick,
   disabled,
   style,
+  duccSignedVersion,
 }: ActionButtonInterface) => {
-  const wasBypassed = !!moduleStatus?.bypassEpochMillis;
-  return isRenewalCompleteForModule(moduleStatus) ? (
+  return isRenewalCompleteForModule(moduleStatus, duccSignedVersion) ? (
     <CompletedOrBypassedButton
       completedText={completedButtonText}
-      wasBypassed={wasBypassed}
+      wasBypassed={isBypassed(moduleStatus)}
       style={style}
     />
   ) : (
@@ -202,23 +204,23 @@ const ActionButton = ({
   );
 };
 
-export const RenewalCardBody = (props: {
+interface RenewalCardBodyProps {
   moduleStatus: AccessModuleStatus;
   setLoading: (boolean) => void;
-  hide?: boolean;
   textStyle?: CSSProperties;
   radioButtonStyle?: CSSProperties;
   showTimeEstimate?: boolean;
-}) => {
-  const {
-    moduleStatus,
-    setLoading,
-    hide,
-    textStyle,
-    radioButtonStyle,
-    showTimeEstimate = false,
-  } = props;
+  duccSignedVersion: number;
+}
 
+export const RenewalCardBody = ({
+  moduleStatus,
+  setLoading,
+  textStyle,
+  radioButtonStyle,
+  showTimeEstimate = false,
+  duccSignedVersion,
+}: RenewalCardBodyProps) => {
   const [, navigateByUrl] = useNavigation();
   const noReportId = useId();
   const reportId = useId();
@@ -276,9 +278,9 @@ export const RenewalCardBody = (props: {
           >
             <TimeEstimate />
             <ActionButton
+              {...{ moduleStatus, duccSignedVersion }}
               actionButtonText='Review'
               completedButtonText='Confirmed'
-              moduleStatus={moduleStatus}
               onClick={() =>
                 navigateByUrl('profile', { queryParams: { renewal: 1 } })
               }
@@ -315,7 +317,10 @@ export const RenewalCardBody = (props: {
                 <RadioButton
                   data-test-id='nothing-to-report'
                   id={noReportId}
-                  disabled={isRenewalCompleteForModule(moduleStatus)}
+                  disabled={isRenewalCompleteForModule(
+                    moduleStatus,
+                    duccSignedVersion
+                  )}
                   style={radioButtonStyle}
                   checked={publications === true}
                   onChange={() => setPublications(true)}
@@ -328,7 +333,10 @@ export const RenewalCardBody = (props: {
                 <RadioButton
                   data-test-id='report-submitted'
                   id={reportId}
-                  disabled={isRenewalCompleteForModule(moduleStatus)}
+                  disabled={isRenewalCompleteForModule(
+                    moduleStatus,
+                    duccSignedVersion
+                  )}
                   style={radioButtonStyle}
                   checked={publications === false}
                   onChange={() => setPublications(false)}
@@ -347,9 +355,9 @@ export const RenewalCardBody = (props: {
             >
               <TimeEstimate />
               <ActionButton
+                {...{ moduleStatus, duccSignedVersion }}
                 actionButtonText='Confirm'
                 completedButtonText='Confirmed'
-                moduleStatus={moduleStatus}
                 onClick={async () => {
                   setLoading(true);
                   await confirmPublications();
@@ -374,7 +382,7 @@ export const RenewalCardBody = (props: {
               to understand the privacy safeguards and the compliance
               requirements for using the <AoU /> Registered Tier Dataset.
             </div>
-            {!isRenewalCompleteForModule(moduleStatus) && (
+            {!isRenewalCompleteForModule(moduleStatus, duccSignedVersion) && (
               <div
                 style={{
                   ...renewalStyle.complianceTrainingExpiring,
@@ -395,15 +403,15 @@ export const RenewalCardBody = (props: {
           >
             <TimeEstimate />
             <ActionButton
+              {...{ moduleStatus, duccSignedVersion }}
               actionButtonText='Complete Training'
               completedButtonText='Completed'
-              moduleStatus={moduleStatus}
               onClick={() => {
                 setTrainingRefreshButtonDisabled(false);
                 redirectToRegisteredTraining();
               }}
             />
-            {!isRenewalCompleteForModule(moduleStatus) && (
+            {!isRenewalCompleteForModule(moduleStatus, duccSignedVersion) && (
               <Button
                 disabled={trainingRefreshButtonDisabled}
                 onClick={async () => {
@@ -435,7 +443,7 @@ export const RenewalCardBody = (props: {
               to understand the privacy safeguards and the compliance
               requirements for using the <AoU /> Controlled Tier Dataset.
             </div>
-            {!isRenewalCompleteForModule(moduleStatus) && (
+            {!isRenewalCompleteForModule(moduleStatus, duccSignedVersion) && (
               <div
                 style={{
                   ...renewalStyle.complianceTrainingExpiring,
@@ -456,15 +464,15 @@ export const RenewalCardBody = (props: {
           >
             <TimeEstimate />
             <ActionButton
+              {...{ moduleStatus, duccSignedVersion }}
               actionButtonText='Complete Training'
               completedButtonText='Completed'
-              moduleStatus={moduleStatus}
               onClick={() => {
                 setTrainingRefreshButtonDisabled(false);
                 redirectToControlledTraining();
               }}
             />
-            {!isRenewalCompleteForModule(moduleStatus) && (
+            {!isRenewalCompleteForModule(moduleStatus, duccSignedVersion) && (
               <Button
                 disabled={trainingRefreshButtonDisabled}
                 onClick={async () => {
@@ -505,9 +513,9 @@ export const RenewalCardBody = (props: {
           >
             <TimeEstimate />
             <ActionButton
+              {...{ moduleStatus, duccSignedVersion }}
               actionButtonText='View & Sign'
               completedButtonText='Completed'
-              moduleStatus={moduleStatus}
               onClick={() =>
                 navigateByUrl('data-code-of-conduct', {
                   queryParams: { renewal: 1 },
@@ -523,7 +531,7 @@ export const RenewalCardBody = (props: {
   return (
     <div style={renewalStyle.moduleContainer}>
       <div style={{ gridArea: 'checkbox' }}>
-        {isRenewalCompleteForModule(moduleStatus) ? (
+        {isRenewalCompleteForModule(moduleStatus, duccSignedVersion) ? (
           <CheckCircle color={colors.success} style={styles.renewalStatus} />
         ) : (
           <Circle color={'#cbcbcb'} style={styles.renewalStatus} />
@@ -532,32 +540,26 @@ export const RenewalCardBody = (props: {
       <div style={{ gridArea: 'title', fontWeight: 500 }}>
         <AARTitleComponent />
       </div>
-      {!hide && module}
+      {module}
     </div>
   );
 };
 
 export const ModulesForAnnualRenewal = (props: RenewalCardProps) => {
   const { profile, modules } = props;
-  const showingStyle = {
+  const baseStyle: CSSProperties = {
     ...styles.clickableModuleBox,
     ...styles.clickableModuleText,
-  };
-  const hiddenStyle = {
-    ...styles.backgroundModuleBox,
-    ...styles.backgroundModuleText,
   };
   return (
     <FlexColumn style={styles.modulesContainer}>
       {modules.map((moduleName, index) => {
-        // TODO RW-7797.  Until then, hardcode
-        const showModule = true;
         return (
           <FlexColumn
             data-test-id={`module-${moduleName}`}
             key={moduleName}
             style={{
-              ...(showModule ? showingStyle : hiddenStyle),
+              ...baseStyle,
               ...{
                 marginTop:
                   index > 0 ||
@@ -575,8 +577,8 @@ export const ModulesForAnnualRenewal = (props: RenewalCardProps) => {
               setLoading={() => {}}
               textStyle={{ fontSize: '0.9rem' }}
               radioButtonStyle={{ marginRight: '0.5em' }}
-              hide={!showModule}
               showTimeEstimate={true}
+              duccSignedVersion={profile.duccSignedVersion}
             />
           </FlexColumn>
         );

--- a/ui/src/app/pages/access/modules-for-annual-renewal.tsx
+++ b/ui/src/app/pages/access/modules-for-annual-renewal.tsx
@@ -231,8 +231,10 @@ export const RenewalCardBody = ({
   const { AARTitleComponent, renewalTimeEstimate } = getAccessModuleConfig(
     moduleStatus.moduleName
   );
-  const { lastConfirmedDate, nextReviewDate } =
-    computeRenewalDisplayDates(moduleStatus);
+  const { lastConfirmedDate, nextReviewDate } = computeRenewalDisplayDates(
+    moduleStatus,
+    duccSignedVersion
+  );
   const TimeEstimate = () =>
     showTimeEstimate ? (
       <FlexColumn style={{ alignItems: 'center' }}>

--- a/ui/src/app/pages/admin/user/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-common.tsx
@@ -187,8 +187,10 @@ const getModuleStatus = (
   profile: Profile,
   moduleName: AccessModule
 ): AccessRenewalStatus =>
-  computeRenewalDisplayDates(getAccessModuleStatusByName(profile, moduleName))
-    .moduleStatus;
+  computeRenewalDisplayDates(
+    getAccessModuleStatusByName(profile, moduleName),
+    profile.duccSignedVersion
+  ).moduleStatus;
 
 const moduleStatusStyle = (moduleStatus) =>
   cond(

--- a/ui/src/app/pages/admin/user/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-common.tsx
@@ -46,6 +46,7 @@ import {
   computeRenewalDisplayDates,
   getAccessModuleConfig,
   getAccessModuleStatusByName,
+  isBypassed,
 } from 'app/utils/access-utils';
 import { formatDate } from 'app/utils/dates';
 import { getRoleOptions } from 'app/utils/institutions';
@@ -210,19 +211,11 @@ const displayModuleStatusAndDate = (
   profile: Profile,
   moduleName: AccessModule,
   child: string
-): JSX.Element => {
-  return (
-    <div style={moduleStatusStyle(getModuleStatus(profile, moduleName))}>
-      {child}
-    </div>
-  );
-};
-
-export const isBypassed = (
-  profile: Profile,
-  moduleName: AccessModule
-): boolean =>
-  !!getAccessModuleStatusByName(profile, moduleName)?.bypassEpochMillis;
+): JSX.Element => (
+  <div style={moduleStatusStyle(getModuleStatus(profile, moduleName))}>
+    {child}
+  </div>
+);
 
 // Some modules may never expire (eg GOOGLE TWO STEP NOTIFICATION, ERA COMMONS etc),
 // in such cases set the expiry date as NEVER
@@ -335,7 +328,9 @@ export const getEraNote = (profile: Profile): string => {
 export const wouldUpdateBypassState = (
   oldProfile: Profile,
   request: AccessBypassRequest
-): boolean => isBypassed(oldProfile, request.moduleName) !== request.bypassed;
+): boolean =>
+  isBypassed(getAccessModuleStatusByName(oldProfile, request.moduleName)) !==
+  request.bypassed;
 
 export const profileNeedsUpdate = (
   oldProfile: Profile,

--- a/ui/src/app/pages/admin/user/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-profile.tsx
@@ -28,7 +28,11 @@ import { EgressEventsTable } from 'app/pages/admin/egress-events-table';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { isBlank, reactStyles } from 'app/utils';
 import { displayNameForTier } from 'app/utils/access-tiers';
-import { getAccessModuleConfig } from 'app/utils/access-utils';
+import {
+  getAccessModuleConfig,
+  getAccessModuleStatusByName,
+  isBypassed,
+} from 'app/utils/access-utils';
 import {
   AuthorityGuardedAction,
   hasAuthorityForAction,
@@ -60,7 +64,6 @@ import {
   InstitutionalRoleDropdown,
   InstitutionalRoleOtherTextInput,
   InstitutionDropdown,
-  isBypassed,
   orderedAccessModules,
   profileNeedsUpdate,
   TierBadgesMaybe,
@@ -323,13 +326,15 @@ const ToggleForModule = (props: ToggleProps) => {
     bypassUpdate,
   } = props;
 
-  const previouslyBypassed = isBypassed(oldProfile, moduleName);
+  const previouslyBypassed = isBypassed(
+    getAccessModuleStatusByName(oldProfile, moduleName)
+  );
   const pendingBypassState = pendingBypassRequests.find(
     (r) => r.moduleName === moduleName
   );
   const isModuleBypassed = pendingBypassState
     ? pendingBypassState.bypassed
-    : isBypassed(updatedProfile, moduleName);
+    : isBypassed(getAccessModuleStatusByName(updatedProfile, moduleName));
   const highlightStyle =
     isModuleBypassed !== previouslyBypassed
       ? { background: colors.highlight }

--- a/ui/src/app/pages/profile/profile-component.tsx
+++ b/ui/src/app/pages/profile/profile-component.tsx
@@ -40,6 +40,7 @@ import { withUserProfile } from 'app/utils';
 import {
   DARPageMode,
   DATA_ACCESS_REQUIREMENTS_PATH,
+  isBypassed,
   wasReferredFromRenewal,
 } from 'app/utils/access-utils';
 import { canRenderSignedDucc } from 'app/utils/code-of-conduct';
@@ -256,9 +257,8 @@ export const ProfileComponent = fp.flow(
       const hasExpired =
         profileConfirmationAccessModule.expirationEpochMillis &&
         profileConfirmationAccessModule.expirationEpochMillis < Date.now();
-      const bypassed = !!profileConfirmationAccessModule.bypassEpochMillis;
       const showRenewalBox =
-        (hasExpired && !bypassed) ||
+        (hasExpired && !isBypassed(profileConfirmationAccessModule)) ||
         wasReferredFromRenewal(this.props.location.search);
 
       // validatejs requires a scheme, which we don't necessarily need in the profile; rather than

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -12,6 +12,8 @@ import {
   eligibleForTier,
   getAccessModuleStatusByNameOrEmpty,
   hasRtExpired,
+  isBypassed,
+  isCompleted,
 } from 'app/utils/access-utils';
 import {
   AuthorityGuardedAction,
@@ -52,7 +54,9 @@ const allCompleteOrBypassed = (
   const modules = profile?.accessModules?.modules;
   return moduleNames.every((moduleName) => {
     const status = getAccessModuleStatusByNameOrEmpty(modules, moduleName);
-    return !!status?.completionEpochMillis || !!status?.bypassEpochMillis;
+    return (
+      isCompleted(status, profile?.duccSignedVersion) || isBypassed(status)
+    );
   });
 };
 

--- a/ui/src/app/utils/access-utils.spec.tsx
+++ b/ui/src/app/utils/access-utils.spec.tsx
@@ -885,18 +885,20 @@ describe(isCompleted.name, () => {
   });
 
   it('should return true when completion time exists', () => {
+    const ignoredDuccVersion = 0;
     const status: AccessModuleStatus = {
       moduleName: arbitraryModuleName,
       completionEpochMillis: 12345,
     };
-    expect(isCompleted(status, 0)).toBeTruthy();
+    expect(isCompleted(status, ignoredDuccVersion)).toBeTruthy();
   });
 
   it('should return false when completion time does not exist', () => {
+    const ignoredDuccVersion = 0;
     const status: AccessModuleStatus = {
       moduleName: arbitraryModuleName,
     };
-    expect(isCompleted(status, 0)).toBeFalsy();
+    expect(isCompleted(status, ignoredDuccVersion)).toBeFalsy();
   });
 
   it('should return true for DUCC when completion time exists and the signed version is current', () => {

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -546,18 +546,6 @@ export const isExpiringOrExpired = (
   return !!expiration && getWholeDaysFromNow(expiration) <= lookback;
 };
 
-// is the module "renewal complete" ?
-// meaning (bypassed || (complete and not expiring))
-export const isRenewalCompleteForModule = (status: AccessModuleStatus) => {
-  const isComplete = !!status?.completionEpochMillis;
-  const wasBypassed = !!status?.bypassEpochMillis;
-  return (
-    wasBypassed ||
-    (isComplete &&
-      !isExpiringOrExpired(status?.expirationEpochMillis, status.moduleName))
-  );
-};
-
 interface RenewalDisplayDates {
   lastConfirmedDate: string;
   nextReviewDate: string;
@@ -689,6 +677,19 @@ export const isCompliant = (
   status: AccessModuleStatus,
   duccSignedVersion: number
 ): boolean => isCompleted(status, duccSignedVersion) || isBypassed(status);
+
+// is the module "renewal complete" ?
+// meaning (bypassed || (complete and not expiring))
+export const isRenewalCompleteForModule = (
+  status: AccessModuleStatus,
+  duccSignedVersion: number
+) => {
+  return (
+    isBypassed(status) ||
+    (isCompleted(status, duccSignedVersion) &&
+      !isExpiringOrExpired(status?.expirationEpochMillis, status.moduleName))
+  );
+};
 
 export const isEligibleModule = (module: AccessModule, profile: Profile) => {
   if (module !== AccessModule.CT_COMPLIANCE_TRAINING) {

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -676,7 +676,6 @@ export const isCompleted = (
   status: AccessModuleStatus,
   duccSignedVersion: number
 ): boolean =>
-  // special case for DUCC: a user with a missing or old version is non-compliant
   status.moduleName === AccessModule.DATA_USER_CODE_OF_CONDUCT &&
   !isCurrentDUCCVersion(duccSignedVersion)
     ? false

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -577,19 +577,6 @@ export const isRenewalCompleteForModule = (
   );
 };
 
-export const isEligibleModule = (module: AccessModule, profile: Profile) => {
-  if (module !== AccessModule.CT_COMPLIANCE_TRAINING) {
-    // Currently a user can only be ineligible for CT modules.
-    // Note: eRA Commons is an edge case which is handled elsewhere. It is
-    // technically also possible for CT eRA commons to be ineligible.
-    return true;
-  }
-  const controlledTierEligibility = profile.tierEligibilities.find(
-    (tier) => tier.accessTierShortName === AccessTierShortNames.Controlled
-  );
-  return !!controlledTierEligibility?.eligible;
-};
-
 interface RenewalDisplayDates {
   lastConfirmedDate: string;
   nextReviewDate: string;
@@ -701,6 +688,19 @@ export const syncModulesExternal = async (moduleNames: AccessModule[]) => {
       }
     })
   );
+};
+
+export const isEligibleModule = (module: AccessModule, profile: Profile) => {
+  if (module !== AccessModule.CT_COMPLIANCE_TRAINING) {
+    // Currently a user can only be ineligible for CT modules.
+    // Note: eRA Commons is an edge case which is handled elsewhere. It is
+    // technically also possible for CT eRA commons to be ineligible.
+    return true;
+  }
+  const controlledTierEligibility = profile.tierEligibilities.find(
+    (tier) => tier.accessTierShortName === AccessTierShortNames.Controlled
+  );
+  return !!controlledTierEligibility?.eligible;
 };
 
 export const getStatusText = (

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -676,6 +676,7 @@ export const isCompleted = (
   status: AccessModuleStatus,
   duccSignedVersion: number
 ): boolean =>
+  // special case for DUCC: considered incomplete if the signed version is missing or old
   status.moduleName === AccessModule.DATA_USER_CODE_OF_CONDUCT &&
   !isCurrentDUCCVersion(duccSignedVersion)
     ? false

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -672,19 +672,23 @@ export const syncModulesExternal = async (moduleNames: AccessModule[]) => {
   );
 };
 
-export const isCompleted = (status: AccessModuleStatus): boolean =>
-  !!status?.completionEpochMillis;
-export const isBypassed = (status: AccessModuleStatus): boolean =>
-  !!status?.bypassEpochMillis;
-export const isCompliant = (
+export const isCompleted = (
   status: AccessModuleStatus,
-  duccSignedVersion?: number | undefined
+  duccSignedVersion: number
 ): boolean =>
   // special case for DUCC: a user with a missing or old version is non-compliant
   status.moduleName === AccessModule.DATA_USER_CODE_OF_CONDUCT &&
   !isCurrentDUCCVersion(duccSignedVersion)
     ? false
-    : isCompleted(status) || isBypassed(status);
+    : !!status?.completionEpochMillis;
+
+export const isBypassed = (status: AccessModuleStatus): boolean =>
+  !!status?.bypassEpochMillis;
+
+export const isCompliant = (
+  status: AccessModuleStatus,
+  duccSignedVersion: number
+): boolean => isCompleted(status, duccSignedVersion) || isBypassed(status);
 
 export const isEligibleModule = (module: AccessModule, profile: Profile) => {
   if (module !== AccessModule.CT_COMPLIANCE_TRAINING) {
@@ -708,7 +712,7 @@ export const getStatusText = (
     'Cannot provide status text for incomplete module'
   );
   const { completionEpochMillis, bypassEpochMillis } = status;
-  return isCompleted(status)
+  return isCompleted(status, duccSignedVersion)
     ? `Completed on: ${displayDateWithoutHours(completionEpochMillis)}`
     : `Bypassed on: ${displayDateWithoutHours(bypassEpochMillis)}`;
 };

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -550,10 +550,9 @@ export const isCompleted = (
   status: AccessModuleStatus,
   duccSignedVersion: number
 ): boolean =>
-  // special case for DUCC: considered incomplete if the signed version is missing or old
-  status?.moduleName === AccessModule.DATA_USER_CODE_OF_CONDUCT &&
-  !isCurrentDUCCVersion(duccSignedVersion)
-    ? false
+  status?.moduleName === AccessModule.DATA_USER_CODE_OF_CONDUCT
+    ? // special case for DUCC: considered incomplete if the signed version is missing or old
+      isCurrentDUCCVersion(duccSignedVersion) && !!status?.completionEpochMillis
     : !!status?.completionEpochMillis;
 
 export const isBypassed = (status: AccessModuleStatus): boolean =>

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -546,38 +546,6 @@ export const isExpiringOrExpired = (
   return !!expiration && getWholeDaysFromNow(expiration) <= lookback;
 };
 
-// return true if user is eligible for registered tier.
-// A user loses tier eligibility when they are removed from institution tier requirement
-export const eligibleForTier = (
-  profile: Profile,
-  accessTierShortName: string
-): boolean => {
-  const rtEligiblity = profile.tierEligibilities.find(
-    (t) => t.accessTierShortName === accessTierShortName
-  );
-  return rtEligiblity?.eligible;
-};
-
-export const syncModulesExternal = async (moduleNames: AccessModule[]) => {
-  // RT and CT compliance training have the same external sync action.
-  // Calling both can cause conflicts, so we need to remove one.
-  // We choose to remove CT arbitrarily.
-  const filteredModuleNames = moduleNames.includes(
-    AccessModule.COMPLIANCE_TRAINING
-  )
-    ? moduleNames.filter((m) => m !== AccessModule.CT_COMPLIANCE_TRAINING)
-    : moduleNames;
-
-  return Promise.all(
-    filteredModuleNames.map(async (moduleName) => {
-      const { externalSyncAction } = getAccessModuleConfig(moduleName);
-      if (externalSyncAction) {
-        await externalSyncAction();
-      }
-    })
-  );
-};
-
 export const isCompleted = (
   status: AccessModuleStatus,
   duccSignedVersion: number
@@ -700,6 +668,38 @@ export const computeRenewalDisplayDates = (
         moduleStatus: AccessRenewalStatus.CURRENT,
       }),
     ]
+  );
+};
+
+// return true if user is eligible for registered tier.
+// A user loses tier eligibility when they are removed from institution tier requirement
+export const eligibleForTier = (
+  profile: Profile,
+  accessTierShortName: string
+): boolean => {
+  const rtEligiblity = profile.tierEligibilities.find(
+    (t) => t.accessTierShortName === accessTierShortName
+  );
+  return rtEligiblity?.eligible;
+};
+
+export const syncModulesExternal = async (moduleNames: AccessModule[]) => {
+  // RT and CT compliance training have the same external sync action.
+  // Calling both can cause conflicts, so we need to remove one.
+  // We choose to remove CT arbitrarily.
+  const filteredModuleNames = moduleNames.includes(
+    AccessModule.COMPLIANCE_TRAINING
+  )
+    ? moduleNames.filter((m) => m !== AccessModule.CT_COMPLIANCE_TRAINING)
+    : moduleNames;
+
+  return Promise.all(
+    filteredModuleNames.map(async (moduleName) => {
+      const { externalSyncAction } = getAccessModuleConfig(moduleName);
+      if (externalSyncAction) {
+        await externalSyncAction();
+      }
+    })
   );
 };
 

--- a/ui/src/app/utils/code-of-conduct.tsx
+++ b/ui/src/app/utils/code-of-conduct.tsx
@@ -4,7 +4,7 @@ import { serverConfigStore } from './stores';
  * Returns the list of current-for-compliance DUCC versions.
  * One of these versions must be signed in order to receive Registered Tier and Controlled Tier data access.
  */
-const getCurrentDUCCVersions = (): number[] =>
+export const getCurrentDUCCVersions = (): number[] =>
   serverConfigStore.get().config.currentDuccVersions;
 
 /**

--- a/ui/src/app/utils/code-of-conduct.tsx
+++ b/ui/src/app/utils/code-of-conduct.tsx
@@ -4,7 +4,7 @@ import { serverConfigStore } from './stores';
  * Returns the list of current-for-compliance DUCC versions.
  * One of these versions must be signed in order to receive Registered Tier and Controlled Tier data access.
  */
-export const getCurrentDUCCVersions = (): number[] =>
+const getCurrentDUCCVersions = (): number[] =>
   serverConfigStore.get().config.currentDuccVersions;
 
 /**
@@ -14,6 +14,10 @@ export const getCurrentDUCCVersions = (): number[] =>
  */
 export const getLiveDUCCVersion = (): number =>
   Math.max(...getCurrentDUCCVersions());
+
+export const isCurrentDUCCVersion = (
+  duccSignedVersion: number | undefined
+): boolean => getCurrentDUCCVersions().includes(duccSignedVersion);
 
 interface VersionInfo {
   version: number;


### PR DESCRIPTION
It's possible to get into a state where the API reports DUCC to be complete, but the API also blocks access because the DUCC is either missing a required DUCC version field or has an outdated one.  It's probably worth discussing how to improve the correctness of the API, but it was already our belief that this was the case, so my assumption is that this would be a more involved fix.  This PR instead takes the approach of aggregating this information in the UI and treating the inconsistency as **incomplete**, to allow users and admins to have a more correct picture of DUCC compliance even when the API is inconsistent.

This PR makes access module completion (and bypass) checking in the UI more consistent by centralizing those checks, and adds an extra check for a correct DUCC version for that module specifically.

Tested locally by removing my user's DUCC version DB entry, and observing that I am stuck in the same way as the user in RW-11048.  After this change, I see that DUCC is incomplete in Data Access Requirements, and I am able to gain access as expected.

This bug also affects Annual Renewal, so it's a good thing we caught this before completing RW-10764.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
