### PR TITLE
[risk=low][no ticket] Update Sam client

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -482,8 +482,9 @@ dependencies {
     implementation 'jakarta.mail:jakarta.mail-api:2.1.1'
     testAnnotationProcessor "org.mapstruct:mapstruct-processor:$project.ext.MAPSTRUCT_VERSION"
 
-    // latest as of 12 May 2023 10:19:45 -0400
-    implementation("org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-00d8cfd-SNAP") {
+    // updated 3 Nov 2023
+    // the latest version of Sam which passed all tests was on 12 October with hash 06ef266...
+    implementation("org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-06ef266") {
       exclude group: 'org.apache.oltu.oauth2', module: 'org.apache.oltu.oauth2.common'
     }
 


### PR DESCRIPTION
Snyk reports transitive vulnerabilities through our Sam client - perhaps an upgrade will help.  Also good to keep up to date generally.

Tested locally by exercising the two paths where we currently use the Sam client:
* Delete Workspace (uses Sam to delete GKE child resources)
* Unshare CT Workspace with Owner/Writer (uses Sam to revoke the Google Life Science Runner role)

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
