### PR TITLE
[DT-514][risk=no] Add person has ehr data to prepackaged conceptset

### DIFF
--- a/api/db-cdr/generate-cdr/build-cb-criteria-menu.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-menu.sh
@@ -118,7 +118,7 @@ echo "Getting parent id"
 query="select id from \`$BQ_PROJECT.$BQ_DATASET.cb_criteria_menu\` where domain_id = 'SURVEY' and is_group = 1"
 PARENT_ID=$(bq --quiet --project_id="$BQ_PROJECT" query --nouse_legacy_sql "$query" | tr -dc '0-9')
 
-SORT_ORDER=0
+SORT_ORDER=1
 
 while IFS= read -r line
 do

--- a/api/db-cdr/generate-cdr/build-ds-linking.sh
+++ b/api/db-cdr/generate-cdr/build-ds-linking.sh
@@ -339,3 +339,20 @@ VALUES
   ($((ID++)), 'LEVEL', 'sleep_level.level', 'FROM \`\${projectId}.\${dataSetId}.sleep_level\` sleep_level', 'Fitbit_sleep_level'),
   ($((ID++)), 'START_DATETIME', 'CAST(sleep_level.start_datetime AS DATE) as date', 'FROM \`\${projectId}.\${dataSetId}.sleep_level\` sleep_level', 'Fitbit_sleep_level'),
   ($((ID++)), 'DURATION_IN_MIN', 'sleep_level.duration_in_min', 'FROM \`\${projectId}.\${dataSetId}.sleep_level\` sleep_level', 'Fitbit_sleep_level')"
+
+echo "ds_linking - inserting person_has_ehr_data data"
+bq --quiet --project_id=$BQ_PROJECT query --nouse_legacy_sql \
+"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (ID, DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
+VALUES
+    ($((ID++)), 'CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
+    ($((ID++)), 'PERSON_ID', 'person.person_id', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
+    ($((ID++)), 'GENDER_CONCEPT_ID', 'person.gender_concept_id', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
+    ($((ID++)), 'GENDER', 'p_gender_concept.concept_name as gender', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_gender_concept ON person.gender_concept_id = p_gender_concept.concept_id', 'Person_has_ehr_data'),
+    ($((ID++)), 'DATE_OF_BIRTH', 'person.birth_datetime as date_of_birth', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
+    ($((ID++)), 'RACE_CONCEPT_ID', 'person.race_concept_id', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
+    ($((ID++)), 'RACE', 'p_race_concept.concept_name as race', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_race_concept ON person.race_concept_id = p_race_concept.concept_id', 'Person_has_ehr_data'),
+    ($((ID++)), 'ETHNICITY_CONCEPT_ID', 'person.ethnicity_concept_id', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
+    ($((ID++)), 'ETHNICITY', 'p_ethnicity_concept.concept_name as ethnicity', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_ethnicity_concept ON person.ethnicity_concept_id = p_ethnicity_concept.concept_id', 'Person_has_ehr_data'),
+    ($((ID++)), 'SEX_AT_BIRTH_CONCEPT_ID', 'person.sex_at_birth_concept_id', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
+    ($((ID++)), 'SEX_AT_BIRTH', 'p_sex_at_birth_concept.concept_name as sex_at_birth', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_sex_at_birth_concept ON person.sex_at_birth_concept_id = p_sex_at_birth_concept.concept_id', 'Person_has_ehr_data')
+    ($((ID++)), 'HAS_EHR_DATA', 'cb_search_person.has_ehr_data as has_ehr_data', 'LEFT JOIN \`\${projectId}.\${dataSetId}.cb_search_person\` cb_search_person ON person.person_id = cb_search_person.person_id', 'Person_has_ehr_data')"

--- a/api/db-cdr/generate-cdr/build-ds-linking.sh
+++ b/api/db-cdr/generate-cdr/build-ds-linking.sh
@@ -339,20 +339,3 @@ VALUES
   ($((ID++)), 'LEVEL', 'sleep_level.level', 'FROM \`\${projectId}.\${dataSetId}.sleep_level\` sleep_level', 'Fitbit_sleep_level'),
   ($((ID++)), 'START_DATETIME', 'CAST(sleep_level.start_datetime AS DATE) as date', 'FROM \`\${projectId}.\${dataSetId}.sleep_level\` sleep_level', 'Fitbit_sleep_level'),
   ($((ID++)), 'DURATION_IN_MIN', 'sleep_level.duration_in_min', 'FROM \`\${projectId}.\${dataSetId}.sleep_level\` sleep_level', 'Fitbit_sleep_level')"
-
-echo "ds_linking - inserting person_has_ehr_data data"
-bq --quiet --project_id=$BQ_PROJECT query --nouse_legacy_sql \
-"INSERT INTO \`$BQ_PROJECT.$BQ_DATASET.ds_linking\` (ID, DENORMALIZED_NAME, OMOP_SQL, JOIN_VALUE, DOMAIN)
-VALUES
-    ($((ID++)), 'CORE_TABLE_FOR_DOMAIN', 'CORE_TABLE_FOR_DOMAIN', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
-    ($((ID++)), 'PERSON_ID', 'person.person_id', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
-    ($((ID++)), 'GENDER_CONCEPT_ID', 'person.gender_concept_id', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
-    ($((ID++)), 'GENDER', 'p_gender_concept.concept_name as gender', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_gender_concept ON person.gender_concept_id = p_gender_concept.concept_id', 'Person_has_ehr_data'),
-    ($((ID++)), 'DATE_OF_BIRTH', 'person.birth_datetime as date_of_birth', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
-    ($((ID++)), 'RACE_CONCEPT_ID', 'person.race_concept_id', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
-    ($((ID++)), 'RACE', 'p_race_concept.concept_name as race', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_race_concept ON person.race_concept_id = p_race_concept.concept_id', 'Person_has_ehr_data'),
-    ($((ID++)), 'ETHNICITY_CONCEPT_ID', 'person.ethnicity_concept_id', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
-    ($((ID++)), 'ETHNICITY', 'p_ethnicity_concept.concept_name as ethnicity', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_ethnicity_concept ON person.ethnicity_concept_id = p_ethnicity_concept.concept_id', 'Person_has_ehr_data'),
-    ($((ID++)), 'SEX_AT_BIRTH_CONCEPT_ID', 'person.sex_at_birth_concept_id', 'FROM \`\${projectId}.\${dataSetId}.person\` person', 'Person_has_ehr_data'),
-    ($((ID++)), 'SEX_AT_BIRTH', 'p_sex_at_birth_concept.concept_name as sex_at_birth', 'LEFT JOIN \`\${projectId}.\${dataSetId}.concept\` p_sex_at_birth_concept ON person.sex_at_birth_concept_id = p_sex_at_birth_concept.concept_id', 'Person_has_ehr_data')
-    ($((ID++)), 'HAS_EHR_DATA', 'cb_search_person.has_ehr_data as has_ehr_data', 'LEFT JOIN \`\${projectId}.\${dataSetId}.cb_search_person\` cb_search_person ON person.person_id = cb_search_person.person_id', 'Person_has_ehr_data')"

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -997,25 +997,22 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
             .getItems();
 
     assertThat(
-        domainWithDomainValues.containsAll(
-            ImmutableList.of(
-                new DomainWithDomainValues()
-                    .domain(Domain.PERSON.toString())
-                    .items(
-                        ImmutableList.of(
-                            new DomainValue().value("person_id"),
-                            new DomainValue().value("gender_concept_id"),
-                            new DomainValue().value("gender"),
-                            new DomainValue().value("date_of_birth"),
-                            new DomainValue().value("race_concept_id"),
-                            new DomainValue().value("race"),
-                            new DomainValue().value("ethnicity_concept_id"),
-                            new DomainValue().value("ethnicity"),
-                            new DomainValue().value("sex_at_birth_concept_id"),
-                            new DomainValue().value("sex_at_birth")
-
-                        )
-                    ))))
+            domainWithDomainValues.containsAll(
+                ImmutableList.of(
+                    new DomainWithDomainValues()
+                        .domain(Domain.PERSON.toString())
+                        .items(
+                            ImmutableList.of(
+                                new DomainValue().value("person_id"),
+                                new DomainValue().value("gender_concept_id"),
+                                new DomainValue().value("gender"),
+                                new DomainValue().value("date_of_birth"),
+                                new DomainValue().value("race_concept_id"),
+                                new DomainValue().value("race"),
+                                new DomainValue().value("ethnicity_concept_id"),
+                                new DomainValue().value("ethnicity"),
+                                new DomainValue().value("sex_at_birth_concept_id"),
+                                new DomainValue().value("sex_at_birth"))))))
         .isEqualTo(true);
   }
 

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -1000,7 +1000,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
             domainWithDomainValues.containsAll(
                 ImmutableList.of(
                     new DomainWithDomainValues()
-                        .domain(Domain.PERSON.toString())
+                        .domain(Domain.PERSON_HAS_EHR_DATA.toString())
                         .items(
                             ImmutableList.of(
                                 new DomainValue().value("person_id"),

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -984,6 +984,42 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
+  public void getValuesFromDomainPersonHasEhrData() {
+    List<DomainWithDomainValues> domainWithDomainValues =
+        Objects.requireNonNull(
+                controller
+                    .getValuesFromDomain(
+                        WORKSPACE_NAMESPACE,
+                        WORKSPACE_NAME,
+                        Domain.PERSON_HAS_EHR_DATA.toString(),
+                        1L)
+                    .getBody())
+            .getItems();
+
+    assertThat(
+        domainWithDomainValues.containsAll(
+            ImmutableList.of(
+                new DomainWithDomainValues()
+                    .domain(Domain.PERSON.toString())
+                    .items(
+                        ImmutableList.of(
+                            new DomainValue().value("person_id"),
+                            new DomainValue().value("gender_concept_id"),
+                            new DomainValue().value("gender"),
+                            new DomainValue().value("date_of_birth"),
+                            new DomainValue().value("race_concept_id"),
+                            new DomainValue().value("race"),
+                            new DomainValue().value("ethnicity_concept_id"),
+                            new DomainValue().value("ethnicity"),
+                            new DomainValue().value("sex_at_birth_concept_id"),
+                            new DomainValue().value("sex_at_birth")
+
+                        )
+                    ))))
+        .isEqualTo(true);
+  }
+
+  @Test
   public void previewDataSetByDomainCondition() {
     DataSetPreviewResponse dataSetPreviewResponse =
         Objects.requireNonNull(

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -436,9 +436,6 @@ public class DataSetController implements DataSetApiDelegate {
           new DomainWithDomainValues()
               .domain(Domain.WHOLE_GENOME_VARIANT.toString())
               .addItemsItem(new DomainValue().value(WHOLE_GENOME_VALUE)));
-    } else if (domainValue.equals(Domain.PERSON_HAS_EHR_DATA.toString())) {
-      response.setItems(
-          dataSetService.getValueListFromDomain(conceptSetId, Domain.PERSON.toString()));
     } else {
       response.setItems(dataSetService.getValueListFromDomain(conceptSetId, domainValue));
     }

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -439,8 +439,6 @@ public class DataSetController implements DataSetApiDelegate {
     } else if (domainValue.equals(Domain.PERSON_HAS_EHR_DATA.toString())) {
       response.setItems(
           dataSetService.getValueListFromDomain(conceptSetId, Domain.PERSON.toString()));
-      response.getItems().get(0).setDomain(Domain.PERSON_HAS_EHR_DATA.toString());
-      response.getItems().get(0).getItems().add(new DomainValue().value(HAS_EHR_DATA_VALUE));
     } else {
       response.setItems(dataSetService.getValueListFromDomain(conceptSetId, domainValue));
     }

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -72,6 +72,8 @@ public class DataSetController implements DataSetApiDelegate {
   public static final String EMPTY_CELL_MARKER = "";
   public static final String WHOLE_GENOME_VALUE = "VCF Files";
 
+  public static final String HAS_EHR_DATA_VALUE = "has_ehr_data";
+
   private static final Logger log = Logger.getLogger(DataSetController.class.getName());
 
   private final DataSetService dataSetService;
@@ -434,6 +436,11 @@ public class DataSetController implements DataSetApiDelegate {
           new DomainWithDomainValues()
               .domain(Domain.WHOLE_GENOME_VARIANT.toString())
               .addItemsItem(new DomainValue().value(WHOLE_GENOME_VALUE)));
+    } else if (domainValue.equals(Domain.PERSON_HAS_EHR_DATA.toString())) {
+      response.setItems(
+          dataSetService.getValueListFromDomain(conceptSetId, Domain.PERSON.toString()));
+      response.getItems().get(0).setDomain(Domain.PERSON_HAS_EHR_DATA.toString());
+      response.getItems().get(0).getItems().add(new DomainValue().value(HAS_EHR_DATA_VALUE));
     } else {
       response.setItems(dataSetService.getValueListFromDomain(conceptSetId, domainValue));
     }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -219,6 +219,7 @@ public final class DbStorageEnums {
           .put(Domain.CONCEPT_SET, (short) 27)
           .put(Domain.CONCEPT_QUICK_ADD, (short) 28)
           .put(Domain.SNP_INDEL_VARIANT, (short) 29)
+          .put(Domain.PERSON_HAS_EHR_DATA, (short) 30)
           .build();
 
   // A mapping from our Domain enum to OMOP domain ID values.
@@ -254,6 +255,7 @@ public final class DbStorageEnums {
           .put(Domain.CONCEPT_SET, "Concept Set")
           .put(Domain.CONCEPT_QUICK_ADD, "Concept Quick Add")
           .put(Domain.SNP_INDEL_VARIANT, "SNP/Indel Variants")
+          .put(Domain.PERSON_HAS_EHR_DATA, "Person Has EHR Data")
           .build();
 
   public static Domain domainFromStorage(Short domain) {

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -342,6 +342,7 @@ public final class DbStorageEnums {
               .put(PrePackagedConceptSetEnum.SURVEY_SDOH, (short) 18)
               .put(PrePackagedConceptSetEnum.SURVEY_COVID_VACCINE, (short) 19)
               .put(PrePackagedConceptSetEnum.SURVEY_PFHH, (short) 20)
+              .put(PrePackagedConceptSetEnum.PERSON_HAS_EHR_DATA, (short) 21)
               .build();
 
   public static PrePackagedConceptSetEnum prePackagedConceptSetsFromStorage(Short conceptSet) {

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -7712,6 +7712,7 @@ components:
       enum:
       - NONE
       - PERSON
+      - PERSON_HAS_EHR_DATA
       - SURVEY
       - SURVEY_BASICS
       - SURVEY_LIFESTYLE
@@ -7731,7 +7732,6 @@ components:
       - WHOLE_GENOME
       - BOTH
       - ZIP_CODE_SOCIOECONOMIC
-      - PERSON_HAS_EHR_DATA
     DataSetExportRequest:
       required:
       - dataSetRequest

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6430,7 +6430,7 @@ components:
       - ARRAY_DATA
       - CONCEPT_SET
       - CONCEPT_QUICK_ADD
-      - -PERSON_HAS_EHR_DATA
+      - PERSON_HAS_EHR_DATA
     Surveys:
       type: string
       description: a survey for concepts
@@ -7731,6 +7731,7 @@ components:
       - WHOLE_GENOME
       - BOTH
       - ZIP_CODE_SOCIOECONOMIC
+      - PERSON_HAS_EHR_DATA
     DataSetExportRequest:
       required:
       - dataSetRequest

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6430,6 +6430,7 @@ components:
       - ARRAY_DATA
       - CONCEPT_SET
       - CONCEPT_QUICK_ADD
+      - -PERSON_HAS_EHR_DATA
     Surveys:
       type: string
       description: a survey for concepts

--- a/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
@@ -533,6 +533,16 @@ public class DataSetServiceTest {
   }
 
   @Test
+  public void testGetValueListFromDomainPersonHasEhrData() {
+    mockPersonDomainTableFields();
+    List<DomainWithDomainValues> personDomainValueList =
+        dataSetServiceImpl.getValueListFromDomain(null, "PERSON_HAS_EHR_DATA");
+    assertThat(personDomainValueList.get(0).getItems().size()).isEqualTo(2);
+    assertThat(
+        personDomainValueList.get(0).getDomain().equals(Domain.PERSON_HAS_EHR_DATA.toString()));
+  }
+
+  @Test
   public void testGetDataSets_cohort() {
     DbConceptSet dbConceptSet = new DbConceptSet();
     dbConceptSet.setConceptSetId(3L);
@@ -812,6 +822,15 @@ public class DataSetServiceTest {
     doReturn(measurementList)
         .when(mockBigQueryService)
         .getTableFieldsFromDomain(Domain.MEASUREMENT);
+  }
+
+  private void mockPersonDomainTableFields() {
+    FieldList personFieldList =
+        FieldList.of(
+            ImmutableList.of(
+                Field.of("person_id", LegacySQLTypeName.INTEGER),
+                Field.of("sex_at_birth", LegacySQLTypeName.STRING)));
+    doReturn(personFieldList).when(mockBigQueryService).getTableFieldsFromDomain(Domain.PERSON);
   }
 
   private String normalizeDomainName(Domain d) {

--- a/ui/src/app/pages/data/cohort/utils.ts
+++ b/ui/src/app/pages/data/cohort/utils.ts
@@ -78,6 +78,9 @@ export function domainToTitle(domain: any): string {
     case Domain.PERSON:
       domain = 'Demographics';
       break;
+    case Domain.PERSON_HAS_EHR_DATA:
+      domain = 'Demographics has EHR data';
+      break;
     case Domain.MEASUREMENT:
       domain = 'Labs and Measurements';
       break;

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -622,7 +622,7 @@ describe('DataSetPage', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(
       wrapper.find('[data-test-id="prePackage-concept-set-item"]').length
-    ).toBe(10);
+    ).toBe(11);
 
     // restore original CDR Version for other tests
     cdrVersionTiersResponse.tiers[0].versions[0] = originalCdrVersion;

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -600,7 +600,7 @@ describe('DataSetPage', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(
       wrapper.find('[data-test-id="prePackage-concept-set-item"]').length
-    ).toBe(14);
+    ).toBe(15);
 
     cdrVersionTiersResponse.tiers[0].versions[0] = {
       ...originalCdrVersion,
@@ -611,7 +611,7 @@ describe('DataSetPage', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(
       wrapper.find('[data-test-id="prePackage-concept-set-item"]').length
-    ).toBe(11);
+    ).toBe(12);
 
     cdrVersionTiersResponse.tiers[0].versions[0] = {
       ...originalCdrVersion,

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -590,7 +590,7 @@ describe('DataSetPage', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(
       wrapper.find('[data-test-id="prePackage-concept-set-item"]').length
-    ).toBe(15);
+    ).toBe(16);
 
     cdrVersionTiersResponse.tiers[0].versions[0] = {
       ...originalCdrVersion,

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -947,7 +947,7 @@ export const DatasetPage = fp.flow(
       values.items.forEach((domainWithDomainValues) => {
         const domain = reverseDomainEnum[domainWithDomainValues.domain];
         if (
-          ![domain, Domain.PHYSICAL_MEASUREMENT_CSS].includes(
+          ![domain, Domain.PHYSICAL_MEASUREMENT_CSS, Domain.PERSON_HAS_EHR_DATA].includes(
             domainWithConceptSetId.domain
           )
         ) {

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -280,6 +280,7 @@ interface ImmutableListItemProps {
   onChange: Function;
   checked: boolean;
   showSourceConceptIcon?: boolean;
+  disabled?: boolean;
 }
 const ImmutableListItem = ({
   name,
@@ -287,6 +288,7 @@ const ImmutableListItem = ({
   onChange,
   checked,
   showSourceConceptIcon,
+  disabled,
 }: ImmutableListItemProps) => {
   const [showNameTooltip, setShowNameTooltip] = useState(false);
   return (
@@ -301,6 +303,7 @@ const ImmutableListItem = ({
             : styles.listItemCheckbox
         }
         checked={checked}
+        disabled={disabled}
       />
       <TooltipTrigger disabled={!showNameTooltip} content={<div>{name}</div>}>
         <div
@@ -947,9 +950,11 @@ export const DatasetPage = fp.flow(
       values.items.forEach((domainWithDomainValues) => {
         const domain = reverseDomainEnum[domainWithDomainValues.domain];
         if (
-          ![domain, Domain.PHYSICAL_MEASUREMENT_CSS, Domain.PERSON_HAS_EHR_DATA].includes(
-            domainWithConceptSetId.domain
-          )
+          ![
+            domain,
+            Domain.PHYSICAL_MEASUREMENT_CSS,
+            Domain.PERSON_HAS_EHR_DATA,
+          ].includes(domainWithConceptSetId.domain)
         ) {
           updatedCrossDomainConceptSetList.add(
             domainWithConceptSetId.conceptSetId
@@ -1034,9 +1039,11 @@ export const DatasetPage = fp.flow(
         values.items.forEach((domainWithDomainValues) => {
           const domain = reverseDomainEnum[domainWithDomainValues.domain];
           if (
-            ![domain, Domain.PHYSICAL_MEASUREMENT_CSS, Domain.PERSON_HAS_EHR_DATA].includes(
-              domainWithConceptSetId.domain
-            )
+            ![
+              domain,
+              Domain.PHYSICAL_MEASUREMENT_CSS,
+              Domain.PERSON_HAS_EHR_DATA,
+            ].includes(domainWithConceptSetId.domain)
           ) {
             newCrossDomainConceptSetList.add(
               domainWithConceptSetId.conceptSetId
@@ -1133,6 +1140,16 @@ export const DatasetPage = fp.flow(
       );
     };
 
+    const prepackagedIsDisabled = (prepackaged: string) =>
+      (prepackaged === PrePackagedConceptSetEnum.PERSON_HAS_EHR_DATA &&
+        selectedPrepackagedConceptSets.includes(
+          PrePackagedConceptSetEnum.PERSON
+        )) ||
+      (prepackaged === PrePackagedConceptSetEnum.PERSON &&
+        selectedPrepackagedConceptSets.includes(
+          PrePackagedConceptSetEnum.PERSON_HAS_EHR_DATA
+        ));
+
     const selectPrePackagedConceptSet = (
       prepackaged: PrePackagedConceptSetEnum,
       selected: boolean
@@ -1168,10 +1185,12 @@ export const DatasetPage = fp.flow(
         // if *any* of the individual survey is unselected, unselect all-surveys
         // code here ...
         if (
-            prepackaged !== PrePackagedConceptSetEnum.PERSON_HAS_EHR_DATA &&
-            updatedPrepackaged.has(prepackaged)
+          prepackaged !== PrePackagedConceptSetEnum.PERSON_HAS_EHR_DATA &&
+          updatedPrepackaged.has(prepackaged)
         ) {
-          updatedPrepackaged.delete(PrePackagedConceptSetEnum.PERSON_HAS_EHR_DATA);
+          updatedPrepackaged.delete(
+            PrePackagedConceptSetEnum.PERSON_HAS_EHR_DATA
+          );
         }
         if (
           prepackaged !== PrePackagedConceptSetEnum.SURVEY &&
@@ -1807,6 +1826,7 @@ export const DatasetPage = fp.flow(
                         data-test-id='prePackage-concept-set-item'
                         key={prepackaged}
                         checked={selectedPrepackagedConceptSets.includes(p)}
+                        disabled={prepackagedIsDisabled(p)}
                         onChange={() =>
                           selectPrePackagedConceptSet(
                             p,

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -657,6 +657,7 @@ const BoxHeader = ({
 
 const prepackagedAllSurveyConceptSetToString = {
   PERSON: 'Demographics',
+  PERSON_HAS_EHR_DATA: 'Demographics Has EHR Data',
   SURVEY: 'All Surveys',
   FITBIT_HEART_RATE_SUMMARY: 'Fitbit Heart Rate Summary',
   FITBIT_ACTIVITY: 'Fitbit Activity Summary',
@@ -681,6 +682,7 @@ const prepackagedSurveyConceptSetToString = {
 
 const PREPACKAGED_SURVEY_PERSON_DOMAIN = {
   [PrePackagedConceptSetEnum.PERSON]: Domain.PERSON,
+  [PrePackagedConceptSetEnum.PERSON_HAS_EHR_DATA]: Domain.PERSON_HAS_EHR_DATA,
   [PrePackagedConceptSetEnum.SURVEY]: Domain.SURVEY,
 };
 
@@ -750,6 +752,7 @@ const reverseDomainEnum = {
   WHOLE_GENOME_VARIANT: Domain.WHOLE_GENOME_VARIANT,
   ZIP_CODE_SOCIOECONOMIC: Domain.ZIP_CODE_SOCIOECONOMIC,
   ARRAY_DATA: Domain.ARRAY_DATA,
+  PERSON_HAS_EHR_DATA: Domain.PERSON_HAS_EHR_DATA,
 };
 
 // Temp workaround to prevent errors from mismatched upper and lower case values

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -1168,6 +1168,12 @@ export const DatasetPage = fp.flow(
         // if *any* of the individual survey is unselected, unselect all-surveys
         // code here ...
         if (
+            prepackaged !== PrePackagedConceptSetEnum.PERSON_HAS_EHR_DATA &&
+            updatedPrepackaged.has(prepackaged)
+        ) {
+          updatedPrepackaged.delete(PrePackagedConceptSetEnum.PERSON_HAS_EHR_DATA);
+        }
+        if (
           prepackaged !== PrePackagedConceptSetEnum.SURVEY &&
           updatedPrepackaged.has(prepackaged) &&
           prepackaged.toString().startsWith('SURVEY_')

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -1034,7 +1034,7 @@ export const DatasetPage = fp.flow(
         values.items.forEach((domainWithDomainValues) => {
           const domain = reverseDomainEnum[domainWithDomainValues.domain];
           if (
-            ![domain, Domain.PHYSICAL_MEASUREMENT_CSS].includes(
+            ![domain, Domain.PHYSICAL_MEASUREMENT_CSS, Domain.PERSON_HAS_EHR_DATA].includes(
               domainWithConceptSetId.domain
             )
           ) {


### PR DESCRIPTION
---
- Added prepackaged conceptSet for Demographics to get participants who have EHR data
- Updated to add new overloaded name/enum `Domain.PERSON_HAS_EHR_DATA` for `Domain.PERSON`
- Updated UI for functionality to choose either `Demographics` or `Demographics Has EHR Data`

https://github.com/all-of-us/workbench/assets/4452480/16a77211-0e34-4c08-aee4-a0acd6d782e9



---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [x] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
