### PR TITLE
[RW-11086][risk=no] Upload test coverage to Codacy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,31 +416,6 @@ jobs:
                 working_directory: ~/workbench/api
                 command: |
                   ./gradlew jacocoTestReport
-            - run:
-                name: ls build
-                working_directory: ~/workbench/api
-                command: |
-                  ls build
-            - run:
-                name: ls build
-                working_directory: ~/workbench/api
-                command: |
-                  ls build
-            - run:
-                name: ls build/reports
-                working_directory: ~/workbench/api
-                command: |
-                  ls build/reports
-            - run:
-                name: ls build/reports/jacoco
-                working_directory: ~/workbench/api
-                command: |
-                  ls build/reports/jacoco
-            - run:
-                name: ls build/reports/jacoco/test
-                working_directory: ~/workbench/api
-                command: |
-                  ls build/reports/jacoco/test
             - coverage-reporter/send_report:
                 coverage-reports: api/build/reports/jacoco/test/jacocoTestReport.xml
                 project-token: $CODACY_PROJECT_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.2.1
   queue: eddiewebb/queue@volatile
+  coverage-reporter: codacy/coverage-reporter@13.13.7
 
 # -------------------------
 #   PIPELINE PARAMETERS
@@ -415,6 +416,39 @@ jobs:
                 working_directory: ~/workbench/api
                 command: |
                   ./gradlew jacocoTestReport
+            - run:
+                name: ls build
+                working_directory: ~/workbench/api
+                command: |
+                  ls build
+            - run:
+                name: ls build
+                working_directory: ~/workbench/api
+                command: |
+                  ls build
+            - run:
+                name: ls build/reports
+                working_directory: ~/workbench/api
+                command: |
+                  ls build/reports
+            - run:
+                name: ls build/reports/JunitTestResult
+                working_directory: ~/workbench/api
+                command: |
+                  ls build/reports/JunitTestResult
+            - run:
+                name: ls build/reports/JunitTestResult/jacoco
+                working_directory: ~/workbench/api
+                command: |
+                  ls build/reports/JunitTestResult/jacoco
+            - run:
+                name: ls build/reports/JunitTestResult/jacoco/test
+                working_directory: ~/workbench/api
+                command: |
+                  ls build/reports/JunitTestResult/jacoco/test
+            - coverage-reporter/send_report:
+                coverage-reports: ./build/reports/JunitTestResult/jacoco/test/jacocoTestReport.xml
+                project-token: $CODACY_PROJECT_TOKEN
             - store_artifacts:
                 path: ~/workbench/api/build/reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,22 +432,17 @@ jobs:
                 command: |
                   ls build/reports
             - run:
-                name: ls build/reports/JunitTestResult
+                name: ls build/reports/jacoco
                 working_directory: ~/workbench/api
                 command: |
-                  ls build/reports/JunitTestResult
+                  ls build/reports/jacoco
             - run:
-                name: ls build/reports/JunitTestResult/jacoco
+                name: ls build/reports/jacoco/test
                 working_directory: ~/workbench/api
                 command: |
-                  ls build/reports/JunitTestResult/jacoco
-            - run:
-                name: ls build/reports/JunitTestResult/jacoco/test
-                working_directory: ~/workbench/api
-                command: |
-                  ls build/reports/JunitTestResult/jacoco/test
+                  ls build/reports/jacoco/test
             - coverage-reporter/send_report:
-                coverage-reports: ./build/reports/JunitTestResult/jacoco/test/jacocoTestReport.xml
+                coverage-reports: ./build/reports/jacoco/test/jacocoTestReport.xml
                 project-token: $CODACY_PROJECT_TOKEN
             - store_artifacts:
                 path: ~/workbench/api/build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -442,7 +442,7 @@ jobs:
                 command: |
                   ls build/reports/jacoco/test
             - coverage-reporter/send_report:
-                coverage-reports: ./build/reports/jacoco/test/jacocoTestReport.xml
+                coverage-reports: api/build/reports/jacoco/test/jacocoTestReport.xml
                 project-token: $CODACY_PROJECT_TOKEN
             - store_artifacts:
                 path: ~/workbench/api/build/reports

--- a/api/src/main/java/org/pmiops/workbench/ras/RasLinkConstants.java
+++ b/api/src/main/java/org/pmiops/workbench/ras/RasLinkConstants.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
 /** Constants used in to process RAS linkage. */
-// Sample comment
 public class RasLinkConstants {
   private RasLinkConstants() {}
 

--- a/api/src/main/java/org/pmiops/workbench/ras/RasLinkConstants.java
+++ b/api/src/main/java/org/pmiops/workbench/ras/RasLinkConstants.java
@@ -3,7 +3,8 @@ package org.pmiops.workbench.ras;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
-/** Constants used in to process RAS linkage.  */
+/** Constants used in to process RAS linkage. */
+// Sample Comment
 public class RasLinkConstants {
   private RasLinkConstants() {}
 

--- a/api/src/main/java/org/pmiops/workbench/ras/RasLinkConstants.java
+++ b/api/src/main/java/org/pmiops/workbench/ras/RasLinkConstants.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
 /** Constants used in to process RAS linkage. */
-// Sample Comment
 public class RasLinkConstants {
   private RasLinkConstants() {}
 

--- a/api/src/main/java/org/pmiops/workbench/ras/RasLinkConstants.java
+++ b/api/src/main/java/org/pmiops/workbench/ras/RasLinkConstants.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
 /** Constants used in to process RAS linkage. */
-//Sample comment
+// Sample comment
 public class RasLinkConstants {
   private RasLinkConstants() {}
 

--- a/api/src/main/java/org/pmiops/workbench/ras/RasLinkConstants.java
+++ b/api/src/main/java/org/pmiops/workbench/ras/RasLinkConstants.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
 /** Constants used in to process RAS linkage. */
+//Sample comment
 public class RasLinkConstants {
   private RasLinkConstants() {}
 

--- a/api/src/main/java/org/pmiops/workbench/ras/RasLinkConstants.java
+++ b/api/src/main/java/org/pmiops/workbench/ras/RasLinkConstants.java
@@ -3,7 +3,7 @@ package org.pmiops.workbench.ras;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
-/** Constants used in to process RAS linkage. */
+/** Constants used in to process RAS linkage.  */
 public class RasLinkConstants {
   private RasLinkConstants() {}
 


### PR DESCRIPTION
Updated CircleCI test coverage job to upload coverage report to Codacy.

I utilized Codacy's Circle CI orb: https://circleci.com/developer/orbs/orb/codacy/coverage-reporter

This upload requires a Codacy token that can be found here: https://app.codacy.com/gh/all-of-us/workbench/settings/coverage

The token is stored as an environment variable in our Circle CI project: https://app.circleci.com/settings/project/github/all-of-us/workbench/environment-variables

Logs showing successful upload:
```
 --> Actual checksum
d61e58a04f56811bf54f3ae2d4bfaabc453b3b80ec19d9d42b243968d9302aa2857b2233e5a9aa75f48a2b9455bae6f1fadbbb07f1471aa86ce385cb1b29ddcf  codacy-coverage-reporter-linux
codacy-coverage-reporter-linux: OK
2023-10-13 14:06:51.863Z  info [ConfigurationRules] API base URL: https://api.codacy.com  - (ConfigurationRules.scala:81)
2023-10-13 14:06:51.961Z  info [CommitUUIDProvider] CI/CD provider Circle CI found Commit UUID 048c94c7e05c4586058c9b5b7580c6d8345e920a  - (CommitUUIDProvider.scala:134)
2023-10-13 14:06:51.994Z  info [ReportRules] Parsing coverage data from: /home/circleci/workbench/api/build/reports/jacoco/test/jacocoTestReport.xml ...  - (ReportRules.scala:37)
2023-10-13 14:06:53.265Z  info [ReportRules] Coverage parser used is com.codacy.parsers.implementation.JacocoParser$@75e05153  - (ReportRules.scala:42)
2023-10-13 14:06:53.302Z  info [ReportRules] Generated coverage report: /tmp/codacy-coverage-11630813900185957860.json (229.74 kB)  - (ReportRules.scala:301)
2023-10-13 14:06:53.302Z  info [ReportRules] Uploading coverage data...  - (ReportRules.scala:302)
2023-10-13 14:06:53.304Z  warn [ReportRules] 

Multiple languages detected in /home/circleci/workbench/api/build/reports/jacoco/test/jacocoTestReport.xml (Java,Kotlin).
  This run will only upload coverage for the Java language.
  To make sure that you upload coverage for all languages in the report,
  see https://docs.codacy.com/coverage-reporter/uploading-coverage-in-advanced-scenarios/#multiple-languages  - (ReportRules.scala:208)
2023-10-13 14:06:53.776Z  info [ReportRules] Coverage data uploaded. Coverage received successfully.  - (ReportRules.scala:177)
2023-10-13 14:06:53.776Z  info [ReportRules] 
To complete the reporting process, call coverage-reporter with the final flag.
 Check https://docs.codacy.com/coverage-reporter/#multiple-reports
 for more information.  - (ReportRules.scala:80)
2023-10-13 14:06:53.776Z  info [CodacyCoverageReporter] All coverage data uploaded.  - (CodacyCoverageReporter.scala:22)
     ______          __
    / ____/___  ____/ /___ ________  __
   / /   / __ \/ __  / __ `/ ___/ / / /
  / /___/ /_/ / /_/ / /_/ / /__/ /_/ /
  \____/\____/\__,_/\__,_/\___/\__, /
                              /____/

  Codacy Coverage Reporter

 --> Codacy reporter codacy-coverage-reporter-linux already in cache
2023-10-13 14:06:54.817Z  info [ConfigurationRules] API base URL: https://api.codacy.com  - (ConfigurationRules.scala:81)
2023-10-13 14:06:54.911Z  info [CommitUUIDProvider] CI/CD provider Circle CI found Commit UUID 048c94c7e05c4586058c9b5b7580c6d8345e920a  - (CommitUUIDProvider.scala:134)
2023-10-13 14:06:55.041Z  info [CodacyCoverageReporter] Final coverage notification sent. Final notification received successfully.  - (CodacyCoverageReporter.scala:22)

 --> Succeeded!
```

Codacy Test Coverage for this branch: https://app.codacy.com/gh/all-of-us/workbench/coverage/commits?branch=eric%2FcodacyCoverage

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
