### PR TITLE
[risk=no][RW-11040] Remove feature flag absorb.enabledForNewUsers

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -92,7 +92,6 @@
   },
   "absorb": {
     "externalDepartmentId": "Development",
-    "enabledForNewUsers": true,
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"
   },

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -92,7 +92,6 @@
   },
   "absorb": {
     "externalDepartmentId": "Researchers",
-    "enabledForNewUsers": true,
     "samlIdentityProviderId": "C02celxus",
     "samlServiceProviderId": "638082479253"
   },

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -92,7 +92,6 @@
   },
   "absorb": {
     "externalDepartmentId": "Researchers",
-    "enabledForNewUsers": true,
     "samlIdentityProviderId": "C02celxus",
     "samlServiceProviderId": "638082479253"
   },

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -92,7 +92,6 @@
   },
   "absorb": {
     "externalDepartmentId": "Development",
-    "enabledForNewUsers": true,
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"
   },

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -92,7 +92,6 @@
   },
   "absorb": {
     "externalDepartmentId": "Development",
-    "enabledForNewUsers": true,
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"
   },

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -92,7 +92,6 @@
   },
   "absorb": {
     "externalDepartmentId": "Development",
-    "enabledForNewUsers": true,
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028"
   },

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -100,7 +100,6 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
 
   @Override
   public boolean useAbsorb() {
-    var featureFlagEnabled = configProvider.get().absorb.enabledForNewUsers;
     var userHasUsedMoodle =
         userAccessModuleDao.getAllByUser(userProvider.get()).stream()
             .anyMatch(
@@ -112,7 +111,7 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
                                     ::getComplianceTrainingVerificationSystem)
                             .orElse(null)
                         == DbComplianceTrainingVerificationSystem.MOODLE);
-    return featureFlagEnabled && !userHasUsedMoodle;
+    return !userHasUsedMoodle;
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -258,7 +258,6 @@ public class WorkbenchConfig {
 
   public static class AbsorbConfig {
     public String externalDepartmentId;
-    public boolean enabledForNewUsers;
     public String samlIdentityProviderId;
     public String samlServiceProviderId;
   }


### PR DESCRIPTION
Remove feature flag absorb.enabledForNewUsers. This feature has been rolled out to all environments. All new users use Absorb instead of Moodle.

To manually test this:
- Create a new user
- Using an admin user, bypass requirements other than RT and CT training
- On the data access modules page, when you select RT training, you are taken to Absorb

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [x] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.