### PR TITLE
[DT-549][risk=no] remove Tanagra submodule from the workbench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ gradle.properties
 **/*.orig
 **/.vscode
 /tanagra-aou-utils/appengine/
+/tanagra-aou-utils/tanagra/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,1 @@
-[submodule "tanagra"]
-	path = tanagra
-	url = https://github.com/DataBiosphere/tanagra
+

--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ To deploy the Tanagra UI and the Workbench UI together locally:
 ```
 yarn dev-up-tanagra-local
 ```
+Optional arguments:
+* `-v` Deploy a tag (Ex: 0.0.252). Default is main
 
 ### Tanagra Deploy to test
 

--- a/README.md
+++ b/README.md
@@ -222,14 +222,9 @@ yarn dev-up-tanagra-local
 
 ### Tanagra Deploy to test
 
-To deploy Tanagra api to test (run from `api` directory):
+To deploy Tanagra (api and ui) to test (run from `workbench` directory):
 ```
-./project.rb deploy-tanagra --project all-of-us-workbench-test --version 0.0.219 --promote --quiet
-```
-
-To deploy Tanagra UI to test (run from `ui` directory):
-```
-./project.rb deploy-tanagra-ui --project all-of-us-workbench-test --version my-version --promote --quiet
+deploy/project.rb deploy-tanagra --project all-of-us-workbench-test --version 0.0.219 --promote --quiet
 ```
 
 ## Building a new CDR Database

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Optional arguments:
 
 To deploy Tanagra (api and ui) to test (run from `workbench` directory):
 ```
-deploy/project.rb deploy-tanagra --project all-of-us-workbench-test --version 0.0.219 --promote --quiet
+deploy/project.rb deploy-tanagra --project all-of-us-workbench-test --version 0.0.219 --promote
 ```
 
 ## Building a new CDR Database

--- a/README.md
+++ b/README.md
@@ -206,11 +206,14 @@ CDR schema lives in `api/db-cdr` --> all cdr/cohort builder related activities a
 
 There are two commands for deploying the Tanagra app locally along with the Workbench
 
-To deploy the Tanagra api locally:
+To deploy the Tanagra api locally (NOTE: the Tanagra api is dependent on the workbench api being deployed in a different terminal window):
 ```
-./project.rb dev-up-tanagra --disable-auth
+./project.rb dev-up-tanagra
 ```
-The normal `./project.rb dev-up` will still need to be run to deploy the Workbench api
+Optional arguments:
+* `--disable-auth` Disable authZ
+* `--version` Deploy a tag (Ex: 0.0.252). Default is main
+* `--drop-db` Drop the Tanagra database and recreate
 
 To deploy the Tanagra UI and the Workbench UI together locally:
 ```
@@ -221,7 +224,7 @@ yarn dev-up-tanagra-local
 
 To deploy Tanagra api to test (run from `api` directory):
 ```
-./project.rb deploy-tanagra --project all-of-us-workbench-test --version my-version --promote --quiet
+./project.rb deploy-tanagra --project all-of-us-workbench-test --version 0.0.219 --promote --quiet
 ```
 
 To deploy Tanagra UI to test (run from `ui` directory):

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -116,6 +116,12 @@ def dev_up_tanagra(cmd_name, args)
   start_local_db_service()
 
   Dir.chdir('../tanagra-aou-utils') do
+    if File.directory?('/tanagra')
+      common.status "repo has been cloned"
+    else
+      common.status "Need to clone repo"
+      common.run_inline %W{git clone https://github.com/DataBiosphere/tanagra.git}
+    end
     if op.opts.disable_auth_checks
       common.status "Starting tanagra-service authorization checks disabled"
       common.run_inline %W{./run_tanagra_server.sh -a}

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2447,6 +2447,11 @@ def deploy_tanagra(cmd_name, args)
   op = WbOptionsParser.new(cmd_name, args)
   op.opts.dry_run = false
   op.add_option(
+    "--project [project]",
+    ->(opts, v) { opts.project = v},
+    "The Google Cloud project to deploy to."
+  )
+  op.add_option(
     "--account [account]",
     ->(opts, v) { opts.account = v},
     "Service account to act as for deployment, if any. Defaults to the GAE " +
@@ -2458,11 +2463,6 @@ def deploy_tanagra(cmd_name, args)
     "Version to deploy (e.g. your-username-test)"
   )
   op.add_validator ->(opts) { raise ArgumentError.new("version required") unless opts.version }
-  op.add_option(
-    "--key-file [keyfile]",
-    ->(opts, v) { opts.key_file = v},
-    "Service account key file to use for deployment authorization"
-  )
   op.add_option(
     "--dry-run",
     ->(opts, _) { opts.dry_run = true},
@@ -2498,10 +2498,6 @@ def deploy_tanagra(cmd_name, args)
   ENV.update({"TANAGRA_AUTH_DISABLE_CHECKS" => env_project.fetch(:tanagra_auth_disable_checks)})
   ENV.update({"TANAGRA_AUTH_BEARER_TOKEN" => env_project.fetch(:tanagra_auth_bearer_token)})
   ENV.update({"TANAGRA_UNDERLAY_FILES" => env_project.fetch(:tanagra_underlay_files)})
-
-  if (op.opts.key_file)
-    ENV["GOOGLE_APPLICATION_CREDENTIALS"] = op.opts.key_file
-  end
 
   promote = "--no-promote"
   unless op.opts.promote.nil?
@@ -2550,6 +2546,7 @@ def deploy_tanagra(cmd_name, args)
       (op.opts.quiet ? %W{--quiet} : []) +
       (op.opts.version ? %W{--version #{deploy_version}} : []))
   end
+  common.status "Deployment of Tanagra API complete!"
 
 end
 

--- a/deploy/libproject/deploy.rb
+++ b/deploy/libproject/deploy.rb
@@ -309,6 +309,74 @@ Common.register_command({
   :fn => ->(*args) { deploy("deploy", args) }
 })
 
+def deploy_tanagra(cmd_name, args)
+  op = WbOptionsParser.new(cmd_name, args)
+  op.add_option(
+    "--project [project]",
+    ->(opts, v) { opts.project = v},
+    "The Google Cloud project to deploy to."
+  )
+  op.add_option(
+    "--account [account]",
+    ->(opts, v) { opts.account = v},
+    "Service account to act as for deployment, if any. Defaults to the GAE " +
+    "default service account."
+  )
+  op.opts.dry_run = false
+  op.add_option(
+    "--dry-run",
+    ->(opts, _) { opts.dry_run = true},
+    "Don't actually deploy, just log the command lines which would be " +
+    "executed on a real invocation."
+  )
+  op.add_option(
+    "--version [version]",
+    ->(opts, v) { opts.version = v},
+    "Version to deploy (e.g. 0.0.219)"
+  )
+  op.add_option(
+    "--promote",
+    ->(opts, _) { opts.promote = true},
+    "Promote this version to immediately begin serving traffic"
+  )
+  op.add_option(
+    "--no-promote",
+    ->(opts, _) { opts.promote = false},
+    "Deploy, but do not yet serve traffic from this version - DB migrations " +
+    "are still applied"
+  )
+  op.add_validator ->(opts) { raise ArgumentError.new("Missing value: Must include a value for --project") if opts.project.nil?}
+  op.add_validator ->(opts) { raise ArgumentError.new("Missing flag: Must include a value for --version") if opts.version.nil?}
+  op.add_validator ->(opts) { raise ArgumentError.new("Missing flag: Must include either --promote or --no-promote") if opts.promote.nil?}
+
+  op.parse.validate
+
+  common = Common.new
+  common.run_inline %W{
+    ../api/project.rb deploy-tanagra
+      --project #{op.opts.project}
+      --account #{op.opts.account}
+      --version #{op.opts.version}
+      #{op.opts.promote ? "--promote" : "--no-promote"}
+      --quiet
+  }
+
+  common.run_inline %W{
+    ../ui/project.rb deploy-tanagra-ui
+      --project #{op.opts.project}
+      --account #{op.opts.account}
+      --version #{op.opts.version}
+      #{op.opts.promote ? "--promote" : "--no-promote"}
+      --quiet
+  }
+end
+
+Common.register_command({
+  :invocation => "deploy-tanagra",
+  :description => "Deploy Tanagra API and UI",
+  :fn => ->(*args) { deploy_tanagra("deploy-tanagra", args) }
+})
+
 def docker_clean()
   common = Common.new
   common.run_inline %W{docker-compose down --volumes}

--- a/tanagra-aou-utils/apiContext.ts
+++ b/tanagra-aou-utils/apiContext.ts
@@ -1,0 +1,355 @@
+import React from "react";
+import * as tanagra from "./tanagra-api";
+
+// TODO(tjennison): Figure out a more comprehensive solutions for faking APIs.
+class FakeUnderlaysApi {
+  async listUnderlays(): Promise<tanagra.UnderlayList> {
+    return {
+      underlays: [await this.getUnderlay({ underlayName: "underlay_name" })],
+    };
+  }
+
+  async getUnderlay(req: { underlayName: string }): Promise<tanagra.Underlay> {
+    const columns = [{ key: "name", width: "100%", title: "Concept name" }];
+
+    const uiConfiguration = {
+      dataConfig: {
+        primaryEntity: {
+          entity: "person",
+          key: "id",
+        },
+        occurrences: [
+          {
+            id: "condition_occurrence",
+            entity: "condition_occurrence",
+            key: "id",
+            classifications: [
+              {
+                id: "condition",
+                attribute: "condition_concept_id",
+                entity: "condition",
+                entityAttribute: "id",
+                hierarchy: "standard",
+              },
+            ],
+          },
+          {
+            id: "observation_occurrence",
+            entity: "observation_occurrence",
+            key: "id",
+            classifications: [
+              {
+                id: "observation",
+                attribute: "observation_concept_id",
+                entity: "observation",
+                entityAttribute: "id",
+              },
+            ],
+          },
+        ],
+      },
+      criteriaConfigs: [
+        {
+          type: "classification",
+          id: "tanagra-condition",
+          title: "Condition",
+          conceptSet: true,
+          columns,
+          occurrence: "condition_occurrence",
+          classification: "condition",
+        },
+        {
+          type: "classification",
+          id: "tanagra-observation",
+          title: "Observation",
+          conceptSet: true,
+          columns,
+          occurrence: "observation_occurrence",
+          classification: "observation",
+        },
+        {
+          type: "attribute",
+          id: "tanagra-race",
+          title: "Race",
+          attribute: "race",
+        },
+        {
+          type: "attribute",
+          id: "tanagra-year_of_birth",
+          title: "Year of birth",
+          attribute: "year_of_birth",
+        },
+      ],
+      criteriaSearchConfig: {
+        criteriaTypeWidth: 120,
+        columns: [
+          { key: "name", width: "100%", title: "Concept name" },
+          { key: "t_rollup_count", width: 120, title: "Roll-up count" },
+        ],
+      },
+    };
+
+    return {
+      name: req.underlayName,
+      displayName: "Test Underlay",
+      primaryEntity: "person",
+      uiConfiguration: JSON.stringify(uiConfiguration),
+    };
+  }
+
+  async listEntities(): Promise<tanagra.EntityList> {
+    return {
+      entities: [
+        {
+          name: "person",
+          idAttribute: "id",
+          attributes: [
+            {
+              name: "id",
+              dataType: tanagra.DataType.Int64,
+            },
+            {
+              name: "race",
+              dataType: tanagra.DataType.Int64,
+            },
+            {
+              name: "year_of_birth",
+              dataType: tanagra.DataType.Int64,
+            },
+          ],
+        },
+        {
+          name: "condition_occurrence",
+          idAttribute: "concept_id",
+          attributes: [
+            {
+              name: "id",
+              dataType: tanagra.DataType.Int64,
+            },
+            {
+              name: "name",
+              dataType: tanagra.DataType.String,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  async listInstances(): Promise<tanagra.InstanceListResult> {
+    return {
+      sql: "SELECT * FROM table WHERE xyz;",
+      instances: [
+        {
+          relationshipFields: [
+            {
+              count: 42,
+            },
+          ],
+          attributes: {
+            id: {
+              value: {
+                dataType: tanagra.DataType.Int64,
+                valueUnion: {
+                  int64Val: 1234,
+                },
+              },
+            },
+            name: {
+              value: {
+                dataType: tanagra.DataType.String,
+                valueUnion: {
+                  stringVal: "test concept",
+                },
+              },
+            },
+          },
+        },
+      ],
+    };
+  }
+
+  async queryHints(): Promise<tanagra.DisplayHintList> {
+    return {
+      displayHints: [
+        {
+          attribute: {
+            name: "race",
+          },
+          displayHint: {
+            enumHint: {
+              enumHintValues: [
+                {
+                  enumVal: {
+                    display: "Asian",
+                    value: {
+                      dataType: tanagra.DataType.Int64,
+                      valueUnion: {
+                        int64Val: 8515,
+                      },
+                    },
+                  },
+                  count: 123,
+                },
+                {
+                  enumVal: {
+                    display: "Black or African American",
+                    value: {
+                      dataType: tanagra.DataType.Int64,
+                      valueUnion: {
+                        int64Val: 8516,
+                      },
+                    },
+                  },
+                  count: 456,
+                },
+              ],
+            },
+          },
+        },
+        {
+          attribute: {
+            name: "year_of_birth",
+          },
+          displayHint: {
+            numericRangeHint: {
+              min: 21,
+              max: 79,
+            },
+          },
+        },
+      ],
+    };
+  }
+}
+
+class FakeStudiesAPI {
+  async listStudies(): Promise<Array<tanagra.Study>> {
+    return [
+      {
+        id: "test_study",
+        created: new Date(),
+        createdBy: "test_user",
+        displayName: "Test Study",
+        lastModified: new Date(),
+      },
+    ];
+  }
+}
+
+class FakeCohortsAPI {
+  async listCohorts(): Promise<Array<tanagra.Cohort>> {
+    return [
+      {
+        id: "test_cohort",
+        created: new Date(),
+        createdBy: "test_user",
+        displayName: "Test Cohort",
+        lastModified: new Date(),
+        underlayName: "test_underlay",
+        criteriaGroupSections: [],
+      },
+    ];
+  }
+}
+
+class FakeConceptSetsAPI {
+  async listConceptSets(): Promise<Array<tanagra.ConceptSet>> {
+    return [
+      {
+        id: "test_concept_set",
+        created: new Date(),
+        createdBy: "test_user",
+        displayName: "Test data feature",
+        lastModified: new Date(),
+        underlayName: "test_underlay",
+        entity: "test_entity",
+        criteria: {
+          id: "entity_id",
+          displayName: "test_entity",
+          pluginName: "test_plugin",
+          selectionData: "test_data",
+          uiConfig: "test_config",
+          tags: {},
+        },
+      },
+    ];
+  }
+}
+
+class FakeReviewsAPI {
+  async listReviews(): Promise<Array<tanagra.Review>> {
+    return [
+      {
+        id: "test_review",
+        created: new Date(),
+        createdBy: "test_user",
+        displayName: "Test Review",
+        lastModified: new Date(),
+        size: 0,
+      },
+    ];
+  }
+}
+
+class FakeAnnotationsAPI {}
+
+class FakeExportAPI {}
+
+class FakeUsersAPI {}
+
+function apiForEnvironment<Real, Fake>(
+  real: { new (c: tanagra.Configuration): Real },
+  fake: { new (): Fake }
+) {
+  const fn = () => {
+    if (process.env.REACT_APP_USE_FAKE_API === "y") {
+      return new fake();
+    }
+
+    const config: tanagra.ConfigurationParameters = {
+      basePath: process.env.REACT_APP_BACKEND_HOST || "",
+    };
+    const accessToken = new URLSearchParams(
+        window.location.href.split("?")[1]
+    ).get("token");
+    if (accessToken) {
+      config.accessToken = accessToken;
+    }
+    return new real(new tanagra.Configuration(config));
+  };
+  return React.createContext(fn());
+}
+
+export const UnderlaysApiContext = apiForEnvironment(
+  tanagra.UnderlaysApi,
+  FakeUnderlaysApi
+);
+export const StudiesApiContext = apiForEnvironment(
+  tanagra.StudiesApi,
+  FakeStudiesAPI
+);
+export const CohortsApiContext = apiForEnvironment(
+  tanagra.CohortsApi,
+  FakeCohortsAPI
+);
+export const ConceptSetsApiContext = apiForEnvironment(
+  tanagra.ConceptSetsApi,
+  FakeConceptSetsAPI
+);
+export const ReviewsApiContext = apiForEnvironment(
+  tanagra.ReviewsApi,
+  FakeReviewsAPI
+);
+export const AnnotationsApiContext = apiForEnvironment(
+  tanagra.AnnotationsApi,
+  FakeAnnotationsAPI
+);
+export const ExportApiContext = apiForEnvironment(
+  tanagra.ExportApi,
+  FakeExportAPI
+);
+export const UsersApiContext = apiForEnvironment(
+  tanagra.UsersApi,
+  FakeUsersAPI
+);

--- a/tanagra-aou-utils/run_tanagra_server.sh
+++ b/tanagra-aou-utils/run_tanagra_server.sh
@@ -30,11 +30,11 @@ export TANAGRA_FEATURE_ARTIFACT_STORAGE_ENABLED=true
 export TANAGRA_AUTH_IAP_GKE_JWT=false
 
 if [[ ${disableAuthChecks} ]]; then
-  echo "Disabling auth checks."
+  echo "Disabling AuthZ"
   export TANAGRA_AUTH_DISABLE_CHECKS=true
   export TANAGRA_AUTH_BEARER_TOKEN=false
 else
-  echo "Enabling auth checks."
+  echo "Enabling AuthZ"
   export TANAGRA_AUTH_DISABLE_CHECKS=false
   export TANAGRA_AUTH_BEARER_TOKEN=true
 fi

--- a/tanagra-aou-utils/run_tanagra_server.sh
+++ b/tanagra-aou-utils/run_tanagra_server.sh
@@ -49,6 +49,6 @@ echo "Using default application credentials from:"
 env | grep GOOGLE_APPLICATION_CREDENTIALS
 
 # run from tanagra sub-module under workbench
-cd ../tanagra
+cd tanagra
 # deploy service
 ./gradlew -PisMySQL service:bootRun

--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -118,6 +118,12 @@ def deploy_tanagra_ui(cmd_name, args)
     end
   end
 
+  #Temp hack to pass the bearer token
+  #This needs to be removed at some point
+  Dir.chdir('../tanagra-aou-utils') do
+    common.run_inline("cp -av apiContext.ts ./tanagra/ui/src")
+  end
+
   Dir.chdir('../tanagra-aou-utils/tanagra/ui') do
     common.status "Building Tanagra UI..."
     common.run_inline("npm ci")
@@ -128,7 +134,7 @@ def deploy_tanagra_ui(cmd_name, args)
     common.run_inline("REACT_APP_POST_MESSAGE_ORIGIN=#{ui_base_url} npm run build --if-present")
 
     common.status "Copying build into appengine folder..."
-    common.run_inline("mkdir -p ../../tanagra-aou-utils/appengine && cp -av ./build ../../tanagra-aou-utils/appengine/")
+    common.run_inline("mkdir -p ../../appengine && cp -av ./build ../../appengine/")
   end
 
   Dir.chdir('../tanagra-aou-utils') do

--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -142,7 +142,7 @@ def deploy_tanagra_ui(cmd_name, args)
     common.run_inline("sed 's/${SERVICE_ACCOUNT}/#{op.opts.project}@appspot.gserviceaccount.com/g' tanagra-ui.yaml > ./appengine/tanagra-ui.yaml")
   end
 
-  deploy_version = "tanagra-ui-" + op.opts.version
+  deploy_version = "tanagra-" + op.opts.version
   deploy_version.gsub!(".", "-")
 
   Dir.chdir('../tanagra-aou-utils/appengine') do

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,10 +15,11 @@
     "test:debug": "react-app-rewired --inspect-brk test --watchAll=false --run-in-band",
     "test": "react-app-rewired test --watchAll=false",
     "lint": "yarn eslint src --ext .ts,.tsx",
-    "codegen": "yarn run codegen-clean && yarn run codegen-swagger && yarn run notebooks-codegen-swagger",
-    "codegen-clean": "rm -rf src/generated src/notebooks-generated",
+    "codegen": "yarn run codegen-clean && yarn run codegen-swagger && yarn run notebooks-codegen-swagger && yarn run tanagra-codegen-openapi",
+    "codegen-clean": "rm -rf src/generated src/notebooks-generated src/tanagra-generated",
     "codegen-swagger": "openapi-generator-cli generate -i ../api/src/main/resources/workbench-api.yaml -g typescript-fetch -p generateAliasAsModel=true --template-dir src/assets/generation --additional-properties=typeScriptThreePlus=true,enumPropertyNaming=UPPERCASE,useSingleRequestParameter=false,prefixParameterInterfaces=true -o src/generated/fetch",
-    "notebooks-codegen-swagger": "java -jar ../aou-utils/swagger-codegen-cli.jar generate --lang typescript-fetch --input-spec ../api/src/main/resources/notebooks.yaml --output src/notebooks-generated/fetch"
+    "notebooks-codegen-swagger": "java -jar ../aou-utils/swagger-codegen-cli.jar generate --lang typescript-fetch --input-spec ../api/src/main/resources/notebooks.yaml --output src/notebooks-generated/fetch",
+    "tanagra-codegen-openapi": "openapi-generator-cli generate -i ../tanagra-aou-utils/tanagra/service/src/main/resources/api/service_openapi.yaml -g typescript-fetch --additional-properties=typescriptThreePlus=true -o src/tanagra-generated"
   },
   "browserslist": [
     "chrome >= 67"

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,20 +6,18 @@
     "build-terra-deps": "./src/terraui/build.sh",
     "deps": "yarn run codegen && yarn run build-terra-deps",
     "start": "BROWSER='none' PORT=4200 react-app-rewired start",
-    "start-tanagra": "npm install --prefix ../tanagra/ui && npm run codegen --prefix ../tanagra/ui && BROWSER='none' REACT_APP_POST_MESSAGE_ORIGIN=http://localhost:4200 npm start --prefix ../tanagra/ui",
     "dev-up": "yarn && yarn run deps && yarn start",
     "dev-up-test": "yarn && yarn run deps && REACT_APP_ENVIRONMENT=localtest yarn start",
     "dev-up-local": "yarn && yarn run deps && REACT_APP_ENVIRONMENT=local yarn start",
-    "dev-up-tanagra-local": "yarn && concurrently \"yarn run start-tanagra\" \"yarn run dev-up-local\"",
+    "dev-up-tanagra-local": "./src/tanagra-ui/dev-up-tanagra-local.sh",
     "build": "react-app-rewired build",
     "test:debug": "react-app-rewired --inspect-brk test --watchAll=false --run-in-band",
     "test": "react-app-rewired test --watchAll=false",
     "lint": "yarn eslint src --ext .ts,.tsx",
-    "codegen": "yarn run codegen-clean && yarn run codegen-swagger && yarn run notebooks-codegen-swagger && yarn run tanagra-codegen-openapi",
+    "codegen": "yarn run codegen-clean && yarn run codegen-swagger && yarn run notebooks-codegen-swagger",
     "codegen-clean": "rm -rf src/generated src/notebooks-generated src/tanagra-generated",
     "codegen-swagger": "openapi-generator-cli generate -i ../api/src/main/resources/workbench-api.yaml -g typescript-fetch -p generateAliasAsModel=true --template-dir src/assets/generation --additional-properties=typeScriptThreePlus=true,enumPropertyNaming=UPPERCASE,useSingleRequestParameter=false,prefixParameterInterfaces=true -o src/generated/fetch",
-    "notebooks-codegen-swagger": "java -jar ../aou-utils/swagger-codegen-cli.jar generate --lang typescript-fetch --input-spec ../api/src/main/resources/notebooks.yaml --output src/notebooks-generated/fetch",
-    "tanagra-codegen-openapi": "openapi-generator-cli generate -i ../tanagra/service/src/main/resources/api/service_openapi.yaml -g typescript-fetch  --additional-properties=typescriptThreePlus=true -o src/tanagra-generated"
+    "notebooks-codegen-swagger": "java -jar ../aou-utils/swagger-codegen-cli.jar generate --lang typescript-fetch --input-spec ../api/src/main/resources/notebooks.yaml --output src/notebooks-generated/fetch"
   },
   "browserslist": [
     "chrome >= 67"

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,6 +6,7 @@
     "build-terra-deps": "./src/terraui/build.sh",
     "deps": "yarn run codegen && yarn run build-terra-deps",
     "start": "BROWSER='none' PORT=4200 react-app-rewired start",
+    "start-tanagra": "BROWSER='none' REACT_APP_POST_MESSAGE_ORIGIN=http://localhost:4200 npm start --prefix ../tanagra-aou-utils/tanagra/ui",
     "dev-up": "yarn && yarn run deps && yarn start",
     "dev-up-test": "yarn && yarn run deps && REACT_APP_ENVIRONMENT=localtest yarn start",
     "dev-up-local": "yarn && yarn run deps && REACT_APP_ENVIRONMENT=local yarn start",
@@ -15,7 +16,7 @@
     "test": "react-app-rewired test --watchAll=false",
     "lint": "yarn eslint src --ext .ts,.tsx",
     "codegen": "yarn run codegen-clean && yarn run codegen-swagger && yarn run notebooks-codegen-swagger",
-    "codegen-clean": "rm -rf src/generated src/notebooks-generated src/tanagra-generated",
+    "codegen-clean": "rm -rf src/generated src/notebooks-generated",
     "codegen-swagger": "openapi-generator-cli generate -i ../api/src/main/resources/workbench-api.yaml -g typescript-fetch -p generateAliasAsModel=true --template-dir src/assets/generation --additional-properties=typeScriptThreePlus=true,enumPropertyNaming=UPPERCASE,useSingleRequestParameter=false,prefixParameterInterfaces=true -o src/generated/fetch",
     "notebooks-codegen-swagger": "java -jar ../aou-utils/swagger-codegen-cli.jar generate --lang typescript-fetch --input-spec ../api/src/main/resources/notebooks.yaml --output src/notebooks-generated/fetch"
   },

--- a/ui/src/tanagra-ui/dev-up-tanagra-local.sh
+++ b/ui/src/tanagra-ui/dev-up-tanagra-local.sh
@@ -20,13 +20,14 @@ else
   git checkout tags/"$version"
 fi
 
+#Temp hack to pass the bearer token
+#This needs to be removed at some point
+cp -av ../apiContext.ts ./ui/src
+
 cd ../../ui
 
 #update yarn
 yarn
-
-#generate openapi
-rm -rf src/tanagra-generated && openapi-generator-cli generate -i ../tanagra-aou-utils/tanagra/service/src/main/resources/api/service_openapi.yaml -g typescript-fetch  --additional-properties=typescriptThreePlus=true -o src/tanagra-generated
 
 #generate Tanagra
 npm install --prefix ../tanagra-aou-utils/tanagra/ui && npm run codegen --prefix ../tanagra-aou-utils/tanagra/ui

--- a/ui/src/tanagra-ui/dev-up-tanagra-local.sh
+++ b/ui/src/tanagra-ui/dev-up-tanagra-local.sh
@@ -26,10 +26,10 @@ cd ../../ui
 yarn
 
 #generate openapi
-openapi-generator-cli generate -i ../tanagra-aou-utils/tanagra/service/src/main/resources/api/service_openapi.yaml -g typescript-fetch  --additional-properties=typescriptThreePlus=true -o src/tanagra-generated
+rm -rf src/tanagra-generated && openapi-generator-cli generate -i ../tanagra-aou-utils/tanagra/service/src/main/resources/api/service_openapi.yaml -g typescript-fetch  --additional-properties=typescriptThreePlus=true -o src/tanagra-generated
 
-#start Tanagra
-npm install --prefix ../tanagra-aou-utils/tanagra/ui && npm run codegen --prefix ../tanagra-aou-utils/tanagra/ui && BROWSER='none' REACT_APP_POST_MESSAGE_ORIGIN=http://localhost:4200 npm start --prefix ../tanagra-aou-utils/tanagra/ui
+#generate Tanagra
+npm install --prefix ../tanagra-aou-utils/tanagra/ui && npm run codegen --prefix ../tanagra-aou-utils/tanagra/ui
 
-#start workbench ui
-yarn run dev-up-local
+#start workbench and tanagra ui
+concurrently "yarn run dev-up-local" "yarn run start-tanagra"

--- a/ui/src/tanagra-ui/dev-up-tanagra-local.sh
+++ b/ui/src/tanagra-ui/dev-up-tanagra-local.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+while getopts v: flag
+do
+  case "${flag}" in
+    v) version=${OPTARG};;
+  esac
+done
+
+cd ../tanagra-aou-utils
+if [ ! -d "tanagra" ]; then
+  echo "Cloning Tanagra repo"
+  git clone https://github.com/DataBiosphere/tanagra.git
+fi
+
+cd tanagra
+if [ -z "$version" ]; then
+  git checkout main
+else
+  git checkout tags/"$version"
+fi
+
+cd ../../ui
+
+#update yarn
+yarn
+
+#generate openapi
+openapi-generator-cli generate -i ../tanagra-aou-utils/tanagra/service/src/main/resources/api/service_openapi.yaml -g typescript-fetch  --additional-properties=typescriptThreePlus=true -o src/tanagra-generated
+
+#start Tanagra
+npm install --prefix ../tanagra-aou-utils/tanagra/ui && npm run codegen --prefix ../tanagra-aou-utils/tanagra/ui && BROWSER='none' REACT_APP_POST_MESSAGE_ORIGIN=http://localhost:4200 npm start --prefix ../tanagra-aou-utils/tanagra/ui
+
+#start workbench ui
+yarn run dev-up-local


### PR DESCRIPTION
This PR removes the tanagra submodule. For local/test deployments the submodule has been replaced by a git ignored subdirectory workbench/tanagra-aou-utils/tanagra.

**NOTE:** the Tanagra API is dependent on the workbench API being deployed in a different terminal window

### Deploying Tanagra API locally 
`./project.rb dev-up-tanagra` 
Optional args:

- --disable-auth - disable authZ
- --version - deploy a tag. default is main
- --drop-db - drop the tanagra database and recreate

### Deploying Tanagra UI locally
`yarn dev-up-tanagra-local` 
Optional args:

- -v - deploy a tag. default is main

### Deploying both Tanagra API/UI to test env 
`deploy/project.rb deploy-tanagra --project all-of-us-workbench-test --version 0.0.219 --promote --quiet` 