### PR TITLE
[risk=no][no ticket] Workaround for a tanagra build problem

### DIFF
--- a/ui/libproject/devstart.rb
+++ b/ui/libproject/devstart.rb
@@ -192,6 +192,16 @@ def checkout_branch_or_tag(op, common)
     env_project = ENVIRONMENTS[environment_name_to_project_name(op.opts.env)]
     common.status op.opts.version ? "Checkout specified Tanagra tag" : "Using project specified tag from environment variables."
     deploy_version = op.opts.version ? op.opts.version : env_project.fetch(:tanagra_tag)
+
+    #### TEMP HACK
+    # fixes this error
+    #       error: Your local changes to the following files would be overwritten by checkout:
+    #               ui/src/apiContext.ts
+    #       Please commit your changes or stash them before you switch branches.
+    #       Aborting
+    common.run_inline %W{git checkout HEAD ui/src/apiContext.ts}
+    #### END TEMP HACK
+
     common.run_inline %W{git checkout tags/#{deploy_version}}
   end
 end


### PR DESCRIPTION
This will cause an error to stop happening and allow building the UI to continue.
```
          error: Your local changes to the following files would be overwritten by checkout:
                  ui/src/apiContext.ts
          Please commit your changes or stash them before you switch branches.
          Aborting
```

This is certainly not a solution to the problem, so don't merge it :)

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
