### PR TITLE
[risk=low][RW-11073] Allow deleting paused apps in the UI

### DIFF
--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -291,6 +291,7 @@ describe('ExpandedApp', () => {
 
     test.each([
       AppStatus.RUNNING,
+      AppStatus.STOPPED,
       AppStatus.ERROR,
       AppStatus.STATUS_UNSPECIFIED,
     ])('should allow deletion when the app status is %s', async (status) => {
@@ -343,13 +344,7 @@ describe('ExpandedApp', () => {
       }
     });
 
-    test.each([
-      AppStatus.STOPPED,
-      AppStatus.STARTING,
-      AppStatus.STOPPING,
-      undefined,
-      null,
-    ])(
+    test.each([AppStatus.STARTING, AppStatus.STOPPING, undefined, null])(
       'should not allow deletion when the app status is %s',
       async (status) => {
         const appName = 'my-app';

--- a/ui/src/app/components/apps-panel/utils.tsx
+++ b/ui/src/app/components/apps-panel/utils.tsx
@@ -117,6 +117,7 @@ export const isDeletable = (status: AppStatus): boolean =>
     [
       AppStatus.STATUS_UNSPECIFIED,
       AppStatus.RUNNING,
+      AppStatus.STOPPED,
       AppStatus.ERROR,
     ] as Array<AppStatus>
   ).includes(status);


### PR DESCRIPTION
Does not work yet.  My understanding is that this is blocked on https://github.com/DataBiosphere/leonardo/pull/3937

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
