### PR TITLE
[risk=low][no ticket] Bump sam client to resolve a vulnerability

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -500,8 +500,8 @@ dependencies {
     implementation 'jakarta.mail:jakarta.mail-api:2.1.1'
     testAnnotationProcessor "org.mapstruct:mapstruct-processor:$project.ext.MAPSTRUCT_VERSION"
 
-    // updated 30 Nov 2023 to most recent passing Sam on 28 Nov
-    implementation("org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-8713af5") {
+    // updated 13 Dec 2023 to most recent passing Sam on 13 Dec
+    implementation("org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-c0263cf") {
       exclude group: 'org.apache.oltu.oauth2', module: 'org.apache.oltu.oauth2.common'
     }
 


### PR DESCRIPTION
Resolves https://app.snyk.io/org/all-of-us-researcher-workbench/project/bf2628cc-574b-4c92-a236-237ad192de46#issue-SNYK-JAVA-COMSQUAREUPOKIO-5820002 transitively by pulling in the latest Sam https://github.com/broadinstitute/sam/pull/1294

Tested locally by interacting with the UI, being sure to exercise the Sam ToS endpoints.
 
---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
