### PR TITLE
[RW-11244][risk=low] Fix reporting dataset name for prod

### DIFF
--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -146,7 +146,7 @@
     "useTestCaptcha": false
   },
   "reporting": {
-    "dataset": "reporting_test",
+    "dataset": "reporting_prod",
     "maxRowsPerInsert": 500,
     "exportTerraDataWarehouse": true,
     "terraWarehouseLeoAppTableId": "broad-dsde-prod-analytics-dev.warehouse.leonardo_app",


### PR DESCRIPTION
Reporting pipleline is broken with error "reporting_test not found". It is broken by this line: https://github.com/all-of-us/workbench/commit/57965bea08a782652d18a90f9fe1e64b2068f673#diff-1c2c731d0766b3759fa81a782d1af209b835d46ec2a8bf5b7a8803b541d20e67R151
It is a copy paste error from test env's config

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
