### PR TITLE
[risk=low][no ticket] Use more appropriate strings for apps in emails

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoAppUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoAppUtils.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.leonardo;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import org.pmiops.workbench.model.AppType;
@@ -11,8 +12,15 @@ public class LeonardoAppUtils {
 
   private static final String APP_TYPE_GROUP_NAME = "appType";
 
+  private static final Map<AppType, String> APP_DISPLAY_NAMES =
+      Map.of(AppType.CROMWELL, "Cromwell", AppType.RSTUDIO, "RStudio", AppType.SAS, "SAS");
+
   public static Optional<AppType> appServiceNameToAppType(String gkeServiceName) {
     return Matchers.getGroup(APP_NAME_PATTERN, gkeServiceName, APP_TYPE_GROUP_NAME)
         .map(s -> AppType.valueOf(s.toUpperCase()));
+  }
+
+  public static String appDisplayName(AppType appType) {
+    return APP_DISPLAY_NAMES.get(appType);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -32,7 +32,6 @@ import javax.annotation.Nullable;
 import javax.inject.Provider;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.text.CaseUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.EgressAlertRemediationPolicy;
@@ -41,6 +40,7 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.exfiltration.EgressRemediationAction;
 import org.pmiops.workbench.google.CloudStorageClient;
+import org.pmiops.workbench.leonardo.LeonardoAppUtils;
 import org.pmiops.workbench.leonardo.LeonardoLabelHelper;
 import org.pmiops.workbench.leonardo.PersistentDiskUtils;
 import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
@@ -291,7 +291,7 @@ public class MailServiceImpl implements MailService {
 
   private String getEnvironmentType(Object labels) {
     return LeonardoLabelHelper.maybeMapLeonardoLabelsToGkeApp(labels)
-        .map(appType -> CaseUtils.toCamelCase(appType.toString(), true))
+        .map(LeonardoAppUtils::appDisplayName)
         .orElse("Jupyter");
   }
 


### PR DESCRIPTION
I got a reminder email about a disk associated with my "Sas" application.  This capitalization is not correct - it should always be SAS.

<img width="1209" alt="Screenshot 2023-11-28 at 10 14 55 AM" src="https://github.com/all-of-us/workbench/assets/2701406/908c73a6-9d5d-490f-856b-0fe2cd66a725">

Add a display-name utility to produce the desired strings.

Alt: update the AppType enum.  That has the potential to be a pretty intrusive change, so I decided against it - for now anyway.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
