### PR TITLE
[noTicket][risk=no]Revert freeTier cron job using cloud task

### DIFF
--- a/api/src/main/webapp/WEB-INF/cron_base.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_base.yaml
@@ -17,7 +17,7 @@ cron:
   timezone: UTC
   target: api
 - description: Find and alert users that have exceeded their free tier billing usage using cloud task
-  url: "/v1/cron/checkFreeTierBillingUsageCloudTask"
+  url: "/v1/cron/checkFreeTierBillingUsage"
   schedule: every 30 minutes
   timezone: UTC
   target: api

--- a/api/src/main/webapp/WEB-INF/cron_test.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_test.yaml
@@ -1,6 +1,6 @@
 cron:
 - url: /v1/cron/checkObjectNameSize
   schedule: every 24 hours
-- url: /v1/cron/checkFreeTierBillingUsageCloudTask
+- url: /v1/cron/checkFreeTierBillingUsage
   schedule: every 24 hours
 


### PR DESCRIPTION
The recent change to use cloud task for checking free tier usage has been failing with the error : _INVALID_ARGUMENT: Task size too large_
. We would have to rethink the strategy of how to send the big query data. 

In the meantime since its a release day, its better to revert the change so that it doesnt go to PROD

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
