### PR TITLE
[DT-669][DT-670][risk=no] Variant search UI fixes

### DIFF
--- a/ui/src/app/pages/data/cohort/utils.ts
+++ b/ui/src/app/pages/data/cohort/utils.ts
@@ -304,6 +304,7 @@ export function parseCohortDefinition(json: string) {
             conceptId,
             ancestorData,
             standard,
+            variantId,
           } = sp;
           return {
             parameterId,
@@ -318,6 +319,7 @@ export function parseCohortDefinition(json: string) {
             hasAttributes: attributes && attributes.length > 0,
             hasAncestorData: ancestorData,
             standard,
+            variantId,
           };
         });
         if (!grp.temporal) {

--- a/ui/src/app/pages/data/cohort/variant-search.tsx
+++ b/ui/src/app/pages/data/cohort/variant-search.tsx
@@ -307,7 +307,7 @@ const VariantFilters = ({
                 range={{ min: filters.countMin, max: filters.countMax }}
                 start={[
                   formState.countMin ?? filters.countMin,
-                  formState.countMin ?? filters.countMax,
+                  formState.countMax ?? filters.countMax,
                 ]}
                 tooltips
                 connect


### PR DESCRIPTION
- Fixes issue where counts for variant search items are zero when loading an existing cohort
- Fixes issue with the allele count filter slider where adjusting the lower limit also sets the upper limit