### PR TITLE
[risk=no][no ticket] CT training enrollment happens after completing RT

### DIFF
--- a/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
@@ -48,7 +48,7 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
 
   @Test
   @Disabled("RW-11039")
-  public void testGetEnrollments_RtIncomplete() throws Exception {
+  public void testGetEnrollmentsRtIncomplete() throws Exception {
     // Setup:
     // - The user has logged into Absorb
     // - The user has not completed RT training
@@ -71,7 +71,7 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
 
   @Test
   @Disabled("RW-11039")
-  public void testGetEnrollments_RtComplete() throws Exception {
+  public void testGetEnrollmentsRtComplete() throws Exception {
     // Setup:
     // - The user has completed RT training in Absorb
     // - The user has not completed CT training in Absorb

--- a/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
@@ -19,9 +19,11 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
 
   @Autowired private AbsorbService absorbService;
 
-  private final String partiallyCompleteUserEmail =
-      "absorb_acceptance_test_02@fake-research-aou.org";
   private final String nonexistantUserEmail = "absorb_acceptance_test_fake@fake-research-aou.org";
+  private final String loggedInRTIncompleteUserEmail =
+      "absorb_acceptance_test_03@fake-research-aou.org";
+  private final String loggedInRTCompleteUserEmail =
+      "absorb_acceptance_test_04@fake-research-aou.org";
 
   @TestConfiguration
   @ComponentScan(basePackageClasses = DirectoryServiceImpl.class)
@@ -33,7 +35,7 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
   public void testUserHasLoggedIntoAbsorb_True() throws Exception {
     // Setup:
     // - The user has logged into Absorb
-    assertThat(absorbService.userHasLoggedIntoAbsorb(partiallyCompleteUserEmail)).isTrue();
+    assertThat(absorbService.userHasLoggedIntoAbsorb(loggedInRTIncompleteUserEmail)).isTrue();
   }
 
   @Test
@@ -46,11 +48,38 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
 
   @Test
   @Disabled("RW-11039")
-  public void testGetEnrollments() throws Exception {
+  public void testGetEnrollments_RTIncomplete() throws Exception {
+    // Setup:
+    // - The user has logged into Absorb
+    // - The user has not completed RT training
+    var enrollments = absorbService.getActiveEnrollmentsForUser(loggedInRTIncompleteUserEmail);
+    assertThat(enrollments.size()).isEqualTo(1);
+
+    var rtTrainingEnrollment =
+        enrollments.stream()
+            .filter(e -> e.courseId.equals(config.absorb.rtTrainingCourseId))
+            .findFirst();
+    assertThat(rtTrainingEnrollment.isPresent()).isTrue();
+    assertThat(rtTrainingEnrollment.get().completionTime).isNull();
+
+    var ctTrainingEnrollment =
+        enrollments.stream()
+            .filter(e -> e.courseId.equals(config.absorb.ctTrainingCourseId))
+            .findFirst();
+    assertThat(ctTrainingEnrollment.isPresent()).isFalse();
+  }
+
+  @Test
+  @Disabled("RW-11039")
+  public void testGetEnrollments_RTComplete() throws Exception {
     // Setup:
     // - The user has completed RT training in Absorb
     // - The user has not completed CT training in Absorb
-    var enrollments = absorbService.getActiveEnrollmentsForUser(partiallyCompleteUserEmail);
+    var enrollments = absorbService.getActiveEnrollmentsForUser(loggedInRTCompleteUserEmail);
+
+    // After completing RT training, it may take a few minutes to be auto-enrolled
+    // in CT training. In that case, this line fails.
+    // See https://docs.google.com/document/d/1ByiB1UVQDWHtRR2LOeNmvjEBbmqT7IRX2MVcwwRKA68
     assertThat(enrollments.size()).isEqualTo(2);
 
     var rtTrainingEnrollment =
@@ -58,9 +87,9 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
             .filter(e -> e.courseId.equals(config.absorb.rtTrainingCourseId))
             .findFirst();
     assertThat(rtTrainingEnrollment.isPresent()).isTrue();
-    // Completed at 2:14PM EST on 2023-10-03
+    // Completed at 2:56PM EST on 2023-10-13
     assertThat(rtTrainingEnrollment.get().completionTime)
-        .isEqualTo(Instant.parse("2023-10-03T18:14:03.977Z"));
+        .isEqualTo(Instant.parse("2023-10-13T18:56:38.500Z"));
 
     var ctTrainingEnrollment =
         enrollments.stream()

--- a/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
@@ -48,7 +48,7 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
 
   @Test
   @Disabled("RW-11039")
-  public void testGetEnrollments_RTIncomplete() throws Exception {
+  public void testGetEnrollments_RtIncomplete() throws Exception {
     // Setup:
     // - The user has logged into Absorb
     // - The user has not completed RT training
@@ -71,7 +71,7 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
 
   @Test
   @Disabled("RW-11039")
-  public void testGetEnrollments_RTComplete() throws Exception {
+  public void testGetEnrollments_RtComplete() throws Exception {
     // Setup:
     // - The user has completed RT training in Absorb
     // - The user has not completed CT training in Absorb

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -240,14 +240,20 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
           enrollments.stream().filter(e -> e.courseId.equals(courseId)).findFirst();
 
       if (maybeEnrollment.isEmpty()) {
-        log.severe(
-            String.format(
-                "User `%s` is not enrolled in Absorb course `%s` for access module `%s`. Users are expected to be automatically enrolled in all courses upon visiting Absorb.",
-                dbUser.getUsername(), courseId, accessModuleName));
-        throw new NotFoundException(
-            String.format(
-                "User %s is not enrolled in Absorb course %s", dbUser.getUsername(), courseId));
+        if (accessModuleName == DbAccessModule.DbAccessModuleName.RT_COMPLIANCE_TRAINING) {
+          log.severe(
+              String.format(
+                  "User `%s` is not enrolled in RT compliance training. Users are expected to be automatically enrolled in RT training upon logging into Absorb.",
+                  dbUser.getUsername()));
+          throw new NotFoundException(
+              String.format(
+                  "User %s is not enrolled in Absorb course %s", dbUser.getUsername(), courseId));
+        }
+
+        // Users are not enrolled in CT training until they complete RT training
+        continue;
       }
+
       var enrollment = maybeEnrollment.get();
 
       // The course is incomplete, do not update the user access module

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -263,6 +263,10 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
                       "User %s is not enrolled in Absorb course %s",
                       dbUser.getUsername(), courseId));
             }
+
+            // Else: The user is not enrolled in CT training.
+            // This is expected behavior. Users are not enrolled in CT training in Absorb until
+            // they complete RT training.
           });
     }
 

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -243,7 +243,8 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
         if (accessModuleName == DbAccessModule.DbAccessModuleName.RT_COMPLIANCE_TRAINING) {
           log.severe(
               String.format(
-                  "User `%s` is not enrolled in RT compliance training. Users are expected to be automatically enrolled in RT training upon logging into Absorb.",
+                  "User `%s` is not enrolled in RT compliance training. "
+                      + "Users are expected to be automatically enrolled in RT training upon logging into Absorb.",
                   dbUser.getUsername()));
           throw new NotFoundException(
               String.format(


### PR DESCRIPTION
The Absorb settings were changed to show the CT training after RT training is complete. This helps ensure users take the correct course when first visiting Absorb. This PR accounts for that breaking change, and documents current API behavior via acceptance tests.

I didn't manually test this as I felt the `testSyncComplianceTrainingStatus_Absorb_DoesNothingIfNoCoursesComplete` test effectively identified the error once the stub methods were updated, and manual tests of Absorb are very slow (they require creating a new account each time). Let me know if you think I should.

Steps to reproduce the bug:
- Create a new user
- Bypass all modules except the training ones
- Log into Absorb
- Do not complete any trainings
- Sync training

Expected:
- The API call succeeds

Actual:
- The API call fails

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [x] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.