### PR TITLE
[risk=low] RW-11041 update chart name

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -251,8 +251,8 @@ public interface LeonardoMapper {
   @ValueMapping(source = "SAS", target = "ALLOWED")
   LeonardoAppType toLeonardoAppType(AppType appType);
 
-  @ValueMapping(source = "RSTUDIO", target = "RSTUDIO_CHART")
-  @ValueMapping(source = "SAS", target = "SAS_CHART")
+  @ValueMapping(source = "RSTUDIO", target = "RSTUDIO")
+  @ValueMapping(source = "SAS", target = "SAS")
   @ValueMapping(source = "CROMWELL", target = MappingConstants.NULL)
   LeonardoAllowedChartName toLeonardoAllowedChartName(AppType appType);
 

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -1501,8 +1501,8 @@ components:
     AllowedChartName:
       type: string
       enum:
-        - aou-rstudio-chart
-        - aou-sas-chart
+        - rstudio
+        - sas
     AppStatus:
       type: string
       enum:

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -235,7 +235,7 @@ public class LeonardoApiClientTest {
         new LeonardoCreateAppRequest()
             .appType(LeonardoAppType.ALLOWED)
             .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig)
-            .allowedChartName(LeonardoAllowedChartName.RSTUDIO_CHART)
+            .allowedChartName(LeonardoAllowedChartName.RSTUDIO)
             .labels(appLabels)
             .diskConfig(leonardoPersistentDiskRequest.labels(diskLabels).name("pd-name"))
             .customEnvironmentVariables(customEnvironmentVariables);

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -148,9 +148,9 @@ public class LeonardoMapperTest {
   @Test
   public void testToLeonardoAllowedAppChart() {
     assertThat(mapper.toLeonardoAllowedChartName(AppType.RSTUDIO))
-        .isEqualTo(LeonardoAllowedChartName.RSTUDIO_CHART);
+        .isEqualTo(LeonardoAllowedChartName.RSTUDIO);
     assertThat(mapper.toLeonardoAllowedChartName(AppType.SAS))
-        .isEqualTo(LeonardoAllowedChartName.SAS_CHART);
+        .isEqualTo(LeonardoAllowedChartName.SAS);
     assertThat(mapper.toLeonardoAllowedChartName(AppType.CROMWELL)).isNull();
   }
 


### PR DESCRIPTION
Related PR https://github.com/DataBiosphere/leonardo/pull/3974

We recently migrated sas and rstudio charts to [terra-helmfile](https://github.com/broadinstitute/terra-helmfile/tree/master/charts). Along with the migration, we also renamed the chart names. Hence updating the chart names we're using

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
