### PR TITLE
[risk=no][no ticket] Add Absorb docs

### DIFF
--- a/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/AbsorbAcceptanceTest.java
@@ -75,6 +75,10 @@ public class AbsorbAcceptanceTest extends BaseIntegrationTest {
         enrollments.stream()
             .filter(e -> e.courseId.equals(ComplianceTrainingServiceImpl.ctTrainingCourseId))
             .findFirst();
+    // Users are enrolled in CT training only after RT training is complete. This prevents
+    // first-time users from seeing two courses upon visiting Absorb and taking the wrong one. We
+    // were unable to directly link to the right course and this is a workaround. The logic for this
+    // is implemented on the Absorb side.
     assertThat(ctTrainingEnrollment.isPresent()).isFalse();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceImpl.java
@@ -79,7 +79,9 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
     this.absorbService = absorbService;
   }
 
-  /** Syncs the current user's training status from Moodle. */
+  /**
+   * Syncs the current user's training status from the relevant LMS (Learning Management System).
+   */
   public DbUser syncComplianceTrainingStatus()
       throws org.pmiops.workbench.moodle.ApiException, NotFoundException, ApiException {
     DbUser user = userProvider.get();
@@ -226,6 +228,12 @@ public class ComplianceTrainingServiceImpl implements ComplianceTrainingService 
 
   @Transactional
   public DbUser syncComplianceTrainingStatusAbsorb(DbUser dbUser, Agent agent) throws ApiException {
+    /*
+    When debugging or manually testing Absorb, it can be helpful to use the Absorb Admin UI.
+    You can log into https://aoudev.myabsorb.com/admin/dashboard using our Absorb API credentials.
+    From there, you can view the current state of Absorb or manually bypass courses.
+     */
+
     log.info("Using Absorb to sync compliance training status.");
 
     Credentials credentials = absorbService.fetchCredentials(dbUser.getUsername());

--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageClientImpl.java
@@ -40,6 +40,10 @@ public class CloudStorageClientImpl implements CloudStorageClient {
 
   @Override
   public JSONObject getAbsorbCredentials() {
+    // Our Absorb credentials are for an "Admin" user, as outlined here:
+    // https://support.absorblms.com/hc/en-us/articles/360053227673-Admin-Roles-Permissions
+    // However, since the user is not a "System Admin" we cannot view "portal settings" such as SSO
+    // configuration.
     return getCredentialsBucketJSON("absorb-credentials.json");
   }
 


### PR DESCRIPTION
Add Absorb docs. This PR introduces no functional changes.

If possible, I'd prefer to avoid maintaining docs outside the code like I do for [auth](https://precisionmedicineinitiative.atlassian.net/wiki/spaces/RW/pages/2833580033/Authentication+and+Authorization), as I think separate docs are less discoverable and maintainable. These comments attempt to place Absorb information at the place you'd be most likely to look for it.

@NehaBroad Is there any other information you feel you need in order to confidently implement [RW-10362](https://precisionmedicineinitiative.atlassian.net/browse/RW-10362)? If so, let me know and we can discuss how that information should be shared.

After this is merged, I will add a small section to the oncall playbook regarding Absorb debugging.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.

[RW-10362]: https://precisionmedicineinitiative.atlassian.net/browse/RW-10362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ