### PR TITLE
[risk=low][RW-10556] Modify the embedded terraui build for Node 18

### DIFF
--- a/ui/src/terraui/build.sh
+++ b/ui/src/terraui/build.sh
@@ -35,7 +35,11 @@ git clone -n --shallow-since='2023-05-01T00:00' \
 # Apply patches. See comments in individual files.
 
 sh patches/removenodeversioncheck.sh $REPODIR/.yarnrc.yml
-(cd $REPODIR; yarn install)
+sh patches/rm-tests.sh
+
+# the change in rm-tests causes yarn.lock to change - i.e. not immutable
+(cd $REPODIR; YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install)
+
 bash patches/commentoutbadimportline.sh
 sh patches/removereactcomponentfromsvgimports.sh $REPODIR/src/components/CloudProviderIcon.ts
 sh patches/removereactcomponentfromsvgimports.sh $REPODIR/src/libs/icon-dict.js

--- a/ui/src/terraui/patches/rm-tests.sh
+++ b/ui/src/terraui/patches/rm-tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+# Puppeteer does not build after upgrading the deployment script to Node 18.
+# Reasons for this are unclear, and we don't care about puppeteer.
+
+# Remove the declaration in package.json that requires it:
+# "workspaces": [
+#   "integration-tests"
+# ],
+
+JSON="$PWD"/.repo/package.json
+TMPJSON=tmp.json
+
+grep -v 'integration-tests' "$JSON" > "$TMPJSON"
+mv "$TMPJSON" "$JSON"


### PR DESCRIPTION
This change is needed to build under Node 18, but it's not clear why.  Because this is for the prototype `ui/src/terraui` which contains many hacks already and will eventually be replace with properly componentized `@terra-ui-packages` elements, and Node 18 is urgent, I didn't look too deeply.

The failure this change avoids is
```
➤ YN0009: │ puppeteer@npm:13.5.1 couldn't be built successfully (exit code 1, logs can be found here: /tmp/xfs-780915ac/build.log)
```
but it only happens under some circumstances - in my experience, this was only when running the deployment script.  Again, unclear why this makes a difference.  I was able to confirm that this change fixes the situation.

The only thing this could affect is the Cloud Environments page.  I observed no changes when testing locally.

To properly test this change, remove the directory `ui/src/terraui/.repo` (to require a terraui build) and build the UI.  I confirmed that this succeeds whether that directory exists or not.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
