### PR TITLE
[risk=no][RW-11144] Associate PDs with workspaces on Cloud Environments Page

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -2,6 +2,8 @@ package org.pmiops.workbench.api;
 
 import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_IS_RUNTIME;
 import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_IS_RUNTIME_TRUE;
+import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAME;
+import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE;
 import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.upsertLeonardoLabel;
 
 import com.google.common.base.Strings;
@@ -193,6 +195,16 @@ public class RuntimeController implements RuntimeApiDelegate {
               persistentDiskRequest.getLabels(),
               LEONARDO_LABEL_IS_RUNTIME,
               LEONARDO_LABEL_IS_RUNTIME_TRUE));
+      persistentDiskRequest.labels(
+          upsertLeonardoLabel(
+              persistentDiskRequest.getLabels(),
+              LEONARDO_LABEL_WORKSPACE_NAMESPACE,
+              workspaceNamespace));
+      persistentDiskRequest.labels(
+          upsertLeonardoLabel(
+              persistentDiskRequest.getLabels(),
+              LEONARDO_LABEL_WORKSPACE_NAME,
+              dbWorkspace.getName()));
     }
     long configCount =
         Stream.of(runtime.getGceConfig(), runtime.getDataprocConfig(), runtime.getGceWithPdConfig())

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -191,7 +191,8 @@ public class RuntimeController implements RuntimeApiDelegate {
         persistentDiskRequest.name(userProvider.get().generatePDName());
       }
       var labels = persistentDiskRequest.getLabels();
-      labels = upsertLeonardoLabel(labels, LEONARDO_LABEL_IS_RUNTIME, LEONARDO_LABEL_IS_RUNTIME_TRUE);
+      labels =
+          upsertLeonardoLabel(labels, LEONARDO_LABEL_IS_RUNTIME, LEONARDO_LABEL_IS_RUNTIME_TRUE);
       labels = upsertLeonardoLabel(labels, LEONARDO_LABEL_WORKSPACE_NAMESPACE, workspaceNamespace);
       labels = upsertLeonardoLabel(labels, LEONARDO_LABEL_WORKSPACE_NAME, dbWorkspace.getName());
       persistentDiskRequest.labels(labels);

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -190,21 +190,11 @@ public class RuntimeController implements RuntimeApiDelegate {
         }
         persistentDiskRequest.name(userProvider.get().generatePDName());
       }
-      persistentDiskRequest.labels(
-          upsertLeonardoLabel(
-              persistentDiskRequest.getLabels(),
-              LEONARDO_LABEL_IS_RUNTIME,
-              LEONARDO_LABEL_IS_RUNTIME_TRUE));
-      persistentDiskRequest.labels(
-          upsertLeonardoLabel(
-              persistentDiskRequest.getLabels(),
-              LEONARDO_LABEL_WORKSPACE_NAMESPACE,
-              workspaceNamespace));
-      persistentDiskRequest.labels(
-          upsertLeonardoLabel(
-              persistentDiskRequest.getLabels(),
-              LEONARDO_LABEL_WORKSPACE_NAME,
-              dbWorkspace.getName()));
+      var labels = persistentDiskRequest.getLabels();
+      labels = upsertLeonardoLabel(labels, LEONARDO_LABEL_IS_RUNTIME, LEONARDO_LABEL_IS_RUNTIME_TRUE);
+      labels = upsertLeonardoLabel(labels, LEONARDO_LABEL_WORKSPACE_NAMESPACE, workspaceNamespace);
+      labels = upsertLeonardoLabel(labels, LEONARDO_LABEL_WORKSPACE_NAME, dbWorkspace.getName());
+      persistentDiskRequest.labels(labels);
     }
     long configCount =
         Stream.of(runtime.getGceConfig(), runtime.getDataprocConfig(), runtime.getGceWithPdConfig())

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_IS_RUNTIME;
 import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_IS_RUNTIME_TRUE;
+import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAME;
+import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE;
 import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 
 import com.google.cloud.Date;
@@ -922,6 +924,8 @@ public class RuntimeControllerTest {
 
     Map<String, String> diskLabels = new HashMap<>();
     diskLabels.put(LEONARDO_LABEL_IS_RUNTIME, LEONARDO_LABEL_IS_RUNTIME_TRUE);
+    diskLabels.put(LEONARDO_LABEL_WORKSPACE_NAMESPACE, WORKSPACE_NS);
+    diskLabels.put(LEONARDO_LABEL_WORKSPACE_NAME, WORKSPACE_NAME);
 
     verify(userRuntimesApi)
         .createRuntime(

--- a/ui/src/app/pages/runtimes-list.tsx
+++ b/ui/src/app/pages/runtimes-list.tsx
@@ -23,7 +23,7 @@ const hiddenTableColumns = [
   },
   {
     tableName: 'persistent disks',
-    columnIndexesToHide: [workspace, pdStatus],
+    columnIndexesToHide: [pdStatus],
   },
 ];
 
@@ -51,7 +51,7 @@ const ajax = (signal) => {
     Metrics: { captureEvent: () => undefined },
     Disks: {
       disksV1: () => ({
-        list: () => jsonLeoFetch('/api/google/v1/disks?role=creator'),
+        list: () => jsonLeoFetch('/api/google/v1/disks?role=creator&includeLabels=saturnWorkspaceNamespace,saturnWorkspaceName'),
         disk: (googleProject, name) => ({
           delete: () =>
             jsonLeoFetch(

--- a/ui/src/app/pages/runtimes-list.tsx
+++ b/ui/src/app/pages/runtimes-list.tsx
@@ -12,7 +12,6 @@ import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { ajaxContext, Environments } from 'terraui/out/Environments';
 
 // Indexes of hidden columns
-const workspace = 2;
 const deleteCloudEnvironment = 11;
 const pdStatus = 5;
 
@@ -51,7 +50,10 @@ const ajax = (signal) => {
     Metrics: { captureEvent: () => undefined },
     Disks: {
       disksV1: () => ({
-        list: () => jsonLeoFetch('/api/google/v1/disks?role=creator&includeLabels=saturnWorkspaceNamespace,saturnWorkspaceName'),
+        list: () =>
+          jsonLeoFetch(
+            '/api/google/v1/disks?role=creator&includeLabels=saturnWorkspaceNamespace,saturnWorkspaceName'
+          ),
         disk: (googleProject, name) => ({
           delete: () =>
             jsonLeoFetch(


### PR DESCRIPTION
This change adds labels when creating persistent disks so the disks may be associated with workspaces on the Cloud Environments Page. Without this association, the page's functionality is degraded.

Before:
![before](https://github.com/all-of-us/workbench/assets/1545444/4c729e19-e50d-4109-8f20-b52d6557eb40)

After:
![after](https://github.com/all-of-us/workbench/assets/1545444/be00e684-d8ce-4587-a904-f8c1ca23f17f)

I manually deleted and re-created a runtime with a persistent disk to see the result of the change.

---
**PR checklist**

- [X] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [X] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [X] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [X] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
