### PR TITLE
[RW-10362][risk=no] Test:  Users who used Absorb can take annual renewal training using Absorb

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
@@ -240,8 +240,10 @@ public class ComplianceTrainingServiceTest {
     user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // Verify database updates for RT and CT training completion
-    assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(rtOriginalCompletionTime));
-    assertModuleCompletionEqual(DbAccessModuleName.CT_COMPLIANCE_TRAINING, Timestamp.from(ctOriginalCompletionTime));
+    assertModuleCompletionEqual(
+        DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(rtOriginalCompletionTime));
+    assertModuleCompletionEqual(
+        DbAccessModuleName.CT_COMPLIANCE_TRAINING, Timestamp.from(ctOriginalCompletionTime));
 
     // Verify Absorb (not Moodle) verification records for RT and CT
     assertAbsorbVerificationSystem(DbAccessModuleName.RT_COMPLIANCE_TRAINING);
@@ -258,8 +260,10 @@ public class ComplianceTrainingServiceTest {
     user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // Verify there is no change in DB if RT completion time is returned null from Absorb.
-    assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(rtOriginalCompletionTime));
-    assertModuleCompletionEqual(DbAccessModuleName.CT_COMPLIANCE_TRAINING, Timestamp.from(ctOriginalCompletionTime));
+    assertModuleCompletionEqual(
+        DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(rtOriginalCompletionTime));
+    assertModuleCompletionEqual(
+        DbAccessModuleName.CT_COMPLIANCE_TRAINING, Timestamp.from(ctOriginalCompletionTime));
 
     // Verify Absorb (not Moodle) verification records still exist
     assertAbsorbVerificationSystem(DbAccessModuleName.RT_COMPLIANCE_TRAINING);
@@ -273,8 +277,10 @@ public class ComplianceTrainingServiceTest {
     user = complianceTrainingService.syncComplianceTrainingStatus();
 
     // Verify RT training completion time is updated
-    assertModuleCompletionEqual(DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(currentRt));
-    assertModuleCompletionEqual(DbAccessModuleName.CT_COMPLIANCE_TRAINING, Timestamp.from(ctOriginalCompletionTime));
+    assertModuleCompletionEqual(
+        DbAccessModuleName.RT_COMPLIANCE_TRAINING, Timestamp.from(currentRt));
+    assertModuleCompletionEqual(
+        DbAccessModuleName.CT_COMPLIANCE_TRAINING, Timestamp.from(ctOriginalCompletionTime));
 
     // Verify Absorb (not Moodle) verification records still exist
     assertAbsorbVerificationSystem(DbAccessModuleName.RT_COMPLIANCE_TRAINING);
@@ -283,9 +289,8 @@ public class ComplianceTrainingServiceTest {
 
   private void assertAbsorbVerificationSystem(DbAccessModuleName moduleName) {
     assertThat(getVerification(moduleName).get().getComplianceTrainingVerificationSystem())
-            .isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.ABSORB);
+        .isEqualTo(DbComplianceTrainingVerification.DbComplianceTrainingVerificationSystem.ABSORB);
   }
-
 
   @Test
   public void testSyncComplianceTrainingStatus_Moodle_ResyncCausesNoChanges() throws Exception {
@@ -542,13 +547,14 @@ public class ComplianceTrainingServiceTest {
   }
 
   private void stubAbsorbOnlyCTComplete(Instant ctCompletionTime)
-          throws org.pmiops.workbench.absorb.ApiException {
+      throws org.pmiops.workbench.absorb.ApiException {
     when(mockAbsorbService.userHasLoggedIntoAbsorb(FAKE_CREDENTIALS)).thenReturn(true);
     when(mockAbsorbService.getActiveEnrollmentsForUser(FAKE_CREDENTIALS))
-            .thenReturn(
-                    List.of(
-                            new Enrollment(ComplianceTrainingServiceImpl.rtTrainingCourseId, null),
-                            new Enrollment(ComplianceTrainingServiceImpl.ctTrainingCourseId, ctCompletionTime)));
+        .thenReturn(
+            List.of(
+                new Enrollment(ComplianceTrainingServiceImpl.rtTrainingCourseId, null),
+                new Enrollment(
+                    ComplianceTrainingServiceImpl.ctTrainingCourseId, ctCompletionTime)));
   }
 
   private void stubAbsorbAllTrainingsComplete(Instant rtCompletionTime, Instant ctCompletionTime)


### PR DESCRIPTION
I am still thinking about integration/acceptance test. In the meantime i wanted to add this test which test:

1) User has already completed RT AND  CT training
2) User is re-enrolled to RT Training
3) User completes RT Training


<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
