### PR TITLE
[no ticket][risk=no] Use different path to store files to be mounted in docker

### DIFF
--- a/deploy/libproject/deploy.rb
+++ b/deploy/libproject/deploy.rb
@@ -102,7 +102,8 @@ def setup_and_enter_docker(cmd_name, opts)
     exit 1
   end
 
-  # By default Tempfile on OS X does not use a docker-friendly location
+  # By default Tempfile on OS X does not use a docker-friendly location/
+  # use /tmp/colima to make it work with colima, see https://github.com/abiosoft/colima/issues/844 for more details
   key_file = Tempfile.new(["#{opts.account}-key", ".json"], "/tmp/colima")
   ServiceAccountContext.new(
     opts.project, opts.account, key_file.path).run do

--- a/deploy/libproject/deploy.rb
+++ b/deploy/libproject/deploy.rb
@@ -103,7 +103,7 @@ def setup_and_enter_docker(cmd_name, opts)
   end
 
   # By default Tempfile on OS X does not use a docker-friendly location
-  key_file = Tempfile.new(["#{opts.account}-key", ".json"], "/tmp")
+  key_file = Tempfile.new(["#{opts.account}-key", ".json"], "/tmp/colima")
   ServiceAccountContext.new(
     opts.project, opts.account, key_file.path).run do
     common.run_inline %W{docker-compose build deploy}


### PR DESCRIPTION
We will mount a volumn in docker and put SA credential in that path. 
The current approach does not work with [colima](https://github.com/abiosoft/colima) (Verily bans docker, verily eng can only use colima).
There is a known issue with single file volumn, the suggested workaround is to use `/tmp/colima`: See: https://github.com/abiosoft/colima/issues/844

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
