### PR TITLE
[risk=low][RW-11491] Automate deployments to the Stable environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,25 +124,55 @@ commands:
       - run:
           command: git submodule update -f --init --recursive
 
-  deploy-to-staging-command:
-    description: "Deploy API and UI to staging App Engine"
+  deploy-command:
+    description: "Deploy API and UI to App Engine"
+    parameters:
+      project_name:
+        type: string
+      service_account:
+        type: string
+      credentials_env_var:
+        type: string
+      key_env_var:
+        type: string
     steps:
       - checkout-code
       - attach_workspace:
           at: .
-      - gcloud-auth-login
+      - gcloud-auth-login:
+          credentials_env_var: << parameters.credentials_env_var >>
+          key_env_var: << parameters.key_env_var >>
       - deploy:
           working_directory: ~/workbench/deploy
           command: |
             ./project.rb deploy \
-              --project all-of-us-rw-staging \
-              --account << pipeline.parameters.circle-service-account >> \
+              --project << parameters.project_name >> \
+              --account << parameters.service_account >> \
               --git-version "${CIRCLE_TAG}" \
               --app-version "${CIRCLE_TAG}" \
               --circle-url "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}" \
               --key-file ~/workbench/api/circle-sa-key.json \
               --promote
-          name: Deploy API and UI to all-of-us-rw-staging App Engine
+          name: Deploy API and UI to << parameters.project_name >> App Engine
+
+  deploy-to-staging-command:
+    description: "Deploy to staging environment"
+    steps:
+      - deploy-command:
+          project_name: "all-of-us-rw-staging"
+          service_account: "<< pipeline.parameters.circle-service-account >>"
+          credentials_env_var: "GCLOUD_CREDENTIALS"
+          key_env_var: "GCLOUD_CREDENTIALS_KEY"
+
+  deploy-to-stable-command:
+    description: "Deploy to stable environment"
+    steps:
+      - deploy-command:
+          project_name: "all-of-us-rw-stable"
+          service_account: "deploy@all-of-us-rw-stable.iam.gserviceaccount.com"
+          credentials_env_var: "SERVICE_ACCOUNT_CREDENTIALS_DEPLOY_STABLE_ENV"
+          key_env_var: "SERVICE_ACCOUNT_CREDENTIALS_DEPLOY_STABLE_ENV_KEY"
+
 
   gcloud-auth-login:
     description: "Activate CircleCI service account credential"
@@ -155,10 +185,16 @@ commands:
           credentials e.g. for gcloud or gsutil commands.
         type: boolean
         default: false
+      credentials_env_var:
+        type: string
+        default: "GCLOUD_CREDENTIALS"
+      key_env_var:
+        type: string
+        default: "GCLOUD_CREDENTIALS_KEY"
     steps:
       - run:
           working_directory: ~/workbench
-          command: ci/activate_creds.sh api/circle-sa-key.json
+          command: ci/activate_creds.sh api/circle-sa-key.json <<parameters.credentials_env_var>> <<parameters.key_env_var>>
       - when:
           condition: << parameters.with_application_default_credentials >>
           steps:
@@ -629,6 +665,12 @@ jobs:
     steps:
       - deploy-to-staging-command
 
+  deploy-to-stable:
+    executor: workbench-executor
+    resource_class: large
+    steps:
+      - deploy-to-stable-command
+
   puppeteer-generate-access-tokens:
     executor: puppeteer-executor
     parameters:
@@ -895,6 +937,15 @@ workflows:
             - deploy-to-staging
             - puppeteer-env-setup
             - puppeteer-generate-access-tokens
+      - deploy-to-stable-approval:
+          <<: *filter-release-tags
+          type: approval
+          requires:
+            - puppeteer-test
+      - deploy-to-stable:
+          <<: *filter-release-tags
+          requires:
+            - deploy-to-stable-approval
 
   nightly-tests:
     triggers:

--- a/ci/Dockerfile.circle_build
+++ b/ci/Dockerfile.circle_build
@@ -1,5 +1,6 @@
 # To build and deploy, from this directory:
 # $ docker build . -f Dockerfile.circle_build -t us.gcr.io/broad-dsp-gcr-public/workbench:buildimage-X.Y.Z .
+# Note: M1 Macs may need to add `--platform linux/x86_64/v8`
 # Test out the new image with:
 # $ docker run -it us.gcr.io/broad-dsp-gcr-public/workbench:buildimage-X.Y.Z /bin/bash
 # Update all mentions of us.gcr.io/broad-dsp-gcr-public/workbench:buildimage-X.Y.Z in

--- a/ci/activate_creds.sh
+++ b/ci/activate_creds.sh
@@ -3,14 +3,18 @@
 # Creates credentials file $1 from two environment variables (see
 # below) which combine to decrypt the keys for a service account.
 # Does gcloud auth using the result.
-if [ ! "${GCLOUD_CREDENTIALS}" ]
-then
-  echo "No GCLOUD_CREDENTIALS env var defined, aborting creds activation."
+
+# Default values for environment variables
+CREDENTIALS_ENV_VAR_NAME=${2:-GCLOUD_CREDENTIALS}
+KEY_ENV_VAR_NAME=${3:-GCLOUD_CREDENTIALS_KEY}
+
+if [ ! "${!CREDENTIALS_ENV_VAR_NAME}" ]; then
+  echo "No ${CREDENTIALS_ENV_VAR_NAME} env var defined, aborting creds activation."
   exit 1
 fi
 
-echo $GCLOUD_CREDENTIALS | \
-     openssl enc -d -md sha256 -aes-256-cbc -base64 -A -k "${GCLOUD_CREDENTIALS_KEY}" \
+echo "${!CREDENTIALS_ENV_VAR_NAME}" | \
+     openssl enc -d -md sha256 -aes-256-cbc -base64 -A -k "${!KEY_ENV_VAR_NAME}" \
      > $1
 
 gcloud auth activate-service-account --key-file $1

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -21,8 +21,6 @@ RUN npm install --global yarn n
 # Upgrade to Node 18, above installs 12.
 RUN n 18
 
-RUN npm install @openapitools/openapi-generator-cli -g
-
 ENV CLOUD_SDK_VERSION 392.0.0
 
 WORKDIR /root

--- a/ui/src/deps/deps.sh
+++ b/ui/src/deps/deps.sh
@@ -10,6 +10,8 @@ if [[ -z ${1} || $envs != *"$1"* ]]; then
   exit 1
 fi
 
+yarn install --frozen-lockfile
+
 ./project.rb tanagra-dep --env "$1"
 
 yarn run codegen && yarn run build-terra-deps


### PR DESCRIPTION
Before this PR, developers deployed the `stable` environment as part of the [release process](https://docs.google.com/document/d/17YVCqu4BhVV8ai3OutHx8u0m6V5NkdM5H9kLNxTPDdo/edit?tab=t.0#heading=h.8kph05q8yxo7). After this PR, `stable` is automatically deployed after `staging` tests pass and the developer manually approves the deployment.

I added a manual approval step because there will still be manual steps between "deploy staging" and "deploy stable" such as assigning the release ticket to yourself. These tasks can be automated in the future.

This is a "low" risk PR because it provides CircleCI with credentials for the `deploy@all-of-us-rw-stable.iam.gserviceaccount.com` service account. I personally suspect this is safer, security-wise, than our current approach because I think CircleCI can keep one secret values safer than ~10 release engineers running this on their local machines. Some evidence of this is the fact that we have multiple long-running _prod_ keys for these accounts active right now, when we should have zero, which I think indicates that errors on developer machines can lead to keys not being revoked. I've asked security about this [here](https://pmi-engteam.slack.com/archives/C0491NK4N1G/p1702397525640409).

I have attemped to implement this in a way that makes automating pre-prod and prod trivial.

Validating this is tricky and must be done manually. I've been deploying to CircleCI by tagging a branch with the following CircleCI config changes:

```
 filter-stable-deployment-manual-verification-tags: &filter-stable-deployment-manual-verification-tags
   filters:
     branches:
       ignore: /.*/
     tags:
       only: /^-manual-verification-[0-9]+$/
creating tags locally

...

 deploy-stable:
   jobs:
     - deploy-to-stable:
         <<: *filter-stable-deployment-manual-verification-tags
```

You can see an example deployment [here](https://app.circleci.com/pipelines/github/all-of-us/workbench/30303/workflows/3cc76336-f0a2-4bac-b5a3-e7bdaa66874c).

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.