### PR TITLE
[risk=low][no ticket] Make pause and resume actions optional for when they are not needed

### DIFF
--- a/ui/src/app/components/common-env-conf-panels/environment-informed-action-panel.tsx
+++ b/ui/src/app/components/common-env-conf-panels/environment-informed-action-panel.tsx
@@ -102,10 +102,13 @@ export const EnvironmentInformedActionPanel = ({
       <StartStopEnvironmentButton {...{ status, onPause, onResume, appType }} />
     )}
     <CostInfo
-      {...{ analysisConfig, environmentChanged }}
+      {...{
+        analysisConfig,
+        creatorFreeCreditsRemaining,
+        environmentChanged,
+        workspace,
+      }}
       currentUser={profile.username}
-      workspace={workspace}
-      creatorFreeCreditsRemaining={creatorFreeCreditsRemaining}
       isGKEApp={appType !== UIAppType.JUPYTER}
     />
   </FlexRow>

--- a/ui/src/app/components/common-env-conf-panels/environment-informed-action-panel.tsx
+++ b/ui/src/app/components/common-env-conf-panels/environment-informed-action-panel.tsx
@@ -81,9 +81,9 @@ interface PanelProps {
   workspace: Workspace;
   analysisConfig: AnalysisConfig;
   status: AppStatus | RuntimeStatus;
-  onPause: () => void;
-  onResume: () => void;
   appType: UIAppType;
+  onPause?: () => void;
+  onResume?: () => void;
   environmentChanged?: boolean;
 }
 export const EnvironmentInformedActionPanel = ({
@@ -92,14 +92,14 @@ export const EnvironmentInformedActionPanel = ({
   workspace,
   analysisConfig,
   status,
+  appType,
   onPause,
   onResume,
-  appType,
   environmentChanged = false,
 }: PanelProps) => (
   <FlexRow style={styles.environmentInformedActionPanelWrapper}>
     {appType === UIAppType.JUPYTER && (
-      <StartStopEnvironmentButton {...{ status, onPause, onResume, appType }} />
+      <StartStopEnvironmentButton {...{ status, appType, onPause, onResume }} />
     )}
     <CostInfo
       {...{

--- a/ui/src/app/components/common-env-conf-panels/start-stop-environment-button.spec.tsx
+++ b/ui/src/app/components/common-env-conf-panels/start-stop-environment-button.spec.tsx
@@ -1,0 +1,88 @@
+import '@testing-library/jest-dom';
+
+import { AppStatus, RuntimeStatus } from 'generated/fetch';
+
+import { appTypeToString } from '../../utils/user-apps-utils';
+import { render, screen, waitFor } from '@testing-library/react';
+import { UIAppType } from 'app/components/apps-panel/utils';
+
+import {
+  StartStopEnvironmentButton,
+  StartStopEnvironmentProps,
+} from './start-stop-environment-button';
+
+describe(StartStopEnvironmentButton.name, () => {
+  const runningText = 'Environment running, click to pause';
+  const pausedText = 'Environment paused, click to resume';
+
+  const onPause = jest.fn();
+  const onResume = jest.fn();
+  const defaultProps: StartStopEnvironmentProps = {
+    appType: UIAppType.JUPYTER,
+    status: RuntimeStatus.RUNNING,
+    onPause,
+    onResume,
+  };
+
+  const component = async (
+    propOverrides?: Partial<StartStopEnvironmentProps>
+  ) =>
+    render(
+      <StartStopEnvironmentButton {...{ ...defaultProps, ...propOverrides }} />
+    );
+
+  describe.each([
+    [UIAppType.JUPYTER, RuntimeStatus.RUNNING, RuntimeStatus.STOPPED],
+    [UIAppType.CROMWELL, AppStatus.RUNNING, AppStatus.STOPPED],
+    [UIAppType.RSTUDIO, AppStatus.RUNNING, AppStatus.STOPPED],
+    [UIAppType.SAS, AppStatus.RUNNING, AppStatus.STOPPED],
+  ])(
+    '%s',
+    (
+      appType: UIAppType,
+      runningStatus: AppStatus | RuntimeStatus,
+      pausedStatus: AppStatus | RuntimeStatus
+    ) => {
+      it('allows pausing a running app', async () => {
+        await component({ status: runningStatus, appType });
+        const pauseButton = screen.getByAltText(runningText);
+        pauseButton.click();
+        await waitFor(() => expect(onPause).toHaveBeenCalled());
+      });
+
+      // not an expected case, but this checks that we handle it gracefully
+      it('does not allow pausing a running app when onPause is not provided', async () => {
+        await component({ status: runningStatus, appType, onPause: undefined });
+        const pauseButton = screen.getByAltText(runningText);
+        pauseButton.click();
+
+        // clicking does nothing: onPause is not called, and we also continue to display the text
+
+        await waitFor(() => {
+          expect(onPause).not.toHaveBeenCalled();
+          expect(screen.getByAltText(runningText)).toBeInTheDocument();
+        });
+      });
+
+      it('allows resuming a paused app', async () => {
+        await component({ status: pausedStatus, appType });
+        const pauseButton = screen.getByAltText(pausedText);
+        pauseButton.click();
+        await waitFor(() => expect(onResume).toHaveBeenCalled());
+      });
+
+      it('does not allow resuming a paused app when onResume is not provided', async () => {
+        await component({ status: pausedStatus, appType, onResume: undefined });
+        const resumeButton = screen.getByAltText(pausedText);
+        resumeButton.click();
+
+        // clicking does nothing: onResume is not called, and we also continue to display the text
+
+        await waitFor(() => {
+          expect(onResume).not.toHaveBeenCalled();
+          expect(screen.getByAltText(pausedText)).toBeInTheDocument();
+        });
+      });
+    }
+  );
+});

--- a/ui/src/app/components/common-env-conf-panels/start-stop-environment-button.spec.tsx
+++ b/ui/src/app/components/common-env-conf-panels/start-stop-environment-button.spec.tsx
@@ -2,7 +2,6 @@ import '@testing-library/jest-dom';
 
 import { AppStatus, RuntimeStatus } from 'generated/fetch';
 
-import { appTypeToString } from '../../utils/user-apps-utils';
 import { render, screen, waitFor } from '@testing-library/react';
 import { UIAppType } from 'app/components/apps-panel/utils';
 

--- a/ui/src/app/components/common-env-conf-panels/start-stop-environment-button.tsx
+++ b/ui/src/app/components/common-env-conf-panels/start-stop-environment-button.tsx
@@ -174,23 +174,13 @@ export const StartStopEnvironmentButton = ({
         borderRadius: '5px 0 0 5px',
       }}
     >
-      {/* TooltipTrigger inside the conditionals because it doesn't handle fragments well. */}
-      {onClick && (
-        <TooltipTrigger content={<div>{imgProps.alt}</div>} side='left'>
-          <FlexRow style={iconWrapperStyle}>
-            <Clickable {...{ onClick }} style={{ display: 'flex' }}>
-              <img {...imgProps} />
-            </Clickable>
-          </FlexRow>
-        </TooltipTrigger>
-      )}
-      {!onClick && (
-        <TooltipTrigger content={<div>{imgProps.alt}</div>} side='left'>
-          <FlexRow style={iconWrapperStyle}>
+      <TooltipTrigger content={<div>{imgProps.alt}</div>} side='left'>
+        <FlexRow style={iconWrapperStyle}>
+          <Clickable {...{ onClick }} style={{ display: 'flex' }}>
             <img {...imgProps} />
-          </FlexRow>
-        </TooltipTrigger>
-      )}
+          </Clickable>
+        </FlexRow>
+      </TooltipTrigger>
     </FlexRow>
   );
 };

--- a/ui/src/app/components/common-env-conf-panels/start-stop-environment-button.tsx
+++ b/ui/src/app/components/common-env-conf-panels/start-stop-environment-button.tsx
@@ -20,18 +20,21 @@ import computeStarting from 'assets/icons/compute-starting.svg';
 import computeStopped from 'assets/icons/compute-stopped.svg';
 import computeStopping from 'assets/icons/compute-stopping.svg';
 
+interface ImgProps {
+  alt: string;
+  src: string;
+  style?: CSSProperties;
+  'data-test-id': string;
+}
+interface ButtonProps extends ImgProps {
+  onClick?: () => void;
+}
+
 interface ComponentProps {
   status: AppStatus | RuntimeStatus;
   onPause: () => void;
   onResume: () => void;
   appType: UIAppType;
-}
-interface ButtonProps {
-  altText: string;
-  iconSrc: string;
-  dataTestId: string;
-  styleOverrides?: CSSProperties;
-  onClick?: () => void;
 }
 export const StartStopEnvironmentButton = ({
   status,
@@ -43,107 +46,104 @@ export const StartStopEnvironmentButton = ({
     toUserEnvironmentStatusByAppType(status, appType);
 
   const rotateStyle = { animation: 'rotation 2s infinite linear' };
-  const {
-    altText,
-    iconSrc,
-    dataTestId,
-    styleOverrides = {},
-    onClick = null,
-  } = switchCase<UserEnvironmentStatus, ButtonProps>(
+  const { onClick = null, ...imgProps } = switchCase<
+    UserEnvironmentStatus,
+    ButtonProps
+  >(
     userEnvironmentStatus,
     [
       UserEnvironmentStatus.CREATING,
       () => ({
-        altText: 'Environment creation in progress',
-        iconSrc: computeStarting,
-        dataTestId: 'environment-status-icon-starting',
-        styleOverrides: rotateStyle,
+        alt: 'Environment creation in progress',
+        src: computeStarting,
+        'data-test-id': 'environment-status-icon-starting',
+        style: rotateStyle,
       }),
     ],
     [
       UserEnvironmentStatus.RUNNING,
       () => ({
-        altText: 'Environment running, click to pause',
-        iconSrc: computeRunning,
-        dataTestId: 'environment-status-icon-running',
+        alt: 'Environment running, click to pause',
+        src: computeRunning,
+        'data-test-id': 'environment-status-icon-running',
         onClick: onPause,
       }),
     ],
     [
       UserEnvironmentStatus.UPDATING,
       () => ({
-        altText: 'Environment update in progress',
-        iconSrc: computeStarting,
-        dataTestId: 'environment-status-icon-starting',
-        styleOverrides: rotateStyle,
+        alt: 'Environment update in progress',
+        src: computeStarting,
+        'data-test-id': 'environment-status-icon-starting',
+        style: rotateStyle,
       }),
     ],
     [
       UserEnvironmentStatus.ERROR,
       () => ({
-        altText: 'Environment in error state',
-        iconSrc: computeError,
-        dataTestId: 'environment-status-icon-error',
+        alt: 'Environment in error state',
+        src: computeError,
+        'data-test-id': 'environment-status-icon-error',
       }),
     ],
     [
       UserEnvironmentStatus.PAUSING,
       () => ({
-        altText: 'Environment pause in progress',
-        iconSrc: computeStopping,
-        dataTestId: 'environment-status-icon-stopping',
-        styleOverrides: rotateStyle,
+        alt: 'Environment pause in progress',
+        src: computeStopping,
+        'data-test-id': 'environment-status-icon-stopping',
+        style: rotateStyle,
       }),
     ],
     [
       UserEnvironmentStatus.PAUSED,
       () => ({
-        altText: 'Environment paused, click to resume',
-        iconSrc: computeStopped,
-        dataTestId: 'environment-status-icon-stopped',
+        alt: 'Environment paused, click to resume',
+        src: computeStopped,
+        'data-test-id': 'environment-status-icon-stopped',
         onClick: onResume,
       }),
     ],
     [
       UserEnvironmentStatus.RESUMING,
       () => ({
-        altText: 'Environment resume in progress',
-        iconSrc: computeStarting,
-        dataTestId: 'environment-status-icon-starting',
-        styleOverrides: rotateStyle,
+        alt: 'Environment resume in progress',
+        src: computeStarting,
+        'data-test-id': 'environment-status-icon-starting',
+        style: rotateStyle,
       }),
     ],
     [
       UserEnvironmentStatus.DELETING,
       () => ({
-        altText: 'Environment deletion in progress',
-        iconSrc: computeStopping,
-        dataTestId: 'environment-status-icon-stopping',
-        styleOverrides: rotateStyle,
+        alt: 'Environment deletion in progress',
+        src: computeStopping,
+        'data-test-id': 'environment-status-icon-stopping',
+        style: rotateStyle,
       }),
     ],
     [
       UserEnvironmentStatus.DELETED,
       () => ({
-        altText: 'Environment has been deleted',
-        iconSrc: computeNone,
-        dataTestId: 'environment-status-icon-none',
+        alt: 'Environment has been deleted',
+        src: computeNone,
+        'data-test-id': 'environment-status-icon-none',
       }),
     ],
     [
       UserEnvironmentStatus.UNKNOWN,
       () => ({
-        altText: 'Environment status unknown',
-        iconSrc: computeNone,
-        dataTestId: 'environment-status-icon-none',
+        alt: 'Environment status unknown',
+        src: computeNone,
+        'data-test-id': 'environment-status-icon-none',
       }),
     ],
     [
       DEFAULT,
       () => ({
-        altText: 'No Environment found',
-        iconSrc: computeNone,
-        dataTestId: 'environment-status-icon-none',
+        alt: 'No Environment found',
+        src: computeNone,
+        'data-test-id': 'environment-status-icon-none',
       }),
     ]
   );
@@ -176,28 +176,18 @@ export const StartStopEnvironmentButton = ({
     >
       {/* TooltipTrigger inside the conditionals because it doesn't handle fragments well. */}
       {onClick && (
-        <TooltipTrigger content={<div>{altText}</div>} side='left'>
+        <TooltipTrigger content={<div>{imgProps.alt}</div>} side='left'>
           <FlexRow style={iconWrapperStyle}>
             <Clickable {...{ onClick }} style={{ display: 'flex' }}>
-              <img
-                alt={altText}
-                src={iconSrc}
-                style={styleOverrides}
-                data-test-id={dataTestId}
-              />
+              <img {...imgProps} />
             </Clickable>
           </FlexRow>
         </TooltipTrigger>
       )}
       {!onClick && (
-        <TooltipTrigger content={<div>{altText}</div>} side='left'>
+        <TooltipTrigger content={<div>{imgProps.alt}</div>} side='left'>
           <FlexRow style={iconWrapperStyle}>
-            <img
-              alt={altText}
-              src={iconSrc}
-              style={styleOverrides}
-              data-test-id={dataTestId}
-            />
+            <img {...imgProps} />
           </FlexRow>
         </TooltipTrigger>
       )}

--- a/ui/src/app/components/common-env-conf-panels/start-stop-environment-button.tsx
+++ b/ui/src/app/components/common-env-conf-panels/start-stop-environment-button.tsx
@@ -30,18 +30,22 @@ interface ButtonProps extends ImgProps {
   onClick?: () => void;
 }
 
-interface ComponentProps {
-  status: AppStatus | RuntimeStatus;
-  onPause: () => void;
-  onResume: () => void;
+export interface StartStopEnvironmentProps {
   appType: UIAppType;
+  status: AppStatus | RuntimeStatus;
+  // This component may be called in a context where pause and resume are not possible,
+  // so these functions are not always necessary.
+  // If we do somehow get into a state where they are *necessary* but not *provided*,
+  // we fail gracefully by present an unclickable icon here instead of crashing.
+  onPause?: () => void;
+  onResume?: () => void;
 }
 export const StartStopEnvironmentButton = ({
+  appType,
   status,
   onPause,
   onResume,
-  appType,
-}: ComponentProps) => {
+}: StartStopEnvironmentProps) => {
   const userEnvironmentStatus: UserEnvironmentStatus =
     toUserEnvironmentStatusByAppType(status, appType);
 
@@ -148,15 +152,9 @@ export const StartStopEnvironmentButton = ({
     ]
   );
 
-  {
-    /* height/width of the icon wrapper are set so that the img element can rotate inside it */
-  }
-  {
-    /* without making it larger. the svg is 36 x 36 px, per pythagorean theorem the diagonal */
-  }
-  {
-    /* is 50.9px, so we round up */
-  }
+  // height/width of the icon wrapper are set so that the img element can rotate inside it
+  // without making it larger. the svg is 36 x 36 px, per pythagorean theorem the diagonal
+  // is 50.9px, so we round up
   const iconWrapperStyle = {
     height: '51px',
     width: '51px',

--- a/ui/src/app/components/common-env-conf-panels/start-stop-environment-button.tsx
+++ b/ui/src/app/components/common-env-conf-panels/start-stop-environment-button.tsx
@@ -3,7 +3,6 @@ import { CSSProperties } from 'react';
 
 import { AppStatus, RuntimeStatus } from 'generated/fetch';
 
-import { DEFAULT, switchCase } from '@terra-ui-packages/core-utils';
 import {
   toUserEnvironmentStatusByAppType,
   UIAppType,
@@ -33,10 +32,10 @@ interface ButtonProps extends ImgProps {
 export interface StartStopEnvironmentProps {
   appType: UIAppType;
   status: AppStatus | RuntimeStatus;
-  // This component may be called in a context where pause and resume are not possible,
+  // This component may be called in a context where pause or resume is not possible,
   // so these functions are not always necessary.
   // If we do somehow get into a state where they are *necessary* but not *provided*,
-  // we fail gracefully by present an unclickable icon here instead of crashing.
+  // we fail gracefully by presenting an unclickable icon here instead of crashing.
   onPause?: () => void;
   onResume?: () => void;
 }
@@ -50,107 +49,67 @@ export const StartStopEnvironmentButton = ({
     toUserEnvironmentStatusByAppType(status, appType);
 
   const rotateStyle = { animation: 'rotation 2s infinite linear' };
-  const { onClick = null, ...imgProps } = switchCase<
-    UserEnvironmentStatus,
-    ButtonProps
-  >(
-    userEnvironmentStatus,
-    [
-      UserEnvironmentStatus.CREATING,
-      () => ({
-        alt: 'Environment creation in progress',
-        src: computeStarting,
-        'data-test-id': 'environment-status-icon-starting',
-        style: rotateStyle,
-      }),
-    ],
-    [
-      UserEnvironmentStatus.RUNNING,
-      () => ({
-        alt: 'Environment running, click to pause',
-        src: computeRunning,
-        'data-test-id': 'environment-status-icon-running',
-        onClick: onPause,
-      }),
-    ],
-    [
-      UserEnvironmentStatus.UPDATING,
-      () => ({
-        alt: 'Environment update in progress',
-        src: computeStarting,
-        'data-test-id': 'environment-status-icon-starting',
-        style: rotateStyle,
-      }),
-    ],
-    [
-      UserEnvironmentStatus.ERROR,
-      () => ({
-        alt: 'Environment in error state',
-        src: computeError,
-        'data-test-id': 'environment-status-icon-error',
-      }),
-    ],
-    [
-      UserEnvironmentStatus.PAUSING,
-      () => ({
-        alt: 'Environment pause in progress',
-        src: computeStopping,
-        'data-test-id': 'environment-status-icon-stopping',
-        style: rotateStyle,
-      }),
-    ],
-    [
-      UserEnvironmentStatus.PAUSED,
-      () => ({
-        alt: 'Environment paused, click to resume',
-        src: computeStopped,
-        'data-test-id': 'environment-status-icon-stopped',
-        onClick: onResume,
-      }),
-    ],
-    [
-      UserEnvironmentStatus.RESUMING,
-      () => ({
-        alt: 'Environment resume in progress',
-        src: computeStarting,
-        'data-test-id': 'environment-status-icon-starting',
-        style: rotateStyle,
-      }),
-    ],
-    [
-      UserEnvironmentStatus.DELETING,
-      () => ({
-        alt: 'Environment deletion in progress',
-        src: computeStopping,
-        'data-test-id': 'environment-status-icon-stopping',
-        style: rotateStyle,
-      }),
-    ],
-    [
-      UserEnvironmentStatus.DELETED,
-      () => ({
-        alt: 'Environment has been deleted',
-        src: computeNone,
-        'data-test-id': 'environment-status-icon-none',
-      }),
-    ],
-    [
-      UserEnvironmentStatus.UNKNOWN,
-      () => ({
-        alt: 'Environment status unknown',
-        src: computeNone,
-        'data-test-id': 'environment-status-icon-none',
-      }),
-    ],
-    [
-      DEFAULT,
-      () => ({
-        alt: 'No Environment found',
-        src: computeNone,
-        'data-test-id': 'environment-status-icon-none',
-      }),
-    ]
-  );
+
+  const toProps: Record<UserEnvironmentStatus, ButtonProps> = {
+    [UserEnvironmentStatus.CREATING]: {
+      alt: 'Environment creation in progress',
+      src: computeStarting,
+      'data-test-id': 'environment-status-icon-starting',
+      style: rotateStyle,
+    },
+    [UserEnvironmentStatus.RUNNING]: {
+      alt: 'Environment running, click to pause',
+      src: computeRunning,
+      'data-test-id': 'environment-status-icon-running',
+      onClick: onPause,
+    },
+    [UserEnvironmentStatus.UPDATING]: {
+      alt: 'Environment update in progress',
+      src: computeStarting,
+      'data-test-id': 'environment-status-icon-starting',
+      style: rotateStyle,
+    },
+    [UserEnvironmentStatus.ERROR]: {
+      alt: 'Environment in error state',
+      src: computeError,
+      'data-test-id': 'environment-status-icon-error',
+    },
+    [UserEnvironmentStatus.PAUSING]: {
+      alt: 'Environment pause in progress',
+      src: computeStopping,
+      'data-test-id': 'environment-status-icon-stopping',
+      style: rotateStyle,
+    },
+    [UserEnvironmentStatus.PAUSED]: {
+      alt: 'Environment paused, click to resume',
+      src: computeStopped,
+      'data-test-id': 'environment-status-icon-stopped',
+      onClick: onResume,
+    },
+    [UserEnvironmentStatus.RESUMING]: {
+      alt: 'Environment resume in progress',
+      src: computeStarting,
+      'data-test-id': 'environment-status-icon-starting',
+      style: rotateStyle,
+    },
+    [UserEnvironmentStatus.DELETING]: {
+      alt: 'Environment deletion in progress',
+      src: computeStopping,
+      'data-test-id': 'environment-status-icon-stopping',
+      style: rotateStyle,
+    },
+    [UserEnvironmentStatus.DELETED]: {
+      alt: 'Environment has been deleted',
+      src: computeNone,
+      'data-test-id': 'environment-status-icon-none',
+    },
+    [UserEnvironmentStatus.UNKNOWN]: {
+      alt: 'Environment status unknown',
+      src: computeNone,
+      'data-test-id': 'environment-status-icon-none',
+    },
+  };
+  const { onClick, ...imgProps } = toProps[userEnvironmentStatus];
 
   // height/width of the icon wrapper are set so that the img element can rotate inside it
   // without making it larger. the svg is 36 x 36 px, per pythagorean theorem the diagonal

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
@@ -138,8 +138,6 @@ export const CreateGkeApp = ({
           }}
           appType={toUIAppType[appType]}
           status={app?.status}
-          onPause={() => Promise.resolve()}
-          onResume={() => Promise.resolve()}
         />
         <CostNote />
       </div>

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -357,12 +357,6 @@ const PanelMain = fp.flow(
                   setPanelContent,
                   workspace,
                 }}
-                onPause={() =>
-                  setRuntimeStatusRequest(RuntimeStatusRequest.Stop)
-                }
-                onResume={() =>
-                  setRuntimeStatusRequest(RuntimeStatusRequest.Start)
-                }
               />
             ),
           ],

--- a/ui/src/app/components/runtime-configuration-panel/create-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/create-panel.spec.tsx
@@ -28,8 +28,6 @@ const defaultAnalysisConfig = toAnalysisConfig(
 
 const setPanelContent = jest.fn();
 const onClose = jest.fn();
-const onPause = jest.fn();
-const onResume = jest.fn();
 const requestAnalysisConfig = jest.fn();
 
 const defaultProps: CreatePanelProps = {
@@ -41,8 +39,6 @@ const defaultProps: CreatePanelProps = {
   runtimeCanBeCreated: true,
   setPanelContent,
   onClose,
-  onPause,
-  onResume,
   requestAnalysisConfig,
 };
 

--- a/ui/src/app/components/runtime-configuration-panel/create-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/create-panel.tsx
@@ -16,8 +16,6 @@ export interface CreatePanelProps {
   analysisConfig: AnalysisConfig;
   creatorFreeCreditsRemaining: number;
   onClose: () => void;
-  onPause: () => void;
-  onResume: () => void;
   profile: Profile;
   requestAnalysisConfig: (ac: AnalysisConfig) => void;
   runtimeCanBeCreated: boolean;
@@ -29,8 +27,6 @@ export const CreatePanel = ({
   analysisConfig,
   creatorFreeCreditsRemaining,
   onClose,
-  onPause,
-  onResume,
   profile,
   requestAnalysisConfig,
   runtimeCanBeCreated,
@@ -52,8 +48,6 @@ export const CreatePanel = ({
             profile,
             workspace,
             analysisConfig,
-            onPause,
-            onResume,
           }}
           status={runtimeStatus}
           appType={UIAppType.JUPYTER}

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -400,12 +400,9 @@ export const WorkspaceEdit = fp.flow(
         },
       } = this.props;
 
-      const freeTierUsageInNumber = freeTierUsage ?? 0;
-
-      const initialCreditsBalance = freeTierDollarQuota - freeTierUsageInNumber;
       return (
         'Use All of Us initial credits - ' +
-        formatInitialCreditsUSD(initialCreditsBalance) +
+        formatInitialCreditsUSD(freeTierDollarQuota - (freeTierUsage ?? 0)) +
         ' left'
       );
     }

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -400,9 +400,12 @@ export const WorkspaceEdit = fp.flow(
         },
       } = this.props;
 
+      const freeTierUsageInNumber = freeTierUsage ?? 0;
+
+      const initialCreditsBalance = freeTierDollarQuota - freeTierUsageInNumber;
       return (
         'Use All of Us initial credits - ' +
-        formatInitialCreditsUSD(freeTierDollarQuota - (freeTierUsage ?? 0)) +
+        formatInitialCreditsUSD(initialCreditsBalance) +
         ' left'
       );
     }


### PR DESCRIPTION
CreatePanel (for Runtimes) and CreateGkeApp no longer need to pass useless pause/resume props to EnvironmentInformedActionPanel because they are optional.

Added tests and did some refactoring too.

Tested locally by working with CreatePanel, Create App, and ConfigurationPanel in the UI

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
