### PR TITLE
[risk=low][no ticket] New Jupyter File modal was not correctly checking for duplicate names

### DIFF
--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -53,13 +53,12 @@ export const NewJupyterNotebookModal = (props: Props) => {
   }, [props.existingNameList]);
 
   const errors = validate(
-    // we expect the notebook name to lack the .ipynb suffix
-    // but we pass it through drop-suffix to also catch the case where the user has explicitly typed it in
+    // append the Jupyter suffix if missing, to both the user-chosen name and the list of existing names
     { name: appendJupyterNotebookFileSuffix(name), kernel },
     {
       kernel: { presence: { allowEmpty: false } },
       name: nameValidationFormat(
-        existingNotebookNameList,
+        existingNotebookNameList.map(appendJupyterNotebookFileSuffix),
         ResourceType.NOTEBOOK
       ),
     }

--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -17,7 +17,7 @@ import { TooltipTrigger } from 'app/components/popups';
 import { getExistingJupyterNotebookNames } from 'app/pages/analysis/util';
 import { analysisTabName } from 'app/routing/utils';
 import { userMetricsApi } from 'app/services/swagger-fetch-clients';
-import { summarizeErrors } from 'app/utils';
+import { isEmpty, summarizeErrors } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { useNavigation } from 'app/utils/navigation';
 import { Kernels } from 'app/utils/notebook-kernels';
@@ -128,7 +128,7 @@ export const NewJupyterNotebookModal = (props: Props) => {
         <TooltipTrigger content={summarizeErrors(errors)}>
           <Button
             style={{ marginLeft: '0.75rem' }}
-            disabled={Object.keys(errors).length > 0}
+            disabled={!isEmpty(errors)}
             onClick={() => {
               AnalyticsTracker.Notebooks.Create(Kernels[kernel]);
               create();

--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -53,7 +53,7 @@ export const NewJupyterNotebookModal = (props: Props) => {
   }, [props.existingNameList]);
 
   const errors = {
-    ...validateNewNotebookName(name, 'name', existingNotebookNameList),
+    ...validateNewNotebookName(name, existingNotebookNameList),
     ...validate(
       { kernel },
       {

--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { validate } from 'validate.js';
 
-import { ResourceType, Workspace } from 'generated/fetch';
+import { Workspace } from 'generated/fetch';
 
 import { Button } from 'app/components/buttons';
 import { styles as headerStyles } from 'app/components/headers';
@@ -21,7 +21,7 @@ import { summarizeErrors } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { useNavigation } from 'app/utils/navigation';
 import { Kernels } from 'app/utils/notebook-kernels';
-import { nameValidationFormat } from 'app/utils/resources';
+import { validateNewNotebookName } from 'app/utils/resources';
 
 import { appendJupyterNotebookFileSuffix } from './util';
 
@@ -52,17 +52,15 @@ export const NewJupyterNotebookModal = (props: Props) => {
     }
   }, [props.existingNameList]);
 
-  const errors = validate(
-    // append the Jupyter suffix if missing, to both the user-chosen name and the list of existing names
-    { name: appendJupyterNotebookFileSuffix(name), kernel },
-    {
-      kernel: { presence: { allowEmpty: false } },
-      name: nameValidationFormat(
-        existingNotebookNameList.map(appendJupyterNotebookFileSuffix),
-        ResourceType.NOTEBOOK
-      ),
-    }
-  );
+  const errors = [
+    ...validateNewNotebookName(name, existingNotebookNameList),
+    ...validate(
+      { kernel },
+      {
+        kernel: { presence: { allowEmpty: false } },
+      }
+    ),
+  ];
 
   const create = () => {
     userMetricsApi().updateRecentResource(workspace.namespace, workspace.id, {

--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -128,7 +128,7 @@ export const NewJupyterNotebookModal = (props: Props) => {
         <TooltipTrigger content={summarizeErrors(errors)}>
           <Button
             style={{ marginLeft: '0.75rem' }}
-            disabled={!!errors}
+            disabled={Object.keys(errors).length > 0}
             onClick={() => {
               AnalyticsTracker.Notebooks.Create(Kernels[kernel]);
               create();

--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -53,7 +53,7 @@ export const NewJupyterNotebookModal = (props: Props) => {
   }, [props.existingNameList]);
 
   const errors = {
-    ...validateNewNotebookName(name, existingNotebookNameList),
+    ...validateNewNotebookName(name, 'name', existingNotebookNameList),
     ...validate(
       { kernel },
       {

--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -52,7 +52,7 @@ export const NewJupyterNotebookModal = (props: Props) => {
     }
   }, [props.existingNameList]);
 
-  const errors = [
+  const errors = {
     ...validateNewNotebookName(name, existingNotebookNameList),
     ...validate(
       { kernel },
@@ -60,7 +60,7 @@ export const NewJupyterNotebookModal = (props: Props) => {
         kernel: { presence: { allowEmpty: false } },
       }
     ),
-  ];
+  };
 
   const create = () => {
     userMetricsApi().updateRecentResource(workspace.namespace, workspace.id, {

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -1,4 +1,4 @@
-import { FileDetail, Workspace } from 'generated/fetch';
+import { AppType, FileDetail, Workspace } from 'generated/fetch';
 
 import { cond } from '@terra-ui-packages/core-utils';
 import { UIAppType } from 'app/components/apps-panel/utils';

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -1,4 +1,4 @@
-import { AppType, FileDetail, Workspace } from 'generated/fetch';
+import { FileDetail, Workspace } from 'generated/fetch';
 
 import { cond } from '@terra-ui-packages/core-utils';
 import { UIAppType } from 'app/components/apps-panel/utils';

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -245,8 +245,8 @@ export const ExportDatasetModal = ({
   const errors = {
     ...validateNewNotebookName(
       notebookNameWithoutSuffix,
-      'notebookName',
-      creatingNewNotebook ? existingNotebooks : []
+      creatingNewNotebook ? existingNotebooks : [],
+      'notebookName'
     ),
     ...(workspace.billingStatus === BillingStatus.INACTIVE
       ? { billing: [ACTION_DISABLED_INVALID_BILLING] }

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -38,7 +38,10 @@ import colors from 'app/styles/colors';
 import { reactStyles, summarizeErrors } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { encodeURIComponentStrict, useNavigation } from 'app/utils/navigation';
-import { nameValidationFormat } from 'app/utils/resources';
+import {
+  nameValidationFormat,
+  validateNewNotebookName,
+} from 'app/utils/resources';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
@@ -245,18 +248,9 @@ export const ExportDatasetModal = ({
   }, [kernelType, genomicsAnalysisTool]);
 
   const errors = {
-    ...validate(
-      // we expect the notebook name to lack the .ipynb suffix
-      // but we pass it through drop-suffix to also catch the case where the user has explicitly typed it in
-      {
-        notebookName: dropJupyterNotebookFileSuffix(notebookNameWithoutSuffix),
-      },
-      {
-        notebookName: nameValidationFormat(
-          creatingNewNotebook ? existingNotebooks : [],
-          ResourceType.NOTEBOOK
-        ),
-      }
+    ...validateNewNotebookName(
+      notebookNameWithoutSuffix,
+      creatingNewNotebook ? existingNotebooks : []
     ),
     ...(workspace.billingStatus === BillingStatus.INACTIVE
       ? { billing: [ACTION_DISABLED_INVALID_BILLING] }

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -102,6 +102,7 @@ export const ExportDatasetModal = ({
       dataset.prePackagedConceptSet
     );
   }
+
   function createExportDatasetRequest(): DataSetExportRequest {
     return {
       dataSetRequest: createDataSetRequest(),

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import * as fp from 'lodash/fp';
 
 import {
   BillingStatus,
@@ -32,7 +31,7 @@ import {
 import { analysisTabPath } from 'app/routing/utils';
 import { dataSetApi, notebooksApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
-import { reactStyles, summarizeErrors } from 'app/utils';
+import { isEmpty, reactStyles, summarizeErrors } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { encodeURIComponentStrict, useNavigation } from 'app/utils/navigation';
 import { validateNewNotebookName } from 'app/utils/resources';
@@ -96,12 +95,10 @@ export const ExportDatasetModal = ({
     };
   }
 
-  function hasWgs() {
-    return fp.includes(
-      PrePackagedConceptSetEnum.WHOLE_GENOME,
-      dataset.prePackagedConceptSet
+  const hasWgs = () =>
+    dataset.prePackagedConceptSet?.includes(
+      PrePackagedConceptSetEnum.WHOLE_GENOME
     );
-  }
 
   function createExportDatasetRequest(): DataSetExportRequest {
     return {
@@ -375,7 +372,7 @@ export const ExportDatasetModal = ({
               <Button
                 type='primary'
                 data-test-id='export-data-set'
-                disabled={!fp.isEmpty(errors)}
+                disabled={!isEmpty(errors)}
                 onClick={() => exportDataset()}
               >
                 Export

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
+import fp from 'lodash/fp';
 
 import {
   BillingStatus,
@@ -95,11 +96,12 @@ export const ExportDatasetModal = ({
     };
   }
 
-  const hasWgs = () =>
-    dataset.prePackagedConceptSet?.includes(
-      PrePackagedConceptSetEnum.WHOLE_GENOME
+  function hasWgs() {
+    return fp.includes(
+      PrePackagedConceptSetEnum.WHOLE_GENOME,
+      dataset.prePackagedConceptSet
     );
-
+  }
   function createExportDatasetRequest(): DataSetExportRequest {
     return {
       dataSetRequest: createDataSetRequest(),

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import * as fp from 'lodash/fp';
-import { validate } from 'validate.js';
 
 import {
   BillingStatus,
@@ -11,7 +10,6 @@ import {
   DataSetRequest,
   KernelTypeEnum,
   PrePackagedConceptSetEnum,
-  ResourceType,
 } from 'generated/fetch';
 
 import { Button } from 'app/components/buttons';
@@ -29,7 +27,6 @@ import { TooltipTrigger } from 'app/components/popups';
 import { Spinner } from 'app/components/spinners';
 import {
   appendJupyterNotebookFileSuffix,
-  dropJupyterNotebookFileSuffix,
   getExistingJupyterNotebookNames,
 } from 'app/pages/analysis/util';
 import { analysisTabPath } from 'app/routing/utils';
@@ -38,10 +35,7 @@ import colors from 'app/styles/colors';
 import { reactStyles, summarizeErrors } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { encodeURIComponentStrict, useNavigation } from 'app/utils/navigation';
-import {
-  nameValidationFormat,
-  validateNewNotebookName,
-} from 'app/utils/resources';
+import { validateNewNotebookName } from 'app/utils/resources';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import { WorkspacePermissionsUtil } from 'app/utils/workspace-permissions';
@@ -67,7 +61,8 @@ export const ExportDatasetModal = ({
   dataset,
   closeFunction,
 }: Props) => {
-  const [existingNotebooks, setExistingNotebooks] = useState(undefined);
+  const [existingNotebooks, setExistingNotebooks] =
+    useState<string[]>(undefined);
   const [kernelType, setKernelType] = useState<KernelTypeEnum>(
     KernelTypeEnum.PYTHON
   );
@@ -250,7 +245,7 @@ export const ExportDatasetModal = ({
   const errors = {
     ...validateNewNotebookName(
       notebookNameWithoutSuffix,
-      creatingNewNotebook ? existingNotebooks : []
+      creatingNewNotebook && existingNotebooks
     ),
     ...(workspace.billingStatus === BillingStatus.INACTIVE
       ? { billing: [ACTION_DISABLED_INVALID_BILLING] }

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -245,7 +245,8 @@ export const ExportDatasetModal = ({
   const errors = {
     ...validateNewNotebookName(
       notebookNameWithoutSuffix,
-      creatingNewNotebook && existingNotebooks
+      'notebookName',
+      creatingNewNotebook ? existingNotebooks : []
     ),
     ...(workspace.billingStatus === BillingStatus.INACTIVE
       ? { billing: [ACTION_DISABLED_INVALID_BILLING] }

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -36,23 +36,7 @@ export function isBlank(toTest: String): boolean {
   }
 }
 
-/**
- * Random String Generator (simplified version)
- *
- * Info:      http://stackoverflow.com/a/27872144/383904
- * Use:       randomString(length);
- * Default:   return a random alpha-numeric string
- */
-export function randomString(len): string {
-  let str = '',
-    i = 0;
-  for (; i++ < len; ) {
-    let rand = Math.floor(Math.random() * 62);
-    const charCode = (rand += rand > 9 ? (rand < 36 ? 55 : 61) : 48);
-    str += String.fromCharCode(charCode);
-  }
-  return str;
-}
+export const isEmpty = (o: Object): boolean => Object.keys(o).length === 0;
 
 const throttleAnimation = (fn) => {
   let running = false;
@@ -122,12 +106,6 @@ export const withWindowSize = () => (WrappedComponent) => {
   return Wrapper;
 };
 
-export const nextSort = ({ field, direction }, newField) => {
-  return newField === field
-    ? { field, direction: direction === 'asc' ? 'desc' : 'asc' }
-    : { field: newField, direction: 'asc' };
-};
-
 type ReactStyles<T> = {
   readonly [P in keyof T]: React.CSSProperties;
 };
@@ -157,15 +135,6 @@ export function reactStyles<T extends { [key: string]: React.CSSProperties }>(
   t: T
 ): ReactStyles<T> {
   return t;
-}
-
-export function decamelize(str: string, separator: string) {
-  separator = typeof separator === 'undefined' ? '_' : separator;
-
-  return str
-    .replace(/([a-z\d])([A-Z])/g, '$1' + separator + '$2')
-    .replace(/([A-Z]+)([A-Z][a-z\d]+)/g, '$1' + separator + '$2')
-    .toLowerCase();
 }
 
 export const withStyle = (styleObj) => (WrappedComponent) => {

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -217,8 +217,8 @@ export const nameValidationFormat = (
 
 export const validateNewNotebookName = (
   name: string,
-  fieldName: string = name,
-  existingNames: string[]
+  existingNames: string[],
+  fieldName: string = 'name' // error validators sometimes depend on the field name
 ) =>
   validate(
     // append the Jupyter suffix if missing, to both the user-chosen name and the list of existing names

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -12,10 +12,7 @@ import {
   WorkspaceResource,
 } from 'generated/fetch';
 
-import {
-  appendAnalysisFileSuffixByOldName,
-  appendJupyterNotebookFileSuffix,
-} from 'app/pages/analysis/util';
+import { appendJupyterNotebookFileSuffix } from 'app/pages/analysis/util';
 import { analysisTabPath, dataTabPath } from 'app/routing/utils';
 
 import { encodeURIComponentStrict, UrlObj } from './navigation';

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -190,7 +190,7 @@ export const convertToResources = (
  * Other AoU resource types do not have the same name restriction and only block slashes.
  */
 export const nameValidationFormat = (
-  existingNames,
+  existingNames: string[],
   resourceType: ResourceType
 ) =>
   resourceType === ResourceType.NOTEBOOK
@@ -220,13 +220,14 @@ export const nameValidationFormat = (
 
 export const validateNewNotebookName = (
   name: string,
+  fieldName: string = name,
   existingNames: string[]
 ) =>
   validate(
     // append the Jupyter suffix if missing, to both the user-chosen name and the list of existing names
-    { name: appendJupyterNotebookFileSuffix(name) },
+    { [fieldName]: appendJupyterNotebookFileSuffix(name) },
     {
-      name: nameValidationFormat(
+      [fieldName]: nameValidationFormat(
         existingNames?.map(appendJupyterNotebookFileSuffix),
         ResourceType.NOTEBOOK
       ),

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -219,15 +219,15 @@ export const nameValidationFormat = (
       };
 
 export const validateNewNotebookName = (
-  newName: string,
+  name: string,
   existingNames: string[]
 ) =>
   validate(
     // append the Jupyter suffix if missing, to both the user-chosen name and the list of existing names
-    { newName: appendJupyterNotebookFileSuffix(newName) },
+    { name: appendJupyterNotebookFileSuffix(name) },
     {
-      newName: nameValidationFormat(
-        existingNames.map(appendJupyterNotebookFileSuffix),
+      name: nameValidationFormat(
+        existingNames?.map(appendJupyterNotebookFileSuffix),
         ResourceType.NOTEBOOK
       ),
     }

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -1,4 +1,5 @@
 import * as fp from 'lodash/fp';
+import validate from 'validate.js';
 
 import {
   Cohort,
@@ -11,6 +12,10 @@ import {
   WorkspaceResource,
 } from 'generated/fetch';
 
+import {
+  appendAnalysisFileSuffixByOldName,
+  appendJupyterNotebookFileSuffix,
+} from 'app/pages/analysis/util';
 import { analysisTabPath, dataTabPath } from 'app/routing/utils';
 
 import { encodeURIComponentStrict, UrlObj } from './navigation';
@@ -212,3 +217,18 @@ export const nameValidationFormat = (
           message: 'already exists',
         },
       };
+
+export const validateNewNotebookName = (
+  newName: string,
+  existingNames: string[]
+) =>
+  validate(
+    // append the Jupyter suffix if missing, to both the user-chosen name and the list of existing names
+    { newName: appendJupyterNotebookFileSuffix(newName) },
+    {
+      newName: nameValidationFormat(
+        existingNames.map(appendJupyterNotebookFileSuffix),
+        ResourceType.NOTEBOOK
+      ),
+    }
+  );


### PR DESCRIPTION
Confirmed that the new-notebook modal now correctly checks for Jupyter filenames

Before
![before](https://github.com/all-of-us/workbench/assets/2701406/67d2c553-c6d7-4969-9bfa-2eb05b228501)


After
![after](https://github.com/all-of-us/workbench/assets/2701406/865a9762-8afb-47e7-98f4-4b161bfdc3c4)


Also confirmed that export-dataset was not broken

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
