### PR TITLE
[risk=no][RW-11283] Reduce re-mount count of access module card titles

### DIFF
--- a/ui/src/app/pages/access/aar-title.spec.tsx
+++ b/ui/src/app/pages/access/aar-title.spec.tsx
@@ -6,12 +6,8 @@ import { AccessModule, ConfigResponse, ProfileApi } from 'generated/fetch';
 
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { AARTitle } from 'app/pages/access/aar-title';
-import {
-  queryForCTTitle,
-  queryForRTTitle,
-} from 'app/pages/access/compliance-training-module-card-title.spec';
-import { DARTitleProps } from 'app/pages/access/dar-title';
+import { AARTitle, AARTitleProps } from 'app/pages/access/aar-title';
+import { queryForCTTitle, queryForRTTitle } from 'app/pages/access/test-utils';
 import { createEmptyProfile } from 'app/pages/login/sign-in';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { serverConfigStore } from 'app/utils/stores';
@@ -19,7 +15,7 @@ import { serverConfigStore } from 'app/utils/stores';
 import defaultServerConfig from 'testing/default-server-config';
 import { ProfileApiStub } from 'testing/stubs/profile-api-stub';
 
-const createProps = (): DARTitleProps => ({
+const createProps = (): AARTitleProps => ({
   moduleName: AccessModule.COMPLIANCE_TRAINING,
   profile: {
     ...createEmptyProfile(),

--- a/ui/src/app/pages/access/aar-title.spec.tsx
+++ b/ui/src/app/pages/access/aar-title.spec.tsx
@@ -1,0 +1,77 @@
+import '@testing-library/jest-dom';
+
+import * as React from 'react';
+
+import { AccessModule, ConfigResponse, ProfileApi } from 'generated/fetch';
+
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AARTitle } from 'app/pages/access/aar-title';
+import {
+  queryForCTTitle,
+  queryForRTTitle,
+} from 'app/pages/access/compliance-training-module-card-title.spec';
+import { DARTitleProps } from 'app/pages/access/dar-title';
+import { createEmptyProfile } from 'app/pages/login/sign-in';
+import { registerApiClient } from 'app/services/swagger-fetch-clients';
+import { serverConfigStore } from 'app/utils/stores';
+
+import defaultServerConfig from 'testing/default-server-config';
+import { ProfileApiStub } from 'testing/stubs/profile-api-stub';
+
+const createProps = (): DARTitleProps => ({
+  moduleName: AccessModule.COMPLIANCE_TRAINING,
+  profile: {
+    ...createEmptyProfile(),
+  },
+});
+
+const setup = (
+  props = createProps(),
+  config: ConfigResponse = { ...defaultServerConfig }
+) => {
+  registerApiClient(ProfileApi, new ProfileApiStub());
+  serverConfigStore.set({ config });
+  render(<AARTitle {...props} />);
+  return userEvent.setup();
+};
+
+describe(AARTitle.name, () => {
+  it('renders registered tier training title if module is COMPLIANCE_TRAINING', () => {
+    setup({
+      ...createProps(),
+      moduleName: AccessModule.COMPLIANCE_TRAINING,
+    });
+
+    expect(queryForRTTitle()).not.toBeNull();
+  });
+
+  it('does not render registered tier training title if module is not COMPLIANCE_TRAINING', () => {
+    setup({
+      ...createProps(),
+      // arbitrary non-COMPLIANCE_TRAINING module
+      moduleName: AccessModule.PROFILE_CONFIRMATION,
+    });
+
+    expect(queryForRTTitle()).toBeNull();
+  });
+
+  it('renders controlled tier training title if module is CT_COMPLIANCE_TRAINING', () => {
+    setup({
+      ...createProps(),
+      moduleName: AccessModule.CT_COMPLIANCE_TRAINING,
+    });
+
+    expect(queryForCTTitle()).not.toBeNull();
+  });
+
+  it('does not render controlled tier training title if module is not CT_COMPLIANCE_TRAINING', () => {
+    setup({
+      ...createProps(),
+      // arbitrary non-COMPLIANCE_TRAINING module
+      moduleName: AccessModule.PROFILE_CONFIRMATION,
+    });
+
+    expect(queryForCTTitle()).toBeNull();
+  });
+});

--- a/ui/src/app/pages/access/aar-title.tsx
+++ b/ui/src/app/pages/access/aar-title.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import { AccessModule, Profile } from 'generated/fetch';
+
+import { DEFAULT, switchCase } from '@terra-ui-packages/core-utils';
+import { ComplianceTrainingModuleCardTitle } from 'app/pages/access/compliance-training-module-card-title';
+import { AccessTierShortNames } from 'app/utils/access-tiers';
+
+export interface AARTitleProps {
+  moduleName: AccessModule;
+  profile: Profile;
+}
+
+export const AARTitle = (props: AARTitleProps) => {
+  return switchCase<AccessModule, React.ReactElement>(
+    props.moduleName,
+    [AccessModule.TWO_FACTOR_AUTH, () => null],
+    [AccessModule.IDENTITY, () => null],
+    [AccessModule.ERA_COMMONS, () => null],
+    [
+      AccessModule.COMPLIANCE_TRAINING,
+      () => (
+        <ComplianceTrainingModuleCardTitle
+          tier={AccessTierShortNames.Registered}
+          profile={props.profile}
+        />
+      ),
+    ],
+    [
+      AccessModule.CT_COMPLIANCE_TRAINING,
+      () => (
+        <ComplianceTrainingModuleCardTitle
+          tier={AccessTierShortNames.Controlled}
+          profile={props.profile}
+        />
+      ),
+    ],
+    [
+      AccessModule.DATA_USER_CODE_OF_CONDUCT,
+      () => <span>Sign Data User Code of Conduct</span>,
+    ],
+    [AccessModule.PROFILE_CONFIRMATION, () => <span>Update your profile</span>],
+    [
+      AccessModule.PUBLICATION_CONFIRMATION,
+      () => (
+        <span>
+          Report any publications or presentations based on your research using
+          the Researcher Workbench
+        </span>
+      ),
+    ],
+    [DEFAULT, () => null]
+  );
+};

--- a/ui/src/app/pages/access/aar-title.tsx
+++ b/ui/src/app/pages/access/aar-title.tsx
@@ -14,9 +14,6 @@ export interface AARTitleProps {
 export const AARTitle = (props: AARTitleProps) => {
   return switchCase<AccessModule, React.ReactElement>(
     props.moduleName,
-    [AccessModule.TWO_FACTOR_AUTH, () => null],
-    [AccessModule.IDENTITY, () => null],
-    [AccessModule.ERA_COMMONS, () => null],
     [
       AccessModule.COMPLIANCE_TRAINING,
       () => (

--- a/ui/src/app/pages/access/compliance-training-module-card-title.spec.tsx
+++ b/ui/src/app/pages/access/compliance-training-module-card-title.spec.tsx
@@ -15,6 +15,7 @@ import {
   ComplianceTrainingModuleCardProps,
   ComplianceTrainingModuleCardTitle,
 } from 'app/pages/access/compliance-training-module-card-title';
+import { queryForCTTitle, queryForRTTitle } from 'app/pages/access/test-utils';
 import { createEmptyProfile } from 'app/pages/login/sign-in';
 import {
   profileApi,
@@ -85,14 +86,6 @@ const setup = (
       .container,
     user: userEvent.setup(),
   };
-};
-
-export const queryForRTTitle = () => {
-  return screen.queryByText(/responsible conduct of research training/i);
-};
-
-export const queryForCTTitle = () => {
-  return screen.queryByText(/controlled tier training/i);
 };
 
 describe(ComplianceTrainingModuleCardTitle.name, () => {

--- a/ui/src/app/pages/access/compliance-training-module-card-title.spec.tsx
+++ b/ui/src/app/pages/access/compliance-training-module-card-title.spec.tsx
@@ -87,6 +87,14 @@ const setup = (
   };
 };
 
+export const queryForRTTitle = () => {
+  return screen.queryByText(/responsible conduct of research training/i);
+};
+
+export const queryForCTTitle = () => {
+  return screen.queryByText(/controlled tier training/i);
+};
+
 describe(ComplianceTrainingModuleCardTitle.name, () => {
   it('renders registered tier training title', () => {
     setup({
@@ -94,9 +102,7 @@ describe(ComplianceTrainingModuleCardTitle.name, () => {
       tier: AccessTierShortNames.Registered,
     });
 
-    expect(
-      screen.queryByText(/responsible conduct of research training/i)
-    ).not.toBeNull();
+    expect(queryForRTTitle()).not.toBeNull();
   });
 
   it('renders controlled tier training title', () => {
@@ -105,7 +111,7 @@ describe(ComplianceTrainingModuleCardTitle.name, () => {
       tier: AccessTierShortNames.Controlled,
     });
 
-    expect(screen.queryByText(/controlled tier training/i)).not.toBeNull();
+    expect(queryForCTTitle()).not.toBeNull();
   });
 
   it('shows help text if module is incomplete', async () => {

--- a/ui/src/app/pages/access/dar-title.spec.tsx
+++ b/ui/src/app/pages/access/dar-title.spec.tsx
@@ -1,0 +1,73 @@
+import '@testing-library/jest-dom';
+
+import * as React from 'react';
+
+import { AccessModule, ConfigResponse } from 'generated/fetch';
+
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  queryForCTTitle,
+  queryForRTTitle,
+} from 'app/pages/access/compliance-training-module-card-title.spec';
+import { DARTitle, DARTitleProps } from 'app/pages/access/dar-title';
+import { createEmptyProfile } from 'app/pages/login/sign-in';
+import { serverConfigStore } from 'app/utils/stores';
+
+import defaultServerConfig from 'testing/default-server-config';
+
+const createProps = (): DARTitleProps => ({
+  moduleName: AccessModule.COMPLIANCE_TRAINING,
+  profile: {
+    ...createEmptyProfile(),
+  },
+});
+
+const setup = (
+  props = createProps(),
+  config: ConfigResponse = { ...defaultServerConfig }
+) => {
+  serverConfigStore.set({ config });
+  render(<DARTitle {...props} />);
+  return userEvent.setup();
+};
+
+describe(DARTitle.name, () => {
+  it('renders registered tier training title if module is COMPLIANCE_TRAINING', () => {
+    setup({
+      ...createProps(),
+      moduleName: AccessModule.COMPLIANCE_TRAINING,
+    });
+
+    expect(queryForRTTitle()).not.toBeNull();
+  });
+
+  it('does not render registered tier training title if module is not COMPLIANCE_TRAINING', () => {
+    setup({
+      ...createProps(),
+      // arbitrary non-COMPLIANCE_TRAINING module
+      moduleName: AccessModule.PROFILE_CONFIRMATION,
+    });
+
+    expect(queryForRTTitle()).toBeNull();
+  });
+
+  it('renders controlled tier training title if module is CT_COMPLIANCE_TRAINING', () => {
+    setup({
+      ...createProps(),
+      moduleName: AccessModule.CT_COMPLIANCE_TRAINING,
+    });
+
+    expect(queryForCTTitle()).not.toBeNull();
+  });
+
+  it('does not render controlled tier training title if module is not CT_COMPLIANCE_TRAINING', () => {
+    setup({
+      ...createProps(),
+      // arbitrary non-COMPLIANCE_TRAINING module
+      moduleName: AccessModule.PROFILE_CONFIRMATION,
+    });
+
+    expect(queryForCTTitle()).toBeNull();
+  });
+});

--- a/ui/src/app/pages/access/dar-title.spec.tsx
+++ b/ui/src/app/pages/access/dar-title.spec.tsx
@@ -2,19 +2,18 @@ import '@testing-library/jest-dom';
 
 import * as React from 'react';
 
-import { AccessModule, ConfigResponse } from 'generated/fetch';
+import { AccessModule, ConfigResponse, ProfileApi } from 'generated/fetch';
 
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {
-  queryForCTTitle,
-  queryForRTTitle,
-} from 'app/pages/access/compliance-training-module-card-title.spec';
 import { DARTitle, DARTitleProps } from 'app/pages/access/dar-title';
+import { queryForCTTitle, queryForRTTitle } from 'app/pages/access/test-utils';
 import { createEmptyProfile } from 'app/pages/login/sign-in';
+import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { serverConfigStore } from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
+import { ProfileApiStub } from 'testing/stubs/profile-api-stub';
 
 const createProps = (): DARTitleProps => ({
   moduleName: AccessModule.COMPLIANCE_TRAINING,
@@ -27,6 +26,7 @@ const setup = (
   props = createProps(),
   config: ConfigResponse = { ...defaultServerConfig }
 ) => {
+  registerApiClient(ProfileApi, new ProfileApiStub());
   serverConfigStore.set({ config });
   render(<DARTitle {...props} />);
   return userEvent.setup();

--- a/ui/src/app/pages/access/dar-title.tsx
+++ b/ui/src/app/pages/access/dar-title.tsx
@@ -78,8 +78,6 @@ export const DARTitle = (props: DARTitleProps) => {
       AccessModule.DATA_USER_CODE_OF_CONDUCT,
       () => <div>Sign Data User Code of Conduct</div>,
     ],
-    [AccessModule.PROFILE_CONFIRMATION, () => null],
-    [AccessModule.PUBLICATION_CONFIRMATION, () => null],
     [DEFAULT, () => null]
   );
 };

--- a/ui/src/app/pages/access/dar-title.tsx
+++ b/ui/src/app/pages/access/dar-title.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+
+import { AccessModule, Profile } from 'generated/fetch';
+
+import { DEFAULT, switchCase } from '@terra-ui-packages/core-utils';
+import { InfoIcon } from 'app/components/icons';
+import { TooltipTrigger } from 'app/components/popups';
+import { ComplianceTrainingModuleCardTitle } from 'app/pages/access/compliance-training-module-card-title';
+import { IdentityHelpText } from 'app/pages/access/identity-help-text';
+import { LoginGovHelpText } from 'app/pages/access/login-gov-help-text';
+import { AccessTierShortNames } from 'app/utils/access-tiers';
+import { serverConfigStore } from 'app/utils/stores';
+
+export interface DARTitleProps {
+  moduleName: AccessModule;
+  profile: Profile;
+  afterInitialClick?: boolean;
+  onClick?: Function;
+}
+
+export const DARTitle = (props: DARTitleProps) => {
+  const { enableRasIdMeLinking } = serverConfigStore.get().config;
+
+  return switchCase<AccessModule, React.ReactElement>(
+    props.moduleName,
+    [
+      AccessModule.TWO_FACTOR_AUTH,
+      () => <div>Turn on Google 2-Step Verification</div>,
+    ],
+    [
+      AccessModule.IDENTITY,
+      () => {
+        return enableRasIdMeLinking ? (
+          <>
+            <div>Verify your identity</div>
+            <IdentityHelpText {...props} />
+          </>
+        ) : (
+          <>
+            <div>
+              Verify your identity with Login.gov{' '}
+              <TooltipTrigger
+                content={
+                  'For additional security, we require you to verify your identity by uploading a photo of your ID.'
+                }
+              >
+                <InfoIcon style={{ margin: '0 0.45rem' }} />
+              </TooltipTrigger>
+            </div>
+            <LoginGovHelpText {...props} />
+          </>
+        );
+      },
+    ],
+    [
+      AccessModule.ERA_COMMONS,
+      () => <div>Connect your eRA Commons account</div>,
+    ],
+    [
+      AccessModule.COMPLIANCE_TRAINING,
+      () => (
+        <ComplianceTrainingModuleCardTitle
+          tier={AccessTierShortNames.Registered}
+          profile={props.profile}
+        />
+      ),
+    ],
+    [
+      AccessModule.CT_COMPLIANCE_TRAINING,
+      () => (
+        <ComplianceTrainingModuleCardTitle
+          tier={AccessTierShortNames.Controlled}
+          profile={props.profile}
+        />
+      ),
+    ],
+    [
+      AccessModule.DATA_USER_CODE_OF_CONDUCT,
+      () => <div>Sign Data User Code of Conduct</div>,
+    ],
+    [AccessModule.PROFILE_CONFIRMATION, () => null],
+    [AccessModule.PUBLICATION_CONFIRMATION, () => null],
+    [DEFAULT, () => null]
+  );
+};

--- a/ui/src/app/pages/access/module.tsx
+++ b/ui/src/app/pages/access/module.tsx
@@ -8,6 +8,7 @@ import { Clickable } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { ArrowRight } from 'app/components/icons';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
+import { DARTitle } from 'app/pages/access/dar-title';
 import {
   getAccessModuleConfig,
   getStatusText,
@@ -72,7 +73,7 @@ export const Module = (props: {
   // whether to show the refresh button: this module has been clicked
   const [showRefresh, setShowRefresh] = useState(false);
 
-  const { DARTitleComponent, refreshAction, isEnabledInEnvironment } =
+  const { refreshAction, isEnabledInEnvironment } =
     getAccessModuleConfig(moduleName);
 
   return isEnabledInEnvironment ? (
@@ -114,7 +115,8 @@ export const Module = (props: {
               ...{ fontWeight: 500 },
             }}
           >
-            <DARTitleComponent
+            <DARTitle
+              moduleName={moduleName}
               {...{ profile }}
               afterInitialClick={showRefresh}
               onClick={() => {

--- a/ui/src/app/pages/access/modules-for-annual-renewal.tsx
+++ b/ui/src/app/pages/access/modules-for-annual-renewal.tsx
@@ -12,6 +12,7 @@ import { RadioButton } from 'app/components/inputs';
 import { withErrorModal, withSuccessModal } from 'app/components/modals';
 import { SupportMailto } from 'app/components/support';
 import { AoU } from 'app/components/text-wrappers';
+import { AARTitle } from 'app/pages/access/aar-title';
 import { profileApi } from 'app/services/swagger-fetch-clients';
 import colors, { addOpacity, colorWithWhiteness } from 'app/styles/colors';
 import { useId } from 'app/utils';
@@ -230,7 +231,7 @@ export const RenewalCardBody = ({
 
   const { duccSignedVersion } = profile;
 
-  const { AARTitleComponent, renewalTimeEstimate } = getAccessModuleConfig(
+  const { renewalTimeEstimate } = getAccessModuleConfig(
     moduleStatus.moduleName
   );
   const { lastConfirmedDate, nextReviewDate } = computeRenewalDisplayDates(
@@ -542,7 +543,7 @@ export const RenewalCardBody = ({
         )}
       </div>
       <div style={{ gridArea: 'title', fontWeight: 500 }}>
-        <AARTitleComponent profile={profile} />
+        <AARTitle moduleName={moduleStatus.moduleName} profile={profile} />
       </div>
       {module}
     </div>

--- a/ui/src/app/pages/access/registered-tier-card.tsx
+++ b/ui/src/app/pages/access/registered-tier-card.tsx
@@ -6,8 +6,9 @@ import { switchCase } from '@terra-ui-packages/core-utils';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { RegisteredTierBadge } from 'app/components/icons';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
+import { DARTitle } from 'app/pages/access/dar-title';
 import { AccessTierDisplayNames } from 'app/utils/access-tiers';
-import { DARPageMode, getAccessModuleConfig } from 'app/utils/access-utils';
+import { DARPageMode } from 'app/utils/access-utils';
 import { serverConfigStore } from 'app/utils/stores';
 
 import {
@@ -24,7 +25,6 @@ import { ModulesForInitialRegistration } from './modules-for-initial-registratio
 // Sep 16 hack while we work out some RAS bugs
 const TemporaryRASModule = (props: { profile: Profile }) => {
   const moduleName = AccessModule.IDENTITY;
-  const { DARTitleComponent } = getAccessModuleConfig(moduleName);
   return (
     <FlexRow data-test-id={`module-${moduleName}`}>
       <FlexRow style={styles.moduleCTA} />
@@ -35,7 +35,7 @@ const TemporaryRASModule = (props: { profile: Profile }) => {
           eligible={false}
         />
         <FlexColumn style={styles.backgroundModuleText}>
-          <DARTitleComponent profile={props.profile} />
+          <DARTitle moduleName={moduleName} profile={props.profile} />
           <div style={{ fontSize: '14px', marginTop: '0.5em' }}>
             <b>Temporarily disabled.</b> Due to technical difficulties, this
             step is disabled. In the future, you'll be prompted to complete

--- a/ui/src/app/pages/access/test-utils.ts
+++ b/ui/src/app/pages/access/test-utils.ts
@@ -1,0 +1,8 @@
+import { screen } from '@testing-library/react';
+
+export const queryForRTTitle = () => {
+  return screen.queryByText(/responsible conduct of research training/i);
+};
+export const queryForCTTitle = () => {
+  return screen.queryByText(/controlled tier training/i);
+};

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -13,11 +13,7 @@ import {
 import { cond, DEFAULT, switchCase } from '@terra-ui-packages/core-utils';
 import { parseQueryParams } from 'app/components/app-router';
 import { Button } from 'app/components/buttons';
-import { InfoIcon } from 'app/components/icons';
-import { TooltipTrigger } from 'app/components/popups';
 import { ComplianceTrainingModuleCardTitle } from 'app/pages/access/compliance-training-module-card-title';
-import { IdentityHelpText } from 'app/pages/access/identity-help-text';
-import { LoginGovHelpText } from 'app/pages/access/login-gov-help-text';
 import { userIsDisabled } from 'app/routing/guards';
 import { profileApi } from 'app/services/swagger-fetch-clients';
 import { AnalyticsTracker } from 'app/utils/analytics';
@@ -175,12 +171,6 @@ export const DATA_ACCESS_REQUIREMENTS_PATH = '/data-access-requirements';
 export const ACCESS_RENEWAL_PATH =
   DATA_ACCESS_REQUIREMENTS_PATH + '?pageMode=' + DARPageMode.ANNUAL_RENEWAL;
 
-interface DARTitleComponentConfig {
-  profile: Profile;
-  afterInitialClick?: boolean;
-  onClick?: Function;
-}
-
 interface AARTitleComponentConfig {
   profile: Profile;
 }
@@ -188,7 +178,6 @@ interface AARTitleComponentConfig {
 interface AccessModuleUIConfig extends AccessModuleConfig {
   isEnabledInEnvironment: boolean; // either true or dependent on a feature flag
   AARTitleComponent: (config: AARTitleComponentConfig) => JSX.Element;
-  DARTitleComponent: (config: DARTitleComponentConfig) => JSX.Element;
   adminPageTitle: string;
   externalSyncAction?: Function;
   refreshAction?: Function;
@@ -207,7 +196,6 @@ export const getAccessModuleConfig = (
   moduleName: AccessModule
 ): AccessModuleUIConfig => {
   const {
-    enableRasIdMeLinking,
     enableRasLoginGovLinking,
     enableEraCommons,
     enableComplianceTraining,
@@ -222,7 +210,6 @@ export const getAccessModuleConfig = (
       () => ({
         ...apiConfig,
         isEnabledInEnvironment: true,
-        DARTitleComponent: () => <div>Turn on Google 2-Step Verification</div>,
         adminPageTitle: 'Google 2-Step Verification',
         externalSyncAction: async () =>
           await profileApi().syncTwoFactorAuthStatus(),
@@ -234,28 +221,6 @@ export const getAccessModuleConfig = (
       () => ({
         ...apiConfig,
         isEnabledInEnvironment: enableRasLoginGovLinking,
-        DARTitleComponent: (props: DARTitleComponentConfig) => {
-          return enableRasIdMeLinking ? (
-            <>
-              <div>Verify your identity</div>
-              <IdentityHelpText {...props} />
-            </>
-          ) : (
-            <>
-              <div>
-                Verify your identity with Login.gov{' '}
-                <TooltipTrigger
-                  content={
-                    'For additional security, we require you to verify your identity by uploading a photo of your ID.'
-                  }
-                >
-                  <InfoIcon style={{ margin: '0 0.45rem' }} />
-                </TooltipTrigger>
-              </div>
-              <LoginGovHelpText {...props} />
-            </>
-          );
-        },
         adminPageTitle: 'Verify your identity with Login.gov',
         refreshAction: () => redirectToRas(false),
       }),
@@ -266,7 +231,6 @@ export const getAccessModuleConfig = (
       () => ({
         ...apiConfig,
         isEnabledInEnvironment: enableEraCommons,
-        DARTitleComponent: () => <div>Connect your eRA Commons account</div>,
         adminPageTitle: 'Connect your eRA Commons* account',
         externalSyncAction: async () =>
           await profileApi().syncEraCommonsStatus(),
@@ -280,12 +244,6 @@ export const getAccessModuleConfig = (
         ...apiConfig,
         isEnabledInEnvironment: enableComplianceTraining,
         AARTitleComponent: (props: AARTitleComponentConfig) => (
-          <ComplianceTrainingModuleCardTitle
-            tier={AccessTierShortNames.Registered}
-            profile={props.profile}
-          />
-        ),
-        DARTitleComponent: (props: DARTitleComponentConfig) => (
           <ComplianceTrainingModuleCardTitle
             tier={AccessTierShortNames.Registered}
             profile={props.profile}
@@ -311,12 +269,6 @@ export const getAccessModuleConfig = (
             profile={props.profile}
           />
         ),
-        DARTitleComponent: (props: DARTitleComponentConfig) => (
-          <ComplianceTrainingModuleCardTitle
-            tier={AccessTierShortNames.Controlled}
-            profile={props.profile}
-          />
-        ),
         adminPageTitle: 'Controlled Tier training',
         externalSyncAction: async () =>
           await profileApi().syncComplianceTrainingStatus(),
@@ -332,7 +284,6 @@ export const getAccessModuleConfig = (
         ...apiConfig,
         isEnabledInEnvironment: true,
         AARTitleComponent: () => 'Sign Data User Code of Conduct',
-        DARTitleComponent: () => <div>Sign Data User Code of Conduct</div>,
         adminPageTitle: 'Sign Data User Code of Conduct',
         renewalTimeEstimate: 5,
       }),

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -13,7 +13,6 @@ import {
 import { cond, DEFAULT, switchCase } from '@terra-ui-packages/core-utils';
 import { parseQueryParams } from 'app/components/app-router';
 import { Button } from 'app/components/buttons';
-import { ComplianceTrainingModuleCardTitle } from 'app/pages/access/compliance-training-module-card-title';
 import { userIsDisabled } from 'app/routing/guards';
 import { profileApi } from 'app/services/swagger-fetch-clients';
 import { AnalyticsTracker } from 'app/utils/analytics';
@@ -171,13 +170,8 @@ export const DATA_ACCESS_REQUIREMENTS_PATH = '/data-access-requirements';
 export const ACCESS_RENEWAL_PATH =
   DATA_ACCESS_REQUIREMENTS_PATH + '?pageMode=' + DARPageMode.ANNUAL_RENEWAL;
 
-interface AARTitleComponentConfig {
-  profile: Profile;
-}
-
 interface AccessModuleUIConfig extends AccessModuleConfig {
   isEnabledInEnvironment: boolean; // either true or dependent on a feature flag
-  AARTitleComponent: (config: AARTitleComponentConfig) => JSX.Element;
   adminPageTitle: string;
   externalSyncAction?: Function;
   refreshAction?: Function;
@@ -243,12 +237,6 @@ export const getAccessModuleConfig = (
       () => ({
         ...apiConfig,
         isEnabledInEnvironment: enableComplianceTraining,
-        AARTitleComponent: (props: AARTitleComponentConfig) => (
-          <ComplianceTrainingModuleCardTitle
-            tier={AccessTierShortNames.Registered}
-            profile={props.profile}
-          />
-        ),
         adminPageTitle: 'Registered Tier training',
         externalSyncAction: async () =>
           await profileApi().syncComplianceTrainingStatus(),
@@ -263,12 +251,6 @@ export const getAccessModuleConfig = (
       () => ({
         ...apiConfig,
         isEnabledInEnvironment: enableComplianceTraining,
-        AARTitleComponent: (props: AARTitleComponentConfig) => (
-          <ComplianceTrainingModuleCardTitle
-            tier={AccessTierShortNames.Controlled}
-            profile={props.profile}
-          />
-        ),
         adminPageTitle: 'Controlled Tier training',
         externalSyncAction: async () =>
           await profileApi().syncComplianceTrainingStatus(),
@@ -283,7 +265,6 @@ export const getAccessModuleConfig = (
       () => ({
         ...apiConfig,
         isEnabledInEnvironment: true,
-        AARTitleComponent: () => 'Sign Data User Code of Conduct',
         adminPageTitle: 'Sign Data User Code of Conduct',
         renewalTimeEstimate: 5,
       }),
@@ -294,7 +275,6 @@ export const getAccessModuleConfig = (
       () => ({
         ...apiConfig,
         isEnabledInEnvironment: true,
-        AARTitleComponent: () => 'Update your profile',
         adminPageTitle: 'Update your profile',
         renewalTimeEstimate: 5,
       }),
@@ -305,8 +285,6 @@ export const getAccessModuleConfig = (
       () => ({
         ...apiConfig,
         isEnabledInEnvironment: true,
-        AARTitleComponent: () =>
-          'Report any publications or presentations based on your research using the Researcher Workbench',
         adminPageTitle: 'Report any publications',
         renewalTimeEstimate: 5,
       }),


### PR DESCRIPTION
Reduce re-mount count of access module card titles. This reduces the number of `useAbsorb` calls on the data access and access renewal pages from 14 to 3 and 2, respectively. Since we render 2 cards and each card invokes `useAbsorb`, 2 is the minimum without other approaches like lifting state.

This can be validated by loading the data access page and counting the number of network calls to `useAbsorb`.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.