### PR TITLE
[DT-563][risk=no] Fix resource display for Tanagra data page

### DIFF
--- a/ui/src/app/pages/data/tanagra-dev/data-component-tanagra.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/data-component-tanagra.tsx
@@ -10,7 +10,6 @@ import {
 
 import { CardButton, TabButton } from 'app/components/buttons';
 import { FadeBox } from 'app/components/containers';
-import { CreateModal } from 'app/components/create-modal';
 import { ClrIcon } from 'app/components/icons';
 import { TooltipTrigger } from 'app/components/popups';
 import { SpinnerOverlay } from 'app/components/spinners';
@@ -97,6 +96,7 @@ export interface TanagraWorkspaceResource extends WorkspaceResource {
   cohortTanagra?: Cohort;
   conceptSetTanagra?: ConceptSet;
   reviewTanagra?: Review;
+  createdBy?: string;
 }
 
 const mapTanagraWorkspaceResource = ({
@@ -137,7 +137,6 @@ export const DataComponentTanagra = fp.flow(
   const [activeTab, setActiveTab] = useState(Tabs.SHOWALL);
   const [isLoading, setIsLoading] = useState(true);
   const [resourceList, setResourceList] = useState([]);
-  const [showCohortModal, setShowCohortModal] = useState(false);
 
   const { cdrVersionTiersResponse, workspace } = props;
   const { bigqueryDataset } = findCdrVersion(
@@ -211,14 +210,11 @@ export const DataComponentTanagra = fp.flow(
     }
   });
 
-  const getCohortNames = async () => [];
-
-  const createCohort = async (name: string, desc: string) => {
+  const createCohort = async () => {
     const createCohortRequest: CreateCohortRequest = {
       studyId: workspace.namespace,
       cohortCreateInfo: {
-        description: desc,
-        displayName: name,
+        displayName: `Untitled cohort ${new Date().toLocaleString()}`,
         underlayName: 'aou' + bigqueryDataset,
       },
     };
@@ -249,7 +245,7 @@ export const DataComponentTanagra = fp.flow(
             <CardButton
               style={styles.resourceTypeButton}
               disabled={!writePermission}
-              onClick={() => setShowCohortModal(true)}
+              onClick={() => createCohort()}
             >
               <div style={styles.cardHeader}>
                 <h2 style={styles.cardHeaderText(!writePermission)}>Cohorts</h2>
@@ -400,15 +396,6 @@ export const DataComponentTanagra = fp.flow(
           {isLoading && <SpinnerOverlay />}
         </div>
       </FadeBox>
-      {showCohortModal && (
-        <CreateModal
-          entityName='Cohort'
-          title='Save Cohort as'
-          getExistingNames={() => getCohortNames()}
-          save={(name, desc) => createCohort(name, desc)}
-          close={() => setShowCohortModal(false)}
-        />
-      )}
     </React.Fragment>
   );
 });

--- a/ui/src/app/pages/data/tanagra-dev/data-component-tanagra.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/data-component-tanagra.tsx
@@ -201,11 +201,11 @@ export const DataComponentTanagra = fp.flow(
       case Tabs.SHOWALL:
         return true;
       case Tabs.COHORTS:
-        return resource.cohortV2;
+        return resource.cohortTanagra;
       case Tabs.COHORTREVIEWS:
-        return resource.reviewV2;
+        return resource.reviewTanagra;
       case Tabs.CONCEPTSETS:
-        return resource.conceptSetV2;
+        return resource.conceptSetTanagra;
       case Tabs.DATASETS:
         return false; // Currently no saved datasets in Tanagra
     }

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
@@ -24,6 +24,7 @@ import {
 } from 'app/components/with-confirm-delete-modal';
 import { TanagraWorkspaceResource } from 'app/pages/data/tanagra-dev/data-component-tanagra';
 import {
+  getCreatedBy,
   getDisplayName,
   getType,
   getTypeString,
@@ -94,7 +95,7 @@ interface TableData {
   resourceName: string;
   formattedLastModified: string;
   lastModifiedDateAsString: string;
-  lastModifiedBy: string;
+  createdBy: string;
   cdrVersionName: string;
   resource: WorkspaceResource;
   workspace: Workspace;
@@ -169,13 +170,9 @@ export const TanagraResourceList = fp.flow(
     if (workspaceResources) {
       setTableData(
         fp.flatMap((r) => {
-          console.log(r);
-          console.log(getTypeString(r));
-          console.log(getDisplayName(r));
           const workspace = workspaces.find(
             (w) => w.namespace === r.workspaceNamespace
           );
-          console.log(workspace);
 
           // Don't return resources where we no longer have access to the workspace.
           // For example: the owner has unshared the workspace, but a recent-resource entry remains.
@@ -195,6 +192,7 @@ export const TanagraResourceList = fp.flow(
                   ),
                   cdrVersionName: getCdrVersionName(r),
                   lastModifiedBy: r.lastModifiedBy,
+                  createdBy: getCreatedBy(r),
                 },
               ]
             : [];
@@ -319,8 +317,8 @@ export const TanagraResourceList = fp.flow(
               />
             )}
             <Column
-              field='lastModifiedBy'
-              header='Last Modified By'
+              field='createdBy'
+              header='Created By'
               style={styles.column}
             />
           </DataTable>

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-resources.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-resources.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import * as fp from 'lodash/fp';
+
+import { ResourceType } from 'generated/fetch';
+
+import { TanagraWorkspaceResource } from 'app/pages/data/tanagra-dev/data-component-tanagra';
+import colors from 'app/styles/colors';
+
+export const isCohort = (resource: TanagraWorkspaceResource): boolean =>
+  !!resource.cohortTanagra;
+export const isCohortReview = (resource: TanagraWorkspaceResource): boolean =>
+  !!resource.reviewTanagra;
+export const isConceptSet = (resource: TanagraWorkspaceResource): boolean =>
+  !!resource.conceptSetTanagra;
+
+export function toDisplay(resourceType: ResourceType): string {
+  return fp.cond([
+    [(rt) => rt === ResourceType.COHORT, () => 'Cohort'],
+    [(rt) => rt === ResourceType.COHORT_REVIEW, () => 'Cohort Review'],
+    [(rt) => rt === ResourceType.CONCEPT_SET, () => 'Concept Set'],
+    [(rt) => rt === ResourceType.DATASET, () => 'Dataset'],
+    [(rt) => rt === ResourceType.NOTEBOOK, () => 'Notebook'],
+
+    [(rt) => rt === ResourceType.COHORT_SEARCH_GROUP, () => 'Group'],
+    [(rt) => rt === ResourceType.COHORT_SEARCH_ITEM, () => 'Item'],
+    [(rt) => rt === ResourceType.WORKSPACE, () => 'Workspace'],
+  ])(resourceType);
+}
+
+export function getDisplayName(resource: TanagraWorkspaceResource): string {
+  return fp.cond([
+    [isCohort, (r) => r.cohortTanagra.displayName],
+    [isCohortReview, (r) => r.reviewTanagra.displayName],
+    [isConceptSet, (r) => r.conceptSetTanagra.displayName],
+  ])(resource);
+}
+
+export function getType(resource: TanagraWorkspaceResource): ResourceType {
+  return fp.cond([
+    [isCohort, () => ResourceType.COHORT],
+    [isCohortReview, () => ResourceType.COHORT_REVIEW],
+    [isConceptSet, () => ResourceType.CONCEPT_SET],
+  ])(resource);
+}
+
+export const getTypeString = (resource: TanagraWorkspaceResource): string =>
+  toDisplay(getType(resource));
+
+export const StyledResourceType = (props: {
+  resource: TanagraWorkspaceResource;
+}) => {
+  const { resource } = props;
+
+  function getColor(): string {
+    return fp.cond([
+      [isCohort, () => colors.resourceCardHighlights.cohort],
+      [isCohortReview, () => colors.resourceCardHighlights.cohortReview],
+      [isConceptSet, () => colors.resourceCardHighlights.conceptSet],
+    ])(resource);
+  }
+  return (
+    <div
+      data-test-id='card-type'
+      style={{
+        height: '22px',
+        width: '9rem',
+        paddingLeft: '10px',
+        paddingRight: '10px',
+        borderRadius: '2px',
+        display: 'flex',
+        justifyContent: 'left',
+        color: colors.white,
+        fontFamily: 'Montserrat, sans-serif',
+        fontSize: '12px',
+        fontWeight: 500,
+        backgroundColor: getColor(),
+      }}
+    >
+      {fp.startCase(fp.camelCase(getTypeString(resource)))}
+    </div>
+  );
+};

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-resources.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-resources.tsx
@@ -27,6 +27,14 @@ export function toDisplay(resourceType: ResourceType): string {
   ])(resourceType);
 }
 
+export function getCreatedBy(resource: TanagraWorkspaceResource): string {
+  return fp.cond([
+    [isCohort, (r) => r.cohortTanagra.createdBy],
+    [isCohortReview, (r) => r.reviewTanagra.createdBy],
+    [isConceptSet, (r) => r.conceptSetTanagra.createdBy],
+  ])(resource);
+}
+
 export function getDisplayName(resource: TanagraWorkspaceResource): string {
   return fp.cond([
     [isCohort, (r) => r.cohortTanagra.displayName],


### PR DESCRIPTION
- Fix display of resources table for Data tab of Tanagra workspaces
- Change create cohort function to match Tanagra (create 'Untitled' cohort instead of prompting for name)

![Screenshot 2023-12-06 at 11 46 28 AM](https://github.com/all-of-us/workbench/assets/40036095/6e3a1261-cb92-40ff-b4c6-eb6357817924)

https://github.com/all-of-us/workbench/assets/40036095/d5385705-1acb-454c-bab7-4d7940f45308

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
