### PR TITLE
[risk=low][RW-11410] Show only Jupyter notebooks in export-dataset-modal

### DIFF
--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -14,7 +14,7 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
-import { getExistingNotebookNames } from 'app/pages/analysis/util';
+import { getExistingJupyterNotebookNames } from 'app/pages/analysis/util';
 import { analysisTabName } from 'app/routing/utils';
 import { userMetricsApi } from 'app/services/swagger-fetch-clients';
 import { summarizeErrors } from 'app/utils';
@@ -46,7 +46,9 @@ export const NewJupyterNotebookModal = (props: Props) => {
     if (!!existingNameList) {
       setExistingNotebookNameList(existingNameList);
     } else {
-      getExistingNotebookNames(workspace).then(setExistingNotebookNameList);
+      getExistingJupyterNotebookNames(workspace).then(
+        setExistingNotebookNameList
+      );
     }
   }, [props.existingNameList]);
 

--- a/ui/src/app/pages/analysis/util.spec.tsx
+++ b/ui/src/app/pages/analysis/util.spec.tsx
@@ -1,6 +1,19 @@
-import { appendAnalysisFileSuffixByOldName } from './util';
+import { NotebooksApi } from 'generated/fetch';
 
-describe('NotebookUtil', () => {
+import {
+  notebooksApi,
+  registerApiClient,
+} from 'app/services/swagger-fetch-clients';
+
+import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
+import { workspaceStubs } from 'testing/stubs/workspaces';
+
+import {
+  appendAnalysisFileSuffixByOldName,
+  getExistingJupyterNotebookNames,
+} from './util';
+
+describe(appendAnalysisFileSuffixByOldName.name, () => {
   it('should append Rmd if old file is Rmd file', () => {
     expect(appendAnalysisFileSuffixByOldName('test', 'old.Rmd')).toEqual(
       'test.Rmd'
@@ -22,6 +35,45 @@ describe('NotebookUtil', () => {
   it('should not append anything if old file neither ipynb nor Rmd file', () => {
     expect(appendAnalysisFileSuffixByOldName('test', 'old.random')).toEqual(
       'test'
+    );
+  });
+});
+
+describe(getExistingJupyterNotebookNames.name, () => {
+  const testWorkspace = workspaceStubs[0];
+
+  const mockListCall = (fileNames: string[]) =>
+    jest.spyOn(notebooksApi(), 'getNoteBookList').mockImplementation(
+      (): Promise<any> =>
+        Promise.resolve(
+          fileNames.map((name) => ({
+            name,
+            path: 'test',
+            lastModifiedTime: 1,
+          }))
+        )
+    );
+
+  beforeEach(async () =>
+    registerApiClient(NotebooksApi, new NotebooksApiStub())
+  );
+
+  it('should return an empty list if the workspace has no notebooks', () => {
+    mockListCall([]);
+    expect(getExistingJupyterNotebookNames(testWorkspace)).resolves.toEqual([]);
+  });
+
+  it('should return a list of names of Jupyter notebooks only', () => {
+    mockListCall([
+      'Jupyter1.ipynb',
+      'Sassy.sas',
+      'arrrrr.Rmd',
+      'yar.R',
+      'Jupyter2.ipynb',
+    ]);
+    const expected = ['Jupyter1', 'Jupyter2'];
+    expect(getExistingJupyterNotebookNames(testWorkspace)).resolves.toEqual(
+      expected
     );
   });
 });

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -1,4 +1,4 @@
-import { AppType, FileDetail, Workspace } from 'generated/fetch';
+import { FileDetail, Workspace } from 'generated/fetch';
 
 import { cond } from '@terra-ui-packages/core-utils';
 import { UIAppType } from 'app/components/apps-panel/utils';

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -1,4 +1,4 @@
-import { FileDetail } from 'generated/fetch';
+import { AppType, FileDetail } from 'generated/fetch';
 
 import { cond } from '@terra-ui-packages/core-utils';
 import { UIAppType } from 'app/components/apps-panel/utils';
@@ -74,11 +74,16 @@ export const listNotebooks = (workspace): Promise<FileDetail[]> => {
   return notebooksApi().getNoteBookList(namespace, id);
 };
 
-export const getExistingNotebookNames = async (
+export const getExistingJupyterNotebookNames = async (
   workspace
 ): Promise<string[]> => {
   const notebooks = await listNotebooks(workspace);
-  return notebooks.map((fd) => dropJupyterNotebookFileSuffix(fd.name));
+  return notebooks
+    .filter(
+      (fd: FileDetail) =>
+        getAppInfoFromFileName(fd.name).appType === UIAppType.JUPYTER
+    )
+    .map((fd: FileDetail) => dropJupyterNotebookFileSuffix(fd.name));
 };
 
 const appsExtensionMap = [

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -1,4 +1,4 @@
-import { AppType, FileDetail } from 'generated/fetch';
+import { AppType, FileDetail, Workspace } from 'generated/fetch';
 
 import { cond } from '@terra-ui-packages/core-utils';
 import { UIAppType } from 'app/components/apps-panel/utils';
@@ -69,23 +69,6 @@ export function appendAnalysisFileSuffixByOldName(
   );
 }
 
-export const listNotebooks = (workspace): Promise<FileDetail[]> => {
-  const { namespace, id } = workspace;
-  return notebooksApi().getNoteBookList(namespace, id);
-};
-
-export const getExistingJupyterNotebookNames = async (
-  workspace
-): Promise<string[]> => {
-  const notebooks = await listNotebooks(workspace);
-  return notebooks
-    .filter(
-      (fd: FileDetail) =>
-        getAppInfoFromFileName(fd.name).appType === UIAppType.JUPYTER
-    )
-    .map((fd: FileDetail) => dropJupyterNotebookFileSuffix(fd.name));
-};
-
 const appsExtensionMap = [
   {
     extension: JUPYTER_FILE_EXT,
@@ -111,4 +94,21 @@ const appsExtensionMap = [
 
 export const getAppInfoFromFileName = (name: string) => {
   return appsExtensionMap.find((app) => name.endsWith(app.extension));
+};
+
+export const listNotebooks = (workspace: Workspace): Promise<FileDetail[]> => {
+  const { namespace, id } = workspace;
+  return notebooksApi().getNoteBookList(namespace, id);
+};
+
+export const getExistingJupyterNotebookNames = async (
+  workspace: Workspace
+): Promise<string[]> => {
+  const notebooks = await listNotebooks(workspace);
+  return notebooks
+    .filter(
+      (fd: FileDetail) =>
+        getAppInfoFromFileName(fd.name).appType === UIAppType.JUPYTER
+    )
+    .map((fd: FileDetail) => dropJupyterNotebookFileSuffix(fd.name));
 };

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -30,7 +30,7 @@ import { Spinner } from 'app/components/spinners';
 import {
   appendJupyterNotebookFileSuffix,
   dropJupyterNotebookFileSuffix,
-  getExistingNotebookNames,
+  getExistingJupyterNotebookNames,
 } from 'app/pages/analysis/util';
 import { analysisTabPath } from 'app/routing/utils';
 import { dataSetApi, notebooksApi } from 'app/services/swagger-fetch-clients';
@@ -233,7 +233,7 @@ export const ExportDatasetModal = ({
   }
 
   useEffect(() => {
-    getExistingNotebookNames(workspace)
+    getExistingJupyterNotebookNames(workspace)
       .then(setExistingNotebooks)
       .catch(() => setExistingNotebooks([])); // If the request fails, at least let the user create new notebooks
   }, [workspace]);


### PR DESCRIPTION
Filter the notebook files to Jupyter only for export-dataset.  Tested locally.

In a workspace with Jupyter, SAS, and RStudio files
<img width="732" alt="Screenshot 2023-11-21 at 5 12 47 PM" src="https://github.com/all-of-us/workbench/assets/2701406/ef8e57b9-a7eb-4004-b76a-f80930bd4dc1">

Test env (Before)
<img width="1001" alt="Screenshot 2023-11-21 at 5 12 35 PM" src="https://github.com/all-of-us/workbench/assets/2701406/a35d0f61-a288-48c0-a634-21243942b427">

Local (after)
<img width="979" alt="Screenshot 2023-11-21 at 5 12 25 PM" src="https://github.com/all-of-us/workbench/assets/2701406/b4f56912-02ec-4590-b2d8-a08f1b37d475">


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
