### PR TITLE
[risk=low][no ticket] Add a little more null-safety to API createRuntime()

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -177,36 +177,38 @@ public class RuntimeController implements RuntimeApiDelegate {
     GceWithPdConfig gceWithPdConfig = runtime.getGceWithPdConfig();
     if (gceWithPdConfig != null) {
       PersistentDiskRequest persistentDiskRequest = gceWithPdConfig.getPersistentDisk();
-      if (persistentDiskRequest != null) {
-        if (Strings.isNullOrEmpty(persistentDiskRequest.getName())) {
-          // If persistentDiskRequest.getName() is empty, UI wants API to create a new disk.
-          // Check with Leo again see if user have READY disk, if so, block this request or logging
-          List<Disk> diskList =
-              PersistentDiskUtils.findTheMostRecentActiveDisks(
-                  leonardoNotebooksClient
-                      .listPersistentDiskByProjectCreatedByCreator(dbWorkspace.getGoogleProject())
-                      .stream()
-                      .map(leonardoMapper::toApiListDisksResponse)
-                      .collect(Collectors.toList()));
-          List<Disk> runtimeDisks =
-              diskList.stream().filter(Disk::isGceRuntime).collect(Collectors.toList());
-          if (!runtimeDisks.isEmpty()) {
-            // Find active disks for runtime VM. Block user from creating new disk.
-            throw new BadRequestException(
-                String.format(
-                    "Can not create new runtime with new PD if user has active runtime PD. Existing disks: %s",
-                    PersistentDiskUtils.prettyPrintDiskNames(runtimeDisks)));
-          }
-          persistentDiskRequest.name(userProvider.get().generatePDName());
-        }
-        var labels = persistentDiskRequest.getLabels();
-        labels =
-            upsertLeonardoLabel(labels, LEONARDO_LABEL_IS_RUNTIME, LEONARDO_LABEL_IS_RUNTIME_TRUE);
-        labels =
-            upsertLeonardoLabel(labels, LEONARDO_LABEL_WORKSPACE_NAMESPACE, workspaceNamespace);
-        labels = upsertLeonardoLabel(labels, LEONARDO_LABEL_WORKSPACE_NAME, dbWorkspace.getName());
-        persistentDiskRequest.labels(labels);
+      if (persistentDiskRequest == null) {
+        throw new BadRequestException("GceWithPdConfig must contain a PersistentDiskRequest");
       }
+
+      if (Strings.isNullOrEmpty(persistentDiskRequest.getName())) {
+        // If persistentDiskRequest.getName() is empty, UI wants API to create a new disk.
+        // Check with Leo again see if user have READY disk, if so, block this request or logging
+        List<Disk> diskList =
+            PersistentDiskUtils.findTheMostRecentActiveDisks(
+                leonardoNotebooksClient
+                    .listPersistentDiskByProjectCreatedByCreator(dbWorkspace.getGoogleProject())
+                    .stream()
+                    .map(leonardoMapper::toApiListDisksResponse)
+                    .collect(Collectors.toList()));
+        List<Disk> runtimeDisks =
+            diskList.stream().filter(Disk::isGceRuntime).collect(Collectors.toList());
+        if (!runtimeDisks.isEmpty()) {
+          // Find active disks for runtime VM. Block user from creating new disk.
+          throw new BadRequestException(
+              String.format(
+                  "Can not create new runtime with new PD if user has active runtime PD. Existing disks: %s",
+                  PersistentDiskUtils.prettyPrintDiskNames(runtimeDisks)));
+        }
+        persistentDiskRequest.name(userProvider.get().generatePDName());
+      }
+
+      var labels = persistentDiskRequest.getLabels();
+      labels =
+          upsertLeonardoLabel(labels, LEONARDO_LABEL_IS_RUNTIME, LEONARDO_LABEL_IS_RUNTIME_TRUE);
+      labels = upsertLeonardoLabel(labels, LEONARDO_LABEL_WORKSPACE_NAMESPACE, workspaceNamespace);
+      labels = upsertLeonardoLabel(labels, LEONARDO_LABEL_WORKSPACE_NAME, dbWorkspace.getName());
+      persistentDiskRequest.labels(labels);
     }
 
     DbUser user = userProvider.get();

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoLabelHelper.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoLabelHelper.java
@@ -46,7 +46,7 @@ public class LeonardoLabelHelper {
   /** Insert or update disk labels. */
   @SuppressWarnings("unchecked")
   public static Map<String, String> upsertLeonardoLabel(
-      Object rawLabelObject, String labelKey, String labelValue) {
+      @Nullable Object rawLabelObject, String labelKey, String labelValue) {
     Map<String, String> labels =
         (Map<String, String>)
             Optional.ofNullable(rawLabelObject).orElse(new HashMap<String, String>());

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -955,6 +955,43 @@ public class RuntimeControllerTest {
   }
 
   @Test
+  public void testCreateRuntime_gceWithPD_noPDRequest() throws ApiException {
+    when(userRuntimesApi.getRuntime(GOOGLE_PROJECT_ID, getRuntimeName()))
+        .thenThrow(new NotFoundException());
+    stubGetWorkspace(WORKSPACE_NS, GOOGLE_PROJECT_ID, WORKSPACE_ID, "test");
+
+    runtimeController.createRuntime(
+        WORKSPACE_NS, new Runtime().gceWithPdConfig(new GceWithPdConfig().machineType("standard")));
+
+    Map<String, String> diskLabels = new HashMap<>();
+    diskLabels.put(LEONARDO_LABEL_IS_RUNTIME, LEONARDO_LABEL_IS_RUNTIME_TRUE);
+    diskLabels.put(LEONARDO_LABEL_WORKSPACE_NAMESPACE, WORKSPACE_NS);
+    diskLabels.put(LEONARDO_LABEL_WORKSPACE_NAME, WORKSPACE_NAME);
+
+    verify(userRuntimesApi)
+        .createRuntime(
+            eq(GOOGLE_PROJECT_ID), eq(getRuntimeName()), createRuntimeRequestCaptor.capture());
+
+    LeonardoCreateRuntimeRequest createRuntimeRequest = createRuntimeRequestCaptor.getValue();
+
+    Gson gson = new Gson();
+    LeonardoGceWithPdConfig createLeonardoGceWithPdConfig =
+        gson.fromJson(
+            gson.toJson(createRuntimeRequest.getRuntimeConfig()), LeonardoGceWithPdConfig.class);
+
+    assertThat(
+            gson.fromJson(
+                    gson.toJson(createRuntimeRequest.getRuntimeConfig()),
+                    LeonardoRuntimeConfig.class)
+                .getCloudService())
+        .isEqualTo(LeonardoRuntimeConfig.CloudServiceEnum.GCE);
+
+    assertThat(createLeonardoGceWithPdConfig.getMachineType()).isEqualTo("standard");
+    assertThat(createLeonardoGceWithPdConfig.getZone()).isEqualTo("us-central-1");
+    assertThat(createLeonardoGceWithPdConfig.getPersistentDisk()).isNull();
+  }
+
+  @Test
   public void testCreateRuntimeFail_newPdp_pdAlreadyExist() throws ApiException {
     when(userRuntimesApi.getRuntime(GOOGLE_PROJECT_ID, getRuntimeName()))
         .thenThrow(new NotFoundException());


### PR DESCRIPTION
I happened to notice some gaps in NPE prevention while looking at this code.  No expected changes except for an edge case: if a GceWithPDConfig is passed to CreateRuntime without a PD Request (an invalid scenario), it will now throw a BadRequestException instead of a NullPointerException.  I'm not aware of any UI paths that would lead to this situation. 

Tested locally: createRuntime continues to work 

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
