### PR TITLE
[risk=low][no ticket] DUCC Version 3 is not current

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -107,7 +107,7 @@
     "unsafeAllowUserCreationFromGSuiteData": true,
     "enableRasIdMeLinking": true,
     "enableRasLoginGovLinking": true,
-    "currentDuccVersions": [3, 4, 5, 6],
+    "currentDuccVersions": [4, 5, 6],
     "renewal": {
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 7, 15],

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -107,7 +107,7 @@
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": false,
     "enableRasLoginGovLinking": false,
-    "currentDuccVersions": [3, 4, 5, 6],
+    "currentDuccVersions": [4, 5, 6],
     "renewal": {
       "expiryDays": 3650,
       "expiryDaysWarningThresholds": [1, 7, 15],

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -107,7 +107,7 @@
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": false,
     "enableRasLoginGovLinking": true,
-    "currentDuccVersions": [3, 4, 5, 6],
+    "currentDuccVersions": [4, 5, 6],
     "renewal": {
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 7, 15],

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -107,7 +107,7 @@
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": false,
     "enableRasLoginGovLinking": true,
-    "currentDuccVersions": [3, 4, 5, 6],
+    "currentDuccVersions": [4, 5, 6],
     "renewal": {
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 7, 15],

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -107,7 +107,7 @@
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": false,
     "enableRasLoginGovLinking": true,
-    "currentDuccVersions": [3, 4, 5, 6],
+    "currentDuccVersions": [4, 5, 6],
     "renewal": {
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 7, 15],

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -107,7 +107,7 @@
     "unsafeAllowUserCreationFromGSuiteData": true,
     "enableRasIdMeLinking": true,
     "enableRasLoginGovLinking": true,
-    "currentDuccVersions": [3, 4, 5, 6],
+    "currentDuccVersions": [4, 5, 6],
     "renewal": {
       "expiryDays": 3650,
       "expiryDaysWarningThresholds": [1, 7, 15],


### PR DESCRIPTION
Researchers who have signed version 3 of the DUCC are non-compliant: newer versions have existed for more than a year on Prod.

Here we can see that we switched to v4 in Feb 2022, so this change is overdue.
```
SELECT signed_version, min(completion_time), max(completion_time)
FROM user_code_of_conduct_agreement
GROUP BY signed_version ORDER BY signed_version;
+----------------+----------------------+----------------------+
| signed_version | min(completion_time) | max(completion_time) |
+----------------+----------------------+----------------------+
|              2 | 2019-10-30 20:01:39  | 2020-04-21 15:59:27  |
|              3 | 2020-04-29 17:03:24  | 2022-02-07 19:36:46  |
|              4 | 2022-02-09 02:27:14  | 2023-08-22 13:34:59  |
|              5 | 2023-08-22 14:33:55  | 2023-10-30 12:42:51  |
+----------------+----------------------+----------------------+
```

Because we compel users to re-sign the latest DUCC annually to maintain access, I would not expect any users to be affected by this change.  This query returns only 2 users in the category of "has access but is only at version of 3 in the DUCC" - we can follow up with them individually if needed.
```
SELECT count(*) 
FROM user NATURAL JOIN user_access_tier NATURAL JOIN user_code_of_conduct_agreement 
WHERE user_access_tier.access_tier_id = 1 AND user_access_tier.access_status = 1 /* current RT access */
AND user_code_of_conduct_agreement.signed_version = 3;
```
 


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
