### PR TITLE
[DT-551][risk=no] Set env var for Tanagra local auth

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
     "build-terra-deps": "./src/terraui/build.sh",
     "deps": "./src/deps/deps.sh",
     "start": "BROWSER='none' PORT=4200 react-app-rewired start",
-    "start-tanagra": "BROWSER='none' REACT_APP_POST_MESSAGE_ORIGIN=http://localhost:4200 npm start --prefix ../tanagra-aou-utils/tanagra/ui",
+    "start-tanagra": "BROWSER='none' REACT_APP_GET_LOCAL_AUTH_TOKEN=true REACT_APP_POST_MESSAGE_ORIGIN=http://localhost:4200 npm start --prefix ../tanagra-aou-utils/tanagra/ui",
     "dev-up": "yarn && yarn run deps test && yarn start",
     "dev-up-test": "yarn && yarn run deps test && REACT_APP_ENVIRONMENT=localtest yarn start",
     "dev-up-local": "yarn && yarn run deps local && REACT_APP_ENVIRONMENT=local yarn start",

--- a/ui/src/app/pages/data/tanagra-dev/data-component-tanagra.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/data-component-tanagra.tsx
@@ -232,6 +232,7 @@ export const DataComponentTanagra = fp.flow(
       'cohorts',
       newCohort.id,
       'first',
+      'none',
     ]);
   };
 

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
@@ -241,6 +241,8 @@ export const TanagraResourceList = fp.flow(
       displayName = cohortV2.displayName;
       url = `${urlPrefix}/cohorts/${cohortV2.id}/${
         cohortV2.criteriaGroupSections?.[0]?.id ?? 'first'
+      }/${
+        cohortV2.criteriaGroupSections?.[0]?.criteriaGroups?.[0]?.id ?? 'none'
       }`;
     } else if (conceptSetV2) {
       const domain = JSON.parse(conceptSetV2.criteria.uiConfig)?.title ?? '';


### PR DESCRIPTION
- Set `REACT_APP_GET_LOCAL_AUTH_TOKEN=true` in local `start-tanagra` script so Tanagra app will expect bearer token passed in the url.
- Update cohort urls to match Tanagra router changes