### PR TITLE
[risk=no][RW-10361] Use Absorb for initial training

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -94,6 +94,8 @@
     "externalDepartmentId": "Development",
     "externalDepartmentIdPopulatedForNewUsers": true,
     "enabledForNewUsers": false,
+    "rtTrainingCourseId": "9ad49c70-3b72-4789-8282-5794efcd4ce1",
+    "ctTrainingCourseId": "3765dc64-cc64-4efa-bfc0-9a4dc2e9d09d",
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"
   },

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -93,7 +93,7 @@
   "absorb": {
     "externalDepartmentId": "Development",
     "externalDepartmentIdPopulatedForNewUsers": true,
-    "enabledForNewUsers": false,
+    "enabledForNewUsers": true,
     "rtTrainingCourseId": "9ad49c70-3b72-4789-8282-5794efcd4ce1",
     "ctTrainingCourseId": "3765dc64-cc64-4efa-bfc0-9a4dc2e9d09d",
     "samlIdentityProviderId": "C03q5hexf",

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -94,6 +94,8 @@
     "externalDepartmentId": "Researchers",
     "externalDepartmentIdPopulatedForNewUsers": true,
     "enabledForNewUsers": false,
+    "rtTrainingCourseId": "TODO",
+    "ctTrainingCourseId": "TODO",
     "samlIdentityProviderId": "TODO",
     "samlServiceProviderId": "TODO"
   },

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -94,6 +94,8 @@
     "externalDepartmentId": "Researchers",
     "externalDepartmentIdPopulatedForNewUsers": false,
     "enabledForNewUsers": false,
+    "rtTrainingCourseId": "TODO",
+    "ctTrainingCourseId": "TODO",
     "samlIdentityProviderId": "TODO",
     "samlServiceProviderId": "TODO"
   },

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -94,6 +94,8 @@
     "externalDepartmentId": "Development",
     "externalDepartmentIdPopulatedForNewUsers": true,
     "enabledForNewUsers": false,
+    "rtTrainingCourseId": "9ad49c70-3b72-4789-8282-5794efcd4ce1",
+    "ctTrainingCourseId": "3765dc64-cc64-4efa-bfc0-9a4dc2e9d09d",
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"
   },

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -93,7 +93,7 @@
   "absorb": {
     "externalDepartmentId": "Development",
     "externalDepartmentIdPopulatedForNewUsers": true,
-    "enabledForNewUsers": false,
+    "enabledForNewUsers": true,
     "rtTrainingCourseId": "9ad49c70-3b72-4789-8282-5794efcd4ce1",
     "ctTrainingCourseId": "3765dc64-cc64-4efa-bfc0-9a4dc2e9d09d",
     "samlIdentityProviderId": "C03q5hexf",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -94,6 +94,8 @@
     "externalDepartmentId": "Development",
     "externalDepartmentIdPopulatedForNewUsers": true,
     "enabledForNewUsers": false,
+    "rtTrainingCourseId": "9ad49c70-3b72-4789-8282-5794efcd4ce1",
+    "ctTrainingCourseId": "3765dc64-cc64-4efa-bfc0-9a4dc2e9d09d",
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"
   },

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -93,7 +93,7 @@
   "absorb": {
     "externalDepartmentId": "Development",
     "externalDepartmentIdPopulatedForNewUsers": true,
-    "enabledForNewUsers": false,
+    "enabledForNewUsers": true,
     "rtTrainingCourseId": "9ad49c70-3b72-4789-8282-5794efcd4ce1",
     "ctTrainingCourseId": "3765dc64-cc64-4efa-bfc0-9a4dc2e9d09d",
     "samlIdentityProviderId": "C03q5hexf",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -94,6 +94,8 @@
     "externalDepartmentId": "Development",
     "externalDepartmentIdPopulatedForNewUsers": true,
     "enabledForNewUsers": false,
+    "rtTrainingCourseId": "9ad49c70-3b72-4789-8282-5794efcd4ce1",
+    "ctTrainingCourseId": "3765dc64-cc64-4efa-bfc0-9a4dc2e9d09d",
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"
   },

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -93,7 +93,7 @@
   "absorb": {
     "externalDepartmentId": "Development",
     "externalDepartmentIdPopulatedForNewUsers": true,
-    "enabledForNewUsers": false,
+    "enabledForNewUsers": true,
     "rtTrainingCourseId": "9ad49c70-3b72-4789-8282-5794efcd4ce1",
     "ctTrainingCourseId": "3765dc64-cc64-4efa-bfc0-9a4dc2e9d09d",
     "samlIdentityProviderId": "C03q5hexf",

--- a/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
@@ -32,7 +32,6 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
   @Disabled("RW-11039")
   public void testUserHasLoggedIntoAbsorb_True() throws Exception {
     // Setup:
-    // - A user with this email exists
     // - The user has logged into Absorb
     assertThat(absorbService.userHasLoggedIntoAbsorb(partiallyCompleteUserEmail)).isTrue();
   }
@@ -49,7 +48,6 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
   @Disabled("RW-11039")
   public void testGetEnrollments() throws Exception {
     // Setup:
-    // - A user with this email exists
     // - The user has completed RT training in Absorb
     // - The user has not completed CT training in Absorb
     var enrollments = absorbService.getActiveEnrollmentsForUser(partiallyCompleteUserEmail);

--- a/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
@@ -19,10 +19,31 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
 
   @Autowired private AbsorbService absorbService;
 
+  private final String partiallyCompleteUserEmail =
+      "absorb_acceptance_test_02@fake-research-aou.org";
+  private final String nonexistantUserEmail = "absorb_acceptance_test_fake@fake-research-aou.org";
+
   @TestConfiguration
   @ComponentScan(basePackageClasses = DirectoryServiceImpl.class)
   @Import({AbsorbServiceImpl.class})
   static class Configuration {}
+
+  @Test
+  @Disabled("RW-11039")
+  public void testUserHasLoggedIntoAbsorb_True() throws Exception {
+    // Setup:
+    // - A user with this email exists
+    // - The user has logged into Absorb
+    assertThat(absorbService.userHasLoggedIntoAbsorb(partiallyCompleteUserEmail)).isTrue();
+  }
+
+  @Test
+  @Disabled("RW-11039")
+  public void testUserHasLoggedIntoAbsorb_False() throws Exception {
+    // Setup:
+    // - A user with this email does not exist, therefore they have not logged into Absorb
+    assertThat(absorbService.userHasLoggedIntoAbsorb(nonexistantUserEmail)).isFalse();
+  }
 
   @Test
   @Disabled("RW-11039")
@@ -31,9 +52,7 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
     // - A user with this email exists
     // - The user has completed RT training in Absorb
     // - The user has not completed CT training in Absorb
-    var email = "absorb_acceptance_test_02@fake-research-aou.org";
-
-    var enrollments = absorbService.getActiveEnrollmentsForUser(email);
+    var enrollments = absorbService.getActiveEnrollmentsForUser(partiallyCompleteUserEmail);
     assertThat(enrollments.size()).isEqualTo(2);
 
     var rtTrainingEnrollment =

--- a/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
@@ -2,58 +2,54 @@ package org.pmiops.workbench;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.time.Instant;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.pmiops.workbench.absorb.api.AuthenticateApi;
-import org.pmiops.workbench.absorb.api.EnrollmentsApi;
-import org.pmiops.workbench.absorb.api.UsersApi;
-import org.pmiops.workbench.absorb.model.AuthenticationRequest;
+import org.pmiops.workbench.absorb.AbsorbService;
+import org.pmiops.workbench.absorb.AbsorbServiceImpl;
 import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.google.DirectoryServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 
 public class AbsorbAcceptanceTest extends BaseIntegrationTest {
   @Autowired private CloudStorageClient cloudStorageClient;
 
+  @Autowired private AbsorbService absorbService;
+
   @TestConfiguration
   @ComponentScan(basePackageClasses = DirectoryServiceImpl.class)
+  @Import({AbsorbServiceImpl.class})
   static class Configuration {}
 
   @Test
   @Disabled("RW-11039")
-  public void testGetCertificates() throws Exception {
-    // Setup: A user with this email exists and has completed both Absorb trainings in the
-    // test environment.
-    var email = "absorb_acceptance_test@fake-research-aou.org";
+  public void testGetEnrollments() throws Exception {
+    // Setup:
+    // - A user with this email exists
+    // - The user has completed RT training in Absorb
+    // - The user has not completed CT training in Absorb
+    var email = "absorb_acceptance_test_02@fake-research-aou.org";
 
-    var config = cloudStorageClient.getAbsorbCredentials();
-    var apiKey = config.getString("apiKey");
+    var enrollments = absorbService.getActiveEnrollmentsForUser(email);
+    assertThat(enrollments.size()).isEqualTo(2);
 
-    // Obtain an access token
-    var accessToken =
-        new AuthenticateApi()
-            .restAuthenticationAuthenticate(
-                new AuthenticationRequest()
-                    .password(config.getString("password"))
-                    .username(config.getString("username"))
-                    .privateKey(apiKey),
-                apiKey);
+    var rtTrainingEnrollment =
+        enrollments.stream()
+            .filter(e -> e.courseId.equals(config.absorb.rtTrainingCourseId))
+            .findFirst();
+    assertThat(rtTrainingEnrollment.isPresent()).isTrue();
+    // Completed at 2:14PM EST on 2023-10-03
+    assertThat(rtTrainingEnrollment.get().completionTime)
+        .isEqualTo(Instant.parse("2023-10-03T18:14:03.977Z"));
 
-    // Find the user id
-    var users = new UsersApi().usersGetUsers(apiKey, accessToken, "username eq '" + email + "'");
-    assertThat(users.getUsers().size()).isEqualTo(1);
-    assertThat(users.getUsers().get(0).getUsername()).isEqualTo(email);
-
-    // Validate the user has completed two courses
-    var enrollments =
-        new EnrollmentsApi()
-            .enrollmentsGetUserEnrollments(
-                apiKey, accessToken, users.getUsers().get(0).getId(), null);
-    assertThat(enrollments.getEnrollments().size()).isEqualTo(2);
-    for (var enrollment : enrollments.getEnrollments()) {
-      assertThat(enrollment.getDateCompleted()).isNotNull();
-    }
+    var ctTrainingEnrollment =
+        enrollments.stream()
+            .filter(e -> e.courseId.equals(config.absorb.ctTrainingCourseId))
+            .findFirst();
+    assertThat(ctTrainingEnrollment.isPresent()).isTrue();
+    assertThat(ctTrainingEnrollment.get().completionTime).isNull();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/absorb/AbsorbService.java
+++ b/api/src/main/java/org/pmiops/workbench/absorb/AbsorbService.java
@@ -3,6 +3,8 @@ package org.pmiops.workbench.absorb;
 import java.util.List;
 
 public interface AbsorbService {
+  Boolean userHasLoggedIntoAbsorb(String email) throws ApiException;
+
   /**
    * Get details about the Registered Tier Training and the Controlled Tier Training for a user
    *

--- a/api/src/main/java/org/pmiops/workbench/absorb/AbsorbService.java
+++ b/api/src/main/java/org/pmiops/workbench/absorb/AbsorbService.java
@@ -1,0 +1,14 @@
+package org.pmiops.workbench.absorb;
+
+import java.util.List;
+
+public interface AbsorbService {
+  /**
+   * Get details about the Registered Tier Training and the Controlled Tier Training for a user
+   *
+   * @param email
+   * @return list of enrollments
+   * @throws org.pmiops.workbench.absorb.ApiException
+   */
+  List<Enrollment> getActiveEnrollmentsForUser(String email) throws ApiException;
+}

--- a/api/src/main/java/org/pmiops/workbench/absorb/AbsorbServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/absorb/AbsorbServiceImpl.java
@@ -29,6 +29,13 @@ public class AbsorbServiceImpl implements AbsorbService {
     this.cloudStorageClient = cloudStorageClient;
   }
 
+  // This function returns false if the user has an account with absorb, even if they have never
+  // logged into Absorb. However, in our case, a users' account is created the first time they log
+  // in, and only then. We may be able to create accounts prior to a user logging in by using the
+  // API but have no plans to do so. Until we do that, the concepts of "logged in before" and "has
+  // account" should be equivalent. We should rename the function if that stops being true. This
+  // method name is clearer to use in other services since it describes the users' actions so far
+  // (domain logic) rather than relying on Absorb-specific state (implementation details).
   @Override
   public Boolean userHasLoggedIntoAbsorb(String email) throws ApiException {
     ensureAuthentication(email);

--- a/api/src/main/java/org/pmiops/workbench/absorb/AbsorbServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/absorb/AbsorbServiceImpl.java
@@ -1,0 +1,70 @@
+package org.pmiops.workbench.absorb;
+
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
+import static java.util.stream.Collectors.toList;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.pmiops.workbench.absorb.api.AuthenticateApi;
+import org.pmiops.workbench.absorb.api.EnrollmentsApi;
+import org.pmiops.workbench.absorb.api.UsersApi;
+import org.pmiops.workbench.absorb.model.AuthenticationRequest;
+import org.pmiops.workbench.absorb.model.UserCourseEnrollmentResource;
+import org.pmiops.workbench.google.CloudStorageClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AbsorbServiceImpl implements AbsorbService {
+  private final CloudStorageClient cloudStorageClient;
+
+  @Autowired
+  public AbsorbServiceImpl(CloudStorageClient cloudStorageClient) {
+    this.cloudStorageClient = cloudStorageClient;
+  }
+
+  @Override
+  public List<Enrollment> getActiveEnrollmentsForUser(String email) throws ApiException {
+    var config = cloudStorageClient.getAbsorbCredentials();
+    var apiKey = config.getString("apiKey");
+
+    // Obtain an access token
+    var accessToken =
+        new AuthenticateApi()
+            .restAuthenticationAuthenticate(
+                new AuthenticationRequest()
+                    .password(config.getString("password"))
+                    .username(config.getString("username"))
+                    .privateKey(apiKey),
+                apiKey);
+
+    // Find the user id
+    var users = new UsersApi().usersGetUsers(apiKey, accessToken, "username eq '" + email + "'");
+
+    if (users.getUsers().size() == 0) {
+      throw new ApiException(404, "User not found");
+    }
+
+    // Fetch enrollments for the user
+    var enrollmentsResponse =
+        new EnrollmentsApi()
+            .enrollmentsGetUserEnrollments(
+                apiKey, accessToken, users.getUsers().get(0).getId(), "isActive")
+            .getEnrollments();
+
+    // Convert enrollments to our simplified and serialized model
+    return enrollmentsResponse.stream().map(this::convertToEnrollment).collect(toList());
+  }
+
+  private Enrollment convertToEnrollment(UserCourseEnrollmentResource e) {
+    if (e.getDateCompleted() == null) {
+      return new Enrollment(e.getCourseId(), null);
+    } else {
+      Instant dateCompleted =
+          LocalDateTime.parse(e.getDateCompleted(), ISO_DATE_TIME).toInstant(ZoneOffset.UTC);
+      return new Enrollment(e.getCourseId(), dateCompleted);
+    }
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/absorb/Enrollment.java
+++ b/api/src/main/java/org/pmiops/workbench/absorb/Enrollment.java
@@ -1,0 +1,14 @@
+package org.pmiops.workbench.absorb;
+
+import java.time.Instant;
+import javax.annotation.Nullable;
+
+public class Enrollment {
+  public final String courseId;
+  @Nullable public final Instant completionTime;
+
+  public Enrollment(String courseId, @Nullable Instant dateCompleted) {
+    this.courseId = courseId;
+    this.completionTime = dateCompleted;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -361,7 +361,7 @@ public class ProfileController implements ProfileApiDelegate {
       complianceTrainingService.syncComplianceTrainingStatus();
     } catch (NotFoundException ex) {
       throw ex;
-    } catch (ApiException e) {
+    } catch (ApiException | org.pmiops.workbench.absorb.ApiException e) {
       throw new ServerErrorException(e);
     }
     return getProfileResponse(userProvider.get());

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingService.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingService.java
@@ -1,11 +1,12 @@
 package org.pmiops.workbench.compliancetraining;
 
+import org.pmiops.workbench.absorb.ApiException;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.NotFoundException;
 
 public interface ComplianceTrainingService {
   public DbUser syncComplianceTrainingStatus()
-      throws org.pmiops.workbench.moodle.ApiException, NotFoundException;
+      throws org.pmiops.workbench.moodle.ApiException, NotFoundException, ApiException;
 
   public boolean useAbsorb();
 }

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -216,19 +216,6 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
     }
   }
 
-  /**
-   * Updates the given user's training status from Moodle.
-   *
-   * <p>We can fetch Moodle data for arbitrary users since we use an API key to access Moodle,
-   * rather than user-specific OAuth tokens.
-   *
-   * <p>Using the user's email, we can get their badges from Moodle's APIs. If the badges are marked
-   * valid, we store their completion dates in the database. If they are marked invalid, we clear
-   * the completion dates from the database as the user will need to complete a new training.
-   *
-   * @param dbUser
-   * @param agent
-   */
   @Transactional
   public DbUser syncComplianceTrainingStatusAbsorb(DbUser dbUser, Agent agent) throws ApiException {
     if (!absorbService.userHasLoggedIntoAbsorb(dbUser.getUsername())) {

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -231,6 +231,10 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
    */
   @Transactional
   public DbUser syncComplianceTrainingStatusAbsorb(DbUser dbUser, Agent agent) throws ApiException {
+    if (!absorbService.userHasLoggedIntoAbsorb(dbUser.getUsername())) {
+        return dbUser;
+    }
+
     Map<String, DbAccessModule.DbAccessModuleName> courseToAccessModuleMap =
         Map.of(
             configProvider.get().absorb.rtTrainingCourseId,

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -232,7 +232,7 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
   @Transactional
   public DbUser syncComplianceTrainingStatusAbsorb(DbUser dbUser, Agent agent) throws ApiException {
     if (!absorbService.userHasLoggedIntoAbsorb(dbUser.getUsername())) {
-        return dbUser;
+      return dbUser;
     }
 
     Map<String, DbAccessModule.DbAccessModuleName> courseToAccessModuleMap =

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -73,7 +73,7 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
   public DbUser syncComplianceTrainingStatus()
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
     DbUser user = userProvider.get();
-    return syncComplianceTrainingStatus(user, Agent.asUser(user));
+    return syncComplianceTrainingStatusMoodle(user, Agent.asUser(user));
   }
 
   @Override
@@ -108,7 +108,7 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
    * @param agent
    */
   @Transactional
-  public DbUser syncComplianceTrainingStatus(DbUser dbUser, Agent agent)
+  public DbUser syncComplianceTrainingStatusMoodle(DbUser dbUser, Agent agent)
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
     // Skip sync for service account user rows.
     if (userService.isServiceAccount(dbUser)) {

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -254,7 +254,8 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
                 "User `%s` is not enrolled in Absorb course `%s` for access module `%s`. Users are expected to be automatically enrolled in all courses upon visiting Absorb.",
                 dbUser.getUsername(), courseId, accessModuleName));
         throw new NotFoundException(
-            String.format("User %s is not enrolled in Absorb course %s", dbUser.getUsername(), courseId));
+            String.format(
+                "User %s is not enrolled in Absorb course %s", dbUser.getUsername(), courseId));
       }
       var enrollment = maybeEnrollment.get();
 

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -73,6 +73,12 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
   public DbUser syncComplianceTrainingStatus()
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
     DbUser user = userProvider.get();
+
+    // Skip sync for service account user rows.
+    if (userService.isServiceAccount(user)) {
+      return user;
+    }
+
     return syncComplianceTrainingStatusMoodle(user, Agent.asUser(user));
   }
 
@@ -110,11 +116,6 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
   @Transactional
   public DbUser syncComplianceTrainingStatusMoodle(DbUser dbUser, Agent agent)
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
-    // Skip sync for service account user rows.
-    if (userService.isServiceAccount(dbUser)) {
-      return dbUser;
-    }
-
     try {
       Map<MoodleService.BadgeName, BadgeDetailsV2> userBadgesByName =
           moodleService.getUserBadgesByBadgeName(dbUser.getUsername());

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -260,6 +260,8 @@ public class WorkbenchConfig {
     public String externalDepartmentId;
     public boolean externalDepartmentIdPopulatedForNewUsers;
     public boolean enabledForNewUsers;
+    public String rtTrainingCourseId;
+    public String ctTrainingCourseId;
     public String samlIdentityProviderId;
     public String samlServiceProviderId;
   }

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.FakeJpaDateTimeConfiguration;
+import org.pmiops.workbench.absorb.AbsorbService;
 import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessModuleServiceImpl;
 import org.pmiops.workbench.access.AccessTierService;
@@ -142,6 +143,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   @MockBean private ShibbolethService mockShibbolethService;
   @MockBean private UserServiceAuditor mockUserServiceAuditor;
   @MockBean private RasLinkService mockRasLinkService;
+  @MockBean private AbsorbService mockAbsorbService;
 
   @Autowired private AccessModuleDao accessModuleDao;
   @Autowired private AccessModuleService accessModuleService;

--- a/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
@@ -242,14 +242,16 @@ public class ComplianceTrainingServiceTest {
     var completionTime = currentInstant();
     mockGetUserEnrollments(completionTime, null);
     user = complianceTrainingService.syncComplianceTrainingStatus();
-    assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(completionTime));
+    assertModuleCompletionEqual(
+        DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(completionTime));
 
     // Time passes and the user re-syncs
     tick();
     user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // Completion timestamp should not change when the method is called again.
-    assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(completionTime));
+    assertModuleCompletionEqual(
+        DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(completionTime));
   }
 
   @Test
@@ -292,7 +294,7 @@ public class ComplianceTrainingServiceTest {
     var rtVerification = getVerification(DbAccessModuleName.RT_COMPLIANCE_TRAINING);
     assertThat(rtVerification.isPresent()).isTrue();
     assertThat(rtVerification.get().getComplianceTrainingVerificationSystem())
-            .isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.ABSORB);
+        .isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.ABSORB);
 
     // CT is incomplete, so there should not be a verification record.
     var ctVerification = getVerification(DbAccessModuleName.CT_COMPLIANCE_TRAINING);
@@ -336,7 +338,7 @@ public class ComplianceTrainingServiceTest {
 
   @Test
   public void testSyncComplianceTrainingStatus_Absorb_UpdatesVerification_OnePerAccessModule()
-          throws Exception {
+      throws Exception {
     providedWorkbenchConfig.absorb.enabledForNewUsers = true;
 
     assertThat(complianceTrainingVerificationDao.findAll()).isEmpty();
@@ -528,7 +530,8 @@ public class ComplianceTrainingServiceTest {
   }
 
   @Test
-  public void testSyncComplianceTrainingStatus_AbsorbRollbacksLeadToUnexpectedComplianceLapse() throws Exception {
+  public void testSyncComplianceTrainingStatus_AbsorbRollbacksLeadToUnexpectedComplianceLapse()
+      throws Exception {
     // This test documents undesired behavior. We think it is unlikely to happen and can
     // be fixed as-needed if we roll back Absorb.
 
@@ -538,7 +541,8 @@ public class ComplianceTrainingServiceTest {
     var rtCompletionTime = currentInstant();
     mockGetUserEnrollments(rtCompletionTime, null);
     user = complianceTrainingService.syncComplianceTrainingStatus();
-    assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(rtCompletionTime));
+    assertModuleCompletionEqual(
+        DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(rtCompletionTime));
 
     // Time passes.
     tick();
@@ -548,8 +552,9 @@ public class ComplianceTrainingServiceTest {
 
     // The user uses Moodle to complete CT training.
     var ctCompletionTime = currentTimestamp();
-    mockGetUserBadgesByBadgeName(ImmutableMap.of(
-        BadgeName.CONTROLLED_TIER_TRAINING, defaultBadgeDetails().lastissued(currentSecond())));
+    mockGetUserBadgesByBadgeName(
+        ImmutableMap.of(
+            BadgeName.CONTROLLED_TIER_TRAINING, defaultBadgeDetails().lastissued(currentSecond())));
     user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // Desired behavior: The user's RT training persists.

--- a/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
@@ -157,7 +157,11 @@ public class ComplianceTrainingServiceTest {
     assertModuleNotCompleted(DbAccessModuleName.CT_COMPLIANCE_TRAINING);
 
     // There should be a Moodle (not Absorb) verification record for RT but not CT.
-    assertThat(getVerification(DbAccessModuleName.RT_COMPLIANCE_TRAINING).get().getComplianceTrainingVerificationSystem()).isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.MOODLE);
+    assertThat(
+            getVerification(DbAccessModuleName.RT_COMPLIANCE_TRAINING)
+                .get()
+                .getComplianceTrainingVerificationSystem())
+        .isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.MOODLE);
     assertThat(getVerification(DbAccessModuleName.CT_COMPLIANCE_TRAINING).isPresent()).isFalse();
 
     // Time passes
@@ -184,8 +188,16 @@ public class ComplianceTrainingServiceTest {
     assertModuleCompletionEqual(DbAccessModuleName.CT_COMPLIANCE_TRAINING, currentTimestamp());
 
     // There should be Moodle (not Absorb) verification records.
-    assertThat(getVerification(DbAccessModuleName.RT_COMPLIANCE_TRAINING).get().getComplianceTrainingVerificationSystem()).isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.MOODLE);
-    assertThat(getVerification(DbAccessModuleName.CT_COMPLIANCE_TRAINING).get().getComplianceTrainingVerificationSystem()).isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.MOODLE);
+    assertThat(
+            getVerification(DbAccessModuleName.RT_COMPLIANCE_TRAINING)
+                .get()
+                .getComplianceTrainingVerificationSystem())
+        .isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.MOODLE);
+    assertThat(
+            getVerification(DbAccessModuleName.CT_COMPLIANCE_TRAINING)
+                .get()
+                .getComplianceTrainingVerificationSystem())
+        .isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.MOODLE);
   }
 
   @Test
@@ -206,7 +218,11 @@ public class ComplianceTrainingServiceTest {
     assertModuleNotCompleted(DbAccessModuleName.CT_COMPLIANCE_TRAINING);
 
     // There should be an Absorb (not Moodle) verification record for RT but not CT.
-    assertThat(getVerification(DbAccessModuleName.RT_COMPLIANCE_TRAINING).get().getComplianceTrainingVerificationSystem()).isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.ABSORB);
+    assertThat(
+            getVerification(DbAccessModuleName.RT_COMPLIANCE_TRAINING)
+                .get()
+                .getComplianceTrainingVerificationSystem())
+        .isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.ABSORB);
     assertThat(getVerification(DbAccessModuleName.CT_COMPLIANCE_TRAINING).isPresent()).isFalse();
 
     // Time passes
@@ -227,8 +243,16 @@ public class ComplianceTrainingServiceTest {
         DbAccessModuleName.CT_COMPLIANCE_TRAINING, Timestamp.from(ctCompletionTime));
 
     // There should be Absorb (not Moodle) verification records.
-    assertThat(getVerification(DbAccessModuleName.RT_COMPLIANCE_TRAINING).get().getComplianceTrainingVerificationSystem()).isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.ABSORB);
-    assertThat(getVerification(DbAccessModuleName.CT_COMPLIANCE_TRAINING).get().getComplianceTrainingVerificationSystem()).isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.ABSORB);
+    assertThat(
+            getVerification(DbAccessModuleName.RT_COMPLIANCE_TRAINING)
+                .get()
+                .getComplianceTrainingVerificationSystem())
+        .isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.ABSORB);
+    assertThat(
+            getVerification(DbAccessModuleName.CT_COMPLIANCE_TRAINING)
+                .get()
+                .getComplianceTrainingVerificationSystem())
+        .isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.ABSORB);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
@@ -375,6 +375,30 @@ public class ComplianceTrainingServiceTest {
   }
 
   @Test
+  public void testSyncComplianceTrainingStatus_Moodle_DoesNothingIfNoCoursesComplete()
+          throws Exception {
+    providedWorkbenchConfig.absorb.enabledForNewUsers = false;
+    mockGetUserBadgesByBadgeName(Map.of());
+
+    user = complianceTrainingService.syncComplianceTrainingStatus();
+
+    assertModuleNotCompleted(DbAccessModuleName.RT_COMPLIANCE_TRAINING);
+    assertModuleNotCompleted(DbAccessModuleName.CT_COMPLIANCE_TRAINING);
+  }
+
+  @Test
+  public void testSyncComplianceTrainingStatus_Absorb_DoesNothingIfNoCoursesComplete()
+          throws Exception {
+    providedWorkbenchConfig.absorb.enabledForNewUsers = true;
+    mockGetUserEnrollments(null, null);
+
+    user = complianceTrainingService.syncComplianceTrainingStatus();
+
+    assertModuleNotCompleted(DbAccessModuleName.RT_COMPLIANCE_TRAINING);
+    assertModuleNotCompleted(DbAccessModuleName.CT_COMPLIANCE_TRAINING);
+  }
+
+  @Test
   public void testSyncComplianceTrainingStatus_Moodle_RenewsExpiredTraining() throws Exception {
     providedWorkbenchConfig.absorb.enabledForNewUsers = false;
 

--- a/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
@@ -363,6 +363,18 @@ public class ComplianceTrainingServiceTest {
   }
 
   @Test
+  public void testSyncComplianceTrainingStatus_Absorb_DoesNothingIfUserHasntSignedIntoAbsorb()
+          throws Exception {
+    providedWorkbenchConfig.absorb.enabledForNewUsers = true;
+    when(mockAbsorbService.userHasLoggedIntoAbsorb(USERNAME)).thenReturn(false);
+
+    user = complianceTrainingService.syncComplianceTrainingStatus();
+
+    assertModuleNotCompleted(DbAccessModuleName.RT_COMPLIANCE_TRAINING);
+    assertModuleNotCompleted(DbAccessModuleName.CT_COMPLIANCE_TRAINING);
+  }
+
+  @Test
   public void testSyncComplianceTrainingStatus_Moodle_RenewsExpiredTraining() throws Exception {
     providedWorkbenchConfig.absorb.enabledForNewUsers = false;
 
@@ -593,6 +605,7 @@ public class ComplianceTrainingServiceTest {
   private void mockGetUserEnrollments(
       @Nullable Instant rtCompletionTime, @Nullable Instant ctCompletionTime)
       throws org.pmiops.workbench.absorb.ApiException {
+    when(mockAbsorbService.userHasLoggedIntoAbsorb(USERNAME)).thenReturn(true);
     when(mockAbsorbService.getActiveEnrollmentsForUser(USERNAME))
         .thenReturn(
             List.of(

--- a/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
@@ -126,7 +126,9 @@ public class ComplianceTrainingServiceTest {
   }
 
   @Test
-  public void testSyncComplianceTrainingStatus() throws Exception {
+  public void testSyncComplianceTrainingStatus_Moodle() throws Exception {
+    providedWorkbenchConfig.absorb.enabledForNewUsers = false;
+
     // User completes RT training in Moodle
     var rtBadge = defaultBadgeDetails().lastissued(currentSecond());
     mockGetUserBadgesByBadgeName(ImmutableMap.of(BadgeName.REGISTERED_TIER_TRAINING, rtBadge));
@@ -168,7 +170,9 @@ public class ComplianceTrainingServiceTest {
   }
 
   @Test
-  public void testSyncComplianceTrainingStatus_ResyncCausesNoChanges() throws Exception {
+  public void testSyncComplianceTrainingStatus_Moodle_ResyncCausesNoChanges() throws Exception {
+    providedWorkbenchConfig.absorb.enabledForNewUsers = false;
+
     // Set up: The user completes ands syncs RT training
     mockGetUserBadgesByBadgeName(
         ImmutableMap.of(BadgeName.REGISTERED_TIER_TRAINING, defaultBadgeDetails()));
@@ -187,8 +191,9 @@ public class ComplianceTrainingServiceTest {
   }
 
   @Test
-  public void testSyncComplianceTrainingStatus_UpdatesVerificationToMoodleIfComplete()
-      throws Exception {
+  public void testSyncComplianceTrainingStatus_Moodle_UpdatesVerification() throws Exception {
+    providedWorkbenchConfig.absorb.enabledForNewUsers = false;
+
     mockGetUserBadgesByBadgeName(
         ImmutableMap.of(BadgeName.REGISTERED_TIER_TRAINING, defaultBadgeDetails()));
 
@@ -212,8 +217,10 @@ public class ComplianceTrainingServiceTest {
   }
 
   @Test
-  public void testSyncComplianceTrainingStatus_UpdatesVerification_OnePerAccessModule()
+  public void testSyncComplianceTrainingStatus_Moodle_UpdatesVerification_OnePerAccessModule()
       throws Exception {
+    providedWorkbenchConfig.absorb.enabledForNewUsers = false;
+
     var userBadgesByNameRTOnly =
         ImmutableMap.of(BadgeName.REGISTERED_TIER_TRAINING, defaultBadgeDetails());
     var userBadgesByNameRTAndCT =
@@ -247,7 +254,9 @@ public class ComplianceTrainingServiceTest {
   }
 
   @Test
-  public void testSyncComplianceTrainingStatus_RenewsExpiredTraining() throws Exception {
+  public void testSyncComplianceTrainingStatus_Moodle_RenewsExpiredTraining() throws Exception {
+    providedWorkbenchConfig.absorb.enabledForNewUsers = false;
+
     // User completes trainings
     BadgeDetailsV2 rtBadge = defaultBadgeDetails().valid(true).lastissued(currentSecond());
     BadgeDetailsV2 ctBadge = defaultBadgeDetails().valid(true).lastissued(currentSecond());
@@ -300,7 +309,9 @@ public class ComplianceTrainingServiceTest {
   }
 
   @Test
-  public void testSyncComplianceTrainingStatus_RenewsExpiringTraining() throws Exception {
+  public void testSyncComplianceTrainingStatus_Moodle_RenewsExpiringTraining() throws Exception {
+    providedWorkbenchConfig.absorb.enabledForNewUsers = false;
+
     // User completes trainings
     BadgeDetailsV2 rtBadge = defaultBadgeDetails().valid(true).lastissued(currentSecond());
     BadgeDetailsV2 ctBadge = defaultBadgeDetails().valid(true).lastissued(currentSecond());
@@ -339,7 +350,9 @@ public class ComplianceTrainingServiceTest {
   }
 
   @Test
-  public void testSyncComplianceTrainingStatus_NullBadge() throws ApiException {
+  public void testSyncComplianceTrainingStatus_Moodle_NullBadge() throws ApiException {
+    providedWorkbenchConfig.absorb.enabledForNewUsers = false;
+
     // When Moodle returns an empty RET badge response, we should clear the completion time.
     accessModuleService.updateCompletionTime(
         user, DbAccessModuleName.RT_COMPLIANCE_TRAINING, new Timestamp(12345));
@@ -353,7 +366,9 @@ public class ComplianceTrainingServiceTest {
   }
 
   @Test
-  public void testSyncComplianceTrainingStatus_BadgeNotFound() throws ApiException {
+  public void testSyncComplianceTrainingStatus_Moodle_BadgeNotFound() throws ApiException {
+    providedWorkbenchConfig.absorb.enabledForNewUsers = false;
+
     // We should propagate a NOT_FOUND exception from the compliance service.
     when(mockMoodleService.getUserBadgesByBadgeName(USERNAME))
         .thenThrow(new ApiException(HttpStatus.NOT_FOUND.value(), "user not found"));

--- a/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
@@ -364,7 +364,7 @@ public class ComplianceTrainingServiceTest {
 
   @Test
   public void testSyncComplianceTrainingStatus_Absorb_DoesNothingIfUserHasntSignedIntoAbsorb()
-          throws Exception {
+      throws Exception {
     providedWorkbenchConfig.absorb.enabledForNewUsers = true;
     when(mockAbsorbService.userHasLoggedIntoAbsorb(USERNAME)).thenReturn(false);
 
@@ -376,7 +376,7 @@ public class ComplianceTrainingServiceTest {
 
   @Test
   public void testSyncComplianceTrainingStatus_Moodle_DoesNothingIfNoCoursesComplete()
-          throws Exception {
+      throws Exception {
     providedWorkbenchConfig.absorb.enabledForNewUsers = false;
     mockGetUserBadgesByBadgeName(Map.of());
 
@@ -388,7 +388,7 @@ public class ComplianceTrainingServiceTest {
 
   @Test
   public void testSyncComplianceTrainingStatus_Absorb_DoesNothingIfNoCoursesComplete()
-          throws Exception {
+      throws Exception {
     providedWorkbenchConfig.absorb.enabledForNewUsers = true;
     mockGetUserEnrollments(null, null);
 

--- a/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
@@ -149,7 +149,7 @@ public class ComplianceTrainingServiceTest {
     tick();
 
     // User syncs training
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // The user should be updated in the database with a non-empty completion
     // for only RT training.
@@ -173,7 +173,7 @@ public class ComplianceTrainingServiceTest {
     tick();
 
     // User syncs training
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // The user should be updated in the database with a non-empty completion
     // for both RT and CT training.
@@ -190,7 +190,7 @@ public class ComplianceTrainingServiceTest {
     mockGetUserEnrollments(rtCompletionTime, null);
 
     // User syncs training
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // The user should be updated in the database with a non-empty completion
     // for only RT training.
@@ -206,7 +206,7 @@ public class ComplianceTrainingServiceTest {
     mockGetUserEnrollments(rtCompletionTime, ctCompletionTime);
 
     // User syncs training
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // The user should be updated in the database with a non-empty completion
     // for both RT and CT training.
@@ -223,13 +223,13 @@ public class ComplianceTrainingServiceTest {
     // Set up: The user completes ands syncs RT training
     mockGetUserBadgesByBadgeName(
         ImmutableMap.of(BadgeName.REGISTERED_TIER_TRAINING, defaultBadgeDetails()));
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
     var completionTime = currentTimestamp();
     assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, completionTime);
 
     // Time passes and the user re-syncs
     tick();
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // Completion timestamp should not change when the method is called again.
     assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, completionTime);
@@ -242,12 +242,12 @@ public class ComplianceTrainingServiceTest {
     // Set up: The user completes ands syncs RT training
     var completionTime = currentInstant();
     mockGetUserEnrollments(completionTime, null);
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
     assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(completionTime));
 
     // Time passes and the user re-syncs
     tick();
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // Completion timestamp should not change when the method is called again.
     assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(completionTime));
@@ -262,11 +262,9 @@ public class ComplianceTrainingServiceTest {
 
     assertThat(complianceTrainingVerificationDao.findAll()).isEmpty();
 
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
 
     assertThat(complianceTrainingVerificationDao.findAll()).hasSize(1);
-
-    reloadUser();
 
     // RT is complete, so there should be a verification record.
     var rtVerification = getVerification(DbAccessModuleName.RT_COMPLIANCE_TRAINING);
@@ -297,15 +295,13 @@ public class ComplianceTrainingServiceTest {
 
     // Complete RT training
     mockGetUserBadgesByBadgeName(userBadgesByNameRTOnly);
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
     assertThat(complianceTrainingVerificationDao.findAll()).hasSize(1);
 
     // Complete CT training
     mockGetUserBadgesByBadgeName(userBadgesByNameRTAndCT);
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
     assertThat(complianceTrainingVerificationDao.findAll()).hasSize(2);
-
-    reloadUser();
 
     // RT is complete, so there should be a verification record.
     var rtVerification = getVerification(DbAccessModuleName.RT_COMPLIANCE_TRAINING);
@@ -334,7 +330,7 @@ public class ComplianceTrainingServiceTest {
     tick();
 
     // User syncs training
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // The user should be updated in the database with a non-empty completion time.
     assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, currentTimestamp());
@@ -351,7 +347,7 @@ public class ComplianceTrainingServiceTest {
     tick();
 
     // Completion timestamp should be wiped out by the expiry timestamp passing.
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
     assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, null);
     assertModuleCompletionEqual(DbAccessModuleName.CT_COMPLIANCE_TRAINING, null);
 
@@ -364,7 +360,7 @@ public class ComplianceTrainingServiceTest {
 
     // Time passes, user syncs training
     tick();
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // Completion and expiry timestamp should be updated.
     assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, currentTimestamp());
@@ -389,7 +385,7 @@ public class ComplianceTrainingServiceTest {
     tick();
 
     // User syncs training
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // The user should be updated in the database with a non-empty completion time.
     assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, currentTimestamp());
@@ -405,7 +401,7 @@ public class ComplianceTrainingServiceTest {
 
     // Time passes, user syncs training
     tick();
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // Completion should be updated to the current time.
     assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, currentTimestamp());
@@ -423,8 +419,7 @@ public class ComplianceTrainingServiceTest {
     // An empty map should be returned when we have no badge information.
     mockGetUserBadgesByBadgeName(ImmutableMap.of());
 
-    complianceTrainingService.syncComplianceTrainingStatus();
-    reloadUser();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
     assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, null);
   }
 
@@ -443,7 +438,7 @@ public class ComplianceTrainingServiceTest {
   public void testSyncComplianceTrainingStatus_SkippedForServiceAccount() throws Exception {
     when(userService.isServiceAccount(user)).thenReturn(true);
     providedWorkbenchConfig.auth.serviceAccountApiUsers.add(USERNAME);
-    complianceTrainingService.syncComplianceTrainingStatus();
+    user = complianceTrainingService.syncComplianceTrainingStatus();
     verifyNoInteractions(mockMoodleService);
   }
 
@@ -572,10 +567,6 @@ public class ComplianceTrainingServiceTest {
             List.of(
                 new Enrollment(RT_ABSORB_COURSE_ID, rtCompletionTime),
                 new Enrollment(CT_ABSORB_COURSE_ID, ctCompletionTime)));
-  }
-
-  private void reloadUser() {
-    user = userDao.findUserByUsername(USERNAME);
   }
 
   private Optional<DbComplianceTrainingVerification> getVerification(

--- a/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
@@ -34,6 +34,7 @@ import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbComplianceTrainingVerification;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.institution.InstitutionService;
@@ -133,7 +134,6 @@ public class ComplianceTrainingServiceTest {
     providedWorkbenchConfig.absorb.ctTrainingCourseId = CT_ABSORB_COURSE_ID;
 
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
-    TestMockFactory.createUserAccessModules(user, accessModules, userAccessModuleDao);
   }
 
   @Test
@@ -569,8 +569,8 @@ public class ComplianceTrainingServiceTest {
   private Timestamp getModuleCompletionTime(DbAccessModuleName moduleName) {
     return userAccessModuleDao
         .getByUserAndAccessModule(user, accessModuleDao.findOneByName(moduleName).get())
-        .get()
-        .getCompletionTime();
+        .map(DbUserAccessModule::getCompletionTime)
+        .orElse(null);
   }
 
   private BadgeDetailsV2 defaultBadgeDetails() {

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -29,11 +29,13 @@ import org.javers.common.collections.Lists;
 import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.db.dao.AccessModuleDao;
 import org.pmiops.workbench.db.dao.AccessTierDao;
+import org.pmiops.workbench.db.dao.UserAccessModuleDao;
 import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
@@ -307,6 +309,18 @@ public class TestMockFactory {
   public static List<DbAccessModule> createAccessModules(AccessModuleDao accessModuleDao) {
     accessModuleDao.saveAll(DEFAULT_ACCESS_MODULES);
     return accessModuleDao.findAll();
+  }
+
+  public static List<DbUserAccessModule> createUserAccessModules(
+      DbUser user, List<DbAccessModule> accessModules, UserAccessModuleDao userAccessModuleDao) {
+    List<DbUserAccessModule> userAccessModules = new ArrayList<>();
+    for (DbAccessModule accessModule : accessModules) {
+      DbUserAccessModule userAccessModule =
+          new DbUserAccessModule().setAccessModule(accessModule).setUser(user);
+      userAccessModules.add(userAccessModule);
+    }
+    userAccessModuleDao.saveAll(userAccessModules);
+    return userAccessModules;
   }
 
   public static DbCdrVersion createDefaultCdrVersion(long id) {

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -29,13 +29,11 @@ import org.javers.common.collections.Lists;
 import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.db.dao.AccessModuleDao;
 import org.pmiops.workbench.db.dao.AccessTierDao;
-import org.pmiops.workbench.db.dao.UserAccessModuleDao;
 import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
@@ -309,18 +307,6 @@ public class TestMockFactory {
   public static List<DbAccessModule> createAccessModules(AccessModuleDao accessModuleDao) {
     accessModuleDao.saveAll(DEFAULT_ACCESS_MODULES);
     return accessModuleDao.findAll();
-  }
-
-  public static List<DbUserAccessModule> createUserAccessModules(
-      DbUser user, List<DbAccessModule> accessModules, UserAccessModuleDao userAccessModuleDao) {
-    List<DbUserAccessModule> userAccessModules = new ArrayList<>();
-    for (DbAccessModule accessModule : accessModules) {
-      DbUserAccessModule userAccessModule =
-          new DbUserAccessModule().setAccessModule(accessModule).setUser(user);
-      userAccessModules.add(userAccessModule);
-    }
-    userAccessModuleDao.saveAll(userAccessModules);
-    return userAccessModules;
   }
 
   public static DbCdrVersion createDefaultCdrVersion(long id) {


### PR DESCRIPTION
When a user who has never completed a training using Moodle (i.e. new users) takes a training they now use Absorb. This is enabled in the local, test, staging, and stable environments.

One missing feature: an indication of which course the user should take when they reach Absorb. This topic is complex enough that I think it warrants a separate ticket, so I will split that out later today with more detail. I'll share this with product/ux when we're ready to discuss that.

Additionally, this only handles _initial training_. Renewal is not supported yet. Therefore, after one year, we would start to see errors. We [plan to work on renewal](https://precisionmedicineinitiative.atlassian.net/browse/RW-10362) immediately after releasing this, so I think this is OK for now.

[RW-10906](https://precisionmedicineinitiative.atlassian.net/browse/RW-10906) enables this in prod.

This may be easiest to review commit-by-commit though I will leave that up to the reviewer.

To manually test this:
- Create a *new* user (SSO for existing users is still [in progress](https://precisionmedicineinitiative.atlassian.net/browse/RW-10895))
- Using an admin user, bypass all modules except the two training ones
- Complete RT training. The Absorb course auto-completes if you click in and out of it.
- Sync RT training
- Complete CT training
- Sync CT training

I've also been thinking about test coverage a lot, so I'm interested in any thoughts you have on the level or depth of coverage in this PR. The Absorb service is intended to be a thin wrapper around using the Absorb API, tested using ([currently disabled](https://precisionmedicineinitiative.atlassian.net/browse/RW-11039)) "acceptance tests" (which make real API calls). The compliance service is entirely business logic and stubs the Absorb service.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [x] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.

[RW-10906]: https://precisionmedicineinitiative.atlassian.net/browse/RW-10906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ