### PR TITLE
[risk=low][no ticket] Drop the user_data_use_agreement table

### DIFF
--- a/api/db/changelog/db.changelog-227-drop-user-data-use-agreement.xml
+++ b/api/db/changelog/db.changelog-227-drop-user-data-use-agreement.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="thibault" id="db.changelog-227-drop-user-data-use-agreement">
+    <dropTable tableName="user_data_use_agreement"/>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -234,6 +234,7 @@
   <include file="changelog/db.changelog-224-cdr-version-tanagra-enabled.xml"/>
   <include file="changelog/db.changelog-225-add-user-discovery-source.xml"/>
   <include file="changelog/db.changelog-226-compliance-training-verification.xml"/>
+  <include file="changelog/db.changelog-227-drop-user-data-use-agreement.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`


### PR DESCRIPTION
This removal is long overdue.  We replaced the concept of the user DUA with the DUCC in Jan/Feb 2022, so the table hasn't been used since then.  To verify, I queried the DB on Test and Prod.

Test:
```
select MAX(completion_time) FROM user_data_use_agreement;
+----------------------+
| MAX(completion_time) |
+----------------------+
| 2022-02-02 17:34:53  |
+----------------------+
```

Prod:
```
+----------------------+
| MAX(completion_time) |
+----------------------+
| 2022-02-08 18:26:37  |
+----------------------+
```


Tested locally: I was able to sign a DUCC without problems.


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
