### PR TITLE
[RW-11063] [risk=no]fix billing format when initial billing project is undefined

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -1089,6 +1089,37 @@ describe('WorkspaceEdit', () => {
     ]);
   });
 
+  it('should show free tier user account correctly when usage is undefined', async () => {
+    mockHasBillingScope.mockImplementation(() => true);
+    workspaceEditMode = WorkspaceEditMode.Create;
+    profileStore.set({
+      ...profileStore.get(),
+      profile: {
+        ...profileStore.get().profile,
+        freeTierUsage: undefined,
+      },
+    });
+
+    const wrapper = component();
+    await waitOneTickAndUpdate(wrapper);
+
+    const billingDropDown = wrapper
+      .find('[data-test-id="billing-dropdown"]')
+      .first();
+
+    expect(billingDropDown.props().value).toEqual('free-tier');
+    // @ts-ignore
+    expect(billingDropDown.props().options.map((o) => o.value)).toEqual([
+      'free-tier',
+      'user-billing',
+    ]);
+    // @ts-ignore
+    expect(billingDropDown.props().options.map((o) => o.label)).toEqual([
+      'Use All of Us initial credits - $34.56 left',
+      'User Billing',
+    ]);
+  });
+
   it('should show free tier and user billing account when they grant billing scope when creating workspace', async () => {
     mockHasBillingScope.mockImplementation(() => true);
     workspaceEditMode = WorkspaceEditMode.Create;

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -399,7 +399,11 @@ export const WorkspaceEdit = fp.flow(
           profile: { freeTierDollarQuota, freeTierUsage },
         },
       } = this.props;
-      const initialCreditsBalance = freeTierDollarQuota - freeTierUsage;
+
+      const freeTierUsageInNumber =
+        typeof freeTierUsage === 'undefined' ? 0 : freeTierUsage;
+
+      const initialCreditsBalance = freeTierDollarQuota - freeTierUsageInNumber;
       return (
         'Use All of Us initial credits - ' +
         formatInitialCreditsUSD(initialCreditsBalance) +


### PR DESCRIPTION
The new sw
![Screenshot 2023-10-05 at 3 29 06 PM](https://github.com/all-of-us/workbench/assets/6351731/3db1fb9b-aebd-4863-b0ff-201ce2000242)
agger UI returns undefined for null values. 
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
