### PR TITLE
[risk=low][no ticket] Update workspace endpoint param names from workspaceId to terraName

### DIFF
--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4033,7 +4033,8 @@ paths:
           type: string
       - name: terraName
         in: path
-        description: the workspace name as stored in Terra and displayed in the URL
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -13152,7 +13153,7 @@ components:
       name: terraName
       in: path
       description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
-         due to confusion with DB IDs, which it is not)
+        due to confusion with DB IDs, which it is not)
       required: true
       schema:
         type: string

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1375,7 +1375,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/isNotebookTransferComplete:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/isNotebookTransferComplete:
     get:
       tags:
       - workspaces
@@ -1388,9 +1388,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+           due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -1425,7 +1426,7 @@ paths:
         403:
           description: Forbidden
           content: {}
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}:
+  /v1/workspaces/{workspaceNamespace}/{terraName}:
     get:
       tags:
       - workspaces
@@ -1438,9 +1439,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+           due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -1469,9 +1471,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -1495,9 +1498,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -1516,7 +1520,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Workspace'
       x-codegen-request-body-name: workspace
-  /v2/workspaces/{workspaceNamespace}/{workspaceId}/resources:
+  /v2/workspaces/{workspaceNamespace}/{terraName}/resources:
     get:
       tags:
       - workspaces
@@ -1529,9 +1533,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -1552,7 +1557,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceResourceResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/billing-usage:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/billing-usage:
     get:
       tags:
       - workspaces
@@ -1565,9 +1570,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -1578,7 +1584,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceBillingUsageResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/creator-free-credits-remaining:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/creator-free-credits-remaining:
     get:
       tags:
       - workspaces
@@ -1592,9 +1598,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -1605,7 +1612,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceCreatorFreeCreditsRemainingResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/share:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/share:
     patch:
       tags:
       - workspaces
@@ -1620,9 +1627,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -1641,7 +1649,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/WorkspaceUserRolesResponse'
       x-codegen-request-body-name: body
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/duplicate:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/duplicate:
     post:
       tags:
       - workspaces
@@ -1658,9 +1666,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -1678,7 +1687,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CloneWorkspaceResponse'
       x-codegen-request-body-name: body
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/duplicateAsync:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/duplicateAsync:
     post:
       tags:
       - workspaces
@@ -1692,9 +1701,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -1712,7 +1722,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/WorkspaceOperation'
       x-codegen-request-body-name: body
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/userRoles:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/userRoles:
     get:
       tags:
       - workspaces
@@ -1725,9 +1735,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -1776,7 +1787,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/publish:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/publish:
     post:
       tags:
       - workspaceAdmin
@@ -1790,9 +1801,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -1803,7 +1815,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmptyResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/unpublish:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/unpublish:
     post:
       tags:
       - workspaceAdmin
@@ -1817,9 +1829,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -1924,7 +1937,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceAuditLogQueryResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/notebook-list:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/notebook-list:
     get:
       tags:
       - notebooks
@@ -1939,9 +1952,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: workspaceId
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -2708,7 +2722,7 @@ paths:
         204:
           description: No content.
           content: {}
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/notebooks/{notebookName}/readonly:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/notebooks/{notebookName}/readonly:
     post:
       tags:
       - notebooks
@@ -2721,9 +2735,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -2739,7 +2754,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReadOnlyNotebookResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/notebooks/rename:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/notebooks/rename:
     post:
       tags:
       - notebooks
@@ -2752,9 +2767,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -2772,7 +2788,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FileDetail'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/notebooks/{notebookName}/duplicate:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/notebooks/{notebookName}/duplicate:
     post:
       tags:
       - notebooks
@@ -2785,9 +2801,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -2803,7 +2820,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FileDetail'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/notebooks/{notebookName}/copy:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/notebooks/{notebookName}/copy:
     post:
       tags:
       - notebooks
@@ -2816,9 +2833,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -2841,7 +2859,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/FileDetail'
       x-codegen-request-body-name: copyNotebookRequest
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/notebooks/{notebookName}/kernel:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/notebooks/{notebookName}/kernel:
     get:
       tags:
       - notebooks
@@ -2854,9 +2872,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -2872,7 +2891,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KernelTypeResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/notebooks/{notebookName}/delete:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/notebooks/{notebookName}/delete:
     delete:
       tags:
       - notebooks
@@ -2885,9 +2904,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -2903,7 +2923,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmptyResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/notebooks/{notebookName}/lockingMetadata:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/notebooks/{notebookName}/lockingMetadata:
     get:
       tags:
       - notebooks
@@ -2921,9 +2941,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -2939,7 +2960,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NotebookLockingMetadataResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/cohort-reviews:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/cohort-reviews:
     get:
       tags:
       - cohortReview
@@ -2952,9 +2973,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -2965,7 +2987,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CohortReviewListResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/cohort-reviews/{id}:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/cohort-reviews/{id}:
     get:
       tags:
       - cohortReview
@@ -2978,9 +3000,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3010,9 +3033,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3043,9 +3067,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3071,7 +3096,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CohortReview'
       x-codegen-request-body-name: cohortReview
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/cohorts:
     get:
       tags:
       - cohorts
@@ -3084,9 +3109,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3109,9 +3135,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3133,7 +3160,7 @@ paths:
           description: Bad Request. Cohort name already exists
           content: {}
       x-codegen-request-body-name: cohort
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts/duplicate:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/cohorts/duplicate:
     post:
       tags:
       - cohorts
@@ -3146,9 +3173,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3170,7 +3198,7 @@ paths:
           description: Bad Request. Cohort name already exists
           content: {}
       x-codegen-request-body-name: DuplicateCohortRequest
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts/{cohortId}:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/cohorts/{cohortId}:
     get:
       tags:
       - cohorts
@@ -3183,9 +3211,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3215,9 +3244,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3248,9 +3278,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3289,7 +3320,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceResourceResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/user-recent-resources/update:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/user-recent-resources/update:
     post:
       tags:
       - userMetrics
@@ -3302,9 +3333,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3342,7 +3374,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RecentWorkspaceResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/user-recent-workspaces/update:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/user-recent-workspaces/update:
     post:
       tags:
       - workspaces
@@ -3355,9 +3387,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3368,7 +3401,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RecentWorkspaceResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/concept-sets:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/concept-sets:
     get:
       tags:
       - conceptSets
@@ -3381,9 +3414,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3406,9 +3440,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3427,7 +3462,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ConceptSet'
       x-codegen-request-body-name: request
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/concept-sets/{conceptSetId}:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/concept-sets/{conceptSetId}:
     get:
       tags:
       - conceptSets
@@ -3440,9 +3475,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3472,9 +3508,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3505,9 +3542,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3533,7 +3571,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ConceptSet'
       x-codegen-request-body-name: conceptSet
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/concept-sets/{conceptSetId}/concept-count:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/concept-sets/{conceptSetId}/concept-count:
     get:
       tags:
       - conceptSets
@@ -3546,9 +3584,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3566,7 +3605,7 @@ paths:
             application/json:
               schema:
                 type: integer
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/concept-sets/{conceptSetId}/concepts:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/concept-sets/{conceptSetId}/concepts:
     post:
       tags:
       - conceptSets
@@ -3579,9 +3618,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3607,7 +3647,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ConceptSet'
       x-codegen-request-body-name: request
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/concept-sets/{conceptSetId}/copy:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/concept-sets/{conceptSetId}/copy:
     post:
       tags:
       - conceptSets
@@ -3620,9 +3660,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3645,7 +3686,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ConceptSet'
       x-codegen-request-body-name: copyConceptSetRequest
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/data-sets:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/data-sets:
     post:
       tags:
       - dataSet
@@ -3658,9 +3699,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3690,7 +3732,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-codegen-request-body-name: dataSetRequest
-  /v1/{workspaceNamespace}/{workspaceId}/data-sets/{dataSetId}:
+  /v1/{workspaceNamespace}/{terraName}/data-sets/{dataSetId}:
     get:
       tags:
       - dataSet
@@ -3702,9 +3744,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3734,9 +3777,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3765,9 +3809,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3805,7 +3850,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-codegen-request-body-name: dataSet
-  /v1/{workspaceNamespace}/{workspaceId}/data-sets/dataSetByResourceId:
+  /v1/{workspaceNamespace}/{terraName}/data-sets/dataSetByResourceId:
     post:
       tags:
       - dataSet
@@ -3817,9 +3862,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3873,7 +3919,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataDictionaryEntry'
-  /v1/{workspaceNamespace}/{workspaceId}/data-set/markDirty:
+  /v1/{workspaceNamespace}/{terraName}/data-set/markDirty:
     post:
       tags:
       - dataSet
@@ -3885,9 +3931,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3906,7 +3953,7 @@ paths:
                 type: boolean
                 default: false
       x-codegen-request-body-name: markDataSetRequest
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/genomicExtractionJobs:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/genomicExtractionJobs:
     get:
       tags:
       - dataSet
@@ -3920,9 +3967,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3933,7 +3981,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenomicExtractionJobListResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/datasets/{dataSetId}/extractGenomicData:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/datasets/{dataSetId}/extractGenomicData:
     post:
       tags:
       - dataSet
@@ -3948,9 +3996,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -3968,7 +4017,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenomicExtractionJob'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/genomicExtractionJobs/{jobId}/abort:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/genomicExtractionJobs/{jobId}/abort:
     post:
       tags:
       - dataSet
@@ -3982,9 +4031,9 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: workspaceId
+        description: the workspace name as stored in Terra and displayed in the URL
         required: true
         schema:
           type: string
@@ -4012,7 +4061,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /v1/{workspaceNamespace}/{workspaceId}/data-set/exportToNotebook:
+  /v1/{workspaceNamespace}/{terraName}/data-set/exportToNotebook:
     post:
       tags:
       - dataSet
@@ -4025,9 +4074,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -4051,7 +4101,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-codegen-request-body-name: dataSetExportRequest
-  /v1/{workspaceNamespace}/{workspaceId}/data-set/exportToNotebook/preview:
+  /v1/{workspaceNamespace}/{terraName}/data-set/exportToNotebook/preview:
     post:
       tags:
       - dataSet
@@ -4064,9 +4114,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -4090,7 +4141,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-codegen-request-body-name: dataSetExportRequest
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/data-set/preview:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/data-set/preview:
     post:
       tags:
       - dataSet
@@ -4103,9 +4154,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -4123,7 +4175,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/DataSetPreviewResponse'
       x-codegen-request-body-name: dataSetPreviewRequest
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/data-set/concept-sets/domainValues/{domain}:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/data-set/concept-sets/domainValues/{domain}:
     get:
       tags:
       - dataSet
@@ -4136,9 +4188,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -4614,7 +4667,7 @@ paths:
           description: Successfully removed the Institution-specific user instructions
             to be sent by email after registration.
           content: {}
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/review/{cohortId}:
     post:
       tags:
       - cohortReview
@@ -4628,9 +4681,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -4656,7 +4710,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CohortReview'
       x-codegen-request-body-name: request
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortId}/cohort-count:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/review/{cohortId}/cohort-count:
     get:
       tags:
       - cohortReview
@@ -4669,9 +4723,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -4690,7 +4745,7 @@ paths:
               schema:
                 type: integer
                 format: int64
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/review/{cohortReviewId}/participants:
     post:
       tags:
       - cohortReview
@@ -4704,9 +4759,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -4732,7 +4788,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CohortReviewWithCountResponse'
       x-codegen-request-body-name: request
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/review/{cohortReviewId}/participants/{participantId}:
     get:
       tags:
       - cohortReview
@@ -4745,9 +4801,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -4784,9 +4841,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -4819,7 +4877,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ParticipantCohortStatus'
       x-codegen-request-body-name: cohortStatusRequest
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/charts/{domain}:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/review/{cohortReviewId}/participants/{participantId}/charts/{domain}:
     get:
       tags:
       - cohortReview
@@ -4833,9 +4891,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -4866,7 +4925,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ParticipantChartDataListResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/annotations:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/review/{cohortReviewId}/participants/{participantId}/annotations:
     get:
       tags:
       - cohortReview
@@ -4879,9 +4938,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -4918,9 +4978,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -4953,7 +5014,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ParticipantCohortAnnotation'
       x-codegen-request-body-name: request
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/data:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/review/{cohortReviewId}/participants/{participantId}/data:
     post:
       tags:
       - cohortReview
@@ -4968,9 +5029,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5003,7 +5065,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ParticipantDataListResponse'
       x-codegen-request-body-name: request
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/count:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/review/{cohortReviewId}/participants/{participantId}/count:
     post:
       tags:
       - cohortReview
@@ -5017,9 +5079,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5052,7 +5115,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ParticipantDataCountResponse'
       x-codegen-request-body-name: request
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/{cohortReviewId}/participants/{participantId}/annotations/{annotationId}:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/review/{cohortReviewId}/participants/{participantId}/annotations/{annotationId}:
     put:
         tags:
         - cohortReview
@@ -5065,9 +5128,10 @@ paths:
           required: true
           schema:
             type: string
-        - name: workspaceId
+        - name: terraName
           in: path
-          description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+          description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed
+           due to confusion with DB IDs, which it is not)
           required: true
           schema:
             type: string
@@ -5119,9 +5183,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5153,7 +5218,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmptyResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/review/vocabularies:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/review/vocabularies:
     get:
       tags:
       - cohortReview
@@ -5166,9 +5231,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5179,7 +5245,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VocabularyListResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/chartinfo/{cohortReviewId}/demo:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/chartinfo/{cohortReviewId}/demo:
     get:
       tags:
       - cohortReview
@@ -5192,9 +5258,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5212,7 +5279,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DemoChartInfoListResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/top/chartinfo/{cohortReviewId}/{domain}:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/top/chartinfo/{cohortReviewId}/{domain}:
     get:
       tags:
       - cohortReview
@@ -5225,9 +5292,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5251,7 +5319,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CohortChartDataListResponse'
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts/{cohortId}/annotationdefinitions:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/cohorts/{cohortId}/annotationdefinitions:
     get:
       tags:
       - cohortAnnotationDefinition
@@ -5264,9 +5332,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5296,9 +5365,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5324,7 +5394,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CohortAnnotationDefinition'
       x-codegen-request-body-name: request
-  /v1/workspaces/{workspaceNamespace}/{workspaceId}/cohorts/{cohortId}/annotationdefinitions/{annotationDefinitionId}:
+  /v1/workspaces/{workspaceNamespace}/{terraName}/cohorts/{cohortId}/annotationdefinitions/{annotationDefinitionId}:
     get:
       tags:
       - cohortAnnotationDefinition
@@ -5337,9 +5407,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5376,9 +5447,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5423,9 +5495,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5450,7 +5523,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmptyResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/menu/{parentId}:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/menu/{parentId}:
     get:
       tags:
       - cohortBuilder
@@ -5463,9 +5536,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5483,7 +5557,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CriteriaMenuListResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/domainCard:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/domainCard:
     get:
       tags:
       - cohortBuilder
@@ -5497,9 +5571,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5510,7 +5585,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DomainCardResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/surveymodule:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/surveymodule:
     get:
       tags:
       - cohortBuilder
@@ -5524,9 +5599,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5537,7 +5613,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SurveysResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/universalDomainCounts:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/universalDomainCounts:
     get:
       tags:
       - cohortBuilder
@@ -5550,9 +5626,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5569,7 +5646,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CardCountResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/conceptCounts:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/conceptCounts:
     get:
       tags:
       - cohortBuilder
@@ -5583,9 +5660,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5603,7 +5681,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CardCountResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/search/term:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/search/term:
     post:
       tags:
       - cohortBuilder
@@ -5616,9 +5694,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5637,7 +5716,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CriteriaListWithCountResponse'
       x-codegen-request-body-name: request
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/{domain}/{conceptId}:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/{domain}/{conceptId}:
     get:
       tags:
       - cohortBuilder
@@ -5650,9 +5729,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5676,7 +5756,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CriteriaListResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/{domain}:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/{domain}:
     get:
       tags:
       - cohortBuilder
@@ -5690,9 +5770,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5738,9 +5819,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5765,7 +5847,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CriteriaListResponse'
       x-codegen-request-body-name: request
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria:
     post:
       tags:
       - cohortBuilder
@@ -5779,9 +5861,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5800,7 +5883,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CriteriaListResponse'
       x-codegen-request-body-name: request
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/autocomplete:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/autocomplete:
     post:
       tags:
       - cohortBuilder
@@ -5813,9 +5896,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5834,7 +5918,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CriteriaListResponse'
       x-codegen-request-body-name: request
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/drug:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/drug:
     get:
       tags:
       - cohortBuilder
@@ -5847,9 +5931,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5866,7 +5951,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CriteriaListResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/drug/ingredient/{conceptId}:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/drug/ingredient/{conceptId}:
     get:
       tags:
       - cohortBuilder
@@ -5879,9 +5964,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5899,7 +5985,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CriteriaListResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/attribute/{conceptId}:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/attribute/{conceptId}:
     get:
       tags:
       - cohortBuilder
@@ -5912,9 +5998,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5932,7 +6019,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CriteriaAttributeListResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/survey/attribute/{questionConceptId}:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/survey/attribute/{questionConceptId}:
     get:
       tags:
       - cohortBuilder
@@ -5945,9 +6032,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -5965,7 +6053,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SurveyVersionListResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/survey/attribute/{questionConceptId}/{answerConceptId}:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/survey/attribute/{questionConceptId}/{answerConceptId}:
     get:
       tags:
       - cohortBuilder
@@ -5978,9 +6066,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -6005,7 +6094,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SurveyVersionListResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/criteria/survey/versions:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/criteria/survey/versions:
     get:
       tags:
       - cohortBuilder
@@ -6018,9 +6107,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -6031,7 +6121,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CriteriaListResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/age/counts:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/age/counts:
     get:
       tags:
       - cohortBuilder
@@ -6044,9 +6134,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -6057,7 +6148,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgeTypeCountListResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/search:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/search:
     post:
       tags:
       - cohortBuilder
@@ -6071,9 +6162,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -6093,7 +6185,7 @@ paths:
                 type: integer
                 format: int64
       x-codegen-request-body-name: request
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/chartinfo/{genderSexRaceOrEth}/{age}:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/chartinfo/{genderSexRaceOrEth}/{age}:
     post:
       tags:
       - cohortBuilder
@@ -6106,9 +6198,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -6139,7 +6232,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/DemoChartInfoListResponse'
       x-codegen-request-body-name: request
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/chartinfo/ethnicity:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/chartinfo/ethnicity:
     post:
       tags:
       - cohortBuilder
@@ -6152,9 +6245,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -6173,7 +6267,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EthnicityInfoListResponse'
       x-codegen-request-body-name: request
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/top/chartinfo/{domain}:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/top/chartinfo/{domain}:
     post:
       tags:
       - cohortBuilder
@@ -6186,9 +6280,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -6213,7 +6308,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CohortChartDataListResponse'
       x-codegen-request-body-name: request
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/demographics:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/demographics:
     get:
       tags:
       - cohortBuilder
@@ -6226,9 +6321,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -6240,7 +6336,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ParticipantDemographics'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/dataFilters:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/dataFilters:
     get:
       tags:
       - cohortBuilder
@@ -6253,9 +6349,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -6266,7 +6363,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataFiltersResponse'
-  /v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/variants:
+  /v1/cohortbuilder/{workspaceNamespace}/{terraName}/variants:
     post:
       tags:
         - cohortBuilder
@@ -6279,9 +6376,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -6299,7 +6397,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VariantListResponse'
-  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/variant/filters":
+  "/v1/cohortbuilder/{workspaceNamespace}/{terraName}/variant/filters":
     post:
       tags:
       - cohortBuilder
@@ -6312,9 +6410,10 @@ paths:
         required: true
         schema:
           type: string
-      - name: workspaceId
+      - name: terraName
         in: path
-        description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+        description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
         required: true
         schema:
           type: string
@@ -6332,7 +6431,7 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/VariantFilterResponse"
-  "/v1/cohortbuilder/{workspaceNamespace}/{workspaceId}/variant/filter/info":
+  "/v1/cohortbuilder/{workspaceNamespace}/{terraName}/variant/filter/info":
     post:
       tags:
         - cohortBuilder
@@ -6345,9 +6444,10 @@ paths:
           required: true
           schema:
             type: string
-        - name: workspaceId
+        - name: terraName
           in: path
-          description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+          description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed
+           due to confusion with DB IDs, which it is not)
           required: true
           schema:
             type: string
@@ -13048,10 +13148,11 @@ components:
       required: true
       schema:
         type: string
-    workspaceId:
-      name: workspaceId
+    terraName:
+      name: terraName
       in: path
-      description: The Workspace ID (a.k.a. the workspace's Firecloud name)
+      description: The Workspace's name in Terra (formerly called "ID" in some contexts - renamed 
+         due to confusion with DB IDs, which it is not)
       required: true
       schema:
         type: string


### PR DESCRIPTION
Part of the "Don't use `ID` to refer to Terra Names" agenda I like to push in the downtime between other work.

Tested locally - no noticeable changes, as expected.  We don't actually use the URL parameter names, so you can think of this as a documentation change.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
