### PR TITLE
[risk=no][no ticket] Add Absorb-specific logging

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/absorb/Enrollment.java
+++ b/api/src/main/java/org/pmiops/workbench/absorb/Enrollment.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.absorb;
 
 import java.time.Instant;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public class Enrollment {
   public final String courseId;
@@ -10,5 +11,12 @@ public class Enrollment {
   public Enrollment(String courseId, @Nullable Instant dateCompleted) {
     this.courseId = courseId;
     this.completionTime = dateCompleted;
+  }
+
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("courseId", courseId)
+        .append("completionTime", completionTime)
+        .toString();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -81,6 +81,8 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException, ApiException {
     DbUser user = userProvider.get();
 
+    log.info(String.format("Syncing compliance training status for user %s", user.getUsername()));
+
     // Skip sync for service account user rows.
     if (userService.isServiceAccount(user)) {
       return user;
@@ -126,6 +128,8 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
   @Transactional
   public DbUser syncComplianceTrainingStatusMoodle(DbUser dbUser, Agent agent)
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException {
+    log.info("Using Moodle to sync compliance training status.");
+
     try {
       Map<MoodleService.BadgeName, BadgeDetailsV2> userBadgesByName =
           moodleService.getUserBadgesByBadgeName(dbUser.getUsername());
@@ -219,6 +223,8 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
 
   @Transactional
   public DbUser syncComplianceTrainingStatusAbsorb(DbUser dbUser, Agent agent) throws ApiException {
+    log.info("Using Absorb to sync compliance training status.");
+
     Credentials credentials = absorbService.fetchCredentials(dbUser.getUsername());
 
     if (!absorbService.userHasLoggedIntoAbsorb(credentials)) {


### PR DESCRIPTION
Add Absorb-specific logging for debugging purposes. I think this provides enough information to identify Absorb-side errors or reproduce workbench-side errors.

Example output obtained by running this locally:
```
[Tue Oct 17 14:45:22 EDT 2023] INFO: org.pmiops.workbench.interceptors.AuthInterceptor preHandle - peterlavigne_local_001@fake-research-aou.org logged in 
[Tue Oct 17 14:45:22 EDT 2023] INFO: org.pmiops.workbench.compliancetraining.ComplianceTrainingServiceImpl syncComplianceTrainingStatus - Syncing compliance training status for user peterlavigne_local_001@fake-research-aou.org 
[Tue Oct 17 14:45:22 EDT 2023] INFO: org.pmiops.workbench.compliancetraining.ComplianceTrainingServiceImpl syncComplianceTrainingStatusAbsorb - Using Absorb to sync compliance training status. 
[Tue Oct 17 14:45:22 EDT 2023] INFO: org.pmiops.workbench.absorb.AbsorbServiceImpl fetchCredentials - Fetching Absorb credentials for workbench user `peterlavigne_local_001@fake-research-aou.org` 
[Tue Oct 17 14:45:24 EDT 2023] INFO: org.pmiops.workbench.absorb.AbsorbServiceImpl fetchCredentials - Fetched Absorb user id `0ee6c447-d37a-47a5-b089-17eb6997719a` for workbench user `peterlavigne_local_001@fake-research-aou.org` 
[Tue Oct 17 14:45:24 EDT 2023] INFO: org.pmiops.workbench.absorb.AbsorbServiceImpl getActiveEnrollmentsForUser - Fetching Absorb enrollments for Absorb user id `0ee6c447-d37a-47a5-b089-17eb6997719a` 
[Tue Oct 17 14:45:24 EDT 2023] INFO: org.pmiops.workbench.absorb.AbsorbServiceImpl getActiveEnrollmentsForUser - Fetched Absorb enrollments for Absorb user id `0ee6c447-d37a-47a5-b089-17eb6997719a`: [org.pmiops.workbench.absorb.Enrollment@3939891f[courseId=3765dc64-cc64-4efa-bfc0-9a4dc2e9d09d,completionTime=<null>], org.pmiops.workbench.absorb.Enrollment@2caef00b[courseId=9ad49c70-3b72-4789-8282-5794efcd4ce1,completionTime=2023-09-22T20:17:15.667Z]] 
```

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [x] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.