### PR TITLE
[risk=low][RW-11523][RW-11538] Catch 4xx errors when checking Terra ToS status

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -603,6 +603,17 @@ public class FireCloudServiceImpl implements FireCloudService {
 
   private UserTermsOfServiceDetails getUserTerraToSStatus() {
     TermsOfServiceApi termsOfServiceApi = termsOfServiceApiProvider.get();
-    return samRetryHandler.run(context -> termsOfServiceApi.userTermsOfServiceGetSelf());
+    UserTermsOfServiceDetails tosDetails;
+    try {
+      tosDetails = samRetryHandler.run(context -> termsOfServiceApi.userTermsOfServiceGetSelf());
+    } catch (Exception e) {
+      log.warning(
+          "Could not retrieve the Terra Terms of Service status for the current user: "
+              + e.getMessage());
+      // assume noncompliance if we can't check
+      tosDetails =
+          new UserTermsOfServiceDetails().permitsSystemUsage(false).isCurrentVersion(false);
+    }
+    return tosDetails;
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
@@ -319,6 +319,25 @@ public class FireCloudServiceImplTest {
   }
 
   @Test
+  public void isUserCompliantWithTerraToS_404()
+      throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
+    when(termsOfServiceApi.userTermsOfServiceGetSelf())
+        .thenThrow(new org.broadinstitute.dsde.workbench.client.sam.ApiException(404, "Not found"));
+    assertThat(service.isUserCompliantWithTerraToS()).isFalse();
+
+    verify(termsOfServiceApi).userTermsOfServiceGetSelf();
+    verifyNoInteractions(firecloudTermsOfServiceApi);
+  }
+
+  @Test
+  public void isUserCompliantWithTerraToS_500()
+      throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
+    when(termsOfServiceApi.userTermsOfServiceGetSelf())
+        .thenThrow(new org.broadinstitute.dsde.workbench.client.sam.ApiException(500, "WELP"));
+    assertThrows(ServerErrorException.class, () -> service.isUserCompliantWithTerraToS());
+  }
+
+  @Test
   public void hasUserAcceptedLatestTerraToS()
       throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
     var toReturn =
@@ -348,6 +367,25 @@ public class FireCloudServiceImplTest {
 
     verify(termsOfServiceApi).userTermsOfServiceGetSelf();
     verifyNoInteractions(firecloudTermsOfServiceApi);
+  }
+
+  @Test
+  public void hasUserAcceptedLatestTerraToS_404()
+      throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
+    when(termsOfServiceApi.userTermsOfServiceGetSelf())
+        .thenThrow(new org.broadinstitute.dsde.workbench.client.sam.ApiException(404, "Not found"));
+    assertThat(service.hasUserAcceptedLatestTerraToS()).isFalse();
+
+    verify(termsOfServiceApi).userTermsOfServiceGetSelf();
+    verifyNoInteractions(firecloudTermsOfServiceApi);
+  }
+
+  @Test
+  public void hasUserAcceptedLatestTerraToS_500()
+      throws org.broadinstitute.dsde.workbench.client.sam.ApiException {
+    when(termsOfServiceApi.userTermsOfServiceGetSelf())
+        .thenThrow(new org.broadinstitute.dsde.workbench.client.sam.ApiException(500, "WELP"));
+    assertThrows(ServerErrorException.class, () -> service.hasUserAcceptedLatestTerraToS());
   }
 
   // these 2 show that hasUserAcceptedLatestTerraToS() is currently dependent on the


### PR DESCRIPTION
Unable to reproduce locally (yet) because we'd have to coordinate with Terra about how to get a user into the correct state, but this change seems straightforward.

Tested locally, observing no change in behavior for my (unaffected) user:
* I can access workspaces normally
* Terra ToS rejection causes my user to require a new ToS acceptance
* after re-acceptance, I have normal workspace access again.
 
---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
