### PR TITLE
[RW-10256][risk=no] Enabled app pausing in local and test environments.

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -124,7 +124,7 @@
     "enableSasGKEApp": true,
     "enableDataExplorer": true,
     "enableHasEhrData": true,
-    "enableAppPausing": true
+    "enableGKEAppPausing": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-local",

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -123,7 +123,8 @@
     "enableRStudioGKEApp": true,
     "enableSasGKEApp": true,
     "enableDataExplorer": true,
-    "enableHasEhrData": true
+    "enableHasEhrData": true,
+    "enableAppPausing": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-local",

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -123,7 +123,8 @@
     "enableRStudioGKEApp": true,
     "enableSasGKEApp": false,
     "enableDataExplorer": false,
-    "enableHasEhrData": true
+    "enableHasEhrData": true,
+    "enableAppPausing": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-preprod",

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -124,7 +124,7 @@
     "enableSasGKEApp": true,
     "enableDataExplorer": false,
     "enableHasEhrData": true,
-    "enableAppPausing": false
+    "enableGKEAppPausing": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-preprod",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -124,7 +124,7 @@
     "enableSasGKEApp": false,
     "enableDataExplorer": false,
     "enableHasEhrData": true,
-    "enableAppPausing": false
+    "enableGKEAppPausing": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-prod",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -123,7 +123,8 @@
     "enableRStudioGKEApp": false,
     "enableSasGKEApp": false,
     "enableDataExplorer": false,
-    "enableHasEhrData": false
+    "enableHasEhrData": false,
+    "enableAppPausing": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-prod",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -124,7 +124,7 @@
     "enableSasGKEApp": true,
     "enableDataExplorer": false,
     "enableHasEhrData": true,
-    "enableAppPausing": false
+    "enableGKEAppPausing": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-stable",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -123,7 +123,8 @@
     "enableRStudioGKEApp": false,
     "enableSasGKEApp": false,
     "enableDataExplorer": false,
-    "enableHasEhrData": true
+    "enableHasEhrData": true,
+    "enableAppPausing": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-stable",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -123,7 +123,8 @@
     "enableRStudioGKEApp": true,
     "enableSasGKEApp": true,
     "enableDataExplorer": false,
-    "enableHasEhrData": true
+    "enableHasEhrData": true,
+    "enableAppPausing": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-staging",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -124,7 +124,7 @@
     "enableSasGKEApp": true,
     "enableDataExplorer": false,
     "enableHasEhrData": true,
-    "enableAppPausing": false
+    "enableGKEAppPausing": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-staging",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -123,7 +123,8 @@
     "enableRStudioGKEApp": true,
     "enableSasGKEApp": true,
     "enableDataExplorer": false,
-    "enableHasEhrData": true
+    "enableHasEhrData": true,
+    "enableAppPausing": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -124,7 +124,7 @@
     "enableSasGKEApp": true,
     "enableDataExplorer": false,
     "enableHasEhrData": true,
-    "enableAppPausing": true
+    "enableGKEAppPausing": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -333,6 +333,8 @@ public class WorkbenchConfig {
     public boolean enableDataExplorer;
     // If true, enable has EHR data
     public boolean enableHasEhrData;
+    // If true, allow users to pause their GKE apps
+    public boolean enableAppPausing;
   }
 
   public static class ActionAuditConfig {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -334,7 +334,7 @@ public class WorkbenchConfig {
     // If true, enable has EHR data
     public boolean enableHasEhrData;
     // If true, allow users to pause their GKE apps
-    public boolean enableAppPausing;
+    public boolean enableGKEAppPausing;
   }
 
   public static class ActionAuditConfig {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -76,5 +76,6 @@ public interface WorkbenchConfigMapper {
   @Mapping(target = "enableSasGKEApp", source = "config.featureFlags.enableSasGKEApp")
   @Mapping(target = "enableDataExplorer", source = "config.featureFlags.enableDataExplorer")
   @Mapping(target = "enableHasEhrData", source = "config.featureFlags.enableHasEhrData")
+  @Mapping(target = "enableAppPausing", source = "config.featureFlags.enableAppPausing")
   ConfigResponse toModel(WorkbenchConfig config, List<DbAccessModule> accessModules);
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -76,6 +76,6 @@ public interface WorkbenchConfigMapper {
   @Mapping(target = "enableSasGKEApp", source = "config.featureFlags.enableSasGKEApp")
   @Mapping(target = "enableDataExplorer", source = "config.featureFlags.enableDataExplorer")
   @Mapping(target = "enableHasEhrData", source = "config.featureFlags.enableHasEhrData")
-  @Mapping(target = "enableAppPausing", source = "config.featureFlags.enableAppPausing")
+  @Mapping(target = "enableGKEAppPausing", source = "config.featureFlags.enableGKEAppPausing")
   ConfigResponse toModel(WorkbenchConfig config, List<DbAccessModule> accessModules);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6894,10 +6894,10 @@ components:
         tanagraBaseUrl:
           type: string
           description: The tanagra base url
-        enableAppPausing:
+        enableGKEAppPausing:
           type: boolean
           default: false
-          description: Whether users are allowed to pause applications.
+          description: Whether users are allowed to pause GKE applications.
     RuntimeImage:
       type: object
       properties:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6894,6 +6894,10 @@ components:
         tanagraBaseUrl:
           type: string
           description: The tanagra base url
+        enableAppPausing:
+          type: boolean
+          default: false
+          description: Whether users are allowed to pause applications.
     RuntimeImage:
       type: object
       properties:

--- a/ui/src/app/components/apps-panel/apps-panel-button.tsx
+++ b/ui/src/app/components/apps-panel/apps-panel-button.tsx
@@ -64,24 +64,23 @@ export const AppsPanelButton = (props: Props) => {
     <TooltipTrigger content={disabledTooltip} disabled={!showTooltip}>
       <Clickable
         {...{ disabled, onClick }}
-        style={{ padding: '0.5em' }}
+        style={{
+          ...(disabled ? buttonStyles.disabledButton : buttonStyles.button),
+          margin: '0.5em',
+        }}
+        as={FlexColumn}
         data-test-id={`apps-panel-button-${buttonText.replace(' ', '-')}`}
         propagateDataTestId
+        role='button'
       >
-        <FlexColumn
-          style={disabled ? buttonStyles.disabledButton : buttonStyles.button}
+        <FontAwesomeIcon {...{ icon }} style={buttonStyles.buttonIcon} />
+        <div
+          style={
+            disabled ? buttonStyles.disabledButtonText : buttonStyles.buttonText
+          }
         >
-          <FontAwesomeIcon {...{ icon }} style={buttonStyles.buttonIcon} />
-          <div
-            style={
-              disabled
-                ? buttonStyles.disabledButtonText
-                : buttonStyles.buttonText
-            }
-          >
-            {buttonText}
-          </div>
-        </FlexColumn>
+          {buttonText}
+        </div>
       </Clickable>
     </TooltipTrigger>
   );

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -165,7 +165,7 @@ describe('ExpandedApp', () => {
         expect(container).toBeInTheDocument();
 
         const actionButton = screen.getByRole('button', { name });
-        expectButtonElementEnabled(actionButton);
+        expectButtonElementDisabled(actionButton);
       }
     );
 
@@ -210,10 +210,26 @@ describe('ExpandedApp', () => {
 
   const gkeAppTypes = [UIAppType.CROMWELL, UIAppType.RSTUDIO, UIAppType.SAS];
   describe.each(gkeAppTypes)('GKE App %s', (appType) => {
-    test.each([
-      [AppStatus.RUNNING, 'Pause'],
-      [AppStatus.STOPPED, 'Resume'],
+    test.each([[AppStatus.RUNNING, 'Pause']])(
+      'should not allow clicking pause/resume when the app status is %s and enableAppPausing is false',
+      async (status, name) => {
+        const appName = 'my-app';
 
+        const { container } = await component(appType, {
+          appName,
+          googleProject,
+          status,
+        });
+        expect(container).toBeInTheDocument();
+
+        screen.logTestingPlaygroundURL();
+        const actionButton = screen.getByRole('button', { name });
+        screen.logTestingPlaygroundURL();
+        expectButtonElementDisabled(actionButton);
+      }
+    );
+
+    test.each([
       [AppStatus.STARTING, 'Resuming'],
       [AppStatus.STOPPING, 'Pausing'],
 
@@ -226,9 +242,12 @@ describe('ExpandedApp', () => {
       [undefined, 'Pause'],
       [null, 'Pause'],
     ])(
-      'should not allow clicking pause/resume when the app status is %s',
+      'should not allow clicking pause/resume when the app status is %s and enableAppPausing is true',
       async (status, name) => {
         const appName = 'my-app';
+        serverConfigStore.set({
+          config: { ...defaultServerConfig, enableAppPausing: true },
+        });
 
         const { container } = await component(appType, {
           appName,
@@ -238,6 +257,27 @@ describe('ExpandedApp', () => {
         expect(container).toBeInTheDocument();
 
         const actionButton = screen.getByRole('button', { name });
+        expectButtonElementDisabled(actionButton);
+      }
+    );
+
+    test.each([[AppStatus.RUNNING, 'Pause']])(
+      'should allow clicking pause/resume when the app status is %s and enableAppPausing is true',
+      async (status, name) => {
+        const appName = 'my-app';
+        serverConfigStore.set({
+          config: { ...defaultServerConfig, enableAppPausing: true },
+        });
+
+        const { container } = await component(appType, {
+          appName,
+          googleProject,
+          status,
+        });
+        expect(container).toBeInTheDocument();
+
+        const actionButton = screen.getByRole('button', { name });
+        screen.logTestingPlaygroundURL();
         expectButtonElementEnabled(actionButton);
       }
     );

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -210,7 +210,12 @@ describe('ExpandedApp', () => {
 
   const gkeAppTypes = [UIAppType.CROMWELL, UIAppType.RSTUDIO, UIAppType.SAS];
   describe.each(gkeAppTypes)('GKE App %s', (appType) => {
-    test.each([[AppStatus.RUNNING, 'Pause']])(
+    test.each([
+      [AppStatus.RUNNING, 'Pause'],
+      [AppStatus.STOPPED, 'Resume'],
+      [AppStatus.STARTING, 'Resuming'],
+      [AppStatus.STOPPING, 'Pausing'],
+    ])(
       'should not allow clicking pause/resume when the app status is %s and enableAppPausing is false',
       async (status, name) => {
         const appName = 'my-app';

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -266,7 +266,10 @@ describe('ExpandedApp', () => {
       }
     );
 
-    test.each([[AppStatus.RUNNING, 'Pause']])(
+    test.each([
+      [AppStatus.RUNNING, 'Pause'],
+      [AppStatus.STOPPED, 'Resume'],
+    ])(
       'should allow clicking pause/resume when the app status is %s and enableGKEAppPausing is true',
       async (status, name) => {
         const appName = 'my-app';

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -216,7 +216,7 @@ describe('ExpandedApp', () => {
       [AppStatus.STARTING, 'Resuming'],
       [AppStatus.STOPPING, 'Pausing'],
     ])(
-      'should not allow clicking pause/resume when the app status is %s and enableAppPausing is false',
+      'should not allow clicking pause/resume when the app status is %s and enableGKEAppPausing is false',
       async (status, name) => {
         const appName = 'my-app';
 
@@ -247,11 +247,11 @@ describe('ExpandedApp', () => {
       [undefined, 'Pause'],
       [null, 'Pause'],
     ])(
-      'should not allow clicking pause/resume when the app status is %s and enableAppPausing is true',
+      'should not allow clicking pause/resume when the app status is %s and enableGKEAppPausing is true',
       async (status, name) => {
         const appName = 'my-app';
         serverConfigStore.set({
-          config: { ...defaultServerConfig, enableAppPausing: true },
+          config: { ...defaultServerConfig, enableGKEAppPausing: true },
         });
 
         const { container } = await component(appType, {
@@ -267,11 +267,11 @@ describe('ExpandedApp', () => {
     );
 
     test.each([[AppStatus.RUNNING, 'Pause']])(
-      'should allow clicking pause/resume when the app status is %s and enableAppPausing is true',
+      'should allow clicking pause/resume when the app status is %s and enableGKEAppPausing is true',
       async (status, name) => {
         const appName = 'my-app';
         serverConfigStore.set({
-          config: { ...defaultServerConfig, enableAppPausing: true },
+          config: { ...defaultServerConfig, enableGKEAppPausing: true },
         });
 
         const { container } = await component(appType, {

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -282,7 +282,6 @@ describe('ExpandedApp', () => {
         expect(container).toBeInTheDocument();
 
         const actionButton = screen.getByRole('button', { name });
-        screen.logTestingPlaygroundURL();
         expectButtonElementEnabled(actionButton);
       }
     );

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -31,7 +31,7 @@ import {
   RuntimeStatusRequest,
   useRuntimeStatus,
 } from 'app/utils/runtime-utils';
-import { runtimeStore, useStore } from 'app/utils/stores';
+import { runtimeStore, serverConfigStore, useStore } from 'app/utils/stores';
 import {
   openRStudio,
   openSAS,
@@ -122,6 +122,7 @@ const PauseUserAppButton = (props: {
   workspaceNamespace: string;
 }) => {
   const { googleProject, appName, status } = props.userApp || {};
+  const { config } = useStore(serverConfigStore);
 
   return (
     <PauseResumeButton
@@ -132,7 +133,7 @@ const PauseUserAppButton = (props: {
       onResume={() =>
         resumeUserApp(googleProject, appName, props.workspaceNamespace)
       }
-      disabled
+      disabled={!config.enableAppPausing}
       disabledTooltip='Pause and resume are not currently available.'
     />
   );

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -133,7 +133,7 @@ const PauseUserAppButton = (props: {
       onResume={() =>
         resumeUserApp(googleProject, appName, props.workspaceNamespace)
       }
-      disabled={!config.enableAppPausing}
+      disabled={!config.enableGKEAppPausing}
       disabledTooltip='Pause and resume are not currently available.'
     />
   );

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -134,7 +134,10 @@ const PauseUserAppButton = (props: {
         resumeUserApp(googleProject, appName, props.workspaceNamespace)
       }
       disabled={!config.enableGKEAppPausing}
-      disabledTooltip='Pause and resume are not currently available.'
+      disabledTooltip={
+        !config.enableGKEAppPausing &&
+        'Pause and resume are not currently available.'
+      }
     />
   );
 };

--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -239,13 +239,21 @@ const computeStyle = (
   };
 };
 
+interface ClickableProps {
+  as?: string | React.ReactElement<any, any> | React.FC;
+  disabled?: boolean;
+  onClick?: any;
+  propagateDataTestId?: boolean;
+  [key: string]: any;
+}
+
 export const Clickable = ({
   as = 'div',
   disabled = false,
   onClick = null,
   propagateDataTestId = false,
   ...props
-}) => {
+}: ClickableProps) => {
   // `fp.omit` used to prevent propagation of test IDs to the rendered child component.
   const childProps = propagateDataTestId
     ? props

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -609,7 +609,7 @@ describe('HelpSidebar', () => {
 
     wrapper
       .find({ 'data-test-id': `Cromwell-expanded` })
-      .find({ 'data-test-id': 'Cromwell-settings-button' })
+      .find('div[data-test-id="apps-panel-button-Settings"]')
       .simulate('click');
     await waitOneTickAndUpdate(wrapper);
 

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -77,7 +77,7 @@ const defaultServerConfig: ConfigResponse = {
   enableRStudioGKEApp: true,
   enableSasGKEApp: true,
   tanagraBaseUrl: 'https://aou-tanagra.dev.pmi-ops.org',
-  enableAppPausing: false,
+  enableGKEAppPausing: false,
 };
 
 export default defaultServerConfig;

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -77,6 +77,7 @@ const defaultServerConfig: ConfigResponse = {
   enableRStudioGKEApp: true,
   enableSasGKEApp: true,
   tanagraBaseUrl: 'https://aou-tanagra.dev.pmi-ops.org',
+  enableAppPausing: false,
 };
 
 export default defaultServerConfig;


### PR DESCRIPTION
In order to test this, run a GKE app. Once it is in the "RUNNING" state, you should be able to click the "PAUSE" button and have your app transition to "PAUSING" and eventually "PAUSED". When "PAUSED", you should be able to click on the "RESUME" button to reverse the process

If you change enableAppPausing to false in config_local.json, you should see a disabled "PAUSE" button on a running GKE app.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
