### PR TITLE
[risk=low][no ticket] Add workspacePath(), analysisTabPath(), and dataTabPath() UI functions

### DIFF
--- a/ui/src/app/components/breadcrumb.spec.tsx
+++ b/ui/src/app/components/breadcrumb.spec.tsx
@@ -1,7 +1,7 @@
 import { WorkspacesApi } from 'generated/fetch';
 
 import { getTrail } from 'app/components/breadcrumb';
-import { dataTabPath, workspacePath } from 'app/routing/utils';
+import { dataTabPath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 

--- a/ui/src/app/components/breadcrumb.spec.tsx
+++ b/ui/src/app/components/breadcrumb.spec.tsx
@@ -1,7 +1,7 @@
 import { WorkspacesApi } from 'generated/fetch';
 
 import { getTrail } from 'app/components/breadcrumb';
-import { workspacePath } from 'app/routing/utils';
+import { dataTabPath, workspacePath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 
@@ -35,8 +35,8 @@ describe('getTrail', () => {
       'Participant 77',
     ]);
     expect(trail[3].url).toEqual(
-      workspacePath('testns', 'testwsid') +
-        '/data/cohorts/88/reviews/99/participants/77'
+      dataTabPath('testns', 'testwsid') +
+        '/cohorts/88/reviews/99/participants/77'
     );
   });
 

--- a/ui/src/app/components/breadcrumb.spec.tsx
+++ b/ui/src/app/components/breadcrumb.spec.tsx
@@ -1,6 +1,7 @@
 import { WorkspacesApi } from 'generated/fetch';
 
 import { getTrail } from 'app/components/breadcrumb';
+import { workspacePath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 
@@ -34,7 +35,8 @@ describe('getTrail', () => {
       'Participant 77',
     ]);
     expect(trail[3].url).toEqual(
-      '/workspaces/testns/testwsid/data/cohorts/88/reviews/99/participants/77'
+      workspacePath('testns', 'testwsid') +
+        '/data/cohorts/88/reviews/99/participants/77'
     );
   });
 

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -11,6 +11,7 @@ import {
 
 import { dropJupyterNotebookFileSuffix } from 'app/pages/analysis/util';
 import { InvalidBillingBanner } from 'app/pages/workspace/invalid-billing-banner';
+import { workspacePath } from 'app/routing/utils';
 import colors from 'app/styles/colors';
 import {
   withCurrentCohort,
@@ -62,7 +63,7 @@ export const getTrail = (
   params: MatchParams
 ): Array<BreadcrumbData> => {
   const { ns, wsid, cid, crid, csid, pid, nbName } = params;
-  const prefix = `/workspaces/${ns}/${wsid}`;
+  const wsPath = workspacePath(ns, wsid);
   switch (type) {
     case BreadcrumbType.Workspaces:
       return [new BreadcrumbData('Workspaces', '/workspaces')];
@@ -78,7 +79,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           workspace ? workspace.name : '...',
-          `${prefix}/data`
+          `${wsPath}/data`
         ),
       ];
     case BreadcrumbType.WorkspaceEdit:
@@ -91,7 +92,7 @@ export const getTrail = (
           conceptSet,
           params
         ),
-        new BreadcrumbData('Edit Workspace', `${prefix}/edit`),
+        new BreadcrumbData('Edit Workspace', `${wsPath}/edit`),
       ];
     case BreadcrumbType.WorkspaceDuplicate:
       return [
@@ -103,7 +104,7 @@ export const getTrail = (
           conceptSet,
           params
         ),
-        new BreadcrumbData('Duplicate Workspace', `${prefix}/duplicate`),
+        new BreadcrumbData('Duplicate Workspace', `${wsPath}/duplicate`),
       ];
     case BreadcrumbType.Analysis:
       return [
@@ -117,11 +118,11 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           fp.upperFirst(analysisTabName),
-          `${prefix}/${analysisTabName}`
+          `${wsPath}/${analysisTabName}`
         ),
         new BreadcrumbData(
           nbName && dropJupyterNotebookFileSuffix(decodeURIComponent(nbName)),
-          `${prefix}/${analysisTabName}/${nbName}`
+          `${wsPath}/${analysisTabName}/${nbName}`
         ),
       ];
     case BreadcrumbType.ConceptSet:
@@ -136,7 +137,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           conceptSet ? conceptSet.name : '...',
-          `${prefix}/data/concepts/sets/${csid}`
+          `${wsPath}/data/concepts/sets/${csid}`
         ),
       ];
     case BreadcrumbType.Cohort:
@@ -151,7 +152,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           cohort ? cohort.name : '...',
-          `${prefix}/data/cohorts/${cid}`
+          `${wsPath}/data/cohorts/${cid}`
         ),
       ];
     case BreadcrumbType.CohortReview:
@@ -166,7 +167,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           cohortReview ? cohortReview.cohortName : '...',
-          `${prefix}/data/cohorts/${cid}/reviews/${crid}`
+          `${wsPath}/data/cohorts/${cid}/reviews/${crid}`
         ),
       ];
     case BreadcrumbType.Participant:
@@ -181,7 +182,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           `Participant ${pid}`,
-          `${prefix}/data/cohorts/${cid}/reviews/${crid}/participants/${pid}`
+          `${wsPath}/data/cohorts/${cid}/reviews/${crid}/participants/${pid}`
         ),
       ];
     case BreadcrumbType.CohortAdd:
@@ -196,7 +197,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           'Build Cohort Criteria',
-          `${prefix}/data/cohorts/build`
+          `${wsPath}/data/cohorts/build`
         ),
       ];
     case BreadcrumbType.SearchConcepts:
@@ -209,7 +210,7 @@ export const getTrail = (
           conceptSet,
           params
         ),
-        new BreadcrumbData('Search Concepts', `${prefix}/data/concepts`),
+        new BreadcrumbData('Search Concepts', `${wsPath}/data/concepts`),
       ];
     case BreadcrumbType.Dataset:
       return [
@@ -221,7 +222,7 @@ export const getTrail = (
           conceptSet,
           params
         ),
-        new BreadcrumbData('Dataset', `${prefix}/data/datasets`),
+        new BreadcrumbData('Dataset', `${wsPath}/data/datasets`),
       ];
     case BreadcrumbType.Data:
       return [
@@ -235,7 +236,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           workspace ? workspace.name : '...',
-          `${prefix}/data`
+          `${wsPath}/data`
         ),
       ];
     default:

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -14,6 +14,7 @@ import { InvalidBillingBanner } from 'app/pages/workspace/invalid-billing-banner
 import {
   analysisTabName,
   analysisTabPath,
+  dataTabPath,
   workspacePath,
 } from 'app/routing/utils';
 import colors from 'app/styles/colors';
@@ -66,7 +67,6 @@ export const getTrail = (
   params: MatchParams
 ): Array<BreadcrumbData> => {
   const { ns, wsid, cid, crid, csid, pid, nbName } = params;
-  const wsPath = workspacePath(ns, wsid);
   switch (type) {
     case BreadcrumbType.Workspaces:
       return [new BreadcrumbData('Workspaces', '/workspaces')];
@@ -82,7 +82,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           workspace ? workspace.name : '...',
-          `${wsPath}/data`
+          dataTabPath(ns, wsid)
         ),
       ];
     case BreadcrumbType.WorkspaceEdit:
@@ -95,7 +95,7 @@ export const getTrail = (
           conceptSet,
           params
         ),
-        new BreadcrumbData('Edit Workspace', `${wsPath}/edit`),
+        new BreadcrumbData('Edit Workspace', `${workspacePath(ns, wsid)}/edit`),
       ];
     case BreadcrumbType.WorkspaceDuplicate:
       return [
@@ -107,7 +107,10 @@ export const getTrail = (
           conceptSet,
           params
         ),
-        new BreadcrumbData('Duplicate Workspace', `${wsPath}/duplicate`),
+        new BreadcrumbData(
+          'Duplicate Workspace',
+          `${workspacePath(ns, wsid)}/duplicate`
+        ),
       ];
     case BreadcrumbType.Analysis:
       return [
@@ -140,7 +143,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           conceptSet ? conceptSet.name : '...',
-          `${wsPath}/data/concepts/sets/${csid}`
+          `${dataTabPath(ns, wsid)}/concepts/sets/${csid}`
         ),
       ];
     case BreadcrumbType.Cohort:
@@ -155,7 +158,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           cohort ? cohort.name : '...',
-          `${wsPath}/data/cohorts/${cid}`
+          `${dataTabPath(ns, wsid)}/cohorts/${cid}`
         ),
       ];
     case BreadcrumbType.CohortReview:
@@ -170,7 +173,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           cohortReview ? cohortReview.cohortName : '...',
-          `${wsPath}/data/cohorts/${cid}/reviews/${crid}`
+          `${dataTabPath(ns, wsid)}/cohorts/${cid}/reviews/${crid}`
         ),
       ];
     case BreadcrumbType.Participant:
@@ -185,7 +188,10 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           `Participant ${pid}`,
-          `${wsPath}/data/cohorts/${cid}/reviews/${crid}/participants/${pid}`
+          `${dataTabPath(
+            ns,
+            wsid
+          )}/cohorts/${cid}/reviews/${crid}/participants/${pid}`
         ),
       ];
     case BreadcrumbType.CohortAdd:
@@ -200,7 +206,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           'Build Cohort Criteria',
-          `${wsPath}/data/cohorts/build`
+          `${dataTabPath(ns, wsid)}/cohorts/build`
         ),
       ];
     case BreadcrumbType.SearchConcepts:
@@ -213,7 +219,10 @@ export const getTrail = (
           conceptSet,
           params
         ),
-        new BreadcrumbData('Search Concepts', `${wsPath}/data/concepts`),
+        new BreadcrumbData(
+          'Search Concepts',
+          `${dataTabPath(ns, wsid)}/concepts`
+        ),
       ];
     case BreadcrumbType.Dataset:
       return [
@@ -225,7 +234,7 @@ export const getTrail = (
           conceptSet,
           params
         ),
-        new BreadcrumbData('Dataset', `${wsPath}/data/datasets`),
+        new BreadcrumbData('Dataset', `${dataTabPath(ns, wsid)}/datasets`),
       ];
     case BreadcrumbType.Data:
       return [
@@ -239,7 +248,7 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           workspace ? workspace.name : '...',
-          `${wsPath}/data`
+          `${dataTabPath(ns, wsid)}`
         ),
       ];
     default:

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -11,7 +11,11 @@ import {
 
 import { dropJupyterNotebookFileSuffix } from 'app/pages/analysis/util';
 import { InvalidBillingBanner } from 'app/pages/workspace/invalid-billing-banner';
-import { workspacePath } from 'app/routing/utils';
+import {
+  analysisTabName,
+  analysisTabPath,
+  workspacePath,
+} from 'app/routing/utils';
 import colors from 'app/styles/colors';
 import {
   withCurrentCohort,
@@ -25,7 +29,6 @@ import {
   routeDataStore,
   withStore,
 } from 'app/utils/stores';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { BreadcrumbType } from './breadcrumb-type';
@@ -118,11 +121,11 @@ export const getTrail = (
         ),
         new BreadcrumbData(
           fp.upperFirst(analysisTabName),
-          `${wsPath}/${analysisTabName}`
+          analysisTabPath(ns, wsid)
         ),
         new BreadcrumbData(
           nbName && dropJupyterNotebookFileSuffix(decodeURIComponent(nbName)),
-          `${wsPath}/${analysisTabName}/${nbName}`
+          `${analysisTabPath(ns, wsid)}/${nbName}`
         ),
       ];
     case BreadcrumbType.ConceptSet:

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -20,6 +20,7 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { Spinner } from 'app/components/spinners';
+import { workspacePath } from 'app/routing/utils';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCdrVersions } from 'app/utils';
@@ -351,7 +352,7 @@ const CopyModal = withCdrVersions()(
         const { namespace, id } = this.state.destination;
         return (
           <Button
-            path={`/workspaces/${namespace}/${id}/${ResourceTypeHomeTabs.get(
+            path={`${workspacePath(namespace, id)}/${ResourceTypeHomeTabs.get(
               this.props.resourceType
             )}`}
             style={{ marginLeft: '0.75rem' }}

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -20,14 +20,13 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { Spinner } from 'app/components/spinners';
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabName, workspacePath } from 'app/routing/utils';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCdrVersions } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
 import { NavigationProps } from 'app/utils/navigation';
 import { toDisplay } from 'app/utils/resources';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 import { WorkspacePermissions } from 'app/utils/workspace-permissions';
 
 import { FlexRow } from './flex';

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -326,7 +326,8 @@ const CopyModal = withCdrVersions()(
     }
 
     renderActionButton() {
-      const resourceType = toDisplay(this.props.resourceType);
+      const { resourceType } = this.props;
+      const resourceString = toDisplay(resourceType);
       if (
         this.state.requestState === RequestState.UNSENT ||
         this.state.requestState === RequestState.COPY_ERROR
@@ -338,7 +339,7 @@ const CopyModal = withCdrVersions()(
             onClick={() => this.save()}
             data-test-id='copy-button'
           >
-            Copy {resourceType}
+            Copy {resourceString}
           </Button>
         );
       } else if (this.state.requestState === RequestState.SUCCESS) {
@@ -352,7 +353,7 @@ const CopyModal = withCdrVersions()(
             }
             style={{ marginLeft: '0.75rem' }}
           >
-            Go to Copied {resourceType}
+            Go to Copied {resourceString}
           </Button>
         );
       }

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -20,7 +20,7 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { Spinner } from 'app/components/spinners';
-import { analysisTabName, workspacePath } from 'app/routing/utils';
+import { analysisTabPath, dataTabPath } from 'app/routing/utils';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCdrVersions } from 'app/utils';
@@ -37,12 +37,6 @@ enum RequestState {
   COPY_ERROR,
   SUCCESS,
 }
-
-const ResourceTypeHomeTabs = new Map()
-  .set(ResourceType.NOTEBOOK, analysisTabName)
-  .set(ResourceType.COHORT, 'data')
-  .set(ResourceType.CONCEPT_SET, 'data')
-  .set(ResourceType.DATASET, 'data');
 
 export interface CopyModalProps {
   fromWorkspaceNamespace: string;
@@ -351,9 +345,11 @@ const CopyModal = withCdrVersions()(
         const { namespace, id } = this.state.destination;
         return (
           <Button
-            path={`${workspacePath(namespace, id)}/${ResourceTypeHomeTabs.get(
-              this.props.resourceType
-            )}`}
+            path={
+              resourceType === ResourceType.NOTEBOOK
+                ? analysisTabPath(namespace, id)
+                : dataTabPath(namespace, id)
+            }
             style={{ marginLeft: '0.75rem' }}
           >
             Go to Copied {resourceType}

--- a/ui/src/app/components/help-sidebar-icons.tsx
+++ b/ui/src/app/components/help-sidebar-icons.tsx
@@ -23,6 +23,7 @@ import {
 } from 'generated/fetch';
 
 import { DEFAULT, switchCase } from '@terra-ui-packages/core-utils';
+import { workspacePath } from 'app/routing/utils';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
 import { getCdrVersion } from 'app/utils/cdr-versions';
@@ -448,7 +449,7 @@ const DisplayIcon = (props: DisplayIconProps) => {
       'terminal',
       () => (
         <RouteLink
-          path={`/workspaces/${workspace.namespace}/${workspace.id}/terminals`}
+          path={`${workspacePath(workspace.namespace, workspace.id)}/terminals`}
         >
           <FontAwesomeIcon
             data-test-id={'help-sidebar-icon-' + icon.id}

--- a/ui/src/app/components/resource-list.tsx
+++ b/ui/src/app/components/resource-list.tsx
@@ -21,7 +21,7 @@ import {
   ResourceNavigation,
   StyledResourceType,
 } from 'app/components/resource-card';
-import { analysisTabName, workspacePath } from 'app/routing/utils';
+import { analysisTabPath, dataTabPath } from 'app/routing/utils';
 import colors from 'app/styles/colors';
 import { reactStyles, withCdrVersions } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
@@ -72,9 +72,9 @@ const WorkspaceNavigation = (props: NavProps) => {
     resource,
     style,
   } = props;
-  const tab = isNotebook(resource) ? analysisTabName : 'data';
-  const url = `${workspacePath(namespace, id)}/${tab}`;
-
+  const url = isNotebook(resource)
+    ? analysisTabPath(namespace, id)
+    : dataTabPath(namespace, id);
   return (
     <Clickable>
       <RouterLink to={url} style={style} data-test-id='workspace-navigation'>

--- a/ui/src/app/components/resource-list.tsx
+++ b/ui/src/app/components/resource-list.tsx
@@ -21,7 +21,7 @@ import {
   ResourceNavigation,
   StyledResourceType,
 } from 'app/components/resource-card';
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabName, workspacePath } from 'app/routing/utils';
 import colors from 'app/styles/colors';
 import { reactStyles, withCdrVersions } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
@@ -33,7 +33,6 @@ import {
   getTypeString,
   isNotebook,
 } from 'app/utils/resources';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 const styles = reactStyles({

--- a/ui/src/app/components/resource-list.tsx
+++ b/ui/src/app/components/resource-list.tsx
@@ -21,6 +21,7 @@ import {
   ResourceNavigation,
   StyledResourceType,
 } from 'app/components/resource-card';
+import { workspacePath } from 'app/routing/utils';
 import colors from 'app/styles/colors';
 import { reactStyles, withCdrVersions } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
@@ -73,7 +74,7 @@ const WorkspaceNavigation = (props: NavProps) => {
     style,
   } = props;
   const tab = isNotebook(resource) ? analysisTabName : 'data';
-  const url = `/workspaces/${namespace}/${id}/${tab}`;
+  const url = `${workspacePath(namespace, id)}/${tab}`;
 
   return (
     <Clickable>

--- a/ui/src/app/components/runtime-configuration-panel/spark-console-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/spark-console-panel.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { RouteLink } from 'app/components/app-router';
 import { styles } from 'app/components/common-env-conf-panels/styles';
 import { FlexColumn } from 'app/components/flex';
+import { workspacePath } from 'app/routing/utils';
 import { SparkConsolePath } from 'app/utils/runtime-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -53,7 +54,7 @@ export const SparkConsolePanel = ({ namespace, id }: WorkspaceData) => {
           <div>{description}</div>
           <div>
             <RouteLink
-              path={`/workspaces/${namespace}/${id}/spark/${path}`}
+              path={`${workspacePath(namespace, id)}/spark/${path}`}
               style={styles.sparkConsoleLaunchButton}
             >
               Launch

--- a/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
@@ -15,7 +15,7 @@ import {
   rstudioConfigIconId,
   sasConfigIconId,
 } from 'app/components/help-sidebar-icons';
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabName, analysisTabPath } from 'app/routing/utils';
 import * as swaggerClients from 'app/services/swagger-fetch-clients';
 import { GKE_APP_PROXY_PATH_SUFFIX } from 'app/utils/constants';
 import {
@@ -23,7 +23,6 @@ import {
   setSidebarActiveIconStore,
 } from 'app/utils/navigation';
 import { MatchParams, userAppsStore } from 'app/utils/stores';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 
 import {
   createListAppsRStudioResponse,
@@ -61,10 +60,9 @@ const renderInteractiveNotebook = (pathParameters: { params: MatchParams }) =>
   render(
     <MemoryRouter
       initialEntries={[
-        `${workspacePath(
-          'sampleNameSpace',
-          'sampleWorkspace'
-        )}/${analysisTabName}/preview/${pathParameters.params.nbName}`,
+        `${analysisTabPath('sampleNameSpace', 'sampleWorkspace')}/preview/${
+          pathParameters.params.nbName
+        }`,
       ]}
     >
       <Route path={`/workspaces/:ns/:wsid/${analysisTabName}/preview/:nbName`}>

--- a/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
@@ -15,6 +15,7 @@ import {
   rstudioConfigIconId,
   sasConfigIconId,
 } from 'app/components/help-sidebar-icons';
+import { workspacePath } from 'app/routing/utils';
 import * as swaggerClients from 'app/services/swagger-fetch-clients';
 import { GKE_APP_PROXY_PATH_SUFFIX } from 'app/utils/constants';
 import {
@@ -60,7 +61,10 @@ const renderInteractiveNotebook = (pathParameters: { params: MatchParams }) =>
   render(
     <MemoryRouter
       initialEntries={[
-        `/workspaces/sampleNameSpace/sampleWorkspace/${analysisTabName}/preview/${pathParameters.params.nbName}`,
+        `${workspacePath(
+          'sampleNameSpace',
+          'sampleWorkspace'
+        )}/${analysisTabName}/preview/${pathParameters.params.nbName}`,
       ]}
     >
       <Route path={`/workspaces/:ns/:wsid/${analysisTabName}/preview/:nbName`}>

--- a/ui/src/app/pages/analysis/interactive-notebook.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.tsx
@@ -15,6 +15,7 @@ import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { EditComponentReact } from 'app/icons/edit';
 import { ConfirmPlaygroundModeModal } from 'app/pages/analysis/confirm-playground-mode-modal';
 import { NotebookInUseModal } from 'app/pages/analysis/notebook-in-use-modal';
+import { analysisTabName } from 'app/routing/utils';
 import { notebooksApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { hasNewValidProps, reactStyles, withCurrentWorkspace } from 'app/utils';
@@ -37,7 +38,6 @@ import {
 } from 'app/utils/stores';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
 import {
-  analysisTabName,
   openRStudioOrConfigPanel,
   openSASOrConfigPanel,
 } from 'app/utils/user-apps-utils';

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
@@ -23,7 +23,11 @@ import {
   Progress,
   ProgressCardState,
 } from 'app/pages/analysis/leonardo-app-launcher';
-import { workspacePath } from 'app/routing/utils';
+import {
+  analysisTabName,
+  analysisTabPath,
+  workspacePath,
+} from 'app/routing/utils';
 import { registerApiClient as registerApiClientNotebooks } from 'app/services/notebooks-swagger-fetch-clients';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { currentWorkspaceStore } from 'app/utils/navigation';
@@ -33,7 +37,6 @@ import {
   runtimeStore,
   serverConfigStore,
 } from 'app/utils/stores';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 import {
   JupyterApi,
   ProxyApi,
@@ -74,10 +77,7 @@ describe('NotebookLauncher', () => {
 
   let runtimeStub;
 
-  const notebookInitialUrl = `${workspacePath(
-    'namespace',
-    'id'
-  )}/${analysisTabName}/wharrgarbl`;
+  const notebookInitialUrl = `${analysisTabPath('namespace', 'id')}/wharrgarbl`;
   const history = createMemoryHistory({ initialEntries: [notebookInitialUrl] });
 
   const notebookComponent = async () => {

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
@@ -23,6 +23,7 @@ import {
   Progress,
   ProgressCardState,
 } from 'app/pages/analysis/leonardo-app-launcher';
+import { workspacePath } from 'app/routing/utils';
 import { registerApiClient as registerApiClientNotebooks } from 'app/services/notebooks-swagger-fetch-clients';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { currentWorkspaceStore } from 'app/utils/navigation';
@@ -73,7 +74,10 @@ describe('NotebookLauncher', () => {
 
   let runtimeStub;
 
-  const notebookInitialUrl = `/workspaces/namespace/id/${analysisTabName}/wharrgarbl`;
+  const notebookInitialUrl = `${workspacePath(
+    'namespace',
+    'id'
+  )}/${analysisTabName}/wharrgarbl`;
   const history = createMemoryHistory({ initialEntries: [notebookInitialUrl] });
 
   const notebookComponent = async () => {
@@ -440,7 +444,7 @@ describe('TerminalLauncher', () => {
 
   let runtimeStub;
 
-  const terminalInitialUrl = '/workspaces/namespace/id/terminals';
+  const terminalInitialUrl = workspacePath('namespace', 'id') + '/terminals';
   const history = createMemoryHistory({ initialEntries: [terminalInitialUrl] });
 
   const terminalComponent = async () => {
@@ -568,7 +572,8 @@ describe('SparkConsoleLauncher', () => {
 
   let runtimeStub;
 
-  const terminalInitialUrl = '/workspaces/namespace/id/spark/apphistory';
+  const terminalInitialUrl =
+    workspacePath('namespace', 'id') + '/spark/apphistory';
   const history = createMemoryHistory({ initialEntries: [terminalInitialUrl] });
 
   const terminalComponent = async () => {

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -16,6 +16,7 @@ import { Spinner } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { NotebookIcon } from 'app/icons/notebook-icon';
 import { ReminderIcon } from 'app/icons/reminder';
+import { analysisTabName, analysisTabPath } from 'app/routing/utils';
 import {
   leoJupyterApi,
   leoProxyApi,
@@ -36,7 +37,6 @@ import {
   withRuntimeStore,
 } from 'app/utils/runtime-utils';
 import { MatchParams, RuntimeStore } from 'app/utils/stores';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -578,7 +578,7 @@ export const LeonardoAppLauncher = fp.flow(
         window.history.replaceState(
           {},
           'Notebook',
-          `workspaces/${namespace}/${id}/${analysisTabName}/${encodeURIComponent(
+          `${analysisTabPath(namespace, id)}/${encodeURIComponent(
             this.getFullJupyterNotebookName()
           )}`
         );

--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -15,13 +15,13 @@ import {
 } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
 import { getExistingNotebookNames } from 'app/pages/analysis/util';
+import { analysisTabName } from 'app/routing/utils';
 import { userMetricsApi } from 'app/services/swagger-fetch-clients';
 import { summarizeErrors } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { useNavigation } from 'app/utils/navigation';
 import { Kernels } from 'app/utils/notebook-kernels';
 import { nameValidationFormat } from 'app/utils/resources';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 
 import { appendJupyterNotebookFileSuffix } from './util';
 

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -11,11 +11,10 @@ import {
   RESOURCE_TYPE_COLUMN_NUMBER,
   resourceTableColumns,
 } from 'app/components/resource-list.spec';
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabPath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
@@ -75,10 +74,10 @@ describe('NotebookList', () => {
     );
     await waitOneTickAndUpdate(wrapper);
 
-    const expected = `${workspacePath(
+    const expected = `${analysisTabPath(
       workspaceDataStub.namespace,
       workspaceDataStub.id
-    )}/${analysisTabName}/preview/mockFile.ipynb`;
+    )}/preview/mockFile.ipynb`;
     expect(
       resourceTableColumns(wrapper)
         .at(RESOURCE_TYPE_COLUMN_NUMBER)

--- a/ui/src/app/pages/analysis/notebook-list.spec.tsx
+++ b/ui/src/app/pages/analysis/notebook-list.spec.tsx
@@ -11,6 +11,7 @@ import {
   RESOURCE_TYPE_COLUMN_NUMBER,
   resourceTableColumns,
 } from 'app/components/resource-list.spec';
+import { workspacePath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
@@ -74,7 +75,10 @@ describe('NotebookList', () => {
     );
     await waitOneTickAndUpdate(wrapper);
 
-    const expected = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${analysisTabName}/preview/mockFile.ipynb`;
+    const expected = `${workspacePath(
+      workspaceDataStub.namespace,
+      workspaceDataStub.id
+    )}/${analysisTabName}/preview/mockFile.ipynb`;
     expect(
       resourceTableColumns(wrapper)
         .at(RESOURCE_TYPE_COLUMN_NUMBER)

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -15,12 +15,11 @@ import { withErrorModal } from 'app/components/modals';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { NotebookActionMenu } from 'app/pages/analysis/notebook-action-menu';
 import { getAppInfoFromFileName, listNotebooks } from 'app/pages/analysis/util';
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabPath } from 'app/routing/utils';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCurrentWorkspace } from 'app/utils';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { convertToResources } from 'app/utils/resources';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { AppSelector } from './app-selector';
@@ -113,10 +112,7 @@ export const AppFilesList = withCurrentWorkspace()(
         workspace: { namespace, id },
       } = props;
       const { name } = row;
-      const url = `${workspacePath(
-        namespace,
-        id
-      )}/${analysisTabName}/preview/${name}`;
+      const url = `${analysisTabPath(namespace, id)}/preview/${name}`;
       return (
         <Clickable>
           <RouterLink to={url} data-test-id='notebook-navigation'>

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -15,6 +15,7 @@ import { withErrorModal } from 'app/components/modals';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { NotebookActionMenu } from 'app/pages/analysis/notebook-action-menu';
 import { getAppInfoFromFileName, listNotebooks } from 'app/pages/analysis/util';
+import { workspacePath } from 'app/routing/utils';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCurrentWorkspace } from 'app/utils';
 import { displayDateWithoutHours } from 'app/utils/dates';
@@ -112,7 +113,10 @@ export const AppFilesList = withCurrentWorkspace()(
         workspace: { namespace, id },
       } = props;
       const { name } = row;
-      const url = `/workspaces/${namespace}/${id}/${analysisTabName}/preview/${name}`;
+      const url = `${workspacePath(
+        namespace,
+        id
+      )}/${analysisTabName}/preview/${name}`;
       return (
         <Clickable>
           <RouterLink to={url} data-test-id='notebook-navigation'>

--- a/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
+++ b/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
@@ -5,11 +5,10 @@ import { mount } from 'enzyme';
 import { NotebooksApi, WorkspacesApi } from 'generated/fetch';
 
 import { AppFilesList } from 'app/pages/appAnalysis/app-files-list';
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabPath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
@@ -86,10 +85,10 @@ describe('AppsList', () => {
     );
     await waitOneTickAndUpdate(wrapper);
 
-    const expected = `${workspacePath(
+    const expected = `${analysisTabPath(
       workspaceDataStub.namespace,
       workspaceDataStub.id
-    )}/${analysisTabName}/preview/mockFile.ipynb`;
+    )}/preview/mockFile.ipynb`;
     expect(
       appsFilesTableColumns(wrapper)
         .at(NAME_COLUMN_NUMBER)

--- a/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
+++ b/ui/src/app/pages/appAnalysis/apps-file-list.spec.tsx
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import { NotebooksApi, WorkspacesApi } from 'generated/fetch';
 
 import { AppFilesList } from 'app/pages/appAnalysis/app-files-list';
+import { workspacePath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { currentWorkspaceStore } from 'app/utils/navigation';
@@ -85,7 +86,10 @@ describe('AppsList', () => {
     );
     await waitOneTickAndUpdate(wrapper);
 
-    const expected = `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/${analysisTabName}/preview/mockFile.ipynb`;
+    const expected = `${workspacePath(
+      workspaceDataStub.namespace,
+      workspaceDataStub.id
+    )}/${analysisTabName}/preview/mockFile.ipynb`;
     expect(
       appsFilesTableColumns(wrapper)
         .at(NAME_COLUMN_NUMBER)

--- a/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
@@ -22,7 +22,7 @@ import { CohortReviewListItem } from 'app/pages/data/cohort-review/cohort-review
 import { CohortReviewOverview } from 'app/pages/data/cohort-review/cohort-review-overview';
 import { CohortReviewParticipantsTable } from 'app/pages/data/cohort-review/cohort-review-participants-table';
 import { CreateCohortReviewModal } from 'app/pages/data/cohort-review/create-cohort-review-modal';
-import { dataTabPath, workspacePath } from 'app/routing/utils';
+import { dataTabPath } from 'app/routing/utils';
 import { visitsFilterOptions } from 'app/services/review-state.service';
 import {
   cohortBuilderApi,

--- a/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
@@ -22,7 +22,7 @@ import { CohortReviewListItem } from 'app/pages/data/cohort-review/cohort-review
 import { CohortReviewOverview } from 'app/pages/data/cohort-review/cohort-review-overview';
 import { CohortReviewParticipantsTable } from 'app/pages/data/cohort-review/cohort-review-participants-table';
 import { CreateCohortReviewModal } from 'app/pages/data/cohort-review/create-cohort-review-modal';
-import { workspacePath } from 'app/routing/utils';
+import { dataTabPath, workspacePath } from 'app/routing/utils';
 import { visitsFilterOptions } from 'app/services/review-state.service';
 import {
   cohortBuilderApi,
@@ -162,9 +162,7 @@ export const CohortReviewPage = fp.flow(
   // sets the cohort review id as a url param or removes it if no id is passed
   const updateUrlWithCohortReviewId = (cohortReviewId?: number) =>
     history.push(
-      `${workspacePath(ns, wsid)}/data/cohorts/${cid}/reviews/${
-        cohortReviewId || ''
-      }`
+      `${dataTabPath(ns, wsid)}/cohorts/${cid}/reviews/${cohortReviewId || ''}`
     );
 
   const loadCohortAndReviews = async () => {
@@ -266,7 +264,7 @@ export const CohortReviewPage = fp.flow(
               style={styles.backBtn}
               type='button'
               onClick={() =>
-                navigateByUrl(`workspaces/${ns}/${wsid}/data/cohorts/build`, {
+                navigateByUrl(`${dataTabPath(ns, wsid)}/cohorts/build`, {
                   queryParams: { cohortId: cid },
                 })
               }

--- a/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/cohort-review-page.tsx
@@ -22,6 +22,7 @@ import { CohortReviewListItem } from 'app/pages/data/cohort-review/cohort-review
 import { CohortReviewOverview } from 'app/pages/data/cohort-review/cohort-review-overview';
 import { CohortReviewParticipantsTable } from 'app/pages/data/cohort-review/cohort-review-participants-table';
 import { CreateCohortReviewModal } from 'app/pages/data/cohort-review/create-cohort-review-modal';
+import { workspacePath } from 'app/routing/utils';
 import { visitsFilterOptions } from 'app/services/review-state.service';
 import {
   cohortBuilderApi,
@@ -161,7 +162,7 @@ export const CohortReviewPage = fp.flow(
   // sets the cohort review id as a url param or removes it if no id is passed
   const updateUrlWithCohortReviewId = (cohortReviewId?: number) =>
     history.push(
-      `/workspaces/${ns}/${wsid}/data/cohorts/${cid}/reviews/${
+      `${workspacePath(ns, wsid)}/data/cohorts/${cid}/reviews/${
         cohortReviewId || ''
       }`
     );

--- a/ui/src/app/pages/data/cohort/cohort-actions.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-actions.tsx
@@ -12,7 +12,7 @@ import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabName, workspacePath } from 'app/routing/utils';
 import { cohortsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
@@ -22,7 +22,6 @@ import {
 } from 'app/utils';
 import { NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 

--- a/ui/src/app/pages/data/cohort/cohort-actions.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-actions.tsx
@@ -12,6 +12,7 @@ import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
+import { workspacePath } from 'app/routing/utils';
 import { cohortsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
@@ -150,7 +151,7 @@ export const CohortActions = fp.flow(
     getNavigationPath(action: string): string {
       const { cohort } = this.state;
       const { namespace, id } = this.props.workspace;
-      let url = `/workspaces/${namespace}/${id}/`;
+      let url = workspacePath(namespace, id);
       let queryParams: any = null;
 
       switch (action) {

--- a/ui/src/app/pages/data/cohort/cohort-actions.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-actions.tsx
@@ -155,20 +155,20 @@ export const CohortActions = fp.flow(
 
       switch (action) {
         case 'cohort':
-          url += 'data/cohorts/build';
+          url += '/data/cohorts/build';
           queryParams = { cohortId: cohort.id };
           break;
         case 'review':
-          url += `data/cohorts/${cohort.id}/reviews`;
+          url += `/data/cohorts/${cohort.id}/reviews`;
           break;
         case 'notebook':
           url += analysisTabName;
           break;
         case 'dataSet':
-          url += 'data/data-sets';
+          url += '/data/data-sets';
           break;
         case 'newCohort':
-          url += 'data/cohorts/build';
+          url += '/data/cohorts/build';
       }
       if (queryParams) {
         url += '?' + querystring.stringify(queryParams);

--- a/ui/src/app/pages/data/cohort/cohort-actions.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-actions.tsx
@@ -150,25 +150,25 @@ export const CohortActions = fp.flow(
     getNavigationPath(action: string): string {
       const { cohort } = this.state;
       const { namespace, id } = this.props.workspace;
-      let url = workspacePath(namespace, id);
+      let url = workspacePath(namespace, id) + '/';
       let queryParams: any = null;
 
       switch (action) {
         case 'cohort':
-          url += '/data/cohorts/build';
+          url += 'data/cohorts/build';
           queryParams = { cohortId: cohort.id };
           break;
         case 'review':
-          url += `/data/cohorts/${cohort.id}/reviews`;
+          url += `data/cohorts/${cohort.id}/reviews`;
           break;
         case 'notebook':
           url += analysisTabName;
           break;
         case 'dataSet':
-          url += '/data/data-sets';
+          url += 'data/data-sets';
           break;
         case 'newCohort':
-          url += '/data/cohorts/build';
+          url += 'data/cohorts/build';
       }
       if (queryParams) {
         url += '?' + querystring.stringify(queryParams);

--- a/ui/src/app/pages/data/cohort/cohort-page.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-page.tsx
@@ -18,6 +18,7 @@ import {
 } from 'app/pages/data/cohort/search-state.service';
 import { mapRequest, parseCohortDefinition } from 'app/pages/data/cohort/utils';
 import { LOCAL_STORAGE_KEY_COHORT_CONTEXT } from 'app/pages/data/criteria-search';
+import { workspacePath } from 'app/routing/utils';
 import { cohortsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
@@ -252,7 +253,7 @@ export const CohortPage = fp.flow(
         () => {
           // Clear cohortId query param if exists in url
           if (search.indexOf('cohortId') > -1) {
-            history.push(`/workspaces/${ns}/${wsid}/data/cohorts/build`);
+            history.push(`${workspacePath(ns, wsid)}/data/cohorts/build`);
           }
         }
       );

--- a/ui/src/app/pages/data/cohort/cohort-page.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-page.tsx
@@ -18,7 +18,7 @@ import {
 } from 'app/pages/data/cohort/search-state.service';
 import { mapRequest, parseCohortDefinition } from 'app/pages/data/cohort/utils';
 import { LOCAL_STORAGE_KEY_COHORT_CONTEXT } from 'app/pages/data/criteria-search';
-import { workspacePath } from 'app/routing/utils';
+import { dataTabPath } from 'app/routing/utils';
 import { cohortsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
@@ -253,7 +253,7 @@ export const CohortPage = fp.flow(
         () => {
           // Clear cohortId query param if exists in url
           if (search.indexOf('cohortId') > -1) {
-            history.push(`${workspacePath(ns, wsid)}/data/cohorts/build`);
+            history.push(`${dataTabPath(ns, wsid)}/cohorts/build`);
           }
         }
       );

--- a/ui/src/app/pages/data/cohort/cohort-resource-card.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-resource-card.tsx
@@ -26,7 +26,7 @@ import {
   withSpinnerOverlay,
   WithSpinnerOverlayProps,
 } from 'app/components/with-spinner-overlay';
-import { workspacePath } from 'app/routing/utils';
+import { dataTabPath, workspacePath } from 'app/routing/utils';
 import { cohortsApi, dataSetApi } from 'app/services/swagger-fetch-clients';
 import { NavigationProps } from 'app/utils/navigation';
 import {
@@ -74,8 +74,8 @@ export const CohortResourceCard = fp.flow(
         this.props.resource;
 
       return (
-        workspacePath(workspaceNamespace, workspaceFirecloudName) +
-        `/data/cohorts/${cohort.id}/reviews`
+        dataTabPath(workspaceNamespace, workspaceFirecloudName) +
+        `/cohorts/${cohort.id}/reviews`
       );
     }
 

--- a/ui/src/app/pages/data/cohort/cohort-resource-card.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-resource-card.tsx
@@ -26,7 +26,7 @@ import {
   withSpinnerOverlay,
   WithSpinnerOverlayProps,
 } from 'app/components/with-spinner-overlay';
-import { dataTabPath, workspacePath } from 'app/routing/utils';
+import { dataTabPath } from 'app/routing/utils';
 import { cohortsApi, dataSetApi } from 'app/services/swagger-fetch-clients';
 import { NavigationProps } from 'app/utils/navigation';
 import {

--- a/ui/src/app/pages/data/cohort/cohort-resource-card.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-resource-card.tsx
@@ -26,6 +26,7 @@ import {
   withSpinnerOverlay,
   WithSpinnerOverlayProps,
 } from 'app/components/with-spinner-overlay';
+import { workspacePath } from 'app/routing/utils';
 import { cohortsApi, dataSetApi } from 'app/services/swagger-fetch-clients';
 import { NavigationProps } from 'app/utils/navigation';
 import {
@@ -73,7 +74,7 @@ export const CohortResourceCard = fp.flow(
         this.props.resource;
 
       return (
-        `/workspaces/${workspaceNamespace}/${workspaceFirecloudName}` +
+        workspacePath(workspaceNamespace, workspaceFirecloudName) +
         `/data/cohorts/${cohort.id}/reviews`
       );
     }

--- a/ui/src/app/pages/data/cohort/modifier-page.spec.tsx
+++ b/ui/src/app/pages/data/cohort/modifier-page.spec.tsx
@@ -9,6 +9,7 @@ import {
   WorkspacesApi,
 } from 'generated/fetch';
 
+import { workspacePath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import {
   currentCohortSearchContextStore,
@@ -50,7 +51,10 @@ describe('ModifierPage', () => {
     return mount(
       <MemoryRouter
         initialEntries={[
-          `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/data/cohorts/build`,
+          `${workspacePath(
+            workspaceDataStub.namespace,
+            workspaceDataStub.id
+          )}/data/cohorts/build`,
         ]}
       >
         <Route exact path='/workspaces/:ns/:wsid/data/cohorts/build'>

--- a/ui/src/app/pages/data/cohort/modifier-page.spec.tsx
+++ b/ui/src/app/pages/data/cohort/modifier-page.spec.tsx
@@ -9,7 +9,7 @@ import {
   WorkspacesApi,
 } from 'generated/fetch';
 
-import { workspacePath } from 'app/routing/utils';
+import { dataTabPath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import {
   currentCohortSearchContextStore,
@@ -51,10 +51,10 @@ describe('ModifierPage', () => {
     return mount(
       <MemoryRouter
         initialEntries={[
-          `${workspacePath(
+          `${dataTabPath(
             workspaceDataStub.namespace,
             workspaceDataStub.id
-          )}/data/cohorts/build`,
+          )}/cohorts/build`,
         ]}
       >
         <Route exact path='/workspaces/:ns/:wsid/data/cohorts/build'>

--- a/ui/src/app/pages/data/cohort/overview.tsx
+++ b/ui/src/app/pages/data/cohort/overview.tsx
@@ -35,12 +35,7 @@ import {
   genderSexRaceOrEthTypeToText,
   mapRequest,
 } from 'app/pages/data/cohort/utils';
-import {
-  analysisTabName,
-  analysisTabPath,
-  dataTabPath,
-  workspacePath,
-} from 'app/routing/utils';
+import { analysisTabName, workspacePath } from 'app/routing/utils';
 import {
   cohortBuilderApi,
   cohortsApi,

--- a/ui/src/app/pages/data/cohort/overview.tsx
+++ b/ui/src/app/pages/data/cohort/overview.tsx
@@ -35,7 +35,12 @@ import {
   genderSexRaceOrEthTypeToText,
   mapRequest,
 } from 'app/pages/data/cohort/utils';
-import { analysisTabPath, dataTabPath } from 'app/routing/utils';
+import {
+  analysisTabName,
+  analysisTabPath,
+  dataTabPath,
+  workspacePath,
+} from 'app/routing/utils';
 import {
   cohortBuilderApi,
   cohortsApi,
@@ -450,15 +455,15 @@ export const ListOverview = fp.flow(
           params: { ns, wsid },
         },
       } = this.props;
-      let url: string;
+      let url = workspacePath(ns, wsid) + '/';
       switch (action) {
         case 'notebook':
           AnalyticsTracker.CohortBuilder.CohortAction('Export to notebook');
-          url = analysisTabPath(ns, wsid);
+          url += analysisTabName;
           break;
         case 'review':
           AnalyticsTracker.CohortBuilder.CohortAction('Review cohort');
-          url = `${dataTabPath(ns, wsid)}/cohorts/${cohort.id}/reviews`;
+          url += `data/cohorts/${cohort.id}/reviews`;
           break;
       }
       this.props.navigateByUrl(url);

--- a/ui/src/app/pages/data/cohort/overview.tsx
+++ b/ui/src/app/pages/data/cohort/overview.tsx
@@ -35,7 +35,7 @@ import {
   genderSexRaceOrEthTypeToText,
   mapRequest,
 } from 'app/pages/data/cohort/utils';
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabName, workspacePath } from 'app/routing/utils';
 import {
   cohortBuilderApi,
   cohortsApi,
@@ -46,7 +46,6 @@ import { AnalyticsTracker } from 'app/utils/analytics';
 import { isAbortError } from 'app/utils/errors';
 import { currentWorkspaceStore, NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 

--- a/ui/src/app/pages/data/cohort/overview.tsx
+++ b/ui/src/app/pages/data/cohort/overview.tsx
@@ -35,7 +35,7 @@ import {
   genderSexRaceOrEthTypeToText,
   mapRequest,
 } from 'app/pages/data/cohort/utils';
-import { analysisTabName, workspacePath } from 'app/routing/utils';
+import { analysisTabPath, dataTabPath } from 'app/routing/utils';
 import {
   cohortBuilderApi,
   cohortsApi,
@@ -450,15 +450,15 @@ export const ListOverview = fp.flow(
           params: { ns, wsid },
         },
       } = this.props;
-      let url = workspacePath(ns, wsid);
+      let url: string;
       switch (action) {
         case 'notebook':
           AnalyticsTracker.CohortBuilder.CohortAction('Export to notebook');
-          url += analysisTabName;
+          url = analysisTabPath(ns, wsid);
           break;
         case 'review':
           AnalyticsTracker.CohortBuilder.CohortAction('Review cohort');
-          url += `data/cohorts/${cohort.id}/reviews`;
+          url = `${dataTabPath(ns, wsid)}/cohorts/${cohort.id}/reviews`;
           break;
       }
       this.props.navigateByUrl(url);

--- a/ui/src/app/pages/data/cohort/overview.tsx
+++ b/ui/src/app/pages/data/cohort/overview.tsx
@@ -35,6 +35,7 @@ import {
   genderSexRaceOrEthTypeToText,
   mapRequest,
 } from 'app/pages/data/cohort/utils';
+import { workspacePath } from 'app/routing/utils';
 import {
   cohortBuilderApi,
   cohortsApi,
@@ -450,7 +451,7 @@ export const ListOverview = fp.flow(
           params: { ns, wsid },
         },
       } = this.props;
-      let url = `/workspaces/${ns}/${wsid}/`;
+      let url = workspacePath(ns, wsid);
       switch (action) {
         case 'notebook':
           AnalyticsTracker.CohortBuilder.CohortAction('Export to notebook');

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -17,6 +17,7 @@ import { TextInput } from 'app/components/inputs';
 import { TooltipTrigger } from 'app/components/popups';
 import { Spinner, SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
+import { dataTabPath } from 'app/routing/utils';
 import { cohortBuilderApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import {
@@ -409,7 +410,7 @@ export const ConceptHomepage = fp.flow(
         searchTerms: this.state.currentSearchString,
         surveyName,
       });
-      const url = `workspaces/${namespace}/${id}/data/concepts/${domain}`;
+      const url = `${dataTabPath(namespace, id)}/concepts/${domain}`;
 
       this.props.navigateByUrl(
         url,

--- a/ui/src/app/pages/data/concept/concept-search.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.spec.tsx
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 
 import { ConceptSet, ConceptSetsApi, WorkspacesApi } from 'generated/fetch';
 
+import { workspacePath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import {
   currentConceptSetStore,
@@ -39,7 +40,10 @@ describe('ConceptSearch', () => {
     return mount(
       <MemoryRouter
         initialEntries={[
-          `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/data/concepts/sets/${conceptSet.id}`,
+          `${workspacePath(
+            workspaceDataStub.namespace,
+            workspaceDataStub.id
+          )}/data/concepts/sets/${conceptSet.id}`,
         ]}
       >
         <Route path='/workspaces/:ns/:wsid/data/concepts/sets/:csid'>

--- a/ui/src/app/pages/data/concept/concept-search.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.spec.tsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 
 import { ConceptSet, ConceptSetsApi, WorkspacesApi } from 'generated/fetch';
 
-import { dataTabPath, workspacePath } from 'app/routing/utils';
+import { dataTabPath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import {
   currentConceptSetStore,

--- a/ui/src/app/pages/data/concept/concept-search.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.spec.tsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 
 import { ConceptSet, ConceptSetsApi, WorkspacesApi } from 'generated/fetch';
 
-import { workspacePath } from 'app/routing/utils';
+import { dataTabPath, workspacePath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import {
   currentConceptSetStore,
@@ -40,10 +40,10 @@ describe('ConceptSearch', () => {
     return mount(
       <MemoryRouter
         initialEntries={[
-          `${workspacePath(
+          `${dataTabPath(
             workspaceDataStub.namespace,
             workspaceDataStub.id
-          )}/data/concepts/sets/${conceptSet.id}`,
+          )}/concepts/sets/${conceptSet.id}`,
         ]}
       >
         <Route path='/workspaces/:ns/:wsid/data/concepts/sets/:csid'>

--- a/ui/src/app/pages/data/concept/concept-set-actions.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-actions.tsx
@@ -4,6 +4,7 @@ import * as fp from 'lodash/fp';
 
 import { ConceptSet } from 'generated/fetch';
 
+import { switchCase } from '@terra-ui-packages/core-utils';
 import { RouteLink } from 'app/components/app-router';
 import { Button } from 'app/components/buttons';
 import { ActionCardBase } from 'app/components/card';
@@ -11,7 +12,7 @@ import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
-import { analysisTabName, workspacePath } from 'app/routing/utils';
+import { analysisTabPath, dataTabPath } from 'app/routing/utils';
 import { conceptSetsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
@@ -148,22 +149,16 @@ export const ConceptSetActions = fp.flow(
     getNavigationPath(action: string): string {
       const { namespace, id } = this.props.workspace;
       const { conceptSet } = this.state;
-      let url = workspacePath(namespace, id);
-      switch (action) {
-        case 'conceptSet':
-          url += `data/concepts/sets/${conceptSet.id}`;
-          break;
-        case 'newConceptSet':
-          url += 'data/concepts';
-          break;
-        case 'notebook':
-          url += analysisTabName;
-          break;
-        case 'dataSet':
-          url += 'data/data-sets';
-          break;
-      }
-      return url;
+      return switchCase(
+        action,
+        [
+          'conceptSet',
+          () => `${dataTabPath(namespace, id)}/concepts/sets/${conceptSet.id}`,
+        ],
+        ['newConceptSet', () => `${dataTabPath(namespace, id)}/concepts`],
+        ['notebook', () => analysisTabPath(namespace, id)],
+        ['dataSet', () => `${dataTabPath(namespace, id)}/data-sets`]
+      );
     }
 
     render() {

--- a/ui/src/app/pages/data/concept/concept-set-actions.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-actions.tsx
@@ -4,7 +4,6 @@ import * as fp from 'lodash/fp';
 
 import { ConceptSet } from 'generated/fetch';
 
-import { switchCase } from '@terra-ui-packages/core-utils';
 import { RouteLink } from 'app/components/app-router';
 import { Button } from 'app/components/buttons';
 import { ActionCardBase } from 'app/components/card';
@@ -12,7 +11,7 @@ import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
-import { analysisTabPath, dataTabPath } from 'app/routing/utils';
+import { analysisTabName, workspacePath } from 'app/routing/utils';
 import { conceptSetsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
@@ -149,16 +148,22 @@ export const ConceptSetActions = fp.flow(
     getNavigationPath(action: string): string {
       const { namespace, id } = this.props.workspace;
       const { conceptSet } = this.state;
-      return switchCase(
-        action,
-        [
-          'conceptSet',
-          () => `${dataTabPath(namespace, id)}/concepts/sets/${conceptSet.id}`,
-        ],
-        ['newConceptSet', () => `${dataTabPath(namespace, id)}/concepts`],
-        ['notebook', () => analysisTabPath(namespace, id)],
-        ['dataSet', () => `${dataTabPath(namespace, id)}/data-sets`]
-      );
+      let url = workspacePath(namespace, id) + '/';
+      switch (action) {
+        case 'conceptSet':
+          url += `data/concepts/sets/${conceptSet.id}`;
+          break;
+        case 'newConceptSet':
+          url += 'data/concepts';
+          break;
+        case 'notebook':
+          url += analysisTabName;
+          break;
+        case 'dataSet':
+          url += 'data/data-sets';
+          break;
+      }
+      return url;
     }
 
     render() {

--- a/ui/src/app/pages/data/concept/concept-set-actions.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-actions.tsx
@@ -11,6 +11,7 @@ import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
+import { workspacePath } from 'app/routing/utils';
 import { conceptSetsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
@@ -148,7 +149,7 @@ export const ConceptSetActions = fp.flow(
     getNavigationPath(action: string): string {
       const { namespace, id } = this.props.workspace;
       const { conceptSet } = this.state;
-      let url = `/workspaces/${namespace}/${id}/`;
+      let url = workspacePath(namespace, id);
       switch (action) {
         case 'conceptSet':
           url += `data/concepts/sets/${conceptSet.id}`;

--- a/ui/src/app/pages/data/concept/concept-set-actions.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-actions.tsx
@@ -11,7 +11,7 @@ import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabName, workspacePath } from 'app/routing/utils';
 import { conceptSetsApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
@@ -21,7 +21,6 @@ import {
 } from 'app/utils';
 import { conceptSetUpdating, NavigationProps } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
 

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -22,6 +22,7 @@ import {
 } from 'app/pages/data/data-set/dataset-page';
 import { ExportDatasetModal } from 'app/pages/data/data-set/export-dataset-modal';
 import { GenomicExtractionModal } from 'app/pages/data/data-set/genomic-extraction-modal';
+import { workspacePath } from 'app/routing/utils';
 import {
   dataSetApi,
   registerApiClient,
@@ -78,9 +79,10 @@ describe('DataSetPage', () => {
     return mount(
       <MemoryRouter
         initialEntries={[
-          `/workspaces/${workspaceDataStub.namespace}/${
+          `${workspacePath(
+            workspaceDataStub.namespace,
             workspaceDataStub.id
-          }/data/data-sets/${stubDataSet().id}`,
+          )}/data/data-sets/${stubDataSet().id}`,
         ]}
       >
         <Route exact path='/workspaces/:ns/:wsid/data/data-sets/:dataSetId'>

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -22,7 +22,7 @@ import {
 } from 'app/pages/data/data-set/dataset-page';
 import { ExportDatasetModal } from 'app/pages/data/data-set/export-dataset-modal';
 import { GenomicExtractionModal } from 'app/pages/data/data-set/genomic-extraction-modal';
-import { dataTabPath, workspacePath } from 'app/routing/utils';
+import { dataTabPath } from 'app/routing/utils';
 import {
   dataSetApi,
   registerApiClient,

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -22,7 +22,7 @@ import {
 } from 'app/pages/data/data-set/dataset-page';
 import { ExportDatasetModal } from 'app/pages/data/data-set/export-dataset-modal';
 import { GenomicExtractionModal } from 'app/pages/data/data-set/genomic-extraction-modal';
-import { workspacePath } from 'app/routing/utils';
+import { dataTabPath, workspacePath } from 'app/routing/utils';
 import {
   dataSetApi,
   registerApiClient,
@@ -79,10 +79,10 @@ describe('DataSetPage', () => {
     return mount(
       <MemoryRouter
         initialEntries={[
-          `${workspacePath(
+          `${dataTabPath(
             workspaceDataStub.namespace,
             workspaceDataStub.id
-          )}/data/data-sets/${stubDataSet().id}`,
+          )}/data-sets/${stubDataSet().id}`,
         ]}
       >
         <Route exact path='/workspaces/:ns/:wsid/data/data-sets/:dataSetId'>
@@ -400,12 +400,10 @@ describe('DataSetPage', () => {
 
   it('should check that the Cohorts and Concept Sets "+" links go to their pages.', async () => {
     const wrapper = component();
-    const pathPrefix =
-      'workspaces/' +
-      workspaceDataStub.namespace +
-      '/' +
-      workspaceDataStub.id +
-      '/data';
+    const pathPrefix = dataTabPath(
+      workspaceDataStub.namespace,
+      workspaceDataStub.id
+    );
 
     // Check Cohorts "+" link
     wrapper.find({ 'data-test-id': 'cohorts-link' }).first().simulate('click');

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -47,7 +47,7 @@ import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { CircleWithText } from 'app/icons/circleWithText';
 import { ExportDatasetModal } from 'app/pages/data/data-set/export-dataset-modal';
 import { GenomicExtractionModal } from 'app/pages/data/data-set/genomic-extraction-modal';
-import { dataTabPath, workspacePath } from 'app/routing/utils';
+import { dataTabPath } from 'app/routing/utils';
 import {
   cohortsApi,
   conceptSetsApi,

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -47,7 +47,7 @@ import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { CircleWithText } from 'app/icons/circleWithText';
 import { ExportDatasetModal } from 'app/pages/data/data-set/export-dataset-modal';
 import { GenomicExtractionModal } from 'app/pages/data/data-set/genomic-extraction-modal';
-import { workspacePath } from 'app/routing/utils';
+import { dataTabPath, workspacePath } from 'app/routing/utils';
 import {
   cohortsApi,
   conceptSetsApi,
@@ -370,10 +370,10 @@ const ImmutableWorkspaceCohortListItem = ({
         </TooltipTrigger>
         <div style={{ marginLeft: 'auto', paddingRight: '1.5rem' }}>
           <StyledRouterLink
-            path={`${workspacePath(
+            path={`${dataTabPath(
               namespace,
               wid
-            )}/data/cohorts/${cohortId}/reviews/cohort-description`}
+            )}/cohorts/${cohortId}/reviews/cohort-description`}
             target='_blank'
           >
             <ClrIcon size='20' shape='bar-chart' />
@@ -1673,7 +1673,7 @@ export const DatasetPage = fp.flow(
     };
 
     const { namespace, id } = workspace;
-    const pathPrefix = 'workspaces/' + namespace + '/' + id + '/data';
+    const pathPrefix = dataTabPath(namespace, id);
     const cohortsPath = pathPrefix + '/cohorts/build';
     const conceptSetsPath = pathPrefix + '/concepts';
     const exportError = !canWrite()

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -47,6 +47,7 @@ import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { CircleWithText } from 'app/icons/circleWithText';
 import { ExportDatasetModal } from 'app/pages/data/data-set/export-dataset-modal';
 import { GenomicExtractionModal } from 'app/pages/data/data-set/genomic-extraction-modal';
+import { workspacePath } from 'app/routing/utils';
 import {
   cohortsApi,
   conceptSetsApi,
@@ -369,7 +370,10 @@ const ImmutableWorkspaceCohortListItem = ({
         </TooltipTrigger>
         <div style={{ marginLeft: 'auto', paddingRight: '1.5rem' }}>
           <StyledRouterLink
-            path={`/workspaces/${namespace}/${wid}/data/cohorts/${cohortId}/reviews/cohort-description`}
+            path={`${workspacePath(
+              namespace,
+              wid
+            )}/data/cohorts/${cohortId}/reviews/cohort-description`}
             target='_blank'
           >
             <ClrIcon size='20' shape='bar-chart' />

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -32,6 +32,7 @@ import {
   dropJupyterNotebookFileSuffix,
   getExistingNotebookNames,
 } from 'app/pages/analysis/util';
+import { workspacePath } from 'app/routing/utils';
 import { dataSetApi, notebooksApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { reactStyles, summarizeErrors } from 'app/utils';
@@ -128,7 +129,10 @@ export const ExportDatasetModal = ({
         createExportDatasetRequest()
       );
       const notebookUrl =
-        `/workspaces/${workspace.namespace}/${workspace.id}/${analysisTabName}/preview/` +
+        `${workspacePath(
+          workspace.namespace,
+          workspace.id
+        )}/${analysisTabName}/preview/` +
         encodeURIComponentStrict(
           appendJupyterNotebookFileSuffix(notebookNameWithoutSuffix)
         );

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -32,7 +32,7 @@ import {
   dropJupyterNotebookFileSuffix,
   getExistingNotebookNames,
 } from 'app/pages/analysis/util';
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabPath } from 'app/routing/utils';
 import { dataSetApi, notebooksApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { reactStyles, summarizeErrors } from 'app/utils';
@@ -40,7 +40,6 @@ import { AnalyticsTracker } from 'app/utils/analytics';
 import { encodeURIComponentStrict, useNavigation } from 'app/utils/navigation';
 import { nameValidationFormat } from 'app/utils/resources';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
 
@@ -129,10 +128,7 @@ export const ExportDatasetModal = ({
         createExportDatasetRequest()
       );
       const notebookUrl =
-        `${workspacePath(
-          workspace.namespace,
-          workspace.id
-        )}/${analysisTabName}/preview/` +
+        `${analysisTabPath(workspace.namespace, workspace.id)}/preview/` +
         encodeURIComponentStrict(
           appendJupyterNotebookFileSuffix(notebookNameWithoutSuffix)
         );

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
@@ -23,6 +23,7 @@ import {
   WithConfirmDeleteModalProps,
 } from 'app/components/with-confirm-delete-modal';
 import { TanagraWorkspaceResource } from 'app/pages/data/tanagra-dev/data-component-tanagra';
+import { workspacePath } from 'app/routing/utils';
 import {
   cohortsApi,
   conceptSetsApi,
@@ -79,7 +80,7 @@ const WorkspaceNavigation = (props: NavProps) => {
     style,
   } = props;
   const tab = isNotebook(resource) ? analysisTabName : 'data';
-  const url = `/workspaces/${namespace}/${id}/${tab}`;
+  const url = `${workspacePath(namespace, id)}/${tab}`;
 
   return (
     <Clickable>

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
@@ -23,7 +23,7 @@ import {
   WithConfirmDeleteModalProps,
 } from 'app/components/with-confirm-delete-modal';
 import { TanagraWorkspaceResource } from 'app/pages/data/tanagra-dev/data-component-tanagra';
-import { analysisTabName, dataTabPath, workspacePath } from 'app/routing/utils';
+import { analysisTabPath, dataTabPath } from 'app/routing/utils';
 import {
   cohortsApi,
   conceptSetsApi,
@@ -78,8 +78,9 @@ const WorkspaceNavigation = (props: NavProps) => {
     resource,
     style,
   } = props;
-  const tab = isNotebook(resource) ? analysisTabName : 'data';
-  const url = `${workspacePath(namespace, id)}/${tab}`;
+  const url = isNotebook(resource)
+    ? analysisTabPath(namespace, id)
+    : dataTabPath(namespace, id);
 
   return (
     <Clickable>

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
@@ -23,7 +23,7 @@ import {
   WithConfirmDeleteModalProps,
 } from 'app/components/with-confirm-delete-modal';
 import { TanagraWorkspaceResource } from 'app/pages/data/tanagra-dev/data-component-tanagra';
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabName, workspacePath } from 'app/routing/utils';
 import {
   cohortsApi,
   conceptSetsApi,
@@ -39,7 +39,6 @@ import {
   getTypeString,
   isNotebook,
 } from 'app/utils/resources';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 const styles = reactStyles({

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
@@ -23,7 +23,7 @@ import {
   WithConfirmDeleteModalProps,
 } from 'app/components/with-confirm-delete-modal';
 import { TanagraWorkspaceResource } from 'app/pages/data/tanagra-dev/data-component-tanagra';
-import { analysisTabName, workspacePath } from 'app/routing/utils';
+import { analysisTabName, dataTabPath, workspacePath } from 'app/routing/utils';
 import {
   cohortsApi,
   conceptSetsApi,
@@ -234,7 +234,8 @@ export const TanagraResourceList = fp.flow(
     } = rowData;
     let displayName = '';
     let url = '';
-    const urlPrefix = `/workspaces/${workspaceNamespace}/${workspaceFirecloudName}/data/tanagra`;
+    const urlPrefix =
+      dataTabPath(workspaceNamespace, workspaceFirecloudName) + 'tanagra';
     if (cohortV2) {
       displayName = cohortV2.displayName;
       url = `${urlPrefix}/cohorts/${cohortV2.id}/${

--- a/ui/src/app/pages/runtimes-list.tsx
+++ b/ui/src/app/pages/runtimes-list.tsx
@@ -5,7 +5,7 @@ import * as fp from 'lodash/fp';
 import { environment } from 'environments/environment';
 import { WarningMessage } from 'app/components/messages';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabPath } from 'app/routing/utils';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import { getAccessToken } from 'app/utils/authentication';
 import { NavigationProps } from 'app/utils/navigation';
@@ -140,7 +140,7 @@ export const RuntimesList = fp.flow(
                   // called from, for example:
                   // https://github.com/DataBiosphere/terra-ui/blob/4333c7b94d6ce10a6fe079361e98c2b6cc71f83a/src/pages/Environments.js#L420
                   getLink: (_, { namespace, name }) =>
-                    `${workspacePath(namespace, stringToSlug(name))}/analysis`,
+                    analysisTabPath(namespace, stringToSlug(name)),
                 },
               }}
             />

--- a/ui/src/app/pages/runtimes-list.tsx
+++ b/ui/src/app/pages/runtimes-list.tsx
@@ -5,6 +5,7 @@ import * as fp from 'lodash/fp';
 import { environment } from 'environments/environment';
 import { WarningMessage } from 'app/components/messages';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
+import { workspacePath } from 'app/routing/utils';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import { getAccessToken } from 'app/utils/authentication';
 import { NavigationProps } from 'app/utils/navigation';
@@ -139,7 +140,7 @@ export const RuntimesList = fp.flow(
                   // called from, for example:
                   // https://github.com/DataBiosphere/terra-ui/blob/4333c7b94d6ce10a6fe079361e98c2b6cc71f83a/src/pages/Environments.js#L420
                   getLink: (_, { namespace, name }) =>
-                    `/workspaces/${namespace}/${stringToSlug(name)}/analysis`,
+                    `${workspacePath(namespace, stringToSlug(name))}/analysis`,
                 },
               }}
             />

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -13,7 +13,7 @@ import { ClrIcon, ControlledTierBadge } from 'app/components/icons';
 import { withErrorModal } from 'app/components/modals';
 import { PopupTrigger, TooltipTrigger } from 'app/components/popups';
 import { WorkspaceShare } from 'app/pages/workspace/workspace-share';
-import { workspacePath } from 'app/routing/utils';
+import { dataTabPath, workspacePath } from 'app/routing/utils';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
@@ -225,7 +225,7 @@ export const WorkspaceCard = fp.flow(withNavigation)(
                       analyticsFn={() => this.trackWorkspaceNavigation()}
                       data-test-id={'workspace-card-link'}
                       propagateDataTestId
-                      path={`${workspacePath(namespace, id)}/data`}
+                      path={dataTabPath(namespace, id)}
                     >
                       <TooltipTrigger
                         content={

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -13,6 +13,7 @@ import { ClrIcon, ControlledTierBadge } from 'app/components/icons';
 import { withErrorModal } from 'app/components/modals';
 import { PopupTrigger, TooltipTrigger } from 'app/components/popups';
 import { WorkspaceShare } from 'app/pages/workspace/workspace-share';
+import { workspacePath } from 'app/routing/utils';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
@@ -224,7 +225,7 @@ export const WorkspaceCard = fp.flow(withNavigation)(
                       analyticsFn={() => this.trackWorkspaceNavigation()}
                       data-test-id={'workspace-card-link'}
                       propagateDataTestId
-                      path={`/workspaces/${namespace}/${id}/data`}
+                      path={`${workspacePath(namespace, id)}/data`}
                     >
                       <TooltipTrigger
                         content={

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -13,7 +13,7 @@ import { ClrIcon, ControlledTierBadge } from 'app/components/icons';
 import { withErrorModal } from 'app/components/modals';
 import { PopupTrigger, TooltipTrigger } from 'app/components/popups';
 import { WorkspaceShare } from 'app/pages/workspace/workspace-share';
-import { dataTabPath, workspacePath } from 'app/routing/utils';
+import { dataTabPath } from 'app/routing/utils';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -4,9 +4,9 @@ import { mount } from 'enzyme';
 import { mockNavigate } from 'setupTests';
 
 import { WorkspaceNavBar } from 'app/pages/workspace/workspace-nav-bar';
+import { analysisTabName } from 'app/routing/utils';
 import { currentWorkspaceStore } from 'app/utils/navigation';
 import { cdrVersionStore, serverConfigStore } from 'app/utils/stores';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 
 import {
   CdrVersionsStubVariables,

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -8,6 +8,7 @@ import { CdrVersionTiersResponse, Workspace } from 'generated/fetch';
 import { Clickable } from 'app/components/buttons';
 import { FlexRow } from 'app/components/flex';
 import { ClrIcon } from 'app/components/icons';
+import { analysisTabName } from 'app/routing/utils';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles, withCdrVersions, withCurrentWorkspace } from 'app/utils';
 import {
@@ -17,7 +18,6 @@ import {
 } from 'app/utils/cdr-versions';
 import { useNavigation } from 'app/utils/navigation';
 import { MatchParams, serverConfigStore } from 'app/utils/stores';
-import { analysisTabName } from 'app/utils/user-apps-utils';
 
 import { CdrVersionUpgradeModal } from './cdr-version-upgrade-modal';
 

--- a/ui/src/app/pages/workspace/workspace-wrapper.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.spec.tsx
@@ -9,6 +9,7 @@ import { AppsApi, RuntimeApi, WorkspacesApi } from 'generated/fetch';
 import { screen } from '@testing-library/dom';
 import { render, waitFor } from '@testing-library/react';
 import { WorkspaceWrapper } from 'app/pages/workspace/workspace-wrapper';
+import { workspacePath } from 'app/routing/utils';
 import {
   registerApiClient,
   workspacesApi,
@@ -62,7 +63,7 @@ describe(WorkspaceWrapper.name, () => {
     render(
       <MemoryRouter
         initialEntries={[
-          `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}`,
+          workspacePath(workspaceDataStub.namespace, workspaceDataStub.id),
         ]}
       >
         <Route path='/workspaces/:ns/:wsid'>

--- a/ui/src/app/routing/guards.tsx
+++ b/ui/src/app/routing/guards.tsx
@@ -24,6 +24,7 @@ import { shouldShowDemographicSurvey } from 'app/utils/profile-utils';
 import { authStore, profileStore } from 'app/utils/stores';
 
 import { AuthorityMissing } from './authority-missing';
+import { workspacePath } from './utils';
 
 export const signInGuard: Guard = {
   allowed: (): boolean => {
@@ -90,7 +91,7 @@ export const getAccessModuleGuard = (): Guard => {
 export const adminLockedGuard = (ns: string, wsid: string): Guard => {
   return {
     allowed: (): boolean => !currentWorkspaceStore.getValue().adminLocked,
-    redirectPath: `/workspaces/${ns}/${wsid}/about`,
+    redirectPath: `${workspacePath(ns, wsid)}/about`,
   };
 };
 

--- a/ui/src/app/routing/utils.tsx
+++ b/ui/src/app/routing/utils.tsx
@@ -10,3 +10,6 @@ export const analysisTabName = environment.showNewAnalysisTab
 
 export const analysisTabPath = (namespace: string, id: string): string =>
   `${workspacePath(namespace, id)}/${analysisTabName}`;
+
+export const dataTabPath = (namespace: string, id: string): string =>
+  `${workspacePath(namespace, id)}/data}`;

--- a/ui/src/app/routing/utils.tsx
+++ b/ui/src/app/routing/utils.tsx
@@ -1,0 +1,2 @@
+export const workspacePath = (namespace: string, id: string): string =>
+  `/workspaces/${namespace}/${id}`;

--- a/ui/src/app/routing/utils.tsx
+++ b/ui/src/app/routing/utils.tsx
@@ -12,4 +12,4 @@ export const analysisTabPath = (namespace: string, id: string): string =>
   `${workspacePath(namespace, id)}/${analysisTabName}`;
 
 export const dataTabPath = (namespace: string, id: string): string =>
-  `${workspacePath(namespace, id)}/data}`;
+  `${workspacePath(namespace, id)}/data`;

--- a/ui/src/app/routing/utils.tsx
+++ b/ui/src/app/routing/utils.tsx
@@ -1,2 +1,12 @@
+import { environment } from 'environments/environment';
+
 export const workspacePath = (namespace: string, id: string): string =>
   `/workspaces/${namespace}/${id}`;
+
+// internal name of the analysis tab, also used to construct URLs
+export const analysisTabName = environment.showNewAnalysisTab
+  ? 'analysis'
+  : 'notebooks';
+
+export const analysisTabPath = (namespace: string, id: string): string =>
+  `${workspacePath(namespace, id)}/${analysisTabName}`;

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -34,7 +34,8 @@ import {
 } from 'app/pages/workspace/workspace-edit';
 import { adminLockedGuard } from 'app/routing/guards';
 import { MatchParams, withParamsKey } from 'app/utils/stores';
-import { analysisTabName } from 'app/utils/user-apps-utils';
+
+import { analysisTabName } from './utils';
 
 const CohortPagePage = fp.flow(withRouteData, withRoutingSpinner)(CohortPage);
 const CohortActionsPage = fp.flow(

--- a/ui/src/app/utils/resources.spec.tsx
+++ b/ui/src/app/utils/resources.spec.tsx
@@ -8,6 +8,8 @@ import {
   WorkspaceResource,
 } from 'generated/fetch';
 
+import { workspacePath } from 'app/routing/utils';
+
 import { exampleCohortStubs } from 'testing/stubs/cohorts-api-stub';
 import { stubResource } from 'testing/stubs/resources-stub';
 import { WorkspaceStubVariables } from 'testing/stubs/workspaces';
@@ -182,7 +184,10 @@ describe('resources.tsx', () => {
   it('should return resource URLs', () => {
     const { DEFAULT_WORKSPACE_NS, DEFAULT_WORKSPACE_ID } =
       WorkspaceStubVariables;
-    const WORKSPACE_URL_PREFIX = `/workspaces/${DEFAULT_WORKSPACE_NS}/${DEFAULT_WORKSPACE_ID}`;
+    const WORKSPACE_URL_PREFIX = workspacePath(
+      DEFAULT_WORKSPACE_NS,
+      DEFAULT_WORKSPACE_ID
+    );
     const EXPECTED_COHORT_URL = `${WORKSPACE_URL_PREFIX}/data/cohorts/build?cohortId=${COHORT_ID}`;
     const EXPECTED_COHORT_REVIEW_URL = `${WORKSPACE_URL_PREFIX}/data/cohorts/${COHORT_REVIEW_COHORT_ID}/reviews/${COHORT_REVIEW_ID}`;
     const EXPECTED_CONCEPT_SET_URL = `${WORKSPACE_URL_PREFIX}/data/concepts/sets/${CONCEPT_SET_ID}`;

--- a/ui/src/app/utils/resources.spec.tsx
+++ b/ui/src/app/utils/resources.spec.tsx
@@ -8,7 +8,7 @@ import {
   WorkspaceResource,
 } from 'generated/fetch';
 
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabName, workspacePath } from 'app/routing/utils';
 
 import { exampleCohortStubs } from 'testing/stubs/cohorts-api-stub';
 import { stubResource } from 'testing/stubs/resources-stub';
@@ -29,7 +29,6 @@ import {
   isNotebook,
   toDisplay,
 } from './resources';
-import { analysisTabName } from './user-apps-utils';
 
 const COHORT_NAME = exampleCohortStubs[0].name;
 const COHORT_DESCRIPTION = exampleCohortStubs[0].description;

--- a/ui/src/app/utils/resources.spec.tsx
+++ b/ui/src/app/utils/resources.spec.tsx
@@ -8,7 +8,7 @@ import {
   WorkspaceResource,
 } from 'generated/fetch';
 
-import { analysisTabName, workspacePath } from 'app/routing/utils';
+import { analysisTabPath, dataTabPath } from 'app/routing/utils';
 
 import { exampleCohortStubs } from 'testing/stubs/cohorts-api-stub';
 import { stubResource } from 'testing/stubs/resources-stub';
@@ -183,15 +183,19 @@ describe('resources.tsx', () => {
   it('should return resource URLs', () => {
     const { DEFAULT_WORKSPACE_NS, DEFAULT_WORKSPACE_ID } =
       WorkspaceStubVariables;
-    const WORKSPACE_URL_PREFIX = workspacePath(
+    const dataTabPrefix = dataTabPath(
       DEFAULT_WORKSPACE_NS,
       DEFAULT_WORKSPACE_ID
     );
-    const EXPECTED_COHORT_URL = `${WORKSPACE_URL_PREFIX}/data/cohorts/build?cohortId=${COHORT_ID}`;
-    const EXPECTED_COHORT_REVIEW_URL = `${WORKSPACE_URL_PREFIX}/data/cohorts/${COHORT_REVIEW_COHORT_ID}/reviews/${COHORT_REVIEW_ID}`;
-    const EXPECTED_CONCEPT_SET_URL = `${WORKSPACE_URL_PREFIX}/data/concepts/sets/${CONCEPT_SET_ID}`;
-    const EXPECTED_DATA_SET_URL = `${WORKSPACE_URL_PREFIX}/data/data-sets/${DATA_SET_ID}`;
-    const EXPECTED_NOTEBOOK_URL = `${WORKSPACE_URL_PREFIX}/${analysisTabName}/preview/${NOTEBOOK_NAME}`;
+    const analysisTabPrefix = analysisTabPath(
+      DEFAULT_WORKSPACE_NS,
+      DEFAULT_WORKSPACE_ID
+    );
+    const EXPECTED_COHORT_URL = `${dataTabPrefix}/cohorts/build?cohortId=${COHORT_ID}`;
+    const EXPECTED_COHORT_REVIEW_URL = `${dataTabPrefix}/cohorts/${COHORT_REVIEW_COHORT_ID}/reviews/${COHORT_REVIEW_ID}`;
+    const EXPECTED_CONCEPT_SET_URL = `${dataTabPrefix}/concepts/sets/${CONCEPT_SET_ID}`;
+    const EXPECTED_DATA_SET_URL = `${dataTabPrefix}/data-sets/${DATA_SET_ID}`;
+    const EXPECTED_NOTEBOOK_URL = `${analysisTabPrefix}/preview/${NOTEBOOK_NAME}`;
 
     expect(stringifyUrl(getResourceUrl(testCohort))).toBe(EXPECTED_COHORT_URL);
     expect(stringifyUrl(getResourceUrl(testCohortReview))).toBe(

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -11,7 +11,7 @@ import {
   WorkspaceResource,
 } from 'generated/fetch';
 
-import { analysisTabPath, workspacePath } from 'app/routing/utils';
+import { analysisTabPath, dataTabPath, workspacePath } from 'app/routing/utils';
 
 import { encodeURIComponentStrict, UrlObj } from './navigation';
 import { WorkspaceData } from './workspace-data';
@@ -73,7 +73,8 @@ export function getId(resource: WorkspaceResource): number {
 
 export function getResourceUrl(resource: WorkspaceResource): UrlObj {
   const { workspaceNamespace, workspaceFirecloudName } = resource;
-  const workspacePrefix = workspacePath(
+  const dataTabPrefix = dataTabPath(workspaceNamespace, workspaceFirecloudName);
+  const analysisTabPrefix = analysisTabPath(
     workspaceNamespace,
     workspaceFirecloudName
   );
@@ -82,33 +83,29 @@ export function getResourceUrl(resource: WorkspaceResource): UrlObj {
     [
       isCohort,
       (r) => ({
-        url: `${workspacePrefix}/data/cohorts/build`,
+        url: `${dataTabPrefix}/cohorts/build`,
         queryParams: { cohortId: r.cohort.id },
       }),
     ],
     [
       isCohortReview,
       (r) => ({
-        url: `${workspacePrefix}/data/cohorts/${r.cohortReview.cohortId}/reviews/${r.cohortReview.cohortReviewId}`,
+        url: `${dataTabPrefix}/cohorts/${r.cohortReview.cohortId}/reviews/${r.cohortReview.cohortReviewId}`,
       }),
     ],
     [
       isConceptSet,
       (r) => ({
-        url: `${workspacePrefix}/data/concepts/sets/${r.conceptSet.id}`,
+        url: `${dataTabPrefix}/concepts/sets/${r.conceptSet.id}`,
       }),
     ],
-    [
-      isDataSet,
-      (r) => ({ url: `${workspacePrefix}/data/data-sets/${r.dataSet.id}` }),
-    ],
+    [isDataSet, (r) => ({ url: `${dataTabPrefix}/data-sets/${r.dataSet.id}` })],
     [
       isNotebook,
       (r) => ({
-        url: `${analysisTabPath(
-          workspaceNamespace,
-          workspaceFirecloudName
-        )}/preview/${encodeURIComponentStrict(r.notebook.name)}`,
+        url: `${analysisTabPrefix}/preview/${encodeURIComponentStrict(
+          r.notebook.name
+        )}`,
       }),
     ],
   ])(resource);

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -11,7 +11,7 @@ import {
   WorkspaceResource,
 } from 'generated/fetch';
 
-import { analysisTabPath, dataTabPath, workspacePath } from 'app/routing/utils';
+import { analysisTabPath, dataTabPath } from 'app/routing/utils';
 
 import { encodeURIComponentStrict, UrlObj } from './navigation';
 import { WorkspaceData } from './workspace-data';

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -11,10 +11,9 @@ import {
   WorkspaceResource,
 } from 'generated/fetch';
 
-import { workspacePath } from 'app/routing/utils';
+import { analysisTabPath, workspacePath } from 'app/routing/utils';
 
 import { encodeURIComponentStrict, UrlObj } from './navigation';
-import { analysisTabName } from './user-apps-utils';
 import { WorkspaceData } from './workspace-data';
 
 export const isCohort = (resource: WorkspaceResource): boolean =>
@@ -106,9 +105,10 @@ export function getResourceUrl(resource: WorkspaceResource): UrlObj {
     [
       isNotebook,
       (r) => ({
-        url: `${workspacePrefix}/${analysisTabName}/preview/${encodeURIComponentStrict(
-          r.notebook.name
-        )}`,
+        url: `${analysisTabPath(
+          workspaceNamespace,
+          workspaceFirecloudName
+        )}/preview/${encodeURIComponentStrict(r.notebook.name)}`,
       }),
     ],
   ])(resource);

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -11,6 +11,8 @@ import {
   WorkspaceResource,
 } from 'generated/fetch';
 
+import { workspacePath } from 'app/routing/utils';
+
 import { encodeURIComponentStrict, UrlObj } from './navigation';
 import { analysisTabName } from './user-apps-utils';
 import { WorkspaceData } from './workspace-data';
@@ -72,7 +74,10 @@ export function getId(resource: WorkspaceResource): number {
 
 export function getResourceUrl(resource: WorkspaceResource): UrlObj {
   const { workspaceNamespace, workspaceFirecloudName } = resource;
-  const workspacePrefix = `/workspaces/${workspaceNamespace}/${workspaceFirecloudName}`;
+  const workspacePrefix = workspacePath(
+    workspaceNamespace,
+    workspaceFirecloudName
+  );
 
   return fp.cond([
     [

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -7,7 +7,6 @@ import {
   UserAppEnvironment,
 } from 'generated/fetch';
 
-import { environment } from 'environments/environment';
 import { findApp, UIAppType } from 'app/components/apps-panel/utils';
 import {
   rstudioConfigIconId,
@@ -166,8 +165,3 @@ export const openSASOrConfigPanel = (
     setSidebarActiveIconStore.next(sasConfigIconId);
   }
 };
-
-// internal name of the analysis tab, also used to construct URLs
-export const analysisTabName = environment.showNewAnalysisTab
-  ? 'analysis'
-  : 'notebooks';


### PR DESCRIPTION
Centralize the construction of AoU UI Workspace URLs instead of constructing them as-needed.

Example: `workspacePath(ns, wsid)` instead of `/workspaces/${ns}/${wsid}`.

We have many occasions to construct URLs to the analysis tab and data tab (and sub-URLs) so there are convenience functions for these as well: analysisTabPath() and dataTabPath()

This is motivated by my work to rename "wsid", "workspaceId", etc. to "terraName" - it will be easier to do a big renaming after these are centralized.

Tested a few pages locally where I was less confident, but I didn't do that for all changes here.  More scrutiny of the Data Apps changes would be welcome.
 

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
