### PR TITLE
[risk=low][RW-5763] Prevent users from creating too-small Dataproc clusters

### DIFF
--- a/ui/src/app/utils/machines.ts
+++ b/ui/src/app/utils/machines.ts
@@ -370,8 +370,10 @@ export const validLeoGceMachineTypes = allMachineTypes.filter(
 export const validLeoDataprocMasterMachineTypes = allMachineTypes.filter(
   ({ memory }) => memory > 4
 );
+// updated 29 Nov 2023 after observing the error:
+// Creating clusters using the n1-standard-1 machine type is not supported for image version 2.1.11-debian11
 export const validLeoDataprocWorkerMachineTypes = allMachineTypes.filter(
-  ({ memory }) => memory >= 3
+  ({ memory }) => memory >= 4
 );
 
 export const findMachineByName = (machineToFind: string) =>


### PR DESCRIPTION
We previously allowed users to configure Dataproc workers that were smaller than our system would actually support.  This change increases the minimum allowable size.

Tested by successfully creating a new Dataproc cluster using the new minimum configuration (`n1-standard-2`, 2 CPUs, 7.5 GB RAM)

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
