### PR TITLE
[RW-11366][risk=no] Fix Access Module Infinite Spinner

### DIFF
--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -2103,10 +2103,10 @@ describe('DataAccessRequirements', () => {
 
     await waitFor(() => {
       expect(notificationStore.get().title).toEqual(
-        'Error Syncronizing Training'
+        'Error Syncronizing Modals'
       );
       expect(notificationStore.get().message).toEqual(
-        'Encountered an error syncronizing your Absorb training.'
+        'Encountered an error syncronizing your external modals.'
       );
     });
   });

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -2103,7 +2103,7 @@ describe('DataAccessRequirements', () => {
 
     await waitFor(() => {
       expect(notificationStore.get().title).toEqual(
-        'Error Syncronizing Modals'
+        'Error Syncronizing Training Status'
       );
       expect(notificationStore.get().message).toEqual(
         'Deliberate testing failure for syncModulesExternal'

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -303,6 +303,7 @@ describe('DataAccessRequirements', () => {
   afterEach(() => {
     // reset to standard behavior after tests which use fake timers
     jest.useRealTimers();
+    notificationStore.reset();
   });
 
   it('should return all required modules from getEligibleModules by default (all FFs enabled)', () => {
@@ -2103,7 +2104,7 @@ describe('DataAccessRequirements', () => {
 
     await waitFor(() => {
       expect(notificationStore.get().title).toEqual(
-        'Error Syncronizing Training Status'
+        'Error Synchronizing Training Status'
       );
       expect(notificationStore.get().message).toEqual(
         'Deliberate testing failure for syncModulesExternal'

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -2097,7 +2097,7 @@ describe('DataAccessRequirements', () => {
     spySyncModulesExternal.mockImplementation(() =>
       Promise.reject('Deliberate testing failure for syncModulesExternal')
     );
-    const { container } = component();
+    component();
     expect(spySyncModulesExternal).toHaveBeenCalledTimes(1);
     expect(notificationStore.get()).toBeNull();
 

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -2106,7 +2106,7 @@ describe('DataAccessRequirements', () => {
         'Error Syncronizing Modals'
       );
       expect(notificationStore.get().message).toEqual(
-        'Encountered an error syncronizing your external modals.'
+        'Deliberate testing failure for syncModulesExternal'
       );
     });
   });

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -11,7 +11,7 @@ import {
 } from 'generated/fetch';
 
 import { switchCase } from '@terra-ui-packages/core-utils';
-import { render, RenderResult, screen } from '@testing-library/react';
+import { render, RenderResult, screen, waitFor } from '@testing-library/react';
 import {
   profileApi,
   registerApiClient,
@@ -24,7 +24,11 @@ import {
   rtAccessRenewalModules,
 } from 'app/utils/access-utils';
 import { nowPlusDays } from 'app/utils/dates';
-import { profileStore, serverConfigStore } from 'app/utils/stores';
+import {
+  notificationStore,
+  profileStore,
+  serverConfigStore,
+} from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
 import {
@@ -2092,6 +2096,15 @@ describe('DataAccessRequirements', () => {
     );
     const { container } = component();
     expect(spySyncModulesExternal).toHaveBeenCalledTimes(1);
-    await screen.findByText('Failed to sync external modals');
+    expect(notificationStore.get()).toBeNull();
+
+    await waitFor(() => {
+      expect(notificationStore.get().title).toEqual(
+        'Error Syncronizing Training'
+      );
+      expect(notificationStore.get().message).toEqual(
+        'Encountered an error syncronizing your Absorb training.'
+      );
+    });
   });
 });

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -2089,9 +2089,12 @@ describe('DataAccessRequirements', () => {
     expectButtonElementEnabled(screen.queryByText('Confirm'));
   });
 
-  const spySyncModulesExternal = jest.spyOn(accessUtils, 'syncModulesExternal');
   it('should show an error modal when syncModulesExternal fails', async () => {
-    spySyncModulesExternal.mockReturnValue(
+    const spySyncModulesExternal = jest.spyOn(
+      accessUtils,
+      'syncModulesExternal'
+    );
+    spySyncModulesExternal.mockImplementation(() =>
       Promise.reject('Deliberate testing failure for syncModulesExternal')
     );
     const { container } = component();

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -17,6 +17,7 @@ import {
   registerApiClient,
 } from 'app/services/swagger-fetch-clients';
 import { AccessTierShortNames } from 'app/utils/access-tiers';
+import * as accessUtils from 'app/utils/access-utils';
 import {
   DARPageMode,
   DATA_ACCESS_REQUIREMENTS_PATH,
@@ -2082,5 +2083,15 @@ describe('DataAccessRequirements', () => {
     ).click();
 
     expectButtonElementEnabled(screen.queryByText('Confirm'));
+  });
+
+  const spySyncModulesExternal = jest.spyOn(accessUtils, 'syncModulesExternal');
+  it('should show an error modal when ', async () => {
+    spySyncModulesExternal.mockReturnValue(
+      Promise.reject('Deliberate testing failure for syncModulesExternal')
+    );
+    const { container } = component();
+    expect(spySyncModulesExternal).toHaveBeenCalledTimes(1);
+    await screen.findByText('Failed to sync external modals');
   });
 });

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -2098,9 +2098,9 @@ describe('DataAccessRequirements', () => {
     spySyncModulesExternal.mockImplementation(() =>
       Promise.reject('Deliberate testing failure for syncModulesExternal')
     );
+    expect(notificationStore.get()).toBeNull();
     component();
     expect(spySyncModulesExternal).toHaveBeenCalledTimes(1);
-    expect(notificationStore.get()).toBeNull();
 
     await waitFor(() => {
       expect(notificationStore.get().title).toEqual(

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -2086,7 +2086,7 @@ describe('DataAccessRequirements', () => {
   });
 
   const spySyncModulesExternal = jest.spyOn(accessUtils, 'syncModulesExternal');
-  it('should show an error modal when ', async () => {
+  it('should show an error modal when syncModulesExternal fails', async () => {
     spySyncModulesExternal.mockReturnValue(
       Promise.reject('Deliberate testing failure for syncModulesExternal')
     );

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -698,19 +698,29 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
 
     // Effects
     useEffect(() => {
-      const onMount = async () => {
-        await syncModulesExternal(
-          incompleteModules(
-            getEligibleModules(allInitialModules, profile),
-            profile,
-            pageMode
-          )
-        );
-        await reload();
-        spinnerProps.hideSpinner();
-      };
+      const syncModalsPromise = fetchWithErrorModal(
+        () =>
+          syncModulesExternal(
+            incompleteModules(
+              getEligibleModules(allInitialModules, profile),
+              profile,
+              pageMode
+            )
+          ),
+        {
+          customErrorResponseFormatter: (apiErrorResponse) => {
+            return {
+              title: 'Error Syncronizing Training',
+              message: `Encountered an error syncronizing your Absorb training.`,
+              showBugReportLink: true,
+            };
+          },
+        }
+      );
 
-      onMount();
+      syncModalsPromise
+        .then(async () => await reload())
+        .finally(() => spinnerProps.hideSpinner());
     }, []);
 
     /*

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -710,8 +710,8 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
         {
           customErrorResponseFormatter: (apiErrorResponse) => {
             return {
-              title: 'Error Syncronizing Training',
-              message: `Encountered an error syncronizing your Absorb training.`,
+              title: 'Error Syncronizing Modals',
+              message: `Encountered an error syncronizing your external modals.`,
               showBugReportLink: true,
             };
           },

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -720,7 +720,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
 
       syncModulesPromise
         .then(async () => await reload())
-        .catch(() => console.error('Failed to syncronize Absorb records.'))
+        .catch((e) => console.error(e))
         .finally(() => spinnerProps.hideSpinner());
     }, []);
 

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -711,7 +711,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
           customErrorResponseFormatter: (apiErrorResponse) => {
             return {
               title: 'Error Syncronizing Modals',
-              message: `Encountered an error syncronizing your external modals.`,
+              message: `${apiErrorResponse.originalResponse}`,
               showBugReportLink: true,
             };
           },

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -710,7 +710,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
         {
           customErrorResponseFormatter: (apiErrorResponse) => {
             return {
-              title: 'Error Synchronizing Modules',
+              title: 'Error Synchronizing Training Status',
               message: `${apiErrorResponse.originalResponse}`,
               showBugReportLink: true,
             };

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -710,7 +710,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
         {
           customErrorResponseFormatter: (apiErrorResponse) => {
             return {
-              title: 'Error Syncronizing Modals',
+              title: 'Error Syncronizing Modules',
               message: `${apiErrorResponse.originalResponse}`,
               showBugReportLink: true,
             };

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -710,7 +710,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
         {
           customErrorResponseFormatter: (apiErrorResponse) => {
             return {
-              title: 'Error Syncronizing Modules',
+              title: 'Error Synchronizing Modules',
               message: `${apiErrorResponse.originalResponse}`,
               showBugReportLink: true,
             };

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -698,7 +698,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
 
     // Effects
     useEffect(() => {
-      const syncModalsPromise = fetchWithErrorModal(
+      const syncModulesPromise = fetchWithErrorModal(
         () =>
           syncModulesExternal(
             incompleteModules(
@@ -718,8 +718,9 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
         }
       );
 
-      syncModalsPromise
+      syncModulesPromise
         .then(async () => await reload())
+        .catch(() => console.error('Failed to syncronize Absorb records.'))
         .finally(() => spinnerProps.hideSpinner());
     }, []);
 

--- a/ui/src/app/utils/access-utils.spec.tsx
+++ b/ui/src/app/utils/access-utils.spec.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Prompt } from 'react-router';
 import { mount, ReactWrapper } from 'enzyme';
 
 import {

--- a/ui/src/app/utils/access-utils.spec.tsx
+++ b/ui/src/app/utils/access-utils.spec.tsx
@@ -941,7 +941,7 @@ describe(syncModulesExternal.name, () => {
   });
 
   it('should return a successful promise when no modules are passed', () => {
-    expect(syncModulesExternal([])).toBeTruthy();
+    expect(syncModulesExternal([])).resolves.toBeTruthy();
   });
 
   it('should return a successful promise when all externalSyncActions succeed ', () => {

--- a/ui/src/app/utils/access-utils.spec.tsx
+++ b/ui/src/app/utils/access-utils.spec.tsx
@@ -942,34 +942,16 @@ describe(syncModulesExternal.name, () => {
   });
 
   it('should return a successful promise when no modules are passed', () => {
-    const ignoredDuccVersion = 0;
-    const status: AccessModuleStatus = {
-      moduleName: arbitraryModuleName,
-      completionEpochMillis: 12345,
-    };
-
     expect(syncModulesExternal([])).toBeTruthy();
   });
 
   it('should return a successful promise when all externalSyncActions succeed ', () => {
-    const ignoredDuccVersion = 0;
-    const status: AccessModuleStatus = {
-      moduleName: arbitraryModuleName,
-      completionEpochMillis: 12345,
-    };
-
     const spyERA = jest.spyOn(profileApi(), 'syncEraCommonsStatus');
     spyERA.mockImplementation(() => Promise.resolve(null));
     expect(syncModulesExternal([AccessModule.ERA_COMMONS])).toBeTruthy();
   });
 
   it('should return a rejected promise when all externalSyncActions fail ', () => {
-    const ignoredDuccVersion = 0;
-    const status: AccessModuleStatus = {
-      moduleName: arbitraryModuleName,
-      completionEpochMillis: 12345,
-    };
-
     const spyCompliance = jest.spyOn(
       profileApi(),
       'syncComplianceTrainingStatus'
@@ -981,12 +963,6 @@ describe(syncModulesExternal.name, () => {
   });
 
   it('should return a rejected promise when one externalSyncAction fails ', () => {
-    const ignoredDuccVersion = 0;
-    const status: AccessModuleStatus = {
-      moduleName: arbitraryModuleName,
-      completionEpochMillis: 12345,
-    };
-
     const spyCompliance = jest.spyOn(
       profileApi(),
       'syncComplianceTrainingStatus'

--- a/ui/src/app/utils/access-utils.spec.tsx
+++ b/ui/src/app/utils/access-utils.spec.tsx
@@ -959,7 +959,7 @@ describe(syncModulesExternal.name, () => {
     spyCompliance.mockImplementation(() => Promise.reject(null));
     expect(
       syncModulesExternal([AccessModule.CT_COMPLIANCE_TRAINING])
-    ).rejects.toEqual('Failed to syncronize Controlled Tier training');
+    ).rejects.toEqual('Failed to synchronize Controlled Tier training');
   });
 
   it('should return a rejected promise when one externalSyncAction fails ', () => {
@@ -978,6 +978,6 @@ describe(syncModulesExternal.name, () => {
         AccessModule.COMPLIANCE_TRAINING,
         AccessModule.ERA_COMMONS,
       ])
-    ).rejects.toEqual('Failed to syncronize Registered Tier training');
+    ).rejects.toEqual('Failed to synchronize Registered Tier training');
   });
 });

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -292,7 +292,8 @@ export const getAccessModuleConfig = (
           />
         ),
         adminPageTitle: 'Registered Tier training',
-        externalSyncAction: async () => Promise.reject(),
+        externalSyncAction: async () =>
+          await profileApi().syncComplianceTrainingStatus(),
         refreshAction: async () =>
           await profileApi().syncComplianceTrainingStatus(),
         renewalTimeEstimate: 60,

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -689,9 +689,14 @@ export const syncModulesExternal = async (moduleNames: AccessModule[]) => {
 
   return Promise.all(
     filteredModuleNames.map(async (moduleName) => {
-      const { externalSyncAction } = getAccessModuleConfig(moduleName);
+      const { adminPageTitle, externalSyncAction } =
+        getAccessModuleConfig(moduleName);
       if (externalSyncAction) {
-        await externalSyncAction();
+        try {
+          await externalSyncAction();
+        } catch (exception) {
+          throw `Failed to syncronize ${adminPageTitle}`;
+        }
       }
     })
   );

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -695,7 +695,7 @@ export const syncModulesExternal = async (moduleNames: AccessModule[]) => {
         try {
           await externalSyncAction();
         } catch (exception) {
-          throw new Error(`Failed to syncronize ${adminPageTitle}`);
+          return Promise.reject(`Failed to syncronize ${adminPageTitle}`);
         }
       }
     })

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -695,7 +695,7 @@ export const syncModulesExternal = async (moduleNames: AccessModule[]) => {
         try {
           await externalSyncAction();
         } catch (exception) {
-          return Promise.reject(`Failed to syncronize ${adminPageTitle}`);
+          return Promise.reject(`Failed to synchronize ${adminPageTitle}`);
         }
       }
     })

--- a/ui/src/app/utils/access-utils.tsx
+++ b/ui/src/app/utils/access-utils.tsx
@@ -292,8 +292,7 @@ export const getAccessModuleConfig = (
           />
         ),
         adminPageTitle: 'Registered Tier training',
-        externalSyncAction: async () =>
-          await profileApi().syncComplianceTrainingStatus(),
+        externalSyncAction: async () => Promise.reject(),
         refreshAction: async () =>
           await profileApi().syncComplianceTrainingStatus(),
         renewalTimeEstimate: 60,
@@ -695,7 +694,7 @@ export const syncModulesExternal = async (moduleNames: AccessModule[]) => {
         try {
           await externalSyncAction();
         } catch (exception) {
-          throw `Failed to syncronize ${adminPageTitle}`;
+          throw new Error(`Failed to syncronize ${adminPageTitle}`);
         }
       }
     })


### PR DESCRIPTION
Previously, data access requirements called syncModulesExternal, there was no catch for when the call failed. This meant that hideSpinner was never called.

To fix this, syncModulesExternal is now being called within fetchWithErrorModal. FetchWithErrorModal returns a promise, and now a finally is called that hides the spinner.

The error modal looks like the following:
![image](https://github.com/all-of-us/workbench/assets/24514630/5d7b072b-6e4f-41fc-8e2b-735b529e7426)

If you would like to test, the easies way to reproduce would be to change line 297 of access-utils.tsx from `await profileApi().syncComplianceTrainingStatus()` to `Promise.reject()`






<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
