### PR TITLE
[risk=no][RW-11144] Fix GKE apps and disks on Cloud Environments Page

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -538,27 +538,26 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
             .put(LeonardoLabelHelper.LEONARDO_LABEL_AOU, "true")
             .put(LeonardoLabelHelper.LEONARDO_LABEL_CREATED_BY, userProvider.get().getUsername())
             .put(LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(appType))
-            .put(LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE, dbWorkspace.getWorkspaceNamespace())
+            .put(
+                LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE,
+                dbWorkspace.getWorkspaceNamespace())
             .put(LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAME, dbWorkspace.getName())
             .build();
 
     var pdLabels = persistentDiskRequest.getLabels();
-    pdLabels = upsertLeonardoLabel(
-        pdLabels,
-        LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE,
-        appTypeToLabelValue(appType));
-    pdLabels = upsertLeonardoLabel(
-        pdLabels,
-        LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE,
-        dbWorkspace.getWorkspaceNamespace());
-    pdLabels = upsertLeonardoLabel(
-        pdLabels,
-        LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAME,
-        dbWorkspace.getName());
+    pdLabels =
+        upsertLeonardoLabel(
+            pdLabels, LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(appType));
+    pdLabels =
+        upsertLeonardoLabel(
+            pdLabels,
+            LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE,
+            dbWorkspace.getWorkspaceNamespace());
+    pdLabels =
+        upsertLeonardoLabel(
+            pdLabels, LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAME, dbWorkspace.getName());
     LeonardoPersistentDiskRequest diskRequest =
-        leonardoMapper
-            .toLeonardoPersistentDiskRequest(persistentDiskRequest)
-            .labels(pdLabels);
+        leonardoMapper.toLeonardoPersistentDiskRequest(persistentDiskRequest).labels(pdLabels);
     // If no disk name in field name from request, that means creating new disk.
     if (Strings.isNullOrEmpty(diskRequest.getName())) {
       // If persistentDiskRequest.getName() is empty, UI wants API to create a new disk.

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -538,16 +538,27 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
             .put(LeonardoLabelHelper.LEONARDO_LABEL_AOU, "true")
             .put(LeonardoLabelHelper.LEONARDO_LABEL_CREATED_BY, userProvider.get().getUsername())
             .put(LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(appType))
+            .put(LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE, dbWorkspace.getWorkspaceNamespace())
+            .put(LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAME, dbWorkspace.getName())
             .build();
 
+    var pdLabels = persistentDiskRequest.getLabels();
+    pdLabels = upsertLeonardoLabel(
+        pdLabels,
+        LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE,
+        appTypeToLabelValue(appType));
+    pdLabels = upsertLeonardoLabel(
+        pdLabels,
+        LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE,
+        dbWorkspace.getWorkspaceNamespace());
+    pdLabels = upsertLeonardoLabel(
+        pdLabels,
+        LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAME,
+        dbWorkspace.getName());
     LeonardoPersistentDiskRequest diskRequest =
         leonardoMapper
             .toLeonardoPersistentDiskRequest(persistentDiskRequest)
-            .labels(
-                upsertLeonardoLabel(
-                    persistentDiskRequest.getLabels(),
-                    LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE,
-                    appTypeToLabelValue(appType)));
+            .labels(pdLabels);
     // If no disk name in field name from request, that means creating new disk.
     if (Strings.isNullOrEmpty(diskRequest.getName())) {
       // If persistentDiskRequest.getName() is empty, UI wants API to create a new disk.

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -220,20 +220,14 @@ public class LeonardoApiClientTest {
     diskLabels.put(
         LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE,
         LeonardoLabelHelper.appTypeToLabelValue(AppType.RSTUDIO));
-    diskLabels.put(
-        LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE,
-        WORKSPACE_NS);
-    diskLabels.put(
-        LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAME,
-        WORKSPACE_NAME);
+    diskLabels.put(LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE, WORKSPACE_NS);
+    diskLabels.put(LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAME, WORKSPACE_NAME);
 
     LeonardoCreateAppRequest createAppRequest = createAppRequestArgumentCaptor.getValue();
     appLabels.put(
         LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE, AppType.RSTUDIO.toString().toLowerCase());
-    appLabels.put(
-        LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE, WORKSPACE_NS);
-    appLabels.put(
-        LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAME, WORKSPACE_NAME);
+    appLabels.put(LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE, WORKSPACE_NS);
+    appLabels.put(LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAME, WORKSPACE_NAME);
     customEnvironmentVariables.put("WORKSPACE_NAME", testWorkspace.getFirecloudName());
     customEnvironmentVariables.put("GOOGLE_PROJECT", testWorkspace.getGoogleProject());
     customEnvironmentVariables.put("OWNER_EMAIL", user.getUsername());

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -205,7 +205,7 @@ public class LeonardoApiClientTest {
   }
 
   @Test
-  public void testCreateAppSuccess_exisingPd() throws Exception {
+  public void testCreateAppSuccess_existingPd() throws Exception {
     stubGetFcWorkspace(WorkspaceAccessLevel.OWNER);
     leonardoApiClient.createApp(
         createAppRequest.persistentDiskRequest(persistentDiskRequest.name("pd-name")),
@@ -220,10 +220,20 @@ public class LeonardoApiClientTest {
     diskLabels.put(
         LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE,
         LeonardoLabelHelper.appTypeToLabelValue(AppType.RSTUDIO));
+    diskLabels.put(
+        LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE,
+        WORKSPACE_NS);
+    diskLabels.put(
+        LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAME,
+        WORKSPACE_NAME);
 
     LeonardoCreateAppRequest createAppRequest = createAppRequestArgumentCaptor.getValue();
     appLabels.put(
         LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE, AppType.RSTUDIO.toString().toLowerCase());
+    appLabels.put(
+        LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAMESPACE, WORKSPACE_NS);
+    appLabels.put(
+        LeonardoLabelHelper.LEONARDO_LABEL_WORKSPACE_NAME, WORKSPACE_NAME);
     customEnvironmentVariables.put("WORKSPACE_NAME", testWorkspace.getFirecloudName());
     customEnvironmentVariables.put("GOOGLE_PROJECT", testWorkspace.getGoogleProject());
     customEnvironmentVariables.put("OWNER_EMAIL", user.getUsername());

--- a/ui/src/app/pages/runtimes-list.tsx
+++ b/ui/src/app/pages/runtimes-list.tsx
@@ -40,7 +40,9 @@ const ajax = (signal) => {
     },
     Apps: {
       listWithoutProject: () =>
-        jsonLeoFetch('/api/google/v1/apps?role=creator&includeDeleted=false&includeLabels=saturnWorkspaceNamespace,saturnWorkspaceName'),
+        jsonLeoFetch(
+          '/api/google/v1/apps?role=creator&includeDeleted=false&includeLabels=saturnWorkspaceNamespace,saturnWorkspaceName'
+        ),
     },
     Metrics: { captureEvent: () => undefined },
     Disks: {

--- a/ui/src/app/pages/runtimes-list.tsx
+++ b/ui/src/app/pages/runtimes-list.tsx
@@ -13,16 +13,11 @@ import { ajaxContext, Environments } from 'terraui/out/Environments';
 
 // Indexes of hidden columns
 const deleteCloudEnvironment = 11;
-const pdStatus = 5;
 
 const hiddenTableColumns = [
   {
     tableName: 'cloud environments',
     columnIndexesToHide: [deleteCloudEnvironment],
-  },
-  {
-    tableName: 'persistent disks',
-    columnIndexesToHide: [pdStatus],
   },
 ];
 
@@ -45,7 +40,7 @@ const ajax = (signal) => {
     },
     Apps: {
       listWithoutProject: () =>
-        jsonLeoFetch('/api/google/v1/apps?role=creator&includeDeleted=false'),
+        jsonLeoFetch('/api/google/v1/apps?role=creator&includeDeleted=false&includeLabels=saturnWorkspaceNamespace,saturnWorkspaceName'),
     },
     Metrics: { captureEvent: () => undefined },
     Disks: {


### PR DESCRIPTION
Before:
![before](https://github.com/all-of-us/workbench/assets/1545444/215ef87e-714a-45d2-9779-63ecc02a7791)

After:
![after](https://github.com/all-of-us/workbench/assets/1545444/910d55e8-9a7c-4b41-94af-d67e1add5383)

Tested manually by creating an RStudio app and observing the difference.

---
**PR checklist**

- [X] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [X] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [X] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [X] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
