### PR TITLE
[RW-11062][risk=low] Fix currentWorkspaceStore has incorrect (previous workspace)

### DIFF
--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -4,6 +4,8 @@ import { useParams } from 'react-router-dom';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import { Workspace } from 'generated/fetch';
+
 import { StyledExternalLink } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { HelpSidebar } from 'app/components/help-sidebar';
@@ -156,6 +158,8 @@ export const WorkspaceWrapper = ({ hideSpinner }) => {
 
   const [pollAborter, setPollAborter] = useState(new AbortController());
 
+  const [workspace, setWorkspace] = useState<Workspace>(undefined);
+
   const [showNewCtNotification, setShowNewCtNotification] = useState(false);
 
   useEffect(() => {
@@ -199,6 +203,7 @@ export const WorkspaceWrapper = ({ hideSpinner }) => {
           accessLevel: wsResponse.accessLevel,
         });
         updateStores(wsResponse.workspace.namespace);
+        setWorkspace(wsResponse.workspace);
       } catch (ex) {
         if (ex.status === 403) {
           navigate(['/workspaces']);
@@ -225,7 +230,7 @@ export const WorkspaceWrapper = ({ hideSpinner }) => {
       }
     }
   }, [ns, wsid]);
-  const workspace = currentWorkspaceStore.getValue();
+
   const showMultiRegionWorkspaceNotification =
     workspace &&
     new Date(workspace.creationTime) < MULTI_REGION_BUCKET_END_DATE;

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -12,7 +12,7 @@ import { WorkspaceNavBar } from 'app/pages/workspace/workspace-nav-bar';
 import { WorkspaceRoutes } from 'app/routing/workspace-app-routing';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
-import { reactStyles, withCurrentWorkspace } from 'app/utils';
+import { reactStyles } from 'app/utils';
 import { AccessTierShortNames } from 'app/utils/access-tiers';
 import { LeoRuntimeInitializer } from 'app/utils/leo-runtime-initializer';
 import {

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import * as fp from 'lodash/fp';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -133,7 +132,7 @@ const MultiRegionWorkspaceNotification = () => {
   );
 };
 
-export const WorkspaceWrapper = fp.flow()(({ hideSpinner }) => {
+export const WorkspaceWrapper = ({ hideSpinner }) => {
   const params = useParams<MatchParams>();
   const { ns, wsid } = params;
   useEffect(() => {
@@ -283,4 +282,4 @@ export const WorkspaceWrapper = fp.flow()(({ hideSpinner }) => {
       )}
     </>
   );
-});
+};

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -225,6 +225,7 @@ export const WorkspaceWrapper = ({ hideSpinner }) => {
       if (nextWs && nextWs.namespace === ns && nextWs.id === wsid) {
         currentWorkspaceStore.next(nextWs);
         updateStores(ns);
+        setWorkspace(nextWs);
       } else {
         getWorkspaceAndUpdateStores(ns, wsid);
       }

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -133,8 +133,10 @@ const MultiRegionWorkspaceNotification = () => {
   );
 };
 
-export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
-  ({ workspace, hideSpinner }) => {
+export const WorkspaceWrapper = fp.flow()(
+  ({ hideSpinner }) => {
+    const params = useParams<MatchParams>();
+    const { ns, wsid } = params;
     useEffect(() => {
       hideSpinner();
       return () => {
@@ -146,17 +148,15 @@ export const WorkspaceWrapper = fp.flow(withCurrentWorkspace())(
     }, []);
 
     useEffect(() => {
-      if (workspace) {
-        maybeStartPollingForUserApps(workspace.namespace);
+      if (ns) {
+        maybeStartPollingForUserApps(ns);
       }
-    }, [workspace]);
+    }, [ns]);
 
     const routeData = useStore(routeDataStore);
     const [navigate] = useNavigation();
 
     const [pollAborter, setPollAborter] = useState(new AbortController());
-    const params = useParams<MatchParams>();
-    const { ns, wsid } = params;
 
     const [showNewCtNotification, setShowNewCtNotification] = useState(false);
 


### PR DESCRIPTION
Workspace: https://github.com/all-of-us/workbench/blob/main/ui/src/app/pages/workspace/workspace-wrapper.tsx#L137
is populated by `withCurrentWorkspace`. 
 But `withCurrentWorkspace` returns previous workspace.  


The change is small, most lines are done by yarn lint. Is that expected? 
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
