### PR TITLE
[DT-646][risk=no] Hide concept option in CB for variant search items

### DIFF
--- a/ui/src/app/pages/data/cohort/search-group-item.tsx
+++ b/ui/src/app/pages/data/cohort/search-group-item.tsx
@@ -455,6 +455,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
       return (
         this.preventItemEdit ||
         type === Domain.PERSON.toString() ||
+        type === Domain.SNP_INDEL_VARIANT.toString() ||
         !searchParameters.some(
           (param) => param.subtype !== CriteriaSubType.ANSWER.toString()
         )


### PR DESCRIPTION
Hide 'Add criteria to concept set' option in the search item menu when the domain is `SNP_INDEL_VARIANT`