### PR TITLE
[risk=low][RW-11558] Increase api-unit-tests instance size to medium+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,8 @@ anchors:
   env-default: &env-default
     JAVA_TOOL_OPTIONS: -Xmx2g
     # See: https://support.circleci.com/hc/en-us/articles/360021812453-Common-Android-memory-issues
-    GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
+    # https://stackoverflow.com/questions/38967991/why-are-my-gradle-builds-dying-with-exit-code-137
+    GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.jvmargs=-XX:+UseContainerSupport
     TERM: dumb
 
   env-db: &env-db
@@ -78,9 +79,10 @@ executors:
   # due to garbage collection timeout. This should be reassessed after upgrading to Junit 5. See RW-6460.
   api-unit-test-executor:
     <<: *workbench-executor
+    resource_class: medium+
     environment:
       <<: *env-default
-      # This still assumes a 4G (medium) machine. This increase is possible for unit tests as they are run
+      # The medium+ machine has 6GB.  Increase the Java memory from the default 2G to 3G. This increase is possible for unit tests as they are run
       # as a ~single-process workflow - in other cases using 3GB may starve other processes. For example,
       # this should not be used for the Local API integration test (which starts both a server, and a test process).
       JAVA_TOOL_OPTIONS: -Xmx3g

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -35,7 +35,6 @@ import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
-import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
@@ -77,7 +76,6 @@ public class UserServiceTest {
   private static final int CLOCK_INCREMENT_MILLIS = 1000;
   private static DbUser providedDbUser;
   private static WorkbenchConfig providedWorkbenchConfig;
-  private static DbAccessTier registeredTier;
   private static List<DbAccessModule> accessModules;
   @MockBean private DirectoryService mockDirectoryService;
   @MockBean private FireCloudService mockFireCloudService;
@@ -147,7 +145,7 @@ public class UserServiceTest {
     providedWorkbenchConfig.termsOfService.latestAouVersion = 5; // arbitrary
 
     // key UserService logic depends on the existence of the Registered Tier
-    registeredTier = accessTierDao.save(createRegisteredTier());
+    accessTierDao.save(createRegisteredTier());
 
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
     Institution institution = new Institution();


### PR DESCRIPTION
Running tests often ran out of memory after the Java upgrade.  Bump the machine size to one with more RAM.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
