### PR TITLE
[risk=low][RW-11417] Use the new Sam endpoint userTermsOfServiceGetSelf to get Terra ToS status

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -482,9 +482,9 @@ dependencies {
     implementation 'jakarta.mail:jakarta.mail-api:2.1.1'
     testAnnotationProcessor "org.mapstruct:mapstruct-processor:$project.ext.MAPSTRUCT_VERSION"
 
-    // updated 3 Nov 2023
-    // the latest version of Sam which passed all tests was on 12 October with hash 06ef266...
-    implementation("org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-06ef266") {
+    // updated 22 Nov 2023
+    // the latest version of Sam which passed all tests was on 21 Nov with hash e074df8...
+    implementation("org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-e074df8") {
       exclude group: 'org.apache.oltu.oauth2', module: 'org.apache.oltu.oauth2.common'
     }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -482,9 +482,8 @@ dependencies {
     implementation 'jakarta.mail:jakarta.mail-api:2.1.1'
     testAnnotationProcessor "org.mapstruct:mapstruct-processor:$project.ext.MAPSTRUCT_VERSION"
 
-    // updated 22 Nov 2023
-    // the latest version of Sam which passed all tests was on 21 Nov with hash e074df8...
-    implementation("org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-e074df8") {
+    // updated 27 Nov 2023
+    implementation("org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-4e524b8") {
       exclude group: 'org.apache.oltu.oauth2', module: 'org.apache.oltu.oauth2.common'
     }
 

--- a/api/src/integration/java/org/pmiops/workbench/FireCloudIntegrationTest.java
+++ b/api/src/integration/java/org/pmiops/workbench/FireCloudIntegrationTest.java
@@ -17,6 +17,7 @@ import org.pmiops.workbench.firecloud.api.NihApi;
 import org.pmiops.workbench.firecloud.api.ProfileApi;
 import org.pmiops.workbench.firecloud.model.FirecloudMe;
 import org.pmiops.workbench.google.StorageConfig;
+import org.pmiops.workbench.sam.SamRetryHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
@@ -32,7 +33,8 @@ public class FireCloudIntegrationTest extends BaseIntegrationTest {
     FirecloudApiClientFactory.class,
     FireCloudServiceImpl.class,
     StorageConfig.class,
-    BaseIntegrationTest.Configuration.class
+    BaseIntegrationTest.Configuration.class,
+    SamRetryHandler.class,
   })
   static class Configuration {}
 

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -195,7 +195,7 @@ public class ProfileController implements ProfileApiDelegate {
   @Override
   public ResponseEntity<Boolean> getUserTermsOfServiceStatus() {
     DbUser loggedInUser = userAuthenticationProvider.get().getUser();
-    return ResponseEntity.ok(userService.hasSignedLatestTermsOfServiceBoth(loggedInUser));
+    return ResponseEntity.ok(userService.hasSignedLatestTermsOfServiceForBoth(loggedInUser));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -157,12 +157,16 @@ public class ProfileController implements ProfileApiDelegate {
     if (dbUser.getFirstSignInTime() == null) {
       // This call should be idempotent. If the user is already registered, their profile will get
       // updated.
+      // TODO: this assumption is false.  We have seen errors because this is not idempotent.
+      // See RW-11393 for such a user error.  We plan to fix this as part of the Nov 2023 ToS work.
       fireCloudService.registerUser();
 
-      // By approving the latest AOU Terms of Service, the user also approves the latest Terra TOS
-      // In case user has not accepted latest AoU version, getUserTermsOfServiceStatus and acceptTos
-      // will take care of scenario by re-directing them to AoU terms of service page. This call
-      // should be idempotent.
+      // By approving the latest AoU Terms of Service, the user also approves the latest Terra ToS.
+      // If the user has not accepted the latest AoU version, then it's not appropriate to call
+      // the Terra ToS acceptance endpoint.  We will require the user to approve the ToS in the UI,
+      // because it will detect that the user is non-compliant at login via
+      // getUserTermsOfServiceStatus(), and it will redirect them to the AoU ToS.
+      // This call should be idempotent.
       if (userService.hasSignedLatestAoUTermsOfService(dbUser)) {
         userService.acceptTerraTermsOfService(dbUser);
       }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -168,7 +168,8 @@ public class ProfileController implements ProfileApiDelegate {
       // getUserTermsOfServiceStatus(), and it will redirect them to the AoU ToS.
       // This call should be idempotent.
       if (userService.hasSignedLatestAoUTermsOfService(dbUser)) {
-        userService.acceptTerraTermsOfService(dbUser);
+        // to be replaced as part of RW-11416
+        userService.acceptTerraTermsOfServiceDeprecated(dbUser);
       }
       dbUser.setFirstSignInTime(new Timestamp(clock.instant().toEpochMilli()));
       return saveUserWithConflictHandling(dbUser);
@@ -201,7 +202,8 @@ public class ProfileController implements ProfileApiDelegate {
   public ResponseEntity<Void> acceptTermsOfService(Integer termsOfServiceVersion) {
     DbUser loggedInUser = userAuthenticationProvider.get().getUser();
     userService.submitAouTermsOfService(loggedInUser, termsOfServiceVersion);
-    userService.acceptTerraTermsOfService(loggedInUser);
+    // to be replaced as part of RW-11416
+    userService.acceptTerraTermsOfServiceDeprecated(loggedInUser);
     return ResponseEntity.ok().build();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -163,7 +163,7 @@ public class ProfileController implements ProfileApiDelegate {
       // In case user has not accepted latest AoU version, getUserTermsOfServiceStatus and acceptTos
       // will take care of scenario by re-directing them to AoU terms of service page. This call
       // should be idempotent.
-      if (userService.validateAllOfUsTermsOfServiceVersion(dbUser)) {
+      if (userService.hasSignedLatestAoUTermsOfService(dbUser)) {
         userService.acceptTerraTermsOfService(dbUser);
       }
       dbUser.setFirstSignInTime(new Timestamp(clock.instant().toEpochMilli()));
@@ -190,7 +190,7 @@ public class ProfileController implements ProfileApiDelegate {
   @Override
   public ResponseEntity<Boolean> getUserTermsOfServiceStatus() {
     DbUser loggedInUser = userAuthenticationProvider.get().getUser();
-    return ResponseEntity.ok(userService.validateTermsOfService(loggedInUser));
+    return ResponseEntity.ok(userService.hasSignedLatestTermsOfServiceBoth(loggedInUser));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/calhoun/CalhounConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/calhoun/CalhounConfig.java
@@ -33,7 +33,6 @@ public class CalhounConfig {
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   public ConvertApi endUserCalhounApi(
       @Qualifier(END_USER_LENIENT_TIMEOUT_API_CLIENT) ApiClient apiClient) {
-    // Billing calls are made by the user
     ConvertApi api = new ConvertApi();
     api.setApiClient(apiClient);
     return api;

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -57,9 +57,23 @@ public interface UserService {
 
   void validateAllOfUsTermsOfService(Integer tosVersion);
 
-  boolean validateAllOfUsTermsOfServiceVersion(@Nonnull DbUser dbUser);
+  /**
+   * Is the user up-to-date with our Terms of Service?
+   *
+   * @param dbUser the current user - used only to generate error messages
+   * @return true only if the user has accepted the latest version of both AoU and Terra Terms of
+   *     Service
+   */
+  boolean hasSignedLatestAoUTermsOfService(@Nonnull DbUser dbUser);
 
-  boolean validateTermsOfService(@Nonnull DbUser dbUser);
+  /**
+   * Is the user up-to-date with both AoU and Terra Terms of Service?
+   *
+   * @param dbUser the current user - used only to generate error messages
+   * @return true only if the user has accepted the latest version of both AoU and Terra Terms of
+   *     Service
+   */
+  boolean hasSignedLatestTermsOfServiceBoth(@Nonnull DbUser dbUser);
 
   // Registers that a user has agreed to a given version of the AoU Terms of Service.
   void submitAouTermsOfService(@Nonnull DbUser dbUser, @Nonnull Integer tosVersion);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -78,7 +78,8 @@ public interface UserService {
   void submitAouTermsOfService(@Nonnull DbUser dbUser, @Nonnull Integer tosVersion);
 
   // Registers that a user has accepted the latest version of the Terra Terms of Service.
-  void acceptTerraTermsOfService(@Nonnull DbUser dbUser);
+  @Deprecated(forRemoval = true) // to be replaced as part of RW-11416
+  void acceptTerraTermsOfServiceDeprecated(@Nonnull DbUser dbUser);
 
   DbUser setDisabledStatus(Long userId, boolean disabled);
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -61,8 +61,6 @@ public interface UserService {
 
   boolean validateTermsOfService(@Nonnull DbUser dbUser);
 
-  boolean getUserTerraTermsOfServiceStatus(@Nonnull DbUser dbUser);
-
   // Registers that a user has agreed to a given version of the AoU Terms of Service.
   void submitAouTermsOfService(@Nonnull DbUser dbUser, @Nonnull Integer tosVersion);
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -78,7 +78,7 @@ public interface UserService {
   void submitAouTermsOfService(@Nonnull DbUser dbUser, @Nonnull Integer tosVersion);
 
   // Registers that a user has accepted the latest version of the Terra Terms of Service.
-  @Deprecated(forRemoval = true) // to be replaced as part of RW-11416
+  @Deprecated // to be replaced as part of RW-11416
   void acceptTerraTermsOfServiceDeprecated(@Nonnull DbUser dbUser);
 
   DbUser setDisabledStatus(Long userId, boolean disabled);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -72,7 +72,7 @@ public interface UserService {
    * @return true only if the user has accepted the latest version of both AoU and Terra Terms of
    *     Service
    */
-  boolean hasSignedLatestTermsOfServiceBoth(@Nonnull DbUser dbUser);
+  boolean hasSignedLatestTermsOfServiceForBoth(@Nonnull DbUser dbUser);
 
   // Registers that a user has agreed to a given version of the AoU Terms of Service.
   void submitAouTermsOfService(@Nonnull DbUser dbUser, @Nonnull Integer tosVersion);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -61,8 +61,7 @@ public interface UserService {
    * Is the user up-to-date with our Terms of Service?
    *
    * @param dbUser the current user - used only to generate error messages
-   * @return true only if the user has accepted the latest version of both AoU and Terra Terms of
-   *     Service
+   * @return true only if the user has accepted the latest version of the AoU Terms of Service
    */
   boolean hasSignedLatestAoUTermsOfService(@Nonnull DbUser dbUser);
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -44,7 +44,6 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
-import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
@@ -444,14 +443,14 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   // service
   @Override
   public boolean validateTermsOfService(@Nonnull DbUser dbUser) {
-    return validateAllOfUsTermsOfServiceVersion(dbUser) && getUserTerraTermsOfServiceStatus(dbUser);
+    return validateAllOfUsTermsOfServiceVersion(dbUser)
+        && getDeprecatedTerraTermsOfServiceStatus(dbUser);
   }
 
-  @Override
-  public boolean getUserTerraTermsOfServiceStatus(@Nonnull DbUser dbUser) {
+  private boolean getDeprecatedTerraTermsOfServiceStatus(@Nonnull DbUser dbUser) {
     try {
-      return fireCloudService.getUserTermsOfServiceStatus();
-    } catch (ApiException e) {
+      return fireCloudService.getUserTermsOfServiceStatusDeprecated();
+    } catch (Exception e) {
       log.log(
           Level.SEVERE,
           String.format(
@@ -477,7 +476,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
 
   @Override
   public void acceptTerraTermsOfService(@Nonnull DbUser dbUser) {
-    fireCloudService.acceptTermsOfService();
+    fireCloudService.acceptTermsOfServiceDeprecated();
     userTermsOfServiceDao.save(
         userTermsOfServiceDao
             .findByUserIdOrThrow(dbUser.getUserId())

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -458,7 +458,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   @Override
-  @Deprecated(forRemoval = true) // to be replaced as part of RW-11416
+  @Deprecated // to be replaced as part of RW-11416
   public void acceptTerraTermsOfServiceDeprecated(@Nonnull DbUser dbUser) {
     fireCloudService.acceptTermsOfServiceDeprecated();
     userTermsOfServiceDao.save(

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -430,26 +430,22 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
     }
   }
 
-  // Returns true if user has accepted the latest AoU Terms of Service Version
   @Override
-  public boolean validateAllOfUsTermsOfServiceVersion(@Nonnull DbUser dbUser) {
+  public boolean hasSignedLatestAoUTermsOfService(@Nonnull DbUser dbUser) {
     return userTermsOfServiceDao
         .findFirstByUserIdOrderByTosVersionDesc(dbUser.getUserId())
         .map(u -> u.getTosVersion() == configProvider.get().termsOfService.latestAouVersion)
         .orElse(false);
   }
 
-  // Returns true only if the user has accepted the latest version of both AoU and Terra terms of
-  // service
   @Override
-  public boolean validateTermsOfService(@Nonnull DbUser dbUser) {
-    return validateAllOfUsTermsOfServiceVersion(dbUser)
-        && getDeprecatedTerraTermsOfServiceStatus(dbUser);
+  public boolean hasSignedLatestTermsOfServiceBoth(@Nonnull DbUser dbUser) {
+    return hasSignedLatestAoUTermsOfService(dbUser) && hasSignedLatestTerraTermsOfService(dbUser);
   }
 
-  private boolean getDeprecatedTerraTermsOfServiceStatus(@Nonnull DbUser dbUser) {
+  private boolean hasSignedLatestTerraTermsOfService(@Nonnull DbUser dbUser) {
     try {
-      return fireCloudService.getUserTermsOfServiceStatusDeprecated();
+      return fireCloudService.hasUserAcceptedLatestTerraToS(dbUser);
     } catch (Exception e) {
       log.log(
           Level.SEVERE,

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -458,7 +458,8 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   @Override
-  public void acceptTerraTermsOfService(@Nonnull DbUser dbUser) {
+  @Deprecated(forRemoval = true) // to be replaced as part of RW-11416
+  public void acceptTerraTermsOfServiceDeprecated(@Nonnull DbUser dbUser) {
     fireCloudService.acceptTermsOfServiceDeprecated();
     userTermsOfServiceDao.save(
         userTermsOfServiceDao

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -440,7 +440,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   @Override
   public boolean hasSignedLatestTermsOfServiceBoth(@Nonnull DbUser dbUser) {
     return hasSignedLatestAoUTermsOfService(dbUser)
-        && fireCloudService.hasUserAcceptedLatestTerraToS(dbUser);
+        && fireCloudService.hasUserAcceptedLatestTerraToS();
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -438,7 +438,7 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
   }
 
   @Override
-  public boolean hasSignedLatestTermsOfServiceBoth(@Nonnull DbUser dbUser) {
+  public boolean hasSignedLatestTermsOfServiceForBoth(@Nonnull DbUser dbUser) {
     return hasSignedLatestAoUTermsOfService(dbUser)
         && fireCloudService.hasUserAcceptedLatestTerraToS();
   }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -43,7 +43,6 @@ import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.NotFoundException;
-import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
@@ -440,20 +439,8 @@ public class UserServiceImpl implements UserService, GaugeDataCollector {
 
   @Override
   public boolean hasSignedLatestTermsOfServiceBoth(@Nonnull DbUser dbUser) {
-    return hasSignedLatestAoUTermsOfService(dbUser) && hasSignedLatestTerraTermsOfService(dbUser);
-  }
-
-  private boolean hasSignedLatestTerraTermsOfService(@Nonnull DbUser dbUser) {
-    try {
-      return fireCloudService.hasUserAcceptedLatestTerraToS(dbUser);
-    } catch (Exception e) {
-      log.log(
-          Level.SEVERE,
-          String.format(
-              "Error while getting Terra Terms of Service status for user %s",
-              dbUser.getUsername()));
-      throw new ServerErrorException(e);
-    }
+    return hasSignedLatestAoUTermsOfService(dbUser)
+        && fireCloudService.hasUserAcceptedLatestTerraToS(dbUser);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -140,7 +140,7 @@ public interface FireCloudService {
 
   boolean workspaceFileTransferComplete(String workspaceNamespace, String fireCloudName);
 
-  @Deprecated(forRemoval = true)
+  @Deprecated
   void acceptTermsOfServiceDeprecated();
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -3,8 +3,6 @@ package org.pmiops.workbench.firecloud;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nonnull;
-import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupWithMembers;
 import org.pmiops.workbench.firecloud.model.FirecloudMe;
@@ -144,22 +142,18 @@ public interface FireCloudService {
   void acceptTermsOfServiceDeprecated();
 
   /**
-   * Is the current user currently compliant with Terra's Terms of Service?
-   *
-   * <p>This will be true of the user has accepted the latest version OR we are in the rolling
+   * Is the current user currently compliant with Terra's Terms of Service?  This will be true if the user has accepted the latest version OR we are in the rolling
    * acceptance window
    *
-   * @param dbUser the current user (only used to construct error message)
    * @return true if Terra allows system usage based on ToS status
    */
-  boolean isUserCompliantWithTerraToS(@Nonnull DbUser dbUser);
+  boolean isUserCompliantWithTerraToS();
 
   /**
    * Has the current user accepted the <b>latest</b> Terra Terms of Service? Note: this is a
-   * stricter requirement than {@link #isUserCompliantWithTerraToS(DbUser)}
+   * stricter requirement than {@link #isUserCompliantWithTerraToS()}
    *
-   * @param dbUser the current user (only used to construct error message)
    * @return true if the user is compliant with the latest Terra ToS
    */
-  boolean hasUserAcceptedLatestTerraToS(@Nonnull DbUser dbUser);
+  boolean hasUserAcceptedLatestTerraToS();
 }

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -140,6 +140,7 @@ public interface FireCloudService {
 
   boolean workspaceFileTransferComplete(String workspaceNamespace, String fireCloudName);
 
+  @Deprecated(forRemoval = true)
   void acceptTermsOfServiceDeprecated();
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -142,8 +142,6 @@ public interface FireCloudService {
 
   void acceptTermsOfServiceDeprecated();
 
-  boolean getUserTermsOfServiceStatusDeprecated();
-
   /**
    * Is the current user currently compliant with Terra's Terms of Service?
    *

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -142,8 +142,8 @@ public interface FireCloudService {
   void acceptTermsOfServiceDeprecated();
 
   /**
-   * Is the current user currently compliant with Terra's Terms of Service?  This will be true if the user has accepted the latest version OR we are in the rolling
-   * acceptance window
+   * Is the current user currently compliant with Terra's Terms of Service? This will be true if the
+   * user has accepted the latest version OR we are in the rolling acceptance window
    *
    * @return true if Terra allows system usage based on ToS status
    */

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -3,6 +3,8 @@ package org.pmiops.workbench.firecloud;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nonnull;
+import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupWithMembers;
 import org.pmiops.workbench.firecloud.model.FirecloudMe;
@@ -138,7 +140,27 @@ public interface FireCloudService {
 
   boolean workspaceFileTransferComplete(String workspaceNamespace, String fireCloudName);
 
-  void acceptTermsOfService();
+  void acceptTermsOfServiceDeprecated();
 
-  boolean getUserTermsOfServiceStatus() throws ApiException;
+  boolean getUserTermsOfServiceStatusDeprecated();
+
+  /**
+   * Is the current user currently compliant with Terra's Terms of Service?
+   *
+   * <p>This will be true of the user has accepted the latest version OR we are in the rolling
+   * acceptance window
+   *
+   * @param dbUser the current user (only used to construct error message)
+   * @return true if Terra allows system usage based on ToS status
+   */
+  boolean isUserCompliantWithTerraToS(@Nonnull DbUser dbUser);
+
+  /**
+   * Has the current user accepted the <b>latest</b> Terra Terms of Service? Note: this is a
+   * stricter requirement than {@link #isUserCompliantWithTerraToS(DbUser)}
+   *
+   * @param dbUser the current user (only used to construct error message)
+   * @return true if the user is compliant with the latest Terra ToS
+   */
+  boolean hasUserAcceptedLatestTerraToS(@Nonnull DbUser dbUser);
 }

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -595,7 +595,13 @@ public class FireCloudServiceImpl implements FireCloudService {
 
   @Override
   public boolean hasUserAcceptedLatestTerraToS(@Nonnull DbUser dbUser) {
-    return getUserTerraToSStatus(dbUser).getIsCurrentVersion();
+    var status = getUserTerraToSStatus(dbUser);
+    // I'd prefer to simply call `getIsCurrentVersion()` but this still returns true if the user
+    // rejects the ToS.
+    // See
+    // https://broadinstitute.slack.com/archives/C0DSD41QT/p1701111037789719?thread_ts=1701103991.553039&cid=C0DSD41QT
+    // TODO link a Terra/Sam bug if they create one for this
+    return status.getPermitsSystemUsage() && status.getIsCurrentVersion();
   }
 
   private UserTermsOfServiceDetails getUserTerraToSStatus(@Nonnull DbUser dbUser) {

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -586,14 +586,6 @@ public class FireCloudServiceImpl implements FireCloudService {
     retryHandler.run((context) -> termsOfServiceApi.acceptTermsOfService(TERMS_OF_SERVICE_BODY));
   }
 
-  @Deprecated(forRemoval = true)
-  @Override
-  public boolean getUserTermsOfServiceStatusDeprecated() {
-    org.pmiops.workbench.firecloud.api.TermsOfServiceApi termsOfServiceApi =
-        firecloudTermsOfServiceApiProvider.get();
-    return retryHandler.run((context) -> termsOfServiceApi.getTermsOfServiceStatus());
-  }
-
   // these relate to the new Terms of Service endpoints, after Nov 2023 update
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -93,7 +93,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   private final Provider<WorkspacesApi> serviceAccountWorkspaceApiProvider;
 
   // old Terms of Service endpoints, before Nov 2023 update
-  @Deprecated(forRemoval = true)
+  @Deprecated
   private final Provider<org.pmiops.workbench.firecloud.api.TermsOfServiceApi>
       firecloudTermsOfServiceApiProvider;
 
@@ -162,7 +162,7 @@ public class FireCloudServiceImpl implements FireCloudService {
       SamRetryHandler samRetryHandler,
 
       // old Terms of Service endpoints, before Nov 2023 update
-      @Deprecated(forRemoval = true)
+      @Deprecated
           Provider<org.pmiops.workbench.firecloud.api.TermsOfServiceApi>
               firecloudTermsOfServiceApiProvider,
       Provider<TermsOfServiceApi> termsOfServiceApiProvider) {
@@ -578,7 +578,7 @@ public class FireCloudServiceImpl implements FireCloudService {
 
   // these relate to the old Terms of Service endpoints, before Nov 2023 update
 
-  @Deprecated(forRemoval = true)
+  @Deprecated
   @Override
   public void acceptTermsOfServiceDeprecated() {
     org.pmiops.workbench.firecloud.api.TermsOfServiceApi termsOfServiceApi =

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -597,7 +597,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   public boolean hasUserAcceptedLatestTerraToS(@Nonnull DbUser dbUser) {
     var status = getUserTerraToSStatus(dbUser);
     // I'd prefer to simply call `getIsCurrentVersion()` but this still returns true if the user
-    // rejects the ToS.
+    // has rejected the ToS.
     // See
     // https://broadinstitute.slack.com/archives/C0DSD41QT/p1701111037789719?thread_ts=1701103991.553039&cid=C0DSD41QT
     // TODO link a Terra/Sam bug if they create one for this

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
 import javax.inject.Provider;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsde.workbench.client.sam.api.TermsOfServiceApi;
@@ -27,7 +26,6 @@ import org.json.JSONObject;
 import org.pmiops.workbench.calhoun.CalhounRetryHandler;
 import org.pmiops.workbench.calhoun.api.ConvertApi;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.firecloud.api.GroupsApi;
@@ -588,12 +586,12 @@ public class FireCloudServiceImpl implements FireCloudService {
   // these relate to the new Terms of Service endpoints, after RW-11416
 
   @Override
-  public boolean isUserCompliantWithTerraToS(@Nonnull DbUser dbUser) {
+  public boolean isUserCompliantWithTerraToS() {
     return getUserTerraToSStatus().getPermitsSystemUsage();
   }
 
   @Override
-  public boolean hasUserAcceptedLatestTerraToS(@Nonnull DbUser dbUser) {
+  public boolean hasUserAcceptedLatestTerraToS() {
     var status = getUserTerraToSStatus();
     // I'd prefer to simply call `getIsCurrentVersion()` but this still returns true if the user
     // has rejected the ToS.

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -92,7 +92,7 @@ public class FireCloudServiceImpl implements FireCloudService {
   private final Provider<WorkspacesApi> endUserLenientTimeoutWorkspacesApiProvider;
   private final Provider<WorkspacesApi> serviceAccountWorkspaceApiProvider;
 
-  // old Terms of Service endpoints, before Nov 2023 update
+  // old Terms of Service endpoints, before RW-11416
   @Deprecated
   private final Provider<org.pmiops.workbench.firecloud.api.TermsOfServiceApi>
       firecloudTermsOfServiceApiProvider;
@@ -161,7 +161,7 @@ public class FireCloudServiceImpl implements FireCloudService {
       CalhounRetryHandler calhounRetryHandler,
       SamRetryHandler samRetryHandler,
 
-      // old Terms of Service endpoints, before Nov 2023 update
+      // old Terms of Service endpoints, before RW-11416
       @Deprecated
           Provider<org.pmiops.workbench.firecloud.api.TermsOfServiceApi>
               firecloudTermsOfServiceApiProvider,
@@ -576,7 +576,7 @@ public class FireCloudServiceImpl implements FireCloudService {
     return !(StringUtils.isEmpty(fileTransferTime) || fileTransferTime.equals("0"));
   }
 
-  // these relate to the old Terms of Service endpoints, before Nov 2023 update
+  // these relate to the old Terms of Service endpoints, before RW-11416
 
   @Deprecated
   @Override
@@ -586,7 +586,7 @@ public class FireCloudServiceImpl implements FireCloudService {
     retryHandler.run((context) -> termsOfServiceApi.acceptTermsOfService(TERMS_OF_SERVICE_BODY));
   }
 
-  // these relate to the new Terms of Service endpoints, after Nov 2023 update
+  // these relate to the new Terms of Service endpoints, after RW-11416
 
   @Override
   public boolean isUserCompliantWithTerraToS(@Nonnull DbUser dbUser) {

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -21,7 +21,7 @@ import javax.annotation.Nonnull;
 import javax.inject.Provider;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsde.workbench.client.sam.api.TermsOfServiceApi;
-import org.broadinstitute.dsde.workbench.client.sam.model.TermsOfServiceComplianceStatus;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserTermsOfServiceDetails;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.pmiops.workbench.calhoun.CalhounRetryHandler;
@@ -595,14 +595,13 @@ public class FireCloudServiceImpl implements FireCloudService {
 
   @Override
   public boolean hasUserAcceptedLatestTerraToS(@Nonnull DbUser dbUser) {
-    return getUserTerraToSStatus(dbUser).getUserHasAcceptedLatestTos();
+    return getUserTerraToSStatus(dbUser).getIsCurrentVersion();
   }
 
-  private TermsOfServiceComplianceStatus getUserTerraToSStatus(@Nonnull DbUser dbUser) {
+  private UserTermsOfServiceDetails getUserTerraToSStatus(@Nonnull DbUser dbUser) {
     TermsOfServiceApi termsOfServiceApi = termsOfServiceApiProvider.get();
     try {
-      return samRetryHandler.run(
-          (context) -> termsOfServiceApi.getTermsOfServiceComplianceStatus());
+      return samRetryHandler.run((context) -> termsOfServiceApi.userTermsOfServiceGetSelf());
     } catch (Exception e) {
       log.log(
           Level.SEVERE,

--- a/api/src/main/java/org/pmiops/workbench/sam/SamApiClientFactory.java
+++ b/api/src/main/java/org/pmiops/workbench/sam/SamApiClientFactory.java
@@ -49,7 +49,7 @@ public class SamApiClientFactory {
    * Creates a SAM API client, unauthenticated. Most clients should use an authenticated, request
    * scoped bean instead of calling this directly.
    */
-  public ApiClient newApiClient() {
+  ApiClient newApiClient() {
     WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
     return new ApiClient()
         .setBasePath(workbenchConfig.firecloud.samBaseUrl)

--- a/api/src/main/java/org/pmiops/workbench/sam/SamApiClientFactory.java
+++ b/api/src/main/java/org/pmiops/workbench/sam/SamApiClientFactory.java
@@ -49,7 +49,7 @@ public class SamApiClientFactory {
    * Creates a SAM API client, unauthenticated. Most clients should use an authenticated, request
    * scoped bean instead of calling this directly.
    */
-  private ApiClient newApiClient() {
+  public ApiClient newApiClient() {
     WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
     return new ApiClient()
         .setBasePath(workbenchConfig.firecloud.samBaseUrl)

--- a/api/src/main/java/org/pmiops/workbench/sam/SamConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/sam/SamConfig.java
@@ -1,0 +1,32 @@
+package org.pmiops.workbench.sam;
+
+import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
+import org.broadinstitute.dsde.workbench.client.sam.api.TermsOfServiceApi;
+import org.pmiops.workbench.auth.UserAuthentication;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.web.context.annotation.RequestScope;
+
+@org.springframework.context.annotation.Configuration
+public class SamConfig {
+  public static final String END_USER_CLIENT = "samEndUserApiClient";
+  public static final String TOS_API = "samTermsOfServiceApi";
+
+  @Bean(name = END_USER_CLIENT)
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  public ApiClient endUserApiClient(
+      UserAuthentication userAuthentication, SamApiClientFactory factory) {
+    ApiClient apiClient = factory.newApiClient();
+    apiClient.setAccessToken(userAuthentication.getCredentials());
+    return apiClient;
+  }
+
+  @Bean(name = TOS_API)
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  public TermsOfServiceApi termsOfServiceApi(@Qualifier(END_USER_CLIENT) ApiClient apiClient) {
+    TermsOfServiceApi api = new TermsOfServiceApi();
+    api.setApiClient(apiClient);
+    return api;
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -310,8 +310,8 @@ public class ProfileControllerTest extends BaseControllerTest {
     try {
       when(mockCaptchaVerificationService.verifyCaptcha(CAPTCHA_TOKEN)).thenReturn(true);
       when(mockCaptchaVerificationService.verifyCaptcha(WRONG_CAPTCHA_TOKEN)).thenReturn(false);
-      when(mockFireCloudService.hasUserAcceptedLatestTerraToS(any())).thenReturn(true);
-      when(mockFireCloudService.isUserCompliantWithTerraToS(any())).thenReturn(true);
+      when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(true);
+      when(mockFireCloudService.isUserCompliantWithTerraToS()).thenReturn(true);
     } catch (ApiException e) {
       e.printStackTrace();
     }
@@ -606,7 +606,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
   @Test
   public void testGetUserTermsOfServiceStatus_UserHasNotAcceptedTerraTOS() {
-    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(any())).thenReturn(false);
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(false);
     createAccountAndDbUserWithAffiliation();
     assertThat(profileController.getUserTermsOfServiceStatus().getBody()).isFalse();
   }

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -310,7 +310,8 @@ public class ProfileControllerTest extends BaseControllerTest {
     try {
       when(mockCaptchaVerificationService.verifyCaptcha(CAPTCHA_TOKEN)).thenReturn(true);
       when(mockCaptchaVerificationService.verifyCaptcha(WRONG_CAPTCHA_TOKEN)).thenReturn(false);
-      when(mockFireCloudService.getUserTermsOfServiceStatusDeprecated()).thenReturn(true);
+      when(mockFireCloudService.hasUserAcceptedLatestTerraToS(any())).thenReturn(true);
+      when(mockFireCloudService.isUserCompliantWithTerraToS(any())).thenReturn(true);
     } catch (ApiException e) {
       e.printStackTrace();
     }
@@ -605,7 +606,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
   @Test
   public void testGetUserTermsOfServiceStatus_UserHasNotAcceptedTerraTOS() {
-    when(mockFireCloudService.getUserTermsOfServiceStatusDeprecated()).thenReturn(false);
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(any())).thenReturn(false);
     createAccountAndDbUserWithAffiliation();
     assertThat(profileController.getUserTermsOfServiceStatus().getBody()).isFalse();
   }

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -702,7 +702,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   }
 
   @Test
-  public void test_AcceptTermsOfService() {
+  public void test_acceptTermsOfServiceDeprecated() {
     createAccountAndDbUserWithAffiliation();
     profileController.acceptTermsOfService(1);
     verify(mockFireCloudService).acceptTermsOfServiceDeprecated();

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -310,8 +310,8 @@ public class ProfileControllerTest extends BaseControllerTest {
     try {
       when(mockCaptchaVerificationService.verifyCaptcha(CAPTCHA_TOKEN)).thenReturn(true);
       when(mockCaptchaVerificationService.verifyCaptcha(WRONG_CAPTCHA_TOKEN)).thenReturn(false);
-      when(mockFireCloudService.getUserTermsOfServiceStatus()).thenReturn(true);
-    } catch (ApiException | org.pmiops.workbench.firecloud.ApiException e) {
+      when(mockFireCloudService.getUserTermsOfServiceStatusDeprecated()).thenReturn(true);
+    } catch (ApiException e) {
       e.printStackTrace();
     }
 
@@ -604,9 +604,8 @@ public class ProfileControllerTest extends BaseControllerTest {
   }
 
   @Test
-  public void testGetUserTermsOfServiceStatus_UserHasNotAcceptedTerraTOS()
-      throws org.pmiops.workbench.firecloud.ApiException {
-    when(mockFireCloudService.getUserTermsOfServiceStatus()).thenReturn(false);
+  public void testGetUserTermsOfServiceStatus_UserHasNotAcceptedTerraTOS() {
+    when(mockFireCloudService.getUserTermsOfServiceStatusDeprecated()).thenReturn(false);
     createAccountAndDbUserWithAffiliation();
     assertThat(profileController.getUserTermsOfServiceStatus().getBody()).isFalse();
   }
@@ -705,7 +704,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   public void test_AcceptTermsOfService() {
     createAccountAndDbUserWithAffiliation();
     profileController.acceptTermsOfService(1);
-    verify(mockFireCloudService).acceptTermsOfService();
+    verify(mockFireCloudService).acceptTermsOfServiceDeprecated();
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -726,8 +726,13 @@ public class ProfileControllerTest extends BaseControllerTest {
   }
 
   @Test
-  public void test_acceptTermsOfServiceDeprecated() {
+  public void test_acceptTermsOfService() {
     createAccountAndDbUserWithAffiliation();
+
+    // current behavior is to record any given version of the AoU ToS in the DB
+    // and always invoke Terra acceptance as well, regardless of version
+    // TODO: should we be more stringent about this in the future for RW-11416?
+
     profileController.acceptTermsOfService(1);
     verify(mockFireCloudService).acceptTermsOfServiceDeprecated();
   }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -299,7 +299,7 @@ public class UserServiceTest {
   }
 
   @Test
-  public void testAcceptTerraTermsOfService() {
+  public void testAcceptTerraTermsOfServiceDeprecated() {
     // confirm empty to start
     assertThat(StreamSupport.stream(userTermsOfServiceDao.findAll().spliterator(), false).count())
         .isEqualTo(0);
@@ -309,7 +309,8 @@ public class UserServiceTest {
     userService.submitAouTermsOfService(
         user, providedWorkbenchConfig.termsOfService.latestAouVersion);
 
-    userService.acceptTerraTermsOfService(userDao.findUserByUsername(USERNAME));
+    // to be replaced as part of RW-11416
+    userService.acceptTerraTermsOfServiceDeprecated(userDao.findUserByUsername(USERNAME));
     verify(mockFireCloudService).acceptTermsOfServiceDeprecated();
 
     Optional<DbUserTermsOfService> tosMaybe =

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -511,69 +511,71 @@ public class UserServiceTest {
   }
 
   @Test
-  public void test_validateAllOfUsTermsOfServiceVersion() {
+  public void test_hasSignedLatestAoUTermsOfService() {
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion);
-    assertThat(userService.validateAllOfUsTermsOfServiceVersion(user)).isTrue();
+    assertThat(userService.hasSignedLatestAoUTermsOfService(user)).isTrue();
   }
 
   @Test
-  public void test_validateAllOfUsTermsOfServiceVersion_incorrectVersion() {
+  public void test_hasSignedLatestAoUTermsOfService_incorrectVersion() {
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion - 1);
-    assertThat(userService.validateAllOfUsTermsOfServiceVersion(user)).isFalse();
+    assertThat(userService.hasSignedLatestAoUTermsOfService(user)).isFalse();
   }
 
   @Test
-  public void test_validateAllOfUsTermsOfServiceVersion_userHasNotAcceptedTOS() {
+  public void test_hasSignedLatestAoUTermsOfService_missing() {
     DbUser dbUser = userDao.findUserByUsername(USERNAME);
-    assertThat(userService.validateAllOfUsTermsOfServiceVersion(dbUser)).isFalse();
+    assertThat(userService.hasSignedLatestAoUTermsOfService(dbUser)).isFalse();
   }
 
   @Test
-  public void test_validateTermsOfService_dbUser_hasNotAcceptedTerraTOS() {
-    when(mockFireCloudService.getUserTermsOfServiceStatusDeprecated()).thenReturn(false);
+  public void test_hasSignedLatestTermsOfServiceBoth() {
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion);
-
-    assertThat(userService.validateTermsOfService(user)).isFalse();
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(user)).thenReturn(true);
+    assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isTrue();
   }
 
   @Test
-  public void test_validateTermsOfService_dbUser() {
-    when(mockFireCloudService.getUserTermsOfServiceStatusDeprecated()).thenReturn(true);
+  public void test_hasSignedLatestTermsOfServiceBoth_has_not_accepted_terra() {
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion);
-    assertThat(userService.validateTermsOfService(user)).isTrue();
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(user)).thenReturn(false);
+    assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
   }
 
   @Test
-  public void test_validateTermsOfService_dbUser_missing_version() {
+  public void test_hasSignedLatestTermsOfServiceBoth_missing_aou_version_has_accepted_terra() {
     DbUser user = userDao.findUserByUsername(USERNAME);
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(user)).thenReturn(true);
     userTermsOfServiceDao.save(new DbUserTermsOfService().setUserId(user.getUserId()));
-    assertThat(userService.validateTermsOfService(user)).isFalse();
+    assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
   }
 
   @Test
-  public void test_validateTermsOfService_dbUser_wrong_aou_version_acceptedTerra() {
-    when(mockFireCloudService.getUserTermsOfServiceStatusDeprecated()).thenReturn(true);
-    DbUser user =
-        createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion - 1);
-    assertThat(userService.validateTermsOfService(user)).isFalse();
-  }
-
-  @Test
-  public void test_validateTermsOfService_dbUser_wrong_aou_version_hasNot_acceptedTerra() {
-    when(mockFireCloudService.getUserTermsOfServiceStatusDeprecated()).thenReturn(false);
-    DbUser user =
-        createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion - 1);
-    assertThat(userService.validateTermsOfService(user)).isFalse();
-  }
-
-  @Test
-  public void test_validateAllOfUsTermsOfService_dbUser_no_tos_entry() {
+  public void test_hasSignedLatestTermsOfServiceBoth_missing_aou_version_has_not_accepted_terra() {
     DbUser user = userDao.findUserByUsername(USERNAME);
-    assertThat(userService.validateTermsOfService(user)).isFalse();
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(user)).thenReturn(false);
+    userTermsOfServiceDao.save(new DbUserTermsOfService().setUserId(user.getUserId()));
+    assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
+  }
+
+  @Test
+  public void test_hasSignedLatestTermsOfServiceBoth_wrong_aou_version_has_accepted_terra() {
+    DbUser user =
+        createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion - 1);
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(user)).thenReturn(true);
+    assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
+  }
+
+  @Test
+  public void test_hasSignedLatestTermsOfServiceBoth_wrong_aou_version_has_not_accepted_terra() {
+    DbUser user =
+        createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion - 1);
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(user)).thenReturn(false);
+    assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -536,7 +536,7 @@ public class UserServiceTest {
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion);
     when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(true);
-    assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isTrue();
+    assertThat(userService.hasSignedLatestTermsOfServiceForBoth(user)).isTrue();
   }
 
   @Test
@@ -544,7 +544,7 @@ public class UserServiceTest {
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion);
     when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(false);
-    assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
+    assertThat(userService.hasSignedLatestTermsOfServiceForBoth(user)).isFalse();
   }
 
   @Test
@@ -552,7 +552,7 @@ public class UserServiceTest {
     DbUser user = userDao.findUserByUsername(USERNAME);
     when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(true);
     userTermsOfServiceDao.save(new DbUserTermsOfService().setUserId(user.getUserId()));
-    assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
+    assertThat(userService.hasSignedLatestTermsOfServiceForBoth(user)).isFalse();
   }
 
   @Test
@@ -560,7 +560,7 @@ public class UserServiceTest {
     DbUser user = userDao.findUserByUsername(USERNAME);
     when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(false);
     userTermsOfServiceDao.save(new DbUserTermsOfService().setUserId(user.getUserId()));
-    assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
+    assertThat(userService.hasSignedLatestTermsOfServiceForBoth(user)).isFalse();
   }
 
   @Test
@@ -568,7 +568,7 @@ public class UserServiceTest {
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion - 1);
     when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(true);
-    assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
+    assertThat(userService.hasSignedLatestTermsOfServiceForBoth(user)).isFalse();
   }
 
   @Test
@@ -576,7 +576,7 @@ public class UserServiceTest {
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion - 1);
     when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(false);
-    assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
+    assertThat(userService.hasSignedLatestTermsOfServiceForBoth(user)).isFalse();
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -535,7 +535,7 @@ public class UserServiceTest {
   public void test_hasSignedLatestTermsOfServiceBoth() {
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion);
-    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(user)).thenReturn(true);
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(true);
     assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isTrue();
   }
 
@@ -543,14 +543,14 @@ public class UserServiceTest {
   public void test_hasSignedLatestTermsOfServiceBoth_has_not_accepted_terra() {
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion);
-    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(user)).thenReturn(false);
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(false);
     assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
   }
 
   @Test
   public void test_hasSignedLatestTermsOfServiceBoth_missing_aou_version_has_accepted_terra() {
     DbUser user = userDao.findUserByUsername(USERNAME);
-    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(user)).thenReturn(true);
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(true);
     userTermsOfServiceDao.save(new DbUserTermsOfService().setUserId(user.getUserId()));
     assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
   }
@@ -558,7 +558,7 @@ public class UserServiceTest {
   @Test
   public void test_hasSignedLatestTermsOfServiceBoth_missing_aou_version_has_not_accepted_terra() {
     DbUser user = userDao.findUserByUsername(USERNAME);
-    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(user)).thenReturn(false);
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(false);
     userTermsOfServiceDao.save(new DbUserTermsOfService().setUserId(user.getUserId()));
     assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
   }
@@ -567,7 +567,7 @@ public class UserServiceTest {
   public void test_hasSignedLatestTermsOfServiceBoth_wrong_aou_version_has_accepted_terra() {
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion - 1);
-    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(user)).thenReturn(true);
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(true);
     assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
   }
 
@@ -575,7 +575,7 @@ public class UserServiceTest {
   public void test_hasSignedLatestTermsOfServiceBoth_wrong_aou_version_has_not_accepted_terra() {
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion - 1);
-    when(mockFireCloudService.hasUserAcceptedLatestTerraToS(user)).thenReturn(false);
+    when(mockFireCloudService.hasUserAcceptedLatestTerraToS()).thenReturn(false);
     assertThat(userService.hasSignedLatestTermsOfServiceBoth(user)).isFalse();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -310,7 +310,7 @@ public class UserServiceTest {
         user, providedWorkbenchConfig.termsOfService.latestAouVersion);
 
     userService.acceptTerraTermsOfService(userDao.findUserByUsername(USERNAME));
-    verify(mockFireCloudService).acceptTermsOfService();
+    verify(mockFireCloudService).acceptTermsOfServiceDeprecated();
 
     Optional<DbUserTermsOfService> tosMaybe =
         userTermsOfServiceDao.findFirstByUserIdOrderByTosVersionDesc(user.getUserId());
@@ -531,9 +531,8 @@ public class UserServiceTest {
   }
 
   @Test
-  public void test_validateTermsOfService_dbUser_hasNotAcceptedTerraTOS()
-      throws org.pmiops.workbench.firecloud.ApiException {
-    when(mockFireCloudService.getUserTermsOfServiceStatus()).thenReturn(false);
+  public void test_validateTermsOfService_dbUser_hasNotAcceptedTerraTOS() {
+    when(mockFireCloudService.getUserTermsOfServiceStatusDeprecated()).thenReturn(false);
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion);
 
@@ -541,9 +540,8 @@ public class UserServiceTest {
   }
 
   @Test
-  public void test_validateTermsOfService_dbUser()
-      throws org.pmiops.workbench.firecloud.ApiException {
-    when(mockFireCloudService.getUserTermsOfServiceStatus()).thenReturn(true);
+  public void test_validateTermsOfService_dbUser() {
+    when(mockFireCloudService.getUserTermsOfServiceStatusDeprecated()).thenReturn(true);
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion);
     assertThat(userService.validateTermsOfService(user)).isTrue();
@@ -557,18 +555,16 @@ public class UserServiceTest {
   }
 
   @Test
-  public void test_validateTermsOfService_dbUser_wrong_aou_version_acceptedTerra()
-      throws org.pmiops.workbench.firecloud.ApiException {
-    when(mockFireCloudService.getUserTermsOfServiceStatus()).thenReturn(true);
+  public void test_validateTermsOfService_dbUser_wrong_aou_version_acceptedTerra() {
+    when(mockFireCloudService.getUserTermsOfServiceStatusDeprecated()).thenReturn(true);
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion - 1);
     assertThat(userService.validateTermsOfService(user)).isFalse();
   }
 
   @Test
-  public void test_validateTermsOfService_dbUser_wrong_aou_version_hasNot_acceptedTerra()
-      throws org.pmiops.workbench.firecloud.ApiException {
-    when(mockFireCloudService.getUserTermsOfServiceStatus()).thenReturn(false);
+  public void test_validateTermsOfService_dbUser_wrong_aou_version_hasNot_acceptedTerra() {
+    when(mockFireCloudService.getUserTermsOfServiceStatusDeprecated()).thenReturn(false);
     DbUser user =
         createUserWithAoUTOSVersion(providedWorkbenchConfig.termsOfService.latestAouVersion - 1);
     assertThat(userService.validateTermsOfService(user)).isFalse();

--- a/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
@@ -12,7 +12,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import org.broadinstitute.dsde.workbench.client.sam.api.TermsOfServiceApi;
-import org.broadinstitute.dsde.workbench.client.sam.model.TermsOfServiceComplianceStatus;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserTermsOfServiceDetails;
 import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -279,44 +279,44 @@ public class FireCloudServiceImplTest {
   @Test
   public void isUserCompliantWithTerraToS()
       throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
-    var toReturn = new TermsOfServiceComplianceStatus().permitsSystemUsage(true);
-    when(termsOfServiceApi.getTermsOfServiceComplianceStatus()).thenReturn(toReturn);
+    var toReturn = new UserTermsOfServiceDetails().permitsSystemUsage(true);
+    when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
     assertThat(service.isUserCompliantWithTerraToS(new DbUser())).isTrue();
 
-    verify(termsOfServiceApi).getTermsOfServiceComplianceStatus();
+    verify(termsOfServiceApi).userTermsOfServiceGetSelf();
     verifyNoInteractions(firecloudTermsOfServiceApi);
   }
 
   @Test
   public void isUserCompliantWithTerraToS_false()
       throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
-    var toReturn = new TermsOfServiceComplianceStatus().permitsSystemUsage(false);
-    when(termsOfServiceApi.getTermsOfServiceComplianceStatus()).thenReturn(toReturn);
+    var toReturn = new UserTermsOfServiceDetails().permitsSystemUsage(false);
+    when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
     assertThat(service.isUserCompliantWithTerraToS(new DbUser())).isFalse();
 
-    verify(termsOfServiceApi).getTermsOfServiceComplianceStatus();
+    verify(termsOfServiceApi).userTermsOfServiceGetSelf();
     verifyNoInteractions(firecloudTermsOfServiceApi);
   }
 
   @Test
   public void hasUserAcceptedLatestTerraToS()
       throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
-    var toReturn = new TermsOfServiceComplianceStatus().userHasAcceptedLatestTos(true);
-    when(termsOfServiceApi.getTermsOfServiceComplianceStatus()).thenReturn(toReturn);
+    var toReturn = new UserTermsOfServiceDetails().isCurrentVersion(true);
+    when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
     assertThat(service.hasUserAcceptedLatestTerraToS(new DbUser())).isTrue();
 
-    verify(termsOfServiceApi).getTermsOfServiceComplianceStatus();
+    verify(termsOfServiceApi).userTermsOfServiceGetSelf();
     verifyNoInteractions(firecloudTermsOfServiceApi);
   }
 
   @Test
   public void hasUserAcceptedLatestTerraToS_false()
       throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
-    var toReturn = new TermsOfServiceComplianceStatus().userHasAcceptedLatestTos(false);
-    when(termsOfServiceApi.getTermsOfServiceComplianceStatus()).thenReturn(toReturn);
+    var toReturn = new UserTermsOfServiceDetails().isCurrentVersion(false);
+    when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
     assertThat(service.hasUserAcceptedLatestTerraToS(new DbUser())).isFalse();
 
-    verify(termsOfServiceApi).getTermsOfServiceComplianceStatus();
+    verify(termsOfServiceApi).userTermsOfServiceGetSelf();
     verifyNoInteractions(firecloudTermsOfServiceApi);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
@@ -76,9 +76,9 @@ public class FireCloudServiceImplTest {
   @MockBean private NihApi nihApi;
   @MockBean private ProfileApi profileApi;
   @MockBean private StatusApi statusApi;
-  // old Terms of Service endpoints, before Nov 2023 update
+  // old Terms of Service endpoints, before RW-11416
   @MockBean private org.pmiops.workbench.firecloud.api.TermsOfServiceApi firecloudTermsOfServiceApi;
-  // new Terms of Service endpoints, after Nov 2023 update
+  // new Terms of Service endpoints, after RW-11416
   @MockBean private TermsOfServiceApi termsOfServiceApi;
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();

--- a/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
@@ -301,7 +301,12 @@ public class FireCloudServiceImplTest {
   @Test
   public void hasUserAcceptedLatestTerraToS()
       throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
-    var toReturn = new UserTermsOfServiceDetails().isCurrentVersion(true);
+    var toReturn =
+        new UserTermsOfServiceDetails()
+            .isCurrentVersion(true)
+            // currently required - see the comment at hasUserAcceptedLatestTerraToS() for more
+            // details
+            .permitsSystemUsage(true);
     when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
     assertThat(service.hasUserAcceptedLatestTerraToS(new DbUser())).isTrue();
 
@@ -312,7 +317,39 @@ public class FireCloudServiceImplTest {
   @Test
   public void hasUserAcceptedLatestTerraToS_false()
       throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
-    var toReturn = new UserTermsOfServiceDetails().isCurrentVersion(false);
+    var toReturn =
+        new UserTermsOfServiceDetails()
+            .isCurrentVersion(false)
+            // currently required - see the comment at hasUserAcceptedLatestTerraToS() for more
+            // details
+            .permitsSystemUsage(true);
+    when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
+    assertThat(service.hasUserAcceptedLatestTerraToS(new DbUser())).isFalse();
+
+    verify(termsOfServiceApi).userTermsOfServiceGetSelf();
+    verifyNoInteractions(firecloudTermsOfServiceApi);
+  }
+
+  // these 2 show that hasUserAcceptedLatestTerraToS() is currently dependent on the
+  // permitsSystemUsage value as well as isCurrentVersion.
+  // see the comment at hasUserAcceptedLatestTerraToS() for more details
+
+  @Test
+  public void hasUserAcceptedLatestTerraToS_permits_false_current_true()
+      throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
+    var toReturn = new UserTermsOfServiceDetails().permitsSystemUsage(false).isCurrentVersion(true);
+    when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
+    assertThat(service.hasUserAcceptedLatestTerraToS(new DbUser())).isFalse();
+
+    verify(termsOfServiceApi).userTermsOfServiceGetSelf();
+    verifyNoInteractions(firecloudTermsOfServiceApi);
+  }
+
+  @Test
+  public void hasUserAcceptedLatestTerraToS_permits_false_current_false()
+      throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
+    var toReturn =
+        new UserTermsOfServiceDetails().permitsSystemUsage(false).isCurrentVersion(false);
     when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
     assertThat(service.hasUserAcceptedLatestTerraToS(new DbUser())).isFalse();
 

--- a/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
@@ -23,7 +23,6 @@ import org.mockito.junit.MockitoRule;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.config.RetryConfig;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
@@ -281,7 +280,7 @@ public class FireCloudServiceImplTest {
       throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
     var toReturn = new UserTermsOfServiceDetails().permitsSystemUsage(true);
     when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
-    assertThat(service.isUserCompliantWithTerraToS(new DbUser())).isTrue();
+    assertThat(service.isUserCompliantWithTerraToS()).isTrue();
 
     verify(termsOfServiceApi).userTermsOfServiceGetSelf();
     verifyNoInteractions(firecloudTermsOfServiceApi);
@@ -292,7 +291,7 @@ public class FireCloudServiceImplTest {
       throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
     var toReturn = new UserTermsOfServiceDetails().permitsSystemUsage(false);
     when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
-    assertThat(service.isUserCompliantWithTerraToS(new DbUser())).isFalse();
+    assertThat(service.isUserCompliantWithTerraToS()).isFalse();
 
     verify(termsOfServiceApi).userTermsOfServiceGetSelf();
     verifyNoInteractions(firecloudTermsOfServiceApi);
@@ -308,7 +307,7 @@ public class FireCloudServiceImplTest {
             // details
             .permitsSystemUsage(true);
     when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
-    assertThat(service.hasUserAcceptedLatestTerraToS(new DbUser())).isTrue();
+    assertThat(service.hasUserAcceptedLatestTerraToS()).isTrue();
 
     verify(termsOfServiceApi).userTermsOfServiceGetSelf();
     verifyNoInteractions(firecloudTermsOfServiceApi);
@@ -324,7 +323,7 @@ public class FireCloudServiceImplTest {
             // details
             .permitsSystemUsage(true);
     when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
-    assertThat(service.hasUserAcceptedLatestTerraToS(new DbUser())).isFalse();
+    assertThat(service.hasUserAcceptedLatestTerraToS()).isFalse();
 
     verify(termsOfServiceApi).userTermsOfServiceGetSelf();
     verifyNoInteractions(firecloudTermsOfServiceApi);
@@ -339,7 +338,7 @@ public class FireCloudServiceImplTest {
       throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
     var toReturn = new UserTermsOfServiceDetails().permitsSystemUsage(false).isCurrentVersion(true);
     when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
-    assertThat(service.hasUserAcceptedLatestTerraToS(new DbUser())).isFalse();
+    assertThat(service.hasUserAcceptedLatestTerraToS()).isFalse();
 
     verify(termsOfServiceApi).userTermsOfServiceGetSelf();
     verifyNoInteractions(firecloudTermsOfServiceApi);
@@ -351,7 +350,7 @@ public class FireCloudServiceImplTest {
     var toReturn =
         new UserTermsOfServiceDetails().permitsSystemUsage(false).isCurrentVersion(false);
     when(termsOfServiceApi.userTermsOfServiceGetSelf()).thenReturn(toReturn);
-    assertThat(service.hasUserAcceptedLatestTerraToS(new DbUser())).isFalse();
+    assertThat(service.hasUserAcceptedLatestTerraToS()).isFalse();
 
     verify(termsOfServiceApi).userTermsOfServiceGetSelf();
     verifyNoInteractions(firecloudTermsOfServiceApi);

--- a/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
@@ -277,13 +277,6 @@ public class FireCloudServiceImplTest {
   }
 
   @Test
-  public void getUserTermsOfServiceStatusDeprecated() throws ApiException {
-    service.getUserTermsOfServiceStatusDeprecated();
-    verify(firecloudTermsOfServiceApi).getTermsOfServiceStatus();
-    verifyNoInteractions(termsOfServiceApi);
-  }
-
-  @Test
   public void isUserCompliantWithTerraToS()
       throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
     var toReturn = new TermsOfServiceComplianceStatus().permitsSystemUsage(true);


### PR DESCRIPTION
Update Get Terra ToS for the sign-in flow and the create-account flow to use the new Sam endpoint, and update the logic to require the latest version, not just a compliant version.

Tested locally by:
1. calling the Reject ToS endpoint (the new one, in Sam) and observing that the AoU UI required me to accept the ToS again.  After doing so, I was able to use the RWB as expected.  I also called the Sam endpoints directly and everything looked correct, with one exception [a].  However I have accounted for this here.
2. creating a new user.  The process was unchanged, and calling the new endpoint reported the expected results.

Exception [a] - if a user rejects the Terra ToS, they will continue to see `"isCurrentVersion": true` and `latestAcceptedVersion` equal to the latest, so a check for either of these values doesn't give the full context.  We also need to do an additional check for `permitsSystemUsage`.  I added a workaround that does this, and tests which show this situation.  Terra is a aware and hopefully they will make a fix which allows for us to remove this.

This endpoint is available on Terra Prod, so there's nothing blocking our deployment.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
