### PR TITLE
[risk=no][no ticket] Refresh Absorb api responses every request

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/absorb/AbsorbServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/absorb/AbsorbServiceImpl.java
@@ -74,10 +74,6 @@ public class AbsorbServiceImpl implements AbsorbService {
   // Obtains and stores a valid API key, access token, and user id for the given email address.
   // Tokens are valid for four hours, which is well under the expected lifetime of this service.
   private void ensureAuthentication(String email) throws ApiException {
-    if (apiKey != null && accessToken != null && userId != null) {
-      return;
-    }
-
     var config = cloudStorageClient.getAbsorbCredentials();
     apiKey = config.getString("apiKey");
 


### PR DESCRIPTION
Refresh Absorb api responses every request. This is a partial fix that will help anyone running into data access issues on the test environment, a full fix will follow.

See [this thread](https://pmi-engteam.slack.com/archives/C0150CWF6FP/p1697040108376699) for details.

The root cause is that injected Spring `@Service` object instances are shared across requests. Therefore, state within the instance is shared across requests. In this case, the Absorb user id was being cached across requests, leading to data leakage across accounts.

Steps to reproduce the bug:
- Create a new user
- Complete RT training using Absorb
- Create a second user
- Visit the data access page

Expected: RT training is incomplete
Actual: RT training is complete

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [x] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.