### PR TITLE
[risk=low][no ticket] Enable deleting of ERROR runtimes

### DIFF
--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -44,7 +44,11 @@ import {
   workspaceDataStub,
   WorkspaceStubVariables,
 } from 'testing/stubs/workspaces';
-import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
+import {
+  ALL_GKE_APP_STATUSES,
+  ALL_RUNTIME_STATUSES,
+  minus,
+} from 'testing/utils';
 
 import { ExpandedApp } from './expanded-app';
 import { toAppType, UIAppType } from './utils';
@@ -165,7 +169,12 @@ describe('ExpandedApp', () => {
       }
     );
 
-    test.each([RuntimeStatus.RUNNING, RuntimeStatus.STOPPED])(
+    const canDeleteStatuses = [
+      RuntimeStatus.RUNNING,
+      RuntimeStatus.STOPPED,
+      RuntimeStatus.ERROR,
+    ];
+    test.each(canDeleteStatuses)(
       'should allow deletion when the Jupyter app status is %s',
       async (status) => {
         runtimeStub.runtime.status = status;
@@ -183,14 +192,7 @@ describe('ExpandedApp', () => {
       }
     );
 
-    test.each([
-      RuntimeStatus.STOPPING,
-      RuntimeStatus.STARTING,
-      RuntimeStatus.ERROR,
-      RuntimeStatus.UNKNOWN,
-      undefined,
-      null,
-    ])(
+    test.each(minus(ALL_RUNTIME_STATUSES, canDeleteStatuses))(
       'should not allow deletion when the Jupyter app status is %s',
       async (status) => {
         runtimeStub.runtime.status = status;

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -27,7 +27,7 @@ import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
 import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import {
-  isActionable,
+  canDeleteRuntime,
   RuntimeStatusRequest,
   useRuntimeStatus,
 } from 'app/utils/runtime-utils';
@@ -256,7 +256,7 @@ export const ExpandedApp = (props: ExpandedAppProps) => {
 
   const trashEnabled =
     appType === UIAppType.JUPYTER
-      ? isActionable(runtime?.status)
+      ? canDeleteRuntime(runtime?.status)
       : canDeleteApp(initialUserAppInfo);
 
   const displayCromwellDeleteModal = () => {

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -33,7 +33,6 @@ import { applyPresetOverride } from 'app/utils/runtime-presets';
 import {
   AnalysisConfig,
   AnalysisDiff,
-  canDeleteRuntime,
   diffsToUpdateMessaging,
   fromAnalysisConfig,
   getAnalysisConfigDiffs,

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -33,6 +33,7 @@ import { applyPresetOverride } from 'app/utils/runtime-presets';
 import {
   AnalysisConfig,
   AnalysisDiff,
+  canDeleteRuntime,
   diffsToUpdateMessaging,
   fromAnalysisConfig,
   getAnalysisConfigDiffs,

--- a/ui/src/app/components/runtime-configuration-panel/customize-panel-footer.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/customize-panel-footer.tsx
@@ -8,7 +8,11 @@ import { DeletePersistentDiskButton } from 'app/components/common-env-conf-panel
 import { styles } from 'app/components/common-env-conf-panels/styles';
 import { FlexRow } from 'app/components/flex';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
-import { AnalysisConfig, PanelContent } from 'app/utils/runtime-utils';
+import {
+  AnalysisConfig,
+  canDeleteRuntime,
+  PanelContent,
+} from 'app/utils/runtime-utils';
 
 export interface CustomizePanelFooterProps {
   disableControls: boolean;
@@ -87,12 +91,12 @@ export const CustomizePanelFooter = ({
       <LinkButton
         style={{
           ...styles.deleteLink,
-          ...(disableControls || !runtimeExists
+          ...(disableControls || !canDeleteRuntime(currentRuntime?.status)
             ? { color: colorWithWhiteness(colors.dark, 0.4) }
             : {}),
         }}
         aria-label='Delete Environment'
-        disabled={disableControls || !runtimeExists}
+        disabled={disableControls || !canDeleteRuntime(currentRuntime?.status)}
         onClick={() => setPanelContent(PanelContent.DeleteRuntime)}
       >
         Delete Environment

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -1265,7 +1265,6 @@ export enum PanelContent {
   DeleteRuntime = 'DeleteRuntime',
   DeleteUnattachedPd = 'DeleteUnattachedPd',
   DeleteUnattachedPdAndCreate = 'DeleteUnattachedPdAndCreate',
-  DeleteUnattachedPdAndUpdate = 'DeleteUnattachedPdAndUpdate',
   Disabled = 'Disabled',
   ConfirmUpdate = 'ConfirmUpdate',
   ConfirmUpdateWithDiskDelete = 'ConfirmUpdateWithDiskDelete',
@@ -1283,6 +1282,16 @@ export const isVisible = (status: RuntimeStatus) =>
 export const isActionable = (status: RuntimeStatus) =>
   (
     [RuntimeStatus.RUNNING, RuntimeStatus.STOPPED] as Array<RuntimeStatus>
+  ).includes(status);
+
+// can the user delete the runtime?
+export const canDeleteRuntime = (status: RuntimeStatus) =>
+  (
+    [
+      RuntimeStatus.RUNNING,
+      RuntimeStatus.STOPPED,
+      RuntimeStatus.ERROR,
+    ] as Array<RuntimeStatus>
   ).includes(status);
 
 export const getCreator = (runtime: ListRuntimeResponse): string | undefined =>

--- a/ui/src/testing/utils.ts
+++ b/ui/src/testing/utils.ts
@@ -1,4 +1,4 @@
-import { AppStatus, TerraJobStatus } from 'generated/fetch';
+import { AppStatus, RuntimeStatus, TerraJobStatus } from 'generated/fetch';
 
 export function minus<T>(a1: T[], a2: T[]): T[] {
   return a1.filter((e) => !a2.includes(e));
@@ -10,4 +10,8 @@ export const ALL_GKE_APP_STATUSES = Object.keys(AppStatus)
 
 export const ALL_TERRA_JOB_STATUSES = Object.keys(TerraJobStatus)
   .map((k) => TerraJobStatus[k])
+  .concat([null, undefined]);
+
+export const ALL_RUNTIME_STATUSES = Object.keys(RuntimeStatus)
+  .map((k) => RuntimeStatus[k])
   .concat([null, undefined]);


### PR DESCRIPTION
Allow deletion of Jupyter runtimes from the Runtime Configuration Panel and the Apps Panel.

Tested locally by creating Error runtimes (due to a current bug, creating a runtime immediately after a GKE app can do this) and observing that deletion is available to users.

![error-delete](https://github.com/all-of-us/workbench/assets/2701406/d25f5b7a-f097-499e-871c-b34d4405181b)


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
